### PR TITLE
fix: retain A1 worker progress on timeout

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -47,7 +47,8 @@ jobs:
             "oracle/windows-dao/scripts/run-a1-controlled.ps1",
             "oracle/windows-dao/scripts/a1/A1.Controller.ps1",
             "oracle/windows-dao/scripts/a1/A1.Worker.ps1",
-            "oracle/windows-dao/scripts/a1/A1.PageStore.ps1"
+            "oracle/windows-dao/scripts/a1/A1.PageStore.ps1",
+            "oracle/windows-dao/scripts/a1/A1.Progress.ps1"
           )
           foreach ($sourcePath in $sourcePaths) {
             $item = Get-Item -LiteralPath $sourcePath -Force
@@ -432,6 +433,7 @@ jobs:
                 "-RepositoryRoot", $repository,
                 "-EnvironmentPath", $environmentPath,
                 "-OutputRoot", $outputRoot,
+                "-DiagnosticsRoot", $diagnostics,
                 "-GitCommit", $env:GITHUB_SHA,
                 "-RunId", $runId
               )

--- a/oracle/windows-dao/scripts/a1/A1.Controller.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Controller.ps1
@@ -183,6 +183,7 @@ function Assert-A1RuntimeGate {
         "oracle/windows-dao/scripts/a1/A1.Controller.ps1",
         "oracle/windows-dao/scripts/a1/A1.Worker.ps1",
         "oracle/windows-dao/scripts/a1/A1.PageStore.ps1",
+        "oracle/windows-dao/scripts/a1/A1.Progress.ps1",
         "oracle/windows-dao/scripts/a1_contract.py"
     )) {
         $path = Join-Path $Repository $relative
@@ -316,11 +317,14 @@ function Invoke-A1ReplicaWorker {
         [Parameter(Mandatory = $true)][string]$PlanSha256,
         [Parameter(Mandatory = $true)][string]$EnvironmentPath,
         [Parameter(Mandatory = $true)][string]$EnvironmentSha256,
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
         [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$Replica,
         [Parameter(Mandatory = $true)][ValidateRange(1, 1800)][int]$TimeoutSeconds
     )
 
     Assert-A1WorkerPowerShell -Binding $Binding
+    $progressPath = New-A1ProgressFile -WorkingRoot $Session.WorkingPath `
+        -ReplicaOrdinal $Replica
     $arguments = @(
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", $WorkerPath, "-RepositoryRoot", $Context.RepositoryRoot,
@@ -342,11 +346,14 @@ function Invoke-A1ReplicaWorker {
     if ($commandLine.Length -gt 32766) {
         throw "A1 worker command line exceeds the Windows ceiling."
     }
-    Initialize-BoundedProcessJobNative
-    $launch = [Jet3BoundedProcessJobNative]::StartSuspendedInJob(
-        $Binding.path, $commandLine
-    )
+    $launch = $null
+    $primary = $null
+    $cleanupErrors = New-Object Collections.ArrayList
     try {
+        Initialize-BoundedProcessJobNative
+        $launch = [Jet3BoundedProcessJobNative]::StartSuspendedInJob(
+            $Binding.path, $commandLine
+        )
         $captured = Read-A1LongProcessOutput -Launch $launch `
             -TimeoutSeconds $TimeoutSeconds -MaximumOutputBytes 1MB
         if ($launch.ExitCode -ne 0) {
@@ -355,9 +362,37 @@ function Invoke-A1ReplicaWorker {
             throw "A1 replica worker failed: $detail"
         }
     }
+    catch { $primary = $_ }
     finally {
-        try { Stop-BoundedProcessJob -Launch $launch }
-        finally { $launch.Dispose() }
+        if ($null -ne $launch) {
+            try { Stop-BoundedProcessJob -Launch $launch }
+            catch { [void]$cleanupErrors.Add($_) }
+            try { $launch.Dispose() }
+            catch { [void]$cleanupErrors.Add($_) }
+        }
+        try {
+            [void](Copy-A1ProgressFile -SourcePath $progressPath `
+                -DiagnosticsRoot $DiagnosticsRoot -ReplicaOrdinal $Replica)
+        }
+        catch { [void]$cleanupErrors.Add($_) }
+    }
+    if ($null -ne $primary) {
+        if ($cleanupErrors.Count -ne 0) {
+            $detail = @($cleanupErrors | ForEach-Object {
+                $_.Exception.Message
+            }) -join "; "
+            if ($detail.Length -gt 2000) { $detail = $detail.Substring(0, 2000) }
+            throw ($primary.Exception.Message +
+                " A1 worker cleanup or progress retention also failed: " + $detail)
+        }
+        throw $primary
+    }
+    if ($cleanupErrors.Count -ne 0) {
+        $detail = @($cleanupErrors | ForEach-Object {
+            $_.Exception.Message
+        }) -join "; "
+        if ($detail.Length -gt 2000) { $detail = $detail.Substring(0, 2000) }
+        throw "A1 worker cleanup or progress retention failed: $detail"
     }
 }
 
@@ -477,16 +512,25 @@ function Invoke-A1Campaign {
         [Parameter(Mandatory = $true)][string]$RepositoryRoot,
         [Parameter(Mandatory = $true)][string]$EnvironmentPath,
         [Parameter(Mandatory = $true)][string]$OutputRoot,
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
         [Parameter(Mandatory = $true)][string]$GitCommit,
         [Parameter(Mandatory = $true)][string]$RunId
     )
 
     $repository = [IO.Path]::GetFullPath($RepositoryRoot)
+    $diagnostics = [IO.Path]::GetFullPath($DiagnosticsRoot)
+    Assert-M1NoReparseComponents -Path $diagnostics
+    $diagnosticsItem = Get-Item -LiteralPath $diagnostics -Force
+    if (-not $diagnosticsItem.PSIsContainer -or
+        ($diagnosticsItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "A1 diagnostics root is not a bounded ordinary directory."
+    }
     $executed = @(
         "oracle/windows-dao/scripts/run-a1-controlled.ps1",
         "oracle/windows-dao/scripts/a1/A1.Controller.ps1",
         "oracle/windows-dao/scripts/a1/A1.Worker.ps1",
         "oracle/windows-dao/scripts/a1/A1.PageStore.ps1",
+        "oracle/windows-dao/scripts/a1/A1.Progress.ps1",
         "oracle/windows-dao/scripts/a1_contract.py",
         "oracle/windows-dao/scripts/a1_bundle.py",
         "oracle/windows-dao/scripts/a1_analysis.py",
@@ -571,6 +615,7 @@ function Invoke-A1Campaign {
                 -PlanSha256 $planInput.sha256 `
                 -EnvironmentPath $stagedEnvironment `
                 -EnvironmentSha256 $a1EnvironmentSha `
+                -DiagnosticsRoot $diagnostics `
                 -Replica $replica `
                 -TimeoutSeconds (Get-A1CampaignAllowance -MaximumSeconds 1800)
             $observation = Get-M1PayloadPath -Session $session `

--- a/oracle/windows-dao/scripts/a1/A1.Progress.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Progress.ps1
@@ -1,0 +1,164 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:A1ProgressMaximumBytes = 1MB
+
+function Get-A1ProgressPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$ReplicaOrdinal
+    )
+
+    $root = [IO.Path]::GetFullPath($WorkingRoot)
+    return (Join-Path $root ("replica-{0:D2}.progress.jsonl" -f $ReplicaOrdinal))
+}
+
+function Assert-A1ProgressFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$WorkingRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$ReplicaOrdinal
+    )
+
+    $expected = Get-A1ProgressPath -WorkingRoot $WorkingRoot `
+        -ReplicaOrdinal $ReplicaOrdinal
+    $full = [IO.Path]::GetFullPath($Path)
+    if (-not $full.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "A1 progress path differs from its private worker binding."
+    }
+    Assert-M1NoReparseComponents -Path $full
+    $item = Get-Item -LiteralPath $full -Force
+    if ($item.PSIsContainer -or
+        ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or
+        $item.Length -gt $script:A1ProgressMaximumBytes) {
+        throw "A1 progress file violates its file or byte bound."
+    }
+    return $full
+}
+
+function New-A1ProgressFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$ReplicaOrdinal
+    )
+
+    $root = [IO.Path]::GetFullPath($WorkingRoot)
+    Assert-M1NoReparseComponents -Path $root
+    $path = Get-A1ProgressPath -WorkingRoot $root `
+        -ReplicaOrdinal $ReplicaOrdinal
+    $stream = New-Object IO.FileStream(
+        $path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write,
+        [IO.FileShare]::Read, 4096, [IO.FileOptions]::WriteThrough
+    )
+    try { $stream.Flush($true) }
+    finally { $stream.Dispose() }
+    return $path
+}
+
+function Open-A1WorkerProgress {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$ReplicaOrdinal
+    )
+
+    $path = Get-A1ProgressPath -WorkingRoot $WorkingRoot `
+        -ReplicaOrdinal $ReplicaOrdinal
+    $path = Assert-A1ProgressFile -Path $path -WorkingRoot $WorkingRoot `
+        -ReplicaOrdinal $ReplicaOrdinal
+    return [pscustomobject]@{
+        Path = $path
+        Clock = [Diagnostics.Stopwatch]::StartNew()
+    }
+}
+
+function Add-A1ProgressRecord {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Progress,
+        [Parameter(Mandatory = $true)][string]$CheckpointId,
+        [Parameter(Mandatory = $true)][long]$PageCount
+    )
+
+    $document = [ordered]@{
+        checkpoint_id = $CheckpointId
+        elapsed_seconds = [Math]::Round(
+            [double]$Progress.Clock.Elapsed.TotalSeconds, 3
+        )
+        page_count = $PageCount
+    }
+    $json = $document | ConvertTo-Json -Depth 3 -Compress
+    $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes($json + "`n")
+    if ($bytes.Length -gt 4096) {
+        throw "A1 checkpoint progress record exceeds its line bound."
+    }
+    $stream = New-Object IO.FileStream(
+        $Progress.Path, [IO.FileMode]::Open, [IO.FileAccess]::Write,
+        ([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete), 4096,
+        [IO.FileOptions]::WriteThrough
+    )
+    try {
+        if ($stream.Length -gt ($script:A1ProgressMaximumBytes - $bytes.Length)) {
+            throw "A1 checkpoint progress exceeds its byte ceiling."
+        }
+        [void]$stream.Seek(0, [IO.SeekOrigin]::End)
+        $stream.Write($bytes, 0, $bytes.Length)
+        $stream.Flush($true)
+    }
+    finally { $stream.Dispose() }
+}
+
+function Copy-A1ProgressFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourcePath,
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$ReplicaOrdinal
+    )
+
+    Assert-M1NoReparseComponents -Path $SourcePath
+    $sourceItem = Get-Item -LiteralPath $SourcePath -Force
+    if ($sourceItem.PSIsContainer -or
+        ($sourceItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or
+        $sourceItem.Length -gt $script:A1ProgressMaximumBytes) {
+        throw "A1 retained progress source violates its byte or file bound."
+    }
+    $diagnostics = [IO.Path]::GetFullPath($DiagnosticsRoot)
+    Assert-M1NoReparseComponents -Path $diagnostics
+    $diagnosticsItem = Get-Item -LiteralPath $diagnostics -Force
+    if (-not $diagnosticsItem.PSIsContainer -or
+        ($diagnosticsItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "A1 diagnostics root is not a bounded ordinary directory."
+    }
+    $retained = [long]0
+    foreach ($path in [IO.Directory]::EnumerateFiles(
+        $diagnostics, "replica-*.progress.jsonl", [IO.SearchOption]::TopDirectoryOnly
+    )) {
+        Assert-M1NoReparseComponents -Path $path
+        $retained += [long](Get-Item -LiteralPath $path -Force).Length
+    }
+    if ($sourceItem.Length -gt ($script:A1ProgressMaximumBytes - $retained)) {
+        throw "A1 retained progress exceeds its aggregate byte ceiling."
+    }
+    $destination = Join-Path $diagnostics `
+        ("replica-{0:D2}.progress.jsonl" -f $ReplicaOrdinal)
+    $input = New-Object IO.FileStream(
+        $SourcePath, [IO.FileMode]::Open, [IO.FileAccess]::Read,
+        ([IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete), 4096,
+        [IO.FileOptions]::SequentialScan
+    )
+    $output = $null
+    try {
+        $output = New-Object IO.FileStream(
+            $destination, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write,
+            [IO.FileShare]::Read, 4096, [IO.FileOptions]::WriteThrough
+        )
+        $buffer = New-Object byte[] 4096
+        while (($read = $input.Read($buffer, 0, $buffer.Length)) -gt 0) {
+            $output.Write($buffer, 0, $read)
+        }
+        $output.Flush($true)
+    }
+    finally {
+        if ($null -ne $output) { $output.Dispose() }
+        $input.Dispose()
+    }
+    return $destination
+}

--- a/oracle/windows-dao/scripts/a1/A1.Worker.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Worker.ps1
@@ -18,9 +18,9 @@ $m1Root = Join-Path $RepositoryRoot "oracle/windows-dao/scripts/m1"
 . (Join-Path $m1Root "M1.Publication.ps1")
 . (Join-Path $m1Root "M1.DaoValues.ps1")
 . (Join-Path $PSScriptRoot "A1.PageStore.ps1")
+. (Join-Path $PSScriptRoot "A1.Progress.ps1")
 $script:A1ExperimentId = "DAO-A1-ALLOCATION-MAPS-001"
-$script:A1FrozenPlanSha256 = `
-    "a7fa44cdb24b6f6e0d3884d478d7eef74685aa90ea12eacfff4b459b1da6ab80"
+$script:A1FrozenPlanSha256 = "a7fa44cdb24b6f6e0d3884d478d7eef74685aa90ea12eacfff4b459b1da6ab80"
 $script:A1DbVersion30 = 32
 # SRC-0021 records these public DAO enumeration values for the oracle only.
 $script:A1DbLong = 4
@@ -565,6 +565,7 @@ function Add-A1Checkpoint {
     })
     $script:A1PriorHashes = [string[]]$snapshot.hashes
     $script:A1PriorCheckpoint = $CheckpointId
+    Add-A1ProgressRecord -Progress $script:A1Progress -CheckpointId $CheckpointId -PageCount ([long]$snapshot.page_count)
 }
 function Add-A1UntilTarget {
     param(
@@ -701,6 +702,7 @@ function Invoke-A1Worker {
     Assert-M1NoReparseComponents -Path $repository
     Assert-M1NoReparseComponents -Path $bundle
     Assert-M1NoReparseComponents -Path $working
+    $script:A1Progress = Open-A1WorkerProgress -WorkingRoot $working -ReplicaOrdinal $ReplicaOrdinal
     $session = [pscustomobject]@{ StagingBundle = $bundle }
     $replicaId = "replica-{0:D2}" -f $ReplicaOrdinal
     $replicaRoot = Join-Path $working $replicaId
@@ -727,7 +729,6 @@ function Invoke-A1Worker {
     $script:A1PriorHashes = $null
     $script:A1PriorCheckpoint = $null
     $script:A1Store = New-A1PageStore -Session $session
-
     $engine = $null
     $workspaces = $null
     $workspace = $null
@@ -794,6 +795,5 @@ function Invoke-A1Worker {
 Invoke-A1Worker -RepositoryRoot $RepositoryRoot -BundleRoot $BundleRoot `
     -WorkingRoot $WorkingRoot -PlanPath $PlanPath `
     -EnvironmentPath $EnvironmentPath -ProducerCommit $ProducerCommit `
-    -RunId $RunId `
-    -PlanSha256 $PlanSha256 -EnvironmentSha256 $EnvironmentSha256 `
-    -ReplicaOrdinal $ReplicaOrdinal
+    -RunId $RunId -PlanSha256 $PlanSha256 `
+    -EnvironmentSha256 $EnvironmentSha256 -ReplicaOrdinal $ReplicaOrdinal

--- a/oracle/windows-dao/scripts/run-a1-controlled.ps1
+++ b/oracle/windows-dao/scripts/run-a1-controlled.ps1
@@ -3,6 +3,7 @@ param(
     [Parameter(Mandatory = $true)][string]$RepositoryRoot,
     [Parameter(Mandatory = $true)][string]$EnvironmentPath,
     [Parameter(Mandatory = $true)][string]$OutputRoot,
+    [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
     [Parameter(Mandatory = $true)][string]$GitCommit,
     [Parameter(Mandatory = $true)][string]$RunId
 )
@@ -110,6 +111,7 @@ $sources = @(
     "oracle/windows-dao/scripts/a1/A1.Controller.ps1",
     "oracle/windows-dao/scripts/a1/A1.Worker.ps1",
     "oracle/windows-dao/scripts/a1/A1.PageStore.ps1",
+    "oracle/windows-dao/scripts/a1/A1.Progress.ps1",
     "oracle/windows-dao/scripts/a1_contract.py",
     "oracle/windows-dao/scripts/a1_bundle.py",
     "oracle/windows-dao/scripts/a1_analysis.py",
@@ -146,9 +148,12 @@ try {
     . (Join-Path $repository `
         "oracle/windows-dao/scripts/m1/M1.DaoValues.ps1")
     . (Join-Path $repository `
+        "oracle/windows-dao/scripts/a1/A1.Progress.ps1")
+    . (Join-Path $repository `
         "oracle/windows-dao/scripts/a1/A1.Controller.ps1")
     $published = Invoke-A1Campaign -RepositoryRoot $repository `
         -EnvironmentPath $EnvironmentPath -OutputRoot $OutputRoot `
+        -DiagnosticsRoot $DiagnosticsRoot `
         -GitCommit $GitCommit -RunId $RunId
     Write-Output "PASS: retained A1 campaign at $published"
     exit 0

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -12,6 +12,7 @@ ENTRY = SCRIPTS / "run-a1-controlled.ps1"
 CONTROLLER = A1 / "A1.Controller.ps1"
 WORKER = A1 / "A1.Worker.ps1"
 PAGE_STORE = A1 / "A1.PageStore.ps1"
+PROGRESS = A1 / "A1.Progress.ps1"
 PLAN = ROOT / "experiments" / "a1" / "a1-allocation-maps.plan.json"
 
 
@@ -22,9 +23,10 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         cls.controller = CONTROLLER.read_text(encoding="utf-8")
         cls.worker = WORKER.read_text(encoding="utf-8")
         cls.page_store = PAGE_STORE.read_text(encoding="utf-8")
+        cls.progress = PROGRESS.read_text(encoding="utf-8")
         cls.plan = json.loads(PLAN.read_text(encoding="utf-8"))
         cls.combined = "\n".join(
-            (cls.entry, cls.controller, cls.worker, cls.page_store)
+            (cls.entry, cls.controller, cls.worker, cls.page_store, cls.progress)
         )
 
     def test_exact_replica_and_checkpoint_schedule_is_plan_driven(self) -> None:
@@ -89,6 +91,28 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         )
         self.assertIn("A1 DAO lock companion remains after close", self.worker)
         self.assertIn("retained_for_physical_analysis = $false", self.worker)
+
+    def test_checkpoint_progress_is_flushed_and_retained_on_worker_failure(self) -> None:
+        for field in ("checkpoint_id", "elapsed_seconds", "page_count"):
+            with self.subTest(field=field):
+                self.assertIn(field, self.progress)
+        self.assertIn("$stream.Flush($true)", self.progress)
+        self.assertIn("$script:A1ProgressMaximumBytes = 1MB", self.progress)
+        self.assertIn("replica-*.progress.jsonl", self.progress)
+        self.assertIn("Open-A1WorkerProgress", self.worker)
+        checkpoint = self.worker.index("function Add-A1Checkpoint")
+        progress = self.worker.index("Add-A1ProgressRecord", checkpoint)
+        prior = self.worker.index("$script:A1PriorCheckpoint = $CheckpointId", checkpoint)
+        self.assertLess(prior, progress)
+        invoke = self.controller.index("function Invoke-A1ReplicaWorker")
+        end = self.controller.index("function Get-A1FileRecord", invoke)
+        worker = self.controller[invoke:end]
+        self.assertLess(worker.index("New-A1ProgressFile"), worker.index("StartSuspendedInJob"))
+        self.assertIn("catch { $primary = $_ }", worker)
+        finally_block = worker[worker.index("finally {") :]
+        self.assertIn("Copy-A1ProgressFile", finally_block)
+        self.assertIn("-DiagnosticsRoot $DiagnosticsRoot", finally_block)
+        self.assertIn("[Parameter(Mandatory = $true)][string]$DiagnosticsRoot", self.entry)
 
     def test_growth_targets_are_crossed_only_by_fixed_batches(self) -> None:
         self.assertIn("do {", self.worker)
@@ -234,7 +258,7 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         self.assertIn('Label "A1 table deletion"', self.worker)
 
     def test_production_scripts_stay_below_800_lines(self) -> None:
-        for path in (ENTRY, CONTROLLER, WORKER, PAGE_STORE):
+        for path in (ENTRY, CONTROLLER, WORKER, PAGE_STORE, PROGRESS):
             with self.subTest(path=path.name):
                 self.assertLess(
                     len(path.read_text(encoding="utf-8").splitlines()), 800

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -51,6 +51,7 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
             "oracle/windows-dao/scripts/a1/A1.Controller.ps1",
             "oracle/windows-dao/scripts/a1/A1.Worker.ps1",
             "oracle/windows-dao/scripts/a1/A1.PageStore.ps1",
+            "oracle/windows-dao/scripts/a1/A1.Progress.ps1",
         ):
             self.assertEqual(self.parse_step.count(path), 1)
         for forbidden in ("Start-Process", "Invoke-A1", "Invoke-Jet3", "& "):
@@ -252,6 +253,7 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
 
     def test_campaign_and_independent_bundle_validator_are_exactly_bound(self) -> None:
         self.assertEqual(self.workflow.count("run-a1-controlled.ps1"), 2)
+        self.assertIn('"-DiagnosticsRoot", $diagnostics', self.workflow)
         self.assertIn("from a1_bundle import validate_bundle", self.workflow)
         self.assertIn('manifest["producer_commit"] != sys.argv[2]', self.workflow)
         self.assertIn('manifest["run_id"] != sys.argv[3]', self.workflow)


### PR DESCRIPTION
## Summary

- write one durable JSONL progress record after every completed A1 checkpoint, containing checkpoint_id, elapsed_seconds, and page_count
- copy each partial replica progress file into hosted diagnostics from the controller cleanup path, including timeout and worker-failure paths
- cap each record, each source file, and all retained replica progress at the existing 1 MiB child-output ceiling
- keep the preregistered plan, ledger, 1800-second worker timeout, 7200-second campaign timeout, and 7500-second hosted timeout unchanged

## Root cause

Run 32442251143 contains an empty campaign stdout and only the controller timeout in stderr, so it cannot identify the last completed checkpoint. The worker has no Start-Sleep, CompactDatabase, stdin read, or interactive prompt. Its cost comes from Add-A1UntilTarget: every 32-row batch opens and closes DAO, forces GC and finalizers, and checks the closed file size; the loop has no time or iteration limit and stops only after Jet grows to the requested page threshold or the 200000-row ceiling is reached.

Every one of the 71 checkpoints also recomputes expected semantic hashes, opens and scans every extant DAO table, and snapshots and SHA-256 hashes every database page. With zero overshoot and minimum baselines, the fixed schedule reaches 17760 pages and snapshots at least 604202 pages, or 1237405696 bytes. At an estimated six to eight fixed 240-character rows per page, it performs roughly 110388 to 147184 inserts in 3450 to 4600 DAO batches and scans roughly 3.57 to 4.76 million DAO rows during checkpoint readback, in addition to the in-memory expected-hash pass.

The observed honest duration therefore exceeds the frozen 1800-second worker ceiling. This PR does not raise that ceiling because the checked plan fixes it; completing acquisition will require a separately reviewed performance/design change or plan amendment after the retained progress identifies the exact slow phase.

## Diagnostics behavior

The controller creates a private progress file before launch. The worker appends one UTF-8 JSON line and Flush(true) after each checkpoint is fully retained. After process termination, the controller copies the bounded file into jet3-a1-diagnostics before the campaign cleanup removes private staging, so the always-uploaded diagnostics artifact preserves partial progress without retaining MDB or page-store data.

## Verification

- python3.13 -m unittest oracle/windows-dao/tests/test_a1_powershell_contract.py oracle/windows-dao/tests/test_windows_dao_a1_workflow.py -v: 23 passed
- python3.13 -m unittest discover -s oracle/windows-dao/tests: 400 passed, 80 skipped
- git diff --check: passed

No preregistered plan, schema, bound, or provenance ledger was changed.