### PR TITLE
docs: preregister A1 plan R2 amendment

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -2823,8 +2823,9 @@ Use `not applicable` explicitly rather than omitting a field.
 ### EXP-0038 — Preregistered A1 report-interpretation amendment
 
 - Recorded: 2026-08-20, OpenAI Codex
-- Kind: additive pre-acquisition experiment-plan revision; no DAO acquisition,
-  physical-format result, or independent scientific validation
+- Kind: additive pre-acquisition experiment-plan revision; no retained DAO
+  scientific acquisition, physical-format result, or independent scientific
+  validation
 - Question: How must the A1 campaign encode preregistered no-outcome reasons
   and retain a decisive analysis while independent recomputation remains
   unavailable?
@@ -2833,9 +2834,13 @@ Use `not applicable` explicitly rather than omitting a field.
   plan and analysis-report schema plus the fail-closed decisive-report rule in
   the checked A1 contract; no MDB input, campaign output, donated fixture, or
   third-party implementation was inspected
-- Environment: not executed; `preregistration.acquisition_started` remains
-  `false`, and the original x86 Windows, PowerShell 5.1, Python 3.13.x, exact
-  clean pushed source, and `DAO.DBEngine.36` bindings remain unchanged
+- Environment: hosted A1 workflow dispatches `32434371779`, `32437968174`,
+  `32439806983`, and `32441192546` stopped in preflight or controller setup
+  before any worker ran. Dispatch `32442251143` bound the proven stock x86 DAO
+  image and ran one worker for approximately 30 minutes before the 1,800-second
+  worker ceiling terminated it. The original Windows, PowerShell 5.1, Python
+  3.13.x, exact clean pushed source, and `DAO.DBEngine.36` requirements remain
+  unchanged.
 - Protocol: preserve the complete `EXP-0037` scientific design and record the
   canonical mapping from each plan prose reason to the snake_case identifiers
   emitted by analysis reports; map the zero/multiple-survivor and record/inline
@@ -2847,12 +2852,22 @@ Use `not applicable` explicitly rather than omitting a field.
   recomputing validator exists and accepts the retained report and bundle
 - Artifacts: revision plan
   `oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json`, SHA-256
-  `4f35f1dbf977051f79eee3b84345dcbf3ced6e2aa64441879214012227213a77`;
+  `6967e72c0ea6c6aa68f102d76c48764a6300caebb4b6f7bbb2e0b931822b5b0c`;
   immutable original plan SHA-256
   `a7fa44cdb24b6f6e0d3884d478d7eef74685aa90ea12eacfff4b459b1da6ab80`
-- Observation: no A1 database, page capture, candidate set, bundle, or
-  scientific report exists. The original plan, schemas, and `a1_spec.py`
-  validation remain byte-for-byte unchanged.
+- Observation: none of the five dispatches produced or retained a checkpoint
+  observation, page capture, replica observation, candidate set, bundle, or
+  scientific report. Run `32442251143` retained only diagnostics artifact
+  `windows-dao-a1-diagnostics-32442251143-1`. The immutable original plan does
+  not define worker launch as acquisition start. For
+  `preregistration.acquisition_started` and its `amendment_rule`, this revision
+  treats acquisition as started when the first schema-valid replica observation
+  is retained for inspection, because that is the first preregistered
+  scientific artifact capable of informing a later amendment. A dispatch,
+  preflight or controller setup, or worker launch without a retained replica
+  observation does not meet that criterion; the flag therefore remains
+  `false`. The original plan, schemas, and `a1_spec.py` validation remain
+  byte-for-byte unchanged.
 - Interpretation: this amendment resolves representation and artifact-status
   conflicts before acquisition without changing a scientific condition or
   authorizing execution. A decisive analyzer result is not independently

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -2820,6 +2820,53 @@ Use `not applicable` explicitly rather than omitting a field.
   contract tests pass; scientific design and capacity audits require the
   pre-acquisition amendments listed above before any manual dispatch
 
