### PR TITLE
docs: preregister set-reference M5 successor

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -489,6 +489,7 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/m4r1/`;
   `oracle/windows-dao/experiments/m4r2/`;
   `oracle/windows-dao/experiments/m5/`;
+  `oracle/windows-dao/experiments/m5s1/`;
   `oracle/windows-dao/scripts/m4_spec.py`;
   `oracle/windows-dao/scripts/m4r1_spec.py`; future Windows `.ldb` correlation
   experiments
@@ -531,7 +532,8 @@ Use `not applicable` explicitly rather than omitting a field.
 - Usage: `oracle/windows-dao/experiments/m4/`;
   `oracle/windows-dao/experiments/m4r1/`;
   `oracle/windows-dao/experiments/m4r2/`;
-  `oracle/windows-dao/experiments/m5/`
+  `oracle/windows-dao/experiments/m5/`;
+  `oracle/windows-dao/experiments/m5s1/`
 - Rights: citations to public Microsoft documentation; no documentation
   content is redistributed
 - Review: pending independent review
@@ -566,7 +568,8 @@ Use `not applicable` explicitly rather than omitting a field.
 - Usage: `oracle/windows-dao/experiments/m4/`;
   `oracle/windows-dao/experiments/m4r1/`;
   `oracle/windows-dao/experiments/m4r2/`;
-  `oracle/windows-dao/experiments/m5/`
+  `oracle/windows-dao/experiments/m5/`;
+  `oracle/windows-dao/experiments/m5s1/`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -605,7 +608,8 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/m4r1/`, and
   `oracle/windows-dao/experiments/m4r2/`; the separately checked experiment
   anticipated here is preregistered as `EXP-0012` and `SRC-0018` in
-  `oracle/windows-dao/experiments/m5/`
+  `oracle/windows-dao/experiments/m5/`; successor experimental controls are
+  preregistered under `oracle/windows-dao/experiments/m5s1/`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -704,7 +708,8 @@ Use `not applicable` explicitly rather than omitting a field.
   flag, encryption algorithm, key, page class, or layout; it does not establish
   that a compacted file is readable by this project; and it does not by itself
   authorize execution.
-- Usage: `EXP-0012`; `oracle/windows-dao/experiments/m5/`
+- Usage: `EXP-0012`; `oracle/windows-dao/experiments/m5/`;
+  `oracle/windows-dao/experiments/m5s1/`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -732,6 +737,7 @@ Use `not applicable` explicitly rather than omitting a field.
   representation, key, offset, layout, or successful provider behavior.
 - Usage: `EXP-0015`; revised M5 preregistrations under
   `oracle/windows-dao/experiments/m5/`;
+  successor preregistration under `oracle/windows-dao/experiments/m5s1/`;
   `oracle/windows-dao/scripts/m5/M5.Dao.ps1`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
@@ -2429,6 +2435,62 @@ Use `not applicable` explicitly rather than omitting a field.
 - Rights: no licensed-provider output was retained or published
 - Review: execution trace and immutable-M4 cause verified; current M5 campaign
   remains blocked with no scientific or compatibility claim
+
+### EXP-0034 — Preregistered M5 set-reference successor
+
+- Recorded: 2026-08-13, OpenAI Codex
+- Kind: separately preregistered declarative successor with a checked plan
+  projection; no DAO acquisition, bundle, analysis result, or format claim
+- Question: For every fresh compacted-database byte in `[0x000,0x600)`, is the
+  value a member of the complete set observed at the same absolute offset in
+  all twelve validated M4 creator/reopen prefixes for the matched documented
+  destination condition?
+- Origin: project-authored `DAO-M5-SET-REFERENCE-001` plan recorded after the
+  terminal `EXP-0033` failure. The design uses only the immutable `EXP-0018`
+  M4 bundle, the DAO API facts in `SRC-0014` through `SRC-0016`, `SRC-0018`,
+  and `SRC-0019`, and the excluded commit region in `SRC-0013`. No retained
+  M5R7 file or observation exists, and no external MDB implementation or new
+  format source was consulted.
+- Environment: not executed; a future run requires a licensed x86 DAO host,
+  exact provider and Windows identities, and an exact clean pushed successor
+  implementation commit recorded before COM activation
+- Protocol: bind the exact immutable M4R2 manifest; construct each reference
+  set from the sorted distinct unsigned bytes in all six creator and all six
+  reopen prefixes for one M4 condition and offset; require all twelve inputs;
+  run a complete new 36-condition, three-replica, three-phase successor
+  acquisition; perform exactly 165,888 primary membership evaluations over
+  `[0x000,0x600)`; never select a representative M4 value, delete an unstable
+  offset, special-case `0x4F0`, use an M4 candidate set as a prerequisite, or
+  reuse the discarded M5R7 acquisition
+- Artifacts:
+  `oracle/windows-dao/experiments/m5s1/m5-set-reference.plan.json`, SHA-256
+  `3f2863fb51338aa2d6ef54553fcbe5b4826c8d98cce85151958b04d500611261`;
+  `oracle/windows-dao/experiments/m5s1/README.md`, SHA-256
+  `0c1fd6cd8ca8133482c8bdc1ced3f86ff378f319209c61219abaf2e14b7b5851`;
+  `oracle/windows-dao/scripts/m5s1_spec.py`, SHA-256
+  `2e7201d2fb6fe756e155f21976566b3141ab8d2b7acacd77d7b9112d8bec1ca7`;
+  `oracle/windows-dao/tests/test_m5s1_plan_contract.py`, SHA-256
+  `6725f9b679d40129e4aee78bf04463360651bf78de9b26781d274d260e8ba86a`
+- Observation: the exact plan derives 36 unique conditions, 108 samples in
+  three fixed 12-position rotations, 324 future isolated workers, 55,296
+  condition-offset reference units, and 165,888 primary memberships. Its
+  execution gate is `BLOCKED` on independent design review, successor-specific
+  controller/worker/bundle contracts, checked set-reference analysis and an
+  independent validator, and exact clean pushed host binding.
+- Interpretation: this is a new experiment family, not M5R8 and not a repair
+  to M5R7. Set-valued references preserve observed M4 instability without
+  choosing a byte or suppressing an offset. A complete valid future run may
+  report only whether all compact observations belong to their matched sets or
+  whether compact observations extend those sets. Either result remains a
+  bounded provider observation and assigns no physical meaning or compatibility.
+- Usage: scientific and implementation contract for future work under
+  `oracle/windows-dao/experiments/m5s1/` and
+  `oracle/windows-dao/scripts/m5s1_spec.py`; no production Rust usage
+- Rights: plan, documentation, checked projection, and tests are original
+  project material; future licensed-provider output requires a separate
+  retention and rights record
+- Review: focused contract tests pass; independent scientific review and all
+  execution implementation remain explicitly blocked
 
 ## Fixtures and black-box results
 

