### PR TITLE
feat: add bounded M5 successor analysis

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -490,6 +490,7 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/m4r2/`;
   `oracle/windows-dao/experiments/m5/`;
   `oracle/windows-dao/experiments/m5s1/`;
+  `oracle/windows-dao/scripts/m5s1_spec.py`;
   `oracle/windows-dao/scripts/m4_spec.py`;
   `oracle/windows-dao/scripts/m4r1_spec.py`; future Windows `.ldb` correlation
   experiments
@@ -533,7 +534,8 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/m4r1/`;
   `oracle/windows-dao/experiments/m4r2/`;
   `oracle/windows-dao/experiments/m5/`;
-  `oracle/windows-dao/experiments/m5s1/`
+  `oracle/windows-dao/experiments/m5s1/`;
+  `oracle/windows-dao/scripts/m5s1_spec.py`
 - Rights: citations to public Microsoft documentation; no documentation
   content is redistributed
 - Review: pending independent review
@@ -569,7 +571,8 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/m4r1/`;
   `oracle/windows-dao/experiments/m4r2/`;
   `oracle/windows-dao/experiments/m5/`;
-  `oracle/windows-dao/experiments/m5s1/`
+  `oracle/windows-dao/experiments/m5s1/`;
+  `oracle/windows-dao/scripts/m5s1_spec.py`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -609,7 +612,8 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/m4r2/`; the separately checked experiment
   anticipated here is preregistered as `EXP-0012` and `SRC-0018` in
   `oracle/windows-dao/experiments/m5/`; successor experimental controls are
-  preregistered under `oracle/windows-dao/experiments/m5s1/`
+  preregistered under `oracle/windows-dao/experiments/m5s1/` and checked by
+  `oracle/windows-dao/scripts/m5s1_spec.py`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -709,7 +713,8 @@ Use `not applicable` explicitly rather than omitting a field.
   that a compacted file is readable by this project; and it does not by itself
   authorize execution.
 - Usage: `EXP-0012`; `oracle/windows-dao/experiments/m5/`;
-  `oracle/windows-dao/experiments/m5s1/`
+  `oracle/windows-dao/experiments/m5s1/`;
+  `oracle/windows-dao/scripts/m5s1_spec.py`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -738,7 +743,8 @@ Use `not applicable` explicitly rather than omitting a field.
 - Usage: `EXP-0015`; revised M5 preregistrations under
   `oracle/windows-dao/experiments/m5/`;
   successor preregistration under `oracle/windows-dao/experiments/m5s1/`;
-  `oracle/windows-dao/scripts/m5/M5.Dao.ps1`
+  `oracle/windows-dao/scripts/m5/M5.Dao.ps1`;
+  `oracle/windows-dao/scripts/m5s1_spec.py`
 - Rights: citation to public Microsoft documentation; no documentation content
   is redistributed
 - Review: pending independent review
@@ -2491,6 +2497,50 @@ Use `not applicable` explicitly rather than omitting a field.
   retention and rights record
 - Review: focused contract tests pass; independent scientific review and all
   execution implementation remain explicitly blocked