+### EXP-0038 — Preregistered A1 report-interpretation amendment
+
+- Recorded: 2026-08-20, OpenAI Codex
+- Kind: additive pre-acquisition experiment-plan revision; no DAO acquisition,
+  physical-format result, or independent scientific validation
+- Question: How must the A1 campaign encode preregistered no-outcome reasons
+  and retain a decisive analysis while independent recomputation remains
+  unavailable?
+- Origin: project-authored revision
+  `DAO-A1-ALLOCATION-MAPS-001-R2`, derived only from the immutable `EXP-0037`
+  plan and analysis-report schema plus the fail-closed decisive-report rule in
+  the checked A1 contract; no MDB input, campaign output, donated fixture, or
+  third-party implementation was inspected
+- Environment: not executed; `preregistration.acquisition_started` remains
+  `false`, and the original x86 Windows, PowerShell 5.1, Python 3.13.x, exact
+  clean pushed source, and `DAO.DBEngine.36` bindings remain unchanged
+- Protocol: preserve the complete `EXP-0037` scientific design and record the
+  canonical mapping from each plan prose reason to the snake_case identifiers
+  emitted by analysis reports; map the zero/multiple-survivor and record/inline
+  ambiguity conditions to their two schema identifiers, forbid emission of the
+  schema-only `incomplete_transition_evidence` identifier, retain any decisive
+  analysis report, record bundle status
+  `decisive_pending_independent_validation`, and cap capability verification at
+  `not_independently_validated` until a separately provenanced independent
+  recomputing validator exists and accepts the retained report and bundle
+- Artifacts: revision plan
+  `oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json`, SHA-256
+  `4f35f1dbf977051f79eee3b84345dcbf3ced6e2aa64441879214012227213a77`;
+  immutable original plan SHA-256
+  `a7fa44cdb24b6f6e0d3884d478d7eef74685aa90ea12eacfff4b459b1da6ab80`
+- Observation: no A1 database, page capture, candidate set, bundle, or
+  scientific report exists. The original plan, schemas, and `a1_spec.py`
+  validation remain byte-for-byte unchanged.
+- Interpretation: this amendment resolves representation and artifact-status
+  conflicts before acquisition without changing a scientific condition or
+  authorizing execution. A decisive analyzer result is not independently
+  validated merely because the existing controller invokes `a1_contract.py`,
+  and this entry establishes no physical meaning, Rust correctness, DAO
+  compatibility, or support-matrix advancement.
+- Usage:
+  `file:oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json`;
+  `file:oracle/windows-dao/tests/test_a1_plan_contract.py`; future checked A1
+  analyzer, controller, bundle-status, and independent-validator work
+- Rights: project-authored plan revision and synthetic hash-pin test; no
+  Microsoft provider binary or generated MDB is redistributed
+- Review: pending independent review before any manual A1 dispatch
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json
+++ b/oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json
@@ -1,0 +1,95 @@
+{
+  "protocol_version": "1.0.0",
+  "document_type": "dao_a1_allocation_maps_plan_revision",
+  "revision_id": "DAO-A1-ALLOCATION-MAPS-001-R2",
+  "preregistration": {
+    "provenance_entry": "EXP-0038",
+    "recorded_utc_date": "2026-08-20",
+    "acquisition_started": false,
+    "revision_of": "DAO-A1-ALLOCATION-MAPS-001",
+    "original_plan": {
+      "path": "oracle/windows-dao/experiments/a1/a1-allocation-maps.plan.json",
+      "sha256": "a7fa44cdb24b6f6e0d3884d478d7eef74685aa90ea12eacfff4b459b1da6ab80"
+    },
+    "scientific_design_inherited_unchanged": [
+      "question",
+      "replicas",
+      "tables",
+      "checkpoint_design",
+      "page_capture",
+      "hypotheses",
+      "decision_rules",
+      "artifacts",
+      "bounds",
+      "claims"
+    ],
+    "revision_scope": "reconcile the preregistered no-outcome prose with the preregistered report identifiers and define fail-closed retention of a decisive report pending independent recomputation",
+    "amendment_rule": "after the first acquisition starts, any change requires a new experiment id, plan file, and provenance entry"
+  },
+  "decision_rule_reconciliation": {
+    "analysis_reports_emit": "report_identifiers",
+    "prose_to_report_identifiers": [
+      {
+        "plan_reason": "replica disagreement",
+        "report_identifiers": ["replica_disagreement"]
+      },
+      {
+        "plan_reason": "missing inline-to-indirect conversion",
+        "report_identifiers": ["missing_inline_to_indirect_conversion"]
+      },
+      {
+        "plan_reason": "any resource bound breach",
+        "report_identifiers": ["resource_bound_breach"]
+      },
+      {
+        "plan_reason": "zero or more than one surviving joint model",
+        "report_identifiers": [
+          "no_surviving_joint_model",
+          "multiple_surviving_joint_models"
+        ]
+      },
+      {
+        "plan_reason": "idle volatility",
+        "report_identifiers": ["idle_volatility"]
+      },
+      {
+        "plan_reason": "unreconstructable snapshot",
+        "report_identifiers": ["unreconstructable_snapshot"]
+      },
+      {
+        "plan_reason": "ambiguous record or inline boundary",
+        "report_identifiers": [
+          "ambiguous_record_boundary",
+          "ambiguous_inline_boundary"
+        ]
+      },
+      {
+        "plan_reason": "unexplained nonzero inline suffix",
+        "report_identifiers": ["unexplained_nonzero_inline_suffix"]
+      },
+      {
+        "plan_reason": "holdout prediction failure",
+        "report_identifiers": ["holdout_prediction_failure"]
+      }
+    ],
+    "schema_identifier_without_plan_condition": {
+      "report_identifier": "incomplete_transition_evidence",
+      "handling": "must_not_be_emitted"
+    }
+  },
+  "decisive_report_handling": {
+    "analysis_report_artifact": "retained",
+    "bundle_status": "decisive_pending_independent_validation",
+    "capability_verification_ceiling": "not_independently_validated",
+    "contract_validator_behavior": "a1_contract.py rejects a decisive report because it is not the separately provenanced independent recomputing validator; that rejection must not discard the retained analysis report",
+    "advancement_rule": "no capability may move past not_independently_validated until a separately provenanced independent recomputing validator exists and accepts the retained decisive report and its complete bundle"
+  },
+  "execution_effect": {
+    "original_plan_remains_immutable": true,
+    "original_schemas_remain_immutable": true,
+    "original_plan_validation_remains_immutable": true,
+    "acquisition_authorized": false,
+    "scientific_projection_changed": false,
+    "support_claim_changed": false
+  }
+}

