### PR TITLE
feat: add A2 checked spec and synthetic generator

### DIFF
--- a/oracle/windows-dao/scripts/a2_generator.py
+++ b/oracle/windows-dao/scripts/a2_generator.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import itertools
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -20,14 +19,17 @@ from typing import Any, Iterator, Mapping
 from a2_generator_pages import PageFixture, build_page_fixture
 from a2_generator_schedule import Schedule, build_schedule, checkpoint_document
 from a2_spec import (
+    A2_CONVERSION_ORDINALS,
     BIT_POLARITIES,
     BOUNDS,
     CHECKPOINT_IDS,
     EXPERIMENT_ID,
+    LEGACY_CONVERSION_ORDINALS,
     PAGE_SIZE,
     PLAN_SHA256,
     ROLE_BINDINGS,
     ROLES,
+    RUN12_CALIBRATION,
     expected_reread_sha256,
     load_checked_plan,
     validate_environment,
@@ -125,33 +127,17 @@ A2SyntheticBundle = SyntheticBundle
 SyntheticBundleView = SyntheticBundle
 
 
-def _calibration_fields() -> tuple[int, int, str, int]:
-    text = _SYNTHETIC["run12_calibration_case"]
-    ordinal = re.search(r"A2 ordinal ([0-9]+)", text)
-    polarity = next((item for item in BIT_POLARITIES if item in text), None)
-    slot_words = {"zero": 0, "one": 1, "two": 2}
-    slots = next(
-        (value for word, value in slot_words.items() if f"{word} active slots" in text),
-        None,
-    )
-    delta = re.search(r"delete page delta \+([0-9]+)", text)
-    if ordinal is None or polarity is None or slots is None or delta is None:
-        raise ValidationError("run12_calibration_case is not mechanically parseable")
-    return int(ordinal.group(1)), slots, polarity, int(delta.group(1))
-
-
 def run12_calibration_parameters() -> SyntheticParameters:
     """Return the plan-declared non-evidential calibration parameter case."""
-    ordinal, slots, polarity, delta = _calibration_fields()
     anchor_states = _FREE["anchor_fill_state"]
     slack_values = _FREE["record_end_uniform_slack_bytes"]
     return SyntheticParameters(
-        conversion_ordinal=ordinal,
-        slot_activation_at_conversion=slots,
-        bit_polarity=polarity,
+        conversion_ordinal=RUN12_CALIBRATION["a2_conversion_ordinal"],
+        slot_activation_at_conversion=RUN12_CALIBRATION["active_slot_count"],
+        bit_polarity=RUN12_CALIBRATION["bit_polarity"],
         anchor_fill_state=anchor_states[-1],
         record_end_uniform_slack_bytes=slack_values[len(slack_values) // 2],
-        delete_page_delta=delta,
+        delete_page_delta=RUN12_CALIBRATION["delete_page_delta"],
     )
 
 
@@ -160,20 +146,12 @@ def iter_parameter_combinations(
 ) -> Iterator[SyntheticParameters]:
     """Enumerate every checked free-parameter combination, including never.
 
-    A2 enumeration covers ordinals 1..24 plus never. Legacy-projection mode
-    reads its 1..70 bound from the same plan sentence and also includes never.
+    Both ordinal ranges are parsed from the checked plan; neither projection
+    inherits a hand-authored schedule bound.
     """
-    if legacy_projection:
-        match = re.search(
-            r"legacy ordinals 1\.\.([0-9]+)", _FREE["conversion_ordinal"]
-        )
-        if match is None:
-            raise ValidationError("legacy conversion bound is absent from the plan")
-        last_ordinal = int(match.group(1))
-    else:
-        last_ordinal = len(CHECKPOINT_IDS) - 1
-    conversion_values: tuple[int | None, ...] = (*range(1, last_ordinal + 1), None)
-    delete_delta = _calibration_fields()[3]
+    ordinals = LEGACY_CONVERSION_ORDINALS if legacy_projection else A2_CONVERSION_ORDINALS
+    conversion_values: tuple[int | None, ...] = (*ordinals, None)
+    delete_delta = RUN12_CALIBRATION["delete_page_delta"]
     for conversion, slots, polarity, fill, slack in itertools.product(
         conversion_values,
         _FREE["slot_activation_at_conversion"],

--- a/oracle/windows-dao/scripts/a2_generator.py
+++ b/oracle/windows-dao/scripts/a2_generator.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Schedule-derived, non-evidential A2 analyzer fixture generator.
+
+``generate_synthetic_bundle`` returns the analyzer-facing in-memory form.
+``write_synthetic_bundles`` materializes the acquisition-shaped directories.
+Every schedule and parameter value originates in the checked A2 plan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Iterator, Mapping
+
+from a2_generator_pages import PageFixture, build_page_fixture
+from a2_generator_schedule import Schedule, build_schedule, checkpoint_document
+from a2_spec import (
+    BIT_POLARITIES,
+    BOUNDS,
+    CHECKPOINT_IDS,
+    EXPERIMENT_ID,
+    PAGE_SIZE,
+    PLAN_SHA256,
+    ROLE_BINDINGS,
+    ROLES,
+    expected_reread_sha256,
+    load_checked_plan,
+    validate_environment,
+    validate_page_index,
+    validate_replica_artifact_manifest,
+    validate_replica_observation,
+)
+from protocol_validation import ValidationError, canonical_json_bytes
+
+_PLAN = load_checked_plan()
+_SYNTHETIC = _PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]
+_FREE = _SYNTHETIC["free_parameters"]
+_REPOSITORY_URL = _PLAN.document["repository_binding"]["canonical_https_url"]
+_PRODUCER_COMMIT = PLAN_SHA256[:40]
+_PROVIDER_SHA256 = hashlib.sha256(
+    _PLAN.document["environment_binding"]["dao_prog_id"].encode("ascii")
+).hexdigest()
+
+
+@dataclass(frozen=True)
+class SyntheticParameters:
+    """One member of the plan's bounded synthetic parameter product."""
+
+    conversion_ordinal: int | None
+    slot_activation_at_conversion: int
+    bit_polarity: str
+    anchor_fill_state: str
+    record_end_uniform_slack_bytes: int
+    delete_page_delta: int
+
+
+@dataclass(frozen=True)
+class GlobalMapFixture:
+    page: int
+    record_start: int
+    record_end: int
+    inline_boundary: int
+    bit_polarity: str
+    conversion_ordinal: int | None
+    inline_base: int
+    extended_base_formula: str
+
+
+@dataclass(frozen=True)
+class TdefFixture:
+    page: int
+    record_start: int
+    record_end: int
+    pointer_layout: str
+    growth_pointer_offset: int
+    delete_reinsert_pointer_offset: int
+
+
+@dataclass(frozen=True)
+class SyntheticBundle:
+    """Bounded analyzer view over one synthetic replica.
+
+    ``checkpoint_ids`` is in frozen plan order. ``page_count`` and
+    ``ordered_page_sha256`` are keyed by those ids, while ``page_bytes``
+    resolves a content address without exposing the backing mapping.
+    """
+
+    checkpoint_ids: tuple[str, ...]
+    page_count: Mapping[str, int]
+    ordered_page_sha256: Mapping[str, tuple[str, ...]]
+    replica: int
+    parameters: SyntheticParameters
+    schedule: Schedule
+    global_map: GlobalMapFixture
+    tdef: TdefFixture
+    documents: Mapping[str, dict[str, Any]]
+    _payloads: Mapping[str, bytes]
+
+    def page_bytes(self, sha256: str) -> bytes:
+        """Return one verified 2,048-byte page by lowercase SHA-256."""
+        try:
+            payload = self._payloads[sha256]
+        except KeyError as exc:
+            raise ValidationError(f"unknown synthetic page digest {sha256!r}") from exc
+        if len(payload) != PAGE_SIZE or hashlib.sha256(payload).hexdigest() != sha256:
+            raise ValidationError("synthetic page store failed its content address")
+        return payload
+
+    @property
+    def page_counts(self) -> Mapping[str, int]:
+        """Plural alias for callers that name checkpoint mappings collectively."""
+        return self.page_count
+
+    @property
+    def ordered_page_hashes(self) -> Mapping[str, tuple[str, ...]]:
+        return self.ordered_page_sha256
+
+
+A2SyntheticBundle = SyntheticBundle
+SyntheticBundleView = SyntheticBundle
+
+
+def _calibration_fields() -> tuple[int, int, str, int]:
+    text = _SYNTHETIC["run12_calibration_case"]
+    ordinal = re.search(r"A2 ordinal ([0-9]+)", text)
+    polarity = next((item for item in BIT_POLARITIES if item in text), None)
+    slot_words = {"zero": 0, "one": 1, "two": 2}
+    slots = next(
+        (value for word, value in slot_words.items() if f"{word} active slots" in text),
+        None,
+    )
+    delta = re.search(r"delete page delta \+([0-9]+)", text)
+    if ordinal is None or polarity is None or slots is None or delta is None:
+        raise ValidationError("run12_calibration_case is not mechanically parseable")
+    return int(ordinal.group(1)), slots, polarity, int(delta.group(1))
+
+
+def run12_calibration_parameters() -> SyntheticParameters:
+    """Return the plan-declared non-evidential calibration parameter case."""
+    ordinal, slots, polarity, delta = _calibration_fields()
+    anchor_states = _FREE["anchor_fill_state"]
+    slack_values = _FREE["record_end_uniform_slack_bytes"]
+    return SyntheticParameters(
+        conversion_ordinal=ordinal,
+        slot_activation_at_conversion=slots,
+        bit_polarity=polarity,
+        anchor_fill_state=anchor_states[-1],
+        record_end_uniform_slack_bytes=slack_values[len(slack_values) // 2],
+        delete_page_delta=delta,
+    )
+
+
+def iter_parameter_combinations(
+    *, legacy_projection: bool = False
+) -> Iterator[SyntheticParameters]:
+    """Enumerate every checked free-parameter combination, including never.
+
+    A2 enumeration covers ordinals 1..24 plus never. Legacy-projection mode
+    reads its 1..70 bound from the same plan sentence and also includes never.
+    """
+    if legacy_projection:
+        match = re.search(
+            r"legacy ordinals 1\.\.([0-9]+)", _FREE["conversion_ordinal"]
+        )
+        if match is None:
+            raise ValidationError("legacy conversion bound is absent from the plan")
+        last_ordinal = int(match.group(1))
+    else:
+        last_ordinal = len(CHECKPOINT_IDS) - 1
+    conversion_values: tuple[int | None, ...] = (*range(1, last_ordinal + 1), None)
+    delete_delta = _calibration_fields()[3]
+    for conversion, slots, polarity, fill, slack in itertools.product(
+        conversion_values,
+        _FREE["slot_activation_at_conversion"],
+        _FREE["bit_polarity"],
+        _FREE["anchor_fill_state"],
+        _FREE["record_end_uniform_slack_bytes"],
+    ):
+        yield SyntheticParameters(conversion, slots, polarity, fill, slack, delete_delta)
+
+
+enumerate_parameter_combinations = iter_parameter_combinations
+
+
+def _identity(replica: int, parameters: SyntheticParameters) -> tuple[str, str]:
+    description = (
+        f"a2-synthetic|{parameters.conversion_ordinal}|"
+        f"{parameters.slot_activation_at_conversion}|{parameters.bit_polarity}|"
+        f"{parameters.anchor_fill_state}|{parameters.record_end_uniform_slack_bytes}|"
+        f"{parameters.delete_page_delta}"
+    )
+    digest = hashlib.sha256(description.encode("ascii")).hexdigest()
+    return f"a2-synthetic-{digest[:16]}", f"replica-{replica:02d}"
+
+
+def _environment(replica: int, campaign_id: str, matrix_job_id: str) -> dict[str, Any]:
+    binding = _PLAN.document["environment_binding"]
+    document = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_environment",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "producer_commit": _PRODUCER_COMMIT,
+        "repository_url": _REPOSITORY_URL,
+        "campaign_id": campaign_id,
+        "replica": replica,
+        "matrix_job_id": matrix_job_id,
+        "status": "ready",
+        "host": {
+            "windows_version": "synthetic-non-evidential",
+            "process_architecture": binding["process_architecture"],
+            "powershell_version": f"{binding['powershell_major']}.1",
+            "python_version": "3.13.0",
+            "runner_image": "synthetic-plan-derived",
+        },
+        "provider": {
+            "prog_id": binding["dao_prog_id"],
+            "clsid": (
+                "{" + _PROVIDER_SHA256[:8] + "-" + _PROVIDER_SHA256[8:12] + "-"
+                + _PROVIDER_SHA256[12:16] + "-" + _PROVIDER_SHA256[16:20] + "-"
+                + _PROVIDER_SHA256[20:32] + "}"
+            ),
+            "provider_version": "synthetic",
+            "server_path": "C:/synthetic/dao360.dll",
+            "server_file_version": "synthetic",
+            "server_sha256": _PROVIDER_SHA256,
+        },
+    }
+    validate_environment(document)
+    return document
+
+
+def _artifact_ref(path: str, payload: bytes) -> dict[str, Any]:
+    return {
+        "path": path,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size_bytes": len(payload),
+    }
+
+
+def _page_indexes(
+    replica: int,
+    campaign_id: str,
+    environment_sha256: str,
+    schedule: Schedule,
+    pages: PageFixture,
+) -> tuple[dict[str, dict[str, Any]], int]:
+    documents: dict[str, dict[str, Any]] = {}
+    changed_total = 0
+    prior: tuple[str, ...] = ()
+    for row in schedule.checkpoints:
+        hashes = pages.ordered_hashes[row.checkpoint_id]
+        changed = [
+            index
+            for index in range(max(len(prior), len(hashes)))
+            if index >= len(prior)
+            or index >= len(hashes)
+            or prior[index] != hashes[index]
+        ]
+        database = hashlib.sha256()
+        for digest in hashes:
+            database.update(pages.payloads[digest])
+        path = (
+            f"page-indexes/replica-{replica:02d}/"
+            f"{row.ordinal:02d}-{row.checkpoint_id}.json"
+        )
+        document = {
+            "protocol_version": "1.0.0",
+            "document_type": "dao_a2_page_index",
+            "experiment_id": EXPERIMENT_ID,
+            "plan_sha256": PLAN_SHA256,
+            "producer_commit": _PRODUCER_COMMIT,
+            "campaign_id": campaign_id,
+            "environment_sha256": environment_sha256,
+            "provider_sha256": _PROVIDER_SHA256,
+            "replica": replica,
+            "checkpoint_id": row.checkpoint_id,
+            "ordinal": row.ordinal,
+            "predecessor_checkpoint_id": (
+                None if row.ordinal == 0 else CHECKPOINT_IDS[row.ordinal - 1]
+            ),
+            "page_count": len(hashes),
+            "file_size_bytes": len(hashes) * PAGE_SIZE,
+            "database_sha256": database.hexdigest(),
+            "ordered_page_sha256": list(hashes),
+            "changed_page_indices": changed,
+        }
+        validate_page_index(document, prior_hashes=prior)
+        documents[path] = document
+        changed_total += len(changed)
+        prior = hashes
+    if changed_total > BOUNDS["max_changed_hash_entries_per_replica"]:
+        raise ValidationError("synthetic changed-hash total exceeds the checked bound")
+    return documents, changed_total
+
+
+def _observation(
+    replica: int,
+    campaign_id: str,
+    matrix_job_id: str,
+    environment_sha256: str,
+    schedule: Schedule,
+    indexes: Mapping[str, dict[str, Any]],
+    changed_total: int,
+) -> dict[str, Any]:
+    checkpoint_documents = []
+    for row in schedule.checkpoints:
+        path = (
+            f"page-indexes/replica-{replica:02d}/"
+            f"{row.ordinal:02d}-{row.checkpoint_id}.json"
+        )
+        retained = canonical_json_bytes(indexes[path])
+        checkpoint = checkpoint_document(row, _artifact_ref(path, retained))
+        reread_roles = tuple(
+            role
+            for role in ROLES
+            if not (row.checkpoint_id == "D_DROP" and role == "D")
+        )
+        checkpoint["dao_reread"] = [
+            {
+                "role": role,
+                "row_count": row.table_row_counts[role],
+                "rolling_sha256": expected_reread_sha256(
+                    role, row.table_row_counts[role]
+                ),
+            }
+            for role in reread_roles
+        ]
+        checkpoint_documents.append(checkpoint)
+    first = schedule.checkpoint("D_GROW_0128")
+    regrow = schedule.checkpoint("D_REGROW_0128")
+    document = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_replica_observation",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "producer_commit": _PRODUCER_COMMIT,
+        "repository_url": _REPOSITORY_URL,
+        "campaign_id": campaign_id,
+        "matrix_job": {
+            "job_id": matrix_job_id,
+            "replica_only": True,
+            "shared_mutable_state": False,
+        },
+        "environment_sha256": environment_sha256,
+        "provider_sha256": _PROVIDER_SHA256,
+        "replica": replica,
+        "role_binding": dict(ROLE_BINDINGS[replica - 1]),
+        "d_growth_observation": {
+            "first_baseline_pages": first.target_baseline_pages,
+            "first_target_pages": first.target_threshold_pages,
+            "first_achieved_pages": first.actual_file_pages,
+            "first_rows": first.table_row_counts["D"],
+            "regrowth_baseline_pages": schedule.checkpoint(
+                "D_RECREATE_EMPTY"
+            ).actual_file_pages,
+            "regrowth_target_pages": regrow.target_threshold_pages,
+            "regrowth_achieved_pages": regrow.actual_file_pages,
+            "regrowth_rows": regrow.table_row_counts["D"],
+        },
+        "logical_checkpoint_read_bytes": sum(
+            row.actual_file_pages * PAGE_SIZE for row in schedule.checkpoints
+        ),
+        "inserted_rows_total": max(
+            row.inserted_rows_total for row in schedule.checkpoints
+        ),
+        "changed_hash_entries": changed_total,
+        "checkpoints": checkpoint_documents,
+    }
+    validate_replica_observation(document)
+    return document
+
+
+def _manifest_entry(
+    path: str, role: str, payload: bytes
+) -> dict[str, Any]:
+    media = "application/octet-stream" if role == "page_blob" else "application/json"
+    return {
+        "path": path,
+        "role": role,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size_bytes": len(payload),
+        "media_type": media,
+    }
+
+
+def _replica_manifest(
+    replica: int,
+    campaign_id: str,
+    matrix_job_id: str,
+    environment_sha256: str,
+    environment: dict[str, Any],
+    observation: dict[str, Any],
+    indexes: Mapping[str, dict[str, Any]],
+    pages: PageFixture,
+) -> dict[str, Any]:
+    files = [
+        _manifest_entry(
+            f"environment/replica-{replica:02d}.json",
+            "environment",
+            canonical_json_bytes(environment),
+        ),
+        _manifest_entry(
+            f"observations/replica-{replica:02d}.json",
+            "replica_observation",
+            canonical_json_bytes(observation),
+        ),
+    ]
+    files.extend(
+        _manifest_entry(path, "page_index", canonical_json_bytes(document))
+        for path, document in indexes.items()
+    )
+    referenced = sorted(
+        {digest for hashes in pages.ordered_hashes.values() for digest in hashes}
+    )
+    files.extend(
+        _manifest_entry(
+            f"page-store/{digest}.page", "page_blob", pages.payloads[digest]
+        )
+        for digest in referenced
+    )
+    document = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_replica_artifact_manifest",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "producer_commit": _PRODUCER_COMMIT,
+        "campaign_id": campaign_id,
+        "matrix_job_id": matrix_job_id,
+        "replica": replica,
+        "environment_sha256": environment_sha256,
+        "provider_sha256": _PROVIDER_SHA256,
+        "checkpoint_count": len(CHECKPOINT_IDS),
+        "inventory_closed": True,
+        "hashes_verified": True,
+        "paths_closed": True,
+        "files": files,
+    }
+    validate_replica_artifact_manifest(document)
+    return document
+
+
+def generate_synthetic_bundle(
+    parameters: SyntheticParameters | None = None,
+    *,
+    replica: int = 1,
+) -> SyntheticBundle:
+    """Generate one validated in-memory A2 bundle view."""
+    if not 1 <= replica <= BOUNDS["replicas"]:
+        raise ValidationError("replica lies outside the checked A2 bounds")
+    selected = run12_calibration_parameters() if parameters is None else parameters
+    schedule = build_schedule(
+        delete_page_delta=selected.delete_page_delta, plan=_PLAN
+    )
+    pages = build_page_fixture(
+        schedule,
+        conversion_ordinal=selected.conversion_ordinal,
+        slot_activation_at_conversion=selected.slot_activation_at_conversion,
+        bit_polarity=selected.bit_polarity,
+        anchor_fill_state=selected.anchor_fill_state,
+        record_end_uniform_slack_bytes=selected.record_end_uniform_slack_bytes,
+    )
+    campaign_id, matrix_job_id = _identity(replica, selected)
+    environment = _environment(replica, campaign_id, matrix_job_id)
+    environment_sha256 = hashlib.sha256(
+        canonical_json_bytes(environment)
+    ).hexdigest()
+    indexes, changed_total = _page_indexes(
+        replica, campaign_id, environment_sha256, schedule, pages
+    )
+    observation = _observation(
+        replica,
+        campaign_id,
+        matrix_job_id,
+        environment_sha256,
+        schedule,
+        indexes,
+        changed_total,
+    )
+    manifest = _replica_manifest(
+        replica,
+        campaign_id,
+        matrix_job_id,
+        environment_sha256,
+        environment,
+        observation,
+        indexes,
+        pages,
+    )
+    documents: dict[str, dict[str, Any]] = {
+        f"environment/replica-{replica:02d}.json": environment,
+        f"observations/replica-{replica:02d}.json": observation,
+        f"replica-artifacts/replica-{replica:02d}-manifest.json": manifest,
+        **indexes,
+    }
+    return SyntheticBundle(
+        checkpoint_ids=CHECKPOINT_IDS,
+        page_count=MappingProxyType(
+            {
+                row.checkpoint_id: row.actual_file_pages
+                for row in schedule.checkpoints
+            }
+        ),
+        ordered_page_sha256=MappingProxyType(dict(pages.ordered_hashes)),
+        replica=replica,
+        parameters=selected,
+        schedule=schedule,
+        global_map=GlobalMapFixture(
+            pages.global_page,
+            *pages.global_record,
+            pages.inline_boundary,
+            selected.bit_polarity,
+            selected.conversion_ordinal,
+            pages.inline_base,
+            pages.extended_base_formula,
+        ),
+        tdef=TdefFixture(
+            pages.tdef_page,
+            *pages.tdef_record,
+            pages.pointer_layout,
+            pages.growth_pointer_offset,
+            pages.delete_reinsert_pointer_offset,
+        ),
+        documents=MappingProxyType(documents),
+        _payloads=MappingProxyType(dict(pages.payloads)),
+    )
+
+
+generate_fixture = generate_synthetic_bundle
+generate_bundle = generate_synthetic_bundle
+
+
+def run12_calibration_case(*, replica: int = 1) -> SyntheticBundle:
+    """Generate the plan's named non-evidential run-12 calibration case."""
+    return generate_synthetic_bundle(
+        run12_calibration_parameters(), replica=replica
+    )
+
+
+def generate_synthetic_bundles(
+    parameters: SyntheticParameters | None = None,
+) -> tuple[SyntheticBundle, ...]:
+    """Generate the three independent replica views declared by the plan."""
+    return tuple(
+        generate_synthetic_bundle(parameters, replica=replica)
+        for replica in range(1, BOUNDS["replicas"] + 1)
+    )
+
+
+def _write_unchanged_or_new(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if not path.is_file() or path.read_bytes() != payload:
+            raise ValidationError(
+                f"refusing to overwrite differing synthetic artifact {path}"
+            )
+        return
+    path.write_bytes(payload)
+
+
+def write_synthetic_bundle(root: Path, bundle: SyntheticBundle) -> None:
+    """Materialize one view without overwriting any differing existing file."""
+    root = root.resolve()
+    for path, document in bundle.documents.items():
+        _write_unchanged_or_new(root / path, canonical_json_bytes(document))
+    referenced = {
+        digest
+        for hashes in bundle.ordered_page_sha256.values()
+        for digest in hashes
+    }
+    for digest in referenced:
+        _write_unchanged_or_new(
+            root / f"page-store/{digest}.page", bundle.page_bytes(digest)
+        )
+
+
+def write_synthetic_bundles(
+    root: Path, parameters: SyntheticParameters | None = None
+) -> tuple[SyntheticBundle, ...]:
+    """Generate and materialize all plan-declared independent replicas."""
+    bundles = generate_synthetic_bundles(parameters)
+    for bundle in bundles:
+        write_synthetic_bundle(root, bundle)
+    return bundles
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        bundles = write_synthetic_bundles(args.output)
+    except (OSError, ValidationError) as exc:
+        parser.exit(1, f"A2 synthetic generation failed: {exc}\n")
+    unique_pages = len(
+        {digest for bundle in bundles for digest in bundle._payloads}
+    )
+    print(
+        f"wrote {len(bundles)} A2 synthetic replicas with "
+        f"{unique_pages} unique pages"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a2_generator_pages.py
+++ b/oracle/windows-dao/scripts/a2_generator_pages.py
@@ -1,0 +1,272 @@
+"""Synthetic global-map and TDEF page-state construction."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from a2_generator_schedule import Schedule
+from a2_spec import BASE_FORMULAS, BIT_POLARITIES, CHECKPOINT_IDS, PAGE_SIZE, POINTER_LAYOUTS, ROLES
+from protocol_validation import ValidationError
+
+
+@dataclass(frozen=True)
+class PageFixture:
+    ordered_hashes: dict[str, tuple[str, ...]]
+    payloads: dict[str, bytes]
+    global_page: int
+    tdef_page: int
+    global_record: tuple[int, int]
+    tdef_record: tuple[int, int]
+    growth_pointer_offset: int
+    delete_reinsert_pointer_offset: int
+    inline_boundary: int
+    inline_base: int
+    pointer_layout: str
+    extended_base_formula: str
+
+
+def _set_bit(payload: bytearray, byte_start: int, bit: int, value: bool) -> None:
+    offset, shift = divmod(bit, 8)
+    mask = 1 << shift
+    if value:
+        payload[byte_start + offset] |= mask
+    else:
+        payload[byte_start + offset] &= ~mask
+
+
+def _encode_reference(payload: bytearray, offset: int, page: int, slot: int, layout: str) -> None:
+    if layout == "u24le_page_then_u8_slot":
+        payload[offset : offset + 3] = page.to_bytes(3, "little")
+        payload[offset + 3] = slot
+    elif layout == "u8_slot_then_u24le_page":
+        payload[offset] = slot
+        payload[offset + 1 : offset + 4] = page.to_bytes(3, "little")
+    else:
+        raise ValidationError(f"unknown plan pointer layout {layout!r}")
+
+
+def _extended_page(
+    bit_polarity: str,
+    in_use_bits: range | tuple[int, ...],
+) -> bytes:
+    header_bytes = len(ROLES)
+    not_in_use_raw = 0xFF if bit_polarity == "set_means_not_in_use" else 0x00
+    payload = bytearray([not_in_use_raw]) * PAGE_SIZE
+    payload[:header_bytes] = bytes(header_bytes)
+    payload[0] = len(ROLES) + 1
+    in_use_bit = bit_polarity == "set_means_in_use"
+    capacity = (PAGE_SIZE - header_bytes) * 8
+    for bit in in_use_bits:
+        if not 0 <= bit < capacity:
+            raise ValidationError("synthetic extended-map bit exceeds its plan-derived page")
+        _set_bit(payload, header_bytes, bit, in_use_bit)
+    return bytes(payload)
+
+
+def build_page_fixture(
+    schedule: Schedule,
+    *,
+    conversion_ordinal: int | None,
+    slot_activation_at_conversion: int,
+    bit_polarity: str,
+    anchor_fill_state: str,
+    record_end_uniform_slack_bytes: int,
+) -> PageFixture:
+    """Build every checkpoint page state from schedule-derived quantities."""
+    if bit_polarity not in BIT_POLARITIES:
+        raise ValidationError("bit_polarity is absent from the checked plan")
+    if anchor_fill_state not in ("empty", "partial", "full"):
+        raise ValidationError("unknown anchor fill state")
+    if slot_activation_at_conversion not in (0, 1, 2):
+        raise ValidationError("slot activation count must be 0, 1, or 2")
+    if conversion_ordinal is not None and not 1 <= conversion_ordinal < len(CHECKPOINT_IDS):
+        raise ValidationError("conversion ordinal lies outside the A2 schedule")
+
+    physical_names = len(ROLES)
+    global_page = physical_names
+    tdef_page = global_page + int(global_page + 1 < schedule.initial_pages)
+    anchor_ordinal = (
+        len(CHECKPOINT_IDS) - 1
+        if conversion_ordinal is None
+        else conversion_ordinal - 1
+    )
+    anchor_pages = schedule.checkpoints[anchor_ordinal].actual_file_pages
+    type_bytes = int(bool(BASE_FORMULAS))
+    inline_base_bytes = len(ROLES)
+    maximum_bitmap_bytes = (
+        PAGE_SIZE
+        - type_bytes
+        - inline_base_bytes
+        - record_end_uniform_slack_bytes
+    )
+    bitmap_bytes = min(
+        maximum_bitmap_bytes,
+        max(1, (anchor_pages - 1) // 8),
+    )
+    bitmap_bits = bitmap_bytes * 8
+    record_bytes = (
+        type_bytes
+        + inline_base_bytes
+        + bitmap_bytes
+        + record_end_uniform_slack_bytes
+    )
+    global_start = PAGE_SIZE - record_bytes
+    if global_start < 0:
+        raise ValidationError("record-end slack exceeds the synthetic global page")
+    bitmap_start = global_start + type_bytes + inline_base_bytes
+    inline_boundary = PAGE_SIZE - record_end_uniform_slack_bytes
+    inline_base = {
+        "empty": anchor_pages,
+        "partial": max(1, anchor_pages - bitmap_bits // 2),
+        "full": max(1, anchor_pages - bitmap_bits),
+    }[anchor_fill_state]
+    tdef_start = len(ROLES) - len(ROLES)
+    stable_flank = int(schedule.batch_rows > 0)
+    pointer_bytes = len(ROLES) * 2
+    tdef_end = tdef_start + pointer_bytes + stable_flank
+    layout = POINTER_LAYOUTS[0]
+    growth_pointer = tdef_start
+    churn_pointer = growth_pointer + pointer_bytes // 2
+    not_in_use_raw = 0xFF if bit_polarity == "set_means_not_in_use" else 0x00
+
+    p_low = schedule.checkpoint("P_ABS_12288").target_threshold_pages
+    p_high = schedule.checkpoint("P_ABS_16480").target_threshold_pages
+    if p_low is None or p_high is None:
+        raise ValidationError("absolute plan targets are missing")
+    reference_pages = (p_low, p_high)
+    filler = bytearray(PAGE_SIZE)
+    filler[0] = len(ROLES) + stable_flank
+    filler_bytes = bytes(filler)
+    filler_hash = hashlib.sha256(filler_bytes).hexdigest()
+    payloads: dict[str, bytes] = {filler_hash: filler_bytes}
+    ordered: dict[str, tuple[str, ...]] = {}
+    growth_generation = 0
+    growth_reference_base = (
+        schedule.checkpoint("D_REGROW_0128").actual_file_pages
+        // len(BIT_POLARITIES)
+    )
+    stable_growth_ref = growth_reference_base
+    churn_ref = max(1, schedule.initial_pages - stable_flank)
+    d_checkpoints = {
+        "E0",
+        "E0R",
+        "D_GROW_0128",
+        "D_DROP",
+        "D_RECREATE_EMPTY",
+        "D_REGROW_0128",
+    }
+
+    for row in schedule.checkpoints:
+        checkpoint_id = row.checkpoint_id
+        global_payload = bytearray([0xA5]) * PAGE_SIZE
+        global_payload[global_start:PAGE_SIZE] = bytes(record_bytes)
+        indirect = (
+            conversion_ordinal is not None
+            and row.ordinal >= conversion_ordinal
+        )
+        global_payload[global_start] = int(indirect)
+        if indirect:
+            active = (
+                slot_activation_at_conversion
+                if row.ordinal == conversion_ordinal
+                else max(
+                    slot_activation_at_conversion,
+                    int(row.ordinal > conversion_ordinal),
+                )
+            )
+            if (
+                row.ordinal >= CHECKPOINT_IDS.index("H_REL_0904")
+                and row.ordinal > conversion_ordinal
+            ):
+                active = len(reference_pages)
+            for slot, reference in enumerate(reference_pages):
+                value = reference if slot < active else 0
+                offset = global_start + type_bytes + slot * len(ROLES)
+                global_payload[offset : offset + len(ROLES)] = value.to_bytes(
+                    len(ROLES), "little"
+                )
+        elif checkpoint_id in d_checkpoints:
+            global_payload[bitmap_start:PAGE_SIZE] = (
+                bytes([not_in_use_raw])
+                * (PAGE_SIZE - bitmap_start)
+            )
+            global_payload[
+                global_start + type_bytes : bitmap_start
+            ] = inline_base.to_bytes(inline_base_bytes, "little")
+            in_use_bit = bit_polarity == "set_means_in_use"
+            if checkpoint_id in ("D_GROW_0128", "D_REGROW_0128"):
+                _set_bit(global_payload, bitmap_start, 0, in_use_bit)
+            if checkpoint_id == "D_REGROW_0128":
+                _set_bit(
+                    global_payload,
+                    bitmap_start,
+                    bitmap_bits - 1,
+                    in_use_bit,
+                )
+        else:
+            global_payload[bitmap_start:inline_boundary] = (
+                bytes([not_in_use_raw]) * bitmap_bytes
+            )
+            global_payload[
+                global_start + type_bytes : bitmap_start
+            ] = inline_base.to_bytes(inline_base_bytes, "little")
+            represented = min(
+                bitmap_bits,
+                max(0, row.actual_file_pages - inline_base),
+            )
+            in_use_bit = bit_polarity == "set_means_in_use"
+            for page in range(represented):
+                _set_bit(global_payload, bitmap_start, page, in_use_bit)
+
+        tdef_payload = bytearray([0xFF]) * PAGE_SIZE
+        if checkpoint_id.startswith(("L_REL_", "H_REL_")):
+            growth_generation += 1
+            stable_growth_ref = min(
+                row.actual_file_pages - 1,
+                growth_reference_base + growth_generation,
+            )
+        growth_slot = growth_generation % (len(ROLES) * len(BIT_POLARITIES))
+        _encode_reference(tdef_payload, growth_pointer, stable_growth_ref, growth_slot, layout)
+        current_churn_ref = 0 if checkpoint_id == "L_DELETE_ALL" else churn_ref
+        _encode_reference(tdef_payload, churn_pointer, current_churn_ref, 1, layout)
+
+        page_hashes = [filler_hash] * row.actual_file_pages
+        for index, payload in ((global_page, bytes(global_payload)), (tdef_page, bytes(tdef_payload))):
+            digest = hashlib.sha256(payload).hexdigest()
+            payloads.setdefault(digest, payload)
+            page_hashes[index] = digest
+        if reference_pages[0] < row.actual_file_pages:
+            represented = min(
+                (PAGE_SIZE - len(ROLES)) * 8,
+                row.actual_file_pages - reference_pages[0],
+            )
+            payload = _extended_page(bit_polarity, range(represented))
+            digest = hashlib.sha256(payload).hexdigest()
+            payloads.setdefault(digest, payload)
+            page_hashes[reference_pages[0]] = digest
+        if reference_pages[1] < row.actual_file_pages:
+            payload = _extended_page(bit_polarity, ())
+            digest = hashlib.sha256(payload).hexdigest()
+            payloads.setdefault(digest, payload)
+            page_hashes[reference_pages[1]] = digest
+        ordered[checkpoint_id] = tuple(page_hashes)
+    return PageFixture(
+        ordered_hashes=ordered,
+        payloads=payloads,
+        global_page=global_page,
+        tdef_page=tdef_page,
+        global_record=(global_start, PAGE_SIZE),
+        tdef_record=(tdef_start, tdef_end),
+        growth_pointer_offset=growth_pointer,
+        delete_reinsert_pointer_offset=churn_pointer,
+        inline_boundary=inline_boundary,
+        inline_base=inline_base,
+        pointer_layout=layout,
+        extended_base_formula=next(
+            name
+            for name in BASE_FORMULAS
+            if name.startswith("referenced_page_relative")
+            and "off_by" not in name
+        ),
+    )

--- a/oracle/windows-dao/scripts/a2_generator_pages.py
+++ b/oracle/windows-dao/scripts/a2_generator_pages.py
@@ -64,6 +64,34 @@ def _extended_page(
     return bytes(payload)
 
 
+def _anchor_checkpoint_id(
+    schedule: Schedule, conversion_ordinal: int | None
+) -> str:
+    cutoff = len(CHECKPOINT_IDS) if conversion_ordinal is None else conversion_ordinal
+    predecessors = [
+        checkpoint_id
+        for checkpoint_id in schedule.conversion_window
+        if CHECKPOINT_IDS.index(checkpoint_id) < cutoff
+    ]
+    return predecessors[-1] if predecessors else schedule.conversion_window[0]
+
+
+def _active_slot_count(
+    row_ordinal: int,
+    conversion_ordinal: int,
+    requested_at_conversion: int,
+    final_ordinal: int,
+    slot_count: int,
+) -> int:
+    if row_ordinal == conversion_ordinal:
+        return requested_at_conversion
+    if conversion_ordinal >= final_ordinal:
+        return requested_at_conversion
+    if row_ordinal >= final_ordinal:
+        return slot_count
+    return max(requested_at_conversion, int(row_ordinal > conversion_ordinal))
+
+
 def build_page_fixture(
     schedule: Schedule,
     *,
@@ -86,12 +114,8 @@ def build_page_fixture(
     physical_names = len(ROLES)
     global_page = physical_names
     tdef_page = global_page + int(global_page + 1 < schedule.initial_pages)
-    anchor_ordinal = (
-        len(CHECKPOINT_IDS) - 1
-        if conversion_ordinal is None
-        else conversion_ordinal - 1
-    )
-    anchor_pages = schedule.checkpoints[anchor_ordinal].actual_file_pages
+    anchor_id = _anchor_checkpoint_id(schedule, conversion_ordinal)
+    anchor_pages = schedule.checkpoint(anchor_id).actual_file_pages
     type_bytes = int(bool(BASE_FORMULAS))
     inline_base_bytes = len(ROLES)
     maximum_bitmap_bytes = (
@@ -116,11 +140,7 @@ def build_page_fixture(
         raise ValidationError("record-end slack exceeds the synthetic global page")
     bitmap_start = global_start + type_bytes + inline_base_bytes
     inline_boundary = PAGE_SIZE - record_end_uniform_slack_bytes
-    inline_base = {
-        "empty": anchor_pages,
-        "partial": max(1, anchor_pages - bitmap_bits // 2),
-        "full": max(1, anchor_pages - bitmap_bits),
-    }[anchor_fill_state]
+    inline_base = max(1, anchor_pages - bitmap_bits)
     tdef_start = len(ROLES) - len(ROLES)
     stable_flank = int(schedule.batch_rows > 0)
     pointer_bytes = len(ROLES) * 2
@@ -167,19 +187,13 @@ def build_page_fixture(
         )
         global_payload[global_start] = int(indirect)
         if indirect:
-            active = (
-                slot_activation_at_conversion
-                if row.ordinal == conversion_ordinal
-                else max(
-                    slot_activation_at_conversion,
-                    int(row.ordinal > conversion_ordinal),
-                )
+            active = _active_slot_count(
+                row.ordinal,
+                conversion_ordinal,
+                slot_activation_at_conversion,
+                CHECKPOINT_IDS.index("H_REL_0904"),
+                len(reference_pages),
             )
-            if (
-                row.ordinal >= CHECKPOINT_IDS.index("H_REL_0904")
-                and row.ordinal > conversion_ordinal
-            ):
-                active = len(reference_pages)
             for slot, reference in enumerate(reference_pages):
                 value = reference if slot < active else 0
                 offset = global_start + type_bytes + slot * len(ROLES)

--- a/oracle/windows-dao/scripts/a2_generator_schedule.py
+++ b/oracle/windows-dao/scripts/a2_generator_schedule.py
@@ -25,6 +25,7 @@ class ScheduledCheckpoint:
 @dataclass(frozen=True)
 class Schedule:
     checkpoints: tuple[ScheduledCheckpoint, ...]
+    conversion_window: tuple[str, ...]
     batch_rows: int
     rows_per_page: int
     pages_per_batch: int
@@ -144,8 +145,14 @@ def build_schedule(*, delete_page_delta: int | None = None, plan: CheckedPlan | 
     regrowth = rows[CHECKPOINT_IDS.index("D_REGROW_0128")]
     if regrowth.actual_file_pages <= first_growth.actual_file_pages:
         raise ValidationError("synthetic D regrowth is not strictly larger than first growth")
+    conversion_window = tuple(
+        checked.document["checkpoint_design"]["transition_coverage"][
+            "inline_to_indirect_conversion_window"
+        ]
+    )
     return Schedule(
         tuple(rows),
+        conversion_window,
         batch_rows,
         rows_per_page,
         pages_per_batch,

--- a/oracle/windows-dao/scripts/a2_generator_schedule.py
+++ b/oracle/windows-dao/scripts/a2_generator_schedule.py
@@ -1,0 +1,177 @@
+"""Plan-derived schedule arithmetic for the A2 synthetic generator."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from a2_spec import BOUNDS, CHECKPOINT_IDS, PAGE_SIZE, ROLES, CheckedPlan, load_checked_plan
+from protocol_validation import ValidationError
+
+
+@dataclass(frozen=True)
+class ScheduledCheckpoint:
+    checkpoint_id: str
+    ordinal: int
+    actual_file_pages: int
+    target_baseline_pages: int | None
+    target_threshold_pages: int | None
+    target_overshoot_pages: int | None
+    inserted_rows_total: int
+    table_row_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class Schedule:
+    checkpoints: tuple[ScheduledCheckpoint, ...]
+    batch_rows: int
+    rows_per_page: int
+    pages_per_batch: int
+    initial_pages: int
+    delete_page_delta: int
+
+    def checkpoint(self, checkpoint_id: str) -> ScheduledCheckpoint:
+        return self.checkpoints[CHECKPOINT_IDS.index(checkpoint_id)]
+
+
+def _derived_storage_units(plan: CheckedPlan) -> tuple[int, int, int]:
+    fields = plan.document["tables"]["definition"]["fields"]
+    row_bytes = sum(field["size"] for field in fields)
+    rows_per_page = PAGE_SIZE // row_bytes
+    batch_rows = plan.document["tables"]["row_algorithm"]["growth_batch_rows"]
+    if rows_per_page < 1 or batch_rows < 1:
+        raise ValidationError("plan fields cannot produce bounded synthetic rows")
+    pages_per_batch = math.ceil(batch_rows / rows_per_page)
+    table_count = len(plan.document["tables"]["physical_names"])
+    initial_pages = table_count * (len(fields) + int(not plan.document["tables"]["definition"]["indexed"]))
+    return rows_per_page, pages_per_batch, initial_pages
+
+
+def build_schedule(*, delete_page_delta: int | None = None, plan: CheckedPlan | None = None) -> Schedule:
+    """Execute the frozen target rules using one derived 32-row storage batch."""
+    checked = load_checked_plan() if plan is None else plan
+    rows_per_page, pages_per_batch, pages = _derived_storage_units(checked)
+    batch_rows = checked.document["tables"]["row_algorithm"]["growth_batch_rows"]
+    if delete_page_delta is None:
+        delete_page_delta = int("delete every row" in checked.document["tables"]["row_algorithm"]["delete_rule"])
+    if isinstance(delete_page_delta, bool) or delete_page_delta < 0:
+        raise ValidationError("delete_page_delta must be a non-negative integer")
+
+    counts = {role: 0 for role in ROLES}
+    inserted_total = 0
+    rows: list[ScheduledCheckpoint] = []
+    baselines: dict[str, int] = {}
+    retained_l_rows = 0
+
+    def capture(checkpoint_id: str, baseline: int | None = None, threshold: int | None = None) -> None:
+        overshoot = None if threshold is None else pages - threshold
+        rows.append(
+            ScheduledCheckpoint(
+                checkpoint_id=checkpoint_id,
+                ordinal=len(rows),
+                actual_file_pages=pages,
+                target_baseline_pages=baseline,
+                target_threshold_pages=threshold,
+                target_overshoot_pages=overshoot,
+                inserted_rows_total=inserted_total,
+                table_row_counts=dict(counts),
+            )
+        )
+
+    def grow(role: str, threshold: int) -> None:
+        nonlocal pages, inserted_total
+        while pages < threshold:
+            counts[role] += batch_rows
+            inserted_total += batch_rows
+            pages += pages_per_batch
+            if (
+                pages > BOUNDS["max_final_pages_per_replica"]
+                or inserted_total > BOUNDS["max_inserted_rows_per_replica"]
+            ):
+                raise ValidationError("synthetic schedule exceeds the checked A2 bounds")
+
+    for checkpoint_id in CHECKPOINT_IDS:
+        if checkpoint_id in ("E0", "E0R"):
+            capture(checkpoint_id)
+        elif checkpoint_id == "D_GROW_0128":
+            baselines["D_FIRST"] = pages
+            threshold = pages + int(checkpoint_id.rsplit("_", 1)[1])
+            grow("D", threshold)
+            capture(checkpoint_id, baselines["D_FIRST"], threshold)
+        elif checkpoint_id == "D_DROP":
+            counts["D"] = 0
+            capture(checkpoint_id)
+        elif checkpoint_id == "D_RECREATE_EMPTY":
+            baselines["D_REGROW"] = pages
+            capture(checkpoint_id)
+        elif checkpoint_id == "D_REGROW_0128":
+            threshold = baselines["D_REGROW"] + int(checkpoint_id.rsplit("_", 1)[1])
+            grow("D", threshold)
+            capture(checkpoint_id, baselines["D_REGROW"], threshold)
+        elif checkpoint_id.startswith("L_REL_"):
+            baselines.setdefault("L", pages)
+            threshold = baselines["L"] + int(checkpoint_id.rsplit("_", 1)[1])
+            grow("L", threshold)
+            capture(checkpoint_id, baselines["L"], threshold)
+            retained_l_rows = counts["L"]
+        elif checkpoint_id == "L_DELETE_ALL":
+            counts["L"] = 0
+            pages += delete_page_delta
+            capture(checkpoint_id)
+        elif checkpoint_id == "L_REINSERT_SAME":
+            counts["L"] = retained_l_rows
+            inserted_total += retained_l_rows
+            capture(checkpoint_id)
+        elif checkpoint_id == "L_IDLE_REOPEN":
+            capture(checkpoint_id)
+        elif checkpoint_id.startswith("P_ABS_"):
+            threshold = int(checkpoint_id.rsplit("_", 1)[1])
+            grow("P", threshold)
+            capture(checkpoint_id, None, threshold)
+        elif checkpoint_id.startswith("H_REL_"):
+            baselines.setdefault("H", pages)
+            threshold = baselines["H"] + int(checkpoint_id.rsplit("_", 1)[1])
+            grow("H", threshold)
+            capture(checkpoint_id, baselines["H"], threshold)
+        elif checkpoint_id == "H_IDLE_REOPEN":
+            capture(checkpoint_id)
+        else:
+            raise ValidationError(f"unimplemented checked A2 checkpoint {checkpoint_id!r}")
+    if tuple(row.checkpoint_id for row in rows) != CHECKPOINT_IDS:
+        raise ValidationError("synthetic schedule did not execute the checked plan order")
+    first_growth = rows[CHECKPOINT_IDS.index("D_GROW_0128")]
+    regrowth = rows[CHECKPOINT_IDS.index("D_REGROW_0128")]
+    if regrowth.actual_file_pages <= first_growth.actual_file_pages:
+        raise ValidationError("synthetic D regrowth is not strictly larger than first growth")
+    return Schedule(
+        tuple(rows),
+        batch_rows,
+        rows_per_page,
+        pages_per_batch,
+        rows[0].actual_file_pages,
+        delete_page_delta,
+    )
+
+
+def checkpoint_document(row: ScheduledCheckpoint, page_index_ref: dict[str, Any]) -> dict[str, Any]:
+    """Render the schedule portion of one schema-shaped observation checkpoint."""
+    return {
+        "checkpoint_id": row.checkpoint_id,
+        "ordinal": row.ordinal,
+        "actual_file_pages": row.actual_file_pages,
+        "actual_size_bytes": row.actual_file_pages * PAGE_SIZE,
+        "target_baseline_pages": row.target_baseline_pages,
+        "target_threshold_pages": row.target_threshold_pages,
+        "target_overshoot_pages": row.target_overshoot_pages,
+        "inserted_rows_total": row.inserted_rows_total,
+        "table_row_counts": dict(row.table_row_counts),
+        "dao_reread": [],
+        "quiescent": True,
+        "post_close_companion": {
+            "present_after_close": False,
+            "observed_size_bytes": 0,
+            "retained_for_physical_analysis": False,
+        },
+        "page_index": page_index_ref,
+    }

--- a/oracle/windows-dao/scripts/a2_spec.py
+++ b/oracle/windows-dao/scripts/a2_spec.py
@@ -7,6 +7,7 @@ import argparse
 import functools
 import hashlib
 import json
+import re
 import stat
 import sys
 from dataclasses import dataclass
@@ -197,6 +198,61 @@ POINTER_LAYOUTS = tuple(_PLAN.document["hypotheses"]["tdef_pointer_layouts"])
 BASE_FORMULAS = tuple(_PLAN.document["hypotheses"]["extended_base_candidates"])
 
 
+def _conversion_ordinals(label: str) -> tuple[int, ...]:
+    source = _PLAN.document["analyzer_dry_run_contract"]["synthetic_input"][
+        "free_parameters"
+    ]["conversion_ordinal"]
+    match = re.search(rf"{re.escape(label)} ordinals 1\.\.([0-9]+)", source)
+    if match is None:
+        raise ValidationError(f"{label} conversion ordinal bound is absent from the plan")
+    return tuple(range(1, int(match.group(1)) + 1))
+
+
+def _run12_calibration() -> Mapping[str, Any]:
+    synthetic = _PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]
+    text = synthetic["run12_calibration_case"]
+    checkpoint_matches = [checkpoint for checkpoint in CHECKPOINT_IDS if checkpoint in text]
+    polarity_matches = [polarity for polarity in BIT_POLARITIES if polarity in text]
+    source_ordinal = re.search(r"source conversion ordinal ([0-9]+)", text)
+    delete_delta = re.search(r"delete page delta \+([0-9]+)", text)
+    slot_names = ("zero", "one", "two")
+    slot_matches = [
+        count
+        for count in synthetic["free_parameters"]["slot_activation_at_conversion"]
+        if count < len(slot_names) and f"{slot_names[count]} active slots" in text
+    ]
+    if (
+        len(checkpoint_matches) != 1
+        or len(polarity_matches) != 1
+        or len(slot_matches) != 1
+        or source_ordinal is None
+        or delete_delta is None
+    ):
+        raise ValidationError("run12_calibration_case is not mechanically parseable")
+    checkpoint = checkpoint_matches[0]
+    return MappingProxyType(
+        {
+            "source_conversion_ordinal": int(source_ordinal.group(1)),
+            "conversion_checkpoint_id": checkpoint,
+            "a2_conversion_ordinal": CHECKPOINT_ORDINALS[checkpoint],
+            "active_slot_count": slot_matches[0],
+            "bit_polarity": polarity_matches[0],
+            "delete_page_delta": int(delete_delta.group(1)),
+            "scientific_evidence": False,
+        }
+    )
+
+
+A2_CONVERSION_ORDINALS = _conversion_ordinals("A2")
+LEGACY_CONVERSION_ORDINALS = _conversion_ordinals("A1 legacy")
+require_equal(
+    A2_CONVERSION_ORDINALS,
+    tuple(range(1, len(CHECKPOINT_IDS))),
+    "A2 conversion ordinal schedule",
+)
+RUN12_CALIBRATION = _run12_calibration()
+
+
 def _schema(document: dict[str, Any], expected_type: str) -> None:
     require_equal(SCHEMAS.validate(document), expected_type, "$.document_type")
     if expected_type != "dao_a2_allocation_maps_plan":
@@ -274,6 +330,21 @@ def _is_target(checkpoint_id: str) -> bool:
     return checkpoint_id.startswith(("D_GROW_", "D_REGROW_", "L_REL_", "H_REL_", "P_ABS_"))
 
 
+def _relative_baseline_sources(checkpoint_ids: tuple[str, ...]) -> dict[str, str]:
+    family_sources: dict[str, str] = {}
+    result: dict[str, str] = {}
+    for ordinal, checkpoint_id in enumerate(checkpoint_ids):
+        if not _is_target(checkpoint_id) or checkpoint_id.startswith("P_ABS_"):
+            continue
+        family = checkpoint_id.rsplit("_", 1)[0]
+        if family not in family_sources:
+            if ordinal == 0:
+                raise ValidationError("relative target has no preceding baseline checkpoint")
+            family_sources[family] = checkpoint_ids[ordinal - 1]
+        result[checkpoint_id] = family_sources[family]
+    return result
+
+
 def validate_replica_observation(document: dict[str, Any], plan: CheckedPlan = _PLAN) -> dict[str, Any]:
     _schema(document, "dao_a2_replica_observation")
     replica = document["replica"]
@@ -283,6 +354,8 @@ def validate_replica_observation(document: dict[str, Any], plan: CheckedPlan = _
     logical_bytes = 0
     maximum_inserted = 0
     prior_inserted = 0
+    checkpoints_by_id = {row["checkpoint_id"]: row for row in checkpoints}
+    baseline_sources = _relative_baseline_sources(plan.checkpoint_ids)
     for ordinal, checkpoint in enumerate(checkpoints):
         location = f"$.checkpoints[{ordinal}]"
         checkpoint_id = checkpoint["checkpoint_id"]
@@ -301,6 +374,12 @@ def validate_replica_observation(document: dict[str, Any], plan: CheckedPlan = _
                 baseline = checkpoint["target_baseline_pages"]
                 if baseline is None:
                     raise ValidationError(f"{location}.target_baseline_pages: missing")
+                baseline_source = baseline_sources[checkpoint_id]
+                require_equal(
+                    baseline,
+                    checkpoints_by_id[baseline_source]["actual_file_pages"],
+                    f"{location}.target_baseline_pages",
+                )
                 expected_target = baseline + named
             require_equal(checkpoint["target_threshold_pages"], expected_target, f"{location}.target_threshold_pages")
             if checkpoint["actual_file_pages"] < expected_target:
@@ -616,8 +695,17 @@ def validate_dry_run_report(document: dict[str, Any]) -> dict[str, Any]:
             "hash_pinned_a2_plan_checkpoint_design",
             "$.checkpoint_schedule_source",
         )
-        require_equal(parameters["conversion_ordinals"], list(range(1, 71)), "$.parameter_coverage.conversion_ordinals")
+        require_equal(
+            parameters["conversion_ordinals"],
+            list(LEGACY_CONVERSION_ORDINALS),
+            "$.parameter_coverage.conversion_ordinals",
+        )
         require_equal(parameters["conversion_never"], True, "$.parameter_coverage.conversion_never")
+        require_equal(
+            parameters["run12_calibration"],
+            dict(RUN12_CALIBRATION),
+            "$.parameter_coverage.run12_calibration",
+        )
         parameter_bindings = (
             ("slot_activation_counts", "slot_activation_at_conversion"),
             ("bit_polarities", "bit_polarity"),

--- a/oracle/windows-dao/scripts/a2_spec.py
+++ b/oracle/windows-dao/scripts/a2_spec.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Fail-closed checked contract for DAO-A2-ALLOCATION-MAPS-001."""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import hashlib
+import json
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from protocol_validation import ProtocolSchemaSet, ValidationError, sha256
+
+DAO_ROOT = Path(__file__).resolve().parents[1]
+A2_ROOT = DAO_ROOT / "experiments" / "a2"
+CHECKED_PLAN = A2_ROOT / "a2-allocation-maps.plan.json"
+PLAN_SHA256 = "804e84dace5c423938f32dd350ebc778d43084d41db1da93f26f1777984480c2"
+EXPERIMENT_ID = "DAO-A2-ALLOCATION-MAPS-001"
+
+_SCHEMA_FILES = {
+    "dao_a2_allocation_maps_plan": "plan.schema.json",
+    "dao_a2_replica_observation": "replica-observation.schema.json",
+    "dao_a2_page_index": "page-index.schema.json",
+    "dao_a2_replica_artifact_manifest": "replica-artifact-manifest.schema.json",
+    "dao_a2_bundle_manifest": "bundle-manifest.schema.json",
+    "dao_a2_analysis_report": "analysis-report.schema.json",
+    "dao_a2_analyzer_dry_run_report": "dry-run-report.schema.json",
+    "dao_a2_holdout_structure_receipt": "holdout-structure-receipt.schema.json",
+    "dao_a2_environment": "environment.schema.json",
+}
+SCHEMA_SHA256: Mapping[str, str] = MappingProxyType(
+    {
+        "analysis-report.schema.json": "0f0e5d930a1da16de4a3df761f4797771d4f28a04c041a8276125e9ef7533e45",
+        "bundle-manifest.schema.json": "9725fc9ab1b2fb9a7b6dd596634410511f99755de1c616dd2c2d3491705734a1",
+        "dry-run-report.schema.json": "ac4972e9b5346afe370bebaa4237fbd43050d0546ad0a1395b3e590425b78bd0",
+        "environment.schema.json": "687e2984e3ba3e7e43b68317ad63f90cd03eb786fb570ab3c2cc1bd2b8b2451a",
+        "holdout-structure-receipt.schema.json": "5d67c196edc2b5281809e1a61e693f79d4aa4b4c109a99479e1d9236a4777376",
+        "page-index.schema.json": "a3cee31952d3d2adc2e6100973ef40ad0cb3366e8d7f4464b263eed2e4b99131",
+        "plan.schema.json": "492c7e4f2de84fd44468499900a70dc5b8e5e32ab3d8510792b49ae8a498cd21",
+        "replica-artifact-manifest.schema.json": "5f72af0c0d28cfbb7d4d5e7cf5c1479c74eaf5cf3407baf3e3113952ae2d8da7",
+        "replica-observation.schema.json": "f474fba5e2c526c26d2d6b9d3d45255cc97b98190faa13a1c41e30b21b5609c7",
+    }
+)
+SCHEMAS = ProtocolSchemaSet(A2_ROOT, _SCHEMA_FILES)
+
+
+def require_equal(actual: Any, expected: Any, location: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{location}: does not match the checked A2 plan")
+
+
+def load_bounded_json(path: Path, maximum: int = 64 * 1024 * 1024) -> dict[str, Any]:
+    """Load one regular, duplicate-key-free, bounded UTF-8 JSON object."""
+    try:
+        metadata = path.lstat()
+        reparse = bool(getattr(metadata, "st_file_attributes", 0) & 0x400)
+        if path.is_symlink() or reparse or not stat.S_ISREG(metadata.st_mode):
+            raise ValidationError(f"{path}: JSON input must be a regular file")
+        if metadata.st_size > maximum:
+            raise ValidationError(f"{path}: exceeds {maximum}-byte JSON ceiling")
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise ValidationError(f"{path}: cannot inspect JSON: {exc}") from exc
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise ValidationError(f"{path}: UTF-8 byte-order marks are forbidden")
+
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_nonfinite(value: str) -> None:
+        raise ValueError(f"non-finite JSON number {value}")
+
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=unique_object,
+            parse_constant=reject_nonfinite,
+        )
+    except (UnicodeError, json.JSONDecodeError, ValueError, RecursionError) as exc:
+        raise ValidationError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path}: JSON root must be an object")
+    return value
+
+
+@dataclass(frozen=True)
+class CheckedPlan:
+    """Validated plan plus its frequently consumed immutable projections."""
+
+    document: dict[str, Any]
+    checkpoint_ids: tuple[str, ...]
+    checkpoint_ordinals: Mapping[str, int]
+    predicate_ids: tuple[str, ...]
+    predicate_reasons: Mapping[str, str]
+    reason_predicates: Mapping[str, str]
+    bounds: Mapping[str, int]
+
+
+def _compile_plan(document: dict[str, Any]) -> CheckedPlan:
+    SCHEMAS.validate(document)
+    require_equal(document["experiment_id"], EXPERIMENT_ID, "$.experiment_id")
+    checkpoint_ids = tuple(document["checkpoint_design"]["checkpoint_ids"])
+    require_equal(
+        len(checkpoint_ids), document["checkpoint_design"]["count"],
+        "$.checkpoint_design.count",
+    )
+    require_equal(len(checkpoint_ids), len(set(checkpoint_ids)), "checkpoint uniqueness")
+    registry = document["predicate_registry"]
+    predicate_ids = tuple(registry["ids"])
+    mappings = registry["mappings"]
+    require_equal(
+        [row["predicate_id"] for row in mappings], list(predicate_ids),
+        "$.predicate_registry.mappings order",
+    )
+    reasons = [row["reason"] for row in mappings]
+    require_equal(len(reasons), len(set(reasons)), "predicate reason uniqueness")
+    require_equal(
+        set(reasons), set(document["decision_rules"]["no_scientific_outcome_identifiers"]),
+        "decision reason registry",
+    )
+    bounds = document["bounds"]
+    require_equal(bounds["page_size"], document["page_capture"]["page_size"], "page size")
+    require_equal(bounds["replicas"], document["replicas"]["count"], "replica bound")
+    require_equal(
+        bounds["planned_checkpoints_per_replica"], len(checkpoint_ids),
+        "planned checkpoint bound",
+    )
+    require_equal(
+        bounds["max_record_candidates_per_page"],
+        document["record_candidate_procedure"]["per_page_candidate_bound"],
+        "record candidate per-page bound",
+    )
+    require_equal(
+        bounds["max_record_candidates"],
+        document["record_candidate_procedure"]["combined_record_candidate_bound"],
+        "combined record candidate bound",
+    )
+    return CheckedPlan(
+        document=document,
+        checkpoint_ids=checkpoint_ids,
+        checkpoint_ordinals=MappingProxyType(
+            {checkpoint: ordinal for ordinal, checkpoint in enumerate(checkpoint_ids)}
+        ),
+        predicate_ids=predicate_ids,
+        predicate_reasons=MappingProxyType(
+            {row["predicate_id"]: row["reason"] for row in mappings}
+        ),
+        reason_predicates=MappingProxyType(
+            {row["reason"]: row["predicate_id"] for row in mappings}
+        ),
+        bounds=MappingProxyType(dict(bounds)),
+    )
+
+
+def load_checked_schemas() -> ProtocolSchemaSet:
+    """Hash-check and lint the complete closed A2 schema set."""
+    require_equal(set(_SCHEMA_FILES.values()), set(SCHEMA_SHA256), "schema pin set")
+    for name, expected in SCHEMA_SHA256.items():
+        require_equal(sha256(A2_ROOT / name), expected, name)
+    SCHEMAS.lint()
+    return SCHEMAS
+
+
+def load_checked_plan(path: Path = CHECKED_PLAN) -> CheckedPlan:
+    """Load the exact preregistered plan after schema and SHA-256 checks."""
+    load_checked_schemas()
+    require_equal(sha256(path), PLAN_SHA256, "preregistered plan sha256")
+    return _compile_plan(load_bounded_json(path))
+
+
+_PLAN = load_checked_plan()
+CHECKPOINT_IDS = _PLAN.checkpoint_ids
+CHECKPOINT_ORDINALS = _PLAN.checkpoint_ordinals
+PREDICATE_IDS = _PLAN.predicate_ids
+PREDICATE_REASONS = _PLAN.predicate_reasons
+REASON_PREDICATES = _PLAN.reason_predicates
+REASON_IDS = tuple(_PLAN.reason_predicates)
+BOUNDS = _PLAN.bounds
+PAGE_SIZE = BOUNDS["page_size"]
+ROLES = tuple(_PLAN.document["tables"]["roles"])
+ROLE_BINDINGS = tuple(
+    {role: row[role] for role in ROLES}
+    for row in _PLAN.document["tables"]["role_bindings"]
+)
+BIT_POLARITIES = tuple(_PLAN.document["hypotheses"]["bit_polarity_candidates"])
+POINTER_LAYOUTS = tuple(_PLAN.document["hypotheses"]["tdef_pointer_layouts"])
+BASE_FORMULAS = tuple(_PLAN.document["hypotheses"]["extended_base_candidates"])
+
+
+def _schema(document: dict[str, Any], expected_type: str) -> None:
+    require_equal(SCHEMAS.validate(document), expected_type, "$.document_type")
+    if expected_type != "dao_a2_allocation_maps_plan":
+        require_equal(document["plan_sha256"], PLAN_SHA256, "$.plan_sha256")
+
+
+def _file_entries(document: dict[str, Any], location: str) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    folded: set[str] = set()
+    for index, entry in enumerate(document["files"]):
+        path = entry["path"]
+        parts = Path(path).parts
+        if Path(path).is_absolute() or ".." in parts or "." in parts or "\\" in path:
+            raise ValidationError(f"{location}[{index}].path: unsafe locator")
+        if path in entries or path.casefold() in folded:
+            raise ValidationError(f"{location}: duplicate or case-colliding path {path!r}")
+        entries[path] = entry
+        folded.add(path.casefold())
+        media = {
+            "page_blob": "application/octet-stream",
+            "acquisition_log": "text/plain",
+        }.get(entry["role"], "application/json")
+        require_equal(entry["media_type"], media, f"{location}[{index}].media_type")
+        if entry["role"] == "page_blob":
+            require_equal(entry["size_bytes"], PAGE_SIZE, f"{location}[{index}].size_bytes")
+            require_equal(Path(path).stem, entry["sha256"], f"{location}[{index}].path")
+    return entries
+
+
+def validate_plan(document: dict[str, Any]) -> CheckedPlan:
+    """Validate an in-memory plan, including its pinned semantic projections."""
+    require_equal(document, _PLAN.document, "checked plan document")
+    return _compile_plan(document)
+
+
+def validate_environment(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a2_environment")
+    require_equal(
+        document["repository_url"],
+        _PLAN.document["repository_binding"]["canonical_https_url"],
+        "$.repository_url",
+    )
+    require_equal(
+        document["provider"]["prog_id"],
+        _PLAN.document["environment_binding"]["dao_prog_id"],
+        "$.provider.prog_id",
+    )
+    return document
+
+
+def expected_reread_sha256(role: str, row_count: int) -> str:
+    """Compute the exact plan-defined DAO reread digest."""
+    return _expected_reread_sha256(role, row_count)
+
+
+@functools.lru_cache(maxsize=4096)
+def _expected_reread_sha256(role: str, row_count: int) -> str:
+    if (
+        role not in ROLES
+        or isinstance(row_count, bool)
+        or not 0 <= row_count <= BOUNDS["max_inserted_rows_per_replica"]
+    ):
+        raise ValidationError("DAO reread digest request exceeds the row contract")
+    digest = hashlib.sha256()
+    for row_id in range(1, row_count + 1):
+        seed = f"A2|{role}|{row_id:010d}|".encode("ascii")
+        payload = (seed * ((240 + len(seed) - 1) // len(seed)))[:240]
+        digest.update(row_id.to_bytes(4, "little", signed=True))
+        digest.update(len(payload).to_bytes(2, "little"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _is_target(checkpoint_id: str) -> bool:
+    return checkpoint_id.startswith(("D_GROW_", "D_REGROW_", "L_REL_", "H_REL_", "P_ABS_"))
+
+
+def validate_replica_observation(document: dict[str, Any], plan: CheckedPlan = _PLAN) -> dict[str, Any]:
+    _schema(document, "dao_a2_replica_observation")
+    replica = document["replica"]
+    require_equal(document["role_binding"], ROLE_BINDINGS[replica - 1], "$.role_binding")
+    checkpoints = document["checkpoints"]
+    require_equal([row["checkpoint_id"] for row in checkpoints], list(plan.checkpoint_ids), "$.checkpoints order")
+    logical_bytes = 0
+    maximum_inserted = 0
+    prior_inserted = 0
+    for ordinal, checkpoint in enumerate(checkpoints):
+        location = f"$.checkpoints[{ordinal}]"
+        checkpoint_id = checkpoint["checkpoint_id"]
+        require_equal(checkpoint["ordinal"], ordinal, f"{location}.ordinal")
+        require_equal(
+            checkpoint["actual_size_bytes"],
+            checkpoint["actual_file_pages"] * PAGE_SIZE,
+            f"{location}.actual_size_bytes",
+        )
+        if _is_target(checkpoint_id):
+            named = int(checkpoint_id.rsplit("_", 1)[1])
+            if checkpoint_id.startswith("P_ABS_"):
+                require_equal(checkpoint["target_baseline_pages"], None, f"{location}.target_baseline_pages")
+                expected_target = named
+            else:
+                baseline = checkpoint["target_baseline_pages"]
+                if baseline is None:
+                    raise ValidationError(f"{location}.target_baseline_pages: missing")
+                expected_target = baseline + named
+            require_equal(checkpoint["target_threshold_pages"], expected_target, f"{location}.target_threshold_pages")
+            if checkpoint["actual_file_pages"] < expected_target:
+                raise ValidationError(f"{location}.actual_file_pages: target not reached")
+            require_equal(
+                checkpoint["target_overshoot_pages"],
+                checkpoint["actual_file_pages"] - expected_target,
+                f"{location}.target_overshoot_pages",
+            )
+        else:
+            for field in ("target_baseline_pages", "target_threshold_pages", "target_overshoot_pages"):
+                require_equal(checkpoint[field], None, f"{location}.{field}")
+        counts = checkpoint["table_row_counts"]
+        reread = checkpoint["dao_reread"]
+        reread_roles = [row["role"] for row in reread]
+        if len(reread_roles) != len(set(reread_roles)):
+            raise ValidationError(f"{location}.dao_reread: duplicate role")
+        expected_roles = tuple(
+            role
+            for role in ROLES
+            if not (checkpoint_id == "D_DROP" and role == "D")
+        )
+        require_equal(reread_roles, list(expected_roles), f"{location}.dao_reread roles")
+        for row in reread:
+            require_equal(row["row_count"], counts[row["role"]], f"{location}.dao_reread row_count")
+            require_equal(
+                row["rolling_sha256"],
+                expected_reread_sha256(row["role"], row["row_count"]),
+                f"{location}.dao_reread rolling_sha256",
+            )
+        inserted = checkpoint["inserted_rows_total"]
+        if inserted < prior_inserted or inserted % _PLAN.document["tables"]["row_algorithm"]["growth_batch_rows"]:
+            raise ValidationError(f"{location}.inserted_rows_total: invalid batch arithmetic")
+        if ordinal == 0:
+            require_equal(inserted, 0, f"{location}.inserted_rows_total")
+            require_equal(counts, {role: 0 for role in ROLES}, f"{location}.table_row_counts")
+        else:
+            prior_counts = checkpoints[ordinal - 1]["table_row_counts"]
+            inserted_delta = inserted - prior_inserted
+            positive_row_delta = sum(
+                max(0, counts[role] - prior_counts[role]) for role in ROLES
+            )
+            require_equal(inserted_delta, positive_row_delta, f"{location}.inserted_rows_total delta")
+            allowed_role = next(
+                (
+                    role
+                    for prefix, role in (
+                        ("D_GROW_", "D"),
+                        ("D_REGROW_", "D"),
+                        ("L_REL_", "L"),
+                        ("L_REINSERT_", "L"),
+                        ("P_ABS_", "P"),
+                        ("H_REL_", "H"),
+                    )
+                    if checkpoint_id.startswith(prefix)
+                ),
+                None,
+            )
+            for role in ROLES:
+                if role == allowed_role:
+                    continue
+                deleted_role = {
+                    "D_DROP": "D",
+                    "L_DELETE_ALL": "L",
+                }.get(checkpoint_id)
+                expected_count = 0 if role == deleted_role else prior_counts[role]
+                require_equal(counts[role], expected_count, f"{location}.table_row_counts.{role}")
+        prior_inserted = inserted
+        maximum_inserted = max(maximum_inserted, inserted)
+        expected_path = f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint_id}.json"
+        require_equal(checkpoint["page_index"]["path"], expected_path, f"{location}.page_index.path")
+        logical_bytes += checkpoint["actual_size_bytes"]
+    require_equal(document["logical_checkpoint_read_bytes"], logical_bytes, "$.logical_checkpoint_read_bytes")
+    require_equal(document["inserted_rows_total"], maximum_inserted, "$.inserted_rows_total")
+    d = document["d_growth_observation"]
+    first = checkpoints[CHECKPOINT_ORDINALS["D_GROW_0128"]]
+    recreated = checkpoints[CHECKPOINT_ORDINALS["D_RECREATE_EMPTY"]]
+    regrown = checkpoints[CHECKPOINT_ORDINALS["D_REGROW_0128"]]
+    require_equal(
+        d["first_baseline_pages"],
+        first["target_baseline_pages"],
+        "$.d_growth_observation.first_baseline_pages",
+    )
+    require_equal(d["first_target_pages"], first["target_threshold_pages"], "$.d_growth_observation.first_target_pages")
+    require_equal(d["first_achieved_pages"], first["actual_file_pages"], "$.d_growth_observation.first_achieved_pages")
+    require_equal(d["first_rows"], first["table_row_counts"]["D"], "$.d_growth_observation.first_rows")
+    require_equal(
+        d["regrowth_baseline_pages"],
+        recreated["actual_file_pages"],
+        "$.d_growth_observation.regrowth_baseline_pages",
+    )
+    require_equal(
+        d["regrowth_target_pages"],
+        regrown["target_threshold_pages"],
+        "$.d_growth_observation.regrowth_target_pages",
+    )
+    require_equal(
+        d["regrowth_achieved_pages"],
+        regrown["actual_file_pages"],
+        "$.d_growth_observation.regrowth_achieved_pages",
+    )
+    require_equal(d["regrowth_rows"], regrown["table_row_counts"]["D"], "$.d_growth_observation.regrowth_rows")
+    if regrown["actual_file_pages"] <= first["actual_file_pages"]:
+        raise ValidationError("D_REGROW_0128 must be strictly larger than D_GROW_0128")
+    return document
+
+
+def validate_page_index(
+    document: dict[str, Any],
+    observation: dict[str, Any] | None = None,
+    checkpoint: dict[str, Any] | None = None,
+    prior_hashes: list[str] | tuple[str, ...] | None = None,
+) -> list[str]:
+    """Validate one page index and, when supplied, its observation binding."""
+    _schema(document, "dao_a2_page_index")
+    ordinal = document["ordinal"]
+    require_equal(document["checkpoint_id"], CHECKPOINT_IDS[ordinal], "$.checkpoint_id")
+    require_equal(
+        document["predecessor_checkpoint_id"],
+        None if ordinal == 0 else CHECKPOINT_IDS[ordinal - 1],
+        "$.predecessor_checkpoint_id",
+    )
+    hashes = document["ordered_page_sha256"]
+    require_equal(len(hashes), document["page_count"], "$.ordered_page_sha256")
+    require_equal(document["file_size_bytes"], len(hashes) * PAGE_SIZE, "$.file_size_bytes")
+    changed = document["changed_page_indices"]
+    require_equal(changed, sorted(changed), "$.changed_page_indices order")
+    if prior_hashes is not None:
+        expected_changed = [
+            index
+            for index in range(max(len(prior_hashes), len(hashes)))
+            if index >= len(prior_hashes)
+            or index >= len(hashes)
+            or prior_hashes[index] != hashes[index]
+        ]
+        require_equal(changed, expected_changed, "$.changed_page_indices")
+    if observation is not None:
+        for key in ("producer_commit", "campaign_id", "environment_sha256", "provider_sha256", "replica"):
+            require_equal(document[key], observation[key], f"$.{key}")
+    if checkpoint is not None:
+        bindings = (
+            ("checkpoint_id", checkpoint["checkpoint_id"]),
+            ("ordinal", checkpoint["ordinal"]),
+            ("page_count", checkpoint["actual_file_pages"]),
+            ("file_size_bytes", checkpoint["actual_size_bytes"]),
+        )
+        for key, expected in bindings:
+            require_equal(document[key], expected, f"$.{key}")
+    return hashes
+
+
+def validate_replica_artifact_manifest(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a2_replica_artifact_manifest")
+    entries = _file_entries(document, "$.files")
+    replica = document["replica"]
+    roles = [entry["role"] for entry in entries.values()]
+    require_equal(roles.count("environment"), 1, "environment file count")
+    require_equal(roles.count("replica_observation"), 1, "observation file count")
+    require_equal(roles.count("page_index"), len(CHECKPOINT_IDS), "page-index file count")
+    if roles.count("page_blob") < 1:
+        raise ValidationError("$.files: replica artifact requires page blobs")
+    return document
+
+
+def validate_bundle_manifest(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a2_bundle_manifest")
+    entries = _file_entries(document, "$.files")
+    roles = [entry["role"] for entry in entries.values()]
+    expected_counts = {
+        "plan": 1,
+        "environment": BOUNDS["replicas"],
+        "replica_artifact_manifest": BOUNDS["replicas"],
+        "replica_observation": BOUNDS["replicas"],
+        "page_index": BOUNDS["replicas"] * len(CHECKPOINT_IDS),
+        "frozen_candidate_set": 1,
+        "analysis_report": 1,
+        "holdout_structure_receipt": 1,
+    }
+    for role, expected in expected_counts.items():
+        require_equal(roles.count(role), expected, f"{role} file count")
+    require_equal(roles.count("page_blob"), document["page_blob_count"], "$.page_blob_count")
+    require_equal(
+        sum(entry["size_bytes"] for entry in entries.values()),
+        document["bundle_size_bytes_excluding_manifest"],
+        "$.bundle_size_bytes_excluding_manifest",
+    )
+    decisive = document["analysis_scientific_outcome"] == "one_or_more_submodels_predict_holdout"
+    expected_status = (
+        "decisive_pending_independent_validation"
+        if decisive
+        else "complete_no_scientific_outcome"
+    )
+    require_equal(document["bundle_status"], expected_status, "$.bundle_status")
+    return document
+
+
+def _layer_rows(document: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    return [
+        ("global_map_record", document["submodels"]["global_map"]["record"]),
+        ("global_map_conversion_inline", document["submodels"]["global_map"]["conversion_inline"]),
+        ("global_map_extended_base", document["submodels"]["global_map"]["extended_base"]),
+        ("tdef_pointer_pair", document["submodels"]["tdef"]["pointer_pair"]),
+    ]
+
+
+def validate_analysis_report(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a2_analysis_report")
+    results = document["predicate_results"]
+    result_ids = [row["predicate_id"] for row in results]
+    if len(result_ids) != len(set(result_ids)):
+        raise ValidationError("$.predicate_results: predicate ids must be unique")
+    mapping_rows = {row["predicate_id"]: row for row in _PLAN.document["predicate_registry"]["mappings"]}
+    for index, result in enumerate(results):
+        expected_layer = mapping_rows[result["predicate_id"]]["layer"]
+        require_equal(result["layer"], expected_layer, f"$.predicate_results[{index}].layer")
+    terminal_ids = set(document["terminal_predicate_ids"])
+    failed_ids = {row["predicate_id"] for row in results if row["status"] == "fail"}
+    require_equal(terminal_ids, failed_ids, "terminal predicate failures")
+    expected_reasons = {PREDICATE_REASONS[predicate] for predicate in terminal_ids}
+    require_equal(set(document["no_outcome_reasons"]), expected_reasons, "$.no_outcome_reasons")
+    decisive_layers = 0
+    layer_reasons: set[str] = set()
+    for name, layer in _layer_rows(document):
+        require_equal(
+            layer["derivation_survivor_count"],
+            document["derivation_survivor_counts"][name],
+            f"{name} survivor count",
+        )
+        status = layer["status"]
+        if status == "decisive_predicts_holdout":
+            decisive_layers += 1
+            if (
+                layer["model"] is None
+                or layer["derivation_survivor_count"] != 1
+                or not layer["holdout_evaluated"]
+                or layer["no_outcome_reasons"]
+            ):
+                raise ValidationError(f"{name}: malformed decisive layer")
+        elif status == "no_outcome":
+            if layer["model"] is not None or not layer["no_outcome_reasons"]:
+                raise ValidationError(f"{name}: malformed no-outcome layer")
+        elif any(
+            (
+                layer["model"] is not None,
+                layer["derivation_survivor_count"],
+                layer["holdout_evaluated"],
+                layer["no_outcome_reasons"],
+            )
+        ):
+            raise ValidationError(f"{name}: malformed not-applicable layer")
+        layer_reasons.update(layer["no_outcome_reasons"])
+    decisive = document["scientific_outcome"] == "one_or_more_submodels_predict_holdout"
+    require_equal(decisive, decisive_layers > 0, "$.scientific_outcome")
+    require_equal(
+        document["holdout_evaluated"],
+        any(layer["holdout_evaluated"] for _, layer in _layer_rows(document)),
+        "$.holdout_evaluated",
+    )
+    if not layer_reasons <= expected_reasons:
+        raise ValidationError("layer reasons are absent from terminal predicate results")
+    conversion = document["submodels"]["global_map"]["conversion_inline"]["model"]
+    global_record = document["submodels"]["global_map"]["record"]["model"]
+    if conversion is not None:
+        require_equal(
+            conversion["conversion_checkpoint_id"],
+            CHECKPOINT_IDS[conversion["conversion_ordinal"]],
+            "conversion checkpoint identity",
+        )
+        if global_record is None:
+            raise ValidationError("conversion layer requires a frozen global record")
+        record = global_record["record"]
+        if not record["start"] + 5 <= conversion["inline_boundary"] <= record["end"]:
+            raise ValidationError("conversion inline boundary lies outside the global record")
+        require_equal(
+            len(conversion["slot_reference_pages"]),
+            conversion["active_slot_count_at_h_rel_0904"],
+            "conversion slot references",
+        )
+    base_model = document["submodels"]["global_map"]["extended_base"]["model"]
+    if base_model is not None and conversion is None:
+        raise ValidationError("extended-base layer requires a frozen conversion")
+    tdef_model = document["submodels"]["tdef"]["pointer_pair"]["model"]
+    if tdef_model is not None:
+        record = tdef_model["record"]
+        offsets = (
+            tdef_model["growth_pointer_offset"],
+            tdef_model["delete_reinsert_pointer_offset"],
+        )
+        if offsets[0] == offsets[1] or any(
+            not record["start"] <= offset <= record["end"] - 4
+            for offset in offsets
+        ):
+            raise ValidationError("TDEF pointer windows are not distinct and contained")
+    for _, layer in _layer_rows(document):
+        model = layer["model"]
+        if model is not None and "record" in model:
+            record = model["record"]
+            if record["start"] >= record["end"]:
+                raise ValidationError("layer record interval is empty")
+    require_equal(document["claims"], {key: _PLAN.document["claims"][key] for key in document["claims"]}, "$.claims")
+    return document
+
+
+def validate_dry_run_report(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a2_analyzer_dry_run_report")
+    if document["result"] != "pass":
+        return document
+    parameters = document["parameter_coverage"]
+    synthetic = _PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]
+    if document["source_kind"] == "a2_schedule_synthetic":
+        require_equal(
+            document["checkpoint_schedule_source"],
+            "hash_pinned_a2_plan_checkpoint_design",
+            "$.checkpoint_schedule_source",
+        )
+        require_equal(parameters["conversion_ordinals"], list(range(1, 71)), "$.parameter_coverage.conversion_ordinals")
+        require_equal(parameters["conversion_never"], True, "$.parameter_coverage.conversion_never")
+        parameter_bindings = (
+            ("slot_activation_counts", "slot_activation_at_conversion"),
+            ("bit_polarities", "bit_polarity"),
+            ("anchor_fill_states", "anchor_fill_state"),
+            (
+                "record_end_uniform_slack_bytes",
+                "record_end_uniform_slack_bytes",
+            ),
+        )
+        for report_key, plan_key in parameter_bindings:
+            require_equal(
+                parameters[report_key],
+                synthetic["free_parameters"][plan_key],
+                f"$.parameter_coverage.{report_key}",
+            )
+        require_equal(
+            set(document["predicted_terminal_states"]),
+            set(synthetic["required_cases"]),
+            "$.predicted_terminal_states",
+        )
+        require_equal(set(document["terminal_predicate_ids"]), set(PREDICATE_IDS), "$.terminal_predicate_ids")
+        if document["source_identity"]["generator_sha256"] is None:
+            raise ValidationError("synthetic dry run requires a generator hash")
+    else:
+        require_equal(
+            document["checkpoint_schedule_source"],
+            "explicit_a1_legacy_projection",
+            "$.checkpoint_schedule_source",
+        )
+        blob_ceiling = _PLAN.document["analyzer_dry_run_contract"][
+            "retained_a1_input"
+        ]["max_input_page_blobs"]
+        if document["input_page_blob_count"] > blob_ceiling:
+            raise ValidationError("$.input_page_blob_count: exceeds the plan ceiling")
+        require_equal(document["source_identity"]["generator_sha256"], None, "$.source_identity.generator_sha256")
+    return document
+
+
+def validate_holdout_structure_receipt(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a2_holdout_structure_receipt")
+    require_equal(document["replica"], _PLAN.document["replicas"]["holdout"], "$.replica")
+    return document
+
+
+_VALIDATORS = {
+    "dao_a2_allocation_maps_plan": validate_plan,
+    "dao_a2_replica_observation": validate_replica_observation,
+    "dao_a2_page_index": validate_page_index,
+    "dao_a2_replica_artifact_manifest": validate_replica_artifact_manifest,
+    "dao_a2_bundle_manifest": validate_bundle_manifest,
+    "dao_a2_analysis_report": validate_analysis_report,
+    "dao_a2_analyzer_dry_run_report": validate_dry_run_report,
+    "dao_a2_holdout_structure_receipt": validate_holdout_structure_receipt,
+    "dao_a2_environment": validate_environment,
+}
+
+
+def validate_document(document: dict[str, Any]) -> Any:
+    """Dispatch an A2 document to its schema and semantic validator."""
+    try:
+        validator = _VALIDATORS[document.get("document_type")]
+    except (AttributeError, KeyError) as exc:
+        raise ValidationError("unknown A2 document type") from exc
+    return validator(document)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=CHECKED_PLAN)
+    args = parser.parse_args(argv)
+    try:
+        document = load_bounded_json(args.path, BOUNDS["max_json_bytes"])
+        validate_document(document)
+    except ValidationError as exc:
+        print(f"A2 validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"A2 validation passed: {args.path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/tests/test_a2_spec_generator.py
+++ b/oracle/windows-dao/tests/test_a2_spec_generator.py
@@ -247,32 +247,67 @@ class A2SpecGeneratorTests(unittest.TestCase):
         legacy = {item.conversion_ordinal for item in iter_parameter_combinations(legacy_projection=True)}
         self.assertEqual(legacy, set(LEGACY_CONVERSION_ORDINALS) | {None})
 
-    def test_anchor_fill_and_slack_do_not_move_declared_boundary_formula(self) -> None:
+    def test_anchor_fill_and_slack_do_not_rewrite_the_inline_extent(self) -> None:
         baseline = run12_calibration_parameters()
         free = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
-        for fill in free["anchor_fill_state"]:
-            for slack in free["record_end_uniform_slack_bytes"]:
+        for slack in free["record_end_uniform_slack_bytes"]:
+            fixtures = []
+            for fill in free["anchor_fill_state"]:
                 parameters = replace(
                     baseline,
                     anchor_fill_state=fill,
                     record_end_uniform_slack_bytes=slack,
                 )
                 bundle = generate_synthetic_bundle(parameters)
+                fixtures.append(bundle)
                 self.assertEqual(bundle.global_map.record_end, PAGE_SIZE)
                 self.assertEqual(bundle.global_map.inline_boundary, PAGE_SIZE - slack)
-                anchor_id = CHECKPOINT_IDS[baseline.conversion_ordinal - 1]
-                payload = bundle.page_bytes(
-                    bundle.ordered_page_sha256[anchor_id][bundle.global_map.page]
+            first = fixtures[0]
+            for bundle in fixtures[1:]:
+                self.assertEqual(bundle.global_map.inline_base, first.global_map.inline_base)
+                self.assertEqual(bundle.global_map.record_start, first.global_map.record_start)
+
+    def test_conversion_anchor_uses_the_applicable_window_predecessor(self) -> None:
+        conversion_id = "L_REINSERT_SAME"
+        conversion = CHECKPOINT_ORDINALS[conversion_id]
+        parameters = replace(
+            run12_calibration_parameters(), conversion_ordinal=conversion
+        )
+        bundle = generate_synthetic_bundle(parameters)
+        window = self.plan.document["checkpoint_design"]["transition_coverage"][
+            "inline_to_indirect_conversion_window"
+        ]
+        anchor_id = next(
+            checkpoint_id
+            for checkpoint_id in reversed(window)
+            if CHECKPOINT_ORDINALS[checkpoint_id] < conversion
+        )
+        bitmap_start = bundle.global_map.record_start + 1 + len(ROLES)
+        capacity = (bundle.global_map.inline_boundary - bitmap_start) * 8
+        expected_base = max(1, bundle.page_count[anchor_id] - capacity)
+        self.assertEqual(anchor_id, "L_REL_1280")
+        self.assertEqual(bundle.global_map.inline_base, expected_base)
+
+    def test_final_slot_state_is_stable_through_the_idle_reopen(self) -> None:
+        final_id = "H_REL_0904"
+        idle_id = "H_IDLE_REOPEN"
+        baseline = run12_calibration_parameters()
+        for slots in self.plan.document["analyzer_dry_run_contract"][
+            "synthetic_input"
+        ]["free_parameters"]["slot_activation_at_conversion"]:
+            bundle = generate_synthetic_bundle(
+                replace(
+                    baseline,
+                    conversion_ordinal=CHECKPOINT_ORDINALS[final_id],
+                    slot_activation_at_conversion=slots,
                 )
-                bitmap = bundle.global_map.record_start + 1 + len(ROLES)
-                capacity = (bundle.global_map.inline_boundary - bitmap) * 8
-                in_use = 0
-                for bit in range(capacity):
-                    byte, shift = divmod(bit, 8)
-                    is_set = bool(payload[bitmap + byte] & (1 << shift))
-                    in_use += is_set if parameters.bit_polarity == "set_means_in_use" else not is_set
-                expected = {"empty": 0, "partial": capacity // 2, "full": capacity}[fill]
-                self.assertEqual(in_use, expected)
+            )
+            self.assertEqual(
+                bundle.ordered_page_sha256[final_id],
+                bundle.ordered_page_sha256[idle_id],
+            )
+            self.assertEqual(self._active_slot_count(bundle, final_id), slots)
+            self.assertEqual(self._active_slot_count(bundle, idle_id), slots)
 
     def test_conversion_and_slot_parameters_are_encoded_at_the_requested_ordinal(self) -> None:
         baseline = run12_calibration_parameters()

--- a/oracle/windows-dao/tests/test_a2_spec_generator.py
+++ b/oracle/windows-dao/tests/test_a2_spec_generator.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -15,24 +17,26 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 from a2_generator import (  # noqa: E402
-    SyntheticParameters,
     generate_synthetic_bundle,
     iter_parameter_combinations,
     run12_calibration_parameters,
     write_synthetic_bundle,
 )
 from a2_spec import (  # noqa: E402
+    A2_CONVERSION_ORDINALS,
     BIT_POLARITIES,
     BOUNDS,
     CHECKPOINT_IDS,
     CHECKPOINT_ORDINALS,
     EXPERIMENT_ID,
+    LEGACY_CONVERSION_ORDINALS,
     PAGE_SIZE,
     PLAN_SHA256,
     POINTER_LAYOUTS,
     PREDICATE_IDS,
     REASON_IDS,
     ROLES,
+    RUN12_CALIBRATION,
     load_bounded_json,
     load_checked_plan,
     validate_analysis_report,
@@ -42,6 +46,7 @@ from a2_spec import (  # noqa: E402
     validate_holdout_structure_receipt,
     validate_page_index,
 )
+from protocol_validation import ValidationError  # noqa: E402
 
 
 class A2SpecGeneratorTests(unittest.TestCase):
@@ -75,6 +80,18 @@ class A2SpecGeneratorTests(unittest.TestCase):
         self.assertEqual(PREDICATE_IDS, tuple(document["predicate_registry"]["ids"]))
         self.assertEqual(set(REASON_IDS), set(document["decision_rules"]["no_scientific_outcome_identifiers"]))
         self.assertEqual(BOUNDS, document["bounds"])
+
+    def test_run12_calibration_uses_checkpoint_identity(self) -> None:
+        parameters = run12_calibration_parameters()
+        checkpoint = RUN12_CALIBRATION["conversion_checkpoint_id"]
+        self.assertEqual(
+            parameters.conversion_ordinal,
+            CHECKPOINT_ORDINALS[checkpoint],
+        )
+        self.assertEqual(
+            RUN12_CALIBRATION["a2_conversion_ordinal"],
+            CHECKPOINT_ORDINALS[checkpoint],
+        )
 
     def test_schedule_produces_d_abac_with_larger_regrowth(self) -> None:
         a = self._global_in_use("E0")
@@ -125,6 +142,20 @@ class A2SpecGeneratorTests(unittest.TestCase):
             schedule.checkpoint("D_RECREATE_EMPTY").actual_file_pages,
         )
 
+    def test_observation_rejects_a_self_consistent_but_wrong_relative_baseline(self) -> None:
+        observation = copy.deepcopy(
+            self.bundle.documents["observations/replica-01.json"]
+        )
+        checkpoint = observation["checkpoints"][CHECKPOINT_ORDINALS["D_GROW_0128"]]
+        checkpoint["target_baseline_pages"] -= 1
+        checkpoint["target_threshold_pages"] -= 1
+        checkpoint["target_overshoot_pages"] += 1
+        growth = observation["d_growth_observation"]
+        growth["first_baseline_pages"] = checkpoint["target_baseline_pages"]
+        growth["first_target_pages"] = checkpoint["target_threshold_pages"]
+        with self.assertRaises(ValidationError):
+            validate_document(observation)
+
     def test_tdef_growth_and_churn_windows_are_transition_selective(self) -> None:
         fixture = self.bundle.tdef
         pointer_bytes = len(ROLES)
@@ -148,7 +179,7 @@ class A2SpecGeneratorTests(unittest.TestCase):
 
     def test_extended_maps_include_slot_zero_and_exact_growth_discriminators(self) -> None:
         global_fixture = self.bundle.global_map
-        conversion = "P_ABS_16480"
+        conversion = RUN12_CALIBRATION["conversion_checkpoint_id"]
         global_payload = self._payload(conversion, global_fixture.page)
         slots = global_fixture.record_start + 1
         references = [
@@ -212,22 +243,19 @@ class A2SpecGeneratorTests(unittest.TestCase):
         self.assertEqual(len(combinations), expected)
         self.assertEqual(len(combinations), len(set(combinations)))
         conversions = {item.conversion_ordinal for item in combinations}
-        self.assertEqual(conversions, set(range(1, len(CHECKPOINT_IDS))) | {None})
+        self.assertEqual(conversions, set(A2_CONVERSION_ORDINALS) | {None})
         legacy = {item.conversion_ordinal for item in iter_parameter_combinations(legacy_projection=True)}
-        self.assertEqual(legacy, set(range(1, 71)) | {None})
+        self.assertEqual(legacy, set(LEGACY_CONVERSION_ORDINALS) | {None})
 
     def test_anchor_fill_and_slack_do_not_move_declared_boundary_formula(self) -> None:
         baseline = run12_calibration_parameters()
         free = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
         for fill in free["anchor_fill_state"]:
             for slack in free["record_end_uniform_slack_bytes"]:
-                parameters = SyntheticParameters(
-                    baseline.conversion_ordinal,
-                    baseline.slot_activation_at_conversion,
-                    baseline.bit_polarity,
-                    fill,
-                    slack,
-                    baseline.delete_page_delta,
+                parameters = replace(
+                    baseline,
+                    anchor_fill_state=fill,
+                    record_end_uniform_slack_bytes=slack,
                 )
                 bundle = generate_synthetic_bundle(parameters)
                 self.assertEqual(bundle.global_map.record_end, PAGE_SIZE)
@@ -248,36 +276,38 @@ class A2SpecGeneratorTests(unittest.TestCase):
 
     def test_conversion_and_slot_parameters_are_encoded_at_the_requested_ordinal(self) -> None:
         baseline = run12_calibration_parameters()
-        for ordinal in (1, len(CHECKPOINT_IDS) // 2, len(CHECKPOINT_IDS) - 1):
-            for slots in self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]["slot_activation_at_conversion"]:
-                parameters = SyntheticParameters(
-                    ordinal,
-                    slots,
-                    baseline.bit_polarity,
-                    baseline.anchor_fill_state,
-                    baseline.record_end_uniform_slack_bytes,
-                    baseline.delete_page_delta,
-                )
-                bundle = generate_synthetic_bundle(parameters)
-                before = CHECKPOINT_IDS[ordinal - 1]
-                at = CHECKPOINT_IDS[ordinal]
-                self.assertEqual(self._tag(bundle, before), 0)
-                self.assertEqual(self._tag(bundle, at), 1)
-                self.assertEqual(self._active_slot_count(bundle, at), slots)
-                if ordinal <= CHECKPOINT_ORDINALS["H_REL_0904"]:
-                    self.assertEqual(
-                        self._active_slot_count(bundle, "H_REL_0904"), 2
-                    )
-        never = SyntheticParameters(
-            None,
-            baseline.slot_activation_at_conversion,
-            baseline.bit_polarity,
-            baseline.anchor_fill_state,
-            baseline.record_end_uniform_slack_bytes,
-            baseline.delete_page_delta,
-        )
-        bundle = generate_synthetic_bundle(never)
-        self.assertTrue(all(self._tag(bundle, checkpoint) == 0 for checkpoint in CHECKPOINT_IDS))
+        free = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"][
+            "free_parameters"
+        ]
+        conversion_values = (*A2_CONVERSION_ORDINALS, None)
+        for ordinal in conversion_values:
+            for slots in free["slot_activation_at_conversion"]:
+                for polarity in free["bit_polarity"]:
+                    with self.subTest(ordinal=ordinal, slots=slots, polarity=polarity):
+                        parameters = replace(
+                            baseline,
+                            conversion_ordinal=ordinal,
+                            slot_activation_at_conversion=slots,
+                            bit_polarity=polarity,
+                        )
+                        bundle = generate_synthetic_bundle(parameters)
+                        if ordinal is None:
+                            self.assertTrue(
+                                all(
+                                    self._tag(bundle, checkpoint) == 0
+                                    for checkpoint in CHECKPOINT_IDS
+                                )
+                            )
+                            continue
+                        before = CHECKPOINT_IDS[ordinal - 1]
+                        at = CHECKPOINT_IDS[ordinal]
+                        self.assertEqual(self._tag(bundle, before), 0)
+                        self.assertEqual(self._tag(bundle, at), 1)
+                        self.assertEqual(self._active_slot_count(bundle, at), slots)
+                        if ordinal < CHECKPOINT_ORDINALS["H_REL_0904"]:
+                            self.assertEqual(
+                                self._active_slot_count(bundle, "H_REL_0904"), 2
+                            )
 
     @staticmethod
     def _tag(bundle: object, checkpoint: str) -> int:
@@ -347,9 +377,38 @@ class A2SpecGeneratorTests(unittest.TestCase):
         validate_holdout_structure_receipt(self._holdout_receipt(report))
         validate_bundle_manifest(self._bundle_manifest(report))
 
+    def test_passing_synthetic_dry_run_requires_run12_calibration(self) -> None:
+        report = self._dry_run_report()
+        report["parameter_coverage"]["run12_calibration"] = None
+        with self.assertRaises(ValidationError):
+            validate_dry_run_report(report)
+
+    @staticmethod
+    def _active_reference_pages(bundle: object, checkpoint: str) -> list[int]:
+        digest = bundle.ordered_page_sha256[checkpoint][bundle.global_map.page]
+        payload = bundle.page_bytes(digest)
+        start = bundle.global_map.record_start + 1
+        references = [
+            int.from_bytes(
+                payload[
+                    start + slot * len(ROLES) : start + (slot + 1) * len(ROLES)
+                ],
+                "little",
+            )
+            for slot in range(len(BIT_POLARITIES))
+        ]
+        return [reference for reference in references if reference]
+
     def _analysis_report(self) -> dict[str, object]:
         record = {"page": self.bundle.global_map.page, "start": self.bundle.global_map.record_start, "end": self.bundle.global_map.record_end}
         layer = lambda model: {"status": "decisive_predicts_holdout", "derivation_survivor_count": 1, "holdout_evaluated": True, "no_outcome_reasons": [], "model": model}
+        conversion_checkpoint = RUN12_CALIBRATION["conversion_checkpoint_id"]
+        conversion_references = self._active_reference_pages(
+            self.bundle, "H_REL_0904"
+        )
+        active_at_conversion = self._active_slot_count(
+            self.bundle, conversion_checkpoint
+        )
         claims = {
             key: value
             for key, value in self.plan.document["claims"].items()
@@ -358,7 +417,7 @@ class A2SpecGeneratorTests(unittest.TestCase):
         return {
             "protocol_version": "1.0.0", "document_type": "dao_a2_analysis_report", "experiment_id": EXPERIMENT_ID,
             "plan_sha256": PLAN_SHA256, "campaign_id": "synthetic-contract", "producer_commit": PLAN_SHA256[:40],
-            "derivation_replicas": [1, 2], "holdout_replica": 3, "input_checkpoint_count": 75,
+            "derivation_replicas": self.plan.document["replicas"]["derivation"], "holdout_replica": self.plan.document["replicas"]["holdout"], "input_checkpoint_count": BOUNDS["replicas"] * len(CHECKPOINT_IDS),
             "qualified_page_counts": {"global_map": 1, "tdef": 1}, "record_candidates_examined": 2,
             "candidate_models_examined": 4, "derivation_survivor_counts": {"global_map_record": 1, "global_map_conversion_inline": 1, "global_map_extended_base": 1, "tdef_pointer_pair": 1},
             "derivation_candidate_set_sha256": "1" * 64, "analysis_work_units": 4,
@@ -367,7 +426,7 @@ class A2SpecGeneratorTests(unittest.TestCase):
             "terminal_predicate_ids": [], "scientific_outcome": "one_or_more_submodels_predict_holdout", "no_outcome_reasons": [],
             "submodels": {"global_map": {
                 "record": layer({"record": record, "bit_polarity": self.bundle.parameters.bit_polarity, "zero_suffix_slack_bytes": self.bundle.parameters.record_end_uniform_slack_bytes}),
-                "conversion_inline": layer({"conversion_checkpoint_id": CHECKPOINT_IDS[self.bundle.parameters.conversion_ordinal], "conversion_ordinal": self.bundle.parameters.conversion_ordinal, "active_slot_count_at_conversion": 2, "active_slot_count_at_h_rel_0904": 2, "inline_boundary": self.bundle.global_map.inline_boundary, "slot_reference_pages": [12288, 16480]}),
+                "conversion_inline": layer({"conversion_checkpoint_id": conversion_checkpoint, "conversion_ordinal": CHECKPOINT_ORDINALS[conversion_checkpoint], "active_slot_count_at_conversion": active_at_conversion, "active_slot_count_at_h_rel_0904": len(conversion_references), "inline_boundary": self.bundle.global_map.inline_boundary, "slot_reference_pages": conversion_references}),
                 "extended_base": layer({"extended_base_formula": self.bundle.global_map.extended_base_formula}),
             }, "tdef": {"pointer_pair": layer({"record": {"page": self.bundle.tdef.page, "start": self.bundle.tdef.record_start, "end": self.bundle.tdef.record_end}, "pointer_layout": POINTER_LAYOUTS[0], "growth_pointer_offset": self.bundle.tdef.growth_pointer_offset, "delete_reinsert_pointer_offset": self.bundle.tdef.delete_reinsert_pointer_offset})}},
             "claims": claims,
@@ -381,17 +440,19 @@ class A2SpecGeneratorTests(unittest.TestCase):
             "plan_sha256": PLAN_SHA256, "analyzer_commit": PLAN_SHA256[:40], "recorded_utc": "2026-08-21T00:00:00Z",
             "source_kind": "a2_schedule_synthetic", "source_identity": {"manifest_or_fixture_sha256": "2" * 64, "generator_sha256": "3" * 64},
             "checkpoint_schedule_source": "hash_pinned_a2_plan_checkpoint_design", "input_page_blob_count": 0, "holdout_opened": False,
-            "parameter_coverage": {"conversion_ordinals": list(range(1, 71)), "conversion_never": True, "slot_activation_counts": free["slot_activation_at_conversion"], "bit_polarities": free["bit_polarity"], "anchor_fill_states": free["anchor_fill_state"], "run12_calibration": {"source_conversion_ordinal": 40, "conversion_checkpoint_id": "P_ABS_16480", "a2_conversion_ordinal": 20, "active_slot_count": 2, "bit_polarity": "set_means_not_in_use", "delete_page_delta": 1, "scientific_evidence": False}, "record_end_uniform_slack_bytes": free["record_end_uniform_slack_bytes"]},
+            "parameter_coverage": {"conversion_ordinals": list(LEGACY_CONVERSION_ORDINALS), "conversion_never": True, "slot_activation_counts": free["slot_activation_at_conversion"], "bit_polarities": free["bit_polarity"], "anchor_fill_states": free["anchor_fill_state"], "run12_calibration": dict(RUN12_CALIBRATION), "record_end_uniform_slack_bytes": free["record_end_uniform_slack_bytes"]},
             "predicted_terminal_states": required, "terminal_predicate_ids": list(PREDICATE_IDS), "result": "pass",
             "assertions": ["schedule_and_worker_arithmetic_generated_from_plan"], "scientific_evidence": False,
             "acquisition_authorized": False, "capability_advancement_authorized": False,
         }
 
     def _holdout_receipt(self, report: dict[str, object]) -> dict[str, object]:
-        return {"protocol_version": "1.0.0", "document_type": "dao_a2_holdout_structure_receipt", "experiment_id": EXPERIMENT_ID, "plan_sha256": PLAN_SHA256, "producer_commit": PLAN_SHA256[:40], "campaign_id": report["campaign_id"], "derivation_candidate_set_sha256": report["derivation_candidate_set_sha256"], "replica": 3, "replica_artifact_manifest_sha256": "4" * 64, "validated_after_candidate_freeze": True, "page_bytes_exposed_to_analyzer": False, "result": "pass"}
+        return {"protocol_version": "1.0.0", "document_type": "dao_a2_holdout_structure_receipt", "experiment_id": EXPERIMENT_ID, "plan_sha256": PLAN_SHA256, "producer_commit": PLAN_SHA256[:40], "campaign_id": report["campaign_id"], "derivation_candidate_set_sha256": report["derivation_candidate_set_sha256"], "replica": self.plan.document["replicas"]["holdout"], "replica_artifact_manifest_sha256": "4" * 64, "validated_after_candidate_freeze": True, "page_bytes_exposed_to_analyzer": False, "result": "pass"}
 
     def _bundle_manifest(self, report: dict[str, object]) -> dict[str, object]:
-        roles = [("plan", 1), ("environment", 3), ("replica_artifact_manifest", 3), ("replica_observation", 3), ("page_index", 75), ("frozen_candidate_set", 1), ("analysis_report", 1), ("holdout_structure_receipt", 1)]
+        replica_count = BOUNDS["replicas"]
+        checkpoint_count = replica_count * len(CHECKPOINT_IDS)
+        roles = [("plan", 1), ("environment", replica_count), ("replica_artifact_manifest", replica_count), ("replica_observation", replica_count), ("page_index", checkpoint_count), ("frozen_candidate_set", 1), ("analysis_report", 1), ("holdout_structure_receipt", 1)]
         files = []
         counter = 1
         for role, count in roles:
@@ -401,7 +462,7 @@ class A2SpecGeneratorTests(unittest.TestCase):
                 counter += 1
         page_digest = f"{counter:064x}"
         files.append({"path": f"page-store/{page_digest}.page", "role": "page_blob", "sha256": page_digest, "size_bytes": PAGE_SIZE, "media_type": "application/octet-stream"})
-        return {"protocol_version": "1.0.0", "document_type": "dao_a2_bundle_manifest", "experiment_id": EXPERIMENT_ID, "campaign_id": report["campaign_id"], "producer_commit": PLAN_SHA256[:40], "repository_url": self.plan.document["repository_binding"]["canonical_https_url"], "created_utc": "2026-08-21T00:00:00Z", "plan_sha256": PLAN_SHA256, "replica_environment_sha256": ["5" * 64, "6" * 64, "7" * 64], "provider_sha256": "8" * 64, "replica_count": 3, "replica_artifact_manifest_sha256": ["9" * 64, "a" * 64, "b" * 64], "checkpoint_count": 75, "page_blob_count": 1, "bundle_size_bytes_excluding_manifest": sum(item["size_bytes"] for item in files), "inventory_closed": True, "hashes_verified": True, "paths_closed": True, "execution_status": "analysis_complete", "campaign_failed": False, "holdout_structure_receipt_sha256": "c" * 64, "analysis_report_retained": True, "analysis_scientific_outcome": "one_or_more_submodels_predict_holdout", "bundle_status": "decisive_pending_independent_validation", "independent_validation_status": "not_independently_validated", "files": files}
+        return {"protocol_version": "1.0.0", "document_type": "dao_a2_bundle_manifest", "experiment_id": EXPERIMENT_ID, "campaign_id": report["campaign_id"], "producer_commit": PLAN_SHA256[:40], "repository_url": self.plan.document["repository_binding"]["canonical_https_url"], "created_utc": "2026-08-21T00:00:00Z", "plan_sha256": PLAN_SHA256, "replica_environment_sha256": [f"{index + 5:064x}" for index in range(replica_count)], "provider_sha256": "8" * 64, "replica_count": replica_count, "replica_artifact_manifest_sha256": [f"{index + 9:064x}" for index in range(replica_count)], "checkpoint_count": checkpoint_count, "page_blob_count": 1, "bundle_size_bytes_excluding_manifest": sum(item["size_bytes"] for item in files), "inventory_closed": True, "hashes_verified": True, "paths_closed": True, "execution_status": "analysis_complete", "campaign_failed": False, "holdout_structure_receipt_sha256": "c" * 64, "analysis_report_retained": True, "analysis_scientific_outcome": "one_or_more_submodels_predict_holdout", "bundle_status": "decisive_pending_independent_validation", "independent_validation_status": "not_independently_validated", "files": files}
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_a2_spec_generator.py
+++ b/oracle/windows-dao/tests/test_a2_spec_generator.py
@@ -1,0 +1,408 @@
+"""Focused contracts for the checked A2 spec and schedule-derived generator."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a2_generator import (  # noqa: E402
+    SyntheticParameters,
+    generate_synthetic_bundle,
+    iter_parameter_combinations,
+    run12_calibration_parameters,
+    write_synthetic_bundle,
+)
+from a2_spec import (  # noqa: E402
+    BIT_POLARITIES,
+    BOUNDS,
+    CHECKPOINT_IDS,
+    CHECKPOINT_ORDINALS,
+    EXPERIMENT_ID,
+    PAGE_SIZE,
+    PLAN_SHA256,
+    POINTER_LAYOUTS,
+    PREDICATE_IDS,
+    REASON_IDS,
+    ROLES,
+    load_bounded_json,
+    load_checked_plan,
+    validate_analysis_report,
+    validate_bundle_manifest,
+    validate_document,
+    validate_dry_run_report,
+    validate_holdout_structure_receipt,
+    validate_page_index,
+)
+
+
+class A2SpecGeneratorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.plan = load_checked_plan()
+        cls.bundle = generate_synthetic_bundle()
+
+    def _payload(self, checkpoint_id: str, page: int) -> bytes:
+        digest = self.bundle.ordered_page_sha256[checkpoint_id][page]
+        return self.bundle.page_bytes(digest)
+
+    def _global_in_use(self, checkpoint_id: str) -> set[int]:
+        fixture = self.bundle.global_map
+        payload = self._payload(checkpoint_id, fixture.page)
+        bitmap = fixture.record_start + 1 + len(ROLES)
+        limit = (fixture.inline_boundary - bitmap) * 8
+        result = set()
+        for page in range(limit):
+            byte, shift = divmod(page, 8)
+            is_set = bool(payload[bitmap + byte] & (1 << shift))
+            in_use = is_set if fixture.bit_polarity == "set_means_in_use" else not is_set
+            if in_use:
+                result.add(page)
+        return result
+
+    def test_plan_projections_are_exact_and_plan_derived(self) -> None:
+        document = self.plan.document
+        self.assertEqual(CHECKPOINT_IDS, tuple(document["checkpoint_design"]["checkpoint_ids"]))
+        self.assertEqual(CHECKPOINT_ORDINALS, {value: index for index, value in enumerate(CHECKPOINT_IDS)})
+        self.assertEqual(PREDICATE_IDS, tuple(document["predicate_registry"]["ids"]))
+        self.assertEqual(set(REASON_IDS), set(document["decision_rules"]["no_scientific_outcome_identifiers"]))
+        self.assertEqual(BOUNDS, document["bounds"])
+
+    def test_schedule_produces_d_abac_with_larger_regrowth(self) -> None:
+        a = self._global_in_use("E0")
+        b = self._global_in_use("D_GROW_0128")
+        dropped = self._global_in_use("D_DROP")
+        recreated = self._global_in_use("D_RECREATE_EMPTY")
+        c = self._global_in_use("D_REGROW_0128")
+        growth = b - a
+        self.assertTrue(growth)
+        self.assertEqual(dropped, a)
+        self.assertEqual(recreated, a)
+        self.assertLessEqual(growth, c)
+        self.assertTrue(c - b)
+        self.assertGreater(
+            self.bundle.page_count["D_REGROW_0128"],
+            self.bundle.page_count["D_GROW_0128"],
+        )
+        self.assertEqual(
+            self.bundle.page_count["D_DROP"],
+            self.bundle.page_count["D_GROW_0128"],
+        )
+        d_checkpoints = self.plan.document["checkpoint_design"]["transition_coverage"]["global_map_record_set_abac"]
+        payloads = [self._payload(checkpoint, self.bundle.global_map.page) for checkpoint in d_checkpoints]
+        changed = [
+            offset
+            for offset in range(PAGE_SIZE)
+            if len({payload[offset] for payload in payloads}) > 1
+        ]
+        self.assertEqual(changed[-1], self.bundle.global_map.inline_boundary - 1)
+        self.assertEqual(
+            PAGE_SIZE - changed[-1] - 1,
+            self.bundle.parameters.record_end_uniform_slack_bytes,
+        )
+
+    def test_targets_batches_and_overshoot_are_derived_for_every_checkpoint(self) -> None:
+        schedule = self.bundle.schedule
+        batch = self.plan.document["tables"]["row_algorithm"]["growth_batch_rows"]
+        for row in schedule.checkpoints:
+            self.assertEqual(row.inserted_rows_total % batch, 0)
+            if row.target_threshold_pages is not None:
+                self.assertGreaterEqual(row.actual_file_pages, row.target_threshold_pages)
+                self.assertEqual(
+                    row.target_overshoot_pages,
+                    row.actual_file_pages - row.target_threshold_pages,
+                )
+        self.assertEqual(
+            schedule.checkpoint("D_REGROW_0128").target_baseline_pages,
+            schedule.checkpoint("D_RECREATE_EMPTY").actual_file_pages,
+        )
+
+    def test_tdef_growth_and_churn_windows_are_transition_selective(self) -> None:
+        fixture = self.bundle.tdef
+        pointer_bytes = len(ROLES)
+        growth = fixture.growth_pointer_offset
+        churn = fixture.delete_reinsert_pointer_offset
+
+        def window(checkpoint: str, offset: int) -> bytes:
+            return self._payload(checkpoint, fixture.page)[offset : offset + pointer_bytes]
+
+        low_growth = self.plan.document["checkpoint_design"]["transition_coverage"]["tdef_low_growth"]
+        self.assertTrue(
+            any(window(left, growth) != window(right, growth) for left, right in zip(low_growth, low_growth[1:]))
+        )
+        self.assertEqual(window("L_REL_1280", growth), window("L_DELETE_ALL", growth))
+        self.assertEqual(window("L_DELETE_ALL", growth), window("L_REINSERT_SAME", growth))
+        before = window("L_REL_1280", churn)
+        deleted = window("L_DELETE_ALL", churn)
+        reinserted = window("L_REINSERT_SAME", churn)
+        self.assertNotEqual(before, deleted)
+        self.assertEqual(before, reinserted)
+
+    def test_extended_maps_include_slot_zero_and_exact_growth_discriminators(self) -> None:
+        global_fixture = self.bundle.global_map
+        conversion = "P_ABS_16480"
+        global_payload = self._payload(conversion, global_fixture.page)
+        slots = global_fixture.record_start + 1
+        references = [
+            int.from_bytes(global_payload[slots + slot * len(ROLES) : slots + (slot + 1) * len(ROLES)], "little")
+            for slot in range(len(BIT_POLARITIES))
+        ]
+
+        def in_use_bits(checkpoint: str, reference: int) -> set[int]:
+            payload = self._payload(checkpoint, reference)
+            result = set()
+            for bit in range((PAGE_SIZE - len(ROLES)) * 8):
+                byte, shift = divmod(bit, 8)
+                is_set = bool(payload[len(ROLES) + byte] & (1 << shift))
+                in_use = is_set if global_fixture.bit_polarity == "set_means_in_use" else not is_set
+                if in_use:
+                    result.add(bit)
+            return result
+
+        slot_zero_before = in_use_bits(conversion, references[0])
+        slot_zero_after = in_use_bits("H_REL_0064", references[0])
+        self.assertEqual(
+            {references[0] + bit for bit in slot_zero_after - slot_zero_before},
+            set(
+                range(
+                    self.bundle.page_count[conversion],
+                    self.bundle.page_count["H_REL_0064"],
+                )
+            ),
+        )
+        before = in_use_bits("H_REL_0064", references[0])
+        after = in_use_bits("H_REL_0896", references[0])
+        predicted = {references[0] + bit for bit in after - before}
+        self.assertEqual(
+            predicted,
+            set(
+                range(
+                    self.bundle.page_count["H_REL_0064"],
+                    self.bundle.page_count["H_REL_0896"],
+                )
+            ),
+        )
+
+    def test_every_plan_idle_equality_is_generator_produced(self) -> None:
+        for left, right in self.plan.document["checkpoint_design"]["idle_pairs"]:
+            self.assertEqual(self.bundle.page_count[left], self.bundle.page_count[right])
+            self.assertEqual(
+                self.bundle.ordered_page_sha256[left],
+                self.bundle.ordered_page_sha256[right],
+            )
+
+    def test_every_free_parameter_combination_is_enumerable(self) -> None:
+        free = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
+        combinations = list(iter_parameter_combinations())
+        expected = (
+            len(CHECKPOINT_IDS)
+            * len(free["slot_activation_at_conversion"])
+            * len(free["bit_polarity"])
+            * len(free["anchor_fill_state"])
+            * len(free["record_end_uniform_slack_bytes"])
+        )
+        self.assertEqual(len(combinations), expected)
+        self.assertEqual(len(combinations), len(set(combinations)))
+        conversions = {item.conversion_ordinal for item in combinations}
+        self.assertEqual(conversions, set(range(1, len(CHECKPOINT_IDS))) | {None})
+        legacy = {item.conversion_ordinal for item in iter_parameter_combinations(legacy_projection=True)}
+        self.assertEqual(legacy, set(range(1, 71)) | {None})
+
+    def test_anchor_fill_and_slack_do_not_move_declared_boundary_formula(self) -> None:
+        baseline = run12_calibration_parameters()
+        free = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
+        for fill in free["anchor_fill_state"]:
+            for slack in free["record_end_uniform_slack_bytes"]:
+                parameters = SyntheticParameters(
+                    baseline.conversion_ordinal,
+                    baseline.slot_activation_at_conversion,
+                    baseline.bit_polarity,
+                    fill,
+                    slack,
+                    baseline.delete_page_delta,
+                )
+                bundle = generate_synthetic_bundle(parameters)
+                self.assertEqual(bundle.global_map.record_end, PAGE_SIZE)
+                self.assertEqual(bundle.global_map.inline_boundary, PAGE_SIZE - slack)
+                anchor_id = CHECKPOINT_IDS[baseline.conversion_ordinal - 1]
+                payload = bundle.page_bytes(
+                    bundle.ordered_page_sha256[anchor_id][bundle.global_map.page]
+                )
+                bitmap = bundle.global_map.record_start + 1 + len(ROLES)
+                capacity = (bundle.global_map.inline_boundary - bitmap) * 8
+                in_use = 0
+                for bit in range(capacity):
+                    byte, shift = divmod(bit, 8)
+                    is_set = bool(payload[bitmap + byte] & (1 << shift))
+                    in_use += is_set if parameters.bit_polarity == "set_means_in_use" else not is_set
+                expected = {"empty": 0, "partial": capacity // 2, "full": capacity}[fill]
+                self.assertEqual(in_use, expected)
+
+    def test_conversion_and_slot_parameters_are_encoded_at_the_requested_ordinal(self) -> None:
+        baseline = run12_calibration_parameters()
+        for ordinal in (1, len(CHECKPOINT_IDS) // 2, len(CHECKPOINT_IDS) - 1):
+            for slots in self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]["slot_activation_at_conversion"]:
+                parameters = SyntheticParameters(
+                    ordinal,
+                    slots,
+                    baseline.bit_polarity,
+                    baseline.anchor_fill_state,
+                    baseline.record_end_uniform_slack_bytes,
+                    baseline.delete_page_delta,
+                )
+                bundle = generate_synthetic_bundle(parameters)
+                before = CHECKPOINT_IDS[ordinal - 1]
+                at = CHECKPOINT_IDS[ordinal]
+                self.assertEqual(self._tag(bundle, before), 0)
+                self.assertEqual(self._tag(bundle, at), 1)
+                self.assertEqual(self._active_slot_count(bundle, at), slots)
+                if ordinal <= CHECKPOINT_ORDINALS["H_REL_0904"]:
+                    self.assertEqual(
+                        self._active_slot_count(bundle, "H_REL_0904"), 2
+                    )
+        never = SyntheticParameters(
+            None,
+            baseline.slot_activation_at_conversion,
+            baseline.bit_polarity,
+            baseline.anchor_fill_state,
+            baseline.record_end_uniform_slack_bytes,
+            baseline.delete_page_delta,
+        )
+        bundle = generate_synthetic_bundle(never)
+        self.assertTrue(all(self._tag(bundle, checkpoint) == 0 for checkpoint in CHECKPOINT_IDS))
+
+    @staticmethod
+    def _tag(bundle: object, checkpoint: str) -> int:
+        digest = bundle.ordered_page_sha256[checkpoint][bundle.global_map.page]
+        return bundle.page_bytes(digest)[bundle.global_map.record_start]
+
+    @staticmethod
+    def _active_slot_count(bundle: object, checkpoint: str) -> int:
+        digest = bundle.ordered_page_sha256[checkpoint][bundle.global_map.page]
+        payload = bundle.page_bytes(digest)
+        start = bundle.global_map.record_start + 1
+        return sum(
+            int.from_bytes(
+                payload[start + slot * len(ROLES) : start + (slot + 1) * len(ROLES)],
+                "little",
+            )
+            != 0
+            for slot in range(len(BIT_POLARITIES))
+        )
+
+    def test_generated_documents_and_disk_artifacts_validate(self) -> None:
+        observation = self.bundle.documents["observations/replica-01.json"]
+        prior: list[str] = []
+        for checkpoint in observation["checkpoints"]:
+            document = self.bundle.documents[checkpoint["page_index"]["path"]]
+            prior = validate_page_index(document, observation, checkpoint, prior)
+        for document in self.bundle.documents.values():
+            validate_document(document)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_synthetic_bundle(root, self.bundle)
+            for path, expected in self.bundle.documents.items():
+                self.assertEqual(load_bounded_json(root / path), expected)
+            for digest in self.bundle._payloads:
+                payload = (root / f"page-store/{digest}.page").read_bytes()
+                self.assertEqual(hashlib.sha256(payload).hexdigest(), digest)
+
+    def test_applicable_source_contracts_reject_inherited_constants_and_blacklists(self) -> None:
+        for name in (
+            "a2_spec.py",
+            "a2_generator.py",
+            "a2_generator_schedule.py",
+            "a2_generator_pages.py",
+        ):
+            source = (SCRIPTS / name).read_text(encoding="utf-8")
+            self.assertLess(len(source.splitlines()), 800)
+            tree = ast.parse(source)
+            imports = {
+                alias.name
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Import)
+                for alias in node.names
+            } | {
+                node.module or ""
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom)
+            }
+            self.assertFalse(any(module.startswith("a1") for module in imports))
+            self.assertNotIn("CONVERSION_CHECKPOINT", source)
+            self.assertNotIn("header_exclusion", source)
+            self.assertNotIn("blacklist", source.lower())
+
+    def test_remaining_schema_validators_accept_consistent_documents(self) -> None:
+        report = self._analysis_report()
+        validate_analysis_report(report)
+        validate_dry_run_report(self._dry_run_report())
+        validate_holdout_structure_receipt(self._holdout_receipt(report))
+        validate_bundle_manifest(self._bundle_manifest(report))
+
+    def _analysis_report(self) -> dict[str, object]:
+        record = {"page": self.bundle.global_map.page, "start": self.bundle.global_map.record_start, "end": self.bundle.global_map.record_end}
+        layer = lambda model: {"status": "decisive_predicts_holdout", "derivation_survivor_count": 1, "holdout_evaluated": True, "no_outcome_reasons": [], "model": model}
+        claims = {
+            key: value
+            for key, value in self.plan.document["claims"].items()
+            if key not in {"a1_exploratory_input_is_a2_evidence", "synthetic_dry_run_is_a2_evidence"}
+        }
+        return {
+            "protocol_version": "1.0.0", "document_type": "dao_a2_analysis_report", "experiment_id": EXPERIMENT_ID,
+            "plan_sha256": PLAN_SHA256, "campaign_id": "synthetic-contract", "producer_commit": PLAN_SHA256[:40],
+            "derivation_replicas": [1, 2], "holdout_replica": 3, "input_checkpoint_count": 75,
+            "qualified_page_counts": {"global_map": 1, "tdef": 1}, "record_candidates_examined": 2,
+            "candidate_models_examined": 4, "derivation_survivor_counts": {"global_map_record": 1, "global_map_conversion_inline": 1, "global_map_extended_base": 1, "tdef_pointer_pair": 1},
+            "derivation_candidate_set_sha256": "1" * 64, "analysis_work_units": 4,
+            "holdout_structurally_validated_after_freeze": True, "holdout_opened_after_freeze": True, "holdout_evaluated": True,
+            "predicate_results": [{"predicate_id": "A2-IDLE-EQUALITY", "status": "pass", "layer": "campaign"}],
+            "terminal_predicate_ids": [], "scientific_outcome": "one_or_more_submodels_predict_holdout", "no_outcome_reasons": [],
+            "submodels": {"global_map": {
+                "record": layer({"record": record, "bit_polarity": self.bundle.parameters.bit_polarity, "zero_suffix_slack_bytes": self.bundle.parameters.record_end_uniform_slack_bytes}),
+                "conversion_inline": layer({"conversion_checkpoint_id": CHECKPOINT_IDS[self.bundle.parameters.conversion_ordinal], "conversion_ordinal": self.bundle.parameters.conversion_ordinal, "active_slot_count_at_conversion": 2, "active_slot_count_at_h_rel_0904": 2, "inline_boundary": self.bundle.global_map.inline_boundary, "slot_reference_pages": [12288, 16480]}),
+                "extended_base": layer({"extended_base_formula": self.bundle.global_map.extended_base_formula}),
+            }, "tdef": {"pointer_pair": layer({"record": {"page": self.bundle.tdef.page, "start": self.bundle.tdef.record_start, "end": self.bundle.tdef.record_end}, "pointer_layout": POINTER_LAYOUTS[0], "growth_pointer_offset": self.bundle.tdef.growth_pointer_offset, "delete_reinsert_pointer_offset": self.bundle.tdef.delete_reinsert_pointer_offset})}},
+            "claims": claims,
+        }
+
+    def _dry_run_report(self) -> dict[str, object]:
+        free = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
+        required = self.plan.document["analyzer_dry_run_contract"]["synthetic_input"]["required_cases"]
+        return {
+            "protocol_version": "1.0.0", "document_type": "dao_a2_analyzer_dry_run_report", "experiment_id": EXPERIMENT_ID,
+            "plan_sha256": PLAN_SHA256, "analyzer_commit": PLAN_SHA256[:40], "recorded_utc": "2026-08-21T00:00:00Z",
+            "source_kind": "a2_schedule_synthetic", "source_identity": {"manifest_or_fixture_sha256": "2" * 64, "generator_sha256": "3" * 64},
+            "checkpoint_schedule_source": "hash_pinned_a2_plan_checkpoint_design", "input_page_blob_count": 0, "holdout_opened": False,
+            "parameter_coverage": {"conversion_ordinals": list(range(1, 71)), "conversion_never": True, "slot_activation_counts": free["slot_activation_at_conversion"], "bit_polarities": free["bit_polarity"], "anchor_fill_states": free["anchor_fill_state"], "run12_calibration": {"source_conversion_ordinal": 40, "conversion_checkpoint_id": "P_ABS_16480", "a2_conversion_ordinal": 20, "active_slot_count": 2, "bit_polarity": "set_means_not_in_use", "delete_page_delta": 1, "scientific_evidence": False}, "record_end_uniform_slack_bytes": free["record_end_uniform_slack_bytes"]},
+            "predicted_terminal_states": required, "terminal_predicate_ids": list(PREDICATE_IDS), "result": "pass",
+            "assertions": ["schedule_and_worker_arithmetic_generated_from_plan"], "scientific_evidence": False,
+            "acquisition_authorized": False, "capability_advancement_authorized": False,
+        }
+
+    def _holdout_receipt(self, report: dict[str, object]) -> dict[str, object]:
+        return {"protocol_version": "1.0.0", "document_type": "dao_a2_holdout_structure_receipt", "experiment_id": EXPERIMENT_ID, "plan_sha256": PLAN_SHA256, "producer_commit": PLAN_SHA256[:40], "campaign_id": report["campaign_id"], "derivation_candidate_set_sha256": report["derivation_candidate_set_sha256"], "replica": 3, "replica_artifact_manifest_sha256": "4" * 64, "validated_after_candidate_freeze": True, "page_bytes_exposed_to_analyzer": False, "result": "pass"}
+
+    def _bundle_manifest(self, report: dict[str, object]) -> dict[str, object]:
+        roles = [("plan", 1), ("environment", 3), ("replica_artifact_manifest", 3), ("replica_observation", 3), ("page_index", 75), ("frozen_candidate_set", 1), ("analysis_report", 1), ("holdout_structure_receipt", 1)]
+        files = []
+        counter = 1
+        for role, count in roles:
+            for _ in range(count):
+                digest = f"{counter:064x}"
+                files.append({"path": f"synthetic/{role}-{counter}.json", "role": role, "sha256": digest, "size_bytes": 1, "media_type": "application/json"})
+                counter += 1
+        page_digest = f"{counter:064x}"
+        files.append({"path": f"page-store/{page_digest}.page", "role": "page_blob", "sha256": page_digest, "size_bytes": PAGE_SIZE, "media_type": "application/octet-stream"})
+        return {"protocol_version": "1.0.0", "document_type": "dao_a2_bundle_manifest", "experiment_id": EXPERIMENT_ID, "campaign_id": report["campaign_id"], "producer_commit": PLAN_SHA256[:40], "repository_url": self.plan.document["repository_binding"]["canonical_https_url"], "created_utc": "2026-08-21T00:00:00Z", "plan_sha256": PLAN_SHA256, "replica_environment_sha256": ["5" * 64, "6" * 64, "7" * 64], "provider_sha256": "8" * 64, "replica_count": 3, "replica_artifact_manifest_sha256": ["9" * 64, "a" * 64, "b" * 64], "checkpoint_count": 75, "page_blob_count": 1, "bundle_size_bytes_excluding_manifest": sum(item["size_bytes"] for item in files), "inventory_closed": True, "hashes_verified": True, "paths_closed": True, "execution_status": "analysis_complete", "campaign_failed": False, "holdout_structure_receipt_sha256": "c" * 64, "analysis_report_retained": True, "analysis_scientific_outcome": "one_or_more_submodels_predict_holdout", "bundle_status": "decisive_pending_independent_validation", "independent_validation_status": "not_independently_validated", "files": files}
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add hash-pinned A2 plan/schema loading and semantic validators for every A2 document type
- add the plan-derived schedule and synthetic page generator with analyzer-facing in-memory access and validated on-disk bundles
- add focused contract tests for checkpoint arithmetic, parameter enumeration, schema validity, and source-contract restrictions

## Testing

- `python3.13 -m unittest discover -s oracle/windows-dao/tests -v` — 462 passed, 83 skipped
- `python3.13 tools/reconcile_tests.py --repo-root "$PWD"` — 236 meaningful tests, 236 runtime tests, 0 ignored