### PR TITLE
fix: observe the fuzz target binary directly

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -131,12 +131,14 @@ seeds, and registry entry together; a missing or seedless target fails
 validation.
 
 `schema/campaign-report.schema.json` defines the durable campaign evidence
-shape. Each version-3 bundle contains `report.json`, the unmodified combined
-cargo-fuzz/libFuzzer `producer.log`, a hashed `observer.json`, `build.json`, and
-the raw locked Cargo metadata result. The observer records the exact command,
+shape. Each version-3 bundle contains `report.json`, the unmodified libFuzzer
+`producer.log`, a hashed `observer.json`, `build.json`, and the raw locked Cargo
+metadata result. After an isolated cargo-fuzz prebuild, the observer executes
+the retained target binary directly and records the exact command,
 cargo, cargo-fuzz, and rustc paths/versions/hashes, executed fuzz binary
 path/hash, UTC timestamps, monotonic elapsed time, sampled process-tree peak
-RSS, exit status, classified outcome, and run count. Every run uses a fresh,
+RSS combined with the child's OS high-water RSS, exit status, classified
+outcome, and run count. Every run uses a fresh,
 isolated target directory with incremental compilation disabled. Subprocesses
 receive only the fully recorded build environment: exact Cargo and rustc
 paths, Cargo home, isolated target/temp paths, deterministic locale/color
@@ -157,8 +159,9 @@ target registry, target source, corpus, lockfile, Cargo configuration, Git
 index, dependency, or seed drift, malformed timestamps or campaign fields,
 mutated or symlinked raw artifacts, non-canonical commands and limits, and
 observed wall-clock or peak-RSS breaches. It reparses the retained producer log
-and requires its run count, executable path, RSS floor, and outcome to agree
-with both the observer and report. Older wrappers without the retained build
+and requires its run count, RSS floor, and outcome to agree with both the
+observer and report, while the direct command and retained prebuild bind the
+executable path and hash. Older wrappers without the retained build
 closure are not evidence. Reports explicitly identify `smoke` or `full`
 campaigns. Smoke reports must cover at least the target's registered duration,
 and full reports must cover at least 600 seconds. A campaign report is evidence

--- a/fuzz/tests/test_fuzz_campaign.py
+++ b/fuzz/tests/test_fuzz_campaign.py
@@ -114,7 +114,6 @@ class FuzzCampaignValidationTests(unittest.TestCase):
         executable_path = "/tmp/fuzz-build-target/release/fuzz-example"
         log_path = self.bundle / "producer.log"
         log_path.write_text(
-            f"Running `{executable_path} /tmp/corpus`\n"
             "#1000 DONE cov: 1 ft: 1 corp: 1/5b lim: 5 exec/s: 16 rss: 1Mb\n",
             encoding="utf-8",
         )
@@ -149,10 +148,7 @@ class FuzzCampaignValidationTests(unittest.TestCase):
             "TMPDIR": "/tmp/process-tmp",
         }
         command = [
-            "/usr/bin/cargo-fuzz", "fuzz", "run", "--fuzz-dir", "fuzz", "example",
-            "--sanitizer", "address",
-            "--target-dir", "/tmp/fuzz-build-target",
-            "/tmp/corpus", "--",
+            executable_path, "/tmp/corpus",
             "-max_total_time=60", "-seed=789231", "-max_len=4096",
             "-rss_limit_mb=256",
         ]
@@ -456,7 +452,6 @@ class FuzzCampaignValidationTests(unittest.TestCase):
             "payload = bytearray(32 * 1024 * 1024)\n"
             "for offset in range(0, len(payload), 4096): payload[offset] = 1\n"
             "del payload\n"
-            f"print({f'Running `{executable}`'!r})\n"
             "print('#1 DONE cov: 1 ft: 1 corp: 1/1b lim: 1 "
             "exec/s: 1 rss: 16Mb')\n"
         )
