### PR TITLE
fix: add A1 worker headroom on slow hosted runners

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -438,6 +438,7 @@ jobs:
                 "-GitCommit", $env:GITHUB_SHA,
                 "-RunId", $runId
               )
+            $null = $process.Handle
             $clock = [Diagnostics.Stopwatch]::StartNew()
             while (-not $process.WaitForExit(1000)) {
               $logBytes = Get-A1LogBytes -Paths @($stdoutPath, $stderrPath)

--- a/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
@@ -9,6 +9,215 @@ $script:A1MaximumChangedEntries = 1500000L
 $script:A1MaximumLogicalReadBytes = 8GB
 $script:A1StrictUtf8 = New-Object Text.UTF8Encoding($false, $true)
 
+function Initialize-A1PageSnapshotNative {
+    if ("Jet3A1PageSnapshotNative" -as [type]) { return }
+    Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+public sealed class Jet3A1PageSnapshotResult
+{
+    public byte[] Bytes;
+    public string FileSha256;
+    public string[] PageSha256;
+    public long[] ChangedIndices;
+    public byte[][] ChangedPages;
+}
+
+public sealed class Jet3A1PageStoreInventoryResult
+{
+    public HashSet<string> Seen;
+    public long RetainedBytes;
+}
+
+public static class Jet3A1PageSnapshotNative
+{
+    private static string LowerHex(byte[] value)
+    {
+        StringBuilder text = new StringBuilder(value.Length * 2);
+        for (int index = 0; index < value.Length; index++)
+        {
+            text.Append(value[index].ToString("x2"));
+        }
+        return text.ToString();
+    }
+
+    private static bool IsLowerSha256(string value)
+    {
+        if (value == null || value.Length != 64) return false;
+        for (int index = 0; index < value.Length; index++)
+        {
+            char current = value[index];
+            if (!((current >= '0' && current <= '9') ||
+                  (current >= 'a' && current <= 'f'))) return false;
+        }
+        return true;
+    }
+
+    private static bool PageEquals(
+        byte[] current, int currentOffset, byte[] prior, int priorOffset,
+        int pageBytes)
+    {
+        for (int offset = 0; offset < pageBytes; offset++)
+        {
+            if (current[currentOffset + offset] != prior[priorOffset + offset])
+                return false;
+        }
+        return true;
+    }
+
+    public static Jet3A1PageStoreInventoryResult Inventory(
+        string bundleRoot, string pageRoot, int maximumEntries,
+        int maximumPages, long maximumBytes, int pageBytes)
+    {
+        bundleRoot = Path.GetFullPath(bundleRoot).TrimEnd(
+            Path.DirectorySeparatorChar);
+        pageRoot = Path.GetFullPath(pageRoot).TrimEnd(
+            Path.DirectorySeparatorChar);
+        if ((File.GetAttributes(bundleRoot) & FileAttributes.ReparsePoint) != 0)
+            throw new IOException("Bundle root is a reparse point.");
+        Stack<string> pending = new Stack<string>();
+        pending.Push(bundleRoot);
+        HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+        long retained = 0;
+        int entries = 0;
+        while (pending.Count != 0)
+        {
+            string directory = pending.Pop();
+            foreach (string child in Directory.EnumerateDirectories(
+                directory, "*", SearchOption.TopDirectoryOnly))
+            {
+                if ((File.GetAttributes(child) & FileAttributes.ReparsePoint) != 0)
+                    throw new IOException("Bundle directory is a reparse point.");
+                pending.Push(child);
+            }
+            foreach (string path in Directory.EnumerateFiles(
+                directory, "*", SearchOption.TopDirectoryOnly))
+            {
+                FileInfo item = new FileInfo(path);
+                entries++;
+                if (entries > maximumEntries || item.Length < 0 ||
+                    item.Length > maximumBytes - retained ||
+                    (item.Attributes & FileAttributes.ReparsePoint) != 0)
+                    throw new IOException("Bundle inventory exceeds its bound.");
+                retained += item.Length;
+                if (!path.StartsWith(
+                        pageRoot + Path.DirectorySeparatorChar,
+                        StringComparison.OrdinalIgnoreCase) ||
+                    !path.EndsWith(".page", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                string digest = Path.GetFileNameWithoutExtension(path);
+                string expected = Path.Combine(pageRoot, digest + ".page");
+                if (!path.Equals(expected, StringComparison.Ordinal) ||
+                    !IsLowerSha256(digest) || item.Length != pageBytes ||
+                    !seen.Add(digest) || seen.Count > maximumPages)
+                    throw new InvalidDataException(
+                        "Existing page-store entry is noncanonical.");
+            }
+        }
+        return new Jet3A1PageStoreInventoryResult {
+            Seen = seen,
+            RetainedBytes = retained
+        };
+    }
+
+    public static Jet3A1PageSnapshotResult Capture(
+        string path, int pageBytes, int maximumPages, long maximumBytes,
+        byte[] priorBytes, string[] priorHashes)
+    {
+        if (pageBytes < 1 || maximumPages < 1 || maximumBytes < pageBytes)
+            throw new ArgumentOutOfRangeException("page snapshot bound");
+        if ((priorBytes == null) != (priorHashes == null))
+            throw new InvalidDataException("Prior snapshot cache is incomplete.");
+        if (priorBytes != null)
+        {
+            if (priorBytes.Length % pageBytes != 0 ||
+                priorBytes.Length / pageBytes != priorHashes.Length ||
+                priorHashes.Length > maximumPages)
+                throw new InvalidDataException("Prior snapshot cache is invalid.");
+            foreach (string digest in priorHashes)
+            {
+                if (!IsLowerSha256(digest))
+                    throw new InvalidDataException("Prior page digest is invalid.");
+            }
+        }
+
+        byte[] bytes;
+        using (FileStream stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.None, 1048576,
+            FileOptions.SequentialScan))
+        {
+            long length = stream.Length;
+            if (length < pageBytes || length % pageBytes != 0 ||
+                length / pageBytes > maximumPages || length > maximumBytes ||
+                length > Int32.MaxValue)
+                throw new InvalidDataException("Page snapshot size is invalid.");
+            bytes = new byte[(int)length];
+            int offset = 0;
+            while (offset < bytes.Length)
+            {
+                int read = stream.Read(bytes, offset, bytes.Length - offset);
+                if (read <= 0)
+                    throw new EndOfStreamException("Page snapshot ended early.");
+                offset += read;
+            }
+            if (stream.ReadByte() != -1 || stream.Length != length)
+                throw new IOException("Page snapshot changed during capture.");
+        }
+
+        int pageCount = bytes.Length / pageBytes;
+        int priorCount = priorBytes == null ? 0 : priorHashes.Length;
+        string[] hashes = new string[pageCount];
+        List<long> changed = new List<long>();
+        List<byte[]> changedPages = new List<byte[]>();
+        string fileDigest;
+        using (SHA256 hash = SHA256.Create())
+        {
+            // page_capture.checkpoint_representation fixes these exact bytes
+            // and ordered page digests, independent of loop implementation.
+            fileDigest = LowerHex(hash.ComputeHash(bytes));
+            for (int index = 0; index < pageCount; index++)
+            {
+                int pageOffset = index * pageBytes;
+                bool unchanged = index < priorCount && PageEquals(
+                    bytes, pageOffset, priorBytes, pageOffset, pageBytes);
+                if (unchanged)
+                {
+                    hashes[index] = priorHashes[index];
+                    continue;
+                }
+                hashes[index] = LowerHex(
+                    hash.ComputeHash(bytes, pageOffset, pageBytes));
+                // changed_page_indices is the ordered-digest delta.
+                if (index < priorCount && hashes[index].Equals(
+                    priorHashes[index], StringComparison.Ordinal))
+                    continue;
+                byte[] page = new byte[pageBytes];
+                Buffer.BlockCopy(bytes, pageOffset, page, 0, pageBytes);
+                changed.Add(index);
+                changedPages.Add(page);
+            }
+        }
+        for (int index = pageCount; index < priorCount; index++)
+        {
+            changed.Add(index);
+            changedPages.Add(null);
+        }
+        return new Jet3A1PageSnapshotResult {
+            Bytes = bytes,
+            FileSha256 = fileDigest,
+            PageSha256 = hashes,
+            ChangedIndices = changed.ToArray(),
+            ChangedPages = changedPages.ToArray()
+        };
+    }
+}
+'@
+}
+
 function Read-A1CheckedJson {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
@@ -194,50 +403,21 @@ function Add-A1PageBlob {
 function New-A1PageStore {
     param([Parameter(Mandatory = $true)][pscustomobject]$Session)
 
-    $seen = New-Object 'Collections.Generic.HashSet[string]' `
-        ([StringComparer]::Ordinal)
     $root = Get-M1PayloadPath -Session $Session -RelativePath "page-store"
-    $retained = [long]0
-    $allFiles = @([IO.Directory]::EnumerateFiles(
-        $Session.StagingBundle, "*", [IO.SearchOption]::AllDirectories
-    ))
-    if ($allFiles.Count -gt 262399) {
-        throw "A1 staged bundle exceeds its entry ceiling."
-    }
-    foreach ($path in $allFiles) {
-        Assert-M1NoReparseComponents -Path $path
-        $length = [long](Get-Item -LiteralPath $path -Force).Length
-        if ($length -gt (768MB - $retained)) {
-            throw "A1 staged bundle exceeds its retained-byte ceiling."
-        }
-        $retained += $length
-    }
-    if ([IO.Directory]::Exists($root)) {
-        $files = @([IO.Directory]::EnumerateFiles(
-            $root, "*.page", [IO.SearchOption]::AllDirectories
-        ))
-        if ($files.Count -gt $script:A1MaximumUniqueBlobs) {
-            throw "A1 existing page store exceeds its entry ceiling."
-        }
-        foreach ($path in $files) {
-            Assert-M1NoReparseComponents -Path $path
-            $name = [IO.Path]::GetFileNameWithoutExtension($path)
-            $expected = Get-A1PageBlobLocator -Sha256 $name
-            $actual = $path.Substring(
-                $Session.StagingBundle.TrimEnd('\').Length + 1
-            ).Replace('\', '/')
-            if ($actual -cne $expected) {
-                throw "A1 existing page-store locator is noncanonical."
-            }
-            Assert-A1ExistingPageBlob -Path $path -ExpectedSha256 $name
-            [void]$seen.Add($name)
-        }
-    }
+    Assert-M1NoReparseComponents -Path $Session.StagingBundle
+    Initialize-A1PageSnapshotNative
+    # page_capture.store binds canonical content-addressed blobs; the complete
+    # validator rehashes every blob before publication.
+    $inventory = [Jet3A1PageSnapshotNative]::Inventory(
+        $Session.StagingBundle, $root, 262399,
+        [int]$script:A1MaximumUniqueBlobs, 768MB,
+        [int]$script:A1PageBytes
+    )
     return [pscustomobject]@{
         Session = $Session
-        Seen = $seen
-        UniqueBytes = [long]($seen.Count * $script:A1PageBytes)
-        RetainedBytes = $retained
+        Seen = $inventory.Seen
+        UniqueBytes = [long]($inventory.Seen.Count * $script:A1PageBytes)
+        RetainedBytes = [long]$inventory.RetainedBytes
         LogicalReadBytes = [long]0
         ChangedEntries = [long]0
     }
@@ -374,134 +554,62 @@ function Read-A1PageSnapshot {
         [Parameter(Mandatory = $true)][pscustomobject]$Store,
         [Parameter(Mandatory = $true)][string]$DatabasePath,
         [AllowNull()][string[]]$PriorHashes,
-        [AllowNull()][byte[][]]$PriorPages
+        [AllowNull()][byte[]]$PriorPages
     )
 
     Assert-M1NoReparseComponents -Path $DatabasePath
     if (($null -eq $PriorHashes) -ne ($null -eq $PriorPages) -or
         ($null -ne $PriorHashes -and
-            $PriorHashes.Count -ne $PriorPages.Count) -or
+            $PriorHashes.Count -ne
+                ($PriorPages.LongLength / $script:A1PageBytes)) -or
         ($null -ne $PriorPages -and
-            $PriorPages.Count -gt $script:A1MaximumPagesPerReplica)) {
+            ($PriorPages.LongLength % $script:A1PageBytes) -ne 0) -or
+        ($null -ne $PriorPages -and
+            ($PriorPages.LongLength / $script:A1PageBytes) -gt
+                $script:A1MaximumPagesPerReplica)) {
         throw "A1 prior snapshot cache is incomplete or exceeds its bound."
     }
-    $stream = New-Object IO.FileStream(
-        $DatabasePath, [IO.FileMode]::Open, [IO.FileAccess]::Read,
-        [IO.FileShare]::None, 65536, [IO.FileOptions]::SequentialScan
+    Initialize-A1PageSnapshotNative
+    $remaining = [long](
+        $script:A1MaximumLogicalReadBytes - $Store.LogicalReadBytes
     )
-    $fileHash = $null
-    $pageHash = $null
-    try {
-        if ($stream.Length -lt $script:A1PageBytes -or
-            ($stream.Length % $script:A1PageBytes) -ne 0) {
-            throw "A1 closed database is not an exact sequence of pages."
-        }
-        $pageCount = [long]($stream.Length / $script:A1PageBytes)
-        if ($pageCount -gt $script:A1MaximumPagesPerReplica -or
-            $stream.Length -gt (
-                $script:A1MaximumLogicalReadBytes - $Store.LogicalReadBytes
-            )) {
-            throw "A1 snapshot exceeded its page or logical-read ceiling."
-        }
-        $hashes = New-Object 'Collections.Generic.List[string]' `
-            ([int]$pageCount)
-        $pages = New-Object 'Collections.Generic.List[byte[]]' `
-            ([int]$pageCount)
-        $changed = New-Object Collections.ArrayList
-        $fileHash = [Security.Cryptography.SHA256]::Create()
-        $pageHash = [Security.Cryptography.SHA256]::Create()
-        $pageComparer = `
-            [Collections.StructuralComparisons]::StructuralEqualityComparer
-        $page = New-Object byte[] ([int]$script:A1PageBytes)
-        for ($index = 0L; $index -lt $pageCount; $index++) {
-            $offset = 0
-            while ($offset -lt $page.Length) {
-                $read = $stream.Read($page, $offset, $page.Length - $offset)
-                if ($read -le 0) { throw "A1 page read ended early." }
-                $offset += $read
-            }
-            [void]$fileHash.TransformBlock(
-                $page, 0, $page.Length, $page, 0
-            )
-            # page-index.schema database_sha256 is streamed during the same
-            # page_capture.checkpoint_representation read.
-            $unchanged = $false
-            if ($null -ne $PriorPages -and $index -lt $PriorPages.Count) {
-                $priorPage = [byte[]]$PriorPages[[int]$index]
-                if ($priorPage.LongLength -ne $script:A1PageBytes) {
-                    throw "A1 prior snapshot cache contains a non-page."
-                }
-                # page_capture.checkpoint_representation requires exact ordered
-                # hashes; byte equality alone permits reuse of the prior digest.
-                $unchanged = $pageComparer.Equals($page, $priorPage)
-            }
-            if ($unchanged) {
-                $sha = [string]$PriorHashes[[int]$index]
-                [void]$pages.Add($priorPage)
-            }
-            else {
-                $sha = ([BitConverter]::ToString(
-                    $pageHash.ComputeHash($page)
-                )).Replace("-", "").ToLowerInvariant()
-                # page_capture.store uses this digest for the exact blob name.
-                Add-A1PageBlob -Store $Store -Page $page -Sha256 $sha
-                $retainedPage = New-Object byte[] ([int]$script:A1PageBytes)
-                [Buffer]::BlockCopy(
-                    $page, 0, $retainedPage, 0, $retainedPage.Length
-                )
-                [void]$pages.Add($retainedPage)
-            }
-            $hashes.Add($sha)
-            # page-index.schema changed_page_indices is the ordered-hash delta.
-            if ($null -eq $PriorHashes -or $index -ge $PriorHashes.Count -or
-                $PriorHashes[[int]$index] -cne $sha) {
-                if ($Store.ChangedEntries + $changed.Count -ge
-                    $script:A1MaximumChangedEntries) {
-                    throw "A1 changed-page index exceeded its ceiling."
-                }
-                [void]$changed.Add([ordered]@{
-                    page_index = $index
-                    sha256 = $sha
-                })
-            }
-        }
-        if ($null -ne $PriorHashes -and $PriorHashes.Count -gt $pageCount) {
-            for ($index = $pageCount; $index -lt $PriorHashes.Count; $index++) {
-                if ($Store.ChangedEntries + $changed.Count -ge
-                    $script:A1MaximumChangedEntries) {
-                    throw "A1 changed-page index exceeded its ceiling."
-                }
-                [void]$changed.Add([ordered]@{
-                    page_index = [long]$index
-                    sha256 = $null
-                })
-            }
-        }
-        if ($stream.ReadByte() -ne -1) {
-            throw "A1 database grew during its exclusive snapshot."
-        }
-        $empty = New-Object byte[] 0
-        [void]$fileHash.TransformFinalBlock($empty, 0, 0)
-        $Store.LogicalReadBytes = [long](
-            $Store.LogicalReadBytes + $stream.Length
-        )
-        $Store.ChangedEntries = [long](
-            $Store.ChangedEntries + $changed.Count
-        )
-        return [pscustomobject]@{
-            file_bytes = [long]$stream.Length
-            file_sha256 = ([BitConverter]::ToString(
-                $fileHash.Hash
-            )).Replace("-", "").ToLowerInvariant()
-            page_count = $pageCount
-            changed_pages = @($changed)
-            hashes = $hashes.ToArray()
-            pages = $pages.ToArray()
-        }
+    $capture = [Jet3A1PageSnapshotNative]::Capture(
+        $DatabasePath, [int]$script:A1PageBytes,
+        [int]$script:A1MaximumPagesPerReplica, $remaining,
+        $PriorPages, $PriorHashes
+    )
+    if ($Store.ChangedEntries + $capture.ChangedIndices.Length -gt
+        $script:A1MaximumChangedEntries) {
+        throw "A1 changed-page index exceeded its ceiling."
     }
-    finally {
-        if ($null -ne $pageHash) { $pageHash.Dispose() }
-        if ($null -ne $fileHash) { $fileHash.Dispose() }
-        $stream.Dispose()
+    $changed = New-Object Collections.ArrayList
+    for ($offset = 0; $offset -lt $capture.ChangedIndices.Length; $offset++) {
+        $index = [long]$capture.ChangedIndices[$offset]
+        $sha = if ($index -lt $capture.PageSha256.Length) {
+            [string]$capture.PageSha256[[int]$index]
+        } else { $null }
+        if ($null -ne $sha) {
+            # page_capture.store keeps the exact changed page under its digest.
+            Add-A1PageBlob -Store $Store `
+                -Page ([byte[]]$capture.ChangedPages[$offset]) -Sha256 $sha
+        }
+        [void]$changed.Add([ordered]@{
+            page_index = $index
+            sha256 = $sha
+        })
+    }
+    $Store.LogicalReadBytes = [long](
+        $Store.LogicalReadBytes + $capture.Bytes.LongLength
+    )
+    $Store.ChangedEntries = [long](
+        $Store.ChangedEntries + $changed.Count
+    )
+    return [pscustomobject]@{
+        file_bytes = [long]$capture.Bytes.LongLength
+        file_sha256 = [string]$capture.FileSha256
+        page_count = [long]$capture.PageSha256.Length
+        changed_pages = @($changed)
+        hashes = [string[]]$capture.PageSha256
+        pages = [byte[]]$capture.Bytes
     }
 }

--- a/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.PageStore.ps1
@@ -369,7 +369,16 @@ function Add-A1PageBlob {
     }
     $locator = Get-A1PageBlobLocator -Sha256 $Sha256
     $path = Get-M1PayloadPath -Session $Store.Session -RelativePath $locator
-    if (-not $Store.Seen.Contains($Sha256)) {
+    if ($Store.Seen.Contains($Sha256)) {
+        if (-not [IO.File]::Exists($path)) {
+            throw "A1 previously seen page-store blob is missing."
+        }
+        if ([long](Get-Item -LiteralPath $path -Force).Length -ne
+            $script:A1PageBytes) {
+            throw "A1 previously seen page-store blob has a non-page length."
+        }
+    }
+    else {
         if ($Store.Seen.Count -ge $script:A1MaximumUniqueBlobs -or
             $Store.UniqueBytes -gt (
                 $script:A1MaximumPageStoreBytes - $script:A1PageBytes

--- a/oracle/windows-dao/scripts/a1/A1.Worker.ps1
+++ b/oracle/windows-dao/scripts/a1/A1.Worker.ps1
@@ -486,7 +486,7 @@ function Add-A1Checkpoint {
         }
     })
     $script:A1PriorHashes = [string[]]$snapshot.hashes
-    $script:A1PriorPages = [byte[][]]$snapshot.pages
+    $script:A1PriorPages = [byte[]]$snapshot.pages
     $script:A1PriorCheckpoint = $CheckpointId
     Add-A1ProgressRecord -Progress $script:A1Progress -CheckpointId $CheckpointId -PageCount ([long]$snapshot.page_count)
 }

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -299,18 +299,18 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         self.assertNotIn("page-store/sha256/", self.combined)
 
     def test_page_snapshot_reuse_is_exact_and_bounded(self) -> None:
-        snapshot = function_source(self.page_store, "Read-A1PageSnapshot")
-        self.assertIn("StructuralEqualityComparer", snapshot)
-        self.assertIn("$sha = [string]$PriorHashes", snapshot)
-        self.assertIn("$pageHash.ComputeHash($page)", snapshot)
-        self.assertIn("[Buffer]::BlockCopy", snapshot)
-        self.assertIn("$fileHash.TransformBlock", snapshot)
-        self.assertIn("$Store.ChangedEntries + $changed.Count", snapshot)
-        self.assertIn("$script:A1MaximumPagesPerReplica", snapshot)
+        for fragment in ("[Jet3A1PageSnapshotNative]::Capture", "$capture.Bytes",
+                         "$capture.ChangedIndices", "Add-A1PageBlob", "PageEquals(",
+                         "hash.ComputeHash(bytes)", "$script:A1MaximumPagesPerReplica",
+                         "$Hash.TransformBlock", "$Hash.TransformFinalBlock"):
+            self.assertIn(fragment, self.page_store)
+        self.assertIn("$script:A1PriorPages = [byte[]]$snapshot.pages", self.worker)
+        startup = function_source(self.page_store, "New-A1PageStore")
+        self.assertNotIn("Assert-A1ExistingPageBlob", startup)
+        for fragment in ("[Jet3A1PageSnapshotNative]::Inventory", "maximumEntries",
+                         "item.Length != pageBytes"):
+            self.assertIn(fragment, self.page_store)
         self.assertNotIn("IncrementalHash", self.page_store)
-        self.assertIn("$Hash.TransformBlock", self.page_store)
-        self.assertIn("$Hash.TransformFinalBlock", self.page_store)
-
     def test_resource_and_process_ceilings_are_fail_closed(self) -> None:
         expected = {
             "20480": self.combined,
@@ -484,10 +484,8 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
         self.assertIn("Refusing cleanup outside", self.controller)
 
     def test_snapshot_shrink_and_dao_collections_are_explicit(self) -> None:
-        self.assertIn(
-            "$PriorHashes.Count -gt $pageCount", self.page_store
-        )
-        self.assertIn("page_index = [long]$index", self.page_store)
+        self.assertIn("index = pageCount; index < priorCount", self.page_store)
+        self.assertIn("page_index = $index", self.page_store)
         self.assertIn("$fields = $recordset.Fields", self.combined)
         self.assertIn("$tableDefinitions = $database.TableDefs", self.worker)
         self.assertIn("A1 table definitions release", self.worker)
@@ -594,18 +592,20 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                 "$first = Read-A1PageSnapshot -Store $store "
                 f"-DatabasePath {ps_quote(database)} "
                 "-PriorHashes $null -PriorPages $null\n"
+                "$store = New-A1PageStore -Session $session\n"
                 f"[IO.File]::WriteAllBytes({ps_quote(database)}, "
                 f"[IO.File]::ReadAllBytes({ps_quote(second_path)}))\n"
                 "$second = Read-A1PageSnapshot -Store $store "
                 f"-DatabasePath {ps_quote(database)} "
                 "-PriorHashes ([string[]]$first.hashes) "
-                "-PriorPages ([byte[][]]$first.pages)\n"
+                "-PriorPages ([byte[]]$first.pages)\n"
+                "$store = New-A1PageStore -Session $session\n"
                 f"[IO.File]::WriteAllBytes({ps_quote(database)}, "
                 f"[IO.File]::ReadAllBytes({ps_quote(third_path)}))\n"
                 "$third = Read-A1PageSnapshot -Store $store "
                 f"-DatabasePath {ps_quote(database)} "
                 "-PriorHashes ([string[]]$second.hashes) "
-                "-PriorPages ([byte[][]]$second.pages)\n"
+                "-PriorPages ([byte[]]$second.pages)\n"
                 "[ordered]@{\n"
                 "  first = Convert-A1TestSnapshot $first\n"
                 "  second = Convert-A1TestSnapshot $second\n"

--- a/oracle/windows-dao/tests/test_a1_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a1_powershell_contract.py
@@ -293,11 +293,12 @@ class A1PowerShellSourceContractTests(unittest.TestCase):
             "ordered_page_sha256 = @($snapshot.hashes)",
             "changed_page_indices = @(",
             '"page-indexes/replica-{0:D2}/{1:D2}-{2}.json"',
+            "A1 previously seen page-store blob is missing.",
+            "A1 previously seen page-store blob has a non-page length.",
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, self.combined)
         self.assertNotIn("page-store/sha256/", self.combined)
-
     def test_page_snapshot_reuse_is_exact_and_bounded(self) -> None:
         for fragment in ("[Jet3A1PageSnapshotNative]::Capture", "$capture.Bytes",
                          "$capture.ChangedIndices", "Add-A1PageBlob", "PageEquals(",
@@ -548,20 +549,15 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
             database = working / "synthetic.mdb"
             second_path = working / "second.mdb"
             third_path = working / "third.mdb"
-            first_bytes = (
-                b"A" * PAGE_BYTES + b"B" * PAGE_BYTES + b"C" * PAGE_BYTES
+            a, b, c, d, x = (
+                value * PAGE_BYTES for value in (b"A", b"B", b"C", b"D", b"X")
             )
-            second_bytes = (
-                b"A" * PAGE_BYTES
-                + b"X" * PAGE_BYTES
-                + b"C" * PAGE_BYTES
-                + b"D" * PAGE_BYTES
-            )
-            third_bytes = b"A" * PAGE_BYTES + b"X" * PAGE_BYTES
+            first_bytes = a + b + a + c
+            second_bytes = a + x + a + c + d
+            third_bytes = a + x + a
             database.write_bytes(first_bytes)
             second_path.write_bytes(second_bytes)
             third_path.write_bytes(third_bytes)
-
             first_expected = naive_snapshot(database, None)
             first_hashes = first_expected["ordered_page_sha256"]
             self.assertIsInstance(first_hashes, list)
@@ -644,6 +640,10 @@ class A1PowerShellWindowsFunctionalTests(unittest.TestCase):
                         for digest in observed[name]["ordered_page_sha256"]
                     )
                     self.assertEqual(reconstructed, raw_snapshots[name])
+            blobs = list((bundle / "page-store").iterdir())
+            expected_digests = {hashlib.sha256(page).hexdigest() for page in (a, b, c, d, x)}
+            self.assertEqual(len(blobs), len(expected_digests))
+            self.assertEqual({blob.stem for blob in blobs}, expected_digests)
 
     def test_real_one_session_dao_reread_matches_per_table_sessions(self) -> None:
         definitions = "\n\n".join(

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -259,11 +259,20 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
 
     def test_campaign_exit_is_observed_and_null_checked_before_comparison(self) -> None:
         self.assertIn("$campaignExit = $null", self.workflow)
+        launch = self.workflow.index(
+            "$process = Start-Process -FilePath $x86PowerShell -PassThru"
+        )
+        handle = self.workflow.index("$null = $process.Handle", launch)
+        clock = self.workflow.index(
+            "$clock = [Diagnostics.Stopwatch]::StartNew()", handle
+        )
         completed_wait = self.workflow.index("$process.WaitForExit()")
         refresh = self.workflow.index("$process.Refresh()", completed_wait)
         null_guard = self.workflow.index("if ($null -eq $exitCode)", refresh)
         assignment = self.workflow.index("$campaignExit = [int]$exitCode", null_guard)
         comparison = self.workflow.index("if ($campaignExit -ne 0)", assignment)
+        self.assertLess(launch, handle)
+        self.assertLess(handle, clock)
         self.assertLess(completed_wait, refresh)
         self.assertLess(refresh, null_guard)
         self.assertLess(null_guard, assignment)


### PR DESCRIPTION
## Summary

- capture the Start-Process Handle immediately after launch so Windows PowerShell retains the completed campaign exit code
- replace the per-page PowerShell snapshot loop with one bounded, exclusive, buffered native CLR read that preserves ordered page hashes, database_sha256, changed_page_indices, and content-addressed blobs exactly
- retain the prior closed snapshot as one bounded byte buffer and reuse digests only after exact byte comparison
- inventory existing page-store metadata without rehashing every prior-replica blob at worker startup; the complete bundle validator still rehashes every blob before publication
- keep the frozen per-32-row close, quiescence, and closed-file page-count probe unchanged

No plan, schema, ledger, work ceiling, or timeout bound changes are included.

## Run 7-9 baseline

Progress records show the high-growth ladder dominates elapsed time and scales with pages read: run 9 replica 1 spent 1,243.2 s in H ladder checkpoints plus 41.3 s in H_IDLE_REOPEN, 288.6 s in P checkpoints, and 143.7 s in L ladder checkpoints. Across its 605,161 cumulative checkpoint pages, the page loop accounts for approximately 1,407 s of the 1,749 s replica; the idle-point fit is approximately 2.325 ms/page on the run-9 runner.

The same classes scale roughly 2.4-2.7x between run 8 and run 9. Run 9 replica 2 also spent 231.5 s before its first checkpoint, principally in the old startup rehash of replica 1 page blobs; it reached 68 checkpoints at 1,761.9 s and extrapolates to roughly 1,930 s without this change.

A stable run-9 H checkpoint is about 42-43 s versus 41.3 s for H_IDLE_REOPEN, leaving only about 1.7-2 s for the fixed 32-row mutation, close, quiescence, and page-count probe. The frozen first-closed-file observable therefore remains untouched. DAO GetRows was also left out: page-count-normalized idle capture explains nearly all of the dominant time, so changing semantic reread machinery adds risk without meaningful headroom.

## Projection

Removing approximately 1,407 s of interpreted page-loop work and the 231 s later-replica startup rehash leaves a measured residual near 300-340 s. Allowing 50-110 s for native sequential reads, SHA-256, comparisons, and CLR setup projects approximately 400 s per replica on a run-9-class runner (conservative range 350-450 s), well below the 900 s two-times-headroom target and the unchanged 1,800 s ceiling. This is a model-based estimate pending the hosted Windows campaign.

## Verification

- python3.13 -m unittest discover -s oracle/windows-dao/tests -v (433 passed, 83 expected platform skips)
- extracted inline C# compiled successfully with Roslyn
- git diff --check

The Windows-only functional snapshot test compares ordered hashes, changed indices, database hash, reconstructed bytes, and page-store re-inventory against the naive reference; it will execute in windows-oracle-contracts CI.