--- a/oracle/windows-dao/experiments/m5s1/README.md
+++ b/oracle/windows-dao/experiments/m5s1/README.md
@@ -1,0 +1,93 @@
+# M5 set-reference successor preregistration
+
+`DAO-M5-SET-REFERENCE-001` is a new bounded, descriptive DAO-only experiment.
+It succeeds the terminally failed M5R7 family; it is not M5R8 and does not edit,
+reinterpret, or make `EXP-0033` pass.
+
+M5R7 required one stable M4 byte for every matched condition and analyzed
+offset. Its complete acquisition was discarded when the immutable M4 input
+contained more than one value for condition `V20-E` at offset `0x4F0`.
+Selecting one observation, deleting that offset, or loosening the old validator
+after acquisition would have been a post-hoc redesign. This successor instead
+defines set-valued M4 references before any new M5 acquisition.
+
+## Question
+
+For each fresh compacted database, matched documented destination condition,
+and absolute offset in `[0x000,0x600)`, is the compacted byte a member of the
+complete set of bytes observed by the validated M4R2 acquisition at that same
+condition and offset?
+
+The question is descriptive. Membership does not identify a field or establish
+that a byte is a version, encryption, generation, checksum, or page-header
+value. It cannot establish Rust compatibility.
+
+## Immutable inputs and new acquisition
+
+The only M4 input is the independently validated `EXP-0018` bundle for
+`DAO-M4-HEADER-DISCRIMINATOR-003`, bound by manifest SHA-256 in the plan. The
+bundle remains read-only and retains its inconclusive outcome.
+
+`EXP-0033` retained no M5R7 database, prefix, record, comparison, or report.
+This successor therefore requires a complete new acquisition. It preserves the
+documented-legal 36-condition factorial, three replicas, three rotated blocks,
+and source/compact/verify worker separation. `SRC-0014`, `SRC-0015`,
+`SRC-0016`, `SRC-0018`, and `SRC-0019` govern only the DAO API controls and
+labels. They assign no meaning to MDB bytes.
+
+The operational implementation must retain the fail-closed R7 protections:
+fresh databases and workers, controller-owned exact byte clones, post-worker
+exclusive quiescence checks, bounded companions, and no companion bytes in
+analysis. This preregistration does not authorize reuse of R7 artifacts or
+silently bind the old controller to the new scientific design.
+
+## Set-valued M4 reference
+
+For one M4 condition and absolute offset, the reference set is the sorted set of
+distinct unsigned byte values from all six creator prefixes and all six reopen
+prefixes. Exactly twelve validated observations are required.
+
+- A singleton means the twelve M4 observations agree.
+- A larger set preserves M4 variation without choosing a representative.
+- An empty or incomplete set is an analysis failure.
+- No unstable offset may be removed, including `0x4F0`.
+
+Each of the three new compacted-database prefixes per M5 condition is primary
+data. Its byte is checked for membership in the complete reference set for the
+condition's matched M4 destination condition. Verify-phase prefixes are
+integrity controls and cannot replace missing compact observations.
+
+The complete design evaluates 36 conditions × 3 replicas × 1,536 offsets, or
+165,888 memberships. It covers 36 × 1,536 condition-offset reference units.
+Reference sets contain at most 256 byte values by construction.
+
+## Fixed outcomes
+
+A complete valid acquisition has exactly one of two scientific outcomes:
+
+- `reference_sets_contain_all_compact_observations` when every compact byte is
+  present in its matched M4 set; or
+- `compact_observations_extend_reference_sets` when at least one is absent.
+
+Failure to bind or validate M4, construct every complete reference set, acquire
+all successor samples, or validate the successor bundle produces no scientific
+outcome. It is not converted into either result.
+
+The report may retain cardinality counts and exact condition/offset/value
+occurrences within `[0x000,0x600)`. `[0x600,0x800)` remains excluded under
+`SRC-0013`. The report may not attach physical names or semantics to offsets.
+
+## Execution gate
+
+Execution remains `BLOCKED`. Before any DAO acquisition, a later exact commit
+must provide and independently review:
+
+1. checked controller, worker, record, and bundle schemas for this successor;
+2. checked set-reference analysis and an independent complete-bundle validator;
+3. corruption, identity, path, arithmetic, and resource-bound tests; and
+4. exact clean pushed commit and licensed x86 DAO-host bindings.
+
+Any change after acquisition begins requires a new plan and provenance entry.
+The current machine-readable plan is
+`oracle/windows-dao/experiments/m5s1/m5-set-reference.plan.json`; `EXP-0034`
+records its timing, hashes, limits, and claim boundary.

