### PR TITLE
fix: enforce provenance usage ledger

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -76,8 +76,7 @@ Use `not applicable` explicitly rather than omitting a field.
   DAO `CreateDatabase` with `dbVersion30` and without `dbEncrypt`. This source
   does not establish any physical file-layout fact or prove that a generated
   file is accepted by Rust.
-- Usage: `docs/validation/ACCEPTANCE.md` G3;
-  `oracle/windows-dao/README.md`
+- Usage: `oracle/windows-dao/scripts/run-dao-gen-probe.ps1`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -102,7 +101,9 @@ Use `not applicable` explicitly rather than omitting a field.
 - Interpretation: a PowerShell oracle using late-bound DAO COM may pass integer
   32 when the named enumeration constant is unavailable. This establishes only
   the oracle API argument, not a byte value or offset in an MDB file.
-- Usage: `oracle/windows-dao/scripts/probe-provider.ps1`
+- Usage: `oracle/windows-dao/scripts/probe-provider.ps1`;
+  `oracle/windows-dao/scripts/run-dao-gen-probe.ps1`;
+  `oracle/windows-dao/scripts/m1/M1.Dao.ps1`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -127,7 +128,8 @@ Use `not applicable` explicitly rather than omitting a field.
 - Interpretation: the DAO oracle may apply this flag to `TableDef.Attributes`
   when excluding system tables from an empty user-schema snapshot. This does
   not establish how a system-table attribute is encoded in an MDB file.
-- Usage: `oracle/windows-dao/scripts/run-dao-gen-probe.ps1`
+- Usage: `oracle/windows-dao/scripts/run-dao-gen-probe.ps1`;
+  `oracle/windows-dao/scripts/m1/M1.Dao.ps1`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -317,7 +319,8 @@ Use `not applicable` explicitly rather than omitting a field.
   numeric values when creating the four controlled field kinds. They are API
   enumeration values only; they do not identify MDB type bytes, physical
   layouts, long-value thresholds, page classes, or storage strategies.
-- Usage: `oracle/windows-dao/protocol/v1_1/scenario.schema.json`;
+- Usage: `oracle/windows-dao/scripts/m1/M1.Dao.ps1`;
+  `oracle/windows-dao/protocol/v1_1/scenario.schema.json`;
   `oracle/windows-dao/examples/m1-inventory.json`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
@@ -426,7 +429,9 @@ Use `not applicable` explicitly rather than omitting a field.
 - Usage: `oracle/windows-dao/protocol/v1_1/README.md`;
   `oracle/windows-dao/examples/DAO-GEN-BINARY-MARKER-001.scenario.json`;
   `oracle/windows-dao/examples/DAO-GEN-MEMO-LADDER-001.scenario.json`;
-  `oracle/windows-dao/examples/DAO-GEN-LONGBINARY-LADDER-001.scenario.json`
+  `oracle/windows-dao/examples/DAO-GEN-LONGBINARY-LADDER-001.scenario.json`;
+  `oracle/windows-dao/scripts/preflight-m1-controlled.ps1`;
+  `oracle/windows-dao/tests/test_m1_preflight_contract.py`
 - Rights: citations to public Microsoft documentation; no documentation
   content is redistributed
 - Review: pending independent review
@@ -524,6 +529,8 @@ Use `not applicable` explicitly rather than omitting a field.
   physical encoding, and a successful call does not establish Rust
   compatibility.
 - Usage: `oracle/windows-dao/experiments/m4/`;
+  `oracle/windows-dao/experiments/m4r1/`;
+  `oracle/windows-dao/experiments/m4r2/`;
   `oracle/windows-dao/experiments/m5/`
 - Rights: citations to public Microsoft documentation; no documentation
   content is redistributed
@@ -557,6 +564,8 @@ Use `not applicable` explicitly rather than omitting a field.
   evidence only; it is not an MDB version field, byte string, encoding, or
   Rust compatibility result.
 - Usage: `oracle/windows-dao/experiments/m4/`;
