### PR TITLE
fix: observe fuzz producer peak RSS via ru_maxrss

### DIFF
--- a/fuzz/tests/test_fuzz_campaign.py
+++ b/fuzz/tests/test_fuzz_campaign.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -445,6 +446,39 @@ class FuzzCampaignValidationTests(unittest.TestCase):
         ):
             observed = fuzz_evidence._process_tree_rss(10)
         self.assertEqual(observed, (100 + 200 + 300) * 1024)
+
+    @unittest.skipUnless(hasattr(os, "wait4"), "requires POSIX wait4 resource usage")
+    def test_observer_uses_child_high_water_rss_when_samples_miss_peak(self) -> None:
+        log_path = self.bundle / "producer.log"
+        executable = Path(sys.executable).resolve()
+        reported_rss = 16 * 1024 * 1024
+        script = (
+            "payload = bytearray(32 * 1024 * 1024)\n"
+            "for offset in range(0, len(payload), 4096): payload[offset] = 1\n"
+            "del payload\n"
+            f"print({f'Running `{executable}`'!r})\n"
+            "print('#1 DONE cov: 1 ft: 1 corp: 1/1b lim: 1 "
+            "exec/s: 1 rss: 16Mb')\n"
+        )
+        with mock.patch.object(
+            fuzz_evidence,
+            "_process_tree_rss",
+            return_value=1024,
+        ):
+            observer = fuzz_evidence.observe_producer(
+                self.root,
+                log_path,
+                [str(executable), "-c", script],
+                10.0,
+                {},
+                {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+            )
+        self.assertLess(1024, reported_rss)
+        self.assertGreaterEqual(observer["peak_rss_bytes"], reported_rss)
+        self.assertGreaterEqual(
+            observer["peak_rss_bytes"],
+            fuzz_evidence.parse_reported_rss(log_path.read_text(encoding="utf-8")),
+        )
 
     def test_vacuous_registry_is_rejected(self) -> None:
         self.registry["targets"] = []

--- a/fuzz/tools/fuzz_evidence.py
+++ b/fuzz/tools/fuzz_evidence.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -166,6 +167,11 @@ def _process_tree_rss(root_pid: int) -> int:
     return sum(rows[pid][1] for pid in descendants if pid in rows) * 1024
 
 
+def _rusage_peak_rss_bytes(usage: Any) -> int:
+    peak = int(usage.ru_maxrss)
+    return peak if sys.platform == "darwin" else peak * 1024
+
+
 def observe_producer(
     root: Path,
     log_path: Path,
@@ -179,6 +185,8 @@ def observe_producer(
     started_clock = time.monotonic()
     peak_rss = 0
     timed_out = False
+    wait_status: int | None = None
+    producer_usage: Any | None = None
     with log_path.open("wb") as log:
         producer = subprocess.Popen(
             command,
@@ -190,19 +198,29 @@ def observe_producer(
         )
         deadline = started_clock + timeout_seconds
         try:
-            while producer.poll() is None:
+            while True:
+                waited_pid, status, usage = os.wait4(producer.pid, os.WNOHANG)
+                if waited_pid == producer.pid:
+                    wait_status = status
+                    producer_usage = usage
+                    break
                 peak_rss = max(peak_rss, _process_tree_rss(producer.pid))
                 if time.monotonic() >= deadline:
                     timed_out = True
                     os.killpg(producer.pid, signal.SIGKILL)
-                    producer.wait()
+                    _, wait_status, producer_usage = os.wait4(producer.pid, 0)
                     break
                 time.sleep(0.05)
         except BaseException:
-            if producer.poll() is None:
+            if wait_status is None:
                 os.killpg(producer.pid, signal.SIGKILL)
-                producer.wait()
+                _, wait_status, producer_usage = os.wait4(producer.pid, 0)
             raise
+        finally:
+            if wait_status is not None:
+                producer.returncode = os.waitstatus_to_exitcode(wait_status)
+        if producer_usage is not None:
+            peak_rss = max(peak_rss, _rusage_peak_rss_bytes(producer_usage))
         exit_code = None if timed_out else producer.returncode
         log.flush()
         os.fsync(log.fileno())


### PR DESCRIPTION
## Summary

- Reap the fuzz producer with `os.wait4` so the observer retains the child resource usage alongside its exit status.
- Convert `ru_maxrss` to bytes correctly: it is already bytes on macOS and KiB on Linux and other supported POSIX runners.
- Record `peak_rss_bytes` as the maximum of sampled process-tree RSS and the producer high-water RSS.
- Preserve process-group termination on timeout and exceptional cleanup, followed by blocking `wait4`.
- Keep the strict producer-reported RSS comparison unchanged.

## Regression coverage

The focused test forces every instantaneous sampler result to 1 KiB while a short producer touches and frees 32 MiB and reports 16 MiB. The resulting observer record still covers the producer-reported RSS through `ru_maxrss`.

## Verification

- `python3 -m unittest discover -s fuzz/tests -v` — 47 tests passed.
- `python3 fuzz/tools/fuzz_campaign.py validate` — passed.