### PR TITLE
chore: add just runner, CLAUDE.md include, and glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ benches/target/
 # Private scratch output is never fixture evidence.
 fixtures/work/
 *.ldb
+
+# Local evidence/handoff output and OS noise; never committed.
+/artifacts/
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ high-level operations. No production source file may exceed 800 lines.
 
 ## Everyday commands
 
+`just` wraps the common tasks; run `just` to list recipes. `just ready`
+(fmt-check, clippy, tests, docs, `acceptance.sh quick`) is the green-able
+pre-publish check; `just accept` is the full release contract below.
+
 ```sh
 cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
@@ -46,3 +50,32 @@ must report `BLOCKED` until every required gate is actually wired and present.
   environment.
 - Use conventional commit messages such as `feat:`, `fix:`, `test:`, `docs:`,
   `refactor:`, `perf:`, `build:`, and `chore:`.
+
+Binding contracts live in `docs/PROVENANCE.md`, `docs/validation/ACCEPTANCE.md`,
+`docs/validation/EVIDENCE.md`, and `docs/validation/DAO_PROVIDER_BLOCKER.md`.
+Amendments are additive: a new revision plan file plus a new provenance entry,
+never an edit to a preregistered plan or a rewrite of ledger history.
+
+## Glossary
+
+- **G0–G8** — the release acceptance gates (`docs/validation/ACCEPTANCE.md`).
+  Fail closed: anything missing reports `BLOCKED` with a nonzero exit.
+- **G1 aggregate** — commit-bound cross-platform (Linux/macOS/Windows) evidence
+  bundle, validated by `tools/ci_evidence.py verify-aggregate`.
+- **M0–M5, M5S1** — preregistered Windows DAO oracle experiment campaigns
+  (`oracle/windows-dao/experiments/`). Evidence campaigns, not product
+  milestones; `R` suffixes (M5R2…) are additive plan revisions.
+- **Semantic reader stages 0–6** — the dependency-ordered reader plan
+  (`docs/architecture/SEMANTIC_READER.md`); each stage gates on recorded
+  provenance, not on any specific experiment.
+- **SRC-nnnn / EXP-nnnn** — provenance ledger entries in `docs/PROVENANCE.md`
+  for format sources and experiments; additive-only, never rewritten.
+- **Preregistration** — an immutable, SHA-256-pinned experiment plan committed
+  before data acquisition; changes require a new revision plan file.
+- **DAO oracle** — licensed Microsoft DAO on Windows used as a black-box
+  behavioral oracle; the only path to `dao_differential` verification.
+- **Support matrix** — the capability catalog
+  (`docs/validation/support-matrix.json`); its schema pins capability ids and
+  required verification levels as constants.
+- **Evidence worktree** — a detached, clean checkout at the exact evidence
+  commit; fixes happen in a separate worktree on the PR branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+# Run `just` to list recipes.
+
+default:
+    @just --list
+
+fmt:
+    cargo fmt --all
+
+fmt-check:
+    cargo fmt --all --check
+
+lint:
+    cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+test:
+    cargo test --workspace --all-targets --all-features --locked
+
+doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
+
+quick:
+    ./scripts/acceptance.sh quick
+
+# Full release contract; by design exits BLOCKED until every gate has current-commit evidence.
+accept:
+    ./scripts/acceptance.sh full
+
+# Everything currently green-able; run before publishing changes.
+ready: fmt-check lint test doc quick


### PR DESCRIPTION
Public-repo onboarding cleanup:

- `justfile` wrapping the everyday commands; `just ready` is the green-able pre-publish check, `just accept` remains the fail-closed release contract.
- `CLAUDE.md` including `AGENTS.md` so Claude Code sessions load the project rules.
- Glossary in `AGENTS.md` covering G-gates, M-campaigns, semantic-reader stages, SRC/EXP ledger entries, preregistration, the DAO oracle, the support matrix, and evidence worktrees, plus a pointer to the binding contracts and the additive amendment model.

No production code, gates, or validators are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)