### PR TITLE
fix: retain A1 post-acquisition diagnostics

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -65,9 +65,9 @@ jobs:
               [ref]$errors
             )
             if (@($errors).Count -ne 0) {
-              $detail = [string](@($errors | ForEach-Object {
+              [string]$detail = [Convert]::ToString((@($errors | ForEach-Object {
                 "line $($_.Extent.StartLineNumber): $($_.Message)"
-              }) -join "; ")
+              }) -join "; "))
               if ($detail.Length -gt 2000) {
                 $detail = $detail.Substring(0, 2000)
               }
@@ -351,7 +351,7 @@ jobs:
               }
             }
             catch {
-              $copyFailure = [string]$_.Exception.Message
+              [string]$copyFailure = [Convert]::ToString($_.Exception.Message)
               if ($copyFailure.Length -gt 2000) {
                 $copyFailure = $copyFailure.Substring(0, 2000)
               }
@@ -419,6 +419,7 @@ jobs:
             "oracle/windows-dao/scripts/run-a1-controlled.ps1"
           $process = $null
           $clock = $null
+          $campaignExit = $null
           $campaignError = $null
           $cleanupErrors = New-Object Collections.ArrayList
           $elapsedSeconds = 0.0
@@ -452,7 +453,13 @@ jobs:
             if ($logBytes -gt [long]$env:CAMPAIGN_MAXIMUM_OUTPUT_BYTES) {
               throw "A1 campaign output exceeded its byte ceiling."
             }
-            $campaignExit = $process.ExitCode
+            $process.WaitForExit()
+            $process.Refresh()
+            $exitCode = $process.ExitCode
+            if ($null -eq $exitCode) {
+              throw "A1 campaign exit code was unavailable after completion."
+            }
+            $campaignExit = [int]$exitCode
           }
           catch {
             $campaignError = $_
@@ -483,22 +490,31 @@ jobs:
           }
           if ($null -ne $campaignError) {
             if ($cleanupErrors.Count -ne 0) {
-              $cleanupDetail = @($cleanupErrors | ForEach-Object {
-                $_.Exception.Message
-              }) -join "; "
-              throw ($campaignError.Exception.Message +
+              [string]$cleanupDetail = [Convert]::ToString((@(
+                $cleanupErrors | ForEach-Object {
+                  [Convert]::ToString($_.Exception.Message)
+                }
+              ) -join "; "))
+              [string]$campaignMessage = [Convert]::ToString(
+                $campaignError.Exception.Message
+              )
+              throw ($campaignMessage +
                 " A1 hosted campaign cleanup also failed: " + $cleanupDetail)
             }
             throw $campaignError
           }
           if ($cleanupErrors.Count -ne 0) {
-            $cleanupDetail = @($cleanupErrors | ForEach-Object {
-              $_.Exception.Message
-            }) -join "; "
+            [string]$cleanupDetail = [Convert]::ToString((@(
+              $cleanupErrors | ForEach-Object {
+                [Convert]::ToString($_.Exception.Message)
+              }) -join "; "
+            ))
             throw "A1 hosted campaign cleanup failed: $cleanupDetail"
           }
           if ($campaignExit -ne 0) {
-            $detail = [string](Get-Content -LiteralPath $publishedStderr -Raw)
+            [string]$detail = [Convert]::ToString((
+              Get-Content -LiteralPath $publishedStderr -Raw
+            ))
             if ($detail.Length -gt 2000) { $detail = $detail.Substring(0, 2000) }
             throw "The checked A1 campaign failed: $detail"
           }

--- a/oracle/windows-dao/scripts/a1/A1.Controller.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Controller.ps1
@@ -116,14 +116,70 @@ function Invoke-A1Python {
         [Parameter(Mandatory = $true)][string]$ScriptPath,
         [Parameter(Mandatory = $true)][string[]]$Arguments,
         [Parameter(Mandatory = $true)][string]$Label,
-        [ValidateRange(1, 1800)][int]$MaximumSeconds = 120
+        [ValidateRange(1, 1800)][int]$MaximumSeconds = 120,
+        [AllowEmptyString()][string]$DiagnosticsRoot = "",
+        [AllowEmptyString()][string]$Phase = ""
     )
 
     $timeout = Get-A1CampaignAllowance -MaximumSeconds $MaximumSeconds
-    [void](Invoke-BoundedChildProcess -Executable $Context.PythonPath `
-        -Arguments (@("-B", $ScriptPath) + $Arguments) `
-        -CallerLabel $Label -TimeoutSeconds $timeout -MaximumOutputBytes 1MB `
-        -ReviewedTimeoutCeilingSeconds $MaximumSeconds)
+    $clock = [Diagnostics.Stopwatch]::StartNew()
+    try {
+        $result = $null
+        try {
+            $result = Invoke-BoundedChildProcess `
+                -Executable $Context.PythonPath `
+                -Arguments (@("-B", $ScriptPath) + $Arguments) `
+                -CallerLabel $Label -TimeoutSeconds $timeout `
+                -MaximumOutputBytes 1MB `
+                -ReviewedTimeoutCeilingSeconds $MaximumSeconds `
+                -ReturnFailureRecord
+        }
+        catch {
+            $failure = $_
+            if (-not [string]::IsNullOrWhiteSpace($DiagnosticsRoot)) {
+                try {
+                    Write-A1ChildFailureDiagnostic `
+                        -DiagnosticsRoot $DiagnosticsRoot -Label $Label `
+                        -Phase $Phase `
+                        -ExitCode $failure.Exception.Data[
+                            "BoundedProcess.ExitCode"
+                        ] -ElapsedSeconds $clock.Elapsed.TotalSeconds `
+                        -Stdout $failure.Exception.Data[
+                            "BoundedProcess.Stdout"
+                        ] -Stderr $failure.Exception.Data[
+                            "BoundedProcess.Stderr"
+                        ] -ErrorMessage $failure.Exception.Message
+                }
+                catch {
+                    throw ([Convert]::ToString($failure.Exception.Message) +
+                        " A1 child diagnostic retention also failed: " +
+                        [Convert]::ToString($_.Exception.Message))
+                }
+            }
+            throw $failure
+        }
+        if ([int]$result.exit_code -ne 0) {
+            if (-not [string]::IsNullOrWhiteSpace($DiagnosticsRoot)) {
+                try {
+                    Write-A1ChildFailureDiagnostic `
+                        -DiagnosticsRoot $DiagnosticsRoot -Label $Label `
+                        -Phase $Phase -ExitCode $result.exit_code `
+                        -ElapsedSeconds $clock.Elapsed.TotalSeconds `
+                        -Stdout $result.stdout -Stderr $result.stderr `
+                        -ErrorMessage "$Label worker exited nonzero."
+                }
+                catch {
+                    throw ("$Label worker exited nonzero. " +
+                        "A1 child diagnostic retention also failed: " +
+                        [Convert]::ToString($_.Exception.Message))
+                }
+            }
+            $stderr = ConvertTo-A1DiagnosticTail -Value $result.stderr `
+                -MaximumChars 2000
+            throw "$Label worker failed: $stderr"
+        }
+    }
+    finally { $clock.Stop() }
 }
 
 function Assert-A1ExactPushedCommit {
@@ -556,6 +612,7 @@ function Invoke-A1Campaign {
     $binding = $null
     $campaignClock = [Diagnostics.Stopwatch]::StartNew()
     $script:A1CampaignClock = $campaignClock
+    $phase = "preflight"
     try {
         $context = Invoke-M1Preflight -RepositoryRoot $repository `
             -EnvironmentPath $EnvironmentPath -OutputRoot $OutputRoot `
@@ -606,6 +663,7 @@ function Invoke-A1Campaign {
             "oracle/windows-dao/scripts/a1/A1.Worker.ps1"
         $binding = Get-A1WorkerPowerShell
         for ($replica = 1; $replica -le 3; $replica++) {
+            $phase = "replica-$replica"
             if ($campaignClock.Elapsed.TotalSeconds -ge 7200) {
                 throw "A1 campaign exceeded its wall-clock ceiling."
             }
@@ -625,6 +683,7 @@ function Invoke-A1Campaign {
                 -Arguments @("validate-document", $observation) `
                 -Label "A1 replica observation validation"
         }
