### PR TITLE
ci: parallel fuzz smokes, path filters, single trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,36 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  changes:
+    name: Detect heavy-job paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      oracle: ${{ steps.filter.outputs.oracle }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 20
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'fuzz/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'tests/manifest.json'
+              - 'rust-toolchain*'
+            oracle:
+              - 'oracle/**'
+              - 'tools/**'
+              - 'docs/validation/**'
+              - '.github/workflows/**'
+
   test:
     name: Core (${{ matrix.os }})
     strategy:
@@ -154,6 +184,8 @@ jobs:
 
   windows-oracle-contracts:
     name: Windows oracle and bounded-process contracts
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.oracle == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -178,6 +210,8 @@ jobs:
 
   benchmarks:
     name: Benchmark harness
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -205,6 +239,8 @@ jobs:
 
   fuzz:
     name: Fuzz target smoke
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: nightly-2026-07-20
@@ -237,6 +273,8 @@ jobs:
 
   miri:
     name: Miri library tests
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:
@@ -212,13 +213,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2026-07-20
+      - uses: Swatinem/rust-cache@v2
+        id: fuzz-rust-cache
+        with:
+          workspaces: fuzz
+          cache-directories: ~/.cargo/bin/cargo-fuzz
       - name: Install pinned cargo-fuzz for the native host
+        if: steps.fuzz-rust-cache.outputs.cache-hit != 'true'
         run: >-
           cargo +nightly-2026-07-20 install cargo-fuzz
           --version 0.13.2 --locked
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: fuzz
       - name: Compile all checked fuzz targets
         run: cargo +nightly-2026-07-20 fuzz build --fuzz-dir fuzz
       - name: Validate fuzz registry, seed manifest, and campaign reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
               - 'Cargo.lock'
               - 'tests/manifest.json'
               - 'rust-toolchain*'
+              - '.github/workflows/**'
             oracle:
               - 'oracle/**'
               - 'tools/**'

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -107,17 +107,21 @@ Run the deterministic developer/CI smoke for every registered target:
 
 ```sh
 python3 fuzz/tools/fuzz_campaign.py smoke \
+  --jobs 4 \
   --output /absolute/path/to/new-fuzz-evidence-suite
 ```
 
-The smoke runner copies only manifest-listed seeds into disposable corpora,
-rejects corpora over their registered byte bounds, and runs every target for
-at least 60 seconds with the registered input and peak-RSS limits. The output
-path must not exist and must be outside the Git checkout. Campaigns refuse to
-start unless the checkout is completely clean; the complete suite is built
-beside its destination and atomically renamed only after every target bundle
-validates. Run one smoke or ten-minute campaign with the same retained-evidence
-path:
+The smoke runner copies only manifest-listed seeds into per-target disposable
+corpora, rejects corpora over their registered byte bounds, and runs every
+target for at least 60 seconds with the registered input and peak-RSS limits.
+It runs up to `min(4, os.cpu_count())` targets concurrently by default; use
+`--jobs 1` for the previous serial behavior. Each target retains its own
+observer and process resource accounting, and suite reports are ordered by
+target name. The output path must not exist and must be outside the Git
+checkout. Campaigns refuse to start unless the checkout is completely clean;
+the complete suite is built beside its destination and atomically renamed only
+after every target bundle validates. Run one smoke or ten-minute campaign with
+the same retained-evidence path:
 
 ```sh
 python3 fuzz/tools/fuzz_campaign.py run binary_cursor --kind smoke \

--- a/fuzz/tests/test_fuzz_campaign.py
+++ b/fuzz/tests/test_fuzz_campaign.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -419,6 +420,56 @@ class FuzzCampaignValidationTests(unittest.TestCase):
                     )
         self.assertFalse(output.exists())
         self.assertEqual(list(self.bundle.glob(".prebuild-failed.tmp-*")), [])
+
+    def test_smoke_runs_targets_concurrently_with_deterministic_results(self) -> None:
+        second_target = copy.deepcopy(self.registry["targets"][0])
+        second_target["name"] = "alpha"
+        self.registry["targets"].append(second_target)
+        started = threading.Barrier(2)
+        observed_outputs: dict[str, Path] = {}
+
+        def run_fake_campaign(
+            _root: Path,
+            target_name: str,
+            _kind: str,
+            _sanitizer: str,
+            _cargo: str,
+            _cargo_fuzz: str,
+            output: Path,
+        ) -> str:
+            observed_outputs[target_name] = output
+            started.wait(timeout=5)
+            output.mkdir()
+            return {"alpha": "clean", "example": "crash"}[target_name]
+
+        output = self.bundle / "parallel-smoke"
+        with mock.patch.object(fuzz_campaign, "require_clean_snapshot"):
+            with mock.patch.object(
+                fuzz_campaign,
+                "validate_repository",
+                return_value=(self.registry, self.manifest),
+            ):
+                with mock.patch.object(
+                    fuzz_campaign,
+                    "run_campaign",
+                    side_effect=run_fake_campaign,
+                ):
+                    results = fuzz_campaign.run_smoke(
+                        self.root,
+                        "/usr/bin/cargo",
+                        "/usr/bin/cargo-fuzz",
+                        "address",
+                        output,
+                        jobs=2,
+                    )
+
+        self.assertEqual(results, ["clean", "crash"])
+        self.assertEqual(set(observed_outputs), {"alpha", "example"})
+        self.assertNotEqual(observed_outputs["alpha"], observed_outputs["example"])
+        self.assertEqual(
+            {path.name for path in output.iterdir()},
+            {"alpha", "example"},
+        )
 
     def test_runtime_rss_sampler_sums_only_the_process_tree(self) -> None:
         process_table = "\n".join(

--- a/fuzz/tools/fuzz_campaign.py
+++ b/fuzz/tools/fuzz_campaign.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import math
 import os
@@ -45,6 +46,7 @@ REQUIRED_SEED_TEXT = ("id", "path", "purpose", "origin", "generator", "rights", 
 REQUIRED_ENVIRONMENT = ("os", "architecture", "encoding", "line_endings")
 RESULTS = {"clean", "crash", "panic", "hang", "sanitizer_finding", "limit_exceeded"}
 SANITIZERS = {"address", "memory", "leak", "thread", "undefined", "none"}
+DEFAULT_SMOKE_JOBS = min(4, os.cpu_count() or 1)
 
 
 ValidationError = EvidenceError
@@ -744,7 +746,10 @@ def run_smoke(
     cargo_fuzz: str,
     sanitizer: str,
     output: Path,
+    jobs: int = DEFAULT_SMOKE_JOBS,
 ) -> list[str]:
+    if jobs < 1:
+        raise ValidationError("smoke jobs must be at least 1")
     require_clean_snapshot(root)
     registry, _ = validate_repository(root)
     output = require_external_output(root, output)
@@ -752,21 +757,24 @@ def run_smoke(
     if output.exists() or output.is_symlink():
         raise ValidationError(f"refusing to replace existing evidence path: {output}")
     suite = Path(tempfile.mkdtemp(prefix=f".{output.name}.tmp-", dir=output.parent))
-    results: list[str] = []
     try:
-        for target in registry["targets"]:
-            print(f"running {target['name']} for {target['smoke_seconds']} seconds", flush=True)
-            results.append(
-                run_campaign(
+        targets = sorted(registry["targets"], key=lambda target: target["name"])
+        futures: dict[str, concurrent.futures.Future[str]] = {}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+            for target in targets:
+                name = target["name"]
+                print(f"running {name} for {target['smoke_seconds']} seconds", flush=True)
+                futures[name] = executor.submit(
+                    run_campaign,
                     root,
-                    target["name"],
+                    name,
                     "smoke",
                     sanitizer,
                     cargo,
                     cargo_fuzz,
-                    suite / target["name"],
+                    suite / name,
                 )
-            )
+            results = [futures[target["name"]].result() for target in targets]
         publish_directory(suite, output)
         return results
     except BaseException:
@@ -793,6 +801,7 @@ def main() -> int:
     smoke_parser.add_argument("--cargo-fuzz", default="cargo-fuzz")
     smoke_parser.add_argument("--sanitizer", choices=sorted(SANITIZERS), default="address")
     smoke_parser.add_argument("--output", type=Path, required=True)
+    smoke_parser.add_argument("--jobs", type=int, default=DEFAULT_SMOKE_JOBS)
     args = parser.parse_args()
     root = args.root.resolve()
     try:
@@ -815,7 +824,7 @@ def main() -> int:
                 return 1
         else:
             results = run_smoke(
-                root, args.cargo, args.cargo_fuzz, args.sanitizer, args.output
+                root, args.cargo, args.cargo_fuzz, args.sanitizer, args.output, args.jobs
             )
             if any(result != "clean" for result in results):
                 print("error: one or more fuzz campaigns recorded a finding", file=sys.stderr)


### PR DESCRIPTION
## Timing expectations

- Pull requests should run CI once instead of once for both `push` and `pull_request`; pushes to `main` still run the complete workflow.
- The nine 60-second fuzz smokes should run in three waves at the default four jobs, reducing the prior 11.7-minute serial job to roughly 3–4 minutes plus fixed setup/build overhead. A local two-target `--jobs 2` smoke completed both clean campaigns in about 61.3 seconds wall time each.
- Fuzz, Miri, and benchmarks skip pull requests without Rust/fuzz inputs; Windows oracle contracts skip pull requests without oracle/tooling/validation/workflow inputs. All four remain unconditional on pushes to `main`.
- Exact smoke durations, isolated corpora/builds, per-process wait4/RSS accounting, report validation, and ungated evidence jobs are unchanged.

## Verification

- `python3 -m unittest discover -s fuzz/tests`
- `python3 fuzz/tools/fuzz_campaign.py validate`
- Disposable two-target real smoke with `--jobs 2 --sanitizer none` (clean; address-sanitized macOS attempt failed closed at the existing RSS cap)