### PR TITLE
fix: permit reviewed A1 analysis timeouts

### DIFF
--- a/oracle/windows-dao/scripts/a1/A1.Controller.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Controller.ps1
@@ -122,7 +122,8 @@ function Invoke-A1Python {
     $timeout = Get-A1CampaignAllowance -MaximumSeconds $MaximumSeconds
     [void](Invoke-BoundedChildProcess -Executable $Context.PythonPath `
         -Arguments (@("-B", $ScriptPath) + $Arguments) `
-        -CallerLabel $Label -TimeoutSeconds $timeout -MaximumOutputBytes 1MB)
+        -CallerLabel $Label -TimeoutSeconds $timeout -MaximumOutputBytes 1MB `
+        -ReviewedTimeoutCeilingSeconds $MaximumSeconds)
 }
 
 function Assert-A1ExactPushedCommit {
@@ -640,7 +641,7 @@ function Invoke-A1Campaign {
                     -RelativePath "observations/replica-03.json"),
                 "--bundle-root", $session.StagingBundle,
                 "--output", $analysisOutput
-            ) -Label "A1 preregistered analysis" -MaximumSeconds 1800
+            ) -Label "A1 preregistered analysis" -MaximumSeconds 600
         $analysisInput = Read-A1ControllerInput -Path $analysisOutput `
             -MaximumBytes 64MB
         Invoke-A1Python -Context $context -ScriptPath $contractPath `
@@ -659,7 +660,7 @@ function Invoke-A1Campaign {
             param($bundle)
             Invoke-A1Python -Context $context -ScriptPath $contractPath `
                 -Arguments @("validate-bundle", $bundle) `
-                -Label "A1 complete bundle validation" -MaximumSeconds 1800
+                -Label "A1 complete bundle validation" -MaximumSeconds 900
         }
         $recheck = {
             param($stage)

--- a/oracle/windows-dao/scripts/shared/BoundedProcess.ps1
+++ b/oracle/windows-dao/scripts/shared/BoundedProcess.ps1
@@ -38,7 +38,8 @@ function Assert-BoundedProcessLimits {
     param(
         [string]$CallerLabel,
         [int]$TimeoutSeconds,
-        [long]$MaximumOutputBytes
+        [long]$MaximumOutputBytes,
+        [int]$ReviewedTimeoutCeilingSeconds = 120
     )
 
     if (
@@ -48,7 +49,16 @@ function Assert-BoundedProcessLimits {
     ) {
         throw "Bounded process caller label is invalid."
     }
-    if ($TimeoutSeconds -lt 1 -or $TimeoutSeconds -gt 120) {
+    if (
+        $ReviewedTimeoutCeilingSeconds -lt 1 -or
+        $ReviewedTimeoutCeilingSeconds -gt 1800
+    ) {
+        throw "$CallerLabel reviewed timeout ceiling is invalid."
+    }
+    if (
+        $TimeoutSeconds -lt 1 -or
+        $TimeoutSeconds -gt $ReviewedTimeoutCeilingSeconds
+    ) {
         throw "$CallerLabel child timeout is outside the reviewed ceiling."
     }
     if ($MaximumOutputBytes -lt 1 -or $MaximumOutputBytes -gt 1MB) {
@@ -94,12 +104,14 @@ function Read-BoundedProcessOutput {
         [Jet3BoundedProcessLaunch]$Launch,
         [string]$CallerLabel,
         [int]$TimeoutSeconds,
-        [long]$MaximumOutputBytes
+        [long]$MaximumOutputBytes,
+        [int]$ReviewedTimeoutCeilingSeconds = 120
     )
 
     Assert-BoundedProcessLimits -CallerLabel $CallerLabel `
         -TimeoutSeconds $TimeoutSeconds `
-        -MaximumOutputBytes $MaximumOutputBytes
+        -MaximumOutputBytes $MaximumOutputBytes `
+        -ReviewedTimeoutCeilingSeconds $ReviewedTimeoutCeilingSeconds
     $stdout = New-Object IO.MemoryStream
     $stderr = New-Object IO.MemoryStream
     $outBuffer = New-Object byte[] 4096
@@ -210,12 +222,14 @@ function Invoke-BoundedChildProcess {
         [string[]]$Arguments,
         [string]$CallerLabel,
         [int]$TimeoutSeconds,
-        [long]$MaximumOutputBytes = 1MB
+        [long]$MaximumOutputBytes = 1MB,
+        [int]$ReviewedTimeoutCeilingSeconds = 120
     )
 
     Assert-BoundedProcessLimits -CallerLabel $CallerLabel `
         -TimeoutSeconds $TimeoutSeconds `
-        -MaximumOutputBytes $MaximumOutputBytes
+        -MaximumOutputBytes $MaximumOutputBytes `
+        -ReviewedTimeoutCeilingSeconds $ReviewedTimeoutCeilingSeconds
     $executablePath = [IO.Path]::GetFullPath($Executable)
     $argumentText = (
         @($Arguments | ForEach-Object {
@@ -239,7 +253,8 @@ function Invoke-BoundedChildProcess {
         $captured = Read-BoundedProcessOutput -Launch $launch `
             -CallerLabel $CallerLabel `
             -TimeoutSeconds $TimeoutSeconds `
-            -MaximumOutputBytes $MaximumOutputBytes
+            -MaximumOutputBytes $MaximumOutputBytes `
+            -ReviewedTimeoutCeilingSeconds $ReviewedTimeoutCeilingSeconds
         if ($launch.ExitCode -ne 0) {
             $stderr = [string]$captured.stderr
             if ($stderr.Length -gt 2000) {

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import struct
 import sys
@@ -47,6 +48,22 @@ def function_source(source: str, name: str) -> str:
     start = source.index(f"function {name}")
     end = source.find("\nfunction ", start + 1)
     return source[start:] if end < 0 else source[start:end]
+
+
+def powershell_invocations(source: str, command: str) -> list[str]:
+    lines = source.splitlines()
+    invocations: list[str] = []
+    for index, line in enumerate(lines):
+        if not line.lstrip().startswith(command + " "):
+            continue
+        block = [line]
+        depth = line.count("(") - line.count(")")
+        while block[-1].rstrip().endswith("`") or depth > 0:
+            index += 1
+            block.append(lines[index])
+            depth += lines[index].count("(") - lines[index].count(")")
+        invocations.append("\n".join(block))
+    return invocations
 
 
 def ps_quote(value: object) -> str:
@@ -333,15 +350,80 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
             self.controller,
         )
         self.assertIn(
-            ') -Label "A1 preregistered analysis" -MaximumSeconds 1800',
+            ') -Label "A1 preregistered analysis" -MaximumSeconds 600',
             self.controller,
         )
         self.assertIn(
-            '-Label "A1 complete bundle validation" -MaximumSeconds 1800',
+            '-Label "A1 complete bundle validation" -MaximumSeconds 900',
             self.controller,
         )