+        $phase = "analysis"
         $analysisPath = Join-Path $repository $script:A1AnalysisRelative
         $analysisOutput = Join-Path $session.WorkingPath `
             "a1-analysis-report.json"
@@ -641,12 +700,16 @@ function Invoke-A1Campaign {
                     -RelativePath "observations/replica-03.json"),
                 "--bundle-root", $session.StagingBundle,
                 "--output", $analysisOutput
-            ) -Label "A1 preregistered analysis" -MaximumSeconds 600
+            ) -Label "A1 preregistered analysis" -MaximumSeconds 600 `
+            -DiagnosticsRoot $diagnostics -Phase $phase
         $analysisInput = Read-A1ControllerInput -Path $analysisOutput `
             -MaximumBytes 64MB
+        $phase = "analysis-report-validation"
         Invoke-A1Python -Context $context -ScriptPath $contractPath `
             -Arguments @("validate-document", $analysisOutput) `
-            -Label "A1 analysis report validation"
+            -Label "A1 analysis report validation" `
+            -DiagnosticsRoot $diagnostics -Phase $phase
+        $phase = "manifest"
         Write-M1DurableBytes -Session $session `
             -RelativePath "analysis/analysis-report.json" `
             -Bytes $analysisInput.bytes
@@ -656,11 +719,14 @@ function Invoke-A1Campaign {
         if ($campaignClock.Elapsed.TotalSeconds -ge 7200) {
             throw "A1 campaign exceeded its wall-clock ceiling."
         }
+        $phase = "complete-bundle-validation"
         $validate = {
             param($bundle)
             Invoke-A1Python -Context $context -ScriptPath $contractPath `
                 -Arguments @("validate-bundle", $bundle) `
-                -Label "A1 complete bundle validation" -MaximumSeconds 900
+                -Label "A1 complete bundle validation" -MaximumSeconds 900 `
+                -DiagnosticsRoot $diagnostics `
+                -Phase "complete-bundle-validation"
         }
         $recheck = {
             param($stage)
@@ -669,6 +735,7 @@ function Invoke-A1Campaign {
             & $validate $stage.StagingBundle
             return $true
         }
+        $phase = "publication"
         Publish-M1Stage -Stage $session -RecheckScriptBlock $recheck `
             -ValidationScriptBlock $validate
         $published = $session.FinalDirectory
@@ -677,14 +744,31 @@ function Invoke-A1Campaign {
     }
     catch {
         $original = $_
+        $secondaryErrors = New-Object Collections.ArrayList
+        try {
+            Write-A1CampaignFailureDiagnostic -DiagnosticsRoot $diagnostics `
+                -Phase $phase `
+                -ElapsedSeconds $campaignClock.Elapsed.TotalSeconds `
+                -ErrorRecord $original
+        }
+        catch {
+            [void]$secondaryErrors.Add(
+                "A1 campaign diagnostic retention failed: " +
+                [Convert]::ToString($_.Exception.Message)
+            )
+        }
         if ($null -ne $session) {
             try { Remove-A1PrivateStaging -Session $session }
             catch {
-                $cleanup = $_
-                throw ($original.Exception.Message +
-                    " A1 private staging cleanup also failed: " +
-                    $cleanup.Exception.Message)
+                [void]$secondaryErrors.Add(
+                    "A1 private staging cleanup also failed: " +
+                    [Convert]::ToString($_.Exception.Message)
+                )
             }
+        }
+        if ($secondaryErrors.Count -ne 0) {
+            throw ([Convert]::ToString($original.Exception.Message) + " " +
+                (@($secondaryErrors) -join " "))
         }
         throw $original
     }