@@ -479,6 +474,7 @@ class FuzzCampaignValidationTests(unittest.TestCase):
             observer["peak_rss_bytes"],
             fuzz_evidence.parse_reported_rss(log_path.read_text(encoding="utf-8")),
         )
+        self.assertEqual(observer["executable"]["path"], str(executable))
 
     def test_vacuous_registry_is_rejected(self) -> None:
         self.registry["targets"] = []
@@ -711,19 +707,14 @@ class FuzzCampaignValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "run count disagrees"):
             self._validate_report(report)
 
-    def test_rehashed_executable_forgery_is_rejected(self) -> None:
+    def test_rehashed_command_executable_forgery_is_rejected(self) -> None:
         commit = self._initialize_git()
         report = self._valid_report(commit)
-        log_path = self.bundle / "producer.log"
-        log_path.write_text(
-            log_path.read_text(encoding="utf-8").replace("fuzz-example", "other-fuzzer"),
-            encoding="utf-8",
-        )
         observer_path = self.bundle / "observer.json"
         observer = json.loads(observer_path.read_text(encoding="utf-8"))
-        observer["producer_log_sha256"] = fuzz_campaign.sha256(log_path)
+        observer["command"][0] = "/tmp/fuzz-build-target/release/other-fuzzer"
         self._rewrite_observer(report, observer)
-        report["producer"]["log"]["sha256"] = fuzz_campaign.sha256(log_path)
+        report["producer"]["command"] = observer["command"]
         with self.assertRaisesRegex(ValidationError, "executable identity disagrees"):
             self._validate_report(report)
 
@@ -795,19 +786,13 @@ class FuzzCampaignValidationTests(unittest.TestCase):
     def test_coherent_executable_escape_is_rejected_by_build_closure(self) -> None:
         commit = self._initialize_git()
         report = self._valid_report(commit)
-        old_path = "/tmp/fuzz-build-target/release/fuzz-example"
         new_path = "/tmp/other-target/release/fuzz-example"
-        log_path = self.bundle / "producer.log"
-        log_path.write_text(
-            log_path.read_text(encoding="utf-8").replace(old_path, new_path),
-            encoding="utf-8",
-        )
         observer_path = self.bundle / "observer.json"
         observer = json.loads(observer_path.read_text(encoding="utf-8"))
-        observer["producer_log_sha256"] = fuzz_campaign.sha256(log_path)
+        observer["command"][0] = new_path
         observer["executable"]["path"] = new_path
         self._rewrite_observer(report, observer)
-        report["producer"]["log"]["sha256"] = fuzz_campaign.sha256(log_path)
+        report["producer"]["command"][0] = new_path
         report["producer"]["executable"]["path"] = new_path
         with self.assertRaisesRegex(ValidationError, "isolated target"):
             self._validate_report(report)

