### PR TITLE
ci: harden A1 hosted acquisition bindings

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.13"
+          python-version: "3.13.7"
 
       - name: Parse checked A1 PowerShell sources without execution
         shell: powershell
@@ -93,11 +93,14 @@ jobs:
     needs: contract
     if: >-
       github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
       inputs.execute_a1_campaign
     runs-on: windows-2022
     timeout-minutes: 210
     env:
       PROVEN_PROVIDER_RUN_ID: "32327232241"
+      EXPECTED_IMAGE_OS: win22
+      EXPECTED_IMAGE_VERSION: "20260802.262.1"
       EXPECTED_PROVIDER_PROG_ID: DAO.DBEngine.36
       EXPECTED_PROVIDER_CLSID: "{00000100-0000-0010-8000-00AA006D2EA4}"
       EXPECTED_PROVIDER_VERSION: "3.6"
@@ -115,14 +118,15 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.13"
+          python-version: "3.13.7"
 
       - name: Bind the exact clean pushed checkout
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          & git remote set-url origin https://github.com/oglassdev/jet3-rs.git
-          if ($LASTEXITCODE -ne 0) { throw "Could not bind the canonical origin." }
+          if ($env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs") {
+            throw "The workflow repository differs from the canonical repository."
+          }
           $head = (& git rev-parse --verify HEAD).Trim()
           if ($LASTEXITCODE -ne 0 -or $head -cne $env:GITHUB_SHA) {
             throw "The checked-out commit differs from GITHUB_SHA."
@@ -141,6 +145,10 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
+          if (-not ($env:ImageOS -ceq $env:EXPECTED_IMAGE_OS) -or
+              -not ($env:ImageVersion -ceq $env:EXPECTED_IMAGE_VERSION)) {
+            throw "The hosted image differs from run $env:PROVEN_PROVIDER_RUN_ID."
+          }
           $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
           New-Item -ItemType Directory -Path $diagnostics | Out-Null
           $environmentPath = Join-Path $diagnostics "environment.json"
@@ -218,6 +226,11 @@ jobs:
           if ($providerHash -cne $env:EXPECTED_PROVIDER_SHA256) {
             throw "The live stock provider binary hash has drifted."
           }
+          $pythonVersion = (& python --version 2>&1).Trim()
+          if ($LASTEXITCODE -ne 0 -or
+              [string]::IsNullOrWhiteSpace($pythonVersion)) {
+            throw "The pinned Python version could not be recorded."
+          }
 
           $binding = [ordered]@{
             document_type = "jet3_windows_dao_a1_host_binding"
@@ -227,6 +240,7 @@ jobs:
             github_run_attempt = $env:GITHUB_RUN_ATTEMPT
             image_os = $env:ImageOS
             image_version = $env:ImageVersion
+            python_version = $pythonVersion
             accepted_provider = $accepted
           }
           $bindingJson = $binding | ConvertTo-Json -Depth 8
@@ -314,7 +328,7 @@ jobs:
           $launchRecordPath = Join-Path $diagnostics "campaign.json"
           $launchRecord = [ordered]@{
             document_type = "jet3_windows_dao_a1_campaign"
-            status = "started"
+            status = "not_independently_validated"
             producer_commit = $env:GITHUB_SHA
             run_id = $runId
             github_run_id = $env:GITHUB_RUN_ID
@@ -428,7 +442,6 @@ jobs:
           if (-not (Test-Path -LiteralPath $bundlePath -PathType Container)) {
             throw "The checked A1 campaign did not publish its exact bundle."
           }
-          $launchRecord.status = "published"
           $launchRecord.completed_utc = [DateTimeOffset]::UtcNow.ToString("o")
           $launchRecord.elapsed_seconds = [Math]::Round($elapsedSeconds, 3)
           $launchRecord.bundle_path = $bundlePath
@@ -464,6 +477,8 @@ jobs:
               raise RuntimeError("A1 bundle run ID differs")
           if manifest["provider_sha256"] != sys.argv[4]:
               raise RuntimeError("A1 bundle provider hash differs")
+          if manifest["repository_url"] != "https://github.com/oglassdev/jet3-rs.git":
+              raise RuntimeError("A1 bundle repository URL differs")
           manifest_bytes = (bundle / "bundle-manifest.json").read_bytes()
           receipt = {
               "document_type": "jet3_windows_dao_a1_validation_receipt",
@@ -497,6 +512,35 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
             throw "Independent validation changed the exact checkout."
           }
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
+          $campaignPath = Join-Path $diagnostics "campaign.json"
+          $campaignRecord = Get-Content -LiteralPath $campaignPath -Raw |
+            ConvertFrom-Json
+          if ($campaignRecord.status -cne "not_independently_validated") {
+            throw "The A1 campaign validation status is not fail-closed."
+          }
+          $attestation = Join-Path $env:RUNNER_TEMP "jet3-a1-attestation"
+          New-Item -ItemType Directory -Path $attestation | Out-Null
+          foreach ($name in @(
+              "provider-binding.json",
+              "validation-receipt.json",
+              "campaign.json"
+            )) {
+            Copy-Item -LiteralPath (Join-Path $diagnostics $name) `
+              -Destination (Join-Path $attestation $name)
+          }
+          $campaignRecord.status = "independently_validated"
+          $validatedCampaignJson = $campaignRecord | ConvertTo-Json -Depth 6
+          [IO.File]::WriteAllText(
+            (Join-Path $attestation "campaign.json"),
+            $validatedCampaignJson,
+            (New-Object Text.UTF8Encoding($false))
+          )
+          [IO.File]::WriteAllText(
+            $campaignPath,
+            $validatedCampaignJson,
+            (New-Object Text.UTF8Encoding($false))
+          )
 
       - name: Upload independently validated A1 evidence
         if: success() && steps.bundle_validation.outcome == 'success'
@@ -506,7 +550,17 @@ jobs:
           path: ${{ steps.campaign.outputs.bundle_path }}
           if-no-files-found: error
           compression-level: 0
-          retention-days: 14
+          retention-days: 90
+
+      - name: Upload independently validated A1 attestation
+        if: success() && steps.bundle_validation.outcome == 'success'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: windows-dao-a1-attestation-${{ github.sha }}-${{ github.run_id }}
+          path: ${{ runner.temp }}\jet3-a1-attestation
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
 
       - name: Upload bounded A1 diagnostics
         if: always()

--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -127,6 +127,8 @@ jobs:
           if ($env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs") {
             throw "The workflow repository differs from the canonical repository."
           }
+          & git remote set-url origin https://github.com/oglassdev/jet3-rs.git
+          if ($LASTEXITCODE -ne 0) { throw "Could not bind the canonical origin." }
           $head = (& git rev-parse --verify HEAD).Trim()
           if ($LASTEXITCODE -ne 0 -or $head -cne $env:GITHUB_SHA) {
             throw "The checked-out commit differs from GITHUB_SHA."

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -17,6 +17,9 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         cls.parse_step = cls.contract.split(
             "- name: Parse checked A1 PowerShell sources without execution", 1
         )[1].split("- name: Validate the frozen plan and workflow contract", 1)[0]
+        cls.probe_step = cls.campaign.split(
+            "      - name: Probe and bind the proven stock x86 provider", 1
+        )[1].split("      - name: Run the bounded checked A1 campaign", 1)[0]
 
     def test_push_validates_only_and_acquisition_is_explicit_manual(self) -> None:
         self.assertIn("workflow_dispatch:", self.workflow)
@@ -28,6 +31,7 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertRegex(
             self.campaign,
             r"github\.event_name == 'workflow_dispatch' &&\s+"
+            r"github\.ref == 'refs/heads/main' &&\s+"
             r"inputs\.execute_a1_campaign",
         )
         self.assertNotIn("pull_request:", self.workflow)
@@ -57,7 +61,7 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertNotIn("windows-2025", self.workflow)
         self.assertRegex(self.workflow, r"permissions:\n  contents: read\n")
         uses = re.findall(r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE)
-        self.assertEqual(len(uses), 6)
+        self.assertEqual(len(uses), 7)
         for action in uses:
             self.assertRegex(action, r"^[^@]+@[0-9a-f]{40}$")
         self.assertEqual(self.workflow.count("persist-credentials: false"), 2)
@@ -67,11 +71,16 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(self.workflow.count('python-version: "3.13"'), 2)
+        self.assertEqual(self.workflow.count('python-version: "3.13.7"'), 2)
+        self.assertNotIn('python-version: "3.13"', self.workflow)
 
     def test_exact_clean_pushed_checkout_is_controller_compatible(self) -> None:
+        self.assertNotIn("git remote set-url origin", self.workflow)
         self.assertIn(
-            "git remote set-url origin https://github.com/oglassdev/jet3-rs.git",
+            '$env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs"', self.workflow
+        )
+        self.assertIn(
+            '$origin -cne "https://github.com/oglassdev/jet3-rs.git"',
             self.workflow,
         )
         self.assertIn("$head -cne $env:GITHUB_SHA", self.workflow)
@@ -82,6 +91,26 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
 
     def test_binds_proven_stock_x86_dao_without_installing_runtime(self) -> None:
         self.assertIn('PROVEN_PROVIDER_RUN_ID: "32327232241"', self.workflow)
+        self.assertIn("EXPECTED_IMAGE_OS: win22", self.workflow)
+        self.assertIn('EXPECTED_IMAGE_VERSION: "20260802.262.1"', self.workflow)
+        self.assertIn(
+            "$env:ImageOS -ceq $env:EXPECTED_IMAGE_OS", self.workflow
+        )
+        self.assertIn(
+            "$env:ImageVersion -ceq $env:EXPECTED_IMAGE_VERSION", self.workflow
+        )
+        self.assertIn(
+            "The hosted image differs from run $env:PROVEN_PROVIDER_RUN_ID.",
+            self.workflow,
+        )
+        probe_checks = self.probe_step.split(
+            '$ErrorActionPreference = "Stop"', 1
+        )[1].lstrip()
+        self.assertTrue(
+            probe_checks.startswith(
+                "if (-not ($env:ImageOS -ceq $env:EXPECTED_IMAGE_OS)"
+            )
+        )
         self.assertIn("EXPECTED_PROVIDER_PROG_ID: DAO.DBEngine.36", self.workflow)
         self.assertIn("03.60.9765.0", self.workflow)
         self.assertIn(
@@ -94,6 +123,10 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         )
         self.assertIn('registry_view = "x86"', self.workflow)
         self.assertIn('registration_scope = "machine"', self.workflow)
+        self.assertIn(
+            "$pythonVersion = (& python --version 2>&1).Trim()", self.workflow
+        )
+        self.assertIn("python_version = $pythonVersion", self.workflow)
         for forbidden in ("AccessRuntime", "AcceptEULA", "ODT_URL", "Invoke-WebRequest"):
             self.assertNotIn(forbidden, self.workflow)
 
@@ -109,7 +142,8 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertIn("if: always()", self.workflow)
         self.assertIn("if-no-files-found: error", self.workflow)
         self.assertIn("compression-level: 0", self.workflow)
-        self.assertIn("retention-days: 14", self.workflow)
+        self.assertEqual(self.workflow.count("retention-days: 90"), 2)
+        self.assertEqual(self.workflow.count("retention-days: 14"), 1)
         self.assertNotIn("${{ runner.temp }}\\jet3-a1-output\n", self.workflow)
         self.assertIn("Stop-Jet3BootstrapProcessTree -Process $process", self.workflow)
         finally_block = self.workflow.index("          finally {")
@@ -131,6 +165,10 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertIn('manifest["producer_commit"] != sys.argv[2]', self.workflow)
         self.assertIn('manifest["run_id"] != sys.argv[3]', self.workflow)
         self.assertIn('manifest["provider_sha256"] != sys.argv[4]', self.workflow)
+        self.assertIn(
+            'manifest["repository_url"] != "https://github.com/oglassdev/jet3-rs.git"',
+            self.workflow,
+        )
         self.assertIn("$env:GITHUB_SHA", self.workflow)
         self.assertIn("$env:EXPECTED_PROVIDER_SHA256", self.workflow)
         self.assertIn("id: bundle_validation", self.workflow)
@@ -139,21 +177,72 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
             self.workflow,
         )
         self.assertIn("Upload independently validated A1 evidence", self.workflow)
+        self.assertIn("Upload independently validated A1 attestation", self.workflow)
         self.assertIn("Upload bounded A1 diagnostics", self.workflow)
         self.assertIn("jet3_windows_dao_a1_validation_receipt", self.workflow)
         self.assertIn('"status": "independently_validated"', self.workflow)
         self.assertIn("bundle_manifest_sha256", self.workflow)
         self.assertIn("if len(receipt_bytes) > 4096", self.workflow)
+        self.assertIn('status = "not_independently_validated"', self.workflow)
+        self.assertIn(
+            '$campaignRecord.status = "independently_validated"', self.workflow
+        )
         evidence = self.workflow.split(
             "      - name: Upload independently validated A1 evidence", 1
+        )[1].split(
+            "      - name: Upload independently validated A1 attestation", 1
+        )[0]
+        attestation = self.workflow.split(
+            "      - name: Upload independently validated A1 attestation", 1
         )[1].split("      - name: Upload bounded A1 diagnostics", 1)[0]
         diagnostics = self.workflow.split(
             "      - name: Upload bounded A1 diagnostics", 1
         )[1]
         self.assertIn("${{ steps.campaign.outputs.bundle_path }}", evidence)
         self.assertNotIn("${{ runner.temp }}\\jet3-a1-diagnostics", evidence)
+        self.assertIn("retention-days: 90", evidence)
+        self.assertIn(
+            "windows-dao-a1-attestation-${{ github.sha }}-${{ github.run_id }}",
+            attestation,
+        )
+        self.assertIn("${{ runner.temp }}\\jet3-a1-attestation", attestation)
+        self.assertIn("retention-days: 90", attestation)
+        self.assertIn(
+            "if: success() && steps.bundle_validation.outcome == 'success'",
+            attestation,
+        )
+        attestation_copy = self.workflow.split(
+            '$attestation = Join-Path $env:RUNNER_TEMP "jet3-a1-attestation"', 1
+        )[1].split(
+            '          $campaignRecord.status = "independently_validated"', 1
+        )[0]
+        self.assertEqual(
+            re.findall(r'^\s+"([^\"]+\.json)",?$', attestation_copy, re.MULTILINE),
+            [
+                "provider-binding.json",
+                "validation-receipt.json",
+                "campaign.json",
+            ],
+        )
+        self.assertEqual(attestation_copy.count("Copy-Item"), 1)
+        self.assertIn("-Destination (Join-Path $attestation $name)", attestation_copy)
+        validation_step = self.workflow.split("        id: bundle_validation", 1)[1].split(
+            "      - name: Upload independently validated A1 evidence", 1
+        )[0]
+        clean_check = validation_step.index(
+            "Independent validation changed the exact checkout."
+        )
+        prepare_attestation = validation_step.index("jet3-a1-attestation")
+        validated_status = validation_step.index(
+            '$campaignRecord.status = "independently_validated"'
+        )
+        final_diagnostics_write = validation_step.rindex("$campaignPath")
+        self.assertLess(clean_check, prepare_attestation)
+        self.assertLess(prepare_attestation, validated_status)
+        self.assertLess(validated_status, final_diagnostics_write)
         self.assertIn("if: always()", diagnostics)
         self.assertIn("${{ runner.temp }}\\jet3-a1-diagnostics", diagnostics)
+        self.assertIn("retention-days: 14", diagnostics)
         self.assertNotIn("${{ steps.campaign.outputs.bundle_path }}", diagnostics)
 
 

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -75,10 +75,13 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertNotIn('python-version: "3.13"', self.workflow)
 
     def test_exact_clean_pushed_checkout_is_controller_compatible(self) -> None:
-        self.assertNotIn("git remote set-url origin", self.workflow)
-        self.assertIn(
-            '$env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs"', self.workflow
+        repository_check = self.workflow.index(
+            '$env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs"'
         )
+        set_url = self.workflow.index(
+            "git remote set-url origin https://github.com/oglassdev/jet3-rs.git"
+        )
+        self.assertLess(repository_check, set_url)
         self.assertIn(
             '$origin -cne "https://github.com/oglassdev/jet3-rs.git"',
             self.workflow,


### PR DESCRIPTION
## Findings addressed

- **F1 — Hosted image binding:** added `EXPECTED_IMAGE_OS: win22` and `EXPECTED_IMAGE_VERSION: "20260802.262.1"`; the provider probe now fails closed on either mismatch as its first check and binds the failure to `PROVEN_PROVIDER_RUN_ID`.
- **F2 — Evidence retention:** increased the independently validated evidence artifact retention to 90 days while keeping diagnostics at 14 days.
- **F3 — Python binding:** pinned both setup-python steps to `3.13.7` and recorded `python --version` in `provider-binding.json` as `python_version`.
- **F4 — Origin binding:** removed the tautological origin rewrite, asserted `GITHUB_REPOSITORY == oglassdev/jet3-rs`, retained the canonical checkout-origin assertion, and independently validated the bundle manifest repository URL.
- **F5 — Acquisition ref binding:** restricted the A1 campaign job to manual dispatches from `refs/heads/main`.
- **F6 — Evidence/diagnostics separation:** added a success-gated, 90-day attestation artifact containing exactly `provider-binding.json`, `validation-receipt.json`, and `campaign.json`; campaign status defaults to `not_independently_validated` and flips only at the end of successful independent validation.

## Verification

- `python3 -m unittest oracle/windows-dao/tests/test_windows_dao_a1_workflow.py` — 7 tests passed.