### PR TITLE
fix: harden A1 validation receipt ordering

### DIFF
--- a/.github/workflows/windows-dao-a1.yml
+++ b/.github/workflows/windows-dao-a1.yml
@@ -539,9 +539,20 @@ jobs:
           A1_RUN_ID: ${{ steps.campaign.outputs.run_id }}
         run: |
           $ErrorActionPreference = "Stop"
-          $env:PYTHONPATH = Join-Path $env:GITHUB_WORKSPACE `
-            "oracle\windows-dao\scripts"
-          $code = @'
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
+          $pending = Join-Path $env:RUNNER_TEMP "jet3-a1-validation-pending"
+          $validatorPath = Join-Path $diagnostics "validate_bundle_step.py"
+          $pendingReceiptPath = Join-Path $pending "validation-receipt.json"
+          $pendingCampaignPath = Join-Path $pending "campaign.json"
+          $receiptPath = Join-Path $diagnostics "validation-receipt.json"
+          $campaignPath = Join-Path $diagnostics "campaign.json"
+          $failurePath = Join-Path $diagnostics "validation-failed.json"
+          $campaignRecord = $null
+          try {
+            $env:PYTHONPATH = Join-Path $env:GITHUB_WORKSPACE `
+              "oracle\windows-dao\scripts"
+            New-Item -ItemType Directory -Path $pending | Out-Null
+            $code = @'
           import hashlib
           import json
           import sys
@@ -578,62 +589,136 @@ jobs:
               raise RuntimeError("A1 validation receipt exceeds its byte ceiling")
           with Path(sys.argv[5]).open("xb") as receipt_file:
               receipt_file.write(receipt_bytes)
-          print("PASS: independently validated complete A1 bundle")
           '@
+            [IO.File]::WriteAllText(
+              $validatorPath,
+              $code,
+              (New-Object Text.UTF8Encoding($false))
+            )
+            & python -B $validatorPath $env:A1_BUNDLE_PATH $env:GITHUB_SHA `
+              $env:A1_RUN_ID $env:EXPECTED_PROVIDER_SHA256 `
+              $pendingReceiptPath $env:GITHUB_RUN_ID $env:GITHUB_RUN_ATTEMPT
+            if ($LASTEXITCODE -ne 0) {
+              throw "Independent complete A1 bundle validation failed."
+            }
+            $receiptBytes = [IO.File]::ReadAllBytes($pendingReceiptPath)
+            if ($receiptBytes.Length -gt 4096) {
+              throw "A1 validation receipt exceeds its byte ceiling."
+            }
+            $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+            if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+              throw "Independent validation changed the exact checkout."
+            }
+            $campaignRecord = Get-Content -LiteralPath $campaignPath -Raw |
+              ConvertFrom-Json
+            if ($campaignRecord.status -cne "not_independently_validated") {
+              throw "The A1 campaign validation status is not fail-closed."
+            }
+            $campaignRecord.status = "independently_validated"
+            $validatedCampaignJson = $campaignRecord | ConvertTo-Json -Depth 6
+            [IO.File]::WriteAllText(
+              $pendingCampaignPath,
+              $validatedCampaignJson,
+              (New-Object Text.UTF8Encoding($false))
+            )
+
+            $attestation = Join-Path $env:RUNNER_TEMP "jet3-a1-attestation"
+            New-Item -ItemType Directory -Path $attestation | Out-Null
+            Copy-Item -LiteralPath `
+              (Join-Path $diagnostics "provider-binding.json") `
+              -Destination (Join-Path $attestation "provider-binding.json")
+            Copy-Item -LiteralPath $pendingReceiptPath `
+              -Destination (Join-Path $attestation "validation-receipt.json")
+            Copy-Item -LiteralPath $pendingCampaignPath `
+              -Destination (Join-Path $attestation "campaign.json")
+
+            [IO.File]::WriteAllText(
+              $campaignPath,
+              $validatedCampaignJson,
+              (New-Object Text.UTF8Encoding($false))
+            )
+            [IO.File]::WriteAllBytes($receiptPath, $receiptBytes)
+          }
+          catch {
+            [string]$failureMessage = [Convert]::ToString($_.Exception.Message)
+            if ($failureMessage.Length -gt 1024) {
+              $failureMessage = $failureMessage.Substring(0, 1024)
+            }
+            try {
+              if (Test-Path -LiteralPath $receiptPath -PathType Leaf) {
+                Remove-Item -LiteralPath $receiptPath -Force
+              }
+            }
+            catch {
+              $failureMessage += " Receipt cleanup also failed."
+            }
+            try {
+              if ($null -ne $campaignRecord) {
+                $campaignRecord.status = "not_independently_validated"
+                [IO.File]::WriteAllText(
+                  $campaignPath,
+                  ($campaignRecord | ConvertTo-Json -Depth 6),
+                  (New-Object Text.UTF8Encoding($false))
+                )
+              }
+            }
+            catch {
+              $failureMessage += " Campaign status cleanup also failed."
+            }
+            $failure = [ordered]@{
+              document_type = "jet3_windows_dao_a1_validation_failure"
+              label = "independent_complete_a1_bundle_validation"
+              message = $failureMessage
+            }
+            $failureJson = ($failure | ConvertTo-Json -Compress) + "`n"
+            $failureBytes = [Text.Encoding]::UTF8.GetBytes($failureJson)
+            if ($failureBytes.Length -gt 4096) {
+              throw "A1 validation failure marker exceeds its byte ceiling."
+            }
+            [IO.File]::WriteAllBytes($failurePath, $failureBytes)
+            throw
+          }
+
+      - name: Record retained A1 bundle validation status
+        id: bundle_upload_status
+        if: always() && steps.campaign.outcome == 'success'
+        shell: powershell
+        env:
+          INDEPENDENT_VALIDATION_OUTCOME: ${{ steps.bundle_validation.outcome }}
+        run: |
+          $ErrorActionPreference = "Stop"
           $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a1-diagnostics"