--- a/fuzz/tools/fuzz_campaign.py
+++ b/fuzz/tools/fuzz_campaign.py
@@ -18,13 +18,11 @@ from typing import Any
 from fuzz_build_identity import (
     BASE_ENVIRONMENT_KEYS,
     WINDOWS_ENVIRONMENT_KEYS,
-    cargo_fuzz_runtime_command,
     copy_seeds,
     prepare_isolated_fuzz_build,
     require_external_output,
     require_clean_snapshot,
     validate_build_manifest,
-    validate_fuzz_runtime_command,
 )
 from fuzz_evidence import (
     EvidenceError,
@@ -32,7 +30,6 @@ from fuzz_evidence import (
     exact_process_environment,
     observe_producer,
     parse_date_time,
-    parse_executable,
     parse_reported_rss,
     parse_runs,
     publish_directory,
@@ -51,6 +48,59 @@ SANITIZERS = {"address", "memory", "leak", "thread", "undefined", "none"}
 
 
 ValidationError = EvidenceError
+
+
+def fuzz_target_runtime_command(
+    executable_path: str,
+    corpus: Path | str,
+    duration_seconds: int,
+    deterministic_seed: int,
+    max_len: int,
+    peak_rss_limit_bytes: int,
+) -> list[str]:
+    """Construct the canonical direct libFuzzer target invocation."""
+    return [
+        executable_path,
+        str(corpus),
+        f"-max_total_time={duration_seconds}",
+        f"-seed={deterministic_seed}",
+        f"-max_len={max_len}",
+        f"-rss_limit_mb={peak_rss_limit_bytes // (1024 * 1024)}",
+    ]
+
+
+def validate_fuzz_target_runtime_command(
+    command: Any,
+    target_directory: str,
+    duration_seconds: int,
+    deterministic_seed: int,
+    max_len: int,
+    peak_rss_limit_bytes: int,
+) -> None:
+    """Require the exact direct target path, corpus, and libFuzzer limits."""
+    if not isinstance(command, list) or not command or any(
+        not isinstance(argument, str) or not argument for argument in command
+    ):
+        raise ValidationError("observer command must be a non-empty string array")
+    if len(command) < 2:
+        raise ValidationError(
+            "observer command is not the canonical direct fuzz-target invocation"
+        )
+    expected_corpus = Path(target_directory).resolve().parent / "corpus"
+    if Path(command[1]).resolve() != expected_corpus:
+        raise ValidationError("observer command does not name the disposable corpus")
+    expected_command = fuzz_target_runtime_command(
+        command[0],
+        command[1],
+        duration_seconds,
+        deterministic_seed,
+        max_len,
+        peak_rss_limit_bytes,
+    )
+    if command != expected_command:
+        raise ValidationError(
+            "observer command is not the canonical direct fuzz-target invocation"
+        )
 
 
 def _load_json(path: Path) -> Any:
@@ -283,10 +333,8 @@ def _validate_observer(
         )
 
     command = observer["command"]
-    validate_fuzz_runtime_command(
+    validate_fuzz_target_runtime_command(
         command,
-        target["name"],
-        report["campaign"]["sanitizer"],
         observer["build_environment"]["CARGO_TARGET_DIR"],
         report["campaign"]["duration_seconds"],
         deterministic_seed,
@@ -333,14 +381,8 @@ def _validate_observer(
     toolchain = _object(observer["toolchain"], "observer.toolchain")
     _exact_keys(toolchain, {"cargo", "cargo_fuzz", "rustc"}, "observer.toolchain")
     cargo = _validate_tool(toolchain["cargo"], "observer.toolchain.cargo")
-    cargo_fuzz = _validate_tool(
-        toolchain["cargo_fuzz"], "observer.toolchain.cargo_fuzz"
-    )
+    _validate_tool(toolchain["cargo_fuzz"], "observer.toolchain.cargo_fuzz")
     _validate_tool(toolchain["rustc"], "observer.toolchain.rustc")
-    if Path(cargo_fuzz["path"]).resolve().as_posix() != Path(
-        command[0]
-    ).resolve().as_posix():
-        raise ValidationError("observer cargo-fuzz identity disagrees with producer command")
     build_environment = _object(
         observer["build_environment"], "observer.build_environment"
     )
@@ -364,10 +406,11 @@ def _validate_observer(
     _exact_keys(executable, {"path", "sha256"}, "observer.executable")
     executable_path = _text(executable["path"], "observer.executable.path")
     _sha256_text(executable["sha256"], "observer.executable.sha256")
-    if Path(executable_path).resolve().as_posix() != Path(
-        parse_executable(log_text)
-    ).resolve().as_posix():
-        raise ValidationError("observer executable identity disagrees with producer log")
+    if (
+        Path(executable_path).resolve().as_posix()
+        != Path(command[0]).resolve().as_posix()
+    ):
+        raise ValidationError("observer executable identity disagrees with producer command")
 
     producer = _object(report["producer"], "producer")
     copied_identity = {
@@ -612,11 +655,8 @@ def run_campaign(
         corpus = temporary / "corpus"
         seeds = copy_seeds(root, corpus, manifest, target_name)
         log_path = temporary / "producer.log"
-        command = cargo_fuzz_runtime_command(
-            cargo_fuzz_identity["path"],
-            target_name,
-            sanitizer,
-            build_environment["CARGO_TARGET_DIR"],
+        command = fuzz_target_runtime_command(
+            prebuild["executable"]["path"],
             corpus,
             duration,
             registry["deterministic_seed"],

--- a/fuzz/tools/fuzz_evidence.py
+++ b/fuzz/tools/fuzz_evidence.py
@@ -17,10 +17,6 @@ from typing import Any
 
 PROGRESS_RE = re.compile(r"(?m)^#(\d+)\s")
 RSS_RE = re.compile(r"\brss:\s*(\d+)Mb\b")
-EXECUTABLE_RES = (
-    re.compile(r"(?m)^\s*Running `([^`\s]+)"),
-    re.compile(r"(?m)^\s*Running ([^\s]+)"),
-)
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 SANITIZER_MARKERS = (
     "ERROR: AddressSanitizer",
@@ -79,15 +75,6 @@ def parse_runs(log_text: str) -> int:
 def parse_reported_rss(log_text: str) -> int:
     samples = [int(value) * 1024 * 1024 for value in RSS_RE.findall(ANSI_RE.sub("", log_text))]
     return max(samples, default=0)
-
-
-def parse_executable(log_text: str) -> str:
-    plain = ANSI_RE.sub("", log_text)
-    for pattern in EXECUTABLE_RES:
-        match = pattern.search(plain)
-        if match:
-            return match.group(1)
-    raise EvidenceError("producer log contains no cargo-fuzz executable identity")
 
 
 def classify_result(log_text: str, exit_code: int | None, timed_out: bool) -> str:
@@ -181,6 +168,13 @@ def observe_producer(
     build_environment: dict[str, str],
 ) -> dict[str, Any]:
     environment = exact_process_environment(build_environment)
+    if not command or not isinstance(command[0], str) or not command[0]:
+        raise EvidenceError("producer command must name its executable")
+    executable_path = Path(command[0]).resolve()
+    if not executable_path.is_file() or executable_path.is_symlink():
+        raise EvidenceError(
+            f"producer executable is missing, a symlink, or not regular: {executable_path}"
+        )
     started_at = datetime.datetime.now(datetime.timezone.utc)
     started_clock = time.monotonic()
     peak_rss = 0
@@ -232,11 +226,6 @@ def observe_producer(
         log_text = log_path.read_text(encoding="utf-8")
     except UnicodeDecodeError as error:
         raise EvidenceError(f"producer log is not valid UTF-8: {error}") from error
-    executable_path = Path(parse_executable(log_text)).resolve()
-    if not executable_path.is_file() or executable_path.is_symlink():
-        raise EvidenceError(
-            f"producer-reported executable is missing, a symlink, or not regular: {executable_path}"
-        )
     return {
         "schema_version": 1,
         "producer_log_sha256": sha256(log_path),


### PR DESCRIPTION
Summary

- Run the retained isolated-prebuild executable directly with the canonical corpus, duration, seed, max-length, and 256 MiB libFuzzer arguments.
- Bind executable identity to command[0] and the retained prebuild path/hash instead of parsing cargo-fuzz wrapper output.
- Keep the strict RSS and evidence validations intact and document the direct-target observer model.

Verification

- python3 -m unittest discover -s fuzz/tests -v (47 tests passed)
- python3 fuzz/tools/fuzz_campaign.py validate
- A pinned-nightly binary_cursor smoke launched the retained target directly on macOS; validation rejected the run at 275087360 observed bytes over the unchanged 268435456-byte limit. The limit was intentionally not changed.