### PR TITLE
feat: implement the preregistered A1 three-layer allocation-map analysis

### DIFF
--- a/oracle/windows-dao/scripts/a1_analysis.py
+++ b/oracle/windows-dao/scripts/a1_analysis.py
@@ -32,6 +32,7 @@ from a1_model import (
     derive,
     joint_shape,
     predicts_holdout,
+    require_unique_boundaries,
     sole_model,
 )
 from a1_spec import (
@@ -187,6 +188,7 @@ def build_analysis(
     model: dict[str, Any] | None = None
     try:
         derivations = [derive(ReplicaView(item, store, work)) for item in replicas]
+        require_unique_boundaries(derivations[0], derivations[1])
         if joint_shape(derivations[0]) != joint_shape(derivations[1]):
             raise Abort(REPLICA_DISAGREEMENT)
         candidates = candidate_counts(derivations[0], derivations[1], CANDIDATE_CEILING)

--- a/oracle/windows-dao/scripts/a1_analysis.py
+++ b/oracle/windows-dao/scripts/a1_analysis.py
@@ -1,26 +1,45 @@
 #!/usr/bin/env python3
-"""Bounded, holdout-safe analysis for DAO-A1-ALLOCATION-MAPS-001."""
+"""Bounded, holdout-safe analysis for DAO-A1-ALLOCATION-MAPS-001.
+
+The derivation replicas (1 and 2) alone produce the complete joint candidate
+set. That set is frozen before the holdout replica is opened, and the holdout
+is evaluated without refit, addition, deletion, relaxation, or reinterpretation.
+"""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from a1_model import (
+    HOLDOUT_PREDICTION_FAILURE,
+    IDLE_VOLATILITY,
+    MULTIPLE_SURVIVING_MODELS,
+    NO_SURVIVING_MODEL,
+    REPLICA_DISAGREEMENT,
+    RESOURCE_BOUND_BREACH,
+    UNRECONSTRUCTABLE_SNAPSHOT,
+    Abort,
+    PageStore,
+    ReplicaIndexes,
+    ReplicaView,
+    WorkCounter,
+    candidate_counts,
+    derive,
+    joint_shape,
+    predicts_holdout,
+    sole_model,
+)
 from a1_spec import (
-    BASE_FORMULAS,
     CANDIDATE_CEILING,
     CHECKPOINT_IDS,
     CLAIMS,
     EXPERIMENT_ID,
-    PAGE_SIZE,
     PLAN_SHA256,
-    POINTER_LAYOUTS,
-    WORK_CEILING,
+    REPLICAS,
     CheckedPlan,
     load_bounded_json,
     load_checked_plan,
@@ -31,47 +50,17 @@ from a1_spec import (
 )
 from protocol_validation import ValidationError, canonical_json_bytes, sha256
 
-
-@dataclass(frozen=True)
-class ReplicaIndexes:
-    observation: dict[str, Any]
-    indexes: dict[str, dict[str, Any]]
-
-
-class WorkCounter:
-    def __init__(self) -> None:
-        self.value = 0
-
-    def charge(self, units: int) -> None:
-        if units < 0 or self.value + units > WORK_CEILING:
-            raise ValidationError("A1 analysis work-unit ceiling exceeded")
-        self.value += units
-
-
-class PageStore:
-    """Lazy content-addressed page reader with exact hash and size checks."""
-
-    def __init__(self, root: Path, work: WorkCounter) -> None:
-        self.root = root
-        self.work = work
-        self.cache: dict[str, bytes] = {}
-
-    def get(self, digest: str) -> bytes:
-        retained = self.cache.get(digest)
-        if retained is not None:
-            return retained
-        path = self.root / f"{digest}.page"
-        try:
-            if not path.is_file() or path.is_symlink() or path.stat().st_size != PAGE_SIZE:
-                raise ValidationError(f"page-store blob {digest} is missing or not exactly 2048 bytes")
-            retained = path.read_bytes()
-        except OSError as exc:
-            raise ValidationError(f"cannot read page-store blob {digest}: {exc}") from exc
-        self.work.charge(1)
-        if hashlib.sha256(retained).hexdigest() != digest:
-            raise ValidationError(f"page-store blob {digest} fails content-address check")
-        self.cache[digest] = retained
-        return retained
+DECISIVE_OUTCOME = "one_joint_model_predicts_holdout"
+NO_OUTCOME = "no_scientific_outcome"
+TERMINAL_REASONS = (IDLE_VOLATILITY, UNRECONSTRUCTABLE_SNAPSHOT, RESOURCE_BOUND_BREACH)
+SHARED_BINDINGS = (
+    "plan_sha256",
+    "producer_commit",
+    "repository_url",
+    "run_id",
+    "environment_sha256",
+    "provider_sha256",
+)
 
 
 def _safe_bundle_path(root: Path, relative: str) -> Path:
@@ -88,9 +77,7 @@ def _safe_bundle_path(root: Path, relative: str) -> Path:
 def load_replica_indexes(
     plan: CheckedPlan, observation_path: Path, bundle_root: Path
 ) -> ReplicaIndexes:
-    observation = validate_replica_observation(
-        load_bounded_json(observation_path), plan
-    )
+    observation = validate_replica_observation(load_bounded_json(observation_path), plan)
     indexes: dict[str, dict[str, Any]] = {}
     prior: list[str] = []
     changed_total = 0
@@ -108,156 +95,26 @@ def load_replica_indexes(
     return ReplicaIndexes(observation=observation, indexes=indexes)
 
 
-def _hashes(replica: ReplicaIndexes, checkpoint: str) -> list[str]:
-    return replica.indexes[checkpoint]["ordered_page_sha256"]
-
-
-def _idle_reasons(replicas: list[ReplicaIndexes]) -> list[str]:
-    for replica in replicas:
-        for left, right in (
-            ("E0", "E0R"),
-            ("L_REINSERT_SAME", "L_IDLE_REOPEN"),
-            ("H_REL_1280", "H_IDLE_REOPEN"),
-        ):
-            if _hashes(replica, left) != _hashes(replica, right):
-                return ["idle_volatility"]
-    return []
-
-
-def _hash_at(replica: ReplicaIndexes, checkpoint: str, page: int) -> str | None:
-    values = _hashes(replica, checkpoint)
-    return values[page] if page < len(values) else None
-
-
-def _record_page_candidates(replica: ReplicaIndexes, work: WorkCounter) -> set[int]:
-    maximum = max(len(_hashes(replica, checkpoint)) for checkpoint in CHECKPOINT_IDS)
-    result: set[int] = set()
-    for page in range(maximum):
-        work.charge(8)
-        d_grown = _hash_at(replica, "D_GROW_0128", page)
-        d_drop = _hash_at(replica, "D_DROP", page)
-        d_regrown = _hash_at(replica, "D_REGROW_0128", page)
-        tracks_l = d_regrown != _hash_at(replica, "L_REL_0064", page)
-        tracks_h = _hash_at(replica, "P_ABS_16480", page) != _hash_at(replica, "H_REL_0064", page)
-        if d_grown is not None and d_grown == d_regrown and d_grown != d_drop and tracks_l and tracks_h:
-            result.add(page)
-    return result
-
-
-def _record_interval(
-    replica: ReplicaIndexes, page: int, store: PageStore, work: WorkCounter
-) -> tuple[int, int] | None:
-    changed: set[int] = set()
-    excluded = {("E0", "E0R"), ("L_REINSERT_SAME", "L_IDLE_REOPEN"), ("H_REL_1280", "H_IDLE_REOPEN")}
-    for left, right in zip(CHECKPOINT_IDS, CHECKPOINT_IDS[1:]):
-        if (left, right) in excluded:
-            continue
-        left_hash = _hash_at(replica, left, page)
-        right_hash = _hash_at(replica, right, page)
-        if left_hash is None or right_hash is None or left_hash == right_hash:
-            continue
-        left_page = store.get(left_hash)
-        right_page = store.get(right_hash)
-        work.charge(PAGE_SIZE)
-        changed.update(index for index, pair in enumerate(zip(left_page, right_page, strict=True)) if pair[0] != pair[1])
-    if not changed:
-        return None
-    return min(changed), max(changed) + 1
-
-
-def _decode_pointer(raw: bytes, layout: str) -> tuple[int, int]:
-    if layout == "u24le_page_then_u8_slot":
-        return int.from_bytes(raw[:3], "little"), raw[3]
-    return int.from_bytes(raw[1:], "little"), raw[0]
-
-
-def _pointer_candidates(
-    replica: ReplicaIndexes,
-    interval: tuple[int, int],
-    store: PageStore,
-    work: WorkCounter,
-) -> tuple[set[tuple[int, str]], set[tuple[int, str]]]:
-    start, end = interval
-    anchors = {
-        checkpoint: store.get(_hash_at(replica, checkpoint, 1) or "")
-        for checkpoint in ("D_REGROW_0128", "L_REL_0064", "L_REL_1280", "L_DELETE_ALTERNATING", "L_REINSERT_SAME")
-    }
-    used: set[tuple[int, str]] = set()
-    free: set[tuple[int, str]] = set()
-    for offset in range(start, max(start, end - 3)):
-        for layout in POINTER_LAYOUTS:
-            work.charge(5)
-            values = {name: page[offset : offset + 4] for name, page in anchors.items()}
-            decoded = [_decode_pointer(value, layout) for value in values.values()]
-            if all(page < FINAL_PAGE_LIMIT and slot <= 255 for page, slot in decoded):
-                if values["D_REGROW_0128"] != values["L_REL_1280"] and values["L_REL_0064"] != values["L_REL_1280"]:
-                    used.add((offset, layout))
-                if values["L_REL_1280"] != values["L_DELETE_ALTERNATING"] and values["L_REL_1280"] == values["L_REINSERT_SAME"]:
-                    free.add((offset, layout))
-    return used, free
-
-
-FINAL_PAGE_LIMIT = 20480
-
-
-def build_analysis(
-    plan: CheckedPlan,
-    replicas: list[ReplicaIndexes],
-    page_store_root: Path,
-) -> dict[str, Any]:
-    if [item.observation["replica"] for item in replicas] != [1, 2, 3]:
+def _require_bindings(replicas: list[ReplicaIndexes]) -> None:
+    if [item.observation["replica"] for item in replicas] != list(range(1, REPLICAS + 1)):
         raise ValidationError("A1 analysis requires replicas 1, 2, and 3 in order")
-    shared = ("plan_sha256", "producer_commit", "repository_url", "run_id", "environment_sha256", "provider_sha256")
-    for key in shared:
+    for key in SHARED_BINDINGS:
         require_equal(len({item.observation[key] for item in replicas}), 1, f"replica binding {key}")
+    for item in replicas:
+        if set(item.indexes) != set(CHECKPOINT_IDS):
+            raise ValidationError("A1 analysis requires every planned checkpoint page index")
 
-    work = WorkCounter()
-    reasons = _idle_reasons(replicas[:2])
-    store = PageStore(page_store_root, work)
-    candidate_models_examined = 0
-    derivation_survivors = 0
 
-    page_candidates = [_record_page_candidates(replica, work) for replica in replicas[:2]]
-    if not reasons and (page_candidates[0] != page_candidates[1]):
-        reasons.append("replica_disagreement")
-    if not reasons and page_candidates[0] != {1}:
-        reasons.append("ambiguous_record_boundary")
-
-    intervals: list[tuple[int, int]] = []
-    if not reasons:
-        observed_intervals = [
-            _record_interval(replica, 1, store, work) for replica in replicas[:2]
-        ]
-        if any(interval is None for interval in observed_intervals) or observed_intervals[0] != observed_intervals[1]:
-            reasons.append("ambiguous_record_boundary")
-        else:
-            intervals = [interval for interval in observed_intervals if interval is not None]
-
-    if not reasons:
-        pointer_sets = [_pointer_candidates(replica, intervals[0], store, work) for replica in replicas[:2]]
-        used = pointer_sets[0][0] & pointer_sets[1][0]
-        free = pointer_sets[0][1] & pointer_sets[1][1]
-        combinations = sum(
-            len({offset for offset, candidate_layout in used if candidate_layout == layout})
-            * len({offset for offset, candidate_layout in free if candidate_layout == layout})
-            - len(
-                {offset for offset, candidate_layout in used if candidate_layout == layout}
-                & {offset for offset, candidate_layout in free if candidate_layout == layout}
-            )
-            for layout in POINTER_LAYOUTS
-        )
-        candidate_models_examined = combinations * len(BASE_FORMULAS)
-        work.charge(min(candidate_models_examined, CANDIDATE_CEILING + 1))
-        if candidate_models_examined > CANDIDATE_CEILING:
-            reasons.append("resource_bound_breach")
-        else:
-            # Pointer deltas alone cannot prove the preregistered inline boundary,
-            # conversion, active type-1 slots, and base formula jointly.
-            reasons.append("missing_inline_to_indirect_conversion")
-
-    if not reasons:
-        reasons.append("no_surviving_joint_model")
-    report: dict[str, Any] = {
+def _report(
+    replicas: list[ReplicaIndexes],
+    work: WorkCounter,
+    examined: int,
+    survivors: int,
+    holdout_evaluated: bool,
+    reasons: list[str],
+    model: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
         "protocol_version": "1.0.0",
         "document_type": "dao_a1_analysis_report",
         "experiment_id": EXPERIMENT_ID,
@@ -266,16 +123,56 @@ def build_analysis(
         "producer_commit": replicas[0].observation["producer_commit"],
         "derivation_replicas": [1, 2],
         "holdout_replica": 3,
-        "input_checkpoint_count": len(CHECKPOINT_IDS) * 3,
-        "candidate_models_examined": candidate_models_examined,
-        "derivation_survivor_count": derivation_survivors,
+        "input_checkpoint_count": len(CHECKPOINT_IDS) * REPLICAS,
+        "candidate_models_examined": examined,
+        "derivation_survivor_count": survivors,
         "analysis_work_units": work.value,
-        "holdout_evaluated": False,
-        "scientific_outcome": "no_scientific_outcome",
+        "holdout_evaluated": holdout_evaluated,
+        "scientific_outcome": NO_OUTCOME if reasons else DECISIVE_OUTCOME,
         "no_outcome_reasons": sorted(set(reasons)),
-        "surviving_model": None,
+        "surviving_model": None if reasons else model,
         "claims": CLAIMS,
     }
+
+
+def build_analysis(
+    plan: CheckedPlan,
+    replicas: list[ReplicaIndexes],
+    page_store_root: Path,
+) -> dict[str, Any]:
+    _require_bindings(replicas)
+    work = WorkCounter()
+    store = PageStore(page_store_root, work)
+    reasons: list[str] = []
+    examined = 0
+    survivors = 0
+    holdout_evaluated = False
+    model: dict[str, Any] | None = None
+    try:
+        derivations = [derive(ReplicaView(item, store, work)) for item in replicas[:2]]
+        if joint_shape(derivations[0]) != joint_shape(derivations[1]):
+            raise Abort(REPLICA_DISAGREEMENT)
+        candidates = candidate_counts(derivations[0], derivations[1], CANDIDATE_CEILING)
+        examined = candidates.examined
+        survivors = candidates.survivors
+        if survivors == 0:
+            raise Abort(NO_SURVIVING_MODEL)
+        if survivors > 1:
+            raise Abort(MULTIPLE_SURVIVING_MODELS)
+        frozen = sole_model(derivations[0], candidates)
+        holdout_evaluated = True
+        try:
+            holdout = derive(ReplicaView(replicas[2], store, work))
+        except Abort as exc:
+            if exc.reason in TERMINAL_REASONS:
+                raise
+            raise Abort(HOLDOUT_PREDICTION_FAILURE) from exc
+        if not predicts_holdout(holdout, frozen):
+            raise Abort(HOLDOUT_PREDICTION_FAILURE)
+        model = frozen
+    except Abort as exc:
+        reasons.append(exc.reason)
+    report = _report(replicas, work, examined, survivors, holdout_evaluated, reasons, model)
     validate_analysis_report(report)
     if len(canonical_json_bytes(report)) > plan.document["bounds"]["max_json_bytes"]:
         raise ValidationError("A1 analysis report exceeds JSON byte ceiling")
@@ -289,17 +186,24 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", type=Path, required=True)
     arguments = parser.parse_args(argv)
     try:
-        if len(arguments.replica) != 3:
+        if len(arguments.replica) != REPLICAS:
             raise ValidationError("exactly three --replica paths are required")
         plan = load_checked_plan()
-        replicas = [load_replica_indexes(plan, path, arguments.bundle_root) for path in arguments.replica]
+        replicas = [
+            load_replica_indexes(plan, path, arguments.bundle_root) for path in arguments.replica
+        ]
         report = build_analysis(plan, replicas, arguments.bundle_root / "page-store")
         arguments.output.parent.mkdir(parents=True, exist_ok=True)
         arguments.output.write_bytes(canonical_json_bytes(report))
     except (OSError, ValidationError) as exc:
         print(f"A1 analysis failed: {exc}", file=sys.stderr)
         return 1
-    print(json.dumps({"output": str(arguments.output), "scientific_outcome": report["scientific_outcome"]}, sort_keys=True))
+    print(
+        json.dumps(
+            {"output": str(arguments.output), "scientific_outcome": report["scientific_outcome"]},
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/oracle/windows-dao/scripts/a1_analysis.py
+++ b/oracle/windows-dao/scripts/a1_analysis.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from a1_model import (
     HOLDOUT_PREDICTION_FAILURE,
@@ -95,8 +96,39 @@ def load_replica_indexes(
     return ReplicaIndexes(observation=observation, indexes=indexes)
 
 
+class ReplicaSource(Protocol):
+    """A replica whose artifacts are opened only when the analysis asks for it."""
+
+    def load(self) -> ReplicaIndexes: ...
+
+
+@dataclass(frozen=True)
+class BundleReplicaSource:
+    plan: CheckedPlan
+    observation_path: Path
+    bundle_root: Path
+
+    def load(self) -> ReplicaIndexes:
+        return load_replica_indexes(self.plan, self.observation_path, self.bundle_root)
+
+
+@dataclass(frozen=True)
+class LoadedReplicaSource:
+    replica: ReplicaIndexes
+
+    def load(self) -> ReplicaIndexes:
+        return self.replica
+
+
+def _as_source(candidate: ReplicaSource | ReplicaIndexes) -> ReplicaSource:
+    if isinstance(candidate, ReplicaIndexes):
+        return LoadedReplicaSource(candidate)
+    return candidate
+
+
 def _require_bindings(replicas: list[ReplicaIndexes]) -> None:
-    if [item.observation["replica"] for item in replicas] != list(range(1, REPLICAS + 1)):
+    """Check the bindings of every replica opened so far, in acquisition order."""
+    if [item.observation["replica"] for item in replicas] != list(range(1, len(replicas) + 1)):
         raise ValidationError("A1 analysis requires replicas 1, 2, and 3 in order")
     for key in SHARED_BINDINGS:
         require_equal(len({item.observation[key] for item in replicas}), 1, f"replica binding {key}")
@@ -137,9 +169,14 @@ def _report(
 
 def build_analysis(
     plan: CheckedPlan,
-    replicas: list[ReplicaIndexes],
+    sources: list[ReplicaSource | ReplicaIndexes],
     page_store_root: Path,
 ) -> dict[str, Any]:
+    """Analyze one A1 bundle; the holdout source is opened only after the freeze."""
+    if len(sources) != REPLICAS:
+        raise ValidationError("A1 analysis requires exactly three replica sources")
+    loaders = [_as_source(candidate) for candidate in sources]
+    replicas = [loaders[0].load(), loaders[1].load()]
     _require_bindings(replicas)
     work = WorkCounter()
     store = PageStore(page_store_root, work)
@@ -149,7 +186,7 @@ def build_analysis(
     holdout_evaluated = False
     model: dict[str, Any] | None = None
     try:
-        derivations = [derive(ReplicaView(item, store, work)) for item in replicas[:2]]
+        derivations = [derive(ReplicaView(item, store, work)) for item in replicas]
         if joint_shape(derivations[0]) != joint_shape(derivations[1]):
             raise Abort(REPLICA_DISAGREEMENT)
         candidates = candidate_counts(derivations[0], derivations[1], CANDIDATE_CEILING)
@@ -160,6 +197,9 @@ def build_analysis(
         if survivors > 1:
             raise Abort(MULTIPLE_SURVIVING_MODELS)
         frozen = sole_model(derivations[0], candidates)
+        # The candidate set is frozen; only now may the holdout be opened.
+        replicas.append(loaders[2].load())
+        _require_bindings(replicas)
         holdout_evaluated = True
         try:
             holdout = derive(ReplicaView(replicas[2], store, work))
@@ -189,10 +229,10 @@ def main(argv: list[str] | None = None) -> int:
         if len(arguments.replica) != REPLICAS:
             raise ValidationError("exactly three --replica paths are required")
         plan = load_checked_plan()
-        replicas = [
-            load_replica_indexes(plan, path, arguments.bundle_root) for path in arguments.replica
+        sources: list[ReplicaSource | ReplicaIndexes] = [
+            BundleReplicaSource(plan, path, arguments.bundle_root) for path in arguments.replica
         ]
-        report = build_analysis(plan, replicas, arguments.bundle_root / "page-store")
+        report = build_analysis(plan, sources, arguments.bundle_root / "page-store")
         arguments.output.parent.mkdir(parents=True, exist_ok=True)
         arguments.output.write_bytes(canonical_json_bytes(report))
     except (OSError, ValidationError) as exc:

--- a/oracle/windows-dao/scripts/a1_model.py
+++ b/oracle/windows-dao/scripts/a1_model.py
@@ -259,6 +259,9 @@ def _observed_changes(view: ReplicaView, page: int) -> set[int]:
 def _record_interval(view: ReplicaView, page: int) -> tuple[int, int]:
     """Select the one caller-delimited record with a unique observed start and end.
 
+    `hypotheses.page_one`: "exactly one caller-delimited allocation-map record
+    has a unique observed start and end on physical page 1".
+
     A candidate interval must contain every observed change on the page and
     must have both of its endpoint bytes witnessed by an observed change; the
     plan supplies no other delimiter. Exactly one interval can satisfy both, so
@@ -565,6 +568,31 @@ def derive(view: ReplicaView) -> Derivation:
         free=free,
         bases=bases,
     )
+
+
+def require_unique_boundaries(first: Derivation, second: Derivation) -> None:
+    """Enforce the one unique observed start and end of `hypotheses.page_one`.
+
+    The observed start and end must be identical across the derivation replicas
+    and must contain every used and free pointer observation; any disagreement
+    is the plan's ambiguous record or inline boundary.
+    """
+    if (first.record_start, first.record_end) != (second.record_start, second.record_end):
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    if first.inline_boundary != second.inline_boundary:
+        raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
+    for derivation in (first, second):
+        observed = {
+            offset
+            for layer in (derivation.used, derivation.free)
+            for offsets in layer.values()
+            for offset in offsets
+        }
+        if any(
+            not derivation.record_start <= offset <= derivation.record_end - POINTER_WIDTH
+            for offset in observed
+        ):
+            raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
 
 
 def joint_shape(derivation: Derivation) -> tuple[int, int, int, int, int, int, int]:

--- a/oracle/windows-dao/scripts/a1_model.py
+++ b/oracle/windows-dao/scripts/a1_model.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Preregistered three-layer model derivation for DAO-A1-ALLOCATION-MAPS-001.
+
+Layer 1 is the caller-delimited global allocation-map record, layer 2 the two
+TDEF pointers inside that record, and layer 3 the type-1 extended maps. Every
+rule implemented here comes from the checked plan's `hypotheses` block; no
+candidate formula, offset layout, or transition predicate is added.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from a1_spec import (
+    BASE_FORMULAS,
+    CHECKPOINT_IDS,
+    FINAL_PAGE_CEILING,
+    IDLE_PAIRS,
+    LADDER,
+    PAGE_SIZE,
+    POINTER_LAYOUTS,
+    WORK_CEILING,
+)
+
+REPLICA_DISAGREEMENT = "replica_disagreement"
+MISSING_CONVERSION = "missing_inline_to_indirect_conversion"
+RESOURCE_BOUND_BREACH = "resource_bound_breach"
+NO_SURVIVING_MODEL = "no_surviving_joint_model"
+MULTIPLE_SURVIVING_MODELS = "multiple_surviving_joint_models"
+IDLE_VOLATILITY = "idle_volatility"
+UNRECONSTRUCTABLE_SNAPSHOT = "unreconstructable_snapshot"
+AMBIGUOUS_RECORD_BOUNDARY = "ambiguous_record_boundary"
+AMBIGUOUS_INLINE_BOUNDARY = "ambiguous_inline_boundary"
+UNEXPLAINED_INLINE_SUFFIX = "unexplained_nonzero_inline_suffix"
+HOLDOUT_PREDICTION_FAILURE = "holdout_prediction_failure"
+INCOMPLETE_TRANSITION_EVIDENCE = "incomplete_transition_evidence"
+
+METADATA_PAGE = 1
+INLINE_TAG = 0x00
+INDIRECT_TAG = 0x01
+EXTENDED_MAP_TAG = 0x05
+EXTENDED_MAP_HEADER_BYTES = 4
+EXTENDED_MAP_BITS = (PAGE_SIZE - EXTENDED_MAP_HEADER_BYTES) * 8
+POINTER_WIDTH = 4
+INLINE_START_PAGE_WIDTH = 4
+RETAINED_PAGE_STORE_CEILING = 536_870_912
+PAGE_CACHE_ENTRIES = 4096
+
+_L_LADDER = tuple(f"L_REL_{target:04d}" for target in LADDER)
+_H_LADDER = tuple(f"H_REL_{target:04d}" for target in LADDER)
+_P_LADDER = ("P_ABS_04096", "P_ABS_08192", "P_ABS_12288", "P_ABS_16480")
+
+
+def _consecutive(ids: tuple[str, ...]) -> tuple[tuple[str, str], ...]:
+    return tuple(zip(ids, ids[1:], strict=False))
+
+
+ORDINAL: dict[str, int] = {name: index for index, name in enumerate(CHECKPOINT_IDS)}
+GROWTH_TRANSITIONS = _consecutive(_L_LADDER) + _consecutive(_P_LADDER) + _consecutive(_H_LADDER)
+CHURN_TRANSITIONS = (
+    ("L_REL_1280", "L_DELETE_ALTERNATING"),
+    ("L_DELETE_ALTERNATING", "L_REINSERT_SAME"),
+)
+ALL_TRANSITIONS = tuple(
+    pair for pair in _consecutive(CHECKPOINT_IDS) if pair not in set(IDLE_PAIRS)
+)
+POINTER_SCOPE = CHECKPOINT_IDS[ORDINAL["L_REL_0064"] :]
+LAST_L_CHECKPOINT = "L_IDLE_REOPEN"
+FINAL_CHECKPOINT = CHECKPOINT_IDS[-1]
+
+
+class Abort(Exception):
+    """A preregistered no-outcome condition detected during analysis."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class WorkCounter:
+    def __init__(self) -> None:
+        self.value = 0
+
+    def charge(self, units: int) -> None:
+        if units < 0 or self.value + units > WORK_CEILING:
+            raise Abort(RESOURCE_BOUND_BREACH)
+        self.value += units
+
+
+class PageStore:
+    """Lazy content-addressed page reader with exact hash and size checks."""
+
+    def __init__(self, root: Path, work: WorkCounter) -> None:
+        self.root = root
+        self.work = work
+        self.bytes_read = 0
+        self.cache: dict[str, bytes] = {}
+
+    def get(self, digest: str) -> bytes:
+        retained = self.cache.get(digest)
+        if retained is not None:
+            return retained
+        path = self.root / f"{digest}.page"
+        try:
+            metadata = path.lstat()
+            if path.is_symlink() or metadata.st_size != PAGE_SIZE:
+                raise Abort(UNRECONSTRUCTABLE_SNAPSHOT)
+            retained = path.read_bytes()
+        except OSError as exc:
+            raise Abort(UNRECONSTRUCTABLE_SNAPSHOT) from exc
+        self.bytes_read += PAGE_SIZE
+        if self.bytes_read > RETAINED_PAGE_STORE_CEILING:
+            raise Abort(RESOURCE_BOUND_BREACH)
+        self.work.charge(PAGE_SIZE)
+        if hashlib.sha256(retained).hexdigest() != digest:
+            raise Abort(UNRECONSTRUCTABLE_SNAPSHOT)
+        if len(self.cache) >= PAGE_CACHE_ENTRIES:
+            self.cache.clear()
+        self.cache[digest] = retained
+        return retained
+
+
+@dataclass(frozen=True)
+class ReplicaIndexes:
+    observation: dict[str, Any]
+    indexes: dict[str, dict[str, Any]]
+
+
+class ReplicaView:
+    """Checkpoint-ordered physical view of one replica."""
+
+    def __init__(self, replica: ReplicaIndexes, store: PageStore, work: WorkCounter) -> None:
+        self.replica = replica
+        self.store = store
+        self.work = work
+        self._counts = {name: len(self._hashes(name)) for name in CHECKPOINT_IDS}
+        if max(self._counts.values()) > FINAL_PAGE_CEILING:
+            raise Abort(RESOURCE_BOUND_BREACH)
+
+    def _hashes(self, checkpoint: str) -> list[str]:
+        return self.replica.indexes[checkpoint]["ordered_page_sha256"]
+
+    def page_count(self, checkpoint: str) -> int:
+        return self._counts[checkpoint]
+
+    def hash_at(self, checkpoint: str, page: int) -> str | None:
+        values = self._hashes(checkpoint)
+        return values[page] if page < len(values) else None
+
+    def page(self, checkpoint: str, page: int) -> bytes:
+        digest = self.hash_at(checkpoint, page)
+        if digest is None:
+            raise Abort(UNRECONSTRUCTABLE_SNAPSHOT)
+        return self.store.get(digest)
+
+    def idle_pairs_identical(self) -> bool:
+        for left, right in IDLE_PAIRS:
+            self.work.charge(1)
+            if self._hashes(left) != self._hashes(right):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class Derivation:
+    record_page: int
+    record_start: int
+    record_end: int
+    map_type_offset: int
+    conversion_ordinal: int
+    inline_boundary: int
+    inline_pages: frozenset[int]
+    low_slot: int
+    high_slot: int
+    low_reference_page: int
+    high_reference_page: int
+    used: dict[str, frozenset[int]]
+    free: dict[str, frozenset[int]]
+    bases: frozenset[str]
+
+
+def _set_bits(value: int) -> Iterator[int]:
+    while value:
+        lowest = value & -value
+        yield lowest.bit_length() - 1
+        value ^= lowest
+
+
+def decode_pointer(raw: bytes, layout: str) -> tuple[int, int]:
+    if layout == "u24le_page_then_u8_slot":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    return int.from_bytes(raw[1:], "little"), raw[0]
+
+
+def _page_tracks_allocation(view: ReplicaView, page: int) -> bool:
+    """The plan's page-one transition predicates, applied to any physical page."""
+    empty = view.hash_at("E0R", page)
+    grown = view.hash_at("D_GROW_0128", page)
+    dropped = view.hash_at("D_DROP", page)
+    regrown = view.hash_at("D_REGROW_0128", page)
+    low_first = view.hash_at("L_REL_0064", page)
+    low_last = view.hash_at("L_REL_1280", page)
+    high_first = view.hash_at("H_REL_0064", page)
+    high_last = view.hash_at("H_REL_1280", page)
+    if None in (empty, grown, dropped, regrown, low_first, low_last, high_first, high_last):
+        return False
+    aba = grown == regrown and grown != dropped and grown != empty
+    return aba and low_first != low_last and high_first != high_last
+
+
+def surviving_record_pages(view: ReplicaView) -> set[int]:
+    observed = max(view.page_count(name) for name in CHECKPOINT_IDS)
+    surviving: set[int] = set()
+    for page in range(observed):
+        view.work.charge(8)
+        if _page_tracks_allocation(view, page):
+            surviving.add(page)
+    return surviving
+
+
+def _record_interval(view: ReplicaView, page: int) -> tuple[int, int]:
+    lowest = PAGE_SIZE
+    highest = -1
+    for left, right in ALL_TRANSITIONS:
+        view.work.charge(1)
+        if view.hash_at(left, page) == view.hash_at(right, page):
+            continue
+        before = view.page(left, page)
+        after = view.page(right, page)
+        first = 0
+        while before[first] == after[first]:
+            first += 1
+        last = PAGE_SIZE - 1
+        while before[last] == after[last]:
+            last -= 1
+        lowest = min(lowest, first)
+        highest = max(highest, last)
+    if highest < 0 or highest + 1 - lowest < INLINE_START_PAGE_WIDTH + 1:
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    return lowest, highest + 1
+
+
+def _map_type_offset(view: ReplicaView, page: int, interval: tuple[int, int]) -> tuple[int, int]:
+    start, end = interval
+    records = [view.page(name, page)[start:end] for name in CHECKPOINT_IDS]
+    candidates: list[tuple[int, int]] = []
+    for offset in range(start, end):
+        view.work.charge(len(CHECKPOINT_IDS))
+        column = [record[offset - start] for record in records]
+        if column[0] != INLINE_TAG or INDIRECT_TAG not in column:
+            continue
+        first = column.index(INDIRECT_TAG)
+        if first == 0:
+            continue
+        if any(value != INLINE_TAG for value in column[:first]):
+            continue
+        if any(value != INDIRECT_TAG for value in column[first:]):
+            continue
+        candidates.append((offset, first))
+    if not candidates:
+        raise Abort(MISSING_CONVERSION)
+    if len(candidates) > 1:
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    return candidates[0]
+
+
+def _inline_extent(
+    view: ReplicaView,
+    page: int,
+    interval: tuple[int, int],
+    type_offset: int,
+    conversion_ordinal: int,
+) -> tuple[int, frozenset[int]]:
+    _, end = interval
+    bitmap_start = type_offset + 1 + INLINE_START_PAGE_WIDTH
+    if bitmap_start >= end:
+        raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
+    anchor = CHECKPOINT_IDS[conversion_ordinal - 1]
+    record = view.page(anchor, page)
+    view.work.charge(end - bitmap_start)
+    nonzero = [index for index in range(bitmap_start, end) if record[index]]
+    if not nonzero:
+        raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
+    boundary = nonzero[-1] + 1
+    for name in CHECKPOINT_IDS[:conversion_ordinal]:
+        view.work.charge(end - boundary)
+        if any(view.page(name, page)[boundary:end]):
+            raise Abort(UNEXPLAINED_INLINE_SUFFIX)
+    first_page = int.from_bytes(record[type_offset + 1 : bitmap_start], "little")
+    count = view.page_count(anchor)
+    pages: set[int] = set()
+    for index in range(bitmap_start, boundary):
+        view.work.charge(8)
+        for bit in _set_bits(record[index]):
+            mapped = first_page + (index - bitmap_start) * 8 + bit
+            if not 0 <= mapped < count:
+                raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
+            pages.add(mapped)
+    if not pages:
+        raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
+    return boundary, frozenset(pages)
+
+
+def _pointer_candidates(
+    view: ReplicaView, page: int, interval: tuple[int, int]
+) -> tuple[dict[str, frozenset[int]], dict[str, frozenset[int]]]:
+    start, end = interval
+    records = {name: view.page(name, page)[start:end] for name in POINTER_SCOPE}
+    counts = {name: view.page_count(name) for name in POINTER_SCOPE}
+    used: dict[str, set[int]] = {layout: set() for layout in POINTER_LAYOUTS}
+    free: dict[str, set[int]] = {layout: set() for layout in POINTER_LAYOUTS}
+    for offset in range(start, end - POINTER_WIDTH + 1):
+        relative = offset - start
+        windows = {
+            name: record[relative : relative + POINTER_WIDTH] for name, record in records.items()
+        }
+        for layout in POINTER_LAYOUTS:
+            view.work.charge(len(POINTER_SCOPE))
+            if not all(
+                1 <= decode_pointer(window, layout)[0] < counts[name]
+                for name, window in windows.items()
+            ):
+                continue
+            grows = any(windows[left] != windows[right] for left, right in GROWTH_TRANSITIONS)
+            churns = any(windows[left] != windows[right] for left, right in CHURN_TRANSITIONS)
+            if grows and not churns:
+                used[layout].add(offset)
+            elif churns and not grows:
+                free[layout].add(offset)
+    return (
+        {layout: frozenset(offsets) for layout, offsets in used.items()},
+        {layout: frozenset(offsets) for layout, offsets in free.items()},
+    )
+
+
+def _active_slots(
+    view: ReplicaView, page: int, interval: tuple[int, int], type_offset: int, checkpoint: str
+) -> dict[int, int]:
+    start, end = interval
+    array_start = type_offset + 1
+    slots = (end - array_start) // POINTER_WIDTH
+    record = view.page(checkpoint, page)
+    view.work.charge(slots + 1)
+    if any(record[array_start + slots * POINTER_WIDTH : end]):
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    active: dict[int, int] = {}
+    for slot in range(slots):
+        offset = array_start + slot * POINTER_WIDTH
+        value = int.from_bytes(record[offset : offset + POINTER_WIDTH], "little")
+        if value:
+            active[slot] = value
+    return active
+
+
+def _type1_slots(
+    view: ReplicaView,
+    page: int,
+    interval: tuple[int, int],
+    type_offset: int,
+    conversion_ordinal: int,
+) -> tuple[int, int, int, int]:
+    indirect = CHECKPOINT_IDS[conversion_ordinal:]
+    low_phase = [name for name in indirect if ORDINAL[name] <= ORDINAL[LAST_L_CHECKPOINT]]
+    if not low_phase:
+        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+    low_active = _active_slots(view, page, interval, type_offset, low_phase[-1])
+    if len(low_active) != 1:
+        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+    low_slot = next(iter(low_active))
+    final_active = _active_slots(view, page, interval, type_offset, FINAL_CHECKPOINT)
+    if len(final_active) != 2 or low_slot not in final_active:
+        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+    high_slot = max(final_active)
+    if high_slot != low_slot + 1:
+        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+    for name in indirect:
+        active = _active_slots(view, page, interval, type_offset, name)
+        if set(active) - {low_slot, high_slot}:
+            raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+        for reference in active.values():
+            if not 1 <= reference < view.page_count(name):
+                raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+            if view.page(name, reference)[0] != EXTENDED_MAP_TAG:
+                raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+    return low_slot, high_slot, final_active[low_slot], final_active[high_slot]
+
+
+def extended_base(formula: str, slot: int, reference_page: int) -> int:
+    if formula == "slot_relative_expected_0_16352":
+        return slot * EXTENDED_MAP_BITS
+    if formula == "slot_relative_off_by_minus_one":
+        return slot * EXTENDED_MAP_BITS - 1
+    if formula == "slot_relative_off_by_plus_one":
+        return slot * EXTENDED_MAP_BITS + 1
+    if formula == "referenced_page_relative":
+        return reference_page
+    if formula == "referenced_page_relative_off_by_minus_one":
+        return reference_page - 1
+    return reference_page + 1
+
+
+def _extended_bitmaps(
+    view: ReplicaView, page: int, interval: tuple[int, int], type_offset: int, checkpoint: str
+) -> dict[int, tuple[int, int]]:
+    result: dict[int, tuple[int, int]] = {}
+    for slot, reference in _active_slots(view, page, interval, type_offset, checkpoint).items():
+        bitmap = view.page(checkpoint, reference)[EXTENDED_MAP_HEADER_BYTES:]
+        result[slot] = (reference, int.from_bytes(bitmap, "little"))
+    return result
+
+
+def _base_candidates(
+    view: ReplicaView,
+    page: int,
+    interval: tuple[int, int],
+    type_offset: int,
+    conversion_ordinal: int,
+    inline_pages: frozenset[int],
+) -> frozenset[str]:
+    indirect = CHECKPOINT_IDS[conversion_ordinal:]
+    bitmaps = {
+        name: _extended_bitmaps(view, page, interval, type_offset, name) for name in indirect
+    }
+    survivors = set(BASE_FORMULAS)
+    conversion = indirect[0]
+    for formula in sorted(survivors):
+        covered: set[int] = set()
+        for slot, (reference, bits) in bitmaps[conversion].items():
+            origin = extended_base(formula, slot, reference)
+            view.work.charge(bits.bit_count())
+            covered.update(origin + bit for bit in _set_bits(bits))
+        if not inline_pages <= covered:
+            survivors.discard(formula)
+    exact_evidence = False
+    for left, right in GROWTH_TRANSITIONS:
+        if ORDINAL[left] < conversion_ordinal:
+            continue
+        before = bitmaps[left]
+        after = bitmaps[right]
+        delta = view.page_count(right) - view.page_count(left)
+        fresh = {
+            slot: bits & ~before.get(slot, (0, 0))[1] for slot, (_, bits) in after.items()
+        }
+        new_bits = sum(value.bit_count() for value in fresh.values())
+        view.work.charge(new_bits + 1)
+        exact = delta > 0 and new_bits == delta
+        exact_evidence = exact_evidence or exact
+        appended = set(range(view.page_count(left), view.page_count(right)))
+        for formula in sorted(survivors):
+            predicted = {
+                extended_base(formula, slot, after[slot][0]) + bit
+                for slot, value in fresh.items()
+                for bit in _set_bits(value)
+            }
+            if exact:
+                if predicted != appended:
+                    survivors.discard(formula)
+            elif any(not 0 <= mapped < view.page_count(right) for mapped in predicted):
+                survivors.discard(formula)
+        if not survivors:
+            break
+    if not exact_evidence:
+        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+    return frozenset(survivors)
+
+
+def derive(view: ReplicaView) -> Derivation:
+    """Derive the complete three-layer candidate state of one replica."""
+    if not view.idle_pairs_identical():
+        raise Abort(IDLE_VOLATILITY)
+    pages = surviving_record_pages(view)
+    if len(pages) != 1:
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    page = next(iter(pages))
+    if page != METADATA_PAGE:
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    interval = _record_interval(view, page)
+    type_offset, conversion_ordinal = _map_type_offset(view, page, interval)
+    boundary, inline_pages = _inline_extent(view, page, interval, type_offset, conversion_ordinal)
+    used, free = _pointer_candidates(view, page, interval)
+    low_slot, high_slot, low_reference, high_reference = _type1_slots(
+        view, page, interval, type_offset, conversion_ordinal
+    )
+    bases = _base_candidates(
+        view, page, interval, type_offset, conversion_ordinal, inline_pages
+    )
+    return Derivation(
+        record_page=page,
+        record_start=interval[0],
+        record_end=interval[1],
+        map_type_offset=type_offset,
+        conversion_ordinal=conversion_ordinal,
+        inline_boundary=boundary,
+        inline_pages=inline_pages,
+        low_slot=low_slot,
+        high_slot=high_slot,
+        low_reference_page=low_reference,
+        high_reference_page=high_reference,
+        used=used,
+        free=free,
+        bases=bases,
+    )
+
+
+def joint_shape(derivation: Derivation) -> tuple[int, int, int, int, int, int, int]:
+    """The replica-independent part of a joint model."""
+    return (
+        derivation.record_page,
+        derivation.record_start,
+        derivation.record_end,
+        derivation.map_type_offset,
+        derivation.inline_boundary,
+        derivation.low_slot,
+        derivation.high_slot,
+    )
+
+
+@dataclass(frozen=True)
+class JointCandidates:
+    examined: int
+    survivors: int
+    pairs: dict[str, tuple[frozenset[int], frozenset[int]]]
+    bases: frozenset[str]
+
+
+def candidate_counts(first: Derivation, second: Derivation, ceiling: int) -> JointCandidates:
+    """Intersect the derivation replicas and count examined and surviving models."""
+    pairs: dict[str, tuple[frozenset[int], frozenset[int]]] = {}
+    bases = first.bases & second.bases
+    examined = 0
+    combinations = 0
+    for layout in POINTER_LAYOUTS:
+        used = first.used[layout] & second.used[layout]
+        free = first.free[layout] & second.free[layout]
+        pairs[layout] = (used, free)
+        examined += len(used) * len(free) * len(BASE_FORMULAS)
+        if examined > ceiling:
+            raise Abort(RESOURCE_BOUND_BREACH)
+        combinations += len(used) * len(free) - len(used & free)
+    return JointCandidates(
+        examined=examined, survivors=combinations * len(bases), pairs=pairs, bases=bases
+    )
+
+
+def sole_model(derivation: Derivation, candidates: JointCandidates) -> dict[str, Any]:
+    """Build the single surviving joint model; the caller has checked uniqueness."""
+    selected = [
+        (layout, used, free)
+        for layout, (used_set, free_set) in candidates.pairs.items()
+        for used in sorted(used_set)
+        for free in sorted(free_set)
+        if used != free
+    ]
+    if len(selected) != 1 or len(candidates.bases) != 1:
+        raise Abort(MULTIPLE_SURVIVING_MODELS)
+    layout, used, free = selected[0]
+    return {
+        "metadata_page": derivation.record_page,
+        "record_start": derivation.record_start,
+        "record_end": derivation.record_end,
+        "pointer_layout": layout,
+        "used_pointer_offset": used,
+        "free_pointer_offset": free,
+        "inline_boundary": derivation.inline_boundary,
+        "low_type1_slot": derivation.low_slot,
+        "high_type1_slot": derivation.high_slot,
+        "low_reference_page": derivation.low_reference_page,
+        "high_reference_page": derivation.high_reference_page,
+        "extended_base_formula": next(iter(candidates.bases)),
+    }
+
+
+def predicts_holdout(holdout: Derivation, model: dict[str, Any]) -> bool:
+    """Evaluate the frozen model against the holdout without refitting it."""
+    layout = model["pointer_layout"]
+    return (
+        holdout.record_page == model["metadata_page"]
+        and holdout.record_start == model["record_start"]
+        and holdout.record_end == model["record_end"]
+        and holdout.inline_boundary == model["inline_boundary"]
+        and holdout.low_slot == model["low_type1_slot"]
+        and holdout.high_slot == model["high_type1_slot"]
+        and model["used_pointer_offset"] in holdout.used[layout]
+        and model["free_pointer_offset"] in holdout.free[layout]
+        and model["extended_base_formula"] in holdout.bases
+    )

--- a/oracle/windows-dao/scripts/a1_model.py
+++ b/oracle/windows-dao/scripts/a1_model.py
@@ -37,7 +37,23 @@ AMBIGUOUS_RECORD_BOUNDARY = "ambiguous_record_boundary"
 AMBIGUOUS_INLINE_BOUNDARY = "ambiguous_inline_boundary"
 UNEXPLAINED_INLINE_SUFFIX = "unexplained_nonzero_inline_suffix"
 HOLDOUT_PREDICTION_FAILURE = "holdout_prediction_failure"
-INCOMPLETE_TRANSITION_EVIDENCE = "incomplete_transition_evidence"
+
+# The plan states its no-outcome conditions as prose; the preregistered report
+# schema accepts only these identifiers. Every emitted reason maps onto exactly
+# one plan condition, and no reason outside this map may be emitted.
+PLAN_REASONS: dict[str, str] = {
+    REPLICA_DISAGREEMENT: "replica disagreement",
+    MISSING_CONVERSION: "missing inline-to-indirect conversion",
+    RESOURCE_BOUND_BREACH: "any resource bound breach",
+    NO_SURVIVING_MODEL: "zero or more than one surviving joint model",
+    MULTIPLE_SURVIVING_MODELS: "zero or more than one surviving joint model",
+    IDLE_VOLATILITY: "idle volatility",
+    UNRECONSTRUCTABLE_SNAPSHOT: "unreconstructable snapshot",
+    AMBIGUOUS_RECORD_BOUNDARY: "ambiguous record or inline boundary",
+    AMBIGUOUS_INLINE_BOUNDARY: "ambiguous record or inline boundary",
+    UNEXPLAINED_INLINE_SUFFIX: "unexplained nonzero inline suffix",
+    HOLDOUT_PREDICTION_FAILURE: "holdout prediction failure",
+}
 
 METADATA_PAGE = 1
 INLINE_TAG = 0x00
@@ -77,6 +93,8 @@ class Abort(Exception):
     """A preregistered no-outcome condition detected during analysis."""
 
     def __init__(self, reason: str) -> None:
+        if reason not in PLAN_REASONS:
+            raise ValueError(f"{reason!r} is not a preregistered no-outcome condition")
         super().__init__(reason)
         self.reason = reason
 
@@ -222,26 +240,46 @@ def surviving_record_pages(view: ReplicaView) -> set[int]:
     return surviving
 
 
-def _record_interval(view: ReplicaView, page: int) -> tuple[int, int]:
-    lowest = PAGE_SIZE
-    highest = -1
+def _observed_changes(view: ReplicaView, page: int) -> set[int]:
+    """Byte positions any preregistered non-idle transition is observed to change."""
+    changed: set[int] = set()
     for left, right in ALL_TRANSITIONS:
         view.work.charge(1)
         if view.hash_at(left, page) == view.hash_at(right, page):
             continue
         before = view.page(left, page)
         after = view.page(right, page)
-        first = 0
-        while before[first] == after[first]:
-            first += 1
-        last = PAGE_SIZE - 1
-        while before[last] == after[last]:
-            last -= 1
-        lowest = min(lowest, first)
-        highest = max(highest, last)
-    if highest < 0 or highest + 1 - lowest < INLINE_START_PAGE_WIDTH + 1:
+        view.work.charge(PAGE_SIZE)
+        changed.update(
+            index for index in range(PAGE_SIZE) if before[index] != after[index]
+        )
+    return changed
+
+
+def _record_interval(view: ReplicaView, page: int) -> tuple[int, int]:
+    """Select the one caller-delimited record with a unique observed start and end.
+
+    A candidate interval must contain every observed change on the page and
+    must have both of its endpoint bytes witnessed by an observed change; the
+    plan supplies no other delimiter. Exactly one interval can satisfy both, so
+    an empty or too-short observation is the ambiguity the plan rules on.
+    """
+    changed = _observed_changes(view, page)
+    if not changed:
         raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
-    return lowest, highest + 1
+    lowest = min(changed)
+    highest = max(changed)
+    intervals = [
+        (start, highest + 1)
+        for start in (lowest,)
+        if start in changed and highest in changed and changed <= set(range(start, highest + 1))
+    ]
+    if len(intervals) != 1:
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    start, end = intervals[0]
+    if end - start < INLINE_START_PAGE_WIDTH + 1:
+        raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
+    return start, end
 
 
 def _map_type_offset(view: ReplicaView, page: int, interval: tuple[int, int]) -> tuple[int, int]:
@@ -274,7 +312,17 @@ def _inline_extent(
     interval: tuple[int, int],
     type_offset: int,
     conversion_ordinal: int,
+    pointer_extent: int,
+    slot_extent: int,
 ) -> tuple[int, frozenset[int]]:
+    """Select the plan's one exact record boundary by candidate elimination.
+
+    A candidate boundary must agree with the used and free pointer
+    observations, explain every final inline bit, explain the inline-to-
+    indirect conversion by containing the observed type-1 slot array, and leave
+    an all-zero suffix at every inline checkpoint. Surviving on none of these
+    or on more than one candidate produces the preregistered ambiguity.
+    """
     _, end = interval
     bitmap_start = type_offset + 1 + INLINE_START_PAGE_WIDTH
     if bitmap_start >= end:
@@ -282,14 +330,26 @@ def _inline_extent(
     anchor = CHECKPOINT_IDS[conversion_ordinal - 1]
     record = view.page(anchor, page)
     view.work.charge(end - bitmap_start)
-    nonzero = [index for index in range(bitmap_start, end) if record[index]]
-    if not nonzero:
+    explained = [
+        boundary
+        for boundary in range(bitmap_start + 1, end + 1)
+        if record[boundary - 1] and boundary >= max(pointer_extent, slot_extent)
+    ]
+    if not explained:
         raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
-    boundary = nonzero[-1] + 1
-    for name in CHECKPOINT_IDS[:conversion_ordinal]:
-        view.work.charge(end - boundary)
-        if any(view.page(name, page)[boundary:end]):
-            raise Abort(UNEXPLAINED_INLINE_SUFFIX)
+    quiet: list[int] = []
+    for boundary in explained:
+        view.work.charge(conversion_ordinal * (end - boundary) + 1)
+        if not any(
+            any(view.page(name, page)[boundary:end])
+            for name in CHECKPOINT_IDS[:conversion_ordinal]
+        ):
+            quiet.append(boundary)
+    if not quiet:
+        raise Abort(UNEXPLAINED_INLINE_SUFFIX)
+    if len(quiet) > 1:
+        raise Abort(AMBIGUOUS_INLINE_BOUNDARY)
+    boundary = quiet[0]
     first_page = int.from_bytes(record[type_offset + 1 : bitmap_start], "little")
     count = view.page_count(anchor)
     pages: set[int] = set()
@@ -366,26 +426,26 @@ def _type1_slots(
     indirect = CHECKPOINT_IDS[conversion_ordinal:]
     low_phase = [name for name in indirect if ORDINAL[name] <= ORDINAL[LAST_L_CHECKPOINT]]
     if not low_phase:
-        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+        raise Abort(NO_SURVIVING_MODEL)
     low_active = _active_slots(view, page, interval, type_offset, low_phase[-1])
     if len(low_active) != 1:
-        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+        raise Abort(NO_SURVIVING_MODEL)
     low_slot = next(iter(low_active))
     final_active = _active_slots(view, page, interval, type_offset, FINAL_CHECKPOINT)
     if len(final_active) != 2 or low_slot not in final_active:
-        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+        raise Abort(NO_SURVIVING_MODEL)
     high_slot = max(final_active)
     if high_slot != low_slot + 1:
-        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+        raise Abort(NO_SURVIVING_MODEL)
     for name in indirect:
         active = _active_slots(view, page, interval, type_offset, name)
         if set(active) - {low_slot, high_slot}:
-            raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+            raise Abort(NO_SURVIVING_MODEL)
         for reference in active.values():
             if not 1 <= reference < view.page_count(name):
-                raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+                raise Abort(NO_SURVIVING_MODEL)
             if view.page(name, reference)[0] != EXTENDED_MAP_TAG:
-                raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
+                raise Abort(NO_SURVIVING_MODEL)
     return low_slot, high_slot, final_active[low_slot], final_active[high_slot]
 
 
@@ -435,7 +495,6 @@ def _base_candidates(
             covered.update(origin + bit for bit in _set_bits(bits))
         if not inline_pages <= covered:
             survivors.discard(formula)
-    exact_evidence = False
     for left, right in GROWTH_TRANSITIONS:
         if ORDINAL[left] < conversion_ordinal:
             continue
@@ -448,7 +507,6 @@ def _base_candidates(
         new_bits = sum(value.bit_count() for value in fresh.values())
         view.work.charge(new_bits + 1)
         exact = delta > 0 and new_bits == delta
-        exact_evidence = exact_evidence or exact
         appended = set(range(view.page_count(left), view.page_count(right)))
         for formula in sorted(survivors):
             predicted = {
@@ -463,8 +521,6 @@ def _base_candidates(
                 survivors.discard(formula)
         if not survivors:
             break
-    if not exact_evidence:
-        raise Abort(INCOMPLETE_TRANSITION_EVIDENCE)
     return frozenset(survivors)
 
 
@@ -480,10 +536,15 @@ def derive(view: ReplicaView) -> Derivation:
         raise Abort(AMBIGUOUS_RECORD_BOUNDARY)
     interval = _record_interval(view, page)
     type_offset, conversion_ordinal = _map_type_offset(view, page, interval)
-    boundary, inline_pages = _inline_extent(view, page, interval, type_offset, conversion_ordinal)
     used, free = _pointer_candidates(view, page, interval)
+    observed = {offset for layer in (used, free) for offsets in layer.values() for offset in offsets}
+    pointer_extent = max(observed, default=interval[0]) + POINTER_WIDTH
     low_slot, high_slot, low_reference, high_reference = _type1_slots(
         view, page, interval, type_offset, conversion_ordinal
+    )
+    slot_extent = type_offset + 1 + (high_slot + 1) * POINTER_WIDTH
+    boundary, inline_pages = _inline_extent(
+        view, page, interval, type_offset, conversion_ordinal, pointer_extent, slot_extent
     )
     bases = _base_candidates(
         view, page, interval, type_offset, conversion_ordinal, inline_pages

--- a/oracle/windows-dao/tests/a1_test_bundle.py
+++ b/oracle/windows-dao/tests/a1_test_bundle.py
@@ -1,0 +1,173 @@
+"""Synthetic A1 replica bundles for analysis contract tests.
+
+No DAO acquisition exists. These bundles are project-authored fabrications used
+only to exercise the analyzer's decision rules, boundary derivation, freeze
+discipline, and fail-closed paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a1_model import EXTENDED_MAP_BITS, ORDINAL, ReplicaIndexes  # noqa: E402
+from a1_spec import CHECKPOINT_IDS, LADDER, PAGE_SIZE, PLAN_SHA256, ROLE_BINDINGS  # noqa: E402
+
+RECORD_BASE = 16
+CONVERSION_CHECKPOINT = "L_REL_0512"
+INLINE_ANCHOR = "L_REL_0064"
+INLINE_CAPACITY_PAGES = 320
+DROPPED_PAGES = range(10, 140)
+EXTENDED_HEADER = b"\x05\x01\x00\x00"
+
+
+def default_counts() -> dict[str, int]:
+    counts = {"E0": 8, "E0R": 8, "D_GROW_0128": 140, "D_DROP": 140, "D_REGROW_0128": 140}
+    for target in LADDER:
+        counts[f"L_REL_{target:04d}"] = 142 + target + 2
+    for name in ("L_DELETE_ALTERNATING", "L_REINSERT_SAME", "L_IDLE_REOPEN"):
+        counts[name] = counts["L_REL_1280"]
+    counts.update(
+        {"P_ABS_04096": 4098, "P_ABS_08192": 8194, "P_ABS_12288": 12290, "P_ABS_16480": 16482}
+    )
+    for target in LADDER:
+        counts[f"H_REL_{target:04d}"] = 16484 + target + 2
+    counts["H_IDLE_REOPEN"] = counts["H_REL_1280"]
+    return counts
+
+
+@dataclass
+class Spec:
+    """One synthetic replica; every flag switches on a single fault path."""
+
+    number: int
+    low_reference: int = 600
+    high_reference: int = 16400
+    free_pages: tuple[int, int, int] = (5, 6, 7)
+    convert: bool = True
+    record_shift: int = 0
+    second_used_pointer: bool = False
+    static_free_pointer: bool = False
+    stray_suffix: bool = False
+    empty_inline_anchor: bool = False
+    activate_high_slot: bool = True
+    bitmap_shift: int = 0
+    page_ceiling_breach: bool = False
+
+
+def _free_page(spec: Spec, checkpoint: str) -> int:
+    if spec.static_free_pointer:
+        return spec.free_pages[0]
+    ordinal = ORDINAL[checkpoint]
+    if ordinal < ORDINAL["L_DELETE_ALTERNATING"]:
+        return spec.free_pages[0]
+    if ordinal < ORDINAL["L_REINSERT_SAME"]:
+        return spec.free_pages[1]
+    return spec.free_pages[2]
+
+
+def _indirect(spec: Spec, checkpoint: str) -> bool:
+    return spec.convert and ORDINAL[checkpoint] >= ORDINAL[CONVERSION_CHECKPOINT]
+
+
+def _high_slot_active(spec: Spec, count: int) -> bool:
+    return spec.activate_high_slot and count > EXTENDED_MAP_BITS
+
+
+def record_page(spec: Spec, checkpoint: str, count: int) -> bytes:
+    body = bytearray(PAGE_SIZE)
+    body[0:8] = b"A1PAGE01"
+    base = RECORD_BASE + spec.record_shift
+    if spec.second_used_pointer:
+        body[base - 4 : base - 1] = (count - 2).to_bytes(3, "little")
+        body[base - 1] = 3
+    body[base : base + 3] = (count - 1).to_bytes(3, "little")
+    body[base + 3] = 3
+    body[base + 4 : base + 7] = _free_page(spec, checkpoint).to_bytes(3, "little")
+    body[base + 7] = 1
+    type_offset = base + 8
+    if _indirect(spec, checkpoint):
+        body[type_offset] = 0x01
+        body[type_offset + 1 : type_offset + 5] = spec.low_reference.to_bytes(4, "little")
+        if _high_slot_active(spec, count):
+            body[type_offset + 5 : type_offset + 9] = spec.high_reference.to_bytes(4, "little")
+    elif not (spec.empty_inline_anchor and checkpoint == INLINE_ANCHOR):
+        bitmap = type_offset + 5
+        allocated = set(range(min(count, INLINE_CAPACITY_PAGES)))
+        if checkpoint == "D_DROP":
+            allocated -= set(DROPPED_PAGES)
+        for page in allocated:
+            body[bitmap + page // 8] |= 1 << (page % 8)
+    if spec.stray_suffix and checkpoint in ("E0", "E0R"):
+        body[base + 44] = 0xAA
+    return bytes(body)
+
+
+def extended_map_page(spec: Spec, slot: int, count: int) -> bytes:
+    origin = slot * EXTENDED_MAP_BITS
+    mapped = min(count, origin + EXTENDED_MAP_BITS) - origin
+    bits = (((1 << mapped) - 1) << spec.bitmap_shift) & ((1 << EXTENDED_MAP_BITS) - 1)
+    return EXTENDED_HEADER + bits.to_bytes(PAGE_SIZE - len(EXTENDED_HEADER), "little")
+
+
+def build_replica(spec: Spec) -> tuple[ReplicaIndexes, dict[str, bytes]]:
+    counts = default_counts()
+    if spec.page_ceiling_breach:
+        counts["H_REL_1280"] = 20481
+        counts["H_IDLE_REOPEN"] = 20481
+    fake = [f"{page:064x}" for page in range(max(counts.values()))]
+    blobs: dict[str, bytes] = {}
+    indexes: dict[str, dict[str, list[str]]] = {}
+    for checkpoint in CHECKPOINT_IDS:
+        count = counts[checkpoint]
+        hashes = fake[:count]
+        record = record_page(spec, checkpoint, count)
+        digest = hashlib.sha256(record).hexdigest()
+        blobs[digest] = record
+        hashes[1] = digest
+        if _indirect(spec, checkpoint):
+            references = [(0, spec.low_reference)]
+            if _high_slot_active(spec, count):
+                references.append((1, spec.high_reference))
+            for slot, reference in references:
+                page = extended_map_page(spec, slot, count)
+                page_digest = hashlib.sha256(page).hexdigest()
+                blobs[page_digest] = page
+                hashes[reference] = page_digest
+        indexes[checkpoint] = {"ordered_page_sha256": hashes}
+    observation = {
+        "replica": spec.number,
+        "plan_sha256": PLAN_SHA256,
+        "producer_commit": "0" * 40,
+        "repository_url": "https://github.com/oglassdev/jet3-rs.git",
+        "run_id": "synthetic",
+        "environment_sha256": "1" * 64,
+        "provider_sha256": "2" * 64,
+        "role_binding": ROLE_BINDINGS[spec.number - 1],
+    }
+    return ReplicaIndexes(observation=observation, indexes=indexes), blobs
+
+
+def build_bundle(specs: list[Spec], page_store: Path) -> list[ReplicaIndexes]:
+    page_store.mkdir(parents=True, exist_ok=True)
+    replicas: list[ReplicaIndexes] = []
+    for spec in specs:
+        replica, blobs = build_replica(spec)
+        for digest, payload in blobs.items():
+            (page_store / f"{digest}.page").write_bytes(payload)
+        replicas.append(replica)
+    return replicas
+
+
+def decisive_specs() -> list[Spec]:
+    return [
+        Spec(1),
+        Spec(2, low_reference=604, free_pages=(5, 6, 8)),
+        Spec(3, low_reference=608, high_reference=16404, free_pages=(9, 10, 11)),
+    ]

--- a/oracle/windows-dao/tests/a1_test_bundle.py
+++ b/oracle/windows-dao/tests/a1_test_bundle.py
@@ -16,8 +16,32 @@ SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-from a1_model import EXTENDED_MAP_BITS, ORDINAL, ReplicaIndexes  # noqa: E402
-from a1_spec import CHECKPOINT_IDS, LADDER, PAGE_SIZE, PLAN_SHA256, ROLE_BINDINGS  # noqa: E402
+from a1_model import ReplicaIndexes  # noqa: E402
+from a1_spec import CHECKED_PLAN, load_checked_plan  # noqa: E402
+from protocol_validation import sha256  # noqa: E402
+
+# Every fixture constant below is read out of the checked plan document, so the
+# synthetic bundles cannot silently mirror the implementation they exercise.
+PLAN = load_checked_plan().document
+PLAN_SHA256 = sha256(CHECKED_PLAN)
+CHECKPOINT_IDS: tuple[str, ...] = tuple(PLAN["checkpoint_design"]["checkpoint_ids"])
+ORDINAL = {name: index for index, name in enumerate(CHECKPOINT_IDS)}
+PAGE_SIZE = PLAN["page_capture"]["page_size"]
+PLAN_NO_OUTCOME_REASONS: tuple[str, ...] = tuple(PLAN["decision_rules"]["no_scientific_outcome"])
+ROLE_BINDINGS = [
+    {role: binding[role] for role in PLAN["tables"]["roles"]}
+    for binding in PLAN["tables"]["role_bindings"]
+]
+LADDER: tuple[int, ...] = tuple(
+    int(name.rsplit("_", 1)[1]) for name in CHECKPOINT_IDS if name.startswith("L_REL_")
+)
+EXTENDED_MAP_BITS = int(
+    next(
+        candidate
+        for candidate in PLAN["hypotheses"]["extended_base_candidates"]
+        if candidate.startswith("slot_relative_expected_")
+    ).rsplit("_", 1)[1]
+)
 
 RECORD_BASE = 16
 CONVERSION_CHECKPOINT = "L_REL_0512"

--- a/oracle/windows-dao/tests/test_a1_analysis.py
+++ b/oracle/windows-dao/tests/test_a1_analysis.py
@@ -1,4 +1,8 @@
-"""Focused fail-closed tests for bounded A1 analysis."""
+"""Focused fail-closed tests for bounded A1 analysis.
+
+Every bundle here is synthetic. No DAO acquisition, page capture, or scientific
+result exists; these tests exercise decision rules, not MDB facts.
+"""
 
 from __future__ import annotations
 
@@ -6,12 +10,16 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
-if str(SCRIPTS) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS))
+TESTS = Path(__file__).resolve().parent
+for location in (SCRIPTS, TESTS):
+    if str(location) not in sys.path:
+        sys.path.insert(0, str(location))
 
-from a1_analysis import ReplicaIndexes, build_analysis  # noqa: E402
+from a1_analysis import build_analysis  # noqa: E402
+from a1_model import Abort, ReplicaIndexes, WorkCounter  # noqa: E402
 from a1_spec import (  # noqa: E402
     CHECKPOINT_IDS,
     CLAIMS,
@@ -20,6 +28,7 @@ from a1_spec import (  # noqa: E402
     load_checked_plan,
     validate_analysis_report,
 )
+from a1_test_bundle import Spec, build_bundle, decisive_specs  # noqa: E402
 from protocol_validation import ValidationError  # noqa: E402
 
 
@@ -31,27 +40,162 @@ class A1AnalysisTests(unittest.TestCase):
     @staticmethod
     def replica(number: int, digest: str = "0" * 64) -> ReplicaIndexes:
         observation = {
-            "replica": number, "plan_sha256": PLAN_SHA256,
+            "replica": number,
+            "plan_sha256": PLAN_SHA256,
             "producer_commit": "0" * 40,
             "repository_url": "https://github.com/oglassdev/jet3-rs.git",
-            "run_id": "synthetic", "environment_sha256": "1" * 64,
-            "provider_sha256": "2" * 64, "role_binding": ROLE_BINDINGS[number - 1],
+            "run_id": "synthetic",
+            "environment_sha256": "1" * 64,
+            "provider_sha256": "2" * 64,
+            "role_binding": ROLE_BINDINGS[number - 1],
         }
         indexes = {
-            checkpoint: {"ordered_page_sha256": [digest]}
-            for checkpoint in CHECKPOINT_IDS
+            checkpoint: {"ordered_page_sha256": [digest]} for checkpoint in CHECKPOINT_IDS
         }
         return ReplicaIndexes(observation=observation, indexes=indexes)
+
+    def analyze(self, specs: list[Spec], holdout: ReplicaIndexes | None = None) -> dict[str, Any]:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Path(directory) / "page-store"
+            replicas = build_bundle(specs, store)
+            if holdout is not None:
+                replicas[2] = holdout
+            return build_analysis(self.plan, replicas, store)
+
+    def assert_no_outcome(self, report: dict[str, Any], reason: str) -> None:
+        self.assertEqual(report["scientific_outcome"], "no_scientific_outcome")
+        self.assertEqual(report["no_outcome_reasons"], [reason])
+        self.assertIsNone(report["surviving_model"])
+        self.assertEqual(report["claims"], CLAIMS)
+
+    def test_one_joint_model_survives_derivation_and_predicts_the_holdout(self) -> None:
+        report = self.analyze(decisive_specs())
+        self.assertEqual(report["scientific_outcome"], "one_joint_model_predicts_holdout")
+        self.assertEqual(report["no_outcome_reasons"], [])
+        self.assertTrue(report["holdout_evaluated"])
+        self.assertEqual(report["derivation_survivor_count"], 1)
+        self.assertEqual(report["candidate_models_examined"], 6)
+        self.assertEqual(
+            report["surviving_model"],
+            {
+                "metadata_page": 1,
+                "record_start": 16,
+                "record_end": 55,
+                "pointer_layout": "u24le_page_then_u8_slot",
+                "used_pointer_offset": 16,
+                "free_pointer_offset": 20,
+                "inline_boundary": 55,
+                "low_type1_slot": 0,
+                "high_type1_slot": 1,
+                "low_reference_page": 600,
+                "high_reference_page": 16400,
+                "extended_base_formula": "slot_relative_expected_0_16352",
+            },
+        )
+        validate_analysis_report(report)
+
+    def test_holdout_cannot_widen_or_change_the_frozen_candidate_set(self) -> None:
+        decisive = self.analyze(decisive_specs())
+        frozen = self.analyze(decisive_specs(), holdout=self.replica(3, "e" * 64))
+        self.assertEqual(
+            frozen["candidate_models_examined"], decisive["candidate_models_examined"]
+        )
+        self.assertEqual(
+            frozen["derivation_survivor_count"], decisive["derivation_survivor_count"]
+        )
+        self.assertTrue(frozen["holdout_evaluated"])
+        self.assert_no_outcome(frozen, "holdout_prediction_failure")
+
+    def test_holdout_base_formula_mismatch_is_not_refitted(self) -> None:
+        specs = decisive_specs()
+        specs[2].bitmap_shift = 1
+        report = self.analyze(specs)
+        self.assertEqual(report["derivation_survivor_count"], 1)
+        self.assert_no_outcome(report, "holdout_prediction_failure")
+
+    def test_derivation_replicas_must_agree_on_the_record_boundary(self) -> None:
+        specs = decisive_specs()
+        specs[1].record_shift = 4
+        self.assert_no_outcome(self.analyze(specs), "replica_disagreement")
+
+    def test_absent_inline_to_indirect_conversion_is_terminal(self) -> None:
+        specs = decisive_specs()
+        for spec in specs:
+            spec.convert = False
+        self.assert_no_outcome(self.analyze(specs), "missing_inline_to_indirect_conversion")
+
+    def test_two_step_offsets_leave_the_record_boundary_ambiguous(self) -> None:
+        specs = decisive_specs()
+        for spec in specs[:2]:
+            spec.low_reference = 344
+        self.assert_no_outcome(self.analyze(specs), "ambiguous_record_boundary")
+
+    def test_empty_final_inline_extent_is_ambiguous(self) -> None:
+        specs = decisive_specs()
+        for spec in specs[:2]:
+            spec.empty_inline_anchor = True
+        self.assert_no_outcome(self.analyze(specs), "ambiguous_inline_boundary")
+
+    def test_nonzero_bytes_beyond_the_inline_boundary_are_unexplained(self) -> None:
+        specs = decisive_specs()
+        for spec in specs[:2]:
+            spec.stray_suffix = True
+        self.assert_no_outcome(self.analyze(specs), "unexplained_nonzero_inline_suffix")
+
+    def test_absent_free_pointer_transition_leaves_no_surviving_model(self) -> None:
+        specs = decisive_specs()
+        for spec in specs[:2]:
+            spec.static_free_pointer = True
+        report = self.analyze(specs)
+        self.assertEqual(report["candidate_models_examined"], 0)
+        self.assertEqual(report["derivation_survivor_count"], 0)
+        self.assertFalse(report["holdout_evaluated"])
+        self.assert_no_outcome(report, "no_surviving_joint_model")
+
+    def test_second_used_pointer_leaves_more_than_one_surviving_model(self) -> None:
+        specs = decisive_specs()
+        for spec in specs[:2]:
+            spec.second_used_pointer = True
+        report = self.analyze(specs)
+        self.assertEqual(report["candidate_models_examined"], 18)
+        self.assertEqual(report["derivation_survivor_count"], 3)
+        self.assertFalse(report["holdout_evaluated"])
+        self.assert_no_outcome(report, "multiple_surviving_joint_models")
+
+    def test_unobserved_high_type1_slot_is_incomplete_evidence(self) -> None:
+        specs = decisive_specs()
+        for spec in specs[:2]:
+            spec.activate_high_slot = False
+        self.assert_no_outcome(self.analyze(specs), "incomplete_transition_evidence")
+
+    def test_final_page_ceiling_breach_fails_closed(self) -> None:
+        specs = decisive_specs()
+        specs[0].page_ceiling_breach = True
+        self.assert_no_outcome(self.analyze(specs), "resource_bound_breach")
+
+    def test_missing_page_store_blob_is_unreconstructable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Path(directory) / "page-store"
+            replicas = build_bundle(decisive_specs(), store)
+            (store / f"{replicas[0].indexes['E0']['ordered_page_sha256'][1]}.page").unlink()
+            report = build_analysis(self.plan, replicas, store)
+        self.assert_no_outcome(report, "unreconstructable_snapshot")
+
+    def test_work_ceiling_is_charged_and_fails_closed(self) -> None:
+        work = WorkCounter()
+        work.charge(1)
+        with self.assertRaises(Abort) as caught:
+            work.charge(10**12)
+        self.assertEqual(caught.exception.reason, "resource_bound_breach")
+        self.assertEqual(work.value, 1)
 
     def test_ambiguous_derivation_returns_no_outcome_without_reading_holdout_pages(self) -> None:
         replicas = [self.replica(1), self.replica(2), self.replica(3, "f" * 64)]
         with tempfile.TemporaryDirectory() as directory:
             report = build_analysis(self.plan, replicas, Path(directory))
-        self.assertEqual(report["scientific_outcome"], "no_scientific_outcome")
         self.assertIn("ambiguous_record_boundary", report["no_outcome_reasons"])
         self.assertFalse(report["holdout_evaluated"])
         self.assertIsNone(report["surviving_model"])
-        self.assertEqual(report["claims"], CLAIMS)
 
     def test_idle_volatility_is_terminal_before_candidate_search(self) -> None:
         replicas = [self.replica(1), self.replica(2), self.replica(3)]
@@ -65,20 +209,30 @@ class A1AnalysisTests(unittest.TestCase):
     def test_replica_binding_disagreement_fails_closed(self) -> None:
         replicas = [self.replica(1), self.replica(2), self.replica(3)]
         replicas[2].observation["run_id"] = "different"
-        with tempfile.TemporaryDirectory() as directory, self.assertRaisesRegex(ValidationError, "run_id"):
+        with tempfile.TemporaryDirectory() as directory, self.assertRaisesRegex(
+            ValidationError, "run_id"
+        ):
             build_analysis(self.plan, replicas, Path(directory))
 
     def test_no_outcome_report_cannot_smuggle_a_model_or_claim(self) -> None:
         report = {
-            "protocol_version": "1.0.0", "document_type": "dao_a1_analysis_report",
-            "experiment_id": "DAO-A1-ALLOCATION-MAPS-001", "plan_sha256": PLAN_SHA256,
-            "run_id": "synthetic", "producer_commit": "0" * 40,
-            "derivation_replicas": [1, 2], "holdout_replica": 3,
-            "input_checkpoint_count": 213, "candidate_models_examined": 0,
-            "derivation_survivor_count": 0, "analysis_work_units": 0,
-            "holdout_evaluated": False, "scientific_outcome": "no_scientific_outcome",
+            "protocol_version": "1.0.0",
+            "document_type": "dao_a1_analysis_report",
+            "experiment_id": "DAO-A1-ALLOCATION-MAPS-001",
+            "plan_sha256": PLAN_SHA256,
+            "run_id": "synthetic",
+            "producer_commit": "0" * 40,
+            "derivation_replicas": [1, 2],
+            "holdout_replica": 3,
+            "input_checkpoint_count": 213,
+            "candidate_models_examined": 0,
+            "derivation_survivor_count": 0,
+            "analysis_work_units": 0,
+            "holdout_evaluated": False,
+            "scientific_outcome": "no_scientific_outcome",
             "no_outcome_reasons": ["no_surviving_joint_model"],
-            "surviving_model": None, "claims": CLAIMS,
+            "surviving_model": None,
+            "claims": CLAIMS,
         }
         validate_analysis_report(report)
         report["claims"] = {**CLAIMS, "rust_correctness": True}

--- a/oracle/windows-dao/tests/test_a1_analysis.py
+++ b/oracle/windows-dao/tests/test_a1_analysis.py
@@ -18,18 +18,35 @@ for location in (SCRIPTS, TESTS):
     if str(location) not in sys.path:
         sys.path.insert(0, str(location))
 
+from unittest import mock  # noqa: E402
+
+import a1_analysis  # noqa: E402
 from a1_analysis import build_analysis  # noqa: E402
-from a1_model import Abort, ReplicaIndexes, WorkCounter  # noqa: E402
-from a1_spec import (  # noqa: E402
+from a1_model import PLAN_REASONS, Abort, ReplicaIndexes, WorkCounter  # noqa: E402
+from a1_spec import CLAIMS, load_checked_plan, validate_analysis_report  # noqa: E402
+from a1_test_bundle import (  # noqa: E402
     CHECKPOINT_IDS,
-    CLAIMS,
+    PLAN_NO_OUTCOME_REASONS,
     PLAN_SHA256,
     ROLE_BINDINGS,
-    load_checked_plan,
-    validate_analysis_report,
+    Spec,
+    build_bundle,
+    decisive_specs,
 )
-from a1_test_bundle import Spec, build_bundle, decisive_specs  # noqa: E402
 from protocol_validation import ValidationError  # noqa: E402
+
+
+class RecordingSource:
+    """A replica source that records exactly when the analysis opens it."""
+
+    def __init__(self, replica: ReplicaIndexes, log: list[str], frozen: list[bool]) -> None:
+        self.replica = replica
+        self.log = log
+        self.frozen = frozen
+
+    def load(self) -> ReplicaIndexes:
+        self.log.append("frozen" if self.frozen[0] else "unfrozen")
+        return self.replica
 
 
 class A1AnalysisTests(unittest.TestCase):
@@ -62,9 +79,12 @@ class A1AnalysisTests(unittest.TestCase):
                 replicas[2] = holdout
             return build_analysis(self.plan, replicas, store)
 
-    def assert_no_outcome(self, report: dict[str, Any], reason: str) -> None:
+    def assert_no_outcome(self, report: dict[str, Any], plan_reason: str) -> None:
+        self.assertIn(plan_reason, PLAN_NO_OUTCOME_REASONS)
         self.assertEqual(report["scientific_outcome"], "no_scientific_outcome")
-        self.assertEqual(report["no_outcome_reasons"], [reason])
+        self.assertEqual(
+            [PLAN_REASONS[reason] for reason in report["no_outcome_reasons"]], [plan_reason]
+        )
         self.assertIsNone(report["surviving_model"])
         self.assertEqual(report["claims"], CLAIMS)
 
@@ -94,6 +114,49 @@ class A1AnalysisTests(unittest.TestCase):
         )
         validate_analysis_report(report)
 
+    def test_holdout_artifacts_are_opened_only_after_the_candidate_freeze(self) -> None:
+        log: list[str] = []
+        frozen = [False]
+
+        original = a1_analysis.sole_model
+
+        def freeze(*arguments: Any) -> dict[str, Any]:
+            frozen[0] = True
+            return original(*arguments)
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = Path(directory) / "page-store"
+            replicas = build_bundle(decisive_specs(), store)
+            sources = [
+                replicas[0],
+                replicas[1],
+                RecordingSource(replicas[2], log, frozen),
+            ]
+            with mock.patch.object(a1_analysis, "sole_model", side_effect=freeze):
+                report = build_analysis(self.plan, sources, store)
+        self.assertEqual(log, ["frozen"])
+        self.assertEqual(report["scientific_outcome"], "one_joint_model_predicts_holdout")
+
+    def test_holdout_artifacts_are_never_opened_when_derivation_is_ambiguous(self) -> None:
+        log: list[str] = []
+        sources = [
+            self.replica(1),
+            self.replica(2),
+            RecordingSource(self.replica(3), log, [False]),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            report = build_analysis(self.plan, sources, Path(directory))
+        self.assertEqual(log, [])
+        self.assertFalse(report["holdout_evaluated"])
+
+    def test_every_emitted_reason_maps_onto_one_preregistered_plan_condition(self) -> None:
+        self.assertEqual(set(PLAN_REASONS.values()), set(PLAN_NO_OUTCOME_REASONS))
+        self.assertEqual(
+            set(PLAN_NO_OUTCOME_REASONS), set(self.plan.document["decision_rules"]["no_scientific_outcome"])
+        )
+        with self.assertRaises(ValueError):
+            Abort("incomplete_transition_evidence")
+
     def test_holdout_cannot_widen_or_change_the_frozen_candidate_set(self) -> None:
         decisive = self.analyze(decisive_specs())
         frozen = self.analyze(decisive_specs(), holdout=self.replica(3, "e" * 64))
@@ -104,43 +167,43 @@ class A1AnalysisTests(unittest.TestCase):
             frozen["derivation_survivor_count"], decisive["derivation_survivor_count"]
         )
         self.assertTrue(frozen["holdout_evaluated"])
-        self.assert_no_outcome(frozen, "holdout_prediction_failure")
+        self.assert_no_outcome(frozen, "holdout prediction failure")
 
     def test_holdout_base_formula_mismatch_is_not_refitted(self) -> None:
         specs = decisive_specs()
         specs[2].bitmap_shift = 1
         report = self.analyze(specs)
         self.assertEqual(report["derivation_survivor_count"], 1)
-        self.assert_no_outcome(report, "holdout_prediction_failure")
+        self.assert_no_outcome(report, "holdout prediction failure")
 
     def test_derivation_replicas_must_agree_on_the_record_boundary(self) -> None:
         specs = decisive_specs()
         specs[1].record_shift = 4
-        self.assert_no_outcome(self.analyze(specs), "replica_disagreement")
+        self.assert_no_outcome(self.analyze(specs), "replica disagreement")
 
     def test_absent_inline_to_indirect_conversion_is_terminal(self) -> None:
         specs = decisive_specs()
         for spec in specs:
             spec.convert = False
-        self.assert_no_outcome(self.analyze(specs), "missing_inline_to_indirect_conversion")
+        self.assert_no_outcome(self.analyze(specs), "missing inline-to-indirect conversion")
 
     def test_two_step_offsets_leave_the_record_boundary_ambiguous(self) -> None:
         specs = decisive_specs()
         for spec in specs[:2]:
             spec.low_reference = 344
-        self.assert_no_outcome(self.analyze(specs), "ambiguous_record_boundary")
+        self.assert_no_outcome(self.analyze(specs), "ambiguous record or inline boundary")
 
     def test_empty_final_inline_extent_is_ambiguous(self) -> None:
         specs = decisive_specs()
         for spec in specs[:2]:
             spec.empty_inline_anchor = True
-        self.assert_no_outcome(self.analyze(specs), "ambiguous_inline_boundary")
+        self.assert_no_outcome(self.analyze(specs), "ambiguous record or inline boundary")
 
     def test_nonzero_bytes_beyond_the_inline_boundary_are_unexplained(self) -> None:
         specs = decisive_specs()
         for spec in specs[:2]:
             spec.stray_suffix = True
-        self.assert_no_outcome(self.analyze(specs), "unexplained_nonzero_inline_suffix")
+        self.assert_no_outcome(self.analyze(specs), "unexplained nonzero inline suffix")
 
     def test_absent_free_pointer_transition_leaves_no_surviving_model(self) -> None:
         specs = decisive_specs()
@@ -150,7 +213,7 @@ class A1AnalysisTests(unittest.TestCase):
         self.assertEqual(report["candidate_models_examined"], 0)
         self.assertEqual(report["derivation_survivor_count"], 0)
         self.assertFalse(report["holdout_evaluated"])
-        self.assert_no_outcome(report, "no_surviving_joint_model")
+        self.assert_no_outcome(report, "zero or more than one surviving joint model")
 
     def test_second_used_pointer_leaves_more_than_one_surviving_model(self) -> None:
         specs = decisive_specs()
@@ -160,18 +223,18 @@ class A1AnalysisTests(unittest.TestCase):
         self.assertEqual(report["candidate_models_examined"], 18)
         self.assertEqual(report["derivation_survivor_count"], 3)
         self.assertFalse(report["holdout_evaluated"])
-        self.assert_no_outcome(report, "multiple_surviving_joint_models")
+        self.assert_no_outcome(report, "zero or more than one surviving joint model")
 
-    def test_unobserved_high_type1_slot_is_incomplete_evidence(self) -> None:
+    def test_unobserved_high_type1_slot_leaves_no_surviving_model(self) -> None:
         specs = decisive_specs()
         for spec in specs[:2]:
             spec.activate_high_slot = False
-        self.assert_no_outcome(self.analyze(specs), "incomplete_transition_evidence")
+        self.assert_no_outcome(self.analyze(specs), "zero or more than one surviving joint model")
 
     def test_final_page_ceiling_breach_fails_closed(self) -> None:
         specs = decisive_specs()
         specs[0].page_ceiling_breach = True
-        self.assert_no_outcome(self.analyze(specs), "resource_bound_breach")
+        self.assert_no_outcome(self.analyze(specs), "any resource bound breach")
 
     def test_missing_page_store_blob_is_unreconstructable(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -179,7 +242,7 @@ class A1AnalysisTests(unittest.TestCase):
             replicas = build_bundle(decisive_specs(), store)
             (store / f"{replicas[0].indexes['E0']['ordered_page_sha256'][1]}.page").unlink()
             report = build_analysis(self.plan, replicas, store)
-        self.assert_no_outcome(report, "unreconstructable_snapshot")
+        self.assert_no_outcome(report, "unreconstructable snapshot")
 
     def test_work_ceiling_is_charged_and_fails_closed(self) -> None:
         work = WorkCounter()
@@ -202,17 +265,27 @@ class A1AnalysisTests(unittest.TestCase):
         replicas[0].indexes["E0R"] = {"ordered_page_sha256": ["a" * 64]}
         with tempfile.TemporaryDirectory() as directory:
             report = build_analysis(self.plan, replicas, Path(directory))
-        self.assertEqual(report["no_outcome_reasons"], ["idle_volatility"])
+        self.assertEqual(
+            [PLAN_REASONS[reason] for reason in report["no_outcome_reasons"]], ["idle volatility"]
+        )
         self.assertEqual(report["candidate_models_examined"], 0)
         self.assertFalse(report["holdout_evaluated"])
 
-    def test_replica_binding_disagreement_fails_closed(self) -> None:
+    def test_derivation_binding_disagreement_fails_closed_before_any_derivation(self) -> None:
         replicas = [self.replica(1), self.replica(2), self.replica(3)]
-        replicas[2].observation["run_id"] = "different"
+        replicas[1].observation["run_id"] = "different"
         with tempfile.TemporaryDirectory() as directory, self.assertRaisesRegex(
             ValidationError, "run_id"
         ):
             build_analysis(self.plan, replicas, Path(directory))
+
+    def test_holdout_binding_disagreement_fails_closed_after_the_freeze(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = Path(directory) / "page-store"
+            replicas = build_bundle(decisive_specs(), store)
+            replicas[2].observation["run_id"] = "different"
+            with self.assertRaisesRegex(ValidationError, "run_id"):
+                build_analysis(self.plan, replicas, store)
 
     def test_no_outcome_report_cannot_smuggle_a_model_or_claim(self) -> None:
         report = {

--- a/oracle/windows-dao/tests/test_a1_analysis.py
+++ b/oracle/windows-dao/tests/test_a1_analysis.py
@@ -179,7 +179,12 @@ class A1AnalysisTests(unittest.TestCase):
     def test_derivation_replicas_must_agree_on_the_record_boundary(self) -> None:
         specs = decisive_specs()
         specs[1].record_shift = 4
-        self.assert_no_outcome(self.analyze(specs), "replica disagreement")
+        self.assert_no_outcome(self.analyze(specs), "ambiguous record or inline boundary")
+
+    def test_disagreeing_observed_record_start_is_ambiguous(self) -> None:
+        specs = decisive_specs()
+        specs[0].second_used_pointer = True
+        self.assert_no_outcome(self.analyze(specs), "ambiguous record or inline boundary")
 
     def test_absent_inline_to_indirect_conversion_is_terminal(self) -> None:
         specs = decisive_specs()


### PR DESCRIPTION
Implements phase B5: `oracle/windows-dao/scripts/a1_analysis.py` goes from a fail-closed skeleton to the full scientific analysis the checked plan `oracle/windows-dao/experiments/a1/a1-allocation-maps.plan.json` (`EXP-0037`, plan SHA-256 `a7fa44cd…`) specifies. No preregistered document, ledger entry, schema, or Rust file is touched.

## Plan clause → code

| Plan clause | Implementation |
| --- | --- |
| `replicas.derivation = [1, 2]`, `replicas.holdout = 3`, `holdout_rule` | `build_analysis` takes **lazy replica sources**. `loaders[0..1].load()` open the derivation replicas; the holdout source is opened only on the line after `sole_model()` returns the frozen model, and its bindings are checked there. Evaluation is a membership/equality check (`predicts_holdout`) — nothing is added, removed, relaxed, or reinterpreted. |
| `hypotheses.page_one` (unique caller-delimited record; ABA on D; same record tracks L and H) | `_page_tracks_allocation`: `D_GROW == D_REGROW != D_DROP`, `D_GROW != E0R`, plus L-ladder and H-ladder change predicates. |
| `hypotheses.negative_page_candidate_space` ("page 1 is not privileged") | `surviving_record_pages` evaluates **every** observed physical page with the same predicates; analysis proceeds only if exactly one page survives and it is page 1. |
| idle-pair identity, `checkpoint_design.idle_pairs` | `ReplicaView.idle_pairs_identical`; volatility is terminal before any candidate search. |
| "unique observed start and end" of the caller-delimited record | `_record_interval` selects the one interval that contains every observed change on the page **and** has both endpoint bytes witnessed by an observed change. No other interval can satisfy both. Zero observations, or an interval too short to hold a map record, emit the preregistered ambiguity. |
| `hypotheses.tdef_pointer_layouts` / `tdef_pointer_rule` | `_pointer_candidates` enumerates every four-byte offset in the delimited record under exactly both preregistered layouts, requires a valid in-file page reference at every checkpoint from `L_REL_0064`, and separates *used* (changes across growth, stable across alternating delete/reinsert) from *free* (the converse). Distinctness is enforced when the joint model is built. |
| `hypotheses.inline_extent_rule` — "one exact record boundary must agree across derivation replicas and used/free observations, explain every final inline bit and the inline-to-indirect conversion, and have an all-zero suffix; ambiguity … produces no outcome" | `_inline_extent` is **candidate elimination**, not a heuristic. Every boundary in the record is a candidate; a candidate survives only if it clears the observed used/free pointer extent, contains the observed type-1 slot array (conversion explained), ends on a byte carrying a final inline bit (every final inline bit explained), and leaves an all-zero suffix at every inline checkpoint. Zero or more than one survivor → `ambiguous record or inline boundary`; survivors killed solely by a nonzero suffix → `unexplained nonzero inline suffix`. Replica agreement is enforced by `joint_shape`. |
| conversion location | `_map_type_offset` takes the unique record offset whose byte sequence is a monotone `0x00 → 0x01` step; none → `missing inline-to-indirect conversion`, several → ambiguity. |
| `hypotheses.type1_rule` | `_type1_slots`: inactive four-byte slots and the trailing partial region exactly zero, active references in-file pages whose byte zero is `0x05`, exactly one slot active at the last L checkpoint (low = L), exactly two at the final checkpoint with `high == low + 1` (H). |
| `hypotheses.extended_base_candidates` / `extended_base_rule` | `extended_base` implements exactly the six preregistered formulas and nothing else. |
| independent recomputation | `_base_candidates` recomputes each extended bitmap from the stored page bytes: at conversion the covered set must contain every page the inline extent explained, and on each post-conversion growth transition the newly set bits must recompute to exactly the appended page range whenever the new-bit count equals the file's page delta. This is what discriminates the ±1 and referenced-page variants. When no transition discriminates, the formulas simply all survive and the surviving-model count rule fires. |
| `decision_rules.decisive` | Emitted only when exactly one joint model survives both derivation replicas *and* is present in the holdout's own derived candidate state without refit. |
| `decision_rules.no_scientific_outcome` | `a1_model.PLAN_REASONS` maps every emittable reason onto exactly one **verbatim** plan condition, and `Abort` raises `ValueError` for anything outside that map, so no unregistered reason can reach a report. |
| `bounds` | `WORK_CEILING` via `WorkCounter`, `max_candidate_models` before enumeration, `max_final_pages_per_replica` at view construction, page-store blob size/content-address plus a retained-bytes ceiling in `PageStore`, `max_json_bytes` on the report. Input/binding faults stay hard `ValidationError`s; preregistered no-outcome conditions become report reasons. |
| `claims` | Copied verbatim from `a1_spec.CLAIMS`; every report passes `validate_analysis_report`. |

Split into `a1_analysis.py` (251 lines, IO/sources/orchestration) and `a1_model.py` (651 lines, layer derivation) to stay under the 800-line rule. **`a1_spec.py` was not modified.**

## Reported conflict: plan prose vs. report schema

The plan states its no-outcome conditions as prose; the preregistered `analysis-report.schema.json` accepts only a snake_case enum, and `validate_analysis_report` enforces the schema. Emitting the plan strings verbatim would fail preregistered validation, so reports carry schema identifiers and `PLAN_REASONS` records the mapping. Two residual disagreements between the two preregistered documents, flagged rather than papered over:

- The schema splits one plan condition, "zero or more than one surviving joint model", into `no_surviving_joint_model` and `multiple_surviving_joint_models`, and "ambiguous record or inline boundary" into `ambiguous_record_boundary` and `ambiguous_inline_boundary`. Both halves map back to the single plan condition.
- The schema offers `incomplete_transition_evidence`, which appears in **no** plan condition. It is no longer emitted; the conditions that used it (unobserved type-1 slot activation, invalid type-1 reference, undiscriminated base formulas) now resolve through "zero or more than one surviving joint model", which covers them exactly.

A test asserts `set(PLAN_REASONS.values()) == set(plan.decision_rules.no_scientific_outcome)` and that constructing `Abort("incomplete_transition_evidence")` raises.

## Tests

`oracle/windows-dao/tests/a1_test_bundle.py` builds synthetic 71-checkpoint replicas (no DAO data exists) with one flag per fault path. Every fixture constant — checkpoint ids and ordinals, page size, ladder targets, role bindings, plan hash, and the 16352-bit extended-map stride — is read out of the **checked plan document**, not out of the implementation.

`tests/test_a1_analysis.py` (22 tests) covers: the decisive path; holdout artifacts opened exactly once and only after the freeze, and never when the derivation aborts (instrumented source at the production entry point — verified to fail if the ordering regresses); the frozen candidate set being unaffected by replica 3; holdout base-formula mismatch; one test per plan no-outcome condition, asserted with the plan's verbatim strings; derivation- and holdout-side binding failures; work ceiling; page-store faults.

```
python3 -m unittest discover -s oracle/windows-dao/tests   →  Ran 417 tests, OK (skipped=80)   [python3.13.15]
python3 -m unittest tests.test_a1_analysis (22 tests)      →  OK, 1.2s
python3 tools/reconcile_tests.py                           →  exit 0, 233/233 unchanged (cargo-only manifest)
```

## Not satisfied / notes

- The execution gate stays `BLOCKED` and `preregistration.acquisition_started` stays `false`; every bundle exercised here is synthetic, so nothing in this PR is an MDB fact or moves any support-matrix capability.
- The plan defines no delimiter for the record **start** — no field, marker, or length is preregistered. The start is therefore observation-derived (the witnessed first changed byte). This is the one place where the analysis must choose a construction the plan does not state; it is documented in `_record_interval`'s docstring rather than hidden, and every downstream boundary decision is candidate elimination with a preregistered ambiguity fallback.
- `a1_contract.py` (the independent bundle validator) still rejects a decisive report pending an independent recomputing validator, per `EXP-0037` — acknowledged as by-design and left untouched.
- No provenance entry is added here; `EXP-0037` already records the pre-acquisition contract, and a ledger entry for this analyzer belongs with whoever lands the accompanying provenance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp6DTLry3q32XBCYyzbo2g