-          $validatorPath = Join-Path $diagnostics "validate_bundle_step.py"
-          [IO.File]::WriteAllText(
-            $validatorPath,
-            $code,
-            (New-Object Text.UTF8Encoding($false))
-          )
-          $receiptPath = Join-Path $env:RUNNER_TEMP `
-            "jet3-a1-diagnostics\validation-receipt.json"
-          & python -B $validatorPath $env:A1_BUNDLE_PATH $env:GITHUB_SHA `
-            $env:A1_RUN_ID $env:EXPECTED_PROVIDER_SHA256 $receiptPath `
-            $env:GITHUB_RUN_ID $env:GITHUB_RUN_ATTEMPT
-          if ($LASTEXITCODE -ne 0) {
-            throw "Independent complete A1 bundle validation failed."
+          $statusPath = Join-Path $diagnostics "bundle-upload-status.json"
+          $status = [ordered]@{
+            document_type = "jet3_windows_dao_a1_bundle_upload_status"
+            independent_validation_passed = [string]::Equals(
+              $env:INDEPENDENT_VALIDATION_OUTCOME,
+              "success",
+              [StringComparison]::Ordinal
+            )
+            independent_validation_outcome = `
+              $env:INDEPENDENT_VALIDATION_OUTCOME
+            github_run_id = $env:GITHUB_RUN_ID
+            github_run_attempt = $env:GITHUB_RUN_ATTEMPT
           }
-          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
-          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
-            throw "Independent validation changed the exact checkout."
+          $statusJson = ($status | ConvertTo-Json -Compress) + "`n"
+          $statusBytes = [Text.Encoding]::UTF8.GetBytes($statusJson)
+          if ($statusBytes.Length -gt 4096) {
+            throw "A1 bundle upload status exceeds its byte ceiling."
           }