--- a/oracle/windows-dao/experiments/m5s1/m5-set-reference.plan.json
+++ b/oracle/windows-dao/experiments/m5s1/m5-set-reference.plan.json
@@ -1,0 +1,230 @@
+{
+  "protocol_version": "1.0.0",
+  "document_type": "dao_m5_successor_plan",
+  "experiment_id": "DAO-M5-SET-REFERENCE-001",
+  "preregistration": {
+    "provenance_entry": "EXP-0034",
+    "recorded_utc_date": "2026-08-13",
+    "recorded_after_validated_m4_result": "EXP-0018",
+    "recorded_after_terminal_m5r7_blocker": "EXP-0033",
+    "prior_m5_artifacts_available": false,
+    "prior_m5_acquisition_may_be_reused": false,
+    "full_new_acquisition_required": true,
+    "amendment_rule": "any change after the first successor acquisition begins requires a new plan file and provenance entry"
+  },
+  "provenance_ids": [
+    "SRC-0013",
+    "SRC-0014",
+    "SRC-0015",
+    "SRC-0016",
+    "SRC-0018",
+    "SRC-0019"
+  ],
+  "related_experiments": [
+    "EXP-0018",
+    "EXP-0033"
+  ],
+  "execution_gate": {
+    "status": "BLOCKED",
+    "reason": "successor_acquisition_and_analysis_are_not_implemented_or_exact_commit_bound",
+    "blocking_requirements": [
+      "independent_scientific_review",
+      "checked_controller_workers_and_bundle_schemas",
+      "checked_set_reference_analysis_and_independent_validator",
+      "windows_dao_host_bound_to_an_exact_clean_pushed_successor_commit"
+    ]
+  },
+  "m4_binding": {
+    "experiment_id": "DAO-M4-HEADER-DISCRIMINATOR-003",
+    "provenance_entry": "EXP-0018",
+    "bundle_manifest_sha256": "0e6dbba7d5f6bd6933dcc932636b4462487a754f40f2a2f17b48f3c4124baa8d",
+    "producer_commit": "35f5f55f0b7277fc07831db540eab7fa69a41a20",
+    "campaign_run_id": "20260810T220332Z-m4-r2",
+    "scientific_outcome": "inconclusive",
+    "read_only_input": true
+  },
+  "acquisition_design": {
+    "question": "Do fresh compacted-database prefix bytes belong to the complete observed M4 byte set for the matched documented destination condition?",
+    "condition_count": 36,
+    "replicas_per_condition": 3,
+    "sample_count": 108,
+    "workers_per_sample": 3,
+    "worker_count": 324,
+    "phases": [
+      "source",
+      "compact",
+      "verify"
+    ],
+    "source_versions": [
+      {
+        "name": "dbVersion20",
+        "token": "20",
+        "api_value": 16,
+        "dao_version": "2.0"
+      },
+      {
+        "name": "dbVersion30",
+        "token": "30",
+        "api_value": 32,
+        "dao_version": "3.0"
+      },
+      {
+        "name": "dbVersion40",
+        "token": "40",
+        "api_value": 64,
+        "dao_version": "4.0"
+      }
+    ],
+    "source_encryption_options": [
+      {
+        "name": "omitted",
+        "token": "U",
+        "api_value": 0,
+        "encrypted": false
+      },
+      {
+        "name": "dbEncrypt",
+        "token": "E",
+        "api_value": 2,
+        "encrypted": true
+      }
+    ],
+    "destination_version_pairs": [
+      "20-20",
+      "20-30",
+      "20-40",
+      "30-30",
+      "30-40",
+      "40-40"
+    ],
+    "compact_encryption_options": [
+      {
+        "name": "omitted",
+        "token": "OMIT",
+        "api_value": 0,
+        "destination_state": "preserve_source"
+      },
+      {
+        "name": "dbEncrypt",
+        "token": "ENC",
+        "api_value": 2,
+        "destination_state": "encrypted"
+      },
+      {
+        "name": "dbDecrypt",
+        "token": "DEC",
+        "api_value": 4,
+        "destination_state": "unencrypted"
+      }
+    ],
+    "condition_id_rule": "S{source_version_token}{source_encryption_token}-D{destination_version_token}-{compact_encryption_token}",
+    "matched_m4_condition_rule": "V{destination_version_token}-{documented_destination_encryption_token}",
+    "schedule": {
+      "block_count": 3,
+      "conditions_per_block": 36,
+      "canonical_condition_order": "source_version_then_source_encryption_then_destination_version_then_compact_encryption_in_declared_order",
+      "block_rotation": "rotate canonical order left by 12 times the zero-based block index"
+    },
+    "operational_contract": {
+      "fresh_workers": true,
+      "fresh_databases": true,
+      "controller_owned_exact_byte_clones": true,
+      "controller_owned_post_worker_quiescence": true,
+      "companions_excluded_from_analysis": true,
+      "m5r7_databases_or_prefixes_may_be_reused": false
+    }
+  },
+  "reference_semantics": {
+    "reference_unit": "matched_m4_condition_and_absolute_offset",
+    "m4_observations_per_reference_unit": 12,
+    "m4_observation_phases": [
+      "creator",
+      "reopen"
+    ],
+    "m4_replicas_per_condition": 6,
+    "construction": "sorted distinct unsigned byte values from every one of the twelve validated M4 retained prefixes",
+    "empty_reference_set_allowed": false,
+    "representative_value_selection_allowed": false,
+    "unstable_offsets_may_be_deleted": false,
+    "singleton_reference_set_means": "all twelve M4 observations agree",
+    "multiple_value_reference_set_means": "M4 observations vary and every observed value remains admissible reference data",
+    "primary_m5_observation": "compacted_database retained prefix from each of the three successor replicas",
+    "verify_phase_role": "integrity control only and never a substitute primary observation",
+    "membership_rule": "each primary M5 byte is tested for membership in the complete matched M4 reference set at the same absolute offset",
+    "novel_value_rule": "a primary M5 byte is novel only when it is absent from the complete matched M4 reference set"
+  },
+  "analysis": {
+    "retained_prefix_range": {
+      "start": 0,
+      "end": 2048
+    },
+    "analyzed_ranges": [
+      {
+        "start": 0,
+        "end": 1536
+      }
+    ],
+    "excluded_ranges": [
+      {
+        "start": 1536,
+        "end": 2048,
+        "provenance_id": "SRC-0013"
+      }
+    ],
+    "primary_reference_units": 55296,
+    "primary_membership_evaluations": 165888,
+    "required_report_fields": [
+      "reference_set_cardinality_histogram",
+      "novel_value_condition_offsets",
+      "novel_value_occurrence_count",
+      "scientific_outcome"
+    ],
+    "scientific_outcome_rules": {
+      "reference_sets_contain_all_compact_observations": "every primary membership evaluation succeeds",
+      "compact_observations_extend_reference_sets": "at least one primary membership evaluation fails",
+      "no_scientific_outcome": "acquisition bundle, M4 binding, reference construction, or successor validation fails"
+    },
+    "offset_1264_special_casing_allowed": false,
+    "m4_candidate_sets_required": false,
+    "physical_meaning_may_be_assigned": false,
+    "compatibility_may_be_claimed": false
+  },
+  "bounds": {
+    "max_plan_bytes": 262144,
+    "max_database_bytes": 1048576,
+    "max_database_artifacts": 432,
+    "max_total_database_bytes": 452984832,
+    "max_acquisition_database_reads": 1620,
+    "max_acquisition_database_read_bytes": 1698693120,
+    "max_validator_database_reads_per_run": 432,
+    "max_validator_database_read_bytes_per_run": 452984832,
+    "max_prefix_artifacts": 324,
+    "prefix_bytes_per_phase": 2048,
+    "max_total_prefix_bytes": 663552,
+    "max_companion_bytes": 65536,
+    "max_companion_artifacts": 432,
+    "max_total_companion_bytes": 28311552,
+    "max_acquisition_companion_reads": 432,
+    "max_acquisition_companion_read_bytes": 28311552,
+    "max_validator_companion_reads_per_run": 432,
+    "max_validator_companion_read_bytes_per_run": 28311552,
+    "quiescence_records_per_sample": 4,
+    "max_quiescence_records": 432,
+    "max_quiescence_record_bytes": 16384,
+    "max_total_quiescence_record_bytes": 7077888,
+    "max_sample_record_bytes": 65536,
+    "max_reference_units": 55296,
+    "max_reference_set_members": 256,
+    "max_primary_membership_evaluations": 165888,
+    "max_novel_value_records": 165888,
+    "max_worker_processes": 324,
+    "worker_timeout_seconds": 120,
+    "max_analysis_report_bytes": 16777216
+  },
+  "claims": {
+    "descriptive_provider_observations_only": true,
+    "format_field_identification": false,
+    "rust_compatibility": false,
+    "mdb_read_write_or_conversion_support": false
+  }
+}