+
+### EXP-0035 — Checked M5 successor set-reference analysis core
+
+- Recorded: 2026-08-13, OpenAI Codex
+- Kind: project-authored bounded analysis implementation and synthetic contract
+  tests; no DAO acquisition, bundle validation, scientific result, or format
+  claim
+- Question: Does the preregistered `EXP-0034` membership algorithm preserve
+  every M4-observed value, evaluate every successor condition/replica/offset,
+  exclude the commit region, and fail closed on incomplete or ambiguous input?
+- Origin: exact `DAO-M5-SET-REFERENCE-001` plan and checked projection from
+  `EXP-0034`; no MDB implementation, new public format source, retained M5R7
+  output, or new DAO observation was consulted
+- Environment: macOS 26.3.1 arm64; Python 3.14.3; no COM activation, Windows
+  provider, external database, or network input
+- Protocol: accept only 72 uniquely identified exact-size M4 prefixes covering
+  six conditions, six replicas, and creator/reopen phases; accept only 108
+  uniquely identified exact-size compact prefixes covering all successor
+  conditions and three replicas; cap iterable consumption before indexing;
+  build all M4 sets for `[0x000,0x600)`; perform the plan's 165,888 primary
+  memberships in canonical order; bound the canonical report bytes; test
+  singleton and unstable references, novel values, excluded bytes, missing,
+  duplicate, short, and permuted inputs
+- Artifacts: `oracle/windows-dao/scripts/m5s1_analysis.py`, SHA-256
+  `d6814ad2de07e506dabb56a4109c2940d6bbd9bb323de9bde51619bc91421c75`;
+  `oracle/windows-dao/tests/test_m5s1_analysis.py`, SHA-256
+  `58f29f705f9479c267f905184b39ddc263b53d0b1c6ff65393e166042503af19`
+- Observation: twelve focused M5S1 plan/analysis tests pass. Synthetic M4
+  variation at `V20-E` offset `0x4F0` admits both observed values without
+  selecting one; an unobserved value produces the exact preregistered extension
+  outcome; changes in `[0x600,0x800)` do not enter the report; reversed complete
+  inputs produce byte-equivalent logical reports.
+- Interpretation: the pure analysis algorithm required by `EXP-0034` now
+  exists and is bounded against its typed complete inputs. This is not an
+  independent bundle validator and does not make successor execution ready.
+  Real input adapters, schemas, retained-tree validation, independent
+  recomputation, Windows acquisition, and exact host/commit bindings remain
+  blocked. Synthetic success establishes robustness only, not an MDB fact.
+- Usage: future M5 successor analysis behind the still-blocked execution gate;
+  no production Rust usage
+- Rights: implementation and tests are original project material; future
+  licensed-provider output requires a separate retention and rights record
+- Review: focused deterministic and corruption-path tests pass; independent
+  analysis and scientific review remain pending
 
 ## Fixtures and black-box results
 