--- a/oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json
+++ b/oracle/windows-dao/experiments/a1/a1-allocation-maps-r2.plan.json
@@ -6,6 +6,24 @@
     "provenance_entry": "EXP-0038",
     "recorded_utc_date": "2026-08-20",
     "acquisition_started": false,
+    "acquisition_start_criterion": "acquisition starts for amendment control when the first schema-valid replica observation is retained for inspection; a hosted dispatch, preflight or controller setup, or worker launch that retains no replica observation does not satisfy this criterion",
+    "prior_hosted_dispatches": {
+      "pre_worker_failures": [
+        32434371779,
+        32437968174,
+        32439806983,
+        32441192546
+      ],
+      "worker_timeout": {
+        "run_id": 32442251143,
+        "host": "proven stock x86 DAO image",
+        "worker_runtime": "approximately 30 minutes",
+        "worker_ceiling_seconds": 1800,
+        "retained_diagnostics_artifact": "windows-dao-a1-diagnostics-32442251143-1"
+      },
+      "retained_replica_observation": false,
+      "checkpoint_observation_page_capture_or_bundle_produced_or_retained": false
+    },
     "revision_of": "DAO-A1-ALLOCATION-MAPS-001",
     "original_plan": {
       "path": "oracle/windows-dao/experiments/a1/a1-allocation-maps.plan.json",

--- a/oracle/windows-dao/tests/test_a1_plan_contract.py
+++ b/oracle/windows-dao/tests/test_a1_plan_contract.py
@@ -31,6 +31,9 @@ from a1_spec import (  # noqa: E402
 )
 from protocol_validation import ValidationError, sha256  # noqa: E402
 
+REVISION_PLAN = CHECKED_PLAN.with_name("a1-allocation-maps-r2.plan.json")
+REVISION_PLAN_SHA256 = "4f35f1dbf977051f79eee3b84345dcbf3ced6e2aa64441879214012227213a77"
+
 
 class A1PlanContractTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -44,6 +47,9 @@ class A1PlanContractTests(unittest.TestCase):
         self.assertEqual(len(checked.checkpoint_ids), 71)
         self.assertEqual(checked.document["bounds"]["max_checkpoints_per_replica"], 72)
         self.assertFalse(checked.document["checkpoint_design"]["adaptive_checkpoints_allowed"])
+
+    def test_r2_amendment_hash_is_frozen(self) -> None:
+        self.assertEqual(sha256(REVISION_PLAN), REVISION_PLAN_SHA256)
 
     def test_roles_rotate_and_holdout_cannot_refit(self) -> None:
         checked = load_checked_plan()

--- a/oracle/windows-dao/tests/test_a1_plan_contract.py
+++ b/oracle/windows-dao/tests/test_a1_plan_contract.py
@@ -32,7 +32,7 @@ from a1_spec import (  # noqa: E402
 from protocol_validation import ValidationError, sha256  # noqa: E402
 
 REVISION_PLAN = CHECKED_PLAN.with_name("a1-allocation-maps-r2.plan.json")
-REVISION_PLAN_SHA256 = "4f35f1dbf977051f79eee3b84345dcbf3ced6e2aa64441879214012227213a77"
+REVISION_PLAN_SHA256 = "6967e72c0ea6c6aa68f102d76c48764a6300caebb4b6f7bbb2e0b931822b5b0c"
 
 
 class A1PlanContractTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a SHA-256-bound, pre-acquisition A1 R2 plan amendment without modifying the immutable original plan, schemas, or `a1_spec.py`
- canonically map the original prose no-outcome reasons to the analysis-report schema identifiers, including both split pairs, and prohibit `incomplete_transition_evidence` because no plan condition names it
- preregister retention of decisive analysis reports with bundle status `decisive_pending_independent_validation` and cap capability verification at `not_independently_validated` until a separately provenanced recomputing validator exists
- append `EXP-0038` and pin the amendment bytes in the focused A1 plan contract tests

## Context

This additive amendment resolves the two preregistration conflicts documented during review of PR #27. It does not authorize A1 acquisition or change a support claim.

## Verification

- `python3.13 -m unittest discover -s oracle/windows-dao/tests` — 400 passed, 80 skipped
- `python3.13 tools/reconcile_tests.py` — 236/236 reconciled