+  `oracle/windows-dao/experiments/m4r1/`;
+  `oracle/windows-dao/experiments/m4r2/`;
   `oracle/windows-dao/experiments/m5/`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
@@ -592,10 +601,11 @@ Use `not applicable` explicitly rather than omitting a field.
   and no compacted file may be treated as compatibility or physical-layout
   evidence without a separately checked experiment.
 - Usage: explicit exclusion and future-control rationale in
-  `oracle/windows-dao/experiments/m4/README.md` and
-  `oracle/windows-dao/experiments/m4/m4-header-discriminator.plan.json`; the
-  separately checked experiment anticipated here is preregistered as
-  `EXP-0012` and `SRC-0018` in `oracle/windows-dao/experiments/m5/`
+  `oracle/windows-dao/experiments/m4/`,
+  `oracle/windows-dao/experiments/m4r1/`, and
+  `oracle/windows-dao/experiments/m4r2/`; the separately checked experiment
+  anticipated here is preregistered as `EXP-0012` and `SRC-0018` in
+  `oracle/windows-dao/experiments/m5/`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -694,8 +704,7 @@ Use `not applicable` explicitly rather than omitting a field.
   flag, encryption algorithm, key, page class, or layout; it does not establish
   that a compacted file is readable by this project; and it does not by itself
   authorize execution.
-- Usage: `EXP-0012`; `oracle/windows-dao/experiments/m5/README.md`;
-  `oracle/windows-dao/experiments/m5/m5-compact-confirm.plan.json`
+- Usage: `EXP-0012`; `oracle/windows-dao/experiments/m5/`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -721,7 +730,9 @@ Use `not applicable` explicitly rather than omitting a field.
   `dbDecrypt` API option after all other checked execution gates pass. This is
   only an API enumeration value; it establishes no MDB byte, encryption
   representation, key, offset, layout, or successful provider behavior.
-- Usage: revised M5 preregistration and future checked M5 compact worker
+- Usage: `EXP-0015`; revised M5 preregistrations under
+  `oracle/windows-dao/experiments/m5/`;
+  `oracle/windows-dao/scripts/m5/M5.Dao.ps1`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review

--- a/tools/tests/test_validate_repository_contract.py
+++ b/tools/tests/test_validate_repository_contract.py
@@ -377,6 +377,51 @@ class FormatKnowledgeTests(unittest.TestCase):
         self.assertTrue(any("is absent from source" in error for error in errors))
 
 
+class SourceUsageLedgerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        (self.root / "src").mkdir()
+
+    def validate(self, provenance: str) -> list[str]:
+        return repository_provenance.validate_source_usage_ledger(
+            self.root, {"src/module.rs"}, provenance
+        )
+
+    def test_exact_file_and_directory_usage_cover_citations(self) -> None:
+        (self.root / "src/module.rs").write_text(
+            "// Evidence: SRC-0001 and SRC-0002.\n", encoding="utf-8"
+        )
+        provenance = (
+            "### SRC-0001 — one\n\n- Usage: `src/module.rs`\n- Rights: test\n\n"
+            "### SRC-0002 — two\n\n- Usage: `src/`\n- Rights: test\n"
+        )
+        self.assertEqual(self.validate(provenance), [])
+
+    def test_missing_usage_path_fails(self) -> None:
+        (self.root / "src/module.rs").write_text(
+            "// Evidence: SRC-0001.\n", encoding="utf-8"
+        )
+        errors = self.validate(
+            "### SRC-0001 — one\n\n- Usage: contextual only\n- Rights: test\n"
+        )
+        self.assertEqual(
+            errors, ["SRC-0001: Usage does not cover citing path src/module.rs"]
+        )
+
+    def test_unknown_source_id_fails(self) -> None:
+        (self.root / "src/module.rs").write_text(
+            "// Evidence: SRC-9999.\n", encoding="utf-8"
+        )
+        errors = self.validate(
+            "### SRC-0001 — one\n\n- Usage: `src/module.rs`\n- Rights: test\n"
+        )
+        self.assertEqual(
+            errors, ["src/module.rs: unknown source provenance ID SRC-9999"]
+        )
+
+
 class FixtureInventoryTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()