--- a/oracle/windows-dao/scripts/m5s1_analysis.py
+++ b/oracle/windows-dao/scripts/m5s1_analysis.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Bounded set-reference analysis for the separately preregistered M5 successor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import islice
+from typing import Iterable
+
+from m5s1_spec import (
+    ANALYZED_BYTES,
+    M4_EXPERIMENT_ID,
+    M4_MANIFEST_SHA256,
+    PREFIX_BYTES,
+    CheckedSuccessorPlan,
+)
+from protocol_validation import ValidationError, canonical_json_bytes
+
+M4_CONDITIONS = ("V20-U", "V20-E", "V30-U", "V30-E", "V40-U", "V40-E")
+M4_PHASES = ("creator", "reopen")
+M4_REPLICAS = 6
+COMPACT_REPLICAS = 3
+MAX_M4_OBSERVATIONS = len(M4_CONDITIONS) * len(M4_PHASES) * M4_REPLICAS
+MAX_COMPACT_OBSERVATIONS = 36 * COMPACT_REPLICAS
+
+
+@dataclass(frozen=True)
+class M4PrefixObservation:
+    """One independently validated M4 retained-prefix observation."""
+
+    condition_id: str
+    replica: int
+    phase: str
+    prefix: bytes
+
+
+@dataclass(frozen=True)
+class CompactPrefixObservation:
+    """One primary compacted-database prefix from a successor sample."""
+
+    condition_id: str
+    replica: int
+    prefix: bytes
+
+
+def _bounded_list(rows: Iterable[object], maximum: int, label: str) -> list[object]:
+    retained = list(islice(iter(rows), maximum + 1))
+    if len(retained) > maximum:
+        raise ValidationError(f"{label}: exceeds the checked observation ceiling")
+    return retained
+
+
+def _validate_prefix(prefix: object, label: str) -> bytes:
+    if not isinstance(prefix, bytes) or len(prefix) != PREFIX_BYTES:
+        raise ValidationError(f"{label}: exact {PREFIX_BYTES}-byte prefix required")
+    return prefix
+
+
+def _index_m4(
+    rows: Iterable[M4PrefixObservation],
+) -> dict[tuple[str, int, str], bytes]:
+    indexed: dict[tuple[str, int, str], bytes] = {}
+    for row in _bounded_list(rows, MAX_M4_OBSERVATIONS, "M4 observations"):
+        if not isinstance(row, M4PrefixObservation):
+            raise ValidationError("M4 observations: typed observation required")
+        if row.condition_id not in M4_CONDITIONS:
+            raise ValidationError(f"M4 observations: unknown condition {row.condition_id}")
+        if isinstance(row.replica, bool) or row.replica not in range(1, M4_REPLICAS + 1):
+            raise ValidationError("M4 observations: replica outside 1..6")
+        if row.phase not in M4_PHASES:
+            raise ValidationError(f"M4 observations: unknown phase {row.phase}")
+        key = (row.condition_id, row.replica, row.phase)
+        if key in indexed:
+            raise ValidationError(f"M4 observations: duplicate identity {key}")
+        indexed[key] = _validate_prefix(row.prefix, f"M4 observation {key}")
+    expected = {
+        (condition, replica, phase)
+        for condition in M4_CONDITIONS
+        for replica in range(1, M4_REPLICAS + 1)
+        for phase in M4_PHASES
+    }
+    if set(indexed) != expected:
+        raise ValidationError("M4 observations: incomplete exact identity set")
+    return indexed
+
+
+def _index_compact(
+    plan: CheckedSuccessorPlan,
+    rows: Iterable[CompactPrefixObservation],
+) -> dict[tuple[str, int], bytes]:
+    indexed: dict[tuple[str, int], bytes] = {}
+    allowed = set(plan.condition_ids)
+    for row in _bounded_list(
+        rows, MAX_COMPACT_OBSERVATIONS, "compact observations"
+    ):
+        if not isinstance(row, CompactPrefixObservation):
+            raise ValidationError("compact observations: typed observation required")
+        if row.condition_id not in allowed:
+            raise ValidationError(
+                f"compact observations: unknown condition {row.condition_id}"
+            )
+        if isinstance(row.replica, bool) or row.replica not in range(
+            1, COMPACT_REPLICAS + 1
+        ):
+            raise ValidationError("compact observations: replica outside 1..3")
+        key = (row.condition_id, row.replica)
+        if key in indexed:
+            raise ValidationError(f"compact observations: duplicate identity {key}")
+        indexed[key] = _validate_prefix(row.prefix, f"compact observation {key}")
+    expected = {
+        (condition, replica)
+        for condition in plan.condition_ids
+        for replica in range(1, COMPACT_REPLICAS + 1)
+    }
+    if set(indexed) != expected:
+        raise ValidationError("compact observations: incomplete exact identity set")
+    return indexed
+
+
+def _reference_sets(
+    indexed: dict[tuple[str, int, str], bytes],
+) -> dict[str, tuple[frozenset[int], ...]]:
+    references: dict[str, tuple[frozenset[int], ...]] = {}
+    for condition in M4_CONDITIONS:
+        prefixes = tuple(
+            indexed[(condition, replica, phase)]
+            for replica in range(1, M4_REPLICAS + 1)
+            for phase in M4_PHASES
+        )
+        references[condition] = tuple(
+            frozenset(prefix[offset] for prefix in prefixes)
+            for offset in range(ANALYZED_BYTES)
+        )
+    return references
+
+
+def build_analysis(
+    plan: CheckedSuccessorPlan,
+    m4_observations: Iterable[M4PrefixObservation],
+    compact_observations: Iterable[CompactPrefixObservation],
+) -> dict[str, object]:
+    """Build the deterministic bounded membership report from complete inputs."""
+    m4 = _index_m4(m4_observations)
+    compact = _index_compact(plan, compact_observations)
+    references = _reference_sets(m4)
+    histogram: dict[str, int] = {}
+    novel_offsets: list[dict[str, object]] = []
+    novel_occurrences = 0
+
+    for condition, matched_m4 in zip(
+        plan.condition_ids, plan.matched_m4_conditions, strict=True
+    ):
+        reference = references[matched_m4]
+        prefixes = tuple(
+            compact[(condition, replica)]
+            for replica in range(1, COMPACT_REPLICAS + 1)
+        )
+        for offset in range(ANALYZED_BYTES):
+            allowed = reference[offset]
+            cardinality = str(len(allowed))
+            histogram[cardinality] = histogram.get(cardinality, 0) + 1
+            novel = [
+                (replica, prefix[offset])
+                for replica, prefix in enumerate(prefixes, start=1)
+                if prefix[offset] not in allowed
+            ]
+            if novel:
+                novel_occurrences += len(novel)
+                novel_offsets.append(
+                    {
+                        "condition_id": condition,
+                        "absolute_offset": offset,
+                        "occurrences": [
+                            {"replica": replica, "value": value}
+                            for replica, value in novel
+                        ],
+                    }
+                )
+
+    outcome = (
+        "reference_sets_contain_all_compact_observations"
+        if not novel_offsets
+        else "compact_observations_extend_reference_sets"
+    )
+    report: dict[str, object] = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_m5_successor_analysis",
+        "experiment_id": plan.document["experiment_id"],
+        "m4_binding": {
+            "experiment_id": M4_EXPERIMENT_ID,
+            "bundle_manifest_sha256": M4_MANIFEST_SHA256,
+        },
+        "analyzed_range": {"start": 0, "end": ANALYZED_BYTES},
+        "reference_set_cardinality_histogram": dict(sorted(histogram.items())),
+        "novel_value_condition_offsets": novel_offsets,
+        "novel_value_occurrence_count": novel_occurrences,
+        "scientific_outcome": outcome,
+        "physical_meaning_assigned": False,
+        "compatibility_claimed": False,
+    }
+    maximum = plan.document["bounds"]["max_analysis_report_bytes"]
+    if len(canonical_json_bytes(report)) > maximum:
+        raise ValidationError("M5 successor analysis report exceeds its byte ceiling")
+    return report