-          $campaignPath = Join-Path $diagnostics "campaign.json"
-          $campaignRecord = Get-Content -LiteralPath $campaignPath -Raw |
-            ConvertFrom-Json
-          if ($campaignRecord.status -cne "not_independently_validated") {
-            throw "The A1 campaign validation status is not fail-closed."
-          }
-          $attestation = Join-Path $env:RUNNER_TEMP "jet3-a1-attestation"
-          New-Item -ItemType Directory -Path $attestation | Out-Null
-          foreach ($name in @(
-              "provider-binding.json",
-              "validation-receipt.json",
-              "campaign.json"
-            )) {
-            Copy-Item -LiteralPath (Join-Path $diagnostics $name) `
-              -Destination (Join-Path $attestation $name)
-          }
-          $campaignRecord.status = "independently_validated"
-          $validatedCampaignJson = $campaignRecord | ConvertTo-Json -Depth 6
-          [IO.File]::WriteAllText(
-            (Join-Path $attestation "campaign.json"),
-            $validatedCampaignJson,
-            (New-Object Text.UTF8Encoding($false))
-          )
-          [IO.File]::WriteAllText(
-            $campaignPath,
-            $validatedCampaignJson,
-            (New-Object Text.UTF8Encoding($false))
-          )
+          [IO.File]::WriteAllBytes($statusPath, $statusBytes)
 
       - name: Upload retained A1 bundle
-        if: always() && steps.campaign.outcome == 'success'
+        if: >-
+          always() &&
+          steps.campaign.outcome == 'success' &&
+          steps.bundle_upload_status.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-dao-a1-bundle-${{ github.sha }}-${{ steps.campaign.outputs.run_id }}
-          path: ${{ steps.campaign.outputs.bundle_path }}
+          path: |
+            ${{ steps.campaign.outputs.bundle_path }}
+            ${{ runner.temp }}\jet3-a1-diagnostics\bundle-upload-status.json
           if-no-files-found: error
           compression-level: 0
           retention-days: 90

--- a/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a1_workflow.py
@@ -314,6 +314,94 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
         self.assertIn(
             '$campaignRecord.status = "independently_validated"', self.workflow
         )
+        validation_step = self.workflow.split("        id: bundle_validation", 1)[
+            1
+        ].split(
+            "      - name: Record retained A1 bundle validation status", 1
+        )[0]
+        validation_try = validation_step.split("          try {", 1)[1].split(
+            "          catch {", 1
+        )[0]
+        python_validation = validation_try.index("& python -B $validatorPath")
+        clean_check = validation_try.index(
+            "Independent validation changed the exact checkout."
+        )
+        campaign_status_check = validation_try.index(
+            "The A1 campaign validation status is not fail-closed."
+        )
+        validated_status = validation_try.index(
+            '$campaignRecord.status = "independently_validated"'
+        )
+        pending_campaign_write = validation_try.index(
+            "$pendingCampaignPath,", validated_status
+        )
+        prepare_attestation = validation_try.index("jet3-a1-attestation")
+        final_campaign_write = validation_try.index(
+            "$campaignPath,", prepare_attestation
+        )
+        final_receipt_write = validation_try.index(
+            "[IO.File]::WriteAllBytes($receiptPath, $receiptBytes)",
+            final_campaign_write,
+        )
+        self.assertLess(python_validation, clean_check)
+        self.assertLess(clean_check, campaign_status_check)
+        self.assertLess(campaign_status_check, validated_status)
+        self.assertLess(validated_status, pending_campaign_write)
+        self.assertLess(pending_campaign_write, prepare_attestation)
+        self.assertLess(prepare_attestation, final_campaign_write)
+        self.assertLess(final_campaign_write, final_receipt_write)
+        self.assertTrue(
+            validation_try.rstrip().endswith(
+                "[IO.File]::WriteAllBytes($receiptPath, $receiptBytes)\n          }"
+            )
+        )
+        self.assertIn(
+            '$pendingReceiptPath = Join-Path $pending "validation-receipt.json"',
+            validation_step,
+        )
+        self.assertIn(
+            "$pendingReceiptPath $env:GITHUB_RUN_ID $env:GITHUB_RUN_ATTEMPT",
+            validation_try,
+        )
+        attestation_prep = validation_try[
+            prepare_attestation:final_campaign_write
+        ]
+        self.assertEqual(attestation_prep.count("Copy-Item"), 3)
+        self.assertIn(
+            '(Join-Path $diagnostics "provider-binding.json")', attestation_prep
+        )
+        self.assertIn("-LiteralPath $pendingReceiptPath", attestation_prep)
+        self.assertIn("-LiteralPath $pendingCampaignPath", attestation_prep)
+
+        validation_failure = validation_step.split("          catch {", 1)[1]
+        self.assertIn('"validation-failed.json"', validation_step)
+        self.assertIn("WriteAllBytes($failurePath, $failureBytes)", validation_failure)
+        self.assertIn(
+            'label = "independent_complete_a1_bundle_validation"',
+            validation_failure,
+        )
+        self.assertIn("message = $failureMessage", validation_failure)
+        self.assertIn("if ($failureMessage.Length -gt 1024)", validation_failure)
+        self.assertIn("if ($failureBytes.Length -gt 4096)", validation_failure)
+        self.assertIn("Remove-Item -LiteralPath $receiptPath", validation_failure)
+        self.assertIn(
+            '$campaignRecord.status = "not_independently_validated"',
+            validation_failure,
+        )
+
+        upload_status = self.workflow.split(
+            "      - name: Record retained A1 bundle validation status", 1
+        )[1].split("      - name: Upload retained A1 bundle", 1)[0]
+        self.assertIn("id: bundle_upload_status", upload_status)
+        self.assertIn(
+            "INDEPENDENT_VALIDATION_OUTCOME: "
+            "${{ steps.bundle_validation.outcome }}",
+            upload_status,
+        )
+        self.assertIn("independent_validation_passed", upload_status)
+        self.assertIn("independent_validation_outcome", upload_status)
+        self.assertIn('"bundle-upload-status.json"', upload_status)
+        self.assertIn("if ($statusBytes.Length -gt 4096)", upload_status)
         evidence = self.workflow.split(
             "      - name: Upload retained A1 bundle", 1
         )[1].split(
@@ -326,8 +414,16 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
             "      - name: Upload bounded A1 diagnostics", 1
         )[1]
         self.assertIn("${{ steps.campaign.outputs.bundle_path }}", evidence)
-        self.assertNotIn("${{ runner.temp }}\\jet3-a1-diagnostics", evidence)
-        self.assertIn("if: always() && steps.campaign.outcome == 'success'", evidence)
+        self.assertIn(
+            "${{ runner.temp }}\\jet3-a1-diagnostics\\bundle-upload-status.json",
+            evidence,
+        )
+        self.assertNotIn(
+            "${{ steps.campaign.outputs.bundle_path }}\\bundle-upload-status.json",
+            evidence,
+        )
+        self.assertIn("steps.campaign.outcome == 'success'", evidence)
+        self.assertIn("steps.bundle_upload_status.outcome == 'success'", evidence)
         self.assertNotIn("steps.bundle_validation.outcome", evidence)
         self.assertIn("windows-dao-a1-bundle-${{ github.sha }}", evidence)
         self.assertNotIn("windows-dao-a1-evidence-", evidence)
@@ -342,35 +438,6 @@ class WindowsDaoA1WorkflowTests(unittest.TestCase):
             "if: success() && steps.bundle_validation.outcome == 'success'",
             attestation,
         )
-        attestation_copy = self.workflow.split(
-            '$attestation = Join-Path $env:RUNNER_TEMP "jet3-a1-attestation"', 1
-        )[1].split(
-            '          $campaignRecord.status = "independently_validated"', 1
-        )[0]
-        self.assertEqual(
-            re.findall(r'^\s+"([^\"]+\.json)",?$', attestation_copy, re.MULTILINE),
-            [
-                "provider-binding.json",
-                "validation-receipt.json",
-                "campaign.json",
-            ],
-        )
-        self.assertEqual(attestation_copy.count("Copy-Item"), 1)
-        self.assertIn("-Destination (Join-Path $attestation $name)", attestation_copy)
-        validation_step = self.workflow.split("        id: bundle_validation", 1)[1].split(
-            "      - name: Upload retained A1 bundle", 1
-        )[0]
-        clean_check = validation_step.index(
-            "Independent validation changed the exact checkout."
-        )
-        prepare_attestation = validation_step.index("jet3-a1-attestation")
-        validated_status = validation_step.index(
-            '$campaignRecord.status = "independently_validated"'
-        )
-        final_diagnostics_write = validation_step.rindex("$campaignPath")
-        self.assertLess(clean_check, prepare_attestation)
-        self.assertLess(prepare_attestation, validated_status)
-        self.assertLess(validated_status, final_diagnostics_write)
         self.assertIn("if: always()", diagnostics)
         self.assertIn("${{ runner.temp }}\\jet3-a1-diagnostics", diagnostics)
         self.assertIn("retention-days: 14", diagnostics)


### PR DESCRIPTION
## Summary

- keep validation receipts and validated campaign status out of diagnostics until every independent gate and attestation preparation succeeds
- emit a bounded validation-failed.json marker and restore fail-closed diagnostics on validation errors
- attach a bounded independent-validation outcome sidecar to every retained A1 bundle artifact
- strengthen workflow contract tests around write ordering, failure diagnostics, and retained-artifact status

## Testing

- python3.13 -m unittest discover -s oracle/windows-dao/tests -p "test_*.py" (433 tests, 83 skipped, passed)
- YAML parse and git diff --check