### PR TITLE
docs: record first retained A1 result

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -2882,6 +2882,85 @@ Use `not applicable` explicitly rather than omitting a field.
   Microsoft provider binary or generated MDB is redistributed
 - Review: pending independent review before any manual A1 dispatch
 
+### EXP-0039 — First retained A1 acquisition: ambiguous record boundary
+
+- Recorded: 2026-08-21, OpenAI Codex
+- Kind: controlled hosted DAO acquisition with an independently validated
+  complete bundle and a preregistered `no_scientific_outcome` analysis result;
+  no physical-format, Rust, or compatibility result
+- Question: Can one preregistered joint model explain and predict the observed
+  global and per-table allocation-map transitions in three fresh Jet 3
+  databases?
+- Origin: project-authored `DAO-A1-ALLOCATION-MAPS-001` campaign executed by
+  GitHub Actions run `32486063559` from exact clean pushed producer commit
+  `947038265f6898c55b39da99340220e548836594`, under the immutable `EXP-0037`
+  plan and the report-interpretation rules recorded by `EXP-0038`; no donated
+  MDB or third-party implementation was used
+- Environment: `windows-2022` image `20260818.277.1`, x86 Windows PowerShell
+  5.1, Python 3.13.7, and machine-registered `DAO.DBEngine.36` from
+  `dao360.dll` file version `03.60.9765.0`, SHA-256
+  `4cc28a5be8dc7425a4c4c1ef275ca392f18be35d70232e777dce6d9f3b4d79ac`;
+  provider proof run `32439805418`; campaign status
+  `independently_validated`; total elapsed time 5,725.92 seconds
+- Protocol: execute all 71 closed-file checkpoints for each of three fresh
+  replicas, with diagnostic progress durations 1,536.912 seconds for replica
+  1, 1,475.135 seconds for replica 2, and 1,467.223 seconds for replica 3;
+  retain the complete content-addressed bundle, run the preregistered bounded
+  analysis, independently validate bundle structure and cross-artifact
+  bindings, and upload the bundle, attestation, and bounded diagnostics
+- Artifacts: Actions bundle artifact
+  `windows-dao-a1-bundle-947038265f6898c55b39da99340220e548836594-20260821T132025Z-a1-gh32486063559-1`,
+  175,556,608 bytes; attestation artifact
+  `windows-dao-a1-attestation-947038265f6898c55b39da99340220e548836594-32486063559`;
+  diagnostics artifact `windows-dao-a1-diagnostics-32486063559-1`;
+  `bundle-manifest.json` SHA-256
+  `97c1286624a5e02fc7bcfc7b1047986e8a15e3ac8aec22488a1a5b4bfa444381`;
+  `analysis/analysis-report.json` SHA-256
+  `5fae61fd7394a8847faef0a88c24a11962409daeffe408d0fb7d241ffd491a74`
+- Observation: the passing manifest closes 21,102 payload entries, including
+  20,883 unique page blobs, three replica observations, and 213 checkpoint
+  indexes. The preregistered report records
+  `scientific_outcome = no_scientific_outcome`, sole reason
+  `ambiguous_record_boundary`, zero candidate models examined, zero derivation
+  survivors, no holdout evaluation, 213 input checkpoints, 142,115 analysis
+  work units, and plan SHA-256
+  `a7fa44cdb24b6f6e0d3884d478d7eef74685aa90ea12eacfff4b459b1da6ab80`.
+  This is the first retained schema-valid A1 replica observation, so acquisition
+  has now started under the `EXP-0038` criterion. Any analyzer change requires
+  a new experiment ID, plan file, and provenance entry before another run.
+- Independent validation: on a separate local copy of the three downloaded
+  artifacts, using Python 3.13.15 and the checked producer-commit validators,
+  `PYTHONPATH=oracle/windows-dao/scripts python3.13 -c 'import sys; from pathlib
+  import Path; from a1_bundle import validate_bundle;
+  result=validate_bundle(Path(sys.argv[1]));
+  print("PASS: a1_bundle.validate_bundle",
+  result["manifest"]["run_id"])' "$BUNDLE"` returned `PASS` for run
+  `20260821T132025Z-a1-gh32486063559-1`;
+  `python3.13 oracle/windows-dao/scripts/a1_contract.py validate-bundle
+  "$BUNDLE"` returned `PASS: checked DAO A1 bundle structure and bindings ...;
+  scientific outcome not validated`;
+  `python3.13 oracle/windows-dao/scripts/a1_spec.py validate-plan
+  "$BUNDLE/plan/a1-allocation-maps.plan.json"`, `validate-observation` for
+  `"$BUNDLE/observations/replica-01.json"` through `replica-03.json`, and
+  `validate-report "$BUNDLE/analysis/analysis-report.json"` each returned
+  `passed`. The local validation was read-only and did not alter the retained
+  artifacts.
+- Interpretation: the hosted A1 lane and complete-bundle validator worked, but
+  the campaign produced no scientific model and assigned no byte, record,
+  pointer, bitmap, page, or allocation-map meaning. The self-produced DAO-only
+  result advances no product capability, establishes no Rust correctness or
+  DAO compatibility, changes no support-matrix entry, and does not satisfy the
+  release differential gate.
+- Usage: `file:docs/validation/DAO_PROVIDER_BLOCKER.md`;
+  `file:oracle/windows-dao/README.md`; future separately preregistered A1
+  experiment design only
+- Rights: project-generated through the licensed Microsoft DAO provider and
+  retained as GitHub Actions artifacts; no provider binary or generated MDB is
+  committed or redistributed by this repository
+- Review: hosted status and attestation passed; manifest and analysis identities
+  were independently recomputed and the complete local bundle passed all
+  checked validators; scientific interpretation remains no outcome
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/validation/DAO_PROVIDER_BLOCKER.md
+++ b/docs/validation/DAO_PROVIDER_BLOCKER.md
@@ -2,7 +2,7 @@
 
 Status: **BLOCKED — hosted provider capability confirmed; release differential evidence absent**
 
