### PR TITLE
fix: cover benchmark and provenance CI paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           filters: |
             rust:
               - 'crates/**'
+              - 'benches/**'
               - 'fuzz/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
@@ -41,6 +42,7 @@ jobs:
             oracle:
               - 'oracle/**'
               - 'tools/**'
+              - 'docs/PROVENANCE.md'
               - 'docs/validation/**'
               - '.github/workflows/**'
 


### PR DESCRIPTION
## Summary
- run Rust-gated jobs when benchmark sources change
- run Windows oracle contract checks when the provenance ledger changes

## Checks
- git diff --check
- searched repository tests for CI path-filter text assertions; none found