--- a/oracle/windows-dao/scripts/a1/A1.Progress.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Progress.ps1
@@ -162,3 +162,105 @@ function Copy-A1ProgressFile {
     }
     return $destination
 }
+
+function ConvertTo-A1DiagnosticTail {
+    param(
+        [AllowNull()][object]$Value,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 131072)][int]$MaximumChars
+    )
+
+    $text = [Convert]::ToString($Value)
+    if ($text.Length -le $MaximumChars) { return $text }
+    return $text.Substring($text.Length - $MaximumChars)
+}
+
+function Write-A1DiagnosticDocument {
+    param(
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory = $true)][string]$FileName,
+        [Parameter(Mandatory = $true)][Collections.IDictionary]$Document
+    )
+
+    $root = [IO.Path]::GetFullPath($DiagnosticsRoot)
+    Assert-M1NoReparseComponents -Path $root
+    $item = Get-Item -LiteralPath $root -Force
+    if (-not $item.PSIsContainer -or
+        ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or
+        $FileName -cnotmatch '^[a-z0-9][a-z0-9.-]{0,127}\.json$') {
+        throw "A1 diagnostic destination is not a bounded ordinary path."
+    }
+    $path = Join-Path $root $FileName
+    $json = $Document | ConvertTo-Json -Depth 6 -Compress
+    $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes($json + "`n")
+    if ($bytes.Length -gt $script:A1ProgressMaximumBytes) {
+        throw "A1 diagnostic document exceeds its byte ceiling."
+    }
+    $stream = New-Object IO.FileStream(
+        $path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write,
+        [IO.FileShare]::Read, 4096, [IO.FileOptions]::WriteThrough
+    )
+    try {
+        $stream.Write($bytes, 0, $bytes.Length)
+        $stream.Flush($true)
+    }
+    finally { $stream.Dispose() }
+    return $path
+}
+
+function Write-A1ChildFailureDiagnostic {
+    param(
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Phase,
+        [AllowNull()][object]$ExitCode,
+        [Parameter(Mandatory = $true)][double]$ElapsedSeconds,
+        [AllowNull()][object]$Stdout,
+        [AllowNull()][object]$Stderr,
+        [AllowNull()][object]$ErrorMessage
+    )
+
+    $slug = ($Label.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+    if ($slug.Length -lt 1 -or $slug.Length -gt 64) {
+        throw "A1 diagnostic child label is invalid."
+    }
+    $exitValue = $null
+    if ($null -ne $ExitCode) { $exitValue = [int]$ExitCode }
+    $document = [ordered]@{
+        document_type = "jet3_a1_child_failure"
+        label = $Label
+        phase = $Phase
+        exit_code = $exitValue
+        elapsed_seconds = [Math]::Round($ElapsedSeconds, 3)
+        stdout_tail = ConvertTo-A1DiagnosticTail -Value $Stdout `
+            -MaximumChars 32768
+        stderr_tail = ConvertTo-A1DiagnosticTail -Value $Stderr `
+            -MaximumChars 32768
+        error_message = ConvertTo-A1DiagnosticTail -Value $ErrorMessage `
+            -MaximumChars 2000
+        recorded_utc = [DateTimeOffset]::UtcNow.ToString("o")
+    }
+    [void](Write-A1DiagnosticDocument -DiagnosticsRoot $DiagnosticsRoot `
+        -FileName ("post-worker-{0}.failure.json" -f $slug) `
+        -Document $document)
+}
+
+function Write-A1CampaignFailureDiagnostic {
+    param(
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory = $true)][string]$Phase,
+        [Parameter(Mandatory = $true)][double]$ElapsedSeconds,
+        [Parameter(Mandatory = $true)][Management.Automation.ErrorRecord]$ErrorRecord
+    )
+
+    $document = [ordered]@{
+        document_type = "jet3_a1_campaign_failure"
+        phase = $Phase
+        elapsed_seconds = [Math]::Round($ElapsedSeconds, 3)
+        exception_type = $ErrorRecord.Exception.GetType().FullName
+        error_message = ConvertTo-A1DiagnosticTail `
+            -Value $ErrorRecord.Exception.Message -MaximumChars 2000
+        recorded_utc = [DateTimeOffset]::UtcNow.ToString("o")
+    }
+    [void](Write-A1DiagnosticDocument -DiagnosticsRoot $DiagnosticsRoot `
+        -FileName "campaign-error.json" -Document $document)
+}

--- a/oracle/windows-dao/scripts/shared/BoundedProcess.ps1
+++ b/oracle/windows-dao/scripts/shared/BoundedProcess.ps1
@@ -209,6 +209,22 @@ function Read-BoundedProcessOutput {
             stderr = $encoding.GetString($stderr.ToArray())
         }
     }
+    catch {
+        $failure = $_
+        $encoding = New-Object Text.UTF8Encoding($false, $false)
+        $failure.Exception.Data["BoundedProcess.Stdout"] =
+            $encoding.GetString($stdout.ToArray())
+        $failure.Exception.Data["BoundedProcess.Stderr"] =
+            $encoding.GetString($stderr.ToArray())
+        try {
+            if ($Launch.HasExited) {
+                $failure.Exception.Data["BoundedProcess.ExitCode"] =
+                    [int]$Launch.ExitCode
+            }
+        }
+        catch { }
+        throw $failure
+    }
     finally {
         $clock.Stop()
         $stdout.Dispose()
@@ -223,7 +239,8 @@ function Invoke-BoundedChildProcess {
         [string]$CallerLabel,
         [int]$TimeoutSeconds,
         [long]$MaximumOutputBytes = 1MB,
-        [int]$ReviewedTimeoutCeilingSeconds = 120
+        [int]$ReviewedTimeoutCeilingSeconds = 120,
+        [switch]$ReturnFailureRecord
     )
 
     Assert-BoundedProcessLimits -CallerLabel $CallerLabel `
@@ -255,6 +272,13 @@ function Invoke-BoundedChildProcess {
             -TimeoutSeconds $TimeoutSeconds `
             -MaximumOutputBytes $MaximumOutputBytes `
             -ReviewedTimeoutCeilingSeconds $ReviewedTimeoutCeilingSeconds
+        if ($ReturnFailureRecord) {
+            return [pscustomobject]@{
+                exit_code = [int]$launch.ExitCode
+                stdout = [Convert]::ToString($captured.stdout)
+                stderr = [Convert]::ToString($captured.stderr)
+            }
+        }
         if ($launch.ExitCode -ne 0) {
             $stderr = [string]$captured.stderr
             if ($stderr.Length -gt 2000) {

--- a/oracle/windows-dao/tests/test_a1_post_acquisition_diagnostics.py
+++ b/oracle/windows-dao/tests/test_a1_post_acquisition_diagnostics.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+TESTS = Path(__file__).resolve().parent
+SCRIPTS = TESTS.parent / "scripts"
+CONTROLLER = SCRIPTS / "a1" / "A1.Controller.ps1"
+PROGRESS = SCRIPTS / "a1" / "A1.Progress.ps1"
+BOUNDED = SCRIPTS / "shared" / "BoundedProcess.ps1"
+
+
+class A1PostAcquisitionDiagnosticsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.controller = CONTROLLER.read_text(encoding="utf-8")
+        cls.progress = PROGRESS.read_text(encoding="utf-8")
+        cls.bounded = BOUNDED.read_text(encoding="utf-8")
+
+    def test_only_post_worker_python_calls_bind_failure_diagnostics(self) -> None:
+        self.assertEqual(self.controller.count("-DiagnosticsRoot $diagnostics"), 5)
+        self.assertIn('$phase = "analysis"', self.controller)
+        self.assertIn('$phase = "analysis-report-validation"', self.controller)
+        self.assertIn('-Phase "complete-bundle-validation"', self.controller)
+        for label in (
+            "A1 preregistered analysis",
+            "A1 analysis report validation",
+            "A1 complete bundle validation",
+        ):
+            start = self.controller.index(f'-Label "{label}"')
+            invocation = self.controller[start : start + 220]
+            self.assertIn("-DiagnosticsRoot $diagnostics", invocation)
+
+    def test_child_failure_record_is_bounded_and_structured(self) -> None:
+        self.assertIn("-ReturnFailureRecord", self.controller)
+        self.assertIn("Write-A1ChildFailureDiagnostic", self.controller)
+        self.assertIn('document_type = "jet3_a1_child_failure"', self.progress)
+        for field in (
+            "label = $Label",
+            "exit_code = $exitValue",
+            "elapsed_seconds =",
+            "stdout_tail =",
+            "stderr_tail =",
+            "error_message =",
+        ):
+            self.assertIn(field, self.progress)
+        self.assertEqual(self.progress.count("-MaximumChars 32768"), 2)
+        self.assertIn("$bytes.Length -gt $script:A1ProgressMaximumBytes", self.progress)
+        self.assertIn("[IO.FileMode]::CreateNew", self.progress)
+
+    def test_campaign_failure_is_recorded_before_private_cleanup(self) -> None:
+        catch = self.controller.split("    catch {\n        $original = $_", 1)[1]
+        record = catch.index("Write-A1CampaignFailureDiagnostic")
+        cleanup = catch.index("Remove-A1PrivateStaging")
+        self.assertLess(record, cleanup)
+        self.assertIn('document_type = "jet3_a1_campaign_failure"', self.progress)
+        self.assertIn('-FileName "campaign-error.json"', self.progress)
+        self.assertIn("phase = $Phase", self.progress)
+        self.assertIn("exception_type =", self.progress)
+
+    def test_shared_launcher_default_nonzero_behavior_is_unchanged(self) -> None:
+        opt_in = self.bounded.index("if ($ReturnFailureRecord)")
+        default_failure = self.bounded.index("if ($launch.ExitCode -ne 0)")
+        self.assertLess(opt_in, default_failure)
+        self.assertIn('throw "$CallerLabel worker failed: $stderr"', self.bounded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_bounded_process_contract.py
+++ b/oracle/windows-dao/tests/test_bounded_process_contract.py
@@ -123,6 +123,10 @@ class BoundedProcessSourceContractTests(unittest.TestCase):
             "                -not ($outDone -and $errDone)",
             self.source,
         )
+        self.assertIn('[switch]$ReturnFailureRecord', self.source)
+        self.assertIn('exit_code = [int]$launch.ExitCode', self.source)
+        self.assertIn('$failure.Exception.Data["BoundedProcess.Stdout"]', self.source)
+        self.assertIn('$failure.Exception.Data["BoundedProcess.Stderr"]', self.source)
 
     def test_launch_has_no_pid_based_or_start_then_assign_fallback(self) -> None:
         combined = self.source + self.native
@@ -185,6 +189,25 @@ class BoundedProcessWindowsTests(unittest.TestCase):
                 "M4 child output limit is outside the reviewed ceiling.",
                 "Bounded process caller label is invalid.",
             ],
+        )
+
+    def test_opt_in_failure_record_retains_exit_code_and_both_streams(self) -> None:
+        assert self.powershell is not None
+        command = (
+            f". '{quoted(SHARED)}';"
+            f"$record=Invoke-BoundedChildProcess -Executable '{quoted(self.powershell)}' "
+            "-Arguments @('-NoProfile','-NonInteractive','-Command',"
+            "'[Console]::Out.Write(''out'');"
+            "[Console]::Error.Write(''err'');exit 7') "
+            "-CallerLabel 'failure-record-probe' -TimeoutSeconds 10 "
+            "-MaximumOutputBytes 1MB -ReturnFailureRecord;"
+            "[Console]::Write(($record|ConvertTo-Json -Compress))"
+        )
+        result = self._run(command, timeout=60)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"exit_code": 7, "stdout": "out", "stderr": "err"},
         )
 
     def test_timeout_terminates_a_descendant_before_it_can_write(self) -> None:

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -242,14 +242,32 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("[IO.File]::ReadAllBytes", publication)
         self.assertIn("if ($null -ne $stream) { $stream.Dispose() }", publication)
-        self.assertIn('$copyFailure = [string]$_.Exception.Message', publication)
+        self.assertIn(
+            '[string]$copyFailure = [Convert]::ToString($_.Exception.Message)',
+            publication,
+        )
         self.assertIn("if ($copyFailure.Length -gt 2000)", publication)
         self.assertIn(
             '"A1 process logs were not retained within their byte ceiling: " +',
             publication,
         )
-        self.assertEqual(self.workflow.count("$detail = [string]("), 2)
+        self.assertEqual(
+            self.workflow.count("[string]$detail = [Convert]::ToString(("), 2
+        )
+        self.assertNotIn("$detail = [string](", self.workflow)
         self.assertNotIn("$detail = Get-Content", self.workflow)
+
+    def test_campaign_exit_is_observed_and_null_checked_before_comparison(self) -> None:
+        self.assertIn("$campaignExit = $null", self.workflow)
+        completed_wait = self.workflow.index("$process.WaitForExit()")
+        refresh = self.workflow.index("$process.Refresh()", completed_wait)
+        null_guard = self.workflow.index("if ($null -eq $exitCode)", refresh)
+        assignment = self.workflow.index("$campaignExit = [int]$exitCode", null_guard)
+        comparison = self.workflow.index("if ($campaignExit -ne 0)", assignment)
+        self.assertLess(completed_wait, refresh)
+        self.assertLess(refresh, null_guard)
+        self.assertLess(null_guard, assignment)
+        self.assertLess(assignment, comparison)
 
     def test_campaign_and_independent_bundle_validator_are_exactly_bound(self) -> None:
         self.assertEqual(self.workflow.count("run-a1-controlled.ps1"), 2)


### PR DESCRIPTION
## Summary

- make every A1 workflow detail/message conversion null-safe and explicitly observe, refresh, and validate the hosted child exit code
- add an opt-in bounded-process failure record while preserving the default M1-M5 launcher semantics
- retain bounded post-worker child failure JSON with label, phase, exit code, elapsed time, and stdout/stderr tails
- retain a structured campaign-error.json before private staging cleanup

## Run 8 root cause

The retained campaign.stdout.log contains PASS: retained A1 campaign, which run-a1-controlled.ps1 emits only after Invoke-A1Campaign returns a published bundle; its explicit next action is exit 0. Therefore analysis, report validation, bundle validation, and publication succeeded in run 32461188555: the hosted Start-Process wrapper observed an unavailable/null ExitCode, PowerShell treated $null -ne 0 as true, and Get-Content -Raw on the empty stderr produced the null value whose Length access crashed reporting. The wrapper now performs the final WaitForExit/Refresh sequence, rejects an unavailable exit code explicitly, and converts all possibly empty messages through Convert.ToString.

No EXP-0038 decisive-report rejection or real-bundle a1_analysis exception was reached in this run. Genuine future post-worker failures will retain both the failed child record and the campaign error in the diagnostics artifact.

## Verification

- python3.13 -m unittest discover -s oracle/windows-dao/tests -v (433 passed, 83 skipped)
- git diff --check