### PR TITLE
fix: preserve A1 bundle validation quoting

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -580,9 +580,16 @@ jobs:
               receipt_file.write(receipt_bytes)
           print("PASS: independently validated complete A1 bundle")
           '@
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
+          $validatorPath = Join-Path $diagnostics "validate_bundle_step.py"
+          [IO.File]::WriteAllText(
+            $validatorPath,
+            $code,
+            (New-Object Text.UTF8Encoding($false))
+          )
           $receiptPath = Join-Path $env:RUNNER_TEMP `
             "jet3-a1-diagnostics\validation-receipt.json"
-          & python -B -c $code $env:A1_BUNDLE_PATH $env:GITHUB_SHA `
+          & python -B $validatorPath $env:A1_BUNDLE_PATH $env:GITHUB_SHA `
             $env:A1_RUN_ID $env:EXPECTED_PROVIDER_SHA256 $receiptPath `
             $env:GITHUB_RUN_ID $env:GITHUB_RUN_ATTEMPT
           if ($LASTEXITCODE -ne 0) {
@@ -592,7 +599,6 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
             throw "Independent validation changed the exact checkout."
           }
-          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
           $campaignPath = Join-Path $diagnostics "campaign.json"
           $campaignRecord = Get-Content -LiteralPath $campaignPath -Raw |
             ConvertFrom-Json
@@ -622,11 +628,11 @@ jobs:
             (New-Object Text.UTF8Encoding($false))
           )
 
-      - name: Upload independently validated A1 evidence
-        if: success() && steps.bundle_validation.outcome == 'success'
+      - name: Upload retained A1 bundle
+        if: always() && steps.campaign.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: windows-dao-a1-evidence-${{ github.sha }}-${{ steps.campaign.outputs.run_id }}
+          name: windows-dao-a1-bundle-${{ github.sha }}-${{ steps.campaign.outputs.run_id }}
           path: ${{ steps.campaign.outputs.bundle_path }}
           if-no-files-found: error
           compression-level: 0

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -292,11 +292,18 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertIn("$env:GITHUB_SHA", self.workflow)
         self.assertIn("$env:EXPECTED_PROVIDER_SHA256", self.workflow)
         self.assertIn("id: bundle_validation", self.workflow)
+        self.assertNotRegex(
+            self.workflow,
+            r"(?m)^\s*&\s+python(?:\.exe)?\b[^\r\n]*\s-c\s+\$[A-Za-z_]\w*",
+        )
+        self.assertIn("validate_bundle_step.py", self.workflow)
+        self.assertIn("[IO.File]::WriteAllText(", self.workflow)
+        self.assertIn("& python -B $validatorPath", self.workflow)
         self.assertIn(
             "if: success() && steps.bundle_validation.outcome == 'success'",
             self.workflow,
         )
-        self.assertIn("Upload independently validated A1 evidence", self.workflow)
+        self.assertIn("Upload retained A1 bundle", self.workflow)
         self.assertIn("Upload independently validated A1 attestation", self.workflow)
         self.assertIn("Upload bounded A1 diagnostics", self.workflow)
         self.assertIn("jet3_windows_dao_a1_validation_receipt", self.workflow)
@@ -308,7 +315,7 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
             '$campaignRecord.status = "independently_validated"', self.workflow
         )
         evidence = self.workflow.split(
-            "      - name: Upload independently validated A1 evidence", 1
+            "      - name: Upload retained A1 bundle", 1
         )[1].split(
             "      - name: Upload independently validated A1 attestation", 1
         )[0]
@@ -320,6 +327,10 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         )[1]
         self.assertIn("${{ steps.campaign.outputs.bundle_path }}", evidence)
         self.assertNotIn("${{ runner.temp }}\\jet3-a1-diagnostics", evidence)
+        self.assertIn("if: always() && steps.campaign.outcome == 'success'", evidence)
+        self.assertNotIn("steps.bundle_validation.outcome", evidence)
+        self.assertIn("windows-dao-a1-bundle-${{ github.sha }}", evidence)
+        self.assertNotIn("windows-dao-a1-evidence-", evidence)
         self.assertIn("retention-days: 90", evidence)
         self.assertIn(
             "windows-dao-a1-attestation-${{ github.sha }}-${{ github.run_id }}",
@@ -347,7 +358,7 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertEqual(attestation_copy.count("Copy-Item"), 1)
         self.assertIn("-Destination (Join-Path $attestation $name)", attestation_copy)
         validation_step = self.workflow.split("        id: bundle_validation", 1)[1].split(
-            "      - name: Upload independently validated A1 evidence", 1
+            "      - name: Upload retained A1 bundle", 1
         )[0]
         clean_check = validation_step.index(
             "Independent validation changed the exact checkout."


### PR DESCRIPTION
## Summary

- write the independent bundle validator here-string to validate_bundle_step.py under the bounded diagnostics root as UTF-8 without a BOM
- invoke Python with the script path so Windows PowerShell 5 cannot strip embedded Python string-literal quotes
- retain the completed acquisition bundle whenever the campaign step succeeds, even if independent validation later fails
- use a neutral windows-dao-a1-bundle artifact name; only the successful validation receipt and attestation confer independently validated status

## Audit

The failing bundle validator was the workflow's only python -c invocation and the only here-string passed as a native executable argument. All remaining Python calls use script, module, or version arguments.

## Verification

- python3.13 -m unittest discover -s oracle/windows-dao/tests -v (433 passed, 83 expected platform skips)
- git diff --check