### PR TITLE
fix: make A1 worker field assignment marshal correctly

### DIFF
--- a/oracle/windows-dao/scripts/a1/A1.Worker.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Worker.ps1
@@ -119,7 +119,7 @@ function Set-A1FieldValue {
     try {
         $fields = $Recordset.Fields
         $field = $fields.Item($Name)
-        $field.Value = $Value
+        switch ($Name) { "Id" { $field.Value = [Int32]$Value } "Payload" { $field.Value = [string]$Value } default { throw "A1 field name is not controlled." } }
     }
     finally {
         Release-M1ComObject -Value $field

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -64,6 +64,9 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
             'CreateField("Id", $script:A1DbLong)',
             'CreateField("Payload", $script:A1DbText, 240)',
             '$payloadField.Attributes = $script:A1DbFixedField',
+            '$field.Value = [Int32]$Value',
+            '$field.Value = [string]$Value',
+            'throw "A1 field name is not controlled."',
             'growth_batch_rows -ne 32',
             '"A1|$Role|$($Id.ToString(\'D10\'))|"',
             "GetBytes([int]$Id)",
@@ -71,6 +74,7 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, self.worker)
+        self.assertNotIn('$field.Value = $Value', self.worker)
         self.assertIn("Id, Payload", self.worker)
         self.assertIn("ORDER BY Id", self.worker)
 


### PR DESCRIPTION
Root cause

A1 used the same Fields.Item lookup and AddNew/Update ordering as the proven M1 DAO row writer reused by M4R1 and M5, and its DAO constants are correct (dbLong=4, dbText=10). The difference was A1 assigning a generically object-typed helper value directly to the late-bound COM Field.Value property, while the proven text path casts at the setter; that left DAO without the required Int32/string Variant shape and deterministically raised InvalidCastException.

Fix

- Marshal Id as System.Int32 and Payload as System.String directly at the COM property assignment.
- Fail closed if the helper is asked to assign any other field name.
- Extend the A1 PowerShell source contract to require both casts and reject the untyped assignment.

Binding audit

The current A1.Worker.ps1 SHA-256 is not pinned by the provenance record, frozen plan, A1 schemas, a1_bundle.py, or a1_spec.py. The plan and schemas are unchanged.

Verification

- python3 -m unittest discover -s oracle/windows-dao/tests (399 passed, 80 skipped)
- python3 oracle/windows-dao/scripts/a1_spec.py validate-plan