### PR TITLE
ci: allowlist proven windows-2022 images for A1

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -99,7 +99,7 @@ jobs:
     timeout-minutes: 210
     env:
       # Add newly proven windows-2022 image/proof pairs only here.
-      PROVEN_IMAGES: '[{"image_version":"20260802.262.1","proof_run_id":"32327232241"}]'
+      PROVEN_IMAGES: '[{"image_version":"20260802.262.1","proof_run_id":"32327232241"},{"image_version":"20260818.277.1","proof_run_id":"32439805418"}]'
       EXPECTED_IMAGE_OS: win22
       EXPECTED_PROVIDER_PROG_ID: DAO.DBEngine.36
       EXPECTED_PROVIDER_CLSID: "{00000100-0000-0010-8000-00AA006D2EA4}"

--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -98,9 +98,9 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 210
     env:
-      PROVEN_PROVIDER_RUN_ID: "32327232241"
+      # Add newly proven windows-2022 image/proof pairs only here.
+      PROVEN_IMAGES: '[{"image_version":"20260802.262.1","proof_run_id":"32327232241"}]'
       EXPECTED_IMAGE_OS: win22
-      EXPECTED_IMAGE_VERSION: "20260802.262.1"
       EXPECTED_PROVIDER_PROG_ID: DAO.DBEngine.36
       EXPECTED_PROVIDER_CLSID: "{00000100-0000-0010-8000-00AA006D2EA4}"
       EXPECTED_PROVIDER_VERSION: "3.6"
