### PR TITLE
fix: unroll A1 image allowlist under Windows PowerShell 5

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -147,7 +147,22 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          $provenImages = @($env:PROVEN_IMAGES | ConvertFrom-Json)
+          $provenImages = @((ConvertFrom-Json -InputObject $env:PROVEN_IMAGES) | ForEach-Object { $_ })
+          foreach ($provenImage in $provenImages) {
+            if ($null -eq $provenImage) {
+              throw "The proven image allowlist contains a malformed entry."
+            }
+            $imageVersionProperty = $provenImage.PSObject.Properties["image_version"]
+            $proofRunIdProperty = $provenImage.PSObject.Properties["proof_run_id"]
+            if ($null -eq $imageVersionProperty -or
+                $imageVersionProperty.Value -isnot [string] -or
+                [string]::IsNullOrWhiteSpace($imageVersionProperty.Value) -or
+                $null -eq $proofRunIdProperty -or
+                $proofRunIdProperty.Value -isnot [string] -or
+                [string]::IsNullOrWhiteSpace($proofRunIdProperty.Value)) {
+              throw "The proven image allowlist contains a malformed entry."
+            }
+          }
           $matchingImages = @($provenImages | Where-Object {
             [string]::Equals(
               [string]$_.image_version,

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -142,6 +142,24 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertIn(
             "[string]$env:ImageVersion,", self.probe_step
         )
+        self.assertIn(
+            "$provenImages = @((ConvertFrom-Json -InputObject "
+            "$env:PROVEN_IMAGES) | ForEach-Object { $_ })",
+            self.probe_step,
+        )
+        self.assertNotIn(
+            "$provenImages = @($env:PROVEN_IMAGES | ConvertFrom-Json)",
+            self.probe_step,
+        )
+        self.assertIn(
+            "$matchingImages = @($provenImages | Where-Object {",
+            self.probe_step,
+        )
+        self.assertEqual(self.probe_step.count("-isnot [string]"), 2)
+        self.assertIn(
+            'throw "The proven image allowlist contains a malformed entry."',
+            self.probe_step,
+        )
         self.assertGreaterEqual(
             self.probe_step.count("[StringComparison]::Ordinal"), 2
         )


### PR DESCRIPTION
Summary

- Explicitly enumerate the Object[] returned by Windows PowerShell 5 ConvertFrom-Json before filtering image entries.
- Reject null, missing, non-string, or blank image_version/proof_run_id values with a clear fail-closed error.
- Preserve the @()-wrapped Where-Object result and require exactly one match.
- Extend the workflow contract test to require the PS5 unroll expression and reject the old nested-array form.

Verification

- python3 -m unittest oracle/windows-dao/tests/test_windows_dao_a1_workflow.py (8 tests passed)