--- a/oracle/windows-dao/tests/test_m5s1_analysis.py
+++ b/oracle/windows-dao/tests/test_m5s1_analysis.py
@@ -1,0 +1,167 @@
+"""Focused tests for bounded M5 successor set-reference analysis."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from m5s1_analysis import (  # noqa: E402
+    M4_CONDITIONS,
+    CompactPrefixObservation,
+    M4PrefixObservation,
+    build_analysis,
+)
+from m5s1_spec import ANALYZED_BYTES, PREFIX_BYTES, load_checked_plan  # noqa: E402
+from protocol_validation import ValidationError  # noqa: E402
+
+
+class M5SuccessorAnalysisTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.plan = load_checked_plan()
+
+    def m4(self) -> list[M4PrefixObservation]:
+        return [
+            M4PrefixObservation(condition, replica, phase, bytes(PREFIX_BYTES))
+            for condition in M4_CONDITIONS
+            for replica in range(1, 7)
+            for phase in ("creator", "reopen")
+        ]
+
+    def compact(self) -> list[CompactPrefixObservation]:
+        return [
+            CompactPrefixObservation(condition, replica, bytes(PREFIX_BYTES))
+            for condition in self.plan.condition_ids
+            for replica in range(1, 4)
+        ]
+
+    @staticmethod
+    def replace_byte(prefix: bytes, offset: int, value: int) -> bytes:
+        changed = bytearray(prefix)
+        changed[offset] = value
+        return bytes(changed)
+
+    def test_all_memberships_inside_singleton_references_pass(self) -> None:
+        report = build_analysis(self.plan, self.m4(), self.compact())
+        self.assertEqual(
+            report["scientific_outcome"],
+            "reference_sets_contain_all_compact_observations",
+        )
+        self.assertEqual(report["novel_value_condition_offsets"], [])
+        self.assertEqual(report["novel_value_occurrence_count"], 0)
+        self.assertEqual(
+            report["reference_set_cardinality_histogram"],
+            {"1": 36 * ANALYZED_BYTES},
+        )
+
+    def test_unstable_m4_offset_accepts_every_observed_value(self) -> None:
+        m4 = self.m4()
+        row = m4.index(
+            next(
+                item
+                for item in m4
+                if item.condition_id == "V20-E"
+                and item.replica == 6
+                and item.phase == "reopen"
+            )
+        )
+        m4[row] = M4PrefixObservation(
+            "V20-E",
+            6,
+            "reopen",
+            self.replace_byte(m4[row].prefix, 1264, 1),
+        )
+        compact = self.compact()
+        target = next(
+            condition
+            for condition, matched in zip(
+                self.plan.condition_ids,
+                self.plan.matched_m4_conditions,
+                strict=True,
+            )
+            if matched == "V20-E"
+        )
+        row = compact.index(
+            next(
+                item
+                for item in compact
+                if item.condition_id == target and item.replica == 1
+            )
+        )
+        compact[row] = CompactPrefixObservation(
+            target, 1, self.replace_byte(compact[row].prefix, 1264, 1)
+        )
+        report = build_analysis(self.plan, m4, compact)
+        self.assertEqual(
+            report["scientific_outcome"],
+            "reference_sets_contain_all_compact_observations",
+        )
+        self.assertGreater(report["reference_set_cardinality_histogram"]["2"], 0)
+
+    def test_novel_value_produces_exact_extension_record(self) -> None:
+        compact = self.compact()
+        first = compact[0]
+        compact[0] = CompactPrefixObservation(
+            first.condition_id, 1, self.replace_byte(first.prefix, 10, 2)
+        )
+        report = build_analysis(self.plan, self.m4(), compact)
+        self.assertEqual(
+            report["scientific_outcome"],
+            "compact_observations_extend_reference_sets",
+        )
+        self.assertEqual(report["novel_value_occurrence_count"], 1)
+        self.assertEqual(
+            report["novel_value_condition_offsets"],
+            [
+                {
+                    "condition_id": first.condition_id,
+                    "absolute_offset": 10,
+                    "occurrences": [{"replica": 1, "value": 2}],
+                }
+            ],
+        )
+
+    def test_excluded_region_never_enters_analysis(self) -> None:
+        compact = self.compact()
+        first = compact[0]
+        compact[0] = CompactPrefixObservation(
+            first.condition_id, 1, self.replace_byte(first.prefix, 1600, 255)
+        )
+        report = build_analysis(self.plan, self.m4(), compact)
+        self.assertEqual(
+            report["scientific_outcome"],
+            "reference_sets_contain_all_compact_observations",
+        )
+
+    def test_missing_duplicate_and_oversized_inputs_fail_closed(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "incomplete"):
+            build_analysis(self.plan, self.m4()[:-1], self.compact())
+
+        compact = self.compact()
+        compact[-1] = compact[0]
+        with self.assertRaisesRegex(ValidationError, "duplicate"):
+            build_analysis(self.plan, self.m4(), compact)
+
+        m4 = self.m4()
+        first = m4[0]
+        m4[0] = M4PrefixObservation(
+            first.condition_id, first.replica, first.phase, bytes(PREFIX_BYTES - 1)
+        )
+        with self.assertRaisesRegex(ValidationError, "2048-byte"):
+            build_analysis(self.plan, m4, self.compact())
+
+    def test_input_order_does_not_change_the_report(self) -> None:
+        forward = build_analysis(self.plan, self.m4(), self.compact())
+        reverse = build_analysis(
+            self.plan, reversed(self.m4()), reversed(self.compact())
+        )
+        self.assertEqual(forward, reverse)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- added the bounded pure analysis core for `DAO-M5-SET-REFERENCE-001`
- requires the exact 72 M4 and 108 compact observation identities and fixed-size prefixes
- constructs every set-valued M4 reference and performs all 165,888 memberships
- emits deterministic contained/extension outcomes with bounded canonical report size
- added focused tests for unstable `0x4F0`, novel values, excluded bytes, malformed inventories, and input-order independence
- recorded `EXP-0035` and completed the M5S1 source Usage ledger

## Why

This implements the preregistered scientific algorithm without requiring Windows or introducing format facts. It preserves all observed M4 values and fails closed on incomplete or ambiguous inputs.

DAO acquisition, schemas/adapters, complete-tree validation, independent recomputation, review, and exact host bindings remain blocked.

## Checks

- `python3 -m unittest oracle.windows-dao.tests.test_m5s1_analysis oracle.windows-dao.tests.test_m5s1_plan_contract`
- `python3 tools/validate_repository_contract.py`
- `python3 tools/validate_contract.py`
- `python3 -m py_compile oracle/windows-dao/scripts/m5s1_analysis.py oracle/windows-dao/tests/test_m5s1_analysis.py`
- `git diff --check`
