### PR TITLE
fix: G0 contract registration and macOS oracle harness portability

### DIFF
--- a/crates/jet3/src/database.rs
+++ b/crates/jet3/src/database.rs
@@ -2,9 +2,10 @@
 //!
 //! This module composes only the generic Jet signature published by Microsoft
 //! (`SRC-0004`), the documented Jet 3 2 KiB page size (`SRC-0005`), and the
-//! documented existence of a database header page (`SRC-0007`). It does not
-//! identify a physical Jet version discriminator, encryption state, page type,
-//! allocation structure, catalog, table, row, or value.
+//! documented identification of the first database page as the database header
+//! page (`SRC-0013`). It does not identify a physical Jet version
+//! discriminator, encryption state, page type, allocation structure, catalog,
+//! table, row, or value.
 
 use std::fmt;
 use std::path::Path;

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -158,9 +158,12 @@ Use `not applicable` explicitly rather than omitting a field.
   not identify a Jet generation, prove that the rest of the file is well
   formed, or establish DAO compatibility.
 - Usage: `crates/jet3/src/header.rs`; `crates/jet3/src/database_header.rs`;
-  `crates/jet3/src/candidate.rs`;
+  `crates/jet3/src/candidate.rs`; `crates/jet3/src/database.rs`;
   `crates/jet3-cli/src/main.rs`; `OBS-0001`;
-  `docs/validation/EXTERNAL_CORPUS.md`
+  `docs/architecture/SEMANTIC_READER.md`;
+  `docs/validation/repository-contract.json`;
+  `docs/validation/EXTERNAL_CORPUS.md`; `fuzz/corpus/manifest.json`;
+  `tests/manifest.json`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -186,9 +189,12 @@ Use `not applicable` explicitly rather than omitting a field.
   byte-level generation discriminator.
 - Usage: `crates/jet3/src/header.rs`; `crates/jet3/src/database_header.rs`;
   `crates/jet3/src/jet3_page.rs`; `crates/jet3/src/candidate.rs`;
-  `crates/jet3/src/raw_page_stream.rs`;
+  `crates/jet3/src/raw_page_stream.rs`; `crates/jet3/src/database.rs`;
   `crates/jet3-cli/src/main.rs`; `EXP-0001`;
-  `docs/validation/EXTERNAL_CORPUS.md`
+  `docs/architecture/SEMANTIC_READER.md`;
+  `docs/validation/repository-contract.json`;
+  `docs/validation/EXTERNAL_CORPUS.md`;
+  `oracle/windows-dao/scripts/observe_m1_pages.py`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -258,8 +264,8 @@ Use `not applicable` explicitly rather than omitting a field.
   tags, header-field offsets, allocation-map encoding, catalog root, row
   layout, or long-value pointers, so none of those details may be inferred or
   implemented from this source.
-- Usage: clean-room experiment planning and future DAO scenario design; not
-  currently cited by production code
+- Usage: `docs/architecture/SEMANTIC_READER.md`; clean-room experiment planning
+  and future DAO scenario design; not currently cited by production code
 - Rights: citation to Microsoft-authored public material; no white-paper
   content is redistributed
 - Review: pending independent review
@@ -471,7 +477,15 @@ Use `not applicable` explicitly rather than omitting a field.
   catalog root, allocation encoding, row layout, index encoding, or long-value
   pointer.
 - Usage: `crates/jet3/src/commit_state.rs`;
-  `crates/jet3/src/database_header.rs`; future Windows `.ldb` correlation
+  `crates/jet3/src/database_header.rs`; `crates/jet3/src/database.rs`;
+  `docs/architecture/SEMANTIC_READER.md`;
+  `docs/validation/repository-contract.json`; `fuzz/corpus/manifest.json`;
+  `oracle/windows-dao/experiments/m4/`;
+  `oracle/windows-dao/experiments/m4r1/`;
+  `oracle/windows-dao/experiments/m4r2/`;
+  `oracle/windows-dao/experiments/m5/`;
+  `oracle/windows-dao/scripts/m4_spec.py`;
+  `oracle/windows-dao/scripts/m4r1_spec.py`; future Windows `.ldb` correlation
   experiments
 - Rights: citation to Microsoft-authored public material; no white-paper
   content is redistributed

--- a/docs/architecture/SEMANTIC_READER.md
+++ b/docs/architecture/SEMANTIC_READER.md
@@ -13,8 +13,8 @@ captured-length `ReadAt` source and, using one caller-owned `ResourceBudget`:
 1. enforces the configured input-length policy;
 2. recognizes a generic Microsoft-published Jet signature (`SRC-0004`);
 3. requires exact 2 KiB page geometry (`SRC-0005`);
-4. reads one complete database-header page, whose existence is named by
-   `SRC-0007`; and
+4. reads one complete database-header page, which is the first database page
+   (`SRC-0013`); and
 5. rejects a signature classification that changes between the initial window
    and the retained page-zero read.
 
@@ -32,7 +32,7 @@ must not reach around these boundaries to decode numeric offsets directly.
 
 | Stage | Intended output | Evidence gate before implementation | Required safety boundary | Present state |
 | --- | --- | --- | --- | --- |
