### PR TITLE
ci: retain A1 controller logs on fast failure

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -64,7 +64,7 @@ jobs:
               [ref]$errors
             )
             if (@($errors).Count -ne 0) {
-              $detail = (@($errors | ForEach-Object {
+              $detail = [string](@($errors | ForEach-Object {
                 "line $($_.Extent.StartLineNumber): $($_.Message)"
               }) -join "; ")
               if ($detail.Length -gt 2000) {
@@ -285,20 +285,50 @@ jobs:
                 throw "A1 process logs exceeded their retained byte ceiling."
               }
               for ($index = 0; $index -lt $RawPaths.Count; $index++) {
-                $bytes = if (Test-Path -LiteralPath $RawPaths[$index] `
-                    -PathType Leaf) {
-                  [IO.File]::ReadAllBytes($RawPaths[$index])
-                }
-                else {
-                  New-Object byte[] 0
+                $bytes = New-Object byte[] 0
+                if (Test-Path -LiteralPath $RawPaths[$index] -PathType Leaf) {
+                  $stream = $null
+                  try {
+                    $stream = New-Object IO.FileStream(
+                      $RawPaths[$index],
+                      [IO.FileMode]::Open,
+                      [IO.FileAccess]::Read,
+                      ([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete)
+                    )
+                    if ($stream.Length -gt $MaximumBytes) {
+                      throw "An A1 process log exceeded its retained byte ceiling."
+                    }
+                    $bytes = New-Object byte[] ([int]$stream.Length)
+                    $offset = 0
+                    while ($offset -lt $bytes.Length) {
+                      $read = $stream.Read(
+                        $bytes, $offset, $bytes.Length - $offset
+                      )
+                      if ($read -eq 0) {
+                        throw "An A1 process log changed during retention."
+                      }
+                      $offset += $read
+                    }
+                    if ($stream.ReadByte() -ne -1) {
+                      throw "An A1 process log changed during retention."
+                    }
+                  }
+                  finally {
+                    if ($null -ne $stream) { $stream.Dispose() }
+                  }
                 }
                 [IO.File]::WriteAllBytes($PublishedPaths[$index], $bytes)
               }
             }
             catch {
+              $copyFailure = [string]$_.Exception.Message
+              if ($copyFailure.Length -gt 2000) {
+                $copyFailure = $copyFailure.Substring(0, 2000)
+              }
               [IO.File]::WriteAllText(
                 $PublishedPaths[0],
-                "A1 process logs were not retained within their byte ceiling.`n"
+                "A1 process logs were not retained within their byte ceiling: " +
+                  $copyFailure + "`n"
               )
               [IO.File]::WriteAllText($PublishedPaths[1], "")
             }
@@ -437,7 +467,7 @@ jobs:
             throw "A1 hosted campaign cleanup failed: $cleanupDetail"
           }
           if ($campaignExit -ne 0) {
-            $detail = Get-Content -LiteralPath $publishedStderr -Raw
+            $detail = [string](Get-Content -LiteralPath $publishedStderr -Raw)
             if ($detail.Length -gt 2000) { $detail = $detail.Substring(0, 2000) }
             throw "The checked A1 campaign failed: $detail"
           }

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -162,6 +162,25 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertNotIn("Stop-Jet3BootstrapProcessTree", monitored)
         self.assertIn("cleanup also failed", self.workflow)
 
+    def test_fast_failure_logs_are_shared_read_and_null_safe(self) -> None:
+        publication = self.workflow.split("          function Publish-A1BoundedLogs", 1)[
+            1
+        ].split("          $repository =", 1)[0]
+        self.assertIn("New-Object IO.FileStream(", publication)
+        self.assertIn(
+            "[IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete", publication
+        )
+        self.assertNotIn("[IO.File]::ReadAllBytes", publication)
+        self.assertIn("if ($null -ne $stream) { $stream.Dispose() }", publication)
+        self.assertIn('$copyFailure = [string]$_.Exception.Message', publication)
+        self.assertIn("if ($copyFailure.Length -gt 2000)", publication)
+        self.assertIn(
+            '"A1 process logs were not retained within their byte ceiling: " +',
+            publication,
+        )
+        self.assertEqual(self.workflow.count("$detail = [string]("), 2)
+        self.assertNotIn("$detail = Get-Content", self.workflow)
+
     def test_campaign_and_independent_bundle_validator_are_exactly_bound(self) -> None:
         self.assertEqual(self.workflow.count("run-a1-controlled.ps1"), 2)
         self.assertIn("from a1_bundle import validate_bundle", self.workflow)


### PR DESCRIPTION
## Summary

- Read raw controller logs through `IO.FileStream` with `FileShare.ReadWrite | FileShare.Delete`, bounded byte reads, change detection, and deterministic disposal so lingering redirect handles do not suppress diagnostics.
- Preserve the bounded copy exception message in the existing fallback placeholder when log publication still fails.
- Cast both `$detail` values to string before checking `.Length`, preventing empty stderr from masking the controller exit with `PropertyNotFoundStrict`.
- Add focused workflow-contract assertions for shared reads, exception retention, disposal, and null-safe detail handling.

## Hosted failure hypothesis

Run 32434371779 proves the provider probe and hosted bindings completed, then the controller failed during its roughly 14-second bootstrap window. The leading hypothesis is Python identity drift inside the controller: the workflow records `python --version` as 3.13.7, but passes no explicit Python path; `Invoke-M1Preflight` independently searches `python3`, then `python`, then `py`, then registry candidates, and `Assert-A1PythonRuntime` later requires the selected `Context.PythonPath` and `Context.Python.Version` to be exact Python 3.13 through the first `Invoke-BoundedChildProcess` call. A different first `python3` candidate could therefore fail quickly even though the workflow-level `python` binding passed. The subsequent `git ls-remote --heads` gate is less likely because `f621b30` is still advertised at `refs/heads/main`, though a transient hosted-network failure remains possible.

The retained stderr from the next run should distinguish those gates. If the Python hypothesis is confirmed, the fix belongs in the reviewed oracle bootstrap interface (for example, an explicit Python binding); this PR intentionally does not modify `oracle/` scripts and stops that follow-up for separate review.

## Verification

- `python3 -m unittest oracle/windows-dao/tests/test_windows_dao_a1_workflow.py` — 8 tests passed.