-        # Two Python calls plus the independently frozen worker allowance.
-        self.assertEqual(self.controller.count("-MaximumSeconds 1800"), 3)
+        self.assertEqual(self.controller.count("-MaximumSeconds 1800"), 1)
+
+    def test_every_controller_child_timeout_fits_its_launcher_limit(self) -> None:
+        bounded_path = SCRIPTS / "shared" / "BoundedProcess.ps1"
+        bounded = bounded_path.read_text(encoding="utf-8")
+        default_match = re.search(r"CeilingSeconds = ([0-9]+)", bounded)
+        hard_match = re.search(r"CeilingSeconds -gt ([0-9]+)", bounded)
+        self.assertIsNotNone(default_match)
+        self.assertIsNotNone(hard_match)
+        default_ceiling = int(default_match.group(1))
+        hard_ceiling = int(hard_match.group(1))
+        self.assertEqual(default_ceiling, 120)
+        self.assertEqual(hard_ceiling, 1800)
+
+        python_launcher = function_source(self.controller, "Invoke-A1Python")
+        self.assertIn(
+            "-ReviewedTimeoutCeilingSeconds $MaximumSeconds", python_launcher
+        )
+        range_match = re.search(r"ValidateRange\(1, ([0-9]+)\)", python_launcher)
+        self.assertIsNotNone(range_match)
+        helper_ceiling = int(range_match.group(1))
+
+        observed: dict[str, int] = {}
+        for invocation in powershell_invocations(self.controller, "Invoke-A1Python"):
+            label_match = re.search(r'-Label "([^"]+)"', invocation)
+            maximum_match = re.search(r"-MaximumSeconds ([0-9]+)", invocation)
+            self.assertIsNotNone(label_match, invocation)
+            maximum = int(maximum_match.group(1)) if maximum_match else default_ceiling
+            self.assertLessEqual(maximum, helper_ceiling, invocation)
+            self.assertLessEqual(maximum, hard_ceiling, invocation)
+            observed[label_match.group(1)] = maximum
+        self.assertEqual(
+            observed,
+            {
+                "A1 immutable plan validation": 120,
+                "A1 environment validation": 120,
+                "A1 replica observation validation": 120,
+                "A1 preregistered analysis": 600,
+                "A1 analysis report validation": 120,
+                "A1 complete bundle validation": 900,
+            },
+        )
+
+        runtime = function_source(self.controller, "Assert-A1PythonRuntime")
+        pushed = function_source(self.controller, "Assert-A1ExactPushedCommit")
+        worker = function_source(self.controller, "Read-A1LongProcessOutput")
+        self.assertLessEqual(
+            int(re.search(r"-TimeoutSeconds ([0-9]+)", runtime).group(1)),
+            default_ceiling,
+        )
+        self.assertLessEqual(
+            int(
+                re.search(
+                    r"Get-A1CampaignAllowance -MaximumSeconds ([0-9]+)", pushed
+                ).group(1)
+            ),
+            default_ceiling,
+        )
+        worker_limit = int(
+            re.search(r"\$TimeoutSeconds -gt ([0-9]+)", worker).group(1)
+        )
+        worker_calls = powershell_invocations(self.controller, "Invoke-A1ReplicaWorker")
+        self.assertEqual(len(worker_calls), 1)
+        worker_requested = int(
+            re.search(r"-MaximumSeconds ([0-9]+)", worker_calls[0]).group(1)
+        )
+        self.assertLessEqual(worker_requested, worker_limit)
 
     def test_clean_pushed_provider_and_source_identity_gates_precede_work(self) -> None:
         for fragment in (

--- a/oracle/windows-dao/tests/test_bounded_process_contract.py
+++ b/oracle/windows-dao/tests/test_bounded_process_contract.py
@@ -90,7 +90,13 @@ class BoundedProcessSourceContractTests(unittest.TestCase):
 
     def test_limits_are_positive_caller_labeled_and_hard_capped(self) -> None:
         self.assertIn("$TimeoutSeconds -lt 1", self.source)
-        self.assertIn("$TimeoutSeconds -gt 120", self.source)
+        self.assertGreaterEqual(
+            self.source.count("[int]$ReviewedTimeoutCeilingSeconds = 120"), 3
+        )
+        self.assertIn("$ReviewedTimeoutCeilingSeconds -gt 1800", self.source)
+        self.assertIn(
+            "$TimeoutSeconds -gt $ReviewedTimeoutCeilingSeconds", self.source
+        )
         self.assertIn("$MaximumOutputBytes -lt 1", self.source)
         self.assertIn("$MaximumOutputBytes -gt 1MB", self.source)
         self.assertIn("[string]::IsNullOrWhiteSpace($CallerLabel)", self.source)


### PR DESCRIPTION
## Summary

- add an explicit reviewed timeout ceiling to the shared job-object bounded launcher, with the existing 120-second default and a fail-closed 1,800-second hard maximum
- have the A1 Python wrapper declare its requested ceiling while leaving every M1-M5 caller on the unchanged 120-second default
- use a 600-second ceiling for preregistered A1 analysis and a 900-second ceiling for each complete-bundle validation pass; all small plan/document validations remain at 120 seconds
- statically audit every A1 controller child timeout against the limit enforced by its launcher

## Run 7 budget and runtime estimate

Run 32448835077 spent 4,323 seconds in the controller through the immediate analysis-launch rejection; the three workers account for 4,298 seconds, leaving approximately 2,877 seconds under the frozen 7,200-second campaign ceiling. The post-worker reviewed maxima are 600 seconds for analysis, 120 seconds for the small analysis-report validation, and 900 seconds for each of the two required complete-bundle validation passes: 2,520 seconds total, with every individual launch additionally clipped to the live remainder by `Get-A1CampaignAllowance`.

The three-replica bundle contains 213 checkpoint indexes and approximately 1.8 million ordered page-digest observations. Analysis must parse those indexes and perform bounded candidate work but reads page blobs lazily, so 1-5 minutes is expected and 10 minutes is reviewed; complete-bundle validation walks all digest references and reconstructs about 3.5 GiB of logical checkpoint bytes per pass, so 5-12 minutes is expected and 15 minutes is reviewed for each pass. The separately invoked workflow validator runs after controller publication and is outside the controller's frozen campaign clock.

## Verification

- `python3.13 -m unittest discover -s oracle/windows-dao/tests -v` (427 tests, 82 expected platform skips locally)
- `git diff --check`