-| 0. Bounded opening | `DatabaseReader<S>`, captured geometry, retained page zero | Existing `SRC-0004`, `SRC-0005`, and `SRC-0007` | Input, single-read, total-read, page-visit, and total-work limits | Implemented internally; no compatibility claim |
+| 0. Bounded opening | `DatabaseReader<S>`, captured geometry, retained page zero | Existing `SRC-0004`, `SRC-0005`, and `SRC-0013` | Input, single-read, total-read, page-visit, and total-work limits | Implemented internally; no compatibility claim |
 | 1. Page classification | A typed page class plus a borrowed or fixed-size page view | Provenance for every tag, tag offset, header field, and validity rule | One fixed page per decode; checked slice ranges; one page visit per source read | Blocked on physical evidence |
 | 2. Allocation and usage | Bounded iterators over allocated/owned page references | Provenance for map location, bit ordering, ownership rules, and continuation semantics | Checked page references, item charging, cycle detection, chain-depth limit, bounded visited state | Blocked on physical evidence |
 | 3. Catalog bootstrap | Streaming catalog records sufficient to locate user objects | Provenance for catalog root/location, record layout, object kinds, identifiers, and name encoding | Allocation charged before buffers/sets; count and page limits; no recursive traversal | Blocked on physical evidence |