--- a/tools/validate_repository_contract.py
+++ b/tools/validate_repository_contract.py
@@ -37,6 +37,7 @@ from validation.repository_provenance import (
     provenance_sections as _provenance_sections,
     tracked_files as _tracked_files,
     validate_format_knowledge,
+    validate_source_usage_ledger,
 )
 from validation.repository_shape import validate_contract_shape
 from validation.repository_workspace_dependency import (
@@ -85,6 +86,7 @@ def validate_repository(
     errors.extend(
         validate_format_knowledge(root, contract, source_files, provenance_text)
     )
+    errors.extend(validate_source_usage_ledger(root, tracked, provenance_text))
 
     fixture_path, _ = _resolve_file(
         root,

--- a/tools/validation/repository_provenance.py
+++ b/tools/validation/repository_provenance.py
@@ -12,6 +12,9 @@ from .repository_common import ContractError, resolve_file, sha256
 PROVENANCE_HEADING = re.compile(
     r"^### ((?:SRC|OBS|EXP|FIX)-[0-9]{4})\b", re.MULTILINE
 )
+SOURCE_ID = re.compile(r"\bSRC-[0-9]{4}\b")
+USAGE_FIELD = re.compile(r"^- Usage:(.*?)(?=^- Rights:)", re.MULTILINE | re.DOTALL)
+BACKTICKED_VALUE = re.compile(r"`([^`\n]+)`")
 
 
 def tracked_files(root: Path) -> set[str]:
@@ -42,6 +45,56 @@ def provenance_sections(text: str) -> dict[str, str]:
         end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
         sections[match.group(1)] = text[match.start() : end]
     return sections
+
+
+def validate_source_usage_ledger(
+    root: Path, tracked: set[str], provenance_text: str
+) -> list[str]:
+    """Require every substantive source citation to appear in its Usage field."""
+    errors: list[str] = []
+    sections = provenance_sections(provenance_text)
+    usage_paths: dict[str, set[str]] = {}
+    for identifier, section in sections.items():
+        if not identifier.startswith("SRC-"):
+            continue
+        match = USAGE_FIELD.search(section)
+        if match is None:
+            errors.append(f"{identifier}: missing Usage field")
+            continue
+        usage_paths[identifier] = {
+            value.removeprefix("./")
+            for value in BACKTICKED_VALUE.findall(match.group(1))
+            if "/" in value
+        }
+
+    for relative in sorted(tracked):
+        if relative == "docs/PROVENANCE.md" or relative.startswith("tools/tests/"):
+            continue
+        path = root / relative
+        if not path.is_file():
+            continue
+        data = path.read_bytes()
+        if b"SRC-" not in data:
+            continue
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            errors.append(f"{relative}: source citation appears in a non-UTF-8 file")
+            continue
+        for identifier in sorted(set(SOURCE_ID.findall(text))):
+            if identifier not in sections:
+                errors.append(f"{relative}: unknown source provenance ID {identifier}")
+                continue
+            declared = usage_paths.get(identifier, set())
+            if not any(
+                relative == candidate
+                or (candidate.endswith("/") and relative.startswith(candidate))
+                for candidate in declared
+            ):
+                errors.append(
+                    f"{identifier}: Usage does not cover citing path {relative}"
+                )
+    return errors
 
 
 def validate_format_knowledge(


### PR DESCRIPTION
## What changed

- reconciled the public-source Usage ledger with current DAO, M4, and M5 consumers
- added repository-contract validation for every substantive tracked `SRC-*` citation
- added focused coverage for exact paths, directory coverage, omissions, and unknown IDs

## Why

Most public-source Usage entries had not been audited after the M1 and M4/M5 revisions. That allowed a source citation to be added without recording the consumer in `docs/PROVENANCE.md`.

## Checks

- `python3 tools/validate_repository_contract.py`
- `python3 tools/validate_contract.py`
- `python3 -m unittest tools.tests.test_validate_repository_contract`
- `git diff --check`