@@ -147,10 +147,24 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          if (-not ($env:ImageOS -ceq $env:EXPECTED_IMAGE_OS) -or
-              -not ($env:ImageVersion -ceq $env:EXPECTED_IMAGE_VERSION)) {
-            throw "The hosted image differs from run $env:PROVEN_PROVIDER_RUN_ID."
+          $provenImages = @($env:PROVEN_IMAGES | ConvertFrom-Json)
+          $matchingImages = @($provenImages | Where-Object {
+            [string]::Equals(
+              [string]$_.image_version,
+              [string]$env:ImageVersion,
+              [StringComparison]::Ordinal
+            )
+          })
+          if (-not [string]::Equals(
+                [string]$env:ImageOS,
+                [string]$env:EXPECTED_IMAGE_OS,
+                [StringComparison]::Ordinal
+              ) -or $matchingImages.Count -ne 1) {
+            throw "The hosted image differs from the proven image allowlist."
           }
+          $proofRunId = [string]$matchingImages[0].proof_run_id
+          "MATCHED_PROVIDER_PROOF_RUN_ID=$proofRunId" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
           New-Item -ItemType Directory -Path $diagnostics | Out-Null
           $environmentPath = Join-Path $diagnostics "environment.json"
@@ -210,7 +224,7 @@ jobs:
               [StringComparison]::Ordinal
             }
             if (-not $actualValue.Equals($expectedValue, $comparison)) {
-              throw "The stock provider differs from run $env:PROVEN_PROVIDER_RUN_ID at $field."
+              throw "The stock provider differs from run $proofRunId at $field."
             }
           }
           $matching = @($environment.provider_candidates | Where-Object {
@@ -236,7 +250,7 @@ jobs:
 
           $binding = [ordered]@{
             document_type = "jet3_windows_dao_a1_host_binding"
-            proof_run_id = $env:PROVEN_PROVIDER_RUN_ID
+            proof_run_id = $proofRunId
             producer_commit = $env:GITHUB_SHA
             github_run_id = $env:GITHUB_RUN_ID
             github_run_attempt = $env:GITHUB_RUN_ATTEMPT
@@ -366,7 +380,7 @@ jobs:
             github_run_id = $env:GITHUB_RUN_ID
             github_run_attempt = $env:GITHUB_RUN_ATTEMPT
             runner_image = "windows-2022"
-            provider_proof_run_id = $env:PROVEN_PROVIDER_RUN_ID
+            provider_proof_run_id = $env:MATCHED_PROVIDER_PROOF_RUN_ID
             controller_timeout_seconds = `
               [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
             hosted_timeout_seconds = [int]$env:HOSTED_CAMPAIGN_TIMEOUT_SECONDS

--- a/docs/validation/DAO_PROVIDER_BLOCKER.md
+++ b/docs/validation/DAO_PROVIDER_BLOCKER.md
@@ -154,3 +154,20 @@ For an exact release commit:
 
 Until every applicable step exists and passes, G3 and release claims depending
 on DAO remain `BLOCKED`.
+
+On 2026-08-20, A1 dispatch run
+[`32437968174`](https://github.com/oglassdev/jet3-rs/actions/runs/32437968174)
+failed closed when `windows-2022` image identity drifted, demonstrating that
+the acquisition guard rejects an unproved hosted image before DAO execution.
+GitHub was concurrently serving image versions `20260802.262.1` and
+`20260818.277.1`. Re-proof run
+[`32438973969`](https://github.com/oglassdev/jet3-rs/actions/runs/32438973969),
+retained as artifact
+`windows-dao-hosted-windows-2022-88b2118dbcef621e7b8bf56c5d1ae623e7d1b49f-1`,
+proved `20260802.262.1`; re-proof run
+[`32439805418`](https://github.com/oglassdev/jet3-rs/actions/runs/32439805418),
+retained as artifact
+`windows-dao-hosted-windows-2022-c3bcd5683f864074776b7d218d53c410aae2d550-1`,
+proved `20260818.277.1`. Both stock probes accepted the same x86
+`DAO.DBEngine.36` provider at `dao360.dll` file version `03.60.9765.0`, SHA-256
+`4cc28a5be8dc7425a4c4c1ef275ca392f18be35d70232e777dce6d9f3b4d79ac`.

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -101,12 +101,18 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         proven_images = json.loads(proven_images_match.group(1))
         self.assertIsInstance(proven_images, list)
         self.assertGreater(len(proven_images), 0)
-        self.assertIn(
-            {
-                "image_version": "20260802.262.1",
-                "proof_run_id": "32327232241",
-            },
+        self.assertEqual(
             proven_images,
+            [
+                {
+                    "image_version": "20260802.262.1",
+                    "proof_run_id": "32327232241",
+                },
+                {
+                    "image_version": "20260818.277.1",
+                    "proof_run_id": "32439805418",
+                },
+            ],
         )
         pairs = []
         versions = []

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -93,26 +94,70 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertIn("fetch-depth: 0", self.campaign)
 
     def test_binds_proven_stock_x86_dao_without_installing_runtime(self) -> None:
-        self.assertIn('PROVEN_PROVIDER_RUN_ID: "32327232241"', self.workflow)
-        self.assertIn("EXPECTED_IMAGE_OS: win22", self.workflow)
-        self.assertIn('EXPECTED_IMAGE_VERSION: "20260802.262.1"', self.workflow)
-        self.assertIn(
-            "$env:ImageOS -ceq $env:EXPECTED_IMAGE_OS", self.workflow
+        proven_images_match = re.search(
+            r"^\s+PROVEN_IMAGES: '([^'\n]+)'$", self.workflow, re.MULTILINE
         )
+        self.assertIsNotNone(proven_images_match)
+        proven_images = json.loads(proven_images_match.group(1))
+        self.assertIsInstance(proven_images, list)
+        self.assertGreater(len(proven_images), 0)
         self.assertIn(
-            "$env:ImageVersion -ceq $env:EXPECTED_IMAGE_VERSION", self.workflow
+            {
+                "image_version": "20260802.262.1",
+                "proof_run_id": "32327232241",
+            },
+            proven_images,
         )
+        pairs = []
+        versions = []
+        for entry in proven_images:
+            self.assertEqual(set(entry), {"image_version", "proof_run_id"})
+            self.assertRegex(entry["image_version"], r"^[0-9]+(?:\.[0-9]+)+$")
+            self.assertRegex(entry["proof_run_id"], r"^[0-9]+$")
+            self.assertNotRegex(entry["proof_run_id"], r"^[0-9a-f]{40}$")
+            versions.append(entry["image_version"])
+            pairs.append((entry["image_version"], entry["proof_run_id"]))
+        self.assertEqual(len(versions), len(set(versions)))
+        self.assertEqual(len(pairs), len(set(pairs)))
+        self.assertEqual(self.workflow.count("PROVEN_IMAGES:"), 1)
         self.assertIn(
-            "The hosted image differs from run $env:PROVEN_PROVIDER_RUN_ID.",
+            "# Add newly proven windows-2022 image/proof pairs only here.",
             self.workflow,
         )
-        probe_checks = self.probe_step.split(
-            '$ErrorActionPreference = "Stop"', 1
-        )[1].lstrip()
-        self.assertTrue(
-            probe_checks.startswith(
-                "if (-not ($env:ImageOS -ceq $env:EXPECTED_IMAGE_OS)"
-            )
+        self.assertNotIn("PROVEN_PROVIDER_RUN_ID", self.workflow)
+        self.assertNotIn("EXPECTED_IMAGE_VERSION", self.workflow)
+        self.assertIn("EXPECTED_IMAGE_OS: win22", self.workflow)
+        self.assertIn(
+            "[string]$env:ImageOS,", self.probe_step
+        )
+        self.assertIn(
+            "[string]$env:EXPECTED_IMAGE_OS,", self.probe_step
+        )
+        self.assertIn(
+            "[string]$env:ImageVersion,", self.probe_step
+        )
+        self.assertGreaterEqual(
+            self.probe_step.count("[StringComparison]::Ordinal"), 2
+        )
+        self.assertIn("$matchingImages.Count -ne 1", self.probe_step)
+        self.assertIn(
+            'throw "The hosted image differs from the proven image allowlist."',
+            self.probe_step,
+        )
+        fail_closed = self.probe_step.index("$matchingImages.Count -ne 1")
+        provider_probe = self.probe_step.index("Invoke-Jet3BootstrapProcess")
+        self.assertLess(fail_closed, provider_probe)
+        self.assertIn(
+            "$proofRunId = [string]$matchingImages[0].proof_run_id",
+            self.probe_step,
+        )
+        self.assertIn("proof_run_id = $proofRunId", self.probe_step)
+        self.assertIn(
+            "MATCHED_PROVIDER_PROOF_RUN_ID=$proofRunId", self.probe_step
+        )
+        self.assertIn(
+            "provider_proof_run_id = $env:MATCHED_PROVIDER_PROOF_RUN_ID",
+            self.campaign,
         )
         self.assertIn("EXPECTED_PROVIDER_PROG_ID: DAO.DBEngine.36", self.workflow)
         self.assertIn("03.60.9765.0", self.workflow)


### PR DESCRIPTION
Summary

- Replace the nondeterministic singleton image pin with a JSON allowlist of proven image-version/proof-run pairs.
- Require one ordinal image-version match before probing DAO, then bind that match into provider-binding.json and campaign.json.
- Allow the concurrently served windows-2022 images 20260802.262.1 and 20260818.277.1 using their reviewed proof runs.
- Validate allowlist shape, numeric proof IDs, dotted versions, uniqueness, and the runtime fail-closed branch.
- Append the image-drift failure and both re-proof artifacts to the DAO provider blocker record.

Verification

- python3 -m unittest oracle/windows-dao/tests/test_windows_dao_a1_workflow.py (8 tests passed)