-Audit date: 2026-08-20
+Audit date: 2026-08-21
 
 This record separates a historically observed provider capability, retained
 controlled evidence, and the evidence required on an exact release commit. A
@@ -14,12 +14,19 @@ retained M1 output descriptively, and M3 completed a replicated one-variable
 physical-delta campaign. None of those earlier-commit or provider-only results
 satisfies G3 for a later release commit.
 
+Actions run `32486063559` has now also completed the full A1 hosted lane from
+exact commit `947038265f6898c55b39da99340220e548836594`, retaining and
+independently validating the first complete A1 bundle. Its preregistered
+analysis returned `no_scientific_outcome` for `ambiguous_record_boundary`; see
+`EXP-0039`. This proves the hosted acquisition and bundle-validation lane, not
+a Rust capability or release differential result.
+
 ## Exact current blocker
 
-Provider discovery is no longer blocking current implementation or controlled
-A1 acquisition: `windows-2022` is the pinned campaign lane, subject to an exact
-fresh probe and all A1 execution gates. G3 remains blocked because the project
-lacks both:
+Provider discovery and the controlled A1 hosted lane are no longer blocking:
+`windows-2022` completed the exact-commit acquisition and independent bundle
+validation recorded by `EXP-0039`. G3 remains blocked because the project lacks
+both:
 
 1. the required Rust implementation and 100-scenario DAO-versus-Rust
    differential inventory; and
@@ -123,22 +130,27 @@ provider-capability result is not A1 output, a physical-format result, Rust
 verification, or a compatibility claim. The project still does not install or
 redistribute Access, DAO, or ACE without an operator licensing decision.
 
-## A1 acquisition boundary
+## A1 acquisition result and boundary
 
-`DAO-A1-ALLOCATION-MAPS-001` has checked acquisition, bundle-validation, and
-bounded-analysis code, but it has not been executed. The earlier hosted run did
-not create an A1 database, inspect campaign pages, or publish an A1 bundle.
-Consequently there is no A1 scientific outcome, allocation-map observation,
-Rust verification result, or new compatibility evidence to cite.
+[`32486063559`](https://github.com/oglassdev/jet3-rs/actions/runs/32486063559)
+completed `DAO-A1-ALLOCATION-MAPS-001` end to end on `windows-2022`, using the
+provider identity proved by run `32439805418`. The campaign retained all 213
+checkpoint indexes and three schema-valid replica observations, published the
+complete bundle from exact producer commit
+`947038265f6898c55b39da99340220e548836594`, and reported status
+`independently_validated`. The retained manifest SHA-256 is
+`97c1286624a5e02fc7bcfc7b1047986e8a15e3ac8aec22488a1a5b4bfa444381`.
 
-The first acquisition remains blocked until one exact pushed commit contains
-the frozen preregistration and a manual hosted workflow pinned to
-`windows-2022`. That workflow must repeat the stock x86 provider probe, reject
-any image or provider-identity drift, run the controlled entry point, validate
-the complete retained bundle independently, and upload that exact bundle. It
-must not fall back to `windows-2025` or install a replacement provider. Even a
-passing campaign would remain descriptive DAO-only physical evidence and would
-not satisfy the release differential gate.
+The preregistered analysis did not identify a model. It reported
+`no_scientific_outcome` with reason `ambiguous_record_boundary`, examined zero
+candidate models, and did not evaluate the holdout. Independent bundle
+validation established the retained tree, hashes, schemas, and cross-artifact
+bindings; it did not independently recompute or validate a scientific outcome.
+Per `EXP-0038`, acquisition has now started because a schema-valid replica
+observation is retained. Any analyzer change requires a new experiment ID,
+plan, and provenance entry. This no-outcome result assigns no physical-format
+meaning, advances no Rust capability, establishes no DAO compatibility, and
+does not satisfy the release differential gate.
 
 ## Requirements for future release evidence
 

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -126,15 +126,22 @@ This result proves hosted provider capability only. It is not an A1
 acquisition, an MDB-format observation, Rust validation, or DAO compatibility
 evidence.
 
+The same pinned lane subsequently completed the full A1 workflow in Actions
+run [`32486063559`](https://github.com/oglassdev/jet3-rs/actions/runs/32486063559)
+from exact commit `947038265f6898c55b39da99340220e548836594`; see `EXP-0039`.
+
 ## A1 allocation-map campaign status
 
 The checked A1 materials under [`experiments/a1`](experiments/a1/README.md)
 define `DAO-A1-ALLOCATION-MAPS-001`, a three-replica, preregistered DAO-only
 physical experiment. The acquisition controller, independent bundle validator,
-bounded analysis, and corruption tests are implemented, but **no A1 acquisition
-has run and no A1 scientific outcome exists**. The hosted run described above
-was only a provider probe; `.github/workflows/windows-dao-hosted.yml` does not
-execute the campaign.
+bounded analysis, and corruption tests completed end to end in run
+`32486063559`. The status was `independently_validated`, and the retained
+manifest SHA-256 is
+`97c1286624a5e02fc7bcfc7b1047986e8a15e3ac8aec22488a1a5b4bfa444381`.
+The preregistered analysis returned `no_scientific_outcome` with sole reason
+`ambiguous_record_boundary`; it examined zero candidate models and did not
+evaluate the holdout.
 
 Execution must use a clean, exact pushed commit on the pinned `windows-2022`
 lane. Before any database is created, the x86 protocol-1.1 provider probe must
@@ -174,11 +181,12 @@ python oracle/windows-dao/scripts/a1_contract.py validate-bundle $bundle
 if ($LASTEXITCODE -ne 0) { throw "Independent A1 bundle validation failed." }
 ```
 
-The first acquisition must use a checked hosted workflow that performs those
-same gates, retains the complete validated bundle, and never installs provider
-software. A successful bundle would remain a bounded observation of its exact
-campaign. It would not by itself establish general allocation-map behavior,
-Rust correctness, a support-matrix advance, or DAO compatibility.
+Run `32486063559` performed those same gates, retained the complete validated
+bundle, and installed no provider software. Acquisition has now started under
+the `EXP-0038` retained-replica-observation criterion, so any analyzer change
+requires a new experiment ID, plan, and provenance entry. The no-outcome bundle
+assigns no physical-format meaning and does not establish general allocation-map
+behavior, Rust correctness, a support-matrix advance, or DAO compatibility.
 
 For an M1 preflight, request a protocol 1.1 environment record explicitly:
 


### PR DESCRIPTION
## Summary

- add `EXP-0039` for the first retained A1 acquisition from hosted run `32486063559`
- pin the independently recomputed manifest and analysis-report SHA-256 identities, exact artifact names, producer/provider runs, elapsed time, and replica durations
- record the preregistered `no_scientific_outcome` / `ambiguous_record_boundary` result without making a physical-format, capability, Rust, or DAO-compatibility claim
- update the provider blocker and oracle README to reflect that the hosted lane now works and that acquisition has started under the R2 retained-observation criterion

## Independent local validation

- direct `a1_bundle.validate_bundle` — PASS
- `python3.13 oracle/windows-dao/scripts/a1_contract.py validate-bundle` — PASS (bundle structure and bindings; scientific outcome not validated)
- `a1_spec.py` retained plan, all three observations, and report — PASS

## Verification

- `python3.13 -m unittest discover -s oracle/windows-dao/tests` — 433 passed, 83 skipped
- `python3.13 tools/reconcile_tests.py` — 236/236 reconciled

No analyzer, plan, or schema changed.