--- a/docs/validation/g6/core-modules.json
+++ b/docs/validation/g6/core-modules.json
@@ -30,7 +30,7 @@
     {
       "path": "crates/jet3/src/database.rs",
       "classification": "format_safety",
-      "sha256": "d5f71d2a292b722939ab4e7d5ba397a14dd57490b5efdb82c7d1bd46b9ec71c8"
+      "sha256": "fa8945663df182544e056a7e721e10325b725c8b929804c207f91837a0d1ed5c"
     },
     {
       "path": "crates/jet3/src/database_header.rs",

--- a/docs/validation/repository-contract.json
+++ b/docs/validation/repository-contract.json
@@ -50,6 +50,15 @@
         "sha256": "d51cdbaef9c49599e36d40595feb596b6c675556821aef25deeba898150f0acd"
       },
       {
+        "path": "crates/jet3/src/database.rs",
+        "provenance_ids": [
+          "SRC-0004",
+          "SRC-0005",
+          "SRC-0013"
+        ],
+        "sha256": "fa8945663df182544e056a7e721e10325b725c8b929804c207f91837a0d1ed5c"
+      },
+      {
         "path": "crates/jet3/src/database_header.rs",
         "provenance_ids": [
           "SRC-0004",
@@ -118,6 +127,11 @@
         "sha256": "bec401286680c08fd2a722e9495c5964bc3ded66f2392166caaef4415d61eda0"
       },
       {
+        "path": "crates/jet3/src/database_tests.rs",
+        "reason": "Test-only verification of the provenance-bound bounded database opening in database.rs.",
+        "sha256": "c5d8d77853323057bcdd008d30278b67d52a99cadb45a7b94b2ef0931d9900aa"
+      },
+      {
         "path": "crates/jet3/src/commit_state_tests.rs",
         "reason": "Test-only verification of the provenance-bound commit-region assertions in commit_state.rs.",
         "sha256": "8fb10981c76447598fafb062b123d6318860e319bec476f32fda2173a769cb07"
@@ -140,7 +154,7 @@
       {
         "path": "crates/jet3/src/lib.rs",
         "reason": "Public product-scope label and re-exports only; physical assertions live in registered modules.",
-        "sha256": "2df762181a994f237d18bf2a7df2dddaed737ca2e733ba8f7aeaf373e6918bbb"
+        "sha256": "512c2b104dea2080101f688d5c42877dd9c83d1b29593b76bb8558bff689cd84"
       },
       {
         "path": "crates/jet3/src/limits.rs",

--- a/oracle/windows-dao/tests/m5_test_bundle.py
+++ b/oracle/windows-dao/tests/m5_test_bundle.py
@@ -20,6 +20,16 @@ RUN_ID = "20260810T230000Z-m5-synthetic"
 IDENTITY = {"volume_serial_number": "00000001", "file_index": "0000000000000001", "link_count": 1}
 
 
+def unaliased_root(directory: str | Path) -> Path:
+    """Return a bundle root free of symlinked path components.
+
+    Platforms such as macOS hand out temporary directories behind a symlinked
+    prefix, and supplied bundle roots must never traverse an alias, so tests
+    resolve the directory before using it as a root.
+    """
+    return Path(directory).resolve()
+
+
 def write_json(path: Path, document: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes((json.dumps(document, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False) + "\n").encode())

--- a/oracle/windows-dao/tests/test_m5_contract.py
+++ b/oracle/windows-dao/tests/test_m5_contract.py
@@ -20,7 +20,7 @@ from m5_bundle import validate_bundle
 from m5_phase import validate_worker_result
 from m5_records import CHECKED_PLAN, SCHEMA_SET, load_checked_plan, resolve_bundle_path
 from m5_spec import M4_MANIFEST_SHA256, PLAN_SHA256, compile_checked_plan
-from m5_test_bundle import build_bundle, synthetic_m4, write_json
+from m5_test_bundle import build_bundle, synthetic_m4, unaliased_root, write_json
 from protocol_validation import ValidationError
 
 
@@ -120,7 +120,7 @@ class M5AnalysisContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._temporary = tempfile.TemporaryDirectory()
-        cls.root = Path(cls._temporary.name)
+        cls.root = unaliased_root(cls._temporary.name)
         cls.manifest, cls.m4 = build_bundle(cls.root)
 
     @classmethod
@@ -186,7 +186,7 @@ class M5AnalysisContractTests(unittest.TestCase):
 
     def test_nested_or_wrong_m4_manifest_name_is_not_discovered(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = unaliased_root(directory)
             (root / "nested").mkdir()
             (root / "manifest.json").write_text("{}", encoding="utf-8")
             (root / "nested" / "bundle-manifest.json").write_text("{}", encoding="utf-8")
@@ -195,7 +195,7 @@ class M5AnalysisContractTests(unittest.TestCase):
 
     def test_wrong_m4_manifest_hash_is_rejected_before_validation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = unaliased_root(directory)
             (root / "bundle-manifest.json").write_text("{}", encoding="utf-8")
             with self.assertRaisesRegex(ValidationError, "SHA-256 differs"):
                 validate_m4_identity(root)
@@ -214,7 +214,7 @@ class M5AnalysisContractTests(unittest.TestCase):
 
     def test_m4_root_symlink_is_rejected_before_manifest_lookup(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = unaliased_root(directory)
             target = root / "target"
             target.mkdir()
             alias = root / "alias"
@@ -230,7 +230,7 @@ class M5BundleIntegrationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._template_temporary = tempfile.TemporaryDirectory()
-        cls.template = Path(cls._template_temporary.name) / "template"
+        cls.template = unaliased_root(cls._template_temporary.name) / "template"
         cls.manifest, cls.m4 = build_bundle(cls.template)
 
     @classmethod
@@ -239,7 +239,7 @@ class M5BundleIntegrationTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self._temporary = tempfile.TemporaryDirectory()
-        self.root = Path(self._temporary.name) / "bundle"
+        self.root = unaliased_root(self._temporary.name) / "bundle"
         shutil.copytree(self.template, self.root)
 
     def tearDown(self) -> None:


### PR DESCRIPTION
### Motivation

Continuing the macOS leg of the cross-platform G1 handoff (PR #1) surfaced two acceptance failures at `4f067b1`:

- **G0 FAIL** on every platform: `bbb7605` added `crates/jet3/src/database.rs` / `database_tests.rs` without updating the format-knowledge inventory in `repository-contract.json` (stale `lib.rs` hash, two uninventoried files).
- **G3 FAIL** on macOS only: the M5 oracle tests handed symlinked `tempfile` roots (`/var → /private/var`) to the fail-closed bundle validator, so 9 tests died on the (by-design) alias rejection before reaching their intended assertions.

### Description

- `003a06c` — add an `unaliased_root` helper to the shared M5 test-support module and resolve the six temp-root creation sites. No validator or assertion changes; the deliberate symlink/reparse rejection tests still construct real symlinks and still pass.
- `38ce7e7` — register `database.rs` as an assertion file citing `SRC-0004`/`SRC-0005`/`SRC-0013` (the module's page-zero-is-header-page fact is SRC-0013's positional observation; SRC-0007 only names the page and is no longer cited), register `database_tests.rs` as reviewed non-assertion, refresh the `lib.rs` hash, correct the same SRC-0007-for-positional-fact attribution in `SEMANTIC_READER.md`, and reconcile the SRC-0004/0005/0007/0013 usage ledgers.

Review process: each lane implemented by a scoped agent, per-lane strictness review by Codex (first round found a real provenance blocker — the SRC-0007 miscitation — which was fixed and re-verified), then a thermonuclear review over the whole range (found the commit-ordering blocker and the SEMANTIC_READER/usage-ledger gaps, all remediated) ending VERDICT: PUSH-OK.

### Testing

- `python3 tools/validate_repository_contract.py`, `validate_contract.py`, `--self-test`: pass at HEAD (contract validation fails at base, as expected — that is the G0 defect).
- Oracle suite (default symlinked macOS `TMPDIR`): 311 tests, OK, 80 skipped — at the intermediate commit and at HEAD.
- `rustup run 1.96.0` fmt / clippy `-D warnings` / full `cargo test --workspace --all-targets --all-features --locked`: pass at HEAD.
- `./scripts/run-acceptance-gate.sh G0` → PASS (incl. cargo-deny); `G3` → suite green, gate BLOCKED awaiting the DAO differential evidence (its designed state; see `DAO_PROVIDER_BLOCKER.md`).
- Cross-platform G1 for `4f067b1`: macOS platform record generated and validated locally, aggregated with the Linux (SHA-256 `840c6bb1…` verified) and Windows handoff archives; `tools/ci_evidence.py verify-aggregate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4qFJ53UigecZ89SDxVtre