### PR TITLE
perf: reduce A1 worker checkpoint overhead

### DIFF
--- a/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
@@ -7,6 +7,7 @@ $script:A1MaximumUniqueBlobs = 262144L
 $script:A1MaximumPageStoreBytes = 512MB
 $script:A1MaximumChangedEntries = 1500000L
 $script:A1MaximumLogicalReadBytes = 8GB
+$script:A1StrictUtf8 = New-Object Text.UTF8Encoding($false, $true)
 
 function Read-A1CheckedJson {
     param(
@@ -44,6 +45,45 @@ function Get-A1LowerSha256 {
         )).Replace("-", "").ToLowerInvariant()
     }
     finally { $hash.Dispose() }
+}
+
+function New-A1IncrementalSha256 {
+    return [Security.Cryptography.IncrementalHash]::CreateHash(
+        [Security.Cryptography.HashAlgorithmName]::SHA256
+    )
+}
+
+function Add-A1SemanticHashRow {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Security.Cryptography.IncrementalHash]$Hash,
+        [Parameter(Mandatory = $true)][int]$Id,
+        [Parameter(Mandatory = $true)][string]$Payload
+    )
+
+    if (-not [BitConverter]::IsLittleEndian) {
+        throw "A1 rolling hash requires an explicitly little-endian host."
+    }
+    $payloadBytes = $script:A1StrictUtf8.GetBytes($Payload)
+    if ($payloadBytes.Length -gt [uint16]::MaxValue) {
+        throw "A1 semantic payload exceeds its rolling-hash length field."
+    }
+    # tables.row_algorithm.rolling_sha256 fixes this exact byte encoding;
+    # one incremental .NET hash instance preserves it across every ordered row.
+    $Hash.AppendData([BitConverter]::GetBytes([int]$Id))
+    $Hash.AppendData([BitConverter]::GetBytes([uint16]$payloadBytes.Length))
+    $Hash.AppendData($payloadBytes)
+}
+
+function Complete-A1IncrementalSha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Security.Cryptography.IncrementalHash]$Hash
+    )
+
+    return ([BitConverter]::ToString(
+        $Hash.GetHashAndReset()
+    )).Replace("-", "").ToLowerInvariant()
 }
 
 function Get-A1PageBlobLocator {
@@ -107,16 +147,16 @@ function Assert-A1ExistingPageBlob {
 function Add-A1PageBlob {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Store,
-        [Parameter(Mandatory = $true)][byte[]]$Page
+        [Parameter(Mandatory = $true)][byte[]]$Page,
+        [Parameter(Mandatory = $true)][string]$Sha256
     )
 
     if ($Page.LongLength -ne $script:A1PageBytes) {
         throw "A1 page store accepts only exact 2048-byte pages."
     }
-    $sha = Get-A1LowerSha256 -Bytes $Page
-    $locator = Get-A1PageBlobLocator -Sha256 $sha
+    $locator = Get-A1PageBlobLocator -Sha256 $Sha256
     $path = Get-M1PayloadPath -Session $Store.Session -RelativePath $locator
-    if (-not $Store.Seen.Contains($sha)) {
+    if (-not $Store.Seen.Contains($Sha256)) {
         if ($Store.Seen.Count -ge $script:A1MaximumUniqueBlobs -or
             $Store.UniqueBytes -gt (
                 $script:A1MaximumPageStoreBytes - $script:A1PageBytes
@@ -124,7 +164,7 @@ function Add-A1PageBlob {
             throw "A1 page store exceeded its preregistered ceiling."
         }
         if ([IO.File]::Exists($path)) {
-            Assert-A1ExistingPageBlob -Path $path -ExpectedSha256 $sha
+            Assert-A1ExistingPageBlob -Path $path -ExpectedSha256 $Sha256
         }
         else {
             try {
@@ -133,10 +173,11 @@ function Add-A1PageBlob {
             }
             catch [IO.IOException] {
                 if (-not [IO.File]::Exists($path)) { throw }
-                Assert-A1ExistingPageBlob -Path $path -ExpectedSha256 $sha
+                Assert-A1ExistingPageBlob -Path $path `
+                    -ExpectedSha256 $Sha256
             }
         }
-        [void]$Store.Seen.Add($sha)
+        [void]$Store.Seen.Add($Sha256)
         $Store.UniqueBytes = [long](
             $Store.UniqueBytes + $script:A1PageBytes
         )
@@ -144,7 +185,6 @@ function Add-A1PageBlob {
             $Store.RetainedBytes + $script:A1PageBytes
         )
     }
-    return $sha
 }
 
 function New-A1PageStore {
@@ -199,19 +239,154 @@ function New-A1PageStore {
     }
 }
 
+function Set-A1ExpectedSemanticDirty {
+    param([Parameter(Mandatory = $true)][string]$Role)
+    [void]$script:A1ExpectedSemanticCache.Remove($Role)
+}
+
+function Get-A1ExpectedSemanticResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)]$Rows
+    )
+
+    if ($script:A1ExpectedSemanticCache.ContainsKey($Role)) {
+        return $script:A1ExpectedSemanticCache[$Role]
+    }
+    $hash = New-A1IncrementalSha256
+    try {
+        foreach ($id in @($Rows | Sort-Object)) {
+            Add-A1SemanticHashRow -Hash $hash -Id ([int]$id) `
+                -Payload (Get-A1Payload -Role $Role -Id ([int]$id))
+        }
+        # tables.row_algorithm.reread_requirement compares the same expected
+        # count/digest; every role mutation invalidates this deterministic cache.
+        $result = [pscustomobject]@{
+            count = [int]$Rows.Count
+            sha256 = Complete-A1IncrementalSha256 -Hash $hash
+        }
+        $script:A1ExpectedSemanticCache[$Role] = $result
+        return $result
+    }
+    finally { $hash.Dispose() }
+}
+
+function Read-A1SemanticTable {
+    param(
+        [Parameter(Mandatory = $true)][object]$Database,
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][pscustomobject]$Expected
+    )
+
+    $name = [string]$script:A1RoleNames[$Role]
+    $rows = $script:A1Rows[$Role]
+    $recordset = $null
+    $fields = $null
+    $idField = $null
+    $payloadField = $null
+    $hash = $null
+    $cleanup = New-Object Collections.ArrayList
+    $primary = $null
+    $count = 0
+    $prior = 0
+    $digest = $null
+    try {
+        $sql = "SELECT Id, Payload FROM [$name] ORDER BY Id"
+        $recordset = $Database.OpenRecordset(
+            $sql, $script:A1DbOpenSnapshot
+        )
+        # tables.row_algorithm.reread_requirement fixes Id-order values;
+        # field COM objects can be cached for this recordset without changing them.
+        $fields = $recordset.Fields
+        $idField = $fields.Item("Id")
+        $payloadField = $fields.Item("Payload")
+        $hash = New-A1IncrementalSha256
+        if (-not $recordset.EOF) { $recordset.MoveFirst() }
+        while (-not $recordset.EOF) {
+            $id = [int]$idField.Value
+            $payload = [string]$payloadField.Value
+            if ($id -le $prior -or -not $rows.Contains($id) -or
+                $payload -cne (Get-A1Payload -Role $Role -Id $id)) {
+                throw "A1 DAO semantic readback differs from expected rows."
+            }
+            Add-A1SemanticHashRow -Hash $hash -Id $id -Payload $payload
+            $prior = $id
+            $count++
+            $recordset.MoveNext()
+        }
+        $digest = Complete-A1IncrementalSha256 -Hash $hash
+    }
+    catch { $primary = $_ }
+    finally {
+        if ($null -ne $hash) { $hash.Dispose() }
+        Release-M1ComObject -Value $payloadField -CleanupErrors $cleanup `
+            -Label "A1 payload field release"
+        Release-M1ComObject -Value $idField -CleanupErrors $cleanup `
+            -Label "A1 id field release"
+        Release-M1ComObject -Value $fields -CleanupErrors $cleanup `
+            -Label "A1 semantic fields release"
+        Close-M1ComObject -Value $recordset -CleanupErrors $cleanup `
+            -Label "A1 semantic recordset close"
+        Release-M1ComObject -Value $recordset -CleanupErrors $cleanup `
+            -Label "A1 semantic recordset release"
+    }
+    Complete-M1DaoHelper -PrimaryError $primary -CleanupErrors $cleanup `
+        -Label "A1 semantic readback"
+    if ($count -ne [int]$Expected.count -or
+        $digest -cne [string]$Expected.sha256) {
+        throw "A1 semantic row count or rolling digest differs from expectation."
+    }
+    return [ordered]@{
+        role = $Role
+        row_count = $count
+        rolling_sha256 = $digest
+    }
+}
+
+function Read-A1SemanticTables {
+    $expectedByRole = @{}
+    foreach ($role in @("D", "L", "P", "H")) {
+        if ([bool]$script:A1Extant[$role]) {
+            $expectedByRole[$role] = Get-A1ExpectedSemanticResult `
+                -Role $role -Rows $script:A1Rows[$role]
+        }
+    }
+    # tables.row_algorithm.reread_requirement still reads every extant table;
+    # the closed checkpoint needs no database close between those ordered scans.
+    $documents = Invoke-A1WithDatabase -Action {
+        param($database)
+        foreach ($role in @("D", "L", "P", "H")) {
+            if ([bool]$script:A1Extant[$role]) {
+                Read-A1SemanticTable -Database $database -Role $role `
+                    -Expected $expectedByRole[$role]
+            }
+        }
+    }
+    return @($documents)
+}
+
 function Read-A1PageSnapshot {
     param(
         [Parameter(Mandatory = $true)][pscustomobject]$Store,
         [Parameter(Mandatory = $true)][string]$DatabasePath,
-        [AllowNull()][string[]]$PriorHashes
+        [AllowNull()][string[]]$PriorHashes,
+        [AllowNull()][byte[][]]$PriorPages
     )
 
     Assert-M1NoReparseComponents -Path $DatabasePath
+    if (($null -eq $PriorHashes) -ne ($null -eq $PriorPages) -or
+        ($null -ne $PriorHashes -and
+            $PriorHashes.Count -ne $PriorPages.Count) -or
+        ($null -ne $PriorPages -and
+            $PriorPages.Count -gt $script:A1MaximumPagesPerReplica)) {
+        throw "A1 prior snapshot cache is incomplete or exceeds its bound."
+    }
     $stream = New-Object IO.FileStream(
         $DatabasePath, [IO.FileMode]::Open, [IO.FileAccess]::Read,
         [IO.FileShare]::None, 65536, [IO.FileOptions]::SequentialScan
     )
     $fileHash = $null
+    $pageHash = $null
     try {
         if ($stream.Length -lt $script:A1PageBytes -or
             ($stream.Length % $script:A1PageBytes) -ne 0) {
@@ -226,9 +401,14 @@ function Read-A1PageSnapshot {
         }
         $hashes = New-Object 'Collections.Generic.List[string]' `
             ([int]$pageCount)
+        $pages = New-Object 'Collections.Generic.List[byte[]]' `
+            ([int]$pageCount)
         $changed = New-Object Collections.ArrayList
-        $page = New-Object byte[] ([int]$script:A1PageBytes)
         $fileHash = [Security.Cryptography.SHA256]::Create()
+        $pageHash = [Security.Cryptography.SHA256]::Create()
+        $pageComparer = `
+            [Collections.StructuralComparisons]::StructuralEqualityComparer
+        $page = New-Object byte[] ([int]$script:A1PageBytes)
         for ($index = 0L; $index -lt $pageCount; $index++) {
             $offset = 0
             while ($offset -lt $page.Length) {
@@ -239,8 +419,36 @@ function Read-A1PageSnapshot {
             [void]$fileHash.TransformBlock(
                 $page, 0, $page.Length, $page, 0
             )
-            $sha = Add-A1PageBlob -Store $Store -Page $page
+            # page-index.schema database_sha256 is streamed during the same
+            # page_capture.checkpoint_representation read.
+            $unchanged = $false
+            if ($null -ne $PriorPages -and $index -lt $PriorPages.Count) {
+                $priorPage = [byte[]]$PriorPages[[int]$index]
+                if ($priorPage.LongLength -ne $script:A1PageBytes) {
+                    throw "A1 prior snapshot cache contains a non-page."
+                }
+                # page_capture.checkpoint_representation requires exact ordered
+                # hashes; byte equality alone permits reuse of the prior digest.
+                $unchanged = $pageComparer.Equals($page, $priorPage)
+            }
+            if ($unchanged) {
+                $sha = [string]$PriorHashes[[int]$index]
+                [void]$pages.Add($priorPage)
+            }
+            else {
+                $sha = ([BitConverter]::ToString(
+                    $pageHash.ComputeHash($page)
+                )).Replace("-", "").ToLowerInvariant()
+                # page_capture.store uses this digest for the exact blob name.
+                Add-A1PageBlob -Store $Store -Page $page -Sha256 $sha
+                $retainedPage = New-Object byte[] ([int]$script:A1PageBytes)
+                [Buffer]::BlockCopy(
+                    $page, 0, $retainedPage, 0, $retainedPage.Length
+                )
+                [void]$pages.Add($retainedPage)
+            }
             $hashes.Add($sha)
+            # page-index.schema changed_page_indices is the ordered-hash delta.
             if ($null -eq $PriorHashes -or $index -ge $PriorHashes.Count -or
                 $PriorHashes[[int]$index] -cne $sha) {
                 if ($Store.ChangedEntries + $changed.Count -ge
@@ -284,9 +492,11 @@ function Read-A1PageSnapshot {
             page_count = $pageCount
             changed_pages = @($changed)
             hashes = $hashes.ToArray()
+            pages = $pages.ToArray()
         }
     }
     finally {
+        if ($null -ne $pageHash) { $pageHash.Dispose() }
         if ($null -ne $fileHash) { $fileHash.Dispose() }
         $stream.Dispose()
     }

--- a/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
@@ -47,16 +47,14 @@ function Get-A1LowerSha256 {
     finally { $hash.Dispose() }
 }
 
-function New-A1IncrementalSha256 {
-    return [Security.Cryptography.IncrementalHash]::CreateHash(
-        [Security.Cryptography.HashAlgorithmName]::SHA256
-    )
+function New-A1SemanticSha256 {
+    return [Security.Cryptography.SHA256]::Create()
 }
 
 function Add-A1SemanticHashRow {
     param(
         [Parameter(Mandatory = $true)]
-        [Security.Cryptography.IncrementalHash]$Hash,
+        [Security.Cryptography.HashAlgorithm]$Hash,
         [Parameter(Mandatory = $true)][int]$Id,
         [Parameter(Mandatory = $true)][string]$Payload
     )
@@ -69,20 +67,26 @@ function Add-A1SemanticHashRow {
         throw "A1 semantic payload exceeds its rolling-hash length field."
     }
     # tables.row_algorithm.rolling_sha256 fixes this exact byte encoding;
-    # one incremental .NET hash instance preserves it across every ordered row.
-    $Hash.AppendData([BitConverter]::GetBytes([int]$Id))
-    $Hash.AppendData([BitConverter]::GetBytes([uint16]$payloadBytes.Length))
-    $Hash.AppendData($payloadBytes)
+    # one reusable SHA256 instance preserves it across every ordered row.
+    foreach ($part in @(
+        [BitConverter]::GetBytes([int]$Id),
+        [BitConverter]::GetBytes([uint16]$payloadBytes.Length),
+        $payloadBytes
+    )) {
+        [void]$Hash.TransformBlock($part, 0, $part.Length, $part, 0)
+    }
 }
 
-function Complete-A1IncrementalSha256 {
+function Complete-A1SemanticSha256 {
     param(
         [Parameter(Mandatory = $true)]
-        [Security.Cryptography.IncrementalHash]$Hash
+        [Security.Cryptography.HashAlgorithm]$Hash
     )
 
+    $empty = New-Object byte[] 0
+    [void]$Hash.TransformFinalBlock($empty, 0, 0)
     return ([BitConverter]::ToString(
-        $Hash.GetHashAndReset()
+        $Hash.Hash
     )).Replace("-", "").ToLowerInvariant()
 }
 
@@ -253,7 +257,7 @@ function Get-A1ExpectedSemanticResult {
     if ($script:A1ExpectedSemanticCache.ContainsKey($Role)) {
         return $script:A1ExpectedSemanticCache[$Role]
     }
-    $hash = New-A1IncrementalSha256
+    $hash = New-A1SemanticSha256
     try {
         foreach ($id in @($Rows | Sort-Object)) {
             Add-A1SemanticHashRow -Hash $hash -Id ([int]$id) `
@@ -263,7 +267,7 @@ function Get-A1ExpectedSemanticResult {
         # count/digest; every role mutation invalidates this deterministic cache.
         $result = [pscustomobject]@{
             count = [int]$Rows.Count
-            sha256 = Complete-A1IncrementalSha256 -Hash $hash
+            sha256 = Complete-A1SemanticSha256 -Hash $hash
         }
         $script:A1ExpectedSemanticCache[$Role] = $result
         return $result
@@ -300,7 +304,7 @@ function Read-A1SemanticTable {
         $fields = $recordset.Fields
         $idField = $fields.Item("Id")
         $payloadField = $fields.Item("Payload")
-        $hash = New-A1IncrementalSha256
+        $hash = New-A1SemanticSha256
         if (-not $recordset.EOF) { $recordset.MoveFirst() }
         while (-not $recordset.EOF) {
             $id = [int]$idField.Value
@@ -314,7 +318,7 @@ function Read-A1SemanticTable {
             $count++
             $recordset.MoveNext()
         }
-        $digest = Complete-A1IncrementalSha256 -Hash $hash
+        $digest = Complete-A1SemanticSha256 -Hash $hash
     }
     catch { $primary = $_ }
     finally {

--- a/oracle/windows-dao/scripts/a1/A1.Worker.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Worker.ps1
@@ -497,6 +497,9 @@ function Add-A1UntilTarget {
     )
     do {
         Add-A1RowBatch -Role $Role
+        # checkpoint_design growth rules require the first fully quiescent
+        # closed-file state after each exact 32-row candidate batch.
+        Assert-A1Quiescent
         $pages = Get-A1ClosedPageCount
     } while ($pages -lt $ThresholdPages)
 }

--- a/oracle/windows-dao/scripts/a1/A1.Worker.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Worker.ps1
@@ -98,72 +98,6 @@ function Get-A1Payload {
     while ($builder.Length -lt 240) { [void]$builder.Append($seed) }
     return $builder.ToString(0, 240)
 }
-function Get-A1FieldValue {
-    param([object]$Recordset, [string]$Name)
-    $fields = $null
-    $field = $null
-    try {
-        $fields = $Recordset.Fields
-        $field = $fields.Item($Name)
-        return $field.Value
-    }
-    finally {
-        Release-M1ComObject -Value $field
-        Release-M1ComObject -Value $fields
-    }
-}
-function Set-A1FieldValue {
-    param([object]$Recordset, [string]$Name, [object]$Value)
-    $fields = $null
-    $field = $null
-    try {
-        $fields = $Recordset.Fields
-        $field = $fields.Item($Name)
-        switch ($Name) { "Id" { $field.Value = [Int32]$Value } "Payload" { $field.Value = [string]$Value } default { throw "A1 field name is not controlled." } }
-    }
-    finally {
-        Release-M1ComObject -Value $field
-        Release-M1ComObject -Value $fields
-    }
-}
-function Add-A1HashRow {
-    param(
-        [Parameter(Mandatory = $true)][Security.Cryptography.HashAlgorithm]$Hash,
-        [Parameter(Mandatory = $true)][int]$Id,
-        [Parameter(Mandatory = $true)][string]$Payload
-    )
-    if (-not [BitConverter]::IsLittleEndian) {
-        throw "A1 rolling hash requires an explicitly little-endian host."
-    }
-    $idBytes = [BitConverter]::GetBytes([int]$Id)
-    $payloadBytes = (New-Object Text.UTF8Encoding($false, $true)).GetBytes($Payload)
-    if ($payloadBytes.Length -gt [uint16]::MaxValue) {
-        throw "A1 semantic payload exceeds its rolling-hash length field."
-    }
-    $lengthBytes = [BitConverter]::GetBytes([uint16]$payloadBytes.Length)
-    foreach ($part in @($idBytes, $lengthBytes, $payloadBytes)) {
-        [void]$Hash.TransformBlock($part, 0, $part.Length, $part, 0)
-    }
-}
-function Get-A1ExpectedSemanticHash {
-    param(
-        [Parameter(Mandatory = $true)][string]$Role,
-        [Parameter(Mandatory = $true)]$Rows
-    )
-    $hash = [Security.Cryptography.SHA256]::Create()
-    try {
-        foreach ($id in @($Rows | Sort-Object)) {
-            Add-A1HashRow -Hash $hash -Id ([int]$id) `
-                -Payload (Get-A1Payload -Role $Role -Id ([int]$id))
-        }
-        $empty = New-Object byte[] 0
-        [void]$hash.TransformFinalBlock($empty, 0, 0)
-        return ([BitConverter]::ToString($hash.Hash)).Replace(
-            "-", ""
-        ).ToLowerInvariant()
-    }
-    finally { $hash.Dispose() }
-}
 function Invoke-A1WithDatabase {
     param(
         [Parameter(Mandatory = $true)][scriptblock]$Action,
@@ -197,8 +131,7 @@ function Invoke-A1WithDatabase {
     }
     Complete-M1DaoHelper -PrimaryError $primary -CleanupErrors $cleanup `
         -Label "A1 database action"
-    [GC]::Collect()
-    [GC]::WaitForPendingFinalizers()
+    # checkpoint_design growth rules observe exclusive closure, not a GC cycle.
     return $result
 }
 function Add-A1Table {
@@ -241,6 +174,7 @@ function Add-A1Table {
     $script:A1Extant[$Role] = $true
     $script:A1Rows[$Role].Clear()
     $script:A1NextId[$Role] = 1
+    Set-A1ExpectedSemanticDirty -Role $Role
 }
 function Remove-A1Table {
     param([Parameter(Mandatory = $true)][string]$Role)
@@ -264,6 +198,7 @@ function Remove-A1Table {
     $script:A1Extant[$Role] = $false
     $script:A1Rows[$Role].Clear()
     $script:A1NextId[$Role] = 1
+    Set-A1ExpectedSemanticDirty -Role $Role
 }
 function Add-A1RowBatch {
     param([Parameter(Mandatory = $true)][string]$Role)
@@ -275,21 +210,36 @@ function Add-A1RowBatch {
     Invoke-A1WithDatabase -Action {
         param($database)
         $recordset = $null
+        $fields = $null
+        $idField = $null
+        $payloadField = $null
         $cleanup = New-Object Collections.ArrayList
         $primary = $null
         try {
             $recordset = $database.OpenRecordset($name)
+            # tables.row_algorithm fixes values, not COM lookup frequency;
+            # these field objects remain scoped to this one ordered recordset.
+            $fields = $recordset.Fields
+            $idField = $fields.Item("Id")
+            $payloadField = $fields.Item("Payload")
             for ($offset = 0; $offset -lt 32; $offset++) {
                 $id = [int]($first + $offset)
                 $recordset.AddNew()
-                Set-A1FieldValue -Recordset $recordset -Name "Id" -Value $id
-                Set-A1FieldValue -Recordset $recordset -Name "Payload" `
-                    -Value (Get-A1Payload -Role $Role -Id $id)
+                $idField.Value = [Int32]$id
+                $payloadField.Value = [string](
+                    Get-A1Payload -Role $Role -Id $id
+                )
                 $recordset.Update()
             }
         }
         catch { $primary = $_ }
         finally {
+            Release-M1ComObject -Value $payloadField `
+                -CleanupErrors $cleanup -Label "A1 payload field release"
+            Release-M1ComObject -Value $idField -CleanupErrors $cleanup `
+                -Label "A1 id field release"
+            Release-M1ComObject -Value $fields -CleanupErrors $cleanup `
+                -Label "A1 recordset fields release"
             Close-M1ComObject -Value $recordset -CleanupErrors $cleanup `
                 -Label "A1 insert recordset close"
             Release-M1ComObject -Value $recordset -CleanupErrors $cleanup `
@@ -303,25 +253,34 @@ function Add-A1RowBatch {
     }
     $script:A1NextId[$Role] = [int]($first + 32)
     $script:A1InsertedRows += 32
+    Set-A1ExpectedSemanticDirty -Role $Role
 }
 function Remove-A1AlternatingRows {
     $name = [string]$script:A1RoleNames["L"]
     Invoke-A1WithDatabase -Action {
         param($database)
         $recordset = $null
+        $fields = $null
+        $idField = $null
         $cleanup = New-Object Collections.ArrayList
         $primary = $null
         try {
             $recordset = $database.OpenRecordset($name)
+            $fields = $recordset.Fields
+            $idField = $fields.Item("Id")
             if (-not $recordset.EOF) { $recordset.MoveFirst() }
             while (-not $recordset.EOF) {
-                $id = [int](Get-A1FieldValue -Recordset $recordset -Name "Id")
+                $id = [int]$idField.Value
                 if (($id % 2) -eq 0) { $recordset.Delete() }
                 $recordset.MoveNext()
             }
         }
         catch { $primary = $_ }
         finally {
+            Release-M1ComObject -Value $idField -CleanupErrors $cleanup `
+                -Label "A1 id field release"
+            Release-M1ComObject -Value $fields -CleanupErrors $cleanup `
+                -Label "A1 recordset fields release"
             Close-M1ComObject -Value $recordset -CleanupErrors $cleanup `
                 -Label "A1 delete recordset close"
             Release-M1ComObject -Value $recordset -CleanupErrors $cleanup `
@@ -335,6 +294,7 @@ function Remove-A1AlternatingRows {
             [void]$script:A1Rows["L"].Remove([int]$id)
         }
     }
+    Set-A1ExpectedSemanticDirty -Role "L"
 }
 function Restore-A1AlternatingRows {
     $limit = [int]($script:A1NextId["L"] - 1)
@@ -346,20 +306,33 @@ function Restore-A1AlternatingRows {
     Invoke-A1WithDatabase -Action {
         param($database)
         $recordset = $null
+        $fields = $null
+        $idField = $null
+        $payloadField = $null
         $cleanup = New-Object Collections.ArrayList
         $primary = $null
         try {
             $recordset = $database.OpenRecordset($name)
+            $fields = $recordset.Fields
+            $idField = $fields.Item("Id")
+            $payloadField = $fields.Item("Payload")
             foreach ($id in $ids) {
                 $recordset.AddNew()
-                Set-A1FieldValue -Recordset $recordset -Name "Id" -Value ([int]$id)
-                Set-A1FieldValue -Recordset $recordset -Name "Payload" `
-                    -Value (Get-A1Payload -Role "L" -Id ([int]$id))
+                $idField.Value = [Int32]$id
+                $payloadField.Value = [string](
+                    Get-A1Payload -Role "L" -Id ([int]$id)
+                )
                 $recordset.Update()
             }
         }
         catch { $primary = $_ }
         finally {
+            Release-M1ComObject -Value $payloadField `
+                -CleanupErrors $cleanup -Label "A1 payload field release"
+            Release-M1ComObject -Value $idField -CleanupErrors $cleanup `
+                -Label "A1 id field release"
+            Release-M1ComObject -Value $fields -CleanupErrors $cleanup `
+                -Label "A1 recordset fields release"
             Close-M1ComObject -Value $recordset -CleanupErrors $cleanup `
                 -Label "A1 reinsert recordset close"
             Release-M1ComObject -Value $recordset -CleanupErrors $cleanup `
@@ -370,14 +343,32 @@ function Restore-A1AlternatingRows {
     } | Out-Null
     foreach ($id in $ids) { [void]$script:A1Rows["L"].Add([int]$id) }
     $script:A1InsertedRows += $ids.Count
+    Set-A1ExpectedSemanticDirty -Role "L"
 }
 function Get-A1ClosedPageCount {
     Assert-M1NoReparseComponents -Path $script:A1DatabasePath
-    $stream = New-Object IO.FileStream(
-        $script:A1DatabasePath, [IO.FileMode]::Open, [IO.FileAccess]::Read,
-        [IO.FileShare]::None, 2048, [IO.FileOptions]::SequentialScan
-    )
+    $stream = $null
     try {
+        try {
+            $stream = New-Object IO.FileStream(
+                $script:A1DatabasePath, [IO.FileMode]::Open,
+                [IO.FileAccess]::Read, [IO.FileShare]::None, 2048,
+                [IO.FileOptions]::SequentialScan
+            )
+        }
+        catch [IO.IOException] {
+            $nativeCode = ($_.Exception.HResult -band 0xffff)
+            if ($nativeCode -notin @(32, 33)) { throw }
+            # checkpoint_design growth rules require each candidate to be closed;
+            # one finalizer retry is bounded proof against a lingering RCW.
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
+            $stream = New-Object IO.FileStream(
+                $script:A1DatabasePath, [IO.FileMode]::Open,
+                [IO.FileAccess]::Read, [IO.FileShare]::None, 2048,
+                [IO.FileOptions]::SequentialScan
+            )
+        }
         if ($stream.Length -lt 2048 -or ($stream.Length % 2048) -ne 0) {
             throw "A1 database length is not an exact page sequence."
         }
@@ -385,7 +376,7 @@ function Get-A1ClosedPageCount {
         if ($pages -gt 20480) { throw "A1 final-page ceiling was exceeded." }
         return $pages
     }
-    finally { $stream.Dispose() }
+    finally { if ($null -ne $stream) { $stream.Dispose() } }
 }
 function Assert-A1Quiescent {
     $companion = [IO.Path]::ChangeExtension($script:A1DatabasePath, ".ldb")
@@ -400,76 +391,6 @@ function Assert-A1Quiescent {
         throw "A1 DAO lock companion was replaced by a directory."
     }
 }
-function Read-A1SemanticTables {
-    $documents = New-Object Collections.ArrayList
-    foreach ($role in @("D", "L", "P", "H")) {
-        if (-not [bool]$script:A1Extant[$role]) { continue }
-        $name = [string]$script:A1RoleNames[$role]
-        $rows = $script:A1Rows[$role]
-        $expectedHash = Get-A1ExpectedSemanticHash -Role $role -Rows $rows
-        $observed = Invoke-A1WithDatabase -Action {
-            param($database)
-            $recordset = $null
-            $hash = $null
-            $cleanup = New-Object Collections.ArrayList
-            $primary = $null
-            $count = 0
-            $prior = 0
-            $digest = $null
-            try {
-                $sql = "SELECT Id, Payload FROM [$name] ORDER BY Id"
-                $recordset = $database.OpenRecordset(
-                    $sql, $script:A1DbOpenSnapshot
-                )
-                $hash = [Security.Cryptography.SHA256]::Create()
-                if (-not $recordset.EOF) { $recordset.MoveFirst() }
-                while (-not $recordset.EOF) {
-                    $id = [int](Get-A1FieldValue `
-                        -Recordset $recordset -Name "Id")
-                    $payload = [string](Get-A1FieldValue `
-                        -Recordset $recordset -Name "Payload")
-                    if ($id -le $prior -or -not $rows.Contains($id) -or
-                        $payload -cne (Get-A1Payload -Role $role -Id $id)) {
-                        throw "A1 DAO semantic readback differs from expected rows."
-                    }
-                    Add-A1HashRow -Hash $hash -Id $id -Payload $payload
-                    $prior = $id
-                    $count++
-                    $recordset.MoveNext()
-                }
-                $empty = New-Object byte[] 0
-                [void]$hash.TransformFinalBlock($empty, 0, 0)
-                $digest = ([BitConverter]::ToString($hash.Hash)).Replace(
-                    "-", ""
-                ).ToLowerInvariant()
-            }
-            catch { $primary = $_ }
-            finally {
-                if ($null -ne $hash) { $hash.Dispose() }
-                Close-M1ComObject -Value $recordset -CleanupErrors $cleanup `
-                    -Label "A1 semantic recordset close"
-                Release-M1ComObject -Value $recordset -CleanupErrors $cleanup `
-                    -Label "A1 semantic recordset release"
-            }
-            Complete-M1DaoHelper -PrimaryError $primary -CleanupErrors $cleanup `
-                -Label "A1 semantic readback"
-            return [pscustomobject]@{ count = $count; sha256 = $digest }
-        }
-        if ([int]$observed.count -ne $rows.Count -or
-            [string]$observed.sha256 -cne $expectedHash) {
-            throw "A1 semantic row count or rolling digest differs from expectation."
-        }
-        [void]$documents.Add([ordered]@{
-            role = $role
-            row_count = [int]$observed.count
-            rolling_sha256 = [string]$observed.sha256
-        })
-    }
-    if ($documents.Count -eq 0) {
-        Invoke-A1WithDatabase -Action { param($database) } | Out-Null
-    }
-    return @($documents)
-}
 function Add-A1Checkpoint {
     param(
         [Parameter(Mandatory = $true)][string]$CheckpointId,
@@ -481,7 +402,8 @@ function Add-A1Checkpoint {
     Assert-A1Quiescent
     $snapshot = Read-A1PageSnapshot -Store $script:A1Store `
         -DatabasePath $script:A1DatabasePath `
-        -PriorHashes $script:A1PriorHashes
+        -PriorHashes $script:A1PriorHashes `
+        -PriorPages $script:A1PriorPages
     $overshoot = $null
     if ($null -ne $Target) {
         $threshold = if ([string]$Target.kind -ceq "relative") {
@@ -564,6 +486,7 @@ function Add-A1Checkpoint {
         }
     })
     $script:A1PriorHashes = [string[]]$snapshot.hashes
+    $script:A1PriorPages = [byte[][]]$snapshot.pages
     $script:A1PriorCheckpoint = $CheckpointId
     Add-A1ProgressRecord -Progress $script:A1Progress -CheckpointId $CheckpointId -PageCount ([long]$snapshot.page_count)
 }
@@ -574,7 +497,6 @@ function Add-A1UntilTarget {
     )
     do {
         Add-A1RowBatch -Role $Role
-        Assert-A1Quiescent
         $pages = Get-A1ClosedPageCount
     } while ($pages -lt $ThresholdPages)
 }
@@ -720,6 +642,7 @@ function Invoke-A1Worker {
     $script:A1Rows = @{}
     $script:A1NextId = @{}
     $script:A1Baselines = @{}
+    $script:A1ExpectedSemanticCache = @{}
     foreach ($role in @("D", "L", "P", "H")) {
         $script:A1Rows[$role] = New-Object 'Collections.Generic.HashSet[int]'
         $script:A1NextId[$role] = 1
@@ -727,6 +650,7 @@ function Invoke-A1Worker {
     $script:A1InsertedRows = 0
     $script:A1Checkpoints = New-Object Collections.ArrayList
     $script:A1PriorHashes = $null
+    $script:A1PriorPages = $null
     $script:A1PriorCheckpoint = $null
     $script:A1Store = New-A1PageStore -Session $session
     $engine = $null

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 import struct
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -16,14 +19,38 @@ CONTROLLER = A1 / "A1.Controller.ps1"
 WORKER = A1 / "A1.Worker.ps1"
 PAGE_STORE = A1 / "A1.PageStore.ps1"
 PROGRESS = A1 / "A1.Progress.ps1"
+M1 = SCRIPTS / "m1"
+DAO_VALUES = M1 / "M1.DaoValues.ps1"
+PUBLICATION = M1 / "M1.Publication.ps1"
 PLAN = ROOT / "experiments" / "a1" / "a1-allocation-maps.plan.json"
 PAGE_BYTES = 2048
+WINDOWS_ROOT = Path(os.environ.get("WINDIR", r"C:\Windows"))
+POWERSHELL_CANDIDATES = (
+    WINDOWS_ROOT
+    / "SysWOW64"
+    / "WindowsPowerShell"
+    / "v1.0"
+    / "powershell.exe",
+    WINDOWS_ROOT
+    / "System32"
+    / "WindowsPowerShell"
+    / "v1.0"
+    / "powershell.exe",
+)
+POWERSHELL = next(
+    (candidate for candidate in POWERSHELL_CANDIDATES if candidate.is_file()),
+    POWERSHELL_CANDIDATES[0],
+)
 
 
 def function_source(source: str, name: str) -> str:
     start = source.index(f"function {name}")
     end = source.find("\nfunction ", start + 1)
     return source[start:] if end < 0 else source[start:end]
+
+
+def ps_quote(value: object) -> str:
+    return "'" + str(value).replace("'", "''") + "'"
 
 
 def payload(role: str, row_id: int) -> str:
@@ -43,7 +70,10 @@ def semantic_digest(role: str, row_ids: set[int]) -> tuple[int, str]:
 def naive_snapshot(path: Path, prior: list[str] | None) -> dict[str, object]:
     data = path.read_bytes()
     assert data and len(data) % PAGE_BYTES == 0
-    pages = [data[index : index + PAGE_BYTES] for index in range(0, len(data), PAGE_BYTES)]
+    pages = [
+        data[index : index + PAGE_BYTES]
+        for index in range(0, len(data), PAGE_BYTES)
+    ]
     hashes = [hashlib.sha256(page).hexdigest() for page in pages]
     changed = [
         index
@@ -57,42 +87,7 @@ def naive_snapshot(path: Path, prior: list[str] | None) -> dict[str, object]:
         "ordered_page_sha256": hashes,
         "changed_page_indices": changed,
         "pages": pages,
-    }
-
-
-def reuse_snapshot(
-    path: Path, prior_pages: list[bytes] | None, prior_hashes: list[str] | None
-) -> tuple[dict[str, object], int]:
-    data = path.read_bytes()
-    pages = [data[index : index + PAGE_BYTES] for index in range(0, len(data), PAGE_BYTES)]
-    hashes: list[str] = []
-    reused = 0
-    for index, page in enumerate(pages):
-        if prior_pages is not None and index < len(prior_pages) and page == prior_pages[index]:
-            assert prior_hashes is not None
-            digest = prior_hashes[index]
-            reused += 1
-        else:
-            digest = hashlib.sha256(page).hexdigest()
-        hashes.append(digest)
-    changed = [
-        index
-        for index, digest in enumerate(hashes)
-        if prior_hashes is None
-        or index >= len(prior_hashes)
-        or prior_hashes[index] != digest
-    ]
-    if prior_hashes is not None:
-        changed.extend(range(len(hashes), len(prior_hashes)))
-    return (
-        {
-            "database_sha256": hashlib.sha256(data).hexdigest(),
-            "ordered_page_sha256": hashes,
-            "changed_page_indices": changed,
-            "pages": pages,
-        },
-        reused,
-    )
+}
 
 
 class A1PowerShellSourceContractTests(unittest.TestCase):
@@ -215,9 +210,12 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         self.assertEqual(closed_probe.count("[GC]::WaitForPendingFinalizers()"), 1)
         self.assertLess(
             growth.index("Add-A1RowBatch -Role $Role"),
+            growth.index("Assert-A1Quiescent"),
+        )
+        self.assertLess(
+            growth.index("Assert-A1Quiescent"),
             growth.index("Get-A1ClosedPageCount"),
         )
-        self.assertNotIn("Assert-A1Quiescent", growth)
         self.assertGreaterEqual(checkpoint.count("Assert-A1Quiescent"), 2)
 
     def test_expected_digest_cache_matches_append_delete_and_restore(self) -> None:
@@ -256,7 +254,7 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
                     function_source(self.worker, name),
                 )
         self.assertIn("ContainsKey($Role)", self.page_store)
-        self.assertIn("New-A1IncrementalSha256", self.page_store)
+        self.assertIn("New-A1SemanticSha256", self.page_store)
 
     def test_checkpoint_uses_one_database_session_for_all_semantic_tables(self) -> None:
         all_tables = function_source(self.page_store, "Read-A1SemanticTables")
@@ -283,38 +281,7 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
                 self.assertIn(fragment, self.combined)
         self.assertNotIn("page-store/sha256/", self.combined)
 
-    def test_page_snapshot_reuse_matches_naive_full_rehash(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "synthetic.mdb"
-            path.write_bytes(b"A" * PAGE_BYTES + b"B" * PAGE_BYTES + b"C" * PAGE_BYTES)
-            first = naive_snapshot(path, None)
-            path.write_bytes(
-                b"A" * PAGE_BYTES
-                + b"X" * PAGE_BYTES
-                + b"C" * PAGE_BYTES
-                + b"D" * PAGE_BYTES
-            )
-            expected = naive_snapshot(path, first["ordered_page_sha256"])
-            actual, reused = reuse_snapshot(
-                path,
-                first["pages"],
-                first["ordered_page_sha256"],
-            )
-            self.assertEqual(actual, expected)
-            self.assertEqual(actual["changed_page_indices"], [1, 3])
-            self.assertEqual(reused, 2)
-
-            path.write_bytes(b"A" * PAGE_BYTES + b"X" * PAGE_BYTES)
-            shrunk_expected = naive_snapshot(path, actual["ordered_page_sha256"])
-            shrunk_actual, reused = reuse_snapshot(
-                path,
-                actual["pages"],
-                actual["ordered_page_sha256"],
-            )
-            self.assertEqual(shrunk_actual, shrunk_expected)
-            self.assertEqual(shrunk_actual["changed_page_indices"], [2, 3])
-            self.assertEqual(reused, 2)
-
+    def test_page_snapshot_reuse_is_exact_and_bounded(self) -> None:
         snapshot = function_source(self.page_store, "Read-A1PageSnapshot")
         self.assertIn("StructuralEqualityComparer", snapshot)
         self.assertIn("$sha = [string]$PriorHashes", snapshot)
@@ -322,6 +289,10 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         self.assertIn("[Buffer]::BlockCopy", snapshot)
         self.assertIn("$fileHash.TransformBlock", snapshot)
         self.assertIn("$Store.ChangedEntries + $changed.Count", snapshot)
+        self.assertIn("$script:A1MaximumPagesPerReplica", snapshot)
+        self.assertNotIn("IncrementalHash", self.page_store)
+        self.assertIn("$Hash.TransformBlock", self.page_store)
+        self.assertIn("$Hash.TransformFinalBlock", self.page_store)
 
     def test_resource_and_process_ceilings_are_fail_closed(self) -> None:
         expected = {
@@ -446,6 +417,257 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
                 self.assertLess(
                     len(path.read_text(encoding="utf-8").splitlines()), 800
                 )
+
+
+@unittest.skipUnless(
+    sys.platform == "win32" and POWERSHELL.is_file(),
+    "Windows PowerShell 5.1 required",
+)
+class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.worker = WORKER.read_text(encoding="utf-8")
+
+    def run_ps(
+        self, body: str, *, timeout: int = 60
+    ) -> subprocess.CompletedProcess[str]:
+        source = (
+            "$ErrorActionPreference = 'Stop'\n"
+            "Set-StrictMode -Version Latest\n"
+            "if ($PSVersionTable.PSVersion.Major -ne 5) { "
+            "throw 'Windows PowerShell 5.1 is required.' }\n"
+            + body
+        )
+        with tempfile.TemporaryDirectory(prefix="a1-ps51-test-") as directory:
+            script = Path(directory) / "contract.ps1"
+            script.write_text(source, encoding="utf-8-sig")
+            return subprocess.run(
+                [
+                    str(POWERSHELL),
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(script),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+            )
+
+    def test_real_page_snapshot_matches_naive_rehash_and_reconstruction(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="a1-page-reuse-") as directory:
+            root = Path(directory)
+            bundle = root / "bundle"
+            bundle.mkdir()
+            database = root / "synthetic.mdb"
+            second_path = root / "second.mdb"
+            third_path = root / "third.mdb"
+            first_bytes = (
+                b"A" * PAGE_BYTES + b"B" * PAGE_BYTES + b"C" * PAGE_BYTES
+            )
+            second_bytes = (
+                b"A" * PAGE_BYTES
+                + b"X" * PAGE_BYTES
+                + b"C" * PAGE_BYTES
+                + b"D" * PAGE_BYTES
+            )
+            third_bytes = b"A" * PAGE_BYTES + b"X" * PAGE_BYTES
+            database.write_bytes(first_bytes)
+            second_path.write_bytes(second_bytes)
+            third_path.write_bytes(third_bytes)
+
+            first_expected = naive_snapshot(database, None)
+            first_hashes = first_expected["ordered_page_sha256"]
+            self.assertIsInstance(first_hashes, list)
+            second_expected = naive_snapshot(second_path, first_hashes)
+            second_hashes = second_expected["ordered_page_sha256"]
+            self.assertIsInstance(second_hashes, list)
+            third_expected = naive_snapshot(third_path, second_hashes)
+
+            body = (
+                f". {ps_quote(PUBLICATION)}\n"
+                f". {ps_quote(PAGE_STORE)}\n"
+                "function Convert-A1TestSnapshot {\n"
+                "  param([pscustomobject]$Snapshot)\n"
+                "  return [ordered]@{\n"
+                "    database_sha256 = [string]$Snapshot.file_sha256\n"
+                "    ordered_page_sha256 = @($Snapshot.hashes)\n"
+                "    changed_page_indices = @(\n"
+                "      $Snapshot.changed_pages | ForEach-Object { "
+                "[long]$_.page_index }\n"
+                "    )\n"
+                "  }\n"
+                "}\n"
+                f"$session = [pscustomobject]@{{ StagingBundle = "
+                f"{ps_quote(bundle)} }}\n"
+                "$store = New-A1PageStore -Session $session\n"
+                "$first = Read-A1PageSnapshot -Store $store "
+                f"-DatabasePath {ps_quote(database)} "
+                "-PriorHashes $null -PriorPages $null\n"
+                f"[IO.File]::WriteAllBytes({ps_quote(database)}, "
+                f"[IO.File]::ReadAllBytes({ps_quote(second_path)}))\n"
+                "$second = Read-A1PageSnapshot -Store $store "
+                f"-DatabasePath {ps_quote(database)} "
+                "-PriorHashes ([string[]]$first.hashes) "
+                "-PriorPages ([byte[][]]$first.pages)\n"
+                f"[IO.File]::WriteAllBytes({ps_quote(database)}, "
+                f"[IO.File]::ReadAllBytes({ps_quote(third_path)}))\n"
+                "$third = Read-A1PageSnapshot -Store $store "
+                f"-DatabasePath {ps_quote(database)} "
+                "-PriorHashes ([string[]]$second.hashes) "
+                "-PriorPages ([byte[][]]$second.pages)\n"
+                "[ordered]@{\n"
+                "  first = Convert-A1TestSnapshot $first\n"
+                "  second = Convert-A1TestSnapshot $second\n"
+                "  third = Convert-A1TestSnapshot $third\n"
+                "} | ConvertTo-Json -Depth 8 -Compress\n"
+            )
+            result = self.run_ps(body)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            observed = json.loads(result.stdout.strip().splitlines()[-1])
+
+            expected_snapshots = {
+                "first": first_expected,
+                "second": second_expected,
+                "third": third_expected,
+            }
+            raw_snapshots = {
+                "first": first_bytes,
+                "second": second_bytes,
+                "third": third_bytes,
+            }
+            for name, expected in expected_snapshots.items():
+                with self.subTest(snapshot=name):
+                    projection = {
+                        key: expected[key]
+                        for key in (
+                            "database_sha256",
+                            "ordered_page_sha256",
+                            "changed_page_indices",
+                        )
+                    }
+                    self.assertEqual(observed[name], projection)
+                    reconstructed = b"".join(
+                        (
+                            bundle / "page-store" / f"{digest}.page"
+                        ).read_bytes()
+                        for digest in observed[name]["ordered_page_sha256"]
+                    )
+                    self.assertEqual(reconstructed, raw_snapshots[name])
+
+    def test_real_one_session_dao_reread_matches_per_table_sessions(self) -> None:
+        definitions = "\n\n".join(
+            function_source(self.worker, name)
+            for name in (
+                "Get-A1Payload",
+                "Invoke-A1WithDatabase",
+                "Add-A1Table",
+                "Add-A1RowBatch",
+            )
+        )
+        with tempfile.TemporaryDirectory(prefix="a1-semantic-reread-") as directory:
+            database = Path(directory) / "semantic.mdb"
+            body = (
+                f". {ps_quote(DAO_VALUES)}\n"
+                f". {ps_quote(PAGE_STORE)}\n"
+                + definitions
+                + "\n"
+                + "if ([IntPtr]::Size -ne 4) { "
+                "throw 'The controlled DAO test requires x86 PowerShell.' }\n"
+                "$script:A1DbVersion30 = 32\n"
+                "$script:A1DbLong = 4\n"
+                "$script:A1DbText = 10\n"
+                "$script:A1DbFixedField = 1\n"
+                "$script:A1DbOpenSnapshot = 4\n"
+                "$script:A1Locale = ';LANGID=0x0409;CP=1252;COUNTRY=0'\n"
+                f"$script:A1DatabasePath = {ps_quote(database)}\n"
+                "$script:A1RoleNames = @{ D = 'A1TAB_A'; L = 'A1TAB_B'; "
+                "P = 'A1TAB_C'; H = 'A1TAB_D' }\n"
+                "$script:A1Extant = @{ D = $false; L = $false; "
+                "P = $false; H = $false }\n"
+                "$script:A1Rows = @{}\n"
+                "$script:A1NextId = @{}\n"
+                "$script:A1ExpectedSemanticCache = @{}\n"
+                "foreach ($role in @('D', 'L', 'P', 'H')) {\n"
+                "  $script:A1Rows[$role] = "
+                "New-Object 'Collections.Generic.HashSet[int]'\n"
+                "  $script:A1NextId[$role] = 1\n"
+                "}\n"
+                "$script:A1InsertedRows = 0\n"
+                "$engine = $null\n"
+                "$workspaces = $null\n"
+                "$workspace = $null\n"
+                "$output = $null\n"
+                "try {\n"
+                "  $providerType = [Type]::GetTypeFromProgID("
+                "'DAO.DBEngine.36', $true)\n"
+                "  $engine = [Activator]::CreateInstance($providerType)\n"
+                "  $workspaces = $engine.Workspaces\n"
+                "  $workspace = $workspaces.Item([int]0)\n"
+                "  $script:A1Workspace = $workspace\n"
+                "  Invoke-A1WithDatabase -Create -Action { "
+                "param($database) } | Out-Null\n"
+                "  Add-A1Table -Role 'D'\n"
+                "  Add-A1RowBatch -Role 'D'\n"
+                "  Add-A1Table -Role 'L'\n"
+                "  Add-A1RowBatch -Role 'L'\n"
+                "  $script:A1OriginalDatabaseAction = "
+                "(Get-Command Invoke-A1WithDatabase).ScriptBlock\n"
+                "  function Invoke-A1WithDatabase {\n"
+                "    param([scriptblock]$Action, [switch]$Create)\n"
+                "    $script:A1MeasuredOpenCount++\n"
+                "    & $script:A1OriginalDatabaseAction "
+                "-Action $Action -Create:$Create\n"
+                "  }\n"
+                "  $script:A1MeasuredOpenCount = 0\n"
+                "  $current = @(Read-A1SemanticTables)\n"
+                "  $currentOpens = $script:A1MeasuredOpenCount\n"
+                "  $script:A1MeasuredOpenCount = 0\n"
+                "  $legacy = New-Object Collections.ArrayList\n"
+                "  foreach ($role in @('D', 'L', 'P', 'H')) {\n"
+                "    if ([bool]$script:A1Extant[$role]) {\n"
+                "      $expected = Get-A1ExpectedSemanticResult "
+                "-Role $role -Rows $script:A1Rows[$role]\n"
+                "      $document = Invoke-A1WithDatabase -Action {\n"
+                "        param($database)\n"
+                "        Read-A1SemanticTable -Database $database "
+                "-Role $role -Expected $expected\n"
+                "      }\n"
+                "      [void]$legacy.Add($document)\n"
+                "    }\n"
+                "  }\n"
+                "  $output = [ordered]@{\n"
+                "    current = @($current)\n"
+                "    legacy = @($legacy)\n"
+                "    current_open_count = $currentOpens\n"
+                "    legacy_open_count = $script:A1MeasuredOpenCount\n"
+                "  } | ConvertTo-Json -Depth 8 -Compress\n"
+                "}\n"
+                "finally {\n"
+                "  Release-M1ComObject -Value $workspace\n"
+                "  Release-M1ComObject -Value $workspaces\n"
+                "  Release-M1ComObject -Value $engine\n"
+                "}\n"
+                "[Console]::Write($output)\n"
+            )
+            result = self.run_ps(body, timeout=90)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            observed = json.loads(result.stdout.strip().splitlines()[-1])
+            self.assertEqual(observed["current_open_count"], 1)
+            self.assertEqual(observed["legacy_open_count"], 2)
+            self.assertEqual(observed["current"], observed["legacy"])
+            expected = [
+                {
+                    "role": role,
+                    "row_count": 32,
+                    "rolling_sha256": semantic_digest(role, set(range(1, 33)))[1],
+                }
+                for role in ("D", "L")
+            ]
+            self.assertEqual(observed["current"], expected)
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -566,10 +566,13 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "Invoke-A1WithDatabase",
                 "Add-A1Table",
                 "Add-A1RowBatch",
+                "Assert-A1Quiescent",
             )
         )
         with tempfile.TemporaryDirectory(prefix="a1-semantic-reread-") as directory:
-            database = Path(directory) / "semantic.mdb"
+            template_database = Path(directory) / "template.mdb"
+            one_session_database = Path(directory) / "one-session.mdb"
+            per_table_database = Path(directory) / "per-table.mdb"
             body = (
                 f". {ps_quote(DAO_VALUES)}\n"
                 f". {ps_quote(PAGE_STORE)}\n"
@@ -583,7 +586,7 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "$script:A1DbFixedField = 1\n"
                 "$script:A1DbOpenSnapshot = 4\n"
                 "$script:A1Locale = ';LANGID=0x0409;CP=1252;COUNTRY=0'\n"
-                f"$script:A1DatabasePath = {ps_quote(database)}\n"
+                f"$script:A1DatabasePath = {ps_quote(template_database)}\n"
                 "$script:A1RoleNames = @{ D = 'A1TAB_A'; L = 'A1TAB_B'; "
                 "P = 'A1TAB_C'; H = 'A1TAB_D' }\n"
                 "$script:A1Extant = @{ D = $false; L = $false; "
@@ -614,6 +617,15 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "  Add-A1RowBatch -Role 'D'\n"
                 "  Add-A1Table -Role 'L'\n"
                 "  Add-A1RowBatch -Role 'L'\n"
+                "  Assert-A1Quiescent\n"
+                f"  [IO.File]::Copy($script:A1DatabasePath, "
+                f"{ps_quote(one_session_database)}, $false)\n"
+                f"  [IO.File]::Copy($script:A1DatabasePath, "
+                f"{ps_quote(per_table_database)}, $false)\n"
+                f"  $currentInputSha = Get-M1FileSha256 -Path "
+                f"{ps_quote(one_session_database)}\n"
+                f"  $legacyInputSha = Get-M1FileSha256 -Path "
+                f"{ps_quote(per_table_database)}\n"
                 "  $script:A1OriginalDatabaseAction = "
                 "(Get-Command Invoke-A1WithDatabase).ScriptBlock\n"
                 "  function Invoke-A1WithDatabase {\n"
@@ -622,9 +634,14 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "    & $script:A1OriginalDatabaseAction "
                 "-Action $Action -Create:$Create\n"
                 "  }\n"
+                f"  $script:A1DatabasePath = {ps_quote(one_session_database)}\n"
                 "  $script:A1MeasuredOpenCount = 0\n"
                 "  $current = @(Read-A1SemanticTables)\n"
                 "  $currentOpens = $script:A1MeasuredOpenCount\n"
+                "  Assert-A1Quiescent\n"
+                "  $currentDatabaseSha = Get-M1FileSha256 "
+                "-Path $script:A1DatabasePath\n"
+                f"  $script:A1DatabasePath = {ps_quote(per_table_database)}\n"
                 "  $script:A1MeasuredOpenCount = 0\n"
                 "  $legacy = New-Object Collections.ArrayList\n"
                 "  foreach ($role in @('D', 'L', 'P', 'H')) {\n"
@@ -639,11 +656,18 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "      [void]$legacy.Add($document)\n"
                 "    }\n"
                 "  }\n"
+                "  Assert-A1Quiescent\n"
+                "  $legacyDatabaseSha = Get-M1FileSha256 "
+                "-Path $script:A1DatabasePath\n"
                 "  $output = [ordered]@{\n"
                 "    current = @($current)\n"
                 "    legacy = @($legacy)\n"
                 "    current_open_count = $currentOpens\n"
                 "    legacy_open_count = $script:A1MeasuredOpenCount\n"
+                "    current_input_sha256 = $currentInputSha\n"
+                "    legacy_input_sha256 = $legacyInputSha\n"
+                "    current_database_sha256 = $currentDatabaseSha\n"
+                "    legacy_database_sha256 = $legacyDatabaseSha\n"
                 "  } | ConvertTo-Json -Depth 8 -Compress\n"
                 "}\n"
                 "finally {\n"
@@ -658,6 +682,21 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
             observed = json.loads(result.stdout.strip().splitlines()[-1])
             self.assertEqual(observed["current_open_count"], 1)
             self.assertEqual(observed["legacy_open_count"], 2)
+            self.assertEqual(
+                observed["current_input_sha256"], observed["legacy_input_sha256"]
+            )
+            self.assertEqual(
+                observed["current_database_sha256"],
+                observed["legacy_database_sha256"],
+            )
+            self.assertEqual(
+                observed["current_database_sha256"],
+                hashlib.sha256(one_session_database.read_bytes()).hexdigest(),
+            )
+            self.assertEqual(
+                observed["legacy_database_sha256"],
+                hashlib.sha256(per_table_database.read_bytes()).hexdigest(),
+            )
             self.assertEqual(observed["current"], observed["legacy"])
             expected = [
                 {

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import struct
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -14,6 +17,82 @@ WORKER = A1 / "A1.Worker.ps1"
 PAGE_STORE = A1 / "A1.PageStore.ps1"
 PROGRESS = A1 / "A1.Progress.ps1"
 PLAN = ROOT / "experiments" / "a1" / "a1-allocation-maps.plan.json"
+PAGE_BYTES = 2048
+
+
+def function_source(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    end = source.find("\nfunction ", start + 1)
+    return source[start:] if end < 0 else source[start:end]
+
+
+def payload(role: str, row_id: int) -> str:
+    seed = f"A1|{role}|{row_id:010d}|"
+    return (seed * ((240 + len(seed) - 1) // len(seed)))[:240]
+
+
+def semantic_digest(role: str, row_ids: set[int]) -> tuple[int, str]:
+    hasher = hashlib.sha256()
+    for row_id in sorted(row_ids):
+        encoded = payload(role, row_id).encode("utf-8")
+        hasher.update(struct.pack("<iH", row_id, len(encoded)))
+        hasher.update(encoded)
+    return len(row_ids), hasher.hexdigest()
+
+
+def naive_snapshot(path: Path, prior: list[str] | None) -> dict[str, object]:
+    data = path.read_bytes()
+    assert data and len(data) % PAGE_BYTES == 0
+    pages = [data[index : index + PAGE_BYTES] for index in range(0, len(data), PAGE_BYTES)]
+    hashes = [hashlib.sha256(page).hexdigest() for page in pages]
+    changed = [
+        index
+        for index, digest in enumerate(hashes)
+        if prior is None or index >= len(prior) or prior[index] != digest
+    ]
+    if prior is not None:
+        changed.extend(range(len(hashes), len(prior)))
+    return {
+        "database_sha256": hashlib.sha256(data).hexdigest(),
+        "ordered_page_sha256": hashes,
+        "changed_page_indices": changed,
+        "pages": pages,
+    }
+
+
+def reuse_snapshot(
+    path: Path, prior_pages: list[bytes] | None, prior_hashes: list[str] | None
+) -> tuple[dict[str, object], int]:
+    data = path.read_bytes()
+    pages = [data[index : index + PAGE_BYTES] for index in range(0, len(data), PAGE_BYTES)]
+    hashes: list[str] = []
+    reused = 0
+    for index, page in enumerate(pages):
+        if prior_pages is not None and index < len(prior_pages) and page == prior_pages[index]:
+            assert prior_hashes is not None
+            digest = prior_hashes[index]
+            reused += 1
+        else:
+            digest = hashlib.sha256(page).hexdigest()
+        hashes.append(digest)
+    changed = [
+        index
+        for index, digest in enumerate(hashes)
+        if prior_hashes is None
+        or index >= len(prior_hashes)
+        or prior_hashes[index] != digest
+    ]
+    if prior_hashes is not None:
+        changed.extend(range(len(hashes), len(prior_hashes)))
+    return (
+        {
+            "database_sha256": hashlib.sha256(data).hexdigest(),
+            "ordered_page_sha256": hashes,
+            "changed_page_indices": changed,
+            "pages": pages,
+        },
+        reused,
+    )
 
 
 class A1PowerShellSourceContractTests(unittest.TestCase):
@@ -66,19 +145,18 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
             'CreateField("Id", $script:A1DbLong)',
             'CreateField("Payload", $script:A1DbText, 240)',
             '$payloadField.Attributes = $script:A1DbFixedField',
-            '$field.Value = [Int32]$Value',
-            '$field.Value = [string]$Value',
-            'throw "A1 field name is not controlled."',
+            '$idField.Value = [Int32]$id',
+            '$payloadField.Value = [string](',
             'growth_batch_rows -ne 32',
             '"A1|$Role|$($Id.ToString(\'D10\'))|"',
             "GetBytes([int]$Id)",
             "GetBytes([uint16]$payloadBytes.Length)",
         ):
             with self.subTest(fragment=fragment):
-                self.assertIn(fragment, self.worker)
-        self.assertNotIn('$field.Value = $Value', self.worker)
-        self.assertIn("Id, Payload", self.worker)
-        self.assertIn("ORDER BY Id", self.worker)
+                self.assertIn(fragment, self.combined)
+        self.assertNotIn('$field.Value = $Value', self.combined)
+        self.assertIn("Id, Payload", self.page_store)
+        self.assertIn("ORDER BY Id", self.page_store)
 
     def test_checkpoint_closes_rereads_and_requires_quiescence(self) -> None:
         checkpoint = self.worker.index("function Add-A1Checkpoint")
@@ -125,6 +203,71 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         for forbidden in ("retune", "adaptive checkpoint", "batch_rows +="):
             self.assertNotIn(forbidden, self.worker.lower())
 
+    def test_closed_state_probe_collects_only_after_a_sharing_failure(self) -> None:
+        database_action = function_source(self.worker, "Invoke-A1WithDatabase")
+        closed_probe = function_source(self.worker, "Get-A1ClosedPageCount")
+        growth = function_source(self.worker, "Add-A1UntilTarget")
+        checkpoint = function_source(self.worker, "Add-A1Checkpoint")
+        self.assertNotIn("[GC]::Collect()", database_action)
+        self.assertIn("[IO.FileShare]::None", closed_probe)
+        self.assertIn("$nativeCode -notin @(32, 33)", closed_probe)
+        self.assertEqual(closed_probe.count("[GC]::Collect()"), 1)
+        self.assertEqual(closed_probe.count("[GC]::WaitForPendingFinalizers()"), 1)
+        self.assertLess(
+            growth.index("Add-A1RowBatch -Role $Role"),
+            growth.index("Get-A1ClosedPageCount"),
+        )
+        self.assertNotIn("Assert-A1Quiescent", growth)
+        self.assertGreaterEqual(checkpoint.count("Assert-A1Quiescent"), 2)
+
+    def test_expected_digest_cache_matches_append_delete_and_restore(self) -> None:
+        cache: dict[str, tuple[int, str]] = {}
+        rows: set[int] = set()
+
+        def cached(role: str) -> tuple[int, str]:
+            if role not in cache:
+                cache[role] = semantic_digest(role, rows)
+            return cache[role]
+
+        for start in (1, 33, 65):
+            rows.update(range(start, start + 32))
+            cache.pop("L", None)
+            self.assertEqual(cached("L"), semantic_digest("L", rows))
+        before_delete = cached("L")
+        deleted = {row_id for row_id in rows if row_id % 2 == 0}
+        rows.difference_update(deleted)
+        cache.pop("L", None)
+        self.assertEqual(cached("L"), semantic_digest("L", rows))
+        rows.update(deleted)
+        cache.pop("L", None)
+        self.assertEqual(cached("L"), semantic_digest("L", rows))
+        self.assertEqual(cached("L"), before_delete)
+
+        for name in ("Add-A1Table", "Remove-A1Table", "Add-A1RowBatch"):
+            with self.subTest(function=name):
+                self.assertIn(
+                    "Set-A1ExpectedSemanticDirty -Role $Role",
+                    function_source(self.worker, name),
+                )
+        for name in ("Remove-A1AlternatingRows", "Restore-A1AlternatingRows"):
+            with self.subTest(function=name):
+                self.assertIn(
+                    'Set-A1ExpectedSemanticDirty -Role "L"',
+                    function_source(self.worker, name),
+                )
+        self.assertIn("ContainsKey($Role)", self.page_store)
+        self.assertIn("New-A1IncrementalSha256", self.page_store)
+
+    def test_checkpoint_uses_one_database_session_for_all_semantic_tables(self) -> None:
+        all_tables = function_source(self.page_store, "Read-A1SemanticTables")
+        one_table = function_source(self.page_store, "Read-A1SemanticTable")
+        self.assertEqual(all_tables.count("Invoke-A1WithDatabase -Action"), 1)
+        self.assertIn('@("D", "L", "P", "H")', all_tables)
+        self.assertIn("ORDER BY Id", one_table)
+        self.assertIn('$fields = $recordset.Fields', one_table)
+        self.assertIn('$idField = $fields.Item("Id")', one_table)
+        self.assertIn('$payloadField = $fields.Item("Payload")', one_table)
+
     def test_page_store_is_exact_content_addressed_and_reconstructable(self) -> None:
         for fragment in (
             '$script:A1PageBytes = 2048L',
@@ -139,6 +282,46 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, self.combined)
         self.assertNotIn("page-store/sha256/", self.combined)
+
+    def test_page_snapshot_reuse_matches_naive_full_rehash(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "synthetic.mdb"
+            path.write_bytes(b"A" * PAGE_BYTES + b"B" * PAGE_BYTES + b"C" * PAGE_BYTES)
+            first = naive_snapshot(path, None)
+            path.write_bytes(
+                b"A" * PAGE_BYTES
+                + b"X" * PAGE_BYTES
+                + b"C" * PAGE_BYTES
+                + b"D" * PAGE_BYTES
+            )
+            expected = naive_snapshot(path, first["ordered_page_sha256"])
+            actual, reused = reuse_snapshot(
+                path,
+                first["pages"],
+                first["ordered_page_sha256"],
+            )
+            self.assertEqual(actual, expected)
+            self.assertEqual(actual["changed_page_indices"], [1, 3])
+            self.assertEqual(reused, 2)
+
+            path.write_bytes(b"A" * PAGE_BYTES + b"X" * PAGE_BYTES)
+            shrunk_expected = naive_snapshot(path, actual["ordered_page_sha256"])
+            shrunk_actual, reused = reuse_snapshot(
+                path,
+                actual["pages"],
+                actual["ordered_page_sha256"],
+            )
+            self.assertEqual(shrunk_actual, shrunk_expected)
+            self.assertEqual(shrunk_actual["changed_page_indices"], [2, 3])
+            self.assertEqual(reused, 2)
+
+        snapshot = function_source(self.page_store, "Read-A1PageSnapshot")
+        self.assertIn("StructuralEqualityComparer", snapshot)
+        self.assertIn("$sha = [string]$PriorHashes", snapshot)
+        self.assertIn("$pageHash.ComputeHash($page)", snapshot)
+        self.assertIn("[Buffer]::BlockCopy", snapshot)
+        self.assertIn("$fileHash.TransformBlock", snapshot)
+        self.assertIn("$Store.ChangedEntries + $changed.Count", snapshot)
 
     def test_resource_and_process_ceilings_are_fail_closed(self) -> None:
         expected = {
@@ -252,7 +435,7 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
             "$PriorHashes.Count -gt $pageCount", self.page_store
         )
         self.assertIn("page_index = [long]$index", self.page_store)
-        self.assertIn("$fields = $Recordset.Fields", self.worker)
+        self.assertIn("$fields = $recordset.Fields", self.combined)
         self.assertIn("$tableDefinitions = $database.TableDefs", self.worker)
         self.assertIn("A1 table definitions release", self.worker)
         self.assertIn('Label "A1 table deletion"', self.worker)

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -460,11 +460,14 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
     def test_real_page_snapshot_matches_naive_rehash_and_reconstruction(self) -> None:
         with tempfile.TemporaryDirectory(prefix="a1-page-reuse-") as directory:
             root = Path(directory)
-            bundle = root / "bundle"
-            bundle.mkdir()
-            database = root / "synthetic.mdb"
-            second_path = root / "second.mdb"
-            third_path = root / "third.mdb"
+            stage = root / "stage"
+            bundle = stage / "bundle"
+            working = stage / "working"
+            bundle.mkdir(parents=True)
+            working.mkdir()
+            database = working / "synthetic.mdb"
+            second_path = working / "second.mdb"
+            third_path = working / "third.mdb"
             first_bytes = (
                 b"A" * PAGE_BYTES + b"B" * PAGE_BYTES + b"C" * PAGE_BYTES
             )
@@ -501,8 +504,10 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "    )\n"
                 "  }\n"
                 "}\n"
-                f"$session = [pscustomobject]@{{ StagingBundle = "
-                f"{ps_quote(bundle)} }}\n"
+                f"$stagingBundle = (Get-Item -LiteralPath {ps_quote(bundle)} "
+                "-Force).FullName\n"
+                "$session = [pscustomobject]@{ StagingBundle = "
+                "$stagingBundle }\n"
                 "$store = New-A1PageStore -Session $session\n"
                 "$first = Read-A1PageSnapshot -Store $store "
                 f"-DatabasePath {ps_quote(database)} "


### PR DESCRIPTION
## Summary

- replace unconditional per-action GC with one bounded sharing-violation recovery after explicit COM release and exclusive closed-file probing
- scan every extant table in Id order through one database session per checkpoint, with recordset-scoped field objects and incremental SHA-256
- cache deterministic expected count/digest pairs and invalidate the affected role after every mutation
- retain bounded prior raw pages, reuse digests only after exact byte equality, stream database_sha256 in the same read, and preserve content-addressed page blobs and changed indices

## Observable equivalence

- every growth candidate remains the first closed-file state after an exact 32-row batch, with unchanged threshold and overshoot calculation
- all extant tables are still reread through DAO after every named checkpoint in Id order and compared against the exact expected count and rolling digest
- all 71 named checkpoints retain full lock-companion quiescence assertions
- ordered page hashes, content-addressed blobs, database_sha256, and changed_page_indices remain identical to a naive full rehash
- no preregistered plan, schema, provenance ledger, resource bound, timeout, controller, or workflow changed

## Run 6 baseline

Run 32445923847 used the pre-optimization worker and reached 45/71 checkpoints (`H_REL_0896`) in 1,685.506 seconds at 17,380 pages. An OLS fit over all 45 progress records gives the interval model `delta_seconds = 0.0541 + 0.009595 * page_count + 0.013967 * delta_page_count` (R-squared 0.99944; mean absolute error 0.61 seconds), and the equivalent cumulative model `elapsed_seconds = -2.326 + 0.014779 * page_count + 0.009519 * cumulative_page_count` (R-squared 0.99997; mean absolute error 1.77 seconds). The measured slopes are therefore about 9.52-9.60 ms per page-checkpoint of cumulative reread/snapshot work and 13.97-14.78 ms per newly allocated page of growth work.

Using the observed 16,484-page H baseline and the fixed remaining H targets gives 605,161 page-checkpoint observations and a pre-optimization full-replica projection of about 6,021 seconds. For a deliberately conservative post-optimization planning projection, reducing only the 9.595 ms page-checkpoint term by 10x for the eliminated per-row field RCW churn, unchanged-role expectation recomputation, and unchanged-page SHA construction, while leaving the measured growth term unimproved, gives about **833 seconds (13.9 minutes) per replica**; this is a projection to be checked by the next hosted run, not acquisition evidence.

## Verification

- python3.13 -m unittest discover -s oracle/windows-dao/tests (426 tests; 82 expected platform skips locally)
- git diff --check