--- a/oracle/windows-dao/scripts/m5s1_spec.py
+++ b/oracle/windows-dao/scripts/m5s1_spec.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Checked preregistration contract for the set-reference M5 successor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from protocol_validation import ValidationError, load_json, sha256
+
+DAO_ROOT = Path(__file__).resolve().parents[1]
+CHECKED_PLAN = (
+    DAO_ROOT / "experiments" / "m5s1" / "m5-set-reference.plan.json"
+)
+PLAN_SHA256 = "3f2863fb51338aa2d6ef54553fcbe5b4826c8d98cce85151958b04d500611261"
+EXPERIMENT_ID = "DAO-M5-SET-REFERENCE-001"
+M4_EXPERIMENT_ID = "DAO-M4-HEADER-DISCRIMINATOR-003"
+M4_MANIFEST_SHA256 = "0e6dbba7d5f6bd6933dcc932636b4462487a754f40f2a2f17b48f3c4124baa8d"
+M4_PRODUCER_COMMIT = "35f5f55f0b7277fc07831db540eab7fa69a41a20"
+M4_RUN_ID = "20260810T220332Z-m4-r2"
+ANALYZED_BYTES = 1536
+PREFIX_BYTES = 2048
+CONDITION_COUNT = 36
+REPLICAS = 3
+
+SOURCE_VERSIONS = [
+    {"name": "dbVersion20", "token": "20", "api_value": 16, "dao_version": "2.0"},
+    {"name": "dbVersion30", "token": "30", "api_value": 32, "dao_version": "3.0"},
+    {"name": "dbVersion40", "token": "40", "api_value": 64, "dao_version": "4.0"},
+]
+SOURCE_ENCRYPTION = [
+    {"name": "omitted", "token": "U", "api_value": 0, "encrypted": False},
+    {"name": "dbEncrypt", "token": "E", "api_value": 2, "encrypted": True},
+]
+VERSION_PAIRS = ["20-20", "20-30", "20-40", "30-30", "30-40", "40-40"]
+COMPACT_ENCRYPTION = [
+    {
+        "name": "omitted",
+        "token": "OMIT",
+        "api_value": 0,
+        "destination_state": "preserve_source",
+    },
+    {
+        "name": "dbEncrypt",
+        "token": "ENC",
+        "api_value": 2,
+        "destination_state": "encrypted",
+    },
+    {
+        "name": "dbDecrypt",
+        "token": "DEC",
+        "api_value": 4,
+        "destination_state": "unencrypted",
+    },
+]
+
+
+@dataclass(frozen=True)
+class CheckedSuccessorPlan:
+    """Derived immutable condition and schedule projection."""
+
+    document: dict[str, Any]
+    condition_ids: tuple[str, ...]
+    matched_m4_conditions: tuple[str, ...]
+    schedule: tuple[tuple[str, ...], ...]
+
+
+def require_equal(actual: Any, expected: Any, location: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{location}: does not match the checked projection")
+
+
+def require_keys(value: Any, expected: set[str], location: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValidationError(f"{location}: expected exact object fields {sorted(expected)}")
+    return value
+
+
+def _derive_conditions(design: dict[str, Any]) -> tuple[tuple[str, str], ...]:
+    conditions: list[tuple[str, str]] = []
+    for source_version in SOURCE_VERSIONS:
+        source_token = source_version["token"]
+        for source_encryption in SOURCE_ENCRYPTION:
+            source_encryption_token = source_encryption["token"]
+            for pair in VERSION_PAIRS:
+                pair_source, destination_token = pair.split("-")
+                if pair_source != source_token:
+                    continue
+                for compact_encryption in COMPACT_ENCRYPTION:
+                    compact_token = compact_encryption["token"]
+                    condition_id = (
+                        f"S{source_token}{source_encryption_token}"
+                        f"-D{destination_token}-{compact_token}"
+                    )
+                    if compact_token == "OMIT":
+                        destination_encryption = source_encryption_token
+                    elif compact_token == "ENC":
+                        destination_encryption = "E"
+                    else:
+                        destination_encryption = "U"
+                    conditions.append(
+                        (condition_id, f"V{destination_token}-{destination_encryption}")
+                    )
+    require_equal(len(conditions), CONDITION_COUNT, "derived condition count")
+    require_equal(len(set(conditions)), CONDITION_COUNT, "derived condition uniqueness")
+    schedule = design["schedule"]
+    require_equal(schedule["block_count"], REPLICAS, "$.acquisition_design.schedule.block_count")
+    require_equal(
+        schedule["conditions_per_block"],
+        CONDITION_COUNT,
+        "$.acquisition_design.schedule.conditions_per_block",
+    )
+    return tuple(conditions)
+
+
+def compile_checked_plan(document: dict[str, Any]) -> CheckedSuccessorPlan:
+    """Validate the preregistration and derive its complete fixed schedule."""
+    require_keys(
+        document,
+        {
+            "protocol_version",
+            "document_type",
+            "experiment_id",
+            "preregistration",
+            "provenance_ids",
+            "related_experiments",
+            "execution_gate",
+            "m4_binding",
+            "acquisition_design",
+            "reference_semantics",
+            "analysis",
+            "bounds",
+            "claims",
+        },
+        "$",
+    )
+    require_equal(document["protocol_version"], "1.0.0", "$.protocol_version")
+    require_equal(document["document_type"], "dao_m5_successor_plan", "$.document_type")
+    require_equal(document["experiment_id"], EXPERIMENT_ID, "$.experiment_id")
+    require_equal(document["related_experiments"], ["EXP-0018", "EXP-0033"], "$.related_experiments")
+    require_equal(
+        document["provenance_ids"],
+        ["SRC-0013", "SRC-0014", "SRC-0015", "SRC-0016", "SRC-0018", "SRC-0019"],
+        "$.provenance_ids",
+    )
+
+    gate = document["execution_gate"]
+    require_equal(gate["status"], "BLOCKED", "$.execution_gate.status")
+    require_equal(
+        gate["blocking_requirements"],
+        [
+            "independent_scientific_review",
+            "checked_controller_workers_and_bundle_schemas",
+            "checked_set_reference_analysis_and_independent_validator",
+            "windows_dao_host_bound_to_an_exact_clean_pushed_successor_commit",
+        ],
+        "$.execution_gate.blocking_requirements",
+    )
+    preregistration = document["preregistration"]
+    for key in (
+        "prior_m5_artifacts_available",
+        "prior_m5_acquisition_may_be_reused",
+    ):
+        require_equal(preregistration[key], False, f"$.preregistration.{key}")
+    require_equal(
+        preregistration["full_new_acquisition_required"],
+        True,
+        "$.preregistration.full_new_acquisition_required",
+    )
+
+    binding = document["m4_binding"]
+    for key, expected in (
+        ("experiment_id", M4_EXPERIMENT_ID),
+        ("bundle_manifest_sha256", M4_MANIFEST_SHA256),
+        ("producer_commit", M4_PRODUCER_COMMIT),
+        ("campaign_run_id", M4_RUN_ID),
+        ("scientific_outcome", "inconclusive"),
+        ("read_only_input", True),
+    ):
+        require_equal(binding[key], expected, f"$.m4_binding.{key}")
+
+    design = document["acquisition_design"]
+    for key, expected in (
+        ("condition_count", CONDITION_COUNT),
+        ("replicas_per_condition", REPLICAS),
+        ("sample_count", CONDITION_COUNT * REPLICAS),
+        ("workers_per_sample", 3),
+        ("worker_count", CONDITION_COUNT * REPLICAS * 3),
+        ("phases", ["source", "compact", "verify"]),
+        ("source_versions", SOURCE_VERSIONS),
+        ("source_encryption_options", SOURCE_ENCRYPTION),
+        ("destination_version_pairs", VERSION_PAIRS),
+        ("compact_encryption_options", COMPACT_ENCRYPTION),
+    ):
+        require_equal(design[key], expected, f"$.acquisition_design.{key}")
+    for key in (
+        "fresh_workers",
+        "fresh_databases",
+        "controller_owned_exact_byte_clones",
+        "controller_owned_post_worker_quiescence",
+        "companions_excluded_from_analysis",
+    ):
+        require_equal(design["operational_contract"][key], True, f"$.acquisition_design.operational_contract.{key}")
+    require_equal(
+        design["operational_contract"]["m5r7_databases_or_prefixes_may_be_reused"],
+        False,
+        "$.acquisition_design.operational_contract.m5r7_databases_or_prefixes_may_be_reused",
+    )
+
+    conditions = _derive_conditions(design)
+    condition_ids = tuple(condition for condition, _ in conditions)
+    schedule = tuple(
+        condition_ids[12 * block :] + condition_ids[: 12 * block]
+        for block in range(REPLICAS)
+    )
+
+    semantics = document["reference_semantics"]
+    for key, expected in (
+        ("m4_observations_per_reference_unit", 12),
+        ("m4_observation_phases", ["creator", "reopen"]),
+        ("m4_replicas_per_condition", 6),
+        ("empty_reference_set_allowed", False),
+        ("representative_value_selection_allowed", False),
+        ("unstable_offsets_may_be_deleted", False),
+    ):
+        require_equal(semantics[key], expected, f"$.reference_semantics.{key}")
+    require_equal(
+        semantics["construction"],
+        "sorted distinct unsigned byte values from every one of the twelve validated M4 retained prefixes",
+        "$.reference_semantics.construction",
+    )
+    require_equal(
+        semantics["membership_rule"],
+        "each primary M5 byte is tested for membership in the complete matched "
+        "M4 reference set at the same absolute offset",
+        "$.reference_semantics.membership_rule",
+    )
+    require_equal(
+        semantics["novel_value_rule"],
+        "a primary M5 byte is novel only when it is absent from the complete matched M4 reference set",
+        "$.reference_semantics.novel_value_rule",
+    )
+
+    analysis = document["analysis"]
+    require_equal(
+        analysis["retained_prefix_range"],
+        {"start": 0, "end": PREFIX_BYTES},
+        "$.analysis.retained_prefix_range",
+    )
+    require_equal(analysis["analyzed_ranges"], [{"start": 0, "end": ANALYZED_BYTES}], "$.analysis.analyzed_ranges")
+    require_equal(
+        analysis["offset_1264_special_casing_allowed"],
+        False,
+        "$.analysis.offset_1264_special_casing_allowed",
+    )
+    require_equal(analysis["m4_candidate_sets_required"], False, "$.analysis.m4_candidate_sets_required")
+    require_equal(analysis["physical_meaning_may_be_assigned"], False, "$.analysis.physical_meaning_may_be_assigned")
+    require_equal(analysis["compatibility_may_be_claimed"], False, "$.analysis.compatibility_may_be_claimed")
+    reference_units = CONDITION_COUNT * ANALYZED_BYTES
+    membership_evaluations = reference_units * REPLICAS
+    require_equal(analysis["primary_reference_units"], reference_units, "$.analysis.primary_reference_units")
+    require_equal(
+        analysis["primary_membership_evaluations"],
+        membership_evaluations,
+        "$.analysis.primary_membership_evaluations",
+    )
+    require_equal(
+        analysis["scientific_outcome_rules"],
+        {
+            "reference_sets_contain_all_compact_observations": "every primary membership evaluation succeeds",
+            "compact_observations_extend_reference_sets": "at least one primary membership evaluation fails",
+            "no_scientific_outcome": (
+                "acquisition bundle, M4 binding, reference construction, or "
+                "successor validation fails"
+            ),
+        },
+        "$.analysis.scientific_outcome_rules",
+    )
+
+    require_equal(
+        document["bounds"],
+        {
+            "max_plan_bytes": 262144,
+            "max_database_bytes": 1048576,
+            "max_database_artifacts": 432,
+            "max_total_database_bytes": 452984832,
+            "max_acquisition_database_reads": 1620,
+            "max_acquisition_database_read_bytes": 1698693120,
+            "max_validator_database_reads_per_run": 432,
+            "max_validator_database_read_bytes_per_run": 452984832,
+            "max_prefix_artifacts": 324,
+            "prefix_bytes_per_phase": PREFIX_BYTES,
+            "max_total_prefix_bytes": 663552,
+            "max_companion_bytes": 65536,
+            "max_companion_artifacts": 432,
+            "max_total_companion_bytes": 28311552,
+            "max_acquisition_companion_reads": 432,
+            "max_acquisition_companion_read_bytes": 28311552,
+            "max_validator_companion_reads_per_run": 432,
+            "max_validator_companion_read_bytes_per_run": 28311552,
+            "quiescence_records_per_sample": 4,
+            "max_quiescence_records": 432,
+            "max_quiescence_record_bytes": 16384,
+            "max_total_quiescence_record_bytes": 7077888,
+            "max_sample_record_bytes": 65536,
+            "max_reference_units": reference_units,
+            "max_reference_set_members": 256,
+            "max_primary_membership_evaluations": membership_evaluations,
+            "max_novel_value_records": membership_evaluations,
+            "max_worker_processes": CONDITION_COUNT * REPLICAS * 3,
+            "worker_timeout_seconds": 120,
+            "max_analysis_report_bytes": 16777216,
+        },
+        "$.bounds",
+    )
+    require_equal(
+        document["claims"],
+        {
+            "descriptive_provider_observations_only": True,
+            "format_field_identification": False,
+            "rust_compatibility": False,
+            "mdb_read_write_or_conversion_support": False,
+        },
+        "$.claims",
+    )
+    return CheckedSuccessorPlan(
+        document=document,
+        condition_ids=condition_ids,
+        matched_m4_conditions=tuple(matched for _, matched in conditions),
+        schedule=schedule,
+    )
+
+
+def load_checked_plan(path: Path = CHECKED_PLAN) -> CheckedSuccessorPlan:
+    """Load only the exact preregistered plan bytes."""
+    if sha256(path) != PLAN_SHA256:
+        raise ValidationError("M5 successor plan bytes differ from the preregistration")
+    document = load_json(path)
+    if not isinstance(document, dict):
+        raise ValidationError("M5 successor plan must be an object")
+    return compile_checked_plan(document)

--- a/oracle/windows-dao/tests/test_m5s1_plan_contract.py
+++ b/oracle/windows-dao/tests/test_m5s1_plan_contract.py
@@ -1,0 +1,108 @@
+"""Focused tests for the separately preregistered M5 set-reference successor."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from m5s1_spec import (  # noqa: E402
+    ANALYZED_BYTES,
+    CHECKED_PLAN,
+    CONDITION_COUNT,
+    PLAN_SHA256,
+    REPLICAS,
+    compile_checked_plan,
+    load_checked_plan,
+)
+from protocol_validation import ValidationError  # noqa: E402
+
+
+class M5SuccessorPlanContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.document = json.loads(CHECKED_PLAN.read_text(encoding="utf-8"))
+
+    def test_exact_plan_derives_complete_factorial_and_rotated_schedule(self) -> None:
+        checked = load_checked_plan()
+        self.assertEqual(len(checked.condition_ids), CONDITION_COUNT)
+        self.assertEqual(len(set(checked.condition_ids)), CONDITION_COUNT)
+        self.assertEqual(len(checked.schedule), REPLICAS)
+        self.assertEqual(checked.schedule[0], checked.condition_ids)
+        self.assertEqual(
+            checked.schedule[1], checked.condition_ids[12:] + checked.condition_ids[:12]
+        )
+        self.assertEqual(
+            checked.schedule[2], checked.condition_ids[24:] + checked.condition_ids[:24]
+        )
+        self.assertEqual(
+            set(checked.matched_m4_conditions),
+            {"V20-U", "V20-E", "V30-U", "V30-E", "V40-U", "V40-E"},
+        )
+
+    def test_plan_is_bound_to_exact_preregistered_bytes(self) -> None:
+        self.assertEqual(len(PLAN_SHA256), 64)
+        with tempfile.TemporaryDirectory() as directory:
+            changed = Path(directory) / "plan.json"
+            changed.write_bytes(CHECKED_PLAN.read_bytes() + b"\n")
+            with self.assertRaisesRegex(ValidationError, "bytes differ"):
+                load_checked_plan(changed)
+
+    def test_reference_semantics_preserve_every_unstable_m4_value(self) -> None:
+        checked = compile_checked_plan(self.document)
+        semantics = checked.document["reference_semantics"]
+        self.assertEqual(semantics["m4_observations_per_reference_unit"], 12)
+        self.assertFalse(semantics["representative_value_selection_allowed"])
+        self.assertFalse(semantics["unstable_offsets_may_be_deleted"])
+        self.assertFalse(
+            checked.document["analysis"]["offset_1264_special_casing_allowed"]
+        )
+        self.assertEqual(
+            checked.document["analysis"]["primary_membership_evaluations"],
+            CONDITION_COUNT * REPLICAS * ANALYZED_BYTES,
+        )
+
+    def test_new_acquisition_and_fail_closed_execution_gate_are_mandatory(self) -> None:
+        changed = copy.deepcopy(self.document)
+        changed["preregistration"]["prior_m5_acquisition_may_be_reused"] = True
+        with self.assertRaisesRegex(ValidationError, "prior_m5_acquisition"):
+            compile_checked_plan(changed)
+
+        changed = copy.deepcopy(self.document)
+        changed["execution_gate"]["status"] = "READY"
+        with self.assertRaisesRegex(ValidationError, "execution_gate.status"):
+            compile_checked_plan(changed)
+
+    def test_factor_or_count_changes_are_rejected(self) -> None:
+        changed = copy.deepcopy(self.document)
+        changed["acquisition_design"]["destination_version_pairs"].append("40-20")
+        with self.assertRaisesRegex(ValidationError, "destination_version_pairs"):
+            compile_checked_plan(changed)
+
+        changed = copy.deepcopy(self.document)
+        changed["analysis"]["primary_membership_evaluations"] -= 1
+        with self.assertRaisesRegex(ValidationError, "primary_membership_evaluations"):
+            compile_checked_plan(changed)
+
+    def test_claim_boundary_forbids_format_and_compatibility_claims(self) -> None:
+        for key in (
+            "format_field_identification",
+            "rust_compatibility",
+            "mdb_read_write_or_conversion_support",
+        ):
+            changed = copy.deepcopy(self.document)
+            changed["claims"][key] = True
+            with self.subTest(key=key), self.assertRaisesRegex(
+                ValidationError, "claims"
+            ):
+                compile_checked_plan(changed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- preregistered `DAO-M5-SET-REFERENCE-001` as a new successor family after terminal M5R7
- defined complete set-valued M4 reference semantics before any new DAO acquisition
- fixed the 36-condition, 108-sample schedule, exact M4 binding, outcomes, and resource ceilings
- added a hash-bound checked plan projection and focused corruption/claim-boundary tests
- recorded `EXP-0034` and reconciled public-source Usage entries

## Why

M5R7 correctly failed because its immutable analysis required a single stable M4 byte and condition `V20-E` varied at `0x4F0`. The successor preserves all twelve M4 observations as a set, forbids representative selection or offset deletion, and requires a complete new acquisition.

Execution remains blocked until successor-specific controller, worker, bundle, analysis, independent validation, review, and exact-host bindings exist.

## Checks

- `python3 -m unittest oracle.windows-dao.tests.test_m5s1_plan_contract`
- `python3 tools/validate_repository_contract.py`
- `python3 tools/validate_contract.py`
- `python3 -m py_compile oracle/windows-dao/scripts/m5s1_spec.py oracle/windows-dao/tests/test_m5s1_plan_contract.py`
- `git diff --check`
