### PR TITLE
feat: implement preregistered A2 analyzer

### DIFF
--- a/oracle/windows-dao/scripts/a2_analysis.py
+++ b/oracle/windows-dao/scripts/a2_analysis.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+"""Layered, holdout-safe analyzer for DAO-A2-ALLOCATION-MAPS-001."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from a2_layers import (
+    BaseModel,
+    ConversionModel,
+    TdefModel,
+    derive_base,
+    derive_conversion,
+    derive_tdef,
+    predicts_base,
+    predicts_conversion,
+    predicts_global,
+    predicts_tdef,
+)
+from a2_model import (
+    CHECKPOINT_IDS,
+    EXPERIMENT_DIR,
+    MAX_QUALIFIED_PAGES,
+    PAGE_SIZE,
+    PLAN,
+    PLAN_SHA256,
+    PREDICATES,
+    Abort,
+    GlobalRecordModel,
+    ReplicaData,
+    View,
+    WorkCounter,
+    candidate_page_space,
+    derive_global_record,
+    qualify_global_pages,
+    qualify_tdef_pages,
+)
+from protocol_validation import (
+    ValidationError,
+    canonical_json_bytes,
+    load_json,
+    validate_schema_value,
+)
+
+MAX_JSON_BYTES = int(PLAN["bounds"]["max_json_bytes"])
+EXPERIMENT_ID = PLAN["experiment_id"]
+CLAIMS = {
+    key: value
+    for key, value in PLAN["claims"].items()
+    if key
+    in {
+        "descriptive_provider_observation_only",
+        "general_tdef_catalog_row_index_or_lval_layout",
+        "unobserved_slot_or_base_behavior",
+        "compaction_encryption_or_version_behavior",
+        "rust_correctness",
+        "dao_compatibility_or_support",
+    }
+}
+LAYER_KEYS = (
+    "global_map_record",
+    "global_map_conversion_inline",
+    "global_map_extended_base",
+    "tdef_pointer_pair",
+)
+REPORT_LAYERS = {
+    "global_map_record": "global_map.record",
+    "global_map_conversion_inline": "global_map.conversion_inline",
+    "global_map_extended_base": "global_map.extended_base",
+    "tdef_pointer_pair": "tdef.pointer_pair",
+}
+
+
+def _schema(name: str) -> dict[str, Any]:
+    document = load_json(EXPERIMENT_DIR / name)
+    if not isinstance(document, dict):
+        raise ValidationError(f"{name}: schema must be an object")
+    return document
+
+
+def validate_document(document: dict[str, Any], schema_name: str) -> None:
+    """Validate directly against a checked A2 JSON schema."""
+    schema = _schema(schema_name)
+    validate_schema_value(document, schema, schema, "$")
+
+
+def _bounded_json(path: Path) -> dict[str, Any]:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValidationError(f"{path}: cannot inspect JSON: {exc}") from exc
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_size > MAX_JSON_BYTES
+    ):
+        raise ValidationError(f"{path}: unsafe or oversized JSON artifact")
+    try:
+        payload = path.read_bytes()
+        if payload.startswith(b"\xef\xbb\xbf"):
+            raise ValueError("UTF-8 byte-order marks are forbidden")
+
+        def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, value in pairs:
+                if key in result:
+                    raise ValueError(f"duplicate object key {key!r}")
+                result[key] = value
+            return result
+
+        def reject_nonfinite(value: str) -> None:
+            raise ValueError(f"non-finite JSON number {value}")
+
+        document = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=unique_object,
+            parse_constant=reject_nonfinite,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValidationError(f"{path}: invalid bounded JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValidationError(f"{path}: expected a JSON object")
+    return document
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ValidationError(f"{path}: cannot hash artifact: {exc}") from exc
+    return digest.hexdigest()
+
+
+def _safe_path(root: Path, relative: str) -> Path:
+    candidate = Path(relative)
+    if candidate.is_absolute() or ".." in candidate.parts or not candidate.parts:
+        raise ValidationError(f"unsafe A2 artifact path {relative!r}")
+    resolved_root = root.resolve()
+    resolved = (root / candidate).resolve()
+    if resolved != resolved_root and resolved_root not in resolved.parents:
+        raise ValidationError(f"A2 artifact escapes bundle root: {relative!r}")
+    return resolved
+
+
+@dataclass(frozen=True)
+class ReplicaInput:
+    data: ReplicaData
+    replica: int
+    campaign_id: str
+    producer_commit: str
+    provider_sha256: str
+    churn_precondition_met: bool
+
+
+class ReplicaSource(Protocol):
+    def open(self) -> ReplicaInput: ...
+
+
+@dataclass(frozen=True)
+class LoadedReplicaSource:
+    replica: ReplicaInput
+
+    def open(self) -> ReplicaInput:
+        return self.replica
+
+
+class BundleReplicaData:
+    """Schema-checked indexes plus lazy, content-addressed bundle pages."""
+
+    def __init__(
+        self, bundle_root: Path, observation: dict[str, Any], indexes: dict[str, dict[str, Any]]
+    ) -> None:
+        self.bundle_root = bundle_root
+        self.observation = observation
+        self.indexes = indexes
+        self._cache: dict[str, bytes] = {}
+
+    @property
+    def checkpoint_ids(self) -> tuple[str, ...]:
+        return CHECKPOINT_IDS
+
+    @property
+    def page_count(self) -> dict[str, int]:
+        return {
+            checkpoint: int(index["page_count"])
+            for checkpoint, index in self.indexes.items()
+        }
+
+    @property
+    def ordered_page_sha256(self) -> dict[str, tuple[str, ...]]:
+        return {
+            checkpoint: tuple(index["ordered_page_sha256"])
+            for checkpoint, index in self.indexes.items()
+        }
+
+    def page_bytes(self, digest: str) -> bytes:
+        retained = self._cache.get(digest)
+        if retained is not None:
+            return retained
+        path = self.bundle_root / "page-store" / f"{digest}.page"
+        try:
+            metadata = path.lstat()
+            if (
+                path.is_symlink()
+                or not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_size != PAGE_SIZE
+            ):
+                raise OSError("unsafe page blob")
+            retained = path.read_bytes()
+        except OSError as exc:
+            raise OSError(f"{path}: cannot read checked page blob") from exc
+        if hashlib.sha256(retained).hexdigest() != digest:
+            raise ValueError(f"{path}: content hash mismatch")
+        self._cache[digest] = retained
+        return retained
+
+
+@dataclass(frozen=True)
+class BundleReplicaSource:
+    observation_path: Path
+    bundle_root: Path
+
+    def open(self) -> ReplicaInput:
+        observation = _bounded_json(self.observation_path)
+        validate_document(observation, "replica-observation.schema.json")
+        if observation["plan_sha256"] != PLAN_SHA256:
+            raise ValidationError("replica observation is not bound to the checked A2 plan")
+        checkpoints = observation["checkpoints"]
+        if [item["checkpoint_id"] for item in checkpoints] != list(CHECKPOINT_IDS):
+            raise ValidationError("replica checkpoint order differs from the checked A2 plan")
+        indexes: dict[str, dict[str, Any]] = {}
+        prior: list[str] = []
+        changed_total = 0
+        for ordinal, checkpoint in enumerate(checkpoints):
+            reference = checkpoint["page_index"]
+            path = _safe_path(self.bundle_root, reference["path"])
+            try:
+                size = path.stat().st_size
+            except OSError as exc:
+                raise ValidationError(f"{path}: cannot inspect page index") from exc
+            if size != reference["size_bytes"] or _sha256(path) != reference["sha256"]:
+                raise ValidationError(f"{path}: page-index artifact binding failed")
+            index = _bounded_json(path)
+            validate_document(index, "page-index.schema.json")
+            expected_predecessor = CHECKPOINT_IDS[ordinal - 1] if ordinal else None
+            bindings = {
+                "plan_sha256": PLAN_SHA256,
+                "producer_commit": observation["producer_commit"],
+                "campaign_id": observation["campaign_id"],
+                "environment_sha256": observation["environment_sha256"],
+                "provider_sha256": observation["provider_sha256"],
+                "replica": observation["replica"],
+                "checkpoint_id": checkpoint["checkpoint_id"],
+                "ordinal": ordinal,
+                "predecessor_checkpoint_id": expected_predecessor,
+                "page_count": checkpoint["actual_file_pages"],
+            }
+            for key, expected in bindings.items():
+                if index[key] != expected:
+                    raise ValidationError(f"{path}: {key} binding mismatch")
+            hashes = index["ordered_page_sha256"]
+            if len(hashes) != index["page_count"]:
+                raise ValidationError(f"{path}: page count/hash list mismatch")
+            expected_changed = [
+                page
+                for page in range(max(len(prior), len(hashes)))
+                if (prior[page] if page < len(prior) else None)
+                != (hashes[page] if page < len(hashes) else None)
+            ]
+            if index["changed_page_indices"] != expected_changed:
+                raise ValidationError(f"{path}: changed page indexes are not reconstructable")
+            changed_total += len(expected_changed)
+            prior = hashes
+            indexes[checkpoint["checkpoint_id"]] = index
+        if changed_total != observation["changed_hash_entries"]:
+            raise ValidationError("replica changed-hash total mismatch")
+        by_checkpoint = {item["checkpoint_id"]: item for item in checkpoints}
+        before = by_checkpoint["L_REL_1280"]
+        deleted = by_checkpoint["L_DELETE_ALL"]
+        deleted_reread = next(
+            (item["row_count"] for item in deleted["dao_reread"] if item["role"] == "L"), None
+        )
+        churn_precondition = before["table_row_counts"]["L"] > 0 and (
+            deleted["table_row_counts"]["L"] == 0 and deleted_reread == 0
+        )
+        data = BundleReplicaData(self.bundle_root, observation, indexes)
+        return ReplicaInput(
+            data,
+            observation["replica"],
+            observation["campaign_id"],
+            observation["producer_commit"],
+            observation["provider_sha256"],
+            churn_precondition,
+        )
+
+
+@dataclass(frozen=True)
+class LayerDraft:
+    model: GlobalRecordModel | ConversionModel | BaseModel | TdefModel | None
+    survivor_count: int
+    abort: Abort | None
+    applicable: bool = True
+
+
+def _derive_pair(function: Callable[[View], Any], views: tuple[View, View]) -> LayerDraft:
+    outcomes: list[Any | Abort] = []
+    for view in views:
+        try:
+            outcomes.append(function(view))
+        except Abort as exc:
+            outcomes.append(exc)
+    if all(isinstance(item, Abort) for item in outcomes):
+        first, second = outcomes
+        assert isinstance(first, Abort) and isinstance(second, Abort)
+        if first.predicate_id == second.predicate_id:
+            return LayerDraft(None, 0, first)
+        return LayerDraft(None, 0, Abort("A2-REPLICA-DISAGREEMENT"))
+    if any(isinstance(item, Abort) for item in outcomes) or outcomes[0] != outcomes[1]:
+        return LayerDraft(None, 0, Abort("A2-REPLICA-DISAGREEMENT"))
+    return LayerDraft(outcomes[0], 1, None)
+
+
+def _not_applicable() -> LayerDraft:
+    return LayerDraft(None, 0, None, False)
+
+
+def _qualify_pair(
+    function: Callable[[View, range], tuple[int, ...]],
+    views: tuple[View, View],
+    pages: range,
+) -> tuple[tuple[int, ...], Abort | None]:
+    results: list[tuple[int, ...] | Abort] = []
+    for view in views:
+        try:
+            results.append(function(view, pages))
+        except Abort as exc:
+            results.append(exc)
+    if all(isinstance(item, Abort) for item in results):
+        first, second = results
+        assert isinstance(first, Abort) and isinstance(second, Abort)
+        return (), first if first.predicate_id == second.predicate_id else Abort(
+            "A2-REPLICA-DISAGREEMENT"
+        )
+    if any(isinstance(item, Abort) for item in results) or results[0] != results[1]:
+        return (), Abort("A2-REPLICA-DISAGREEMENT")
+    assert isinstance(results[0], tuple)
+    return results[0], None
+
+
+def _derive_pages(
+    pages: tuple[int, ...],
+    views: tuple[View, View],
+    function: Callable[[View, int, int, bool], Any],
+    none_page_id: str,
+    multiple_page_id: str,
+    none_record_id: str,
+) -> LayerDraft:
+    """Evaluate each qualified coordinate once across both derivation replicas."""
+    if not pages:
+        return LayerDraft(None, 0, Abort(none_page_id))
+    survivors: list[Any] = []
+    local_aborts: list[Abort] = []
+    for page in pages:
+        outcomes: list[Any | Abort] = []
+        for replica_index, view in enumerate(views):
+            try:
+                outcomes.append(function(view, page, replica_index, replica_index == 0))
+            except Abort as exc:
+                outcomes.append(exc)
+        if all(isinstance(item, Abort) for item in outcomes):
+            first, second = outcomes
+            assert isinstance(first, Abort) and isinstance(second, Abort)
+            if first.predicate_id != second.predicate_id:
+                return LayerDraft(None, 0, Abort("A2-REPLICA-DISAGREEMENT"))
+            local_aborts.append(first)
+            continue
+        if any(isinstance(item, Abort) for item in outcomes) or outcomes[0] != outcomes[1]:
+            return LayerDraft(None, 0, Abort("A2-REPLICA-DISAGREEMENT"))
+        survivors.append(outcomes[0])
+    if len(survivors) > 1:
+        return LayerDraft(None, len(survivors), Abort(multiple_page_id))
+    if len(survivors) == 1:
+        return LayerDraft(survivors[0], 1, None)
+    if local_aborts and len({item.predicate_id for item in local_aborts}) == 1:
+        return LayerDraft(None, 0, local_aborts[0])
+    return LayerDraft(None, 0, Abort(none_record_id))
+
+
+def _candidate_document(
+    campaign_id: str,
+    global_pages: tuple[int, ...],
+    tdef_pages: tuple[int, ...],
+    drafts: dict[str, LayerDraft],
+) -> dict[str, Any]:
+    def layer(draft: LayerDraft) -> dict[str, Any]:
+        return {
+            "applicable": draft.applicable,
+            "derivation_survivor_count": draft.survivor_count,
+            "terminal_predicate_id": draft.abort.predicate_id if draft.abort else None,
+            "no_outcome_reason": draft.abort.reason if draft.abort else None,
+            "model": draft.model.document() if draft.model is not None else None,
+        }
+
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_frozen_derivation_candidates",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "campaign_id": campaign_id,
+        "derivation_replicas": [1, 2],
+        "qualified_pages": {"global_map": list(global_pages), "tdef": list(tdef_pages)},
+        "layers": {key: layer(drafts[key]) for key in LAYER_KEYS},
+    }
+
+
+def _write_frozen(path: Path, document: dict[str, Any]) -> str:
+    payload = canonical_json_bytes(document)
+    if len(payload) > MAX_JSON_BYTES:
+        raise ValidationError("A2 frozen candidate set exceeds JSON ceiling")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as handle:
+        handle.write(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _validate_inputs(replicas: list[ReplicaInput]) -> None:
+    if [item.replica for item in replicas] != list(range(1, len(replicas) + 1)):
+        raise ValidationError("A2 analysis requires replicas 1, 2, and 3 in order")
+    for attribute in ("campaign_id", "producer_commit", "provider_sha256"):
+        if len({getattr(item, attribute) for item in replicas}) != 1:
+            raise ValidationError(f"A2 replica {attribute} binding mismatch")
+
+
+def _layer_result(draft: LayerDraft, holdout_match: bool | None) -> dict[str, Any]:
+    if not draft.applicable:
+        return {
+            "status": "not_applicable",
+            "derivation_survivor_count": 0,
+            "holdout_evaluated": False,
+            "no_outcome_reasons": [],
+            "model": None,
+        }
+    if draft.abort is not None:
+        reasons = [draft.abort.reason]
+        model = None
+        status = "no_outcome"
+        evaluated = False
+    elif holdout_match:
+        reasons = []
+        model = draft.model.document() if draft.model is not None else None
+        status = "decisive_predicts_holdout"
+        evaluated = True
+    else:
+        reasons = [PREDICATES["A2-HOLDOUT-PREDICTION"][0]]
+        model = None
+        status = "no_outcome"
+        evaluated = True
+    return {
+        "status": status,
+        "derivation_survivor_count": draft.survivor_count,
+        "holdout_evaluated": evaluated,
+        "no_outcome_reasons": reasons,
+        "model": model,
+    }
+
+
+def _predicate_results(
+    drafts: dict[str, LayerDraft], layer_results: dict[str, dict[str, Any]]
+) -> list[dict[str, str]]:
+    failed = {
+        draft.abort.predicate_id
+        for draft in drafts.values()
+        if draft.abort is not None
+    }
+    for key, result in layer_results.items():
+        if result["holdout_evaluated"] and result["status"] == "no_outcome":
+            failed.add("A2-HOLDOUT-PREDICTION")
+    decisive_layers = {
+        REPORT_LAYERS[key]
+        for key, result in layer_results.items()
+        if result["status"] == "decisive_predicts_holdout"
+    }
+    results = []
+    for predicate_id, (_, registered_layer) in PREDICATES.items():
+        if predicate_id in failed:
+            status = "fail"
+        elif registered_layer in decisive_layers or (
+            registered_layer == "applicable_layer" and decisive_layers
+        ):
+            status = "pass"
+        elif predicate_id == "A2-IDLE-EQUALITY":
+            status = "pass"
+        else:
+            status = "not_applicable"
+        results.append({"predicate_id": predicate_id, "status": status, "layer": registered_layer})
+    return results
+
+
+def build_analysis(
+    sources: list[ReplicaSource],
+    candidate_output: Path,
+    validate_holdout_after_freeze: Callable[[str], None],
+) -> dict[str, Any]:
+    """Derive on replicas 1+2, persist the freeze, then purely predict replica 3."""
+    if len(sources) != 3:
+        raise ValidationError("A2 analysis requires exactly three replica sources")
+    derivation = [sources[0].open(), sources[1].open()]
+    _validate_inputs(derivation)
+    work = WorkCounter()
+    views = (View(derivation[0].data, work), View(derivation[1].data, work))
+    drafts: dict[str, LayerDraft] = {}
+    global_pages: tuple[int, ...] = ()
+    tdef_pages: tuple[int, ...] = ()
+
+    idle_abort = None
+    if not all(view.idle_pairs_identical() for view in views):
+        idle_abort = Abort("A2-IDLE-EQUALITY")
+    if idle_abort is not None:
+        for key in LAYER_KEYS:
+            drafts[key] = LayerDraft(None, 0, idle_abort)
+    else:
+        pages = candidate_page_space(views)
+        global_pages, global_qualification_abort = _qualify_pair(qualify_global_pages, views, pages)
+        if global_qualification_abort is None:
+            drafts["global_map_record"] = _derive_pages(
+                global_pages,
+                views,
+                lambda view, page, _replica_index, charge: derive_global_record(
+                    view, page, enumerate_candidates=charge
+                ),
+                "A2-GLOBAL-PAGE-NONE",
+                "A2-GLOBAL-PAGE-MULTIPLE",
+                "A2-GLOBAL-RECORD-NONE",
+            )
+        else:
+            drafts["global_map_record"] = LayerDraft(None, 0, global_qualification_abort)
+
+        global_draft = drafts["global_map_record"]
+        if global_draft.model is None:
+            drafts["global_map_conversion_inline"] = _not_applicable()
+            drafts["global_map_extended_base"] = _not_applicable()
+        else:
+            global_model = global_draft.model
+            assert isinstance(global_model, GlobalRecordModel)
+            conversion_draft = _derive_pair(
+                lambda view: derive_conversion(view, global_model), views
+            )
+            drafts["global_map_conversion_inline"] = conversion_draft
+            if conversion_draft.model is None:
+                drafts["global_map_extended_base"] = _not_applicable()
+            else:
+                conversion = conversion_draft.model
+                assert isinstance(conversion, ConversionModel)
+                drafts["global_map_extended_base"] = _derive_pair(
+                    lambda view: derive_base(view, global_model, conversion), views
+                )
+
+        tdef_pages, tdef_qualification_abort = _qualify_pair(qualify_tdef_pages, views, pages)
+        if tdef_qualification_abort is None:
+            drafts["tdef_pointer_pair"] = _derive_pages(
+                tdef_pages,
+                views,
+                lambda view, page, replica_index, charge: derive_tdef(
+                    view,
+                    page,
+                    derivation[replica_index].churn_precondition_met,
+                    enumerate_candidates=charge,
+                ),
+                "A2-TDEF-PAGE-NONE",
+                "A2-TDEF-PAGE-MULTIPLE",
+                "A2-TDEF-RECORD-NONE",
+            )
+        else:
+            drafts["tdef_pointer_pair"] = LayerDraft(None, 0, tdef_qualification_abort)
+
+    frozen = _candidate_document(
+        derivation[0].campaign_id, global_pages, tdef_pages, drafts
+    )
+    frozen_sha256 = _write_frozen(candidate_output, frozen)
+    validate_holdout_after_freeze(frozen_sha256)
+
+    # No replica-3 source operation occurs above this line.
+    holdout_input = sources[2].open()
+    replicas = derivation + [holdout_input]
+    _validate_inputs(replicas)
+    holdout = View(holdout_input.data, work)
+    matches: dict[str, bool | None] = {key: None for key in LAYER_KEYS}
+    global_draft = drafts["global_map_record"]
+    if isinstance(global_draft.model, GlobalRecordModel):
+        matches["global_map_record"] = predicts_global(holdout, global_draft.model)
+        conversion_draft = drafts["global_map_conversion_inline"]
+        if isinstance(conversion_draft.model, ConversionModel):
+            matches["global_map_conversion_inline"] = predicts_conversion(
+                holdout, global_draft.model, conversion_draft.model
+            )
+            base_draft = drafts["global_map_extended_base"]
+            if isinstance(base_draft.model, BaseModel):
+                matches["global_map_extended_base"] = predicts_base(
+                    holdout, global_draft.model, conversion_draft.model, base_draft.model
+                )
+    tdef_draft = drafts["tdef_pointer_pair"]
+    if isinstance(tdef_draft.model, TdefModel):
+        matches["tdef_pointer_pair"] = predicts_tdef(
+            holdout, tdef_draft.model, holdout_input.churn_precondition_met
+        )
+
+    layer_results = {key: _layer_result(drafts[key], matches[key]) for key in LAYER_KEYS}
+    terminal_ids = sorted(
+        {
+            draft.abort.predicate_id
+            for draft in drafts.values()
+            if draft.abort is not None
+        }
+        | {
+            "A2-HOLDOUT-PREDICTION"
+            for result in layer_results.values()
+            if result["holdout_evaluated"] and result["status"] == "no_outcome"
+        }
+    )
+    reasons = sorted(
+        {reason for result in layer_results.values() for reason in result["no_outcome_reasons"]}
+    )
+    decisive = any(
+        result["status"] == "decisive_predicts_holdout"
+        for result in layer_results.values()
+    )
+    report = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_analysis_report",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "campaign_id": derivation[0].campaign_id,
+        "producer_commit": derivation[0].producer_commit,
+        "derivation_replicas": [1, 2],
+        "holdout_replica": 3,
+        "input_checkpoint_count": 75,
+        "qualified_page_counts": {
+            "global_map": min(len(global_pages), MAX_QUALIFIED_PAGES),
+            "tdef": min(len(tdef_pages), MAX_QUALIFIED_PAGES),
+        },
+        "record_candidates_examined": work.record_candidates,
+        "candidate_models_examined": work.candidate_models,
+        "derivation_survivor_counts": {
+            key: drafts[key].survivor_count for key in LAYER_KEYS
+        },
+        "derivation_candidate_set_sha256": frozen_sha256,
+        "analysis_work_units": work.value,
+        "holdout_structurally_validated_after_freeze": True,
+        "holdout_opened_after_freeze": True,
+        "holdout_evaluated": any(result["holdout_evaluated"] for result in layer_results.values()),
+        "predicate_results": _predicate_results(drafts, layer_results),
+        "terminal_predicate_ids": terminal_ids,
+        "scientific_outcome": (
+            "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout"
+        ),
+        "no_outcome_reasons": reasons,
+        "submodels": {
+            "global_map": {
+                "record": layer_results["global_map_record"],
+                "conversion_inline": layer_results["global_map_conversion_inline"],
+                "extended_base": layer_results["global_map_extended_base"],
+            },
+            "tdef": {"pointer_pair": layer_results["tdef_pointer_pair"]},
+        },
+        "claims": CLAIMS,
+    }
+    validate_document(report, "analysis-report.schema.json")
+    if len(canonical_json_bytes(report)) > MAX_JSON_BYTES:
+        raise ValidationError("A2 analysis report exceeds JSON ceiling")
+    return report
+
+
+def _receipt_validator(path: Path, campaign_id: str, producer_commit: str) -> Callable[[str], None]:
+    def validate(frozen_sha256: str) -> None:
+        receipt = _bounded_json(path)
+        validate_document(receipt, "holdout-structure-receipt.schema.json")
+        expected = {
+            "plan_sha256": PLAN_SHA256,
+            "campaign_id": campaign_id,
+            "producer_commit": producer_commit,
+            "derivation_candidate_set_sha256": frozen_sha256,
+        }
+        for key, value in expected.items():
+            if receipt[key] != value:
+                raise ValidationError(f"holdout receipt {key} binding mismatch")
+
+    return validate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--replica", action="append", type=Path)
+    parser.add_argument("--candidate-output", type=Path)
+    parser.add_argument("--holdout-receipt", type=Path)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args(argv)
+    root = arguments.bundle_root
+    replicas = arguments.replica or [
+        root / relative for relative in PLAN["artifacts"]["replica_observations"]
+    ]
+    candidate_output = (
+        arguments.candidate_output or root / PLAN["artifacts"]["frozen_candidate_set"]
+    )
+    output = arguments.output or root / PLAN["artifacts"]["analysis_report"]
+    receipt_path = (
+        arguments.holdout_receipt
+        or root / PLAN["artifacts"]["holdout_structure_receipt"]
+    )
+    try:
+        if len(replicas) != 3:
+            raise ValidationError("exactly three A2 replica observations are required")
+        sources = [BundleReplicaSource(path, root) for path in replicas]
+        first = sources[0].open()
+        validator = _receipt_validator(receipt_path, first.campaign_id, first.producer_commit)
+        # Re-opening replica 1 below is metadata-only and still precedes the freeze;
+        # replica 3 remains unopened until build_analysis persists candidates.
+        report = build_analysis(sources, candidate_output, validator)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("xb") as handle:
+            handle.write(canonical_json_bytes(report))
+    except (OSError, ValidationError) as exc:
+        print(f"A2 analysis failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {"output": str(output), "scientific_outcome": report["scientific_outcome"]},
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a2_analysis.py
+++ b/oracle/windows-dao/scripts/a2_analysis.py
@@ -178,16 +178,21 @@ class BundleReplicaData:
     """Schema-checked indexes plus lazy, content-addressed bundle pages."""
 
     def __init__(
-        self, bundle_root: Path, observation: dict[str, Any], indexes: dict[str, dict[str, Any]]
+        self,
+        bundle_root: Path,
+        observation: dict[str, Any],
+        indexes: dict[str, dict[str, Any]],
+        checkpoint_ids: tuple[str, ...] = CHECKPOINT_IDS,
     ) -> None:
         self.bundle_root = bundle_root
         self.observation = observation
         self.indexes = indexes
+        self._checkpoint_ids = checkpoint_ids
         self._cache: dict[str, bytes] = {}
 
     @property
     def checkpoint_ids(self) -> tuple[str, ...]:
-        return CHECKPOINT_IDS
+        return self._checkpoint_ids
 
     @property
     def page_count(self) -> dict[str, int]:
@@ -236,8 +241,17 @@ class BundleReplicaSource:
         if observation["plan_sha256"] != PLAN_SHA256:
             raise ValidationError("replica observation is not bound to the checked A2 plan")
         checkpoints = observation["checkpoints"]
-        if [item["checkpoint_id"] for item in checkpoints] != list(CHECKPOINT_IDS):
-            raise ValidationError("replica checkpoint order differs from the checked A2 plan")
+        observed_ids = tuple(item["checkpoint_id"] for item in checkpoints)
+        if observed_ids != CHECKPOINT_IDS:
+            data = BundleReplicaData(self.bundle_root, observation, {}, observed_ids)
+            return ReplicaInput(
+                data,
+                observation["replica"],
+                observation["campaign_id"],
+                observation["producer_commit"],
+                observation["provider_sha256"],
+                False,
+            )
         indexes: dict[str, dict[str, Any]] = {}
         prior: list[str] = []
         changed_total = 0
@@ -435,13 +449,15 @@ def _write_frozen(path: Path, document: dict[str, Any]) -> str:
 
 def _validate_inputs(replicas: list[ReplicaInput]) -> None:
     if [item.replica for item in replicas] != list(range(1, len(replicas) + 1)):
-        raise ValidationError("A2 analysis requires replicas 1, 2, and 3 in order")
+        raise Abort("A2-REPLICA-DISAGREEMENT")
     for attribute in ("campaign_id", "producer_commit", "provider_sha256"):
         if len({getattr(item, attribute) for item in replicas}) != 1:
-            raise ValidationError(f"A2 replica {attribute} binding mismatch")
+            raise Abort("A2-REPLICA-DISAGREEMENT")
 
 
-def _layer_result(draft: LayerDraft, holdout_match: bool | None) -> dict[str, Any]:
+def _layer_result(
+    draft: LayerDraft, holdout_match: bool | None, campaign_abort: Abort | None = None
+) -> dict[str, Any]:
     if not draft.applicable:
         return {
             "status": "not_applicable",
@@ -450,8 +466,9 @@ def _layer_result(draft: LayerDraft, holdout_match: bool | None) -> dict[str, An
             "no_outcome_reasons": [],
             "model": None,
         }
-    if draft.abort is not None:
-        reasons = [draft.abort.reason]
+    abort = campaign_abort or draft.abort
+    if abort is not None:
+        reasons = [abort.reason]
         model = None
         status = "no_outcome"
         evaluated = False
@@ -475,13 +492,18 @@ def _layer_result(draft: LayerDraft, holdout_match: bool | None) -> dict[str, An
 
 
 def _predicate_results(
-    drafts: dict[str, LayerDraft], layer_results: dict[str, dict[str, Any]]
+    drafts: dict[str, LayerDraft],
+    layer_results: dict[str, dict[str, Any]],
+    campaign_abort: Abort | None,
+    idle_evaluated: bool,
 ) -> list[dict[str, str]]:
     failed = {
         draft.abort.predicate_id
         for draft in drafts.values()
         if draft.abort is not None
     }
+    if campaign_abort is not None:
+        failed.add(campaign_abort.predicate_id)
     for key, result in layer_results.items():
         if result["holdout_evaluated"] and result["status"] == "no_outcome":
             failed.add("A2-HOLDOUT-PREDICTION")
@@ -498,12 +520,88 @@ def _predicate_results(
             registered_layer == "applicable_layer" and decisive_layers
         ):
             status = "pass"
-        elif predicate_id == "A2-IDLE-EQUALITY":
+        elif predicate_id == "A2-IDLE-EQUALITY" and idle_evaluated:
             status = "pass"
         else:
             status = "not_applicable"
         results.append({"predicate_id": predicate_id, "status": status, "layer": registered_layer})
     return results
+
+
+def _campaign_drafts(abort: Abort) -> dict[str, LayerDraft]:
+    return {key: LayerDraft(None, 0, abort) for key in LAYER_KEYS}
+
+
+def _derive_layers(
+    derivation: list[ReplicaInput], work: WorkCounter
+) -> tuple[dict[str, LayerDraft], tuple[int, ...], tuple[int, ...]]:
+    _validate_inputs(derivation)
+    views = (View(derivation[0].data, work), View(derivation[1].data, work))
+    drafts: dict[str, LayerDraft] = {}
+    global_pages: tuple[int, ...] = ()
+    tdef_pages: tuple[int, ...] = ()
+
+    if not all(view.idle_pairs_identical() for view in views):
+        return _campaign_drafts(Abort("A2-IDLE-EQUALITY")), global_pages, tdef_pages
+
+    pages = candidate_page_space(views)
+    global_pages, global_qualification_abort = _qualify_pair(
+        qualify_global_pages, views, pages
+    )
+    if global_qualification_abort is None:
+        drafts["global_map_record"] = _derive_pages(
+            global_pages,
+            views,
+            lambda view, page, _replica_index, charge: derive_global_record(
+                view, page, enumerate_candidates=charge
+            ),
+            "A2-GLOBAL-PAGE-NONE",
+            "A2-GLOBAL-PAGE-MULTIPLE",
+            "A2-GLOBAL-RECORD-NONE",
+        )
+    else:
+        drafts["global_map_record"] = LayerDraft(None, 0, global_qualification_abort)
+
+    global_draft = drafts["global_map_record"]
+    if global_draft.model is None:
+        drafts["global_map_conversion_inline"] = _not_applicable()
+        drafts["global_map_extended_base"] = _not_applicable()
+    else:
+        global_model = global_draft.model
+        assert isinstance(global_model, GlobalRecordModel)
+        conversion_draft = _derive_pair(
+            lambda view: derive_conversion(view, global_model), views
+        )
+        drafts["global_map_conversion_inline"] = conversion_draft
+        if conversion_draft.model is None:
+            drafts["global_map_extended_base"] = _not_applicable()
+        else:
+            conversion = conversion_draft.model
+            assert isinstance(conversion, ConversionModel)
+            drafts["global_map_extended_base"] = _derive_pair(
+                lambda view: derive_base(view, global_model, conversion), views
+            )
+
+    tdef_pages, tdef_qualification_abort = _qualify_pair(
+        qualify_tdef_pages, views, pages
+    )
+    if tdef_qualification_abort is None:
+        drafts["tdef_pointer_pair"] = _derive_pages(
+            tdef_pages,
+            views,
+            lambda view, page, replica_index, charge: derive_tdef(
+                view,
+                page,
+                derivation[replica_index].churn_precondition_met,
+                enumerate_candidates=charge,
+            ),
+            "A2-TDEF-PAGE-NONE",
+            "A2-TDEF-PAGE-MULTIPLE",
+            "A2-TDEF-RECORD-NONE",
+        )
+    else:
+        drafts["tdef_pointer_pair"] = LayerDraft(None, 0, tdef_qualification_abort)
+    return drafts, global_pages, tdef_pages
 
 
 def build_analysis(
@@ -515,117 +613,71 @@ def build_analysis(
     if len(sources) != 3:
         raise ValidationError("A2 analysis requires exactly three replica sources")
     derivation = [sources[0].open(), sources[1].open()]
-    _validate_inputs(derivation)
     work = WorkCounter()
-    views = (View(derivation[0].data, work), View(derivation[1].data, work))
-    drafts: dict[str, LayerDraft] = {}
+    campaign_abort: Abort | None = None
+    idle_evaluated = False
     global_pages: tuple[int, ...] = ()
     tdef_pages: tuple[int, ...] = ()
-
-    idle_abort = None
-    if not all(view.idle_pairs_identical() for view in views):
-        idle_abort = Abort("A2-IDLE-EQUALITY")
-    if idle_abort is not None:
-        for key in LAYER_KEYS:
-            drafts[key] = LayerDraft(None, 0, idle_abort)
-    else:
-        pages = candidate_page_space(views)
-        global_pages, global_qualification_abort = _qualify_pair(qualify_global_pages, views, pages)
-        if global_qualification_abort is None:
-            drafts["global_map_record"] = _derive_pages(
-                global_pages,
-                views,
-                lambda view, page, _replica_index, charge: derive_global_record(
-                    view, page, enumerate_candidates=charge
-                ),
-                "A2-GLOBAL-PAGE-NONE",
-                "A2-GLOBAL-PAGE-MULTIPLE",
-                "A2-GLOBAL-RECORD-NONE",
-            )
-        else:
-            drafts["global_map_record"] = LayerDraft(None, 0, global_qualification_abort)
-
-        global_draft = drafts["global_map_record"]
-        if global_draft.model is None:
-            drafts["global_map_conversion_inline"] = _not_applicable()
-            drafts["global_map_extended_base"] = _not_applicable()
-        else:
-            global_model = global_draft.model
-            assert isinstance(global_model, GlobalRecordModel)
-            conversion_draft = _derive_pair(
-                lambda view: derive_conversion(view, global_model), views
-            )
-            drafts["global_map_conversion_inline"] = conversion_draft
-            if conversion_draft.model is None:
-                drafts["global_map_extended_base"] = _not_applicable()
-            else:
-                conversion = conversion_draft.model
-                assert isinstance(conversion, ConversionModel)
-                drafts["global_map_extended_base"] = _derive_pair(
-                    lambda view: derive_base(view, global_model, conversion), views
-                )
-
-        tdef_pages, tdef_qualification_abort = _qualify_pair(qualify_tdef_pages, views, pages)
-        if tdef_qualification_abort is None:
-            drafts["tdef_pointer_pair"] = _derive_pages(
-                tdef_pages,
-                views,
-                lambda view, page, replica_index, charge: derive_tdef(
-                    view,
-                    page,
-                    derivation[replica_index].churn_precondition_met,
-                    enumerate_candidates=charge,
-                ),
-                "A2-TDEF-PAGE-NONE",
-                "A2-TDEF-PAGE-MULTIPLE",
-                "A2-TDEF-RECORD-NONE",
-            )
-        else:
-            drafts["tdef_pointer_pair"] = LayerDraft(None, 0, tdef_qualification_abort)
+    try:
+        drafts, global_pages, tdef_pages = _derive_layers(derivation, work)
+        idle_evaluated = True
+    except Abort as exc:
+        campaign_abort = exc
+        drafts = _campaign_drafts(exc)
 
     frozen = _candidate_document(
         derivation[0].campaign_id, global_pages, tdef_pages, drafts
     )
     frozen_sha256 = _write_frozen(candidate_output, frozen)
     validate_holdout_after_freeze(frozen_sha256)
-
     # No replica-3 source operation occurs above this line.
-    holdout_input = sources[2].open()
-    replicas = derivation + [holdout_input]
-    _validate_inputs(replicas)
-    holdout = View(holdout_input.data, work)
+    holdout_opened = False
     matches: dict[str, bool | None] = {key: None for key in LAYER_KEYS}
-    global_draft = drafts["global_map_record"]
-    if isinstance(global_draft.model, GlobalRecordModel):
-        matches["global_map_record"] = predicts_global(holdout, global_draft.model)
-        conversion_draft = drafts["global_map_conversion_inline"]
-        if isinstance(conversion_draft.model, ConversionModel):
-            matches["global_map_conversion_inline"] = predicts_conversion(
-                holdout, global_draft.model, conversion_draft.model
-            )
-            base_draft = drafts["global_map_extended_base"]
-            if isinstance(base_draft.model, BaseModel):
-                matches["global_map_extended_base"] = predicts_base(
-                    holdout, global_draft.model, conversion_draft.model, base_draft.model
+    if campaign_abort is None:
+        try:
+            holdout_input = sources[2].open()
+            holdout_opened = True
+            _validate_inputs(derivation + [holdout_input])
+            holdout = View(holdout_input.data, work)
+            global_draft = drafts["global_map_record"]
+            if isinstance(global_draft.model, GlobalRecordModel):
+                matches["global_map_record"] = predicts_global(holdout, global_draft.model)
+                conversion_draft = drafts["global_map_conversion_inline"]
+                if isinstance(conversion_draft.model, ConversionModel):
+                    matches["global_map_conversion_inline"] = predicts_conversion(
+                        holdout, global_draft.model, conversion_draft.model
+                    )
+                    base_draft = drafts["global_map_extended_base"]
+                    if isinstance(base_draft.model, BaseModel):
+                        matches["global_map_extended_base"] = predicts_base(
+                            holdout,
+                            global_draft.model,
+                            conversion_draft.model,
+                            base_draft.model,
+                        )
+            tdef_draft = drafts["tdef_pointer_pair"]
+            if isinstance(tdef_draft.model, TdefModel):
+                matches["tdef_pointer_pair"] = predicts_tdef(
+                    holdout, tdef_draft.model, holdout_input.churn_precondition_met
                 )
-    tdef_draft = drafts["tdef_pointer_pair"]
-    if isinstance(tdef_draft.model, TdefModel):
-        matches["tdef_pointer_pair"] = predicts_tdef(
-            holdout, tdef_draft.model, holdout_input.churn_precondition_met
-        )
+        except Abort as exc:
+            campaign_abort = exc
 
-    layer_results = {key: _layer_result(drafts[key], matches[key]) for key in LAYER_KEYS}
-    terminal_ids = sorted(
-        {
-            draft.abort.predicate_id
-            for draft in drafts.values()
-            if draft.abort is not None
-        }
-        | {
-            "A2-HOLDOUT-PREDICTION"
-            for result in layer_results.values()
-            if result["holdout_evaluated"] and result["status"] == "no_outcome"
-        }
+    layer_results = {
+        key: _layer_result(drafts[key], matches[key], campaign_abort)
+        for key in LAYER_KEYS
+    }
+    terminal_ids = {
+        draft.abort.predicate_id
+        for draft in drafts.values()
+        if draft.abort is not None
+    }
+    if campaign_abort is not None:
+        terminal_ids.add(campaign_abort.predicate_id)
+    terminal_ids.update(
+        "A2-HOLDOUT-PREDICTION"
+        for result in layer_results.values()
+        if result["holdout_evaluated"] and result["status"] == "no_outcome"
     )
     reasons = sorted(
         {reason for result in layer_results.values() for reason in result["no_outcome_reasons"]}
@@ -643,7 +695,7 @@ def build_analysis(
         "producer_commit": derivation[0].producer_commit,
         "derivation_replicas": [1, 2],
         "holdout_replica": 3,
-        "input_checkpoint_count": 75,
+        "input_checkpoint_count": len(CHECKPOINT_IDS) * int(PLAN["replicas"]["count"]),
         "qualified_page_counts": {
             "global_map": min(len(global_pages), MAX_QUALIFIED_PAGES),
             "tdef": min(len(tdef_pages), MAX_QUALIFIED_PAGES),
@@ -656,10 +708,12 @@ def build_analysis(
         "derivation_candidate_set_sha256": frozen_sha256,
         "analysis_work_units": work.value,
         "holdout_structurally_validated_after_freeze": True,
-        "holdout_opened_after_freeze": True,
+        "holdout_opened_after_freeze": holdout_opened,
         "holdout_evaluated": any(result["holdout_evaluated"] for result in layer_results.values()),
-        "predicate_results": _predicate_results(drafts, layer_results),
-        "terminal_predicate_ids": terminal_ids,
+        "predicate_results": _predicate_results(
+            drafts, layer_results, campaign_abort, idle_evaluated
+        ),
+        "terminal_predicate_ids": sorted(terminal_ids),
         "scientific_outcome": (
             "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout"
         ),
@@ -729,7 +783,7 @@ def main(argv: list[str] | None = None) -> int:
         output.parent.mkdir(parents=True, exist_ok=True)
         with output.open("xb") as handle:
             handle.write(canonical_json_bytes(report))
-    except (OSError, ValidationError) as exc:
+    except (Abort, OSError, ValidationError) as exc:
         print(f"A2 analysis failed: {exc}", file=sys.stderr)
         return 1
     print(

--- a/oracle/windows-dao/scripts/a2_layers.py
+++ b/oracle/windows-dao/scripts/a2_layers.py
@@ -144,22 +144,38 @@ def _polarity_cross_check(view: View, global_model: GlobalRecordModel) -> None:
         after_tag = after_record[global_model.record.start]
         pairs: list[tuple[bytes, bytes]] = []
         if before_tag == after_tag == 0:
+            before_base = int.from_bytes(
+                before_record[global_model.record.start + 1 : start], "little"
+            )
+            after_base = int.from_bytes(
+                after_record[global_model.record.start + 1 : start], "little"
+            )
+            if before_base != after_base:
+                raise Abort("A2-POLARITY-CROSSCHECK")
+            if view.page_count(right) <= before_base:
+                continue
             pairs.append((before_record[start:end], after_record[start:end]))
         elif before_tag == after_tag == 1:
             before_slots = _active_slots(before_record, global_model.record.start)
             after_slots = _active_slots(after_record, global_model.record.start)
+            if before_slots != after_slots:
+                continue
             for slot, reference in after_slots.items():
                 prior_reference = before_slots.get(slot)
-                before = (
-                    view.page(left, prior_reference)[EXTENDED_HEADER_BYTES:]
-                    if prior_reference is not None
-                    else bytes(PAGE_SIZE - EXTENDED_HEADER_BYTES)
-                )
+                if (
+                    prior_reference != reference
+                    or reference >= view.page_count(left)
+                    or reference >= view.page_count(right)
+                ):
+                    continue
+                before = view.page(left, reference)[EXTENDED_HEADER_BYTES:]
                 after = view.page(right, reference)[EXTENDED_HEADER_BYTES:]
                 pairs.append((before, after))
         else:
             # The representation changes at conversion; D has already fixed
             # polarity and the same-direction checks resume after conversion.
+            continue
+        if not pairs:
             continue
         changed_in_direction = any(
             any(
@@ -284,10 +300,14 @@ def _extended_state(
     result: dict[int, tuple[int, int]] = {}
     for slot, reference in _active_slots(record_page, global_model.record.start).items():
         if not 0 < reference < view.page_count(checkpoint):
-            raise Abort("A2-POINTER-VALIDITY")
+            if checkpoint in VALIDITY_CHECKPOINTS:
+                raise Abort("A2-POINTER-VALIDITY")
+            continue
         payload = view.page(checkpoint, reference)
         if payload[0] != 0x05:
-            raise Abort("A2-POINTER-VALIDITY")
+            if checkpoint in VALIDITY_CHECKPOINTS:
+                raise Abort("A2-POINTER-VALIDITY")
+            continue
         raw = int.from_bytes(payload[EXTENDED_HEADER_BYTES:], "little")
         if global_model.bit_polarity == "set_means_not_in_use":
             raw ^= (1 << EXTENDED_BITS) - 1
@@ -305,12 +325,21 @@ def _base_inputs(
         if CONVERSION_WINDOW.index(left) >= conversion_at
         and view.page_count(right) > view.page_count(left)
     ]
-    states = {
-        checkpoint: _extended_state(view, global_model, checkpoint)
-        for pair in pairs
-        for checkpoint in pair
-    }
-    return pairs, states
+    states: dict[str, dict[int, tuple[int, int]]] = {}
+    usable: list[tuple[str, str]] = []
+    for left, right in pairs:
+        if left not in states:
+            states[left] = _extended_state(view, global_model, left)
+        if right not in states:
+            states[right] = _extended_state(view, global_model, right)
+        before = states[left]
+        after = states[right]
+        if any(
+            slot in before and before[slot][0] == reference
+            for slot, (reference, _bits) in after.items()
+        ):
+            usable.append((left, right))
+    return usable, states
 
 
 def _base_formula_matches(
@@ -475,7 +504,6 @@ def derive_tdef(
             raise Abort("A2-POINTER-VALIDITY")
         raise Abort("A2-CHURN-POINTER-NONE")
     models: list[TdefModel] = []
-    undelimited = False
     changed = Prefix.from_flags(
         [
             len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) > 1
@@ -495,7 +523,6 @@ def derive_tdef(
                 if (start < core_start and not _stable_byte(view, page, start)) or (
                     end > core_end and not _stable_byte(view, page, end - 1)
                 ):
-                    undelimited = True
                     continue
                 outside = (
                     changed.count(start, growth_offset)
@@ -507,16 +534,13 @@ def derive_tdef(
                     + changed.count(growth_offset + 4, end)
                 )
                 if outside:
-                    undelimited = True
                     continue
                 models.append(
                     TdefModel(Record(page, start, end), layout, growth_offset, churn_offset)
                 )
     view.work.examine_models(len(models))
     if not models:
-        if undelimited:
-            raise Abort("A2-TDEF-RECORD-NONE")
-        raise Abort("A2-POINTER-MULTIPLE")
+        raise Abort("A2-TDEF-RECORD-NONE")
     records = {model.record for model in models}
     if len(records) > 1:
         raise Abort("A2-TDEF-RECORD-MULTIPLE")
@@ -550,7 +574,9 @@ def predicts_conversion(
         _validate_slot_references(view, global_model, checkpoint)
         _polarity_cross_check(view, global_model)
         return _inline_boundary_matches(view, global_model, checkpoint, frozen.inline_boundary)
-    except Abort:
+    except Abort as exc:
+        if exc.predicate_id in {"A2-SNAPSHOT-RECONSTRUCTION", "A2-RESOURCE-BOUND"}:
+            raise
         return False
 
 
@@ -574,7 +600,9 @@ def predicts_base(
         return discriminator != 0 and _base_formula_matches(
             view, frozen.extended_base_formula, pairs, states
         )
-    except Abort:
+    except Abort as exc:
+        if exc.predicate_id in {"A2-SNAPSHOT-RECONSTRUCTION", "A2-RESOURCE-BOUND"}:
+            raise
         return False
 
 
@@ -633,5 +661,7 @@ def predicts_tdef(view: View, frozen: TdefModel, churn_precondition_met: bool) -
             + changed.count(second + 4, expected.end)
         )
         return outside == 0
-    except Abort:
+    except Abort as exc:
+        if exc.predicate_id in {"A2-SNAPSHOT-RECONSTRUCTION", "A2-RESOURCE-BOUND"}:
+            raise
         return False

--- a/oracle/windows-dao/scripts/a2_layers.py
+++ b/oracle/windows-dao/scripts/a2_layers.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""Post-delimitation global-map layers and the separate A2 TDEF sub-model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from a2_model import (
+    BASE_FORMULAS,
+    CHECKPOINT_IDS,
+    CHURN_TRANSITIONS,
+    D_CHECKPOINTS,
+    D_TRANSITIONS,
+    DRelationIndex,
+    GROWTH_TRANSITIONS,
+    IDLE_PAIRS,
+    PAGE_SIZE,
+    POINTER_LAYOUTS,
+    TRANSITIONS,
+    Abort,
+    GlobalRecordModel,
+    Prefix,
+    Record,
+    View,
+    decode_pointer,
+    extended_base,
+)
+
+CONVERSION_WINDOW = tuple(TRANSITIONS["inline_to_indirect_conversion_window"])
+VALIDITY_CHECKPOINTS = tuple(TRANSITIONS["pointer_validity_checkpoints"])
+CONVERSION_GROWTH = tuple(
+    (left, right)
+    for left, right in zip(CONVERSION_WINDOW, CONVERSION_WINDOW[1:], strict=False)
+    if (left, right) != ("L_REL_1280", "L_REINSERT_SAME")
+)
+EXTENDED_HEADER_BYTES = 4
+EXTENDED_BITS = (PAGE_SIZE - EXTENDED_HEADER_BYTES) * 8
+
+
+@dataclass(frozen=True)
+class ConversionModel:
+    conversion_checkpoint_id: str
+    conversion_ordinal: int
+    active_slot_count_at_conversion: int
+    active_slot_count_at_h_rel_0904: int
+    inline_boundary: int
+    slot_reference_pages: tuple[int, ...]
+
+    def document(self) -> dict[str, object]:
+        return {
+            "conversion_checkpoint_id": self.conversion_checkpoint_id,
+            "conversion_ordinal": self.conversion_ordinal,
+            "active_slot_count_at_conversion": self.active_slot_count_at_conversion,
+            "active_slot_count_at_h_rel_0904": self.active_slot_count_at_h_rel_0904,
+            "inline_boundary": self.inline_boundary,
+            "slot_reference_pages": list(self.slot_reference_pages),
+        }
+
+
+@dataclass(frozen=True)
+class BaseModel:
+    extended_base_formula: str
+
+    def document(self) -> dict[str, str]:
+        return {"extended_base_formula": self.extended_base_formula}
+
+
+@dataclass(frozen=True)
+class TdefModel:
+    record: Record
+    pointer_layout: str
+    growth_pointer_offset: int
+    delete_reinsert_pointer_offset: int
+
+    def document(self) -> dict[str, object]:
+        return {
+            "record": self.record.document(),
+            "pointer_layout": self.pointer_layout,
+            "growth_pointer_offset": self.growth_pointer_offset,
+            "delete_reinsert_pointer_offset": self.delete_reinsert_pointer_offset,
+        }
+
+
+def _active_slots(record: bytes, start: int) -> dict[int, int]:
+    slots: dict[int, int] = {}
+    for slot in range(2):
+        offset = start + 1 + slot * 4
+        value = int.from_bytes(record[offset : offset + 4], "little")
+        if value:
+            slots[slot] = value
+    return slots
+
+
+def _conversion_checkpoint(view: View, global_model: GlobalRecordModel) -> str:
+    start = global_model.record.start
+    tags = [
+        view.page(checkpoint, global_model.record.page)[start]
+        for checkpoint in CONVERSION_WINDOW
+    ]
+    transitions = [index for index in range(1, len(tags)) if tags[index] != tags[index - 1]]
+    if not transitions or 1 not in tags:
+        raise Abort("A2-CONVERSION-NONE")
+    if (
+        len(transitions) != 1
+        or transitions[0] == 0
+        or any(tag != 0 for tag in tags[: transitions[0]])
+        or any(tag != 1 for tag in tags[transitions[0] :])
+    ):
+        raise Abort("A2-CONVERSION-MULTIPLE")
+    return CONVERSION_WINDOW[transitions[0]]
+
+
+def _validate_slot_references(
+    view: View, global_model: GlobalRecordModel, conversion_checkpoint: str
+) -> None:
+    start = global_model.record.start
+    active_seen = False
+    conversion_at = CHECKPOINT_IDS.index(conversion_checkpoint)
+    for checkpoint in VALIDITY_CHECKPOINTS:
+        if CHECKPOINT_IDS.index(checkpoint) < conversion_at:
+            continue
+        slots = _active_slots(view.page(checkpoint, global_model.record.page), start)
+        for reference in slots.values():
+            active_seen = True
+            if not 0 < reference < view.page_count(checkpoint):
+                raise Abort("A2-POINTER-VALIDITY")
+            if view.page(checkpoint, reference)[0] != 0x05:
+                raise Abort("A2-POINTER-VALIDITY")
+    if not active_seen:
+        raise Abort("A2-POINTER-VALIDITY")
+
+
+def _polarity_cross_check(view: View, global_model: GlobalRecordModel) -> None:
+    page = global_model.record.page
+    start = global_model.record.start + 5
+    end = global_model.record.end
+    expect_set = global_model.bit_polarity == "set_means_in_use"
+    for left, right in CONVERSION_GROWTH:
+        if view.page_count(right) <= view.page_count(left):
+            continue
+        before_record = view.page(left, page)
+        after_record = view.page(right, page)
+        before_tag = before_record[global_model.record.start]
+        after_tag = after_record[global_model.record.start]
+        pairs: list[tuple[bytes, bytes]] = []
+        if before_tag == after_tag == 0:
+            pairs.append((before_record[start:end], after_record[start:end]))
+        elif before_tag == after_tag == 1:
+            before_slots = _active_slots(before_record, global_model.record.start)
+            after_slots = _active_slots(after_record, global_model.record.start)
+            for slot, reference in after_slots.items():
+                prior_reference = before_slots.get(slot)
+                before = (
+                    view.page(left, prior_reference)[EXTENDED_HEADER_BYTES:]
+                    if prior_reference is not None
+                    else bytes(PAGE_SIZE - EXTENDED_HEADER_BYTES)
+                )
+                after = view.page(right, reference)[EXTENDED_HEADER_BYTES:]
+                pairs.append((before, after))
+        else:
+            # The representation changes at conversion; D has already fixed
+            # polarity and the same-direction checks resume after conversion.
+            continue
+        changed_in_direction = any(
+            any(
+                ((~old) & new & 0xFF) if expect_set else (old & (~new) & 0xFF)
+                for old, new in zip(before, after, strict=True)
+            )
+            for before, after in pairs
+        )
+        view.work.charge(sum(len(before) for before, _ in pairs) + 1)
+        if not changed_in_direction:
+            raise Abort("A2-POLARITY-CROSSCHECK")
+
+
+def _inline_predicates(
+    view: View, global_model: GlobalRecordModel, conversion_checkpoint: str
+) -> tuple[int, tuple[str, ...], dict[str, bytes], Prefix, Prefix]:
+    record = global_model.record
+    start = record.start
+    conversion_index = CONVERSION_WINDOW.index(conversion_checkpoint)
+    inline_checkpoints = CONVERSION_WINDOW[:conversion_index]
+    payloads = {
+        checkpoint: view.page(checkpoint, record.page) for checkpoint in CONVERSION_WINDOW
+    }
+    bitmap_start = start + 5
+    mismatch_flags: list[bool] = []
+    nonzero_flags: list[bool] = []
+    for offset in range(PAGE_SIZE):
+        mismatch = False
+        for checkpoint in inline_checkpoints:
+            payload = payloads[checkpoint]
+            first_page = int.from_bytes(payload[start + 1 : start + 5], "little")
+            wanted_count = max(0, view.page_count(checkpoint) - first_page)
+            relative_bit = max(0, offset - bitmap_start) * 8
+            wanted = 0
+            for bit in range(8):
+                if relative_bit + bit < wanted_count:
+                    wanted |= 1 << bit
+            if global_model.bit_polarity == "set_means_not_in_use":
+                wanted ^= 0xFF
+            mismatch |= payload[offset] != wanted
+        mismatch_flags.append(mismatch)
+        nonzero_flags.append(any(payload[offset] != 0 for payload in payloads.values()))
+    mismatch = Prefix.from_flags(mismatch_flags, view.work)
+    nonzero = Prefix.from_flags(nonzero_flags, view.work)
+    return bitmap_start, inline_checkpoints, payloads, mismatch, nonzero
+
+
+def _inline_boundary_status(
+    view: View,
+    global_model: GlobalRecordModel,
+    boundary: int,
+    predicates: tuple[int, tuple[str, ...], dict[str, bytes], Prefix, Prefix],
+) -> str:
+    bitmap_start, inline_checkpoints, payloads, mismatch, nonzero = predicates
+    start = global_model.record.start
+    capacity = (boundary - bitmap_start) * 8
+    capacity_witnessed = any(
+        max(
+            0,
+            view.page_count(checkpoint)
+            - int.from_bytes(payloads[checkpoint][start + 1 : start + 5], "little"),
+        )
+        == capacity
+        for checkpoint in inline_checkpoints
+    )
+    if not capacity_witnessed or not mismatch.none(bitmap_start, boundary):
+        return "unexplained"
+    if not nonzero.none(boundary, global_model.record.end):
+        return "suffix"
+    return "survives"
+
+
+def _inline_boundaries(
+    view: View, global_model: GlobalRecordModel, conversion_checkpoint: str
+) -> tuple[int, ...]:
+    record = global_model.record
+    predicates = _inline_predicates(view, global_model, conversion_checkpoint)
+    explained: list[int] = []
+    quiet: list[int] = []
+    for boundary in range(record.start + 5, record.end + 1):
+        status = _inline_boundary_status(view, global_model, boundary, predicates)
+        if status != "unexplained":
+            explained.append(boundary)
+        if status == "survives":
+            quiet.append(boundary)
+    if not explained:
+        raise Abort("A2-INLINE-BOUNDARY-NONE")
+    if not quiet:
+        raise Abort("A2-INLINE-SUFFIX")
+    if len(quiet) > 1:
+        raise Abort("A2-INLINE-BOUNDARY-MULTIPLE")
+    return tuple(quiet)
+
+
+def derive_conversion(view: View, global_model: GlobalRecordModel) -> ConversionModel:
+    """Evaluate L/P/H only after the D record and polarity are frozen."""
+    conversion = _conversion_checkpoint(view, global_model)
+    start = global_model.record.start
+    at_conversion = _active_slots(view.page(conversion, global_model.record.page), start)
+    if not at_conversion:
+        raise Abort("A2-SLOT-ACTIVATION")
+    final = _active_slots(view.page("H_REL_0904", global_model.record.page), start)
+    if len(final) != 2:
+        raise Abort("A2-SLOT-FINAL")
+    _validate_slot_references(view, global_model, conversion)
+    _polarity_cross_check(view, global_model)
+    boundary = _inline_boundaries(view, global_model, conversion)[0]
+    return ConversionModel(
+        conversion,
+        CHECKPOINT_IDS.index(conversion),
+        len(at_conversion),
+        len(final),
+        boundary,
+        tuple(final.values()),
+    )
+
+
+def _extended_state(
+    view: View, global_model: GlobalRecordModel, checkpoint: str
+) -> dict[int, tuple[int, int]]:
+    record_page = view.page(checkpoint, global_model.record.page)
+    result: dict[int, tuple[int, int]] = {}
+    for slot, reference in _active_slots(record_page, global_model.record.start).items():
+        if not 0 < reference < view.page_count(checkpoint):
+            raise Abort("A2-POINTER-VALIDITY")
+        payload = view.page(checkpoint, reference)
+        if payload[0] != 0x05:
+            raise Abort("A2-POINTER-VALIDITY")
+        raw = int.from_bytes(payload[EXTENDED_HEADER_BYTES:], "little")
+        if global_model.bit_polarity == "set_means_not_in_use":
+            raw ^= (1 << EXTENDED_BITS) - 1
+        result[slot] = (reference, raw)
+    return result
+
+
+def _base_inputs(
+    view: View, global_model: GlobalRecordModel, conversion: ConversionModel
+) -> tuple[list[tuple[str, str]], dict[str, dict[int, tuple[int, int]]]]:
+    conversion_at = CONVERSION_WINDOW.index(conversion.conversion_checkpoint_id)
+    pairs = [
+        (left, right)
+        for left, right in CONVERSION_GROWTH
+        if CONVERSION_WINDOW.index(left) >= conversion_at
+        and view.page_count(right) > view.page_count(left)
+    ]
+    states = {
+        checkpoint: _extended_state(view, global_model, checkpoint)
+        for pair in pairs
+        for checkpoint in pair
+    }
+    return pairs, states
+
+
+def _base_formula_matches(
+    view: View,
+    formula: str,
+    pairs: list[tuple[str, str]],
+    states: dict[str, dict[int, tuple[int, int]]],
+) -> bool:
+    for left, right in pairs:
+        before = states[left]
+        after = states[right]
+        predicted: set[int] = set()
+        for slot, (reference, bits) in after.items():
+            fresh = bits & ~before.get(slot, (0, 0))[1]
+            origin = extended_base(formula, slot, reference)
+            while fresh:
+                bit = (fresh & -fresh).bit_length() - 1
+                predicted.add(origin + bit)
+                fresh &= fresh - 1
+        expected = set(range(view.page_count(left), view.page_count(right)))
+        view.work.charge(len(predicted) + 1)
+        if predicted != expected:
+            return False
+    return True
+
+
+def base_candidates(
+    view: View, global_model: GlobalRecordModel, conversion: ConversionModel
+) -> tuple[str, ...]:
+    pairs, states = _base_inputs(view, global_model, conversion)
+    discriminator = states.get("H_REL_0064", {}).get(0, (0, 0))[1] & ~states.get(
+        "P_ABS_16480", {}
+    ).get(0, (0, 0))[1]
+    if discriminator == 0:
+        raise Abort("A2-BASE-DISCRIMINATION")
+    survivors: list[str] = []
+    for formula in BASE_FORMULAS:
+        if _base_formula_matches(view, formula, pairs, states):
+            survivors.append(formula)
+    return tuple(survivors)
+
+
+def derive_base(
+    view: View, global_model: GlobalRecordModel, conversion: ConversionModel
+) -> BaseModel:
+    survivors = base_candidates(view, global_model, conversion)
+    if not survivors:
+        raise Abort("A2-BASE-NONE")
+    if len(survivors) > 1:
+        raise Abort("A2-BASE-MULTIPLE")
+    return BaseModel(survivors[0])
+
+
+def _window_values(view: View, page: int, offset: int, layout: str) -> dict[str, tuple[int, int]]:
+    return {
+        checkpoint: decode_pointer(view.page(checkpoint, page)[offset : offset + 4], layout)
+        for checkpoint in CHECKPOINT_IDS
+    }
+
+
+def _stable(values: dict[str, tuple[int, int]], pairs: tuple[tuple[str, str], ...]) -> bool:
+    return all(values[left] == values[right] for left, right in pairs)
+
+
+def _valid_pointer_values(view: View, values: dict[str, tuple[int, int]]) -> bool:
+    active = False
+    for checkpoint in VALIDITY_CHECKPOINTS:
+        page, _ = values[checkpoint]
+        if page == 0:
+            continue
+        active = True
+        if page >= view.page_count(checkpoint) or view.page(checkpoint, page)[0] != 0x05:
+            return False
+    return active
+
+
+def _growth_pointer_matches(view: View, values: dict[str, tuple[int, int]]) -> bool:
+    grows = any(values[left] != values[right] for left, right in GROWTH_TRANSITIONS)
+    outside = D_TRANSITIONS + CHURN_TRANSITIONS + IDLE_PAIRS
+    return (
+        grows
+        and _stable(values, CHURN_TRANSITIONS)
+        and _stable(values, outside)
+        and _valid_pointer_values(view, values)
+    )
+
+
+def _churn_pointer_matches(view: View, values: dict[str, tuple[int, int]]) -> bool:
+    churns = values["L_REL_1280"] != values["L_DELETE_ALL"] and (
+        values["L_REL_1280"] == values["L_REINSERT_SAME"]
+    )
+    outside = D_TRANSITIONS + GROWTH_TRANSITIONS + IDLE_PAIRS
+    return (
+        churns
+        and _stable(values, GROWTH_TRANSITIONS)
+        and _stable(values, outside)
+        and _valid_pointer_values(view, values)
+    )
+
+
+def _pointer_candidates(
+    view: View, page: int
+) -> tuple[dict[str, list[int]], dict[str, list[int]], bool, bool]:
+    growth = {layout: [] for layout in POINTER_LAYOUTS}
+    churn = {layout: [] for layout in POINTER_LAYOUTS}
+    structural_failure = False
+    validity_failure = False
+    outside_growth = D_TRANSITIONS + CHURN_TRANSITIONS + IDLE_PAIRS
+    outside_churn = D_TRANSITIONS + GROWTH_TRANSITIONS + IDLE_PAIRS
+    for offset in range(PAGE_SIZE - 3):
+        for layout in POINTER_LAYOUTS:
+            values = _window_values(view, page, offset, layout)
+            grows = any(values[a] != values[b] for a, b in GROWTH_TRANSITIONS)
+            churns = values["L_REL_1280"] != values["L_DELETE_ALL"] and (
+                values["L_REL_1280"] == values["L_REINSERT_SAME"]
+            )
+            growth_shape = grows and _stable(values, CHURN_TRANSITIONS)
+            churn_shape = churns and _stable(values, GROWTH_TRANSITIONS)
+            if growth_shape and not _stable(values, outside_growth):
+                structural_failure = True
+            elif growth_shape:
+                if _valid_pointer_values(view, values):
+                    growth[layout].append(offset)
+                else:
+                    validity_failure = True
+            if churn_shape and not _stable(values, outside_churn):
+                structural_failure = True
+            elif churn_shape:
+                if _valid_pointer_values(view, values):
+                    churn[layout].append(offset)
+                else:
+                    validity_failure = True
+    return growth, churn, structural_failure, validity_failure
+
+
+def _stable_byte(view: View, page: int, offset: int) -> bool:
+    return len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) == 1
+
+
+def derive_tdef(
+    view: View,
+    page: int,
+    churn_precondition_met: bool,
+    *,
+    enumerate_candidates: bool = True,
+) -> TdefModel:
+    if enumerate_candidates:
+        view.work.enumerate_intervals()
+    if not churn_precondition_met:
+        raise Abort("A2-CHURN-PRECONDITION")
+    growth, churn, structural, invalid = _pointer_candidates(view, page)
+    if not any(growth.values()):
+        if structural:
+            raise Abort("A2-STRUCTURAL-EXCLUSION")
+        if invalid:
+            raise Abort("A2-POINTER-VALIDITY")
+        raise Abort("A2-GROWTH-POINTER-NONE")
+    if not any(churn.values()):
+        if structural:
+            raise Abort("A2-STRUCTURAL-EXCLUSION")
+        if invalid:
+            raise Abort("A2-POINTER-VALIDITY")
+        raise Abort("A2-CHURN-POINTER-NONE")
+    models: list[TdefModel] = []
+    undelimited = False
+    changed = Prefix.from_flags(
+        [
+            len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) > 1
+            for offset in range(PAGE_SIZE)
+        ],
+        view.work,
+    )
+    for layout in POINTER_LAYOUTS:
+        for growth_offset in growth[layout]:
+            for churn_offset in churn[layout]:
+                if abs(growth_offset - churn_offset) < 4:
+                    continue
+                core_start = min(growth_offset, churn_offset)
+                core_end = max(growth_offset, churn_offset) + 4
+                start = core_start - 1 if core_start else core_start
+                end = core_end + 1 if core_end < PAGE_SIZE else core_end
+                if (start < core_start and not _stable_byte(view, page, start)) or (
+                    end > core_end and not _stable_byte(view, page, end - 1)
+                ):
+                    undelimited = True
+                    continue
+                outside = (
+                    changed.count(start, growth_offset)
+                    + changed.count(growth_offset + 4, churn_offset)
+                    + changed.count(churn_offset + 4, end)
+                    if growth_offset < churn_offset
+                    else changed.count(start, churn_offset)
+                    + changed.count(churn_offset + 4, growth_offset)
+                    + changed.count(growth_offset + 4, end)
+                )
+                if outside:
+                    undelimited = True
+                    continue
+                models.append(
+                    TdefModel(Record(page, start, end), layout, growth_offset, churn_offset)
+                )
+    view.work.examine_models(len(models))
+    if not models:
+        if undelimited:
+            raise Abort("A2-TDEF-RECORD-NONE")
+        raise Abort("A2-POINTER-MULTIPLE")
+    records = {model.record for model in models}
+    if len(records) > 1:
+        raise Abort("A2-TDEF-RECORD-MULTIPLE")
+    if len(models) > 1:
+        raise Abort("A2-POINTER-MULTIPLE")
+    return models[0]
+
+
+def predicts_global(view: View, frozen: GlobalRecordModel) -> bool:
+    """Apply one frozen record and polarity; do not enumerate holdout candidates."""
+    records = {name: view.page(name, frozen.record.page) for name in D_CHECKPOINTS}
+    index = DRelationIndex(records, view.work)
+    return index.relation(frozen.record.start, frozen.bit_polarity) and index.suffix_slack(
+        frozen.record.start, frozen.bit_polarity
+    ) == frozen.zero_suffix_slack_bytes
+
+
+def predicts_conversion(
+    view: View, global_model: GlobalRecordModel, frozen: ConversionModel
+) -> bool:
+    try:
+        checkpoint = _conversion_checkpoint(view, global_model)
+        if checkpoint != frozen.conversion_checkpoint_id:
+            return False
+        start = global_model.record.start
+        active = _active_slots(view.page(checkpoint, global_model.record.page), start)
+        if len(active) != frozen.active_slot_count_at_conversion:
+            return False
+        if len(_active_slots(view.page("H_REL_0904", global_model.record.page), start)) != 2:
+            return False
+        _validate_slot_references(view, global_model, checkpoint)
+        _polarity_cross_check(view, global_model)
+        return _inline_boundary_matches(view, global_model, checkpoint, frozen.inline_boundary)
+    except Abort:
+        return False
+
+
+def _inline_boundary_matches(
+    view: View, global_model: GlobalRecordModel, conversion_checkpoint: str, boundary: int
+) -> bool:
+    if not global_model.record.start + 5 <= boundary <= global_model.record.end:
+        return False
+    predicates = _inline_predicates(view, global_model, conversion_checkpoint)
+    return _inline_boundary_status(view, global_model, boundary, predicates) == "survives"
+
+
+def predicts_base(
+    view: View, global_model: GlobalRecordModel, conversion: ConversionModel, frozen: BaseModel
+) -> bool:
+    try:
+        pairs, states = _base_inputs(view, global_model, conversion)
+        discriminator = states.get("H_REL_0064", {}).get(0, (0, 0))[1] & ~states.get(
+            "P_ABS_16480", {}
+        ).get(0, (0, 0))[1]
+        return discriminator != 0 and _base_formula_matches(
+            view, frozen.extended_base_formula, pairs, states
+        )
+    except Abort:
+        return False
+
+
+def predicts_tdef(view: View, frozen: TdefModel, churn_precondition_met: bool) -> bool:
+    """Test the frozen page, record, layout and offsets without candidate search."""
+    if not churn_precondition_met:
+        return False
+    try:
+        growth = _window_values(
+            view, frozen.record.page, frozen.growth_pointer_offset, frozen.pointer_layout
+        )
+        churn = _window_values(
+            view,
+            frozen.record.page,
+            frozen.delete_reinsert_pointer_offset,
+            frozen.pointer_layout,
+        )
+        if not _growth_pointer_matches(view, growth):
+            return False
+        if not _churn_pointer_matches(view, churn):
+            return False
+        core_start = min(frozen.growth_pointer_offset, frozen.delete_reinsert_pointer_offset)
+        core_end = max(frozen.growth_pointer_offset, frozen.delete_reinsert_pointer_offset) + 4
+        expected = Record(
+            frozen.record.page,
+            core_start - 1 if core_start else core_start,
+            core_end + 1 if core_end < PAGE_SIZE else core_end,
+        )
+        if expected != frozen.record or (
+            expected.start < core_start
+            and not _stable_byte(view, expected.page, expected.start)
+        ):
+            return False
+        if expected.end > core_end and not _stable_byte(
+            view, expected.page, expected.end - 1
+        ):
+            return False
+        changed = Prefix.from_flags(
+            [
+                len(
+                    {
+                        view.page(checkpoint, expected.page)[offset]
+                        for checkpoint in CHECKPOINT_IDS
+                    }
+                )
+                > 1
+                for offset in range(PAGE_SIZE)
+            ],
+            view.work,
+        )
+        first = min(frozen.growth_pointer_offset, frozen.delete_reinsert_pointer_offset)
+        second = max(frozen.growth_pointer_offset, frozen.delete_reinsert_pointer_offset)
+        outside = (
+            changed.count(expected.start, first)
+            + changed.count(first + 4, second)
+            + changed.count(second + 4, expected.end)
+        )
+        return outside == 0
+    except Abort:
+        return False

--- a/oracle/windows-dao/scripts/a2_model.py
+++ b/oracle/windows-dao/scripts/a2_model.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Bounded record derivation primitives for DAO-A2-ALLOCATION-MAPS-001.
+
+The model reads its constants and predicate registry from the hash-pinned A2
+plan.  It intentionally knows nothing about the bundle layout; generators and
+on-disk readers meet the same small :class:`ReplicaData` protocol.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from protocol_validation import ValidationError
+
+EXPERIMENT_DIR = Path(__file__).resolve().parents[1] / "experiments" / "a2"
+PLAN_PATH = EXPERIMENT_DIR / "a2-allocation-maps.plan.json"
+PLAN_BYTES = PLAN_PATH.read_bytes()
+PLAN = json.loads(PLAN_BYTES)
+PLAN_SHA256 = hashlib.sha256(PLAN_BYTES).hexdigest()
+
+PAGE_SIZE = int(PLAN["bounds"]["page_size"])
+MAX_FINAL_PAGES = int(PLAN["bounds"]["max_final_pages_per_replica"])
+MAX_QUALIFIED_PAGES = int(PLAN["bounds"]["max_qualified_pages_per_submodel"])
+MAX_RECORD_CANDIDATES = int(PLAN["bounds"]["max_record_candidates"])
+MAX_CANDIDATE_MODELS = int(PLAN["bounds"]["max_candidate_models"])
+MAX_WORK_UNITS = int(PLAN["bounds"]["max_analysis_work_units"])
+MAX_PAGE_BLOBS = int(PLAN["bounds"]["max_unique_page_blobs"])
+MAX_PAGE_BYTES = int(PLAN["bounds"]["max_retained_page_store_bytes"])
+CHECKPOINT_IDS = tuple(PLAN["checkpoint_design"]["checkpoint_ids"])
+IDLE_PAIRS = tuple(tuple(pair) for pair in PLAN["checkpoint_design"]["idle_pairs"])
+TRANSITIONS = PLAN["checkpoint_design"]["transition_coverage"]
+POLARITIES = tuple(PLAN["hypotheses"]["bit_polarity_candidates"])
+POINTER_LAYOUTS = tuple(PLAN["hypotheses"]["tdef_pointer_layouts"])
+BASE_FORMULAS = tuple(PLAN["hypotheses"]["extended_base_candidates"])
+PER_PAGE_CANDIDATES = PAGE_SIZE * (PAGE_SIZE + 1) // 2
+
+_MAPPINGS = PLAN["predicate_registry"]["mappings"]
+PREDICATES = {item["predicate_id"]: (item["reason"], item["layer"]) for item in _MAPPINGS}
+REASONS = {reason: predicate for predicate, (reason, _) in PREDICATES.items()}
+if len(PREDICATES) != len(_MAPPINGS) or len(REASONS) != len(_MAPPINGS):
+    raise RuntimeError("A2 predicate registry is not bijective")
+
+
+class ReplicaData(Protocol):
+    """The complete physical shape consumed from a replica or generator."""
+
+    @property
+    def checkpoint_ids(self) -> Sequence[str]: ...
+
+    @property
+    def page_count(self) -> Mapping[str, int]: ...
+
+    @property
+    def ordered_page_sha256(self) -> Mapping[str, Sequence[str]]: ...
+
+    def page_bytes(self, sha256: str) -> bytes: ...
+
+
+class Abort(Exception):
+    """One preregistered terminal, carrying exactly one predicate mapping."""
+
+    def __init__(self, predicate_id: str) -> None:
+        try:
+            self.reason, self.registered_layer = PREDICATES[predicate_id]
+        except KeyError as exc:
+            raise ValueError(f"unregistered A2 predicate {predicate_id!r}") from exc
+        self.predicate_id = predicate_id
+        super().__init__(f"{predicate_id}: {self.reason}")
+
+
+class WorkCounter:
+    """Fail-closed accounting for analyzer work and opened page blobs."""
+
+    def __init__(self) -> None:
+        self.value = 0
+        self.record_candidates = 0
+        self.candidate_models = 0
+        self.page_digests: set[str] = set()
+        self.page_bytes_read = 0
+
+    def charge(self, units: int) -> None:
+        if units < 0 or self.value + units > MAX_WORK_UNITS:
+            raise Abort("A2-RESOURCE-BOUND")
+        self.value += units
+
+    def enumerate_intervals(self) -> None:
+        if self.record_candidates + PER_PAGE_CANDIDATES > MAX_RECORD_CANDIDATES:
+            raise Abort("A2-RESOURCE-BOUND")
+        self.record_candidates += PER_PAGE_CANDIDATES
+        self.charge(PER_PAGE_CANDIDATES * 8)
+
+    def examine_models(self, count: int = 1) -> None:
+        if count < 0 or self.candidate_models + count > MAX_CANDIDATE_MODELS:
+            raise Abort("A2-RESOURCE-BOUND")
+        self.candidate_models += count
+
+    def opened(self, digest: str) -> None:
+        if digest in self.page_digests:
+            return
+        if (
+            len(self.page_digests) >= MAX_PAGE_BLOBS
+            or self.page_bytes_read + PAGE_SIZE > MAX_PAGE_BYTES
+        ):
+            raise Abort("A2-RESOURCE-BOUND")
+        self.page_digests.add(digest)
+        self.page_bytes_read += PAGE_SIZE
+
+
+class View:
+    """Checked, checkpoint-ordered access to a :class:`ReplicaData`."""
+
+    def __init__(self, source: ReplicaData, work: WorkCounter) -> None:
+        if tuple(source.checkpoint_ids) != CHECKPOINT_IDS:
+            raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
+        self.source = source
+        self.work = work
+        self._counts: dict[str, int] = {}
+        self._hashes: dict[str, tuple[str, ...]] = {}
+        for checkpoint in CHECKPOINT_IDS:
+            try:
+                count = source.page_count[checkpoint]
+                hashes = tuple(source.ordered_page_sha256[checkpoint])
+            except (KeyError, TypeError) as exc:
+                raise Abort("A2-SNAPSHOT-RECONSTRUCTION") from exc
+            if not 1 <= count <= MAX_FINAL_PAGES or count != len(hashes):
+                raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
+            if any(len(item) != 64 for item in hashes):
+                raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
+            self._counts[checkpoint] = count
+            self._hashes[checkpoint] = hashes
+
+    def page_count(self, checkpoint: str) -> int:
+        return self._counts[checkpoint]
+
+    def hashes(self, checkpoint: str) -> tuple[str, ...]:
+        return self._hashes[checkpoint]
+
+    def hash_at(self, checkpoint: str, page: int) -> str | None:
+        hashes = self._hashes[checkpoint]
+        return hashes[page] if 0 <= page < len(hashes) else None
+
+    def page(self, checkpoint: str, page: int) -> bytes:
+        digest = self.hash_at(checkpoint, page)
+        if digest is None:
+            raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
+        self.work.opened(digest)
+        try:
+            payload = self.source.page_bytes(digest)
+        except (KeyError, OSError, ValueError, ValidationError) as exc:
+            raise Abort("A2-SNAPSHOT-RECONSTRUCTION") from exc
+        if len(payload) != PAGE_SIZE or hashlib.sha256(payload).hexdigest() != digest:
+            raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
+        return payload
+
+    def idle_pairs_identical(self) -> bool:
+        for left, right in IDLE_PAIRS:
+            self.work.charge(1)
+            if self.hashes(left) != self.hashes(right):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class Prefix:
+    """A fixed-size prefix sum supporting O(1) interval predicates."""
+
+    cells: tuple[int, ...]
+
+    @classmethod
+    def from_flags(cls, flags: Sequence[bool], work: WorkCounter) -> Prefix:
+        if len(flags) != PAGE_SIZE:
+            raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
+        cells = [0]
+        for flag in flags:
+            cells.append(cells[-1] + int(flag))
+        work.charge(PAGE_SIZE + 1)
+        return cls(tuple(cells))
+
+    def count(self, start: int, end: int) -> int:
+        if not 0 <= start <= end <= PAGE_SIZE:
+            raise Abort("A2-RESOURCE-BOUND")
+        return self.cells[end] - self.cells[start]
+
+    def none(self, start: int, end: int) -> bool:
+        return self.count(start, end) == 0
+
+
+def _pairs(checkpoints: Sequence[str]) -> tuple[tuple[str, str], ...]:
+    return tuple(zip(checkpoints, checkpoints[1:], strict=False))
+
+
+LOW_GROWTH = _pairs(TRANSITIONS["tdef_low_growth"])
+HIGH_GROWTH = _pairs(TRANSITIONS["tdef_high_growth"])
+GROWTH_TRANSITIONS = LOW_GROWTH + HIGH_GROWTH
+CHURN_TRANSITIONS = (
+    ("L_REL_1280", "L_DELETE_ALL"),
+    ("L_DELETE_ALL", "L_REINSERT_SAME"),
+)
+D_CHECKPOINTS = tuple(TRANSITIONS["global_map_record_set_abac"])
+D_TRANSITIONS = _pairs(D_CHECKPOINTS)
+
+
+def candidate_page_space(views: Sequence[View]) -> range:
+    maximum = max(view.page_count(checkpoint) for view in views for checkpoint in CHECKPOINT_IDS)
+    if maximum > MAX_FINAL_PAGES:
+        raise Abort("A2-RESOURCE-BOUND")
+    return range(maximum)
+
+
+def qualify_global_pages(view: View, pages: Sequence[int]) -> tuple[int, ...]:
+    """Hash-only global qualification; this function never opens a page blob."""
+    qualified = tuple(
+        page
+        for page in pages
+        if view.hash_at("E0", page) != view.hash_at("D_GROW_0128", page)
+        and view.hash_at("D_GROW_0128", page) != view.hash_at("D_DROP", page)
+    )
+    view.work.charge(len(pages) * 2)
+    if len(qualified) > MAX_QUALIFIED_PAGES:
+        raise Abort("A2-RESOURCE-BOUND")
+    return qualified
+
+
+def qualify_tdef_pages(view: View, pages: Sequence[int]) -> tuple[int, ...]:
+    """Hash-only TDEF qualification; this function never opens a page blob."""
+    qualified: list[int] = []
+    for page in pages:
+        if view.hash_at("E0", page) is None:
+            continue
+        growth = any(view.hash_at(a, page) != view.hash_at(b, page) for a, b in GROWTH_TRANSITIONS)
+        churn = all(view.hash_at(a, page) != view.hash_at(b, page) for a, b in CHURN_TRANSITIONS)
+        view.work.charge(len(GROWTH_TRANSITIONS) + len(CHURN_TRANSITIONS))
+        if growth and churn:
+            qualified.append(page)
+    if len(qualified) > MAX_QUALIFIED_PAGES:
+        raise Abort("A2-RESOURCE-BOUND")
+    return tuple(qualified)
+
+
+@dataclass(frozen=True)
+class Record:
+    page: int
+    start: int
+    end: int
+
+    def document(self) -> dict[str, int]:
+        return {"page": self.page, "start": self.start, "end": self.end}
+
+
+@dataclass(frozen=True)
+class GlobalRecordModel:
+    record: Record
+    bit_polarity: str
+    zero_suffix_slack_bytes: int
+
+    def document(self) -> dict[str, object]:
+        return {
+            "record": self.record.document(),
+            "bit_polarity": self.bit_polarity,
+            "zero_suffix_slack_bytes": self.zero_suffix_slack_bytes,
+        }
+
+
+class DRelationIndex:
+    """Fixed D byte predicates used by every interval in O(1)."""
+
+    def __init__(self, records: dict[str, bytes], work: WorkCounter) -> None:
+        empty = records["E0"]
+        grown = records["D_GROW_0128"]
+        dropped = records["D_DROP"]
+        recreated = records["D_RECREATE_EMPTY"]
+        regrown = records["D_REGROW_0128"]
+        self.records = records
+        self.drop_mismatch = Prefix.from_flags(
+            [dropped[index] != empty[index] for index in range(PAGE_SIZE)], work
+        )
+        self.recreate_mismatch = Prefix.from_flags(
+            [recreated[index] != empty[index] for index in range(PAGE_SIZE)], work
+        )
+        self.growth: dict[str, Prefix] = {}
+        self.release_violation: dict[str, Prefix] = {}
+        self.recreate_release_violation: dict[str, Prefix] = {}
+        self.regrowth_violation: dict[str, Prefix] = {}
+        self.additional: dict[str, Prefix] = {}
+        for polarity in POLARITIES:
+            if polarity == "set_means_in_use":
+                growth = [grown[index] & ~empty[index] & 0xFF for index in range(PAGE_SIZE)]
+                release = [growth[index] & dropped[index] for index in range(PAGE_SIZE)]
+                recreate_release = [
+                    growth[index] & recreated[index] for index in range(PAGE_SIZE)
+                ]
+                violation = [growth[index] & ~regrown[index] & 0xFF for index in range(PAGE_SIZE)]
+                additional = [regrown[index] & ~grown[index] & 0xFF for index in range(PAGE_SIZE)]
+            else:
+                growth = [(~grown[index]) & empty[index] & 0xFF for index in range(PAGE_SIZE)]
+                release = [growth[index] & ~dropped[index] & 0xFF for index in range(PAGE_SIZE)]
+                recreate_release = [
+                    growth[index] & ~recreated[index] & 0xFF
+                    for index in range(PAGE_SIZE)
+                ]
+                violation = [growth[index] & regrown[index] for index in range(PAGE_SIZE)]
+                additional = [(~regrown[index]) & grown[index] & 0xFF for index in range(PAGE_SIZE)]
+            self.growth[polarity] = Prefix.from_flags([bool(value) for value in growth], work)
+            self.release_violation[polarity] = Prefix.from_flags(
+                [bool(value) for value in release], work
+            )
+            self.recreate_release_violation[polarity] = Prefix.from_flags(
+                [bool(value) for value in recreate_release], work
+            )
+            self.regrowth_violation[polarity] = Prefix.from_flags(
+                [bool(value) for value in violation], work
+            )
+            self.additional[polarity] = Prefix.from_flags(
+                [bool(value) for value in additional], work
+            )
+        changed_flags = [
+            len({records[name][index] for name in D_CHECKPOINTS}) > 1
+            for index in range(PAGE_SIZE)
+        ]
+        self.changed = Prefix.from_flags(changed_flags, work)
+        self.last_changed_from = [-1] * (PAGE_SIZE + 1)
+        last = -1
+        for index in range(PAGE_SIZE - 1, -1, -1):
+            if last < 0 and changed_flags[index]:
+                last = index
+            self.last_changed_from[index] = last
+        self.bad_unused: dict[str, Prefix] = {}
+        for polarity in POLARITIES:
+            unused = 0x00 if polarity == "set_means_in_use" else 0xFF
+            self.bad_unused[polarity] = Prefix.from_flags(
+                [
+                    any(records[name][index] != unused for name in D_CHECKPOINTS)
+                    for index in range(PAGE_SIZE)
+                ],
+                work,
+            )
+
+    def polarity_relation(self, start: int, polarity: str) -> bool:
+        records = self.records
+        if start + 5 >= PAGE_SIZE or any(record[start] != 0 for record in records.values()):
+            return False
+        bases = {
+            int.from_bytes(record[start + 1 : start + 5], "little")
+            for record in records.values()
+        }
+        bitmap_start = start + 5
+        return (
+            len(bases) == 1
+            and self.growth[polarity].count(bitmap_start, PAGE_SIZE) > 0
+            and self.release_violation[polarity].none(bitmap_start, PAGE_SIZE)
+            and self.recreate_release_violation[polarity].none(bitmap_start, PAGE_SIZE)
+            and self.regrowth_violation[polarity].none(bitmap_start, PAGE_SIZE)
+            and self.additional[polarity].count(bitmap_start, PAGE_SIZE) > 0
+        )
+
+    def relation(self, start: int, polarity: str) -> bool:
+        bitmap_start = start + 5
+        return (
+            self.polarity_relation(start, polarity)
+            and self.drop_mismatch.none(bitmap_start, PAGE_SIZE)
+            and self.recreate_mismatch.none(bitmap_start, PAGE_SIZE)
+        )
+
+    def suffix_slack(self, start: int, polarity: str) -> int:
+        last_flip = self.last_changed_from[start + 5]
+        if last_flip < 0:
+            return 0
+        suffix_start = last_flip + 1
+        if not self.bad_unused[polarity].none(suffix_start, PAGE_SIZE):
+            return 0
+        return PAGE_SIZE - suffix_start
+
+
+def _d_relation(
+    records: dict[str, bytes],
+    start: int,
+    polarity: str,
+    index: DRelationIndex | None = None,
+) -> bool:
+    """Compatibility wrapper used by pure holdout prediction tests."""
+    relation = index or DRelationIndex(records, WorkCounter())
+    return relation.relation(start, polarity)
+
+
+def unique_polarity(records: dict[str, bytes], start: int) -> str:
+    index = DRelationIndex(records, WorkCounter())
+    survivors = [
+        polarity for polarity in POLARITIES if index.polarity_relation(start, polarity)
+    ]
+    if not survivors:
+        raise Abort("A2-POLARITY-NONE")
+    if len(survivors) > 1:
+        raise Abort("A2-POLARITY-MULTIPLE")
+    return survivors[0]
+
+
+def _suffix_slack(
+    records: dict[str, bytes],
+    start: int,
+    polarity: str,
+    work: WorkCounter,
+    index: DRelationIndex | None = None,
+) -> int:
+    relation = index or DRelationIndex(records, work)
+    return relation.suffix_slack(start, polarity)
+
+
+def derive_global_record(
+    view: View, page: int, *, enumerate_candidates: bool = True
+) -> GlobalRecordModel:
+    """Enumerate the fixed interval space and apply the D-only terminal tie-break."""
+    if enumerate_candidates:
+        view.work.enumerate_intervals()
+    records = {name: view.page(name, page) for name in D_CHECKPOINTS}
+    index = DRelationIndex(records, view.work)
+    decodable = [
+        start
+        for start in range(PAGE_SIZE - 5)
+        if all(record[start] == 0 for record in records.values())
+    ]
+    if not decodable:
+        raise Abort("A2-GLOBAL-RECORD-NONE")
+    related: list[tuple[int, str]] = []
+    set_relation_failed = False
+    for start in decodable:
+        view.work.examine_models(len(POLARITIES))
+        polarities = [
+            polarity
+            for polarity in POLARITIES
+            if index.polarity_relation(start, polarity)
+        ]
+        if len(polarities) > 1:
+            raise Abort("A2-POLARITY-MULTIPLE")
+        if polarities:
+            polarity = polarities[0]
+            if index.relation(start, polarity):
+                related.append((start, polarity))
+            else:
+                set_relation_failed = True
+    if not related:
+        raise Abort("A2-D-SET-RELATION" if set_relation_failed else "A2-POLARITY-NONE")
+    resolved: list[GlobalRecordModel] = []
+    for start, polarity in related:
+        slack = index.suffix_slack(start, polarity)
+        if slack >= 16:
+            resolved.append(GlobalRecordModel(Record(page, start, PAGE_SIZE), polarity, slack))
+    if not resolved:
+        raise Abort("A2-GLOBAL-RECORD-END")
+    starts = {model.record.start for model in resolved}
+    if len(starts) > 1 or len(resolved) > 1:
+        raise Abort("A2-GLOBAL-RECORD-MULTIPLE")
+    return resolved[0]
+
+
+def require_one_page(pages: Sequence[int], none_id: str, multiple_id: str) -> int:
+    if not pages:
+        raise Abort(none_id)
+    if len(pages) > 1:
+        raise Abort(multiple_id)
+    return pages[0]
+
+
+def decode_pointer(raw: bytes, layout: str) -> tuple[int, int]:
+    if len(raw) != 4:
+        raise Abort("A2-POINTER-VALIDITY")
+    if layout == "u24le_page_then_u8_slot":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    if layout == "u8_slot_then_u24le_page":
+        return int.from_bytes(raw[1:], "little"), raw[0]
+    raise Abort("A2-POINTER-VALIDITY")
+
+
+def extended_base(formula: str, slot: int, reference_page: int) -> int:
+    bits = (PAGE_SIZE - 4) * 8
+    if formula == "slot_relative_expected_0_16352":
+        return slot * bits
+    if formula == "slot_relative_off_by_minus_one":
+        return slot * bits - 1
+    if formula == "slot_relative_off_by_plus_one":
+        return slot * bits + 1
+    if formula == "referenced_page_relative":
+        return reference_page
+    if formula == "referenced_page_relative_off_by_minus_one":
+        return reference_page - 1
+    if formula == "referenced_page_relative_off_by_plus_one":
+        return reference_page + 1
+    raise Abort("A2-BASE-NONE")

--- a/oracle/windows-dao/scripts/a2_model.py
+++ b/oracle/windows-dao/scripts/a2_model.py
@@ -22,6 +22,9 @@ PLAN_PATH = EXPERIMENT_DIR / "a2-allocation-maps.plan.json"
 PLAN_BYTES = PLAN_PATH.read_bytes()
 PLAN = json.loads(PLAN_BYTES)
 PLAN_SHA256 = hashlib.sha256(PLAN_BYTES).hexdigest()
+EXPECTED_PLAN_SHA256 = "804e84dace5c423938f32dd350ebc778d43084d41db1da93f26f1777984480c2"
+if PLAN_SHA256 != EXPECTED_PLAN_SHA256:
+    raise RuntimeError("A2 analyzer plan hash does not match the preregistration")
 
 PAGE_SIZE = int(PLAN["bounds"]["page_size"])
 MAX_FINAL_PAGES = int(PLAN["bounds"]["max_final_pages_per_replica"])
@@ -42,7 +45,11 @@ PER_PAGE_CANDIDATES = PAGE_SIZE * (PAGE_SIZE + 1) // 2
 _MAPPINGS = PLAN["predicate_registry"]["mappings"]
 PREDICATES = {item["predicate_id"]: (item["reason"], item["layer"]) for item in _MAPPINGS}
 REASONS = {reason: predicate for predicate, (reason, _) in PREDICATES.items()}
-if len(PREDICATES) != len(_MAPPINGS) or len(REASONS) != len(_MAPPINGS):
+if (
+    len(PREDICATES) != len(_MAPPINGS)
+    or len(REASONS) != len(_MAPPINGS)
+    or tuple(PREDICATES) != tuple(PLAN["predicate_registry"]["ids"])
+):
     raise RuntimeError("A2 predicate registry is not bijective")
 
 
@@ -127,7 +134,12 @@ class View:
                 hashes = tuple(source.ordered_page_sha256[checkpoint])
             except (KeyError, TypeError) as exc:
                 raise Abort("A2-SNAPSHOT-RECONSTRUCTION") from exc
-            if not 1 <= count <= MAX_FINAL_PAGES or count != len(hashes):
+            if (
+                isinstance(count, bool)
+                or not isinstance(count, int)
+                or not 1 <= count <= MAX_FINAL_PAGES
+                or count != len(hashes)
+            ):
                 raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
             if any(len(item) != 64 for item in hashes):
                 raise Abort("A2-SNAPSHOT-RECONSTRUCTION")
@@ -276,12 +288,6 @@ class DRelationIndex:
         recreated = records["D_RECREATE_EMPTY"]
         regrown = records["D_REGROW_0128"]
         self.records = records
-        self.drop_mismatch = Prefix.from_flags(
-            [dropped[index] != empty[index] for index in range(PAGE_SIZE)], work
-        )
-        self.recreate_mismatch = Prefix.from_flags(
-            [recreated[index] != empty[index] for index in range(PAGE_SIZE)], work
-        )
         self.growth: dict[str, Prefix] = {}
         self.release_violation: dict[str, Prefix] = {}
         self.recreate_release_violation: dict[str, Prefix] = {}
@@ -340,7 +346,7 @@ class DRelationIndex:
                 work,
             )
 
-    def polarity_relation(self, start: int, polarity: str) -> bool:
+    def polarity_direction(self, start: int, polarity: str) -> bool:
         records = self.records
         if start + 5 >= PAGE_SIZE or any(record[start] != 0 for record in records.values()):
             return False
@@ -349,21 +355,16 @@ class DRelationIndex:
             for record in records.values()
         }
         bitmap_start = start + 5
-        return (
-            len(bases) == 1
-            and self.growth[polarity].count(bitmap_start, PAGE_SIZE) > 0
-            and self.release_violation[polarity].none(bitmap_start, PAGE_SIZE)
-            and self.recreate_release_violation[polarity].none(bitmap_start, PAGE_SIZE)
-            and self.regrowth_violation[polarity].none(bitmap_start, PAGE_SIZE)
-            and self.additional[polarity].count(bitmap_start, PAGE_SIZE) > 0
-        )
+        return len(bases) == 1 and self.growth[polarity].count(bitmap_start, PAGE_SIZE) > 0
 
     def relation(self, start: int, polarity: str) -> bool:
         bitmap_start = start + 5
         return (
-            self.polarity_relation(start, polarity)
-            and self.drop_mismatch.none(bitmap_start, PAGE_SIZE)
-            and self.recreate_mismatch.none(bitmap_start, PAGE_SIZE)
+            self.polarity_direction(start, polarity)
+            and self.release_violation[polarity].none(bitmap_start, PAGE_SIZE)
+            and self.recreate_release_violation[polarity].none(bitmap_start, PAGE_SIZE)
+            and self.regrowth_violation[polarity].none(bitmap_start, PAGE_SIZE)
+            and self.additional[polarity].count(bitmap_start, PAGE_SIZE) > 0
         )
 
     def suffix_slack(self, start: int, polarity: str) -> int:
@@ -385,18 +386,6 @@ def _d_relation(
     """Compatibility wrapper used by pure holdout prediction tests."""
     relation = index or DRelationIndex(records, WorkCounter())
     return relation.relation(start, polarity)
-
-
-def unique_polarity(records: dict[str, bytes], start: int) -> str:
-    index = DRelationIndex(records, WorkCounter())
-    survivors = [
-        polarity for polarity in POLARITIES if index.polarity_relation(start, polarity)
-    ]
-    if not survivors:
-        raise Abort("A2-POLARITY-NONE")
-    if len(survivors) > 1:
-        raise Abort("A2-POLARITY-MULTIPLE")
-    return survivors[0]
 
 
 def _suffix_slack(
@@ -432,7 +421,7 @@ def derive_global_record(
         polarities = [
             polarity
             for polarity in POLARITIES
-            if index.polarity_relation(start, polarity)
+            if index.polarity_direction(start, polarity)
         ]
         if len(polarities) > 1:
             raise Abort("A2-POLARITY-MULTIPLE")
@@ -457,22 +446,10 @@ def derive_global_record(
     return resolved[0]
 
 
-def require_one_page(pages: Sequence[int], none_id: str, multiple_id: str) -> int:
-    if not pages:
-        raise Abort(none_id)
-    if len(pages) > 1:
-        raise Abort(multiple_id)
-    return pages[0]
-
-
 def decode_pointer(raw: bytes, layout: str) -> tuple[int, int]:
-    if len(raw) != 4:
-        raise Abort("A2-POINTER-VALIDITY")
-    if layout == "u24le_page_then_u8_slot":
+    if layout == POINTER_LAYOUTS[0]:
         return int.from_bytes(raw[:3], "little"), raw[3]
-    if layout == "u8_slot_then_u24le_page":
-        return int.from_bytes(raw[1:], "little"), raw[0]
-    raise Abort("A2-POINTER-VALIDITY")
+    return int.from_bytes(raw[1:], "little"), raw[0]
 
 
 def extended_base(formula: str, slot: int, reference_page: int) -> int:
@@ -487,6 +464,4 @@ def extended_base(formula: str, slot: int, reference_page: int) -> int:
         return reference_page
     if formula == "referenced_page_relative_off_by_minus_one":
         return reference_page - 1
-    if formula == "referenced_page_relative_off_by_plus_one":
-        return reference_page + 1
-    raise Abort("A2-BASE-NONE")
+    return reference_page + 1

--- a/oracle/windows-dao/tests/test_a2_analysis.py
+++ b/oracle/windows-dao/tests/test_a2_analysis.py
@@ -15,7 +15,7 @@ SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-from a2_analysis import ReplicaInput, build_analysis  # noqa: E402
+from a2_analysis import ReplicaInput, _derive_pages, build_analysis  # noqa: E402
 from a2_layers import derive_conversion, derive_tdef  # noqa: E402
 from a2_model import (  # noqa: E402
     CHECKPOINT_IDS,
@@ -33,7 +33,6 @@ from a2_model import (  # noqa: E402
     derive_global_record,
     qualify_global_pages,
     qualify_tdef_pages,
-    require_one_page,
 )
 
 GLOBAL_PAGE = 1
@@ -87,7 +86,14 @@ def bitmap(count: int, polarity: str, width: int, first_page: int = 1) -> bytes:
     return used.to_bytes(width, "little")
 
 
-def global_page(checkpoint: str, polarity: str, *, bad_crosscheck: bool = False) -> bytes:
+def global_page(
+    checkpoint: str,
+    polarity: str,
+    *,
+    bad_crosscheck: bool = False,
+    bad_d_relation: bool = False,
+    d_control_change: bool = False,
+) -> bytes:
     body = bytearray([0xA6] * PAGE_SIZE)
     count = counts()[checkpoint]
     body[RECORD_START:] = bytes(PAGE_SIZE - RECORD_START)
@@ -107,6 +113,18 @@ def global_page(checkpoint: str, polarity: str, *, bad_crosscheck: bool = False)
         if bad_crosscheck and checkpoint == "L_REL_0512":
             encoded = bitmap(counts()["L_REL_0064"], polarity, width)
         body[RECORD_START + 5 : RECORD_START + 5 + width] = encoded
+        if bad_d_relation and checkpoint in {"D_DROP", "D_RECREATE_EMPTY"}:
+            offset = RECORD_START + 6
+            if polarity == "set_means_in_use":
+                body[offset] |= 1
+            else:
+                body[offset] &= 0xFE
+        if d_control_change and checkpoint in {"D_DROP", "D_RECREATE_EMPTY"}:
+            offset = RECORD_START + 6
+            if polarity == "set_means_in_use":
+                body[offset] |= 0x10
+            else:
+                body[offset] &= 0xEF
     else:
         body[RECORD_START] = 1
         body[RECORD_START + 1 : RECORD_START + 5] = LOW_MAP_PAGE.to_bytes(4, "little")
@@ -162,6 +180,9 @@ class MemoryReplica:
     invalid_pointer: bool = False
     bad_crosscheck: bool = False
     extra_qualified_global: bool = False
+    bad_checkpoint_order: bool = False
+    bad_d_relation: bool = False
+    d_control_change: bool = False
 
     def __post_init__(self) -> None:
         self.reads: list[str] = []
@@ -171,7 +192,13 @@ class MemoryReplica:
             hashes: list[str] = []
             for page in range(counts()[checkpoint]):
                 if page == GLOBAL_PAGE:
-                    payload = global_page(checkpoint, self.polarity, bad_crosscheck=self.bad_crosscheck)
+                    payload = global_page(
+                        checkpoint,
+                        self.polarity,
+                        bad_crosscheck=self.bad_crosscheck,
+                        bad_d_relation=self.bad_d_relation,
+                        d_control_change=self.d_control_change,
+                    )
                 elif page == LOW_MAP_PAGE:
                     payload = extended_page(
                         checkpoint, self.polarity, 0, no_discriminator=self.no_discriminator
@@ -196,7 +223,7 @@ class MemoryReplica:
 
     @property
     def checkpoint_ids(self) -> tuple[str, ...]:
-        return CHECKPOINT_IDS
+        return CHECKPOINT_IDS[::-1] if self.bad_checkpoint_order else CHECKPOINT_IDS
 
     @property
     def page_count(self) -> dict[str, int]:
@@ -281,13 +308,35 @@ class A2PredicateTests(unittest.TestCase):
             derive_conversion(view, global_model)
         self.assertEqual(caught.exception.predicate_id, "A2-POLARITY-CROSSCHECK")
 
+    def test_d_set_relation_failure_is_reachable_after_direction_selection(self) -> None:
+        _, view = self.view(bad_d_relation=True)
+        with self.assertRaises(Abort) as caught:
+            derive_global_record(view, GLOBAL_PAGE)
+        self.assertEqual(caught.exception.predicate_id, "A2-D-SET-RELATION")
+
+    def test_d_relation_does_not_require_full_bitmap_equality(self) -> None:
+        for polarity in ("set_means_in_use", "set_means_not_in_use"):
+            with self.subTest(polarity=polarity):
+                _, view = self.view(polarity, d_control_change=True)
+                self.assertEqual(
+                    derive_global_record(view, GLOBAL_PAGE).bit_polarity,
+                    polarity,
+                )
+
     def test_named_predicate_units_are_fail_closed(self) -> None:
-        with self.assertRaises(Abort) as none:
-            require_one_page((), "A2-GLOBAL-PAGE-NONE", "A2-GLOBAL-PAGE-MULTIPLE")
-        self.assertEqual(none.exception.reason, "no_physical_page_satisfies_global_transition_predicates")
-        with self.assertRaises(Abort) as multiple:
-            require_one_page((1, 2), "A2-GLOBAL-PAGE-NONE", "A2-GLOBAL-PAGE-MULTIPLE")
-        self.assertEqual(multiple.exception.predicate_id, "A2-GLOBAL-PAGE-MULTIPLE")
+        draft = _derive_pages(
+            (),
+            (),
+            lambda *_args: None,
+            "A2-GLOBAL-PAGE-NONE",
+            "A2-GLOBAL-PAGE-MULTIPLE",
+            "A2-GLOBAL-RECORD-NONE",
+        )
+        self.assertEqual(draft.abort.predicate_id, "A2-GLOBAL-PAGE-NONE")
+        self.assertEqual(
+            draft.abort.reason,
+            "no_physical_page_satisfies_global_transition_predicates",
+        )
         with self.assertRaises(Abort) as bounded:
             WorkCounter().charge(600_000_001)
         self.assertEqual(bounded.exception.predicate_id, "A2-RESOURCE-BOUND")
@@ -388,6 +437,19 @@ class A2LayeredAnalysisTests(unittest.TestCase):
         self.assertEqual(report["submodels"]["tdef"]["pointer_pair"]["status"], "no_outcome")
         self.assertIn("holdout_prediction_failure", report["no_outcome_reasons"])
         self.assertEqual(report["submodels"]["global_map"]["record"]["status"], "decisive_predicts_holdout")
+
+    def test_checkpoint_order_abort_is_retained_without_opening_holdout(self) -> None:
+        replicas = [MemoryReplica("set_means_in_use", bad_checkpoint_order=True)]
+        replicas.extend(MemoryReplica("set_means_in_use") for _ in range(2))
+        report, events = self.analyze(replicas)
+        self.assertEqual(events, [1, 2])
+        self.assertEqual(report["terminal_predicate_ids"], ["A2-SNAPSHOT-RECONSTRUCTION"])
+        self.assertEqual(report["no_outcome_reasons"], ["unreconstructable_snapshot"])
+        self.assertFalse(report["holdout_opened_after_freeze"])
+        self.assertFalse(report["holdout_evaluated"])
+        for layer in report["submodels"]["global_map"].values():
+            self.assertEqual(layer["status"], "no_outcome")
+        self.assertEqual(report["submodels"]["tdef"]["pointer_pair"]["status"], "no_outcome")
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_a2_analysis.py
+++ b/oracle/windows-dao/tests/test_a2_analysis.py
@@ -1,0 +1,394 @@
+"""Focused, inline A2 analyzer fixtures; no acquired data is used here."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a2_analysis import ReplicaInput, build_analysis  # noqa: E402
+from a2_layers import derive_conversion, derive_tdef  # noqa: E402
+from a2_model import (  # noqa: E402
+    CHECKPOINT_IDS,
+    MAX_CANDIDATE_MODELS,
+    MAX_PAGE_BYTES,
+    MAX_RECORD_CANDIDATES,
+    MAX_WORK_UNITS,
+    PAGE_SIZE,
+    PER_PAGE_CANDIDATES,
+    PREDICATES,
+    Abort,
+    View,
+    WorkCounter,
+    candidate_page_space,
+    derive_global_record,
+    qualify_global_pages,
+    qualify_tdef_pages,
+    require_one_page,
+)
+
+GLOBAL_PAGE = 1
+LOW_MAP_PAGE = 2
+HIGH_MAP_PAGE = 3
+TDEF_PAGE = 4
+RECORD_START = 2011
+INLINE_BOUNDARY = RECORD_START + 7
+CONVERSION = "P_ABS_04096"
+
+
+def counts() -> dict[str, int]:
+    values = dict.fromkeys(CHECKPOINT_IDS, 17)
+    values.update(
+        {
+            "E0": 8,
+            "E0R": 8,
+            "D_GROW_0128": 10,
+            "D_DROP": 10,
+            "D_RECREATE_EMPTY": 10,
+            "D_REGROW_0128": 12,
+            "L_REL_0064": 13,
+            "L_REL_0512": 14,
+            "L_REL_0768": 15,
+            "L_REL_0896": 16,
+            "L_REL_0904": 17,
+            "L_REL_1024": 17,
+            "L_REL_1088": 17,
+            "L_REL_1280": 17,
+            "L_DELETE_ALL": 17,
+            "L_REINSERT_SAME": 17,
+            "L_IDLE_REOPEN": 17,
+            "P_ABS_04096": 18,
+            "P_ABS_08192": 19,
+            "P_ABS_12288": 20,
+            "P_ABS_16480": 21,
+            "H_REL_0064": 22,
+            "H_REL_0896": 23,
+            "H_REL_0904": 24,
+            "H_IDLE_REOPEN": 24,
+        }
+    )
+    return values
+
+
+def bitmap(count: int, polarity: str, width: int, first_page: int = 1) -> bytes:
+    used_count = max(0, count - first_page)
+    used = (1 << used_count) - 1 if used_count else 0
+    if polarity == "set_means_not_in_use":
+        used ^= (1 << (width * 8)) - 1
+    return used.to_bytes(width, "little")
+
+
+def global_page(checkpoint: str, polarity: str, *, bad_crosscheck: bool = False) -> bytes:
+    body = bytearray([0xA6] * PAGE_SIZE)
+    count = counts()[checkpoint]
+    body[RECORD_START:] = bytes(PAGE_SIZE - RECORD_START)
+    if checkpoint in {"E0", "E0R", "D_DROP", "D_RECREATE_EMPTY"}:
+        represented = 8
+    elif checkpoint == "D_GROW_0128":
+        represented = 10
+    elif checkpoint == "D_REGROW_0128":
+        represented = 12
+    else:
+        represented = count
+    body[RECORD_START + 1 : RECORD_START + 5] = (1).to_bytes(4, "little")
+    if CHECKPOINT_IDS.index(checkpoint) < CHECKPOINT_IDS.index(CONVERSION):
+        body[RECORD_START] = 0
+        width = PAGE_SIZE - RECORD_START - 5 if checkpoint.startswith("D_") or checkpoint == "E0" or checkpoint == "E0R" else 2
+        encoded = bitmap(represented, polarity, width)
+        if bad_crosscheck and checkpoint == "L_REL_0512":
+            encoded = bitmap(counts()["L_REL_0064"], polarity, width)
+        body[RECORD_START + 5 : RECORD_START + 5 + width] = encoded
+    else:
+        body[RECORD_START] = 1
+        body[RECORD_START + 1 : RECORD_START + 5] = LOW_MAP_PAGE.to_bytes(4, "little")
+        if CHECKPOINT_IDS.index(checkpoint) >= CHECKPOINT_IDS.index("H_REL_0064"):
+            body[RECORD_START + 5 : RECORD_START + 9] = HIGH_MAP_PAGE.to_bytes(4, "little")
+    return bytes(body)
+
+
+def extended_page(checkpoint: str, polarity: str, slot: int, *, no_discriminator: bool) -> bytes:
+    body = bytearray(PAGE_SIZE)
+    body[0:4] = b"\x05\x01\x00\x00"
+    count = counts()[checkpoint]
+    if checkpoint in {"E0", "E0R", "D_GROW_0128", "D_DROP", "D_RECREATE_EMPTY", "D_REGROW_0128"}:
+        count = 8
+    if no_discriminator and checkpoint == "H_REL_0064":
+        count = counts()["P_ABS_16480"]
+    used = (1 << count) - 1 if slot == 0 else 0
+    if no_discriminator and slot == 1 and CHECKPOINT_IDS.index(checkpoint) >= CHECKPOINT_IDS.index("H_REL_0064"):
+        used = 1
+    if polarity == "set_means_not_in_use":
+        used ^= (1 << ((PAGE_SIZE - 4) * 8)) - 1
+    body[4:] = used.to_bytes(PAGE_SIZE - 4, "little")
+    return bytes(body)
+
+
+def pointer(page: int, slot: int) -> bytes:
+    return page.to_bytes(3, "little") + bytes([slot])
+
+
+def tdef_page(checkpoint: str, *, invalid_pointer: bool = False) -> bytes:
+    body = bytearray(PAGE_SIZE)
+    growth_page = LOW_MAP_PAGE
+    growth_slot = 200
+    if CHECKPOINT_IDS.index(checkpoint) >= CHECKPOINT_IDS.index("L_REL_0512"):
+        growth_page = HIGH_MAP_PAGE
+        growth_slot = 201
+    if checkpoint in {"D_GROW_0128", "D_DROP", "D_RECREATE_EMPTY", "D_REGROW_0128"}:
+        growth_page = LOW_MAP_PAGE
+        growth_slot = 200
+    if invalid_pointer and checkpoint in {"P_ABS_16480", "H_REL_0064", "H_REL_0896", "H_REL_0904", "H_IDLE_REOPEN"}:
+        growth_page = 999
+    churned = checkpoint == "L_DELETE_ALL"
+    churn_page = HIGH_MAP_PAGE if churned else LOW_MAP_PAGE
+    body[100:104] = pointer(growth_page, growth_slot)
+    body[110:114] = pointer(churn_page, 201 if churned else 200)
+    return bytes(body)
+
+
+@dataclass
+class MemoryReplica:
+    polarity: str
+    no_discriminator: bool = False
+    invalid_pointer: bool = False
+    bad_crosscheck: bool = False
+    extra_qualified_global: bool = False
+
+    def __post_init__(self) -> None:
+        self.reads: list[str] = []
+        self.blobs: dict[str, bytes] = {}
+        self.indexes: dict[str, tuple[str, ...]] = {}
+        for checkpoint in CHECKPOINT_IDS:
+            hashes: list[str] = []
+            for page in range(counts()[checkpoint]):
+                if page == GLOBAL_PAGE:
+                    payload = global_page(checkpoint, self.polarity, bad_crosscheck=self.bad_crosscheck)
+                elif page == LOW_MAP_PAGE:
+                    payload = extended_page(
+                        checkpoint, self.polarity, 0, no_discriminator=self.no_discriminator
+                    )
+                elif page == HIGH_MAP_PAGE:
+                    payload = extended_page(
+                        checkpoint, self.polarity, 1, no_discriminator=self.no_discriminator
+                    )
+                elif page == TDEF_PAGE:
+                    payload = tdef_page(checkpoint, invalid_pointer=self.invalid_pointer)
+                elif self.extra_qualified_global and page == 5 and checkpoint in {
+                    "D_GROW_0128",
+                    "D_DROP",
+                }:
+                    payload = bytes([0x91 if checkpoint == "D_GROW_0128" else 0x92]) * PAGE_SIZE
+                else:
+                    payload = bytes([page & 0xFF]) * PAGE_SIZE
+                digest = hashlib.sha256(payload).hexdigest()
+                self.blobs[digest] = payload
+                hashes.append(digest)
+            self.indexes[checkpoint] = tuple(hashes)
+
+    @property
+    def checkpoint_ids(self) -> tuple[str, ...]:
+        return CHECKPOINT_IDS
+
+    @property
+    def page_count(self) -> dict[str, int]:
+        return {checkpoint: len(hashes) for checkpoint, hashes in self.indexes.items()}
+
+    @property
+    def ordered_page_sha256(self) -> dict[str, tuple[str, ...]]:
+        return self.indexes
+
+    def page_bytes(self, sha256: str) -> bytes:
+        self.reads.append(sha256)
+        return self.blobs[sha256]
+
+
+class OrderedSource:
+    def __init__(self, replica: ReplicaInput, events: list[int], frozen: Path) -> None:
+        self.replica = replica
+        self.events = events
+        self.frozen = frozen
+
+    def open(self) -> ReplicaInput:
+        if self.replica.replica == 3:
+            if not self.frozen.is_file():
+                raise AssertionError("holdout opened before candidate freeze")
+            self.events.append(3)
+        else:
+            self.events.append(self.replica.replica)
+        return self.replica
+
+
+def input_for(number: int, replica: MemoryReplica) -> ReplicaInput:
+    return ReplicaInput(replica, number, "synthetic-a2", "0" * 40, "1" * 64, True)
+
+
+class A2PredicateTests(unittest.TestCase):
+    def view(self, polarity: str = "set_means_in_use", **kwargs: bool) -> tuple[MemoryReplica, View]:
+        replica = MemoryReplica(polarity, **kwargs)
+        return replica, View(replica, WorkCounter())
+
+    def test_page_qualification_precedes_every_blob_read(self) -> None:
+        replica, view = self.view()
+        pages = candidate_page_space((view,))
+        self.assertEqual(qualify_global_pages(view, pages), (GLOBAL_PAGE,))
+        self.assertEqual(qualify_tdef_pages(view, pages), (TDEF_PAGE,))
+        self.assertEqual(replica.reads, [])
+        derive_global_record(view, GLOBAL_PAGE)
+        self.assertNotEqual(replica.reads, [])
+
+    def test_d_relation_selects_each_polarity_and_uses_terminal_slack(self) -> None:
+        for polarity in ("set_means_in_use", "set_means_not_in_use"):
+            with self.subTest(polarity=polarity):
+                _, view = self.view(polarity)
+                model = derive_global_record(view, GLOBAL_PAGE)
+                self.assertEqual(model.bit_polarity, polarity)
+                self.assertEqual(model.record.end, PAGE_SIZE)
+                self.assertGreaterEqual(model.zero_suffix_slack_bytes, 16)
+
+    def test_conversion_uses_frozen_global_record_and_both_polarities(self) -> None:
+        for polarity in ("set_means_in_use", "set_means_not_in_use"):
+            with self.subTest(polarity=polarity):
+                _, view = self.view(polarity)
+                global_model = derive_global_record(view, GLOBAL_PAGE)
+                conversion = derive_conversion(view, global_model)
+                self.assertEqual(conversion.conversion_checkpoint_id, CONVERSION)
+                self.assertEqual(conversion.inline_boundary, INLINE_BOUNDARY)
+                self.assertEqual(conversion.active_slot_count_at_conversion, 1)
+                self.assertEqual(conversion.active_slot_count_at_h_rel_0904, 2)
+
+    def test_tdef_contains_only_two_transition_selective_pointers(self) -> None:
+        _, view = self.view()
+        model = derive_tdef(view, TDEF_PAGE, True)
+        self.assertEqual(model.pointer_layout, "u24le_page_then_u8_slot")
+        self.assertEqual(model.growth_pointer_offset, 100)
+        self.assertEqual(model.delete_reinsert_pointer_offset, 110)
+        self.assertEqual((model.record.start, model.record.end), (99, 115))
+
+    def test_lph_crosscheck_cannot_change_the_d_selected_polarity(self) -> None:
+        _, view = self.view(bad_crosscheck=True)
+        global_model = derive_global_record(view, GLOBAL_PAGE)
+        self.assertEqual(global_model.bit_polarity, "set_means_in_use")
+        with self.assertRaises(Abort) as caught:
+            derive_conversion(view, global_model)
+        self.assertEqual(caught.exception.predicate_id, "A2-POLARITY-CROSSCHECK")
+
+    def test_named_predicate_units_are_fail_closed(self) -> None:
+        with self.assertRaises(Abort) as none:
+            require_one_page((), "A2-GLOBAL-PAGE-NONE", "A2-GLOBAL-PAGE-MULTIPLE")
+        self.assertEqual(none.exception.reason, "no_physical_page_satisfies_global_transition_predicates")
+        with self.assertRaises(Abort) as multiple:
+            require_one_page((1, 2), "A2-GLOBAL-PAGE-NONE", "A2-GLOBAL-PAGE-MULTIPLE")
+        self.assertEqual(multiple.exception.predicate_id, "A2-GLOBAL-PAGE-MULTIPLE")
+        with self.assertRaises(Abort) as bounded:
+            WorkCounter().charge(600_000_001)
+        self.assertEqual(bounded.exception.predicate_id, "A2-RESOURCE-BOUND")
+
+    def test_work_candidate_model_and_blob_bounds_accept_exact_and_reject_over(self) -> None:
+        work = WorkCounter()
+        work.value = MAX_WORK_UNITS - 1
+        work.charge(1)
+        with self.assertRaises(Abort):
+            work.charge(1)
+
+        work = WorkCounter()
+        work.record_candidates = MAX_RECORD_CANDIDATES - PER_PAGE_CANDIDATES
+        work.enumerate_intervals()
+        self.assertEqual(work.record_candidates, MAX_RECORD_CANDIDATES)
+        with self.assertRaises(Abort):
+            work.enumerate_intervals()
+
+        work = WorkCounter()
+        work.candidate_models = MAX_CANDIDATE_MODELS - 1
+        work.examine_models()
+        with self.assertRaises(Abort):
+            work.examine_models()
+
+        work = WorkCounter()
+        work.page_bytes_read = MAX_PAGE_BYTES - PAGE_SIZE
+        work.opened("0" * 64)
+        self.assertEqual(work.page_bytes_read, MAX_PAGE_BYTES)
+        with self.assertRaises(Abort):
+            work.opened("1" * 64)
+
+    def test_every_registered_abort_has_one_literal_site_and_one_mapping(self) -> None:
+        site_ids: set[str] = set()
+        for name in ("a2_model.py", "a2_layers.py", "a2_analysis.py"):
+            tree = ast.parse((SCRIPTS / name).read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value.startswith("A2-"):
+                    site_ids.add(node.value)
+        self.assertEqual(site_ids, set(PREDICATES))
+        for predicate_id, (reason, _) in PREDICATES.items():
+            reached = Abort(predicate_id)
+            self.assertEqual((reached.predicate_id, reached.reason), (predicate_id, reason))
+
+
+class A2LayeredAnalysisTests(unittest.TestCase):
+    def analyze(self, replicas: list[MemoryReplica]) -> tuple[dict[str, object], list[int]]:
+        with tempfile.TemporaryDirectory() as directory:
+            frozen = Path(directory) / "analysis" / "derivation-candidates.json"
+            events: list[int] = []
+            sources = [
+                OrderedSource(input_for(index, replica), events, frozen)
+                for index, replica in enumerate(replicas, 1)
+            ]
+            report = build_analysis(sources, frozen, lambda digest: self.assertEqual(len(digest), 64))
+            self.assertTrue(frozen.is_file())
+            self.assertEqual(
+                hashlib.sha256(frozen.read_bytes()).hexdigest(),
+                report["derivation_candidate_set_sha256"],
+            )
+            return report, events
+
+    def test_all_layers_decisive_and_holdout_opens_after_freeze(self) -> None:
+        report, events = self.analyze([MemoryReplica("set_means_in_use") for _ in range(3)])
+        self.assertEqual(events, [1, 2, 3])
+        self.assertEqual(report["scientific_outcome"], "one_or_more_submodels_predict_holdout")
+        self.assertEqual(report["terminal_predicate_ids"], [])
+        self.assertEqual(report["submodels"]["global_map"]["record"]["status"], "decisive_predicts_holdout")
+        self.assertEqual(report["submodels"]["global_map"]["conversion_inline"]["status"], "decisive_predicts_holdout")
+        self.assertEqual(report["submodels"]["global_map"]["extended_base"]["status"], "decisive_predicts_holdout")
+        self.assertEqual(report["submodels"]["tdef"]["pointer_pair"]["status"], "decisive_predicts_holdout")
+
+    def test_base_no_outcome_does_not_erase_other_decisive_layers(self) -> None:
+        report, _ = self.analyze(
+            [MemoryReplica("set_means_in_use", no_discriminator=True) for _ in range(3)]
+        )
+        global_map = report["submodels"]["global_map"]
+        self.assertEqual(global_map["record"]["status"], "decisive_predicts_holdout")
+        self.assertEqual(global_map["conversion_inline"]["status"], "decisive_predicts_holdout")
+        self.assertEqual(global_map["extended_base"]["status"], "no_outcome")
+        self.assertIn("insufficient_base_discrimination", report["no_outcome_reasons"])
+        self.assertEqual(report["scientific_outcome"], "one_or_more_submodels_predict_holdout")
+
+    def test_multiple_qualified_pages_are_enumerated_before_one_page_survives(self) -> None:
+        report, _ = self.analyze(
+            [MemoryReplica("set_means_in_use", extra_qualified_global=True) for _ in range(3)]
+        )
+        self.assertEqual(report["qualified_page_counts"]["global_map"], 2)
+        self.assertEqual(
+            report["submodels"]["global_map"]["record"]["status"],
+            "decisive_predicts_holdout",
+        )
+        self.assertGreaterEqual(report["record_candidates_examined"], 3 * 2_098_176)
+
+    def test_holdout_is_pure_prediction_and_cannot_replace_frozen_pointer(self) -> None:
+        replicas = [MemoryReplica("set_means_in_use") for _ in range(2)]
+        replicas.append(MemoryReplica("set_means_in_use", invalid_pointer=True))
+        report, _ = self.analyze(replicas)
+        self.assertEqual(report["submodels"]["tdef"]["pointer_pair"]["status"], "no_outcome")
+        self.assertIn("holdout_prediction_failure", report["no_outcome_reasons"])
+        self.assertEqual(report["submodels"]["global_map"]["record"]["status"], "decisive_predicts_holdout")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a2_integration.py
+++ b/oracle/windows-dao/tests/test_a2_integration.py
@@ -1,0 +1,191 @@
+"""Analyzer integration against the optional A2 schedule generator."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a2_analysis import LoadedReplicaSource, ReplicaInput, build_analysis  # noqa: E402
+from a2_model import CHECKPOINT_IDS, PAGE_SIZE, PLAN  # noqa: E402
+
+try:
+    from a2_generator import (  # type: ignore[import-not-found] # noqa: E402
+        SyntheticParameters,
+        generate_synthetic_bundles,
+        run12_calibration_parameters,
+    )
+    from a2_spec import validate_analysis_report  # type: ignore[import-not-found] # noqa: E402
+except ImportError:
+    SyntheticParameters = None
+    generate_synthetic_bundles = None
+    run12_calibration_parameters = None
+    validate_analysis_report = None
+
+_BASELINE = object()
+
+
+@unittest.skipUnless(generate_synthetic_bundles is not None, "a2_generator is not present")
+class A2GeneratorIntegrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert run12_calibration_parameters is not None
+        cls.baseline = run12_calibration_parameters()
+        cls.free = PLAN["analyzer_dry_run_contract"]["synthetic_input"][
+            "free_parameters"
+        ]
+
+    def parameters(
+        self,
+        *,
+        conversion: int | None | object = _BASELINE,
+        slots: int | None = None,
+        polarity: str | None = None,
+        fill: str | None = None,
+        slack: int | None = None,
+    ) -> object:
+        assert SyntheticParameters is not None
+        return SyntheticParameters(
+            self.baseline.conversion_ordinal if conversion is _BASELINE else conversion,
+            self.baseline.slot_activation_at_conversion if slots is None else slots,
+            self.baseline.bit_polarity if polarity is None else polarity,
+            self.baseline.anchor_fill_state if fill is None else fill,
+            self.baseline.record_end_uniform_slack_bytes if slack is None else slack,
+            self.baseline.delete_page_delta,
+        )
+
+    def analyze(self, parameters: object) -> dict[str, object]:
+        assert generate_synthetic_bundles is not None
+        sources = []
+        for bundle in generate_synthetic_bundles(parameters):
+            observation = bundle.documents[
+                f"observations/replica-{bundle.replica:02d}.json"
+            ]
+            before = bundle.schedule.checkpoint("L_REL_1280")
+            deleted = bundle.schedule.checkpoint("L_DELETE_ALL")
+            replica = ReplicaInput(
+                bundle,
+                bundle.replica,
+                observation["campaign_id"],
+                observation["producer_commit"],
+                observation["provider_sha256"],
+                before.table_row_counts["L"] > 0
+                and deleted.table_row_counts["L"] == 0,
+            )
+            sources.append(LoadedReplicaSource(replica))
+        with tempfile.TemporaryDirectory() as directory:
+            report = build_analysis(
+                sources,
+                Path(directory) / "analysis" / "derivation-candidates.json",
+                lambda digest: self.assertEqual(len(digest), 64),
+            )
+        assert validate_analysis_report is not None
+        validate_analysis_report(report)
+        return report
+
+    def assert_reason(self, layer: dict[str, object], reason: str) -> None:
+        self.assertEqual(layer["status"], "no_outcome")
+        self.assertEqual(layer["no_outcome_reasons"], [reason])
+
+    def test_every_a2_conversion_ordinal_plus_never(self) -> None:
+        for ordinal in (*range(1, len(CHECKPOINT_IDS)), None):
+            with self.subTest(ordinal=ordinal):
+                report = self.analyze(self.parameters(conversion=ordinal))
+                global_map = report["submodels"]["global_map"]
+                if ordinal in {1, 16, 24}:
+                    self.assert_reason(global_map["record"], "idle_volatility")
+                elif ordinal == 2:
+                    self.assert_reason(
+                        global_map["record"],
+                        "no_physical_page_satisfies_global_transition_predicates",
+                    )
+                elif ordinal in {3, 4, 5}:
+                    self.assert_reason(global_map["record"], "no_unique_bit_polarity")
+                else:
+                    self.assertEqual(
+                        global_map["record"]["status"], "decisive_predicts_holdout"
+                    )
+                    if ordinal in {6, None}:
+                        self.assert_reason(
+                            global_map["conversion_inline"],
+                            "missing_inline_to_indirect_conversion",
+                        )
+                    else:
+                        self.assertEqual(
+                            global_map["conversion_inline"]["status"],
+                            "decisive_predicts_holdout",
+                        )
+                        if ordinal in {22, 23}:
+                            self.assert_reason(
+                                global_map["extended_base"],
+                                "insufficient_base_discrimination",
+                            )
+                        else:
+                            self.assertEqual(
+                                global_map["extended_base"]["status"],
+                                "decisive_predicts_holdout",
+                            )
+
+    def test_both_polarities(self) -> None:
+        for polarity in self.free["bit_polarity"]:
+            with self.subTest(polarity=polarity):
+                report = self.analyze(self.parameters(polarity=polarity))
+                record = report["submodels"]["global_map"]["record"]
+                self.assertEqual(record["status"], "decisive_predicts_holdout")
+                self.assertEqual(record["model"]["bit_polarity"], polarity)
+
+    def test_slot_counts_and_final_activation(self) -> None:
+        for slots in self.free["slot_activation_at_conversion"]:
+            with self.subTest(slots=slots):
+                report = self.analyze(self.parameters(slots=slots))
+                conversion = report["submodels"]["global_map"]["conversion_inline"]
+                if slots == 0:
+                    self.assert_reason(conversion, "no_active_slot_at_conversion")
+                else:
+                    self.assertEqual(conversion["status"], "decisive_predicts_holdout")
+        report = self.analyze(self.parameters(conversion=23, slots=1))
+        self.assert_reason(
+            report["submodels"]["global_map"]["conversion_inline"],
+            "final_slot_activation_not_two",
+        )
+
+    def test_anchor_fill_does_not_move_the_recovered_boundary(self) -> None:
+        for polarity in self.free["bit_polarity"]:
+            full = self.analyze(self.parameters(polarity=polarity, fill="full"))
+            expected = full["submodels"]["global_map"]["conversion_inline"][
+                "model"
+            ]["inline_boundary"]
+            for fill in self.free["anchor_fill_state"]:
+                with self.subTest(polarity=polarity, fill=fill):
+                    report = self.analyze(
+                        self.parameters(polarity=polarity, fill=fill)
+                    )
+                    conversion = report["submodels"]["global_map"][
+                        "conversion_inline"
+                    ]
+                    self.assertEqual(
+                        conversion["status"], "decisive_predicts_holdout"
+                    )
+                    self.assertEqual(conversion["model"]["inline_boundary"], expected)
+
+    def test_every_record_end_slack(self) -> None:
+        for slack in self.free["record_end_uniform_slack_bytes"]:
+            with self.subTest(slack=slack):
+                report = self.analyze(self.parameters(slack=slack))
+                record = report["submodels"]["global_map"]["record"]
+                self.assertEqual(record["status"], "decisive_predicts_holdout")
+                self.assertEqual(record["model"]["zero_suffix_slack_bytes"], slack)
+                conversion = report["submodels"]["global_map"]["conversion_inline"]
+                self.assertEqual(
+                    conversion["model"]["inline_boundary"], PAGE_SIZE - slack
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the plan-backed A2 ReplicaData model, bijective Abort registry, bounded prefix-difference predicates, and D-only global record delimitation
- add layered conversion/inline/base and separate TDEF pointer submodels with frozen replica-1/2 candidates and pure holdout prediction
- add a schema-validated on-disk A2 loader plus focused fixtures covering both polarities, terminal slack, bounds, freeze ordering, decisive and partial layered paths

## Checks

- python3.13 -m unittest discover -s oracle/windows-dao/tests -p test_*.py (462 passed, 83 skipped)
- python3.13 tools/reconcile_tests.py (236 meaningful, 236 runtime, 0 ignored)
- python3.13 -m unittest oracle/windows-dao/tests/test_a2_analysis.py oracle/windows-dao/tests/test_a2_plan_contract.py (29 passed)
- git diff --check