### PR TITLE
feat: add A2 matrix/fan-in workflow and bundle tooling

### DIFF
--- a/.github/workflows/windows-dao-a2.yml
+++ b/.github/workflows/windows-dao-a2.yml
@@ -103,23 +103,24 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      inputs.execute_a2_campaign
+      inputs.execute_a2_campaign &&
+      needs.contract.result == 'success'
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
         replica: [1, 2, 3]
     runs-on: windows-latest
-    timeout-minutes: 31
+    timeout-minutes: 37
     env:
       FROZEN_WORKER_TIMEOUT_SECONDS: "1700"
-      HOSTED_REPLICA_TIMEOUT_SECONDS: "1800"
+      HOSTED_REPLICA_TIMEOUT_SECONDS: "2120"
       FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"
       REPLICA_MAXIMUM_OUTPUT_BYTES: "1048576"
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -193,6 +194,7 @@ jobs:
             worker_timeout_seconds = [int]$env:FROZEN_WORKER_TIMEOUT_SECONDS
             hosted_timeout_seconds = [int]$env:HOSTED_REPLICA_TIMEOUT_SECONDS
             campaign_timeout_seconds = [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+            started_utc = [DateTimeOffset]::UtcNow.ToString("o")
           }
           [IO.File]::WriteAllText(
             (Join-Path $diagnostics "hosted-replica.json"),
@@ -211,6 +213,7 @@ jobs:
           $replicaExit = $null
           $replicaError = $null
           $cleanupErrors = New-Object Collections.ArrayList
+          $elapsedSeconds = 0.0
           try {
             $process = Start-Process -FilePath $x86PowerShell -PassThru `
               -RedirectStandardOutput $stdoutPath `
@@ -261,11 +264,24 @@ jobs:
               }
               catch { [void]$cleanupErrors.Add($_) }
             }
-            if ($null -ne $clock) { $clock.Stop() }
+            if ($null -ne $clock) {
+              $clock.Stop()
+              $elapsedSeconds = $clock.Elapsed.TotalSeconds
+            }
             if ($null -ne $process) {
               try { $process.Dispose() }
               catch { [void]$cleanupErrors.Add($_) }
             }
+            try {
+              $hostedRecord.completed_utc = [DateTimeOffset]::UtcNow.ToString("o")
+              $hostedRecord.elapsed_seconds = [Math]::Round($elapsedSeconds, 3)
+              [IO.File]::WriteAllText(
+                (Join-Path $diagnostics "hosted-replica.json"),
+                ($hostedRecord | ConvertTo-Json -Compress),
+                (New-Object Text.UTF8Encoding($false))
+              )
+            }
+            catch { [void]$cleanupErrors.Add($_) }
           }
           if ($null -ne $replicaError) { throw $replicaError }
           if ($cleanupErrors.Count -ne 0) {
@@ -309,7 +325,9 @@ jobs:
       needs.contract.result == 'success' &&
       needs.a2-replica.result == 'success'
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    env:
+      FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -338,7 +356,14 @@ jobs:
           name: windows-dao-a2-replica-3
           path: ${{ runner.temp }}\jet3-a2-replicas\replica-03
 
+      - name: Download bounded A2 replica timing diagnostics
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: windows-dao-a2-diagnostics-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\jet3-a2-replica-diagnostics
+
       - name: Assemble the three checked replica trees
+        id: assemble
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
@@ -353,6 +378,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "A2 replica assembly failed." }
 
       - name: Freeze derivation, validate holdout separately, and analyze
+        id: analyze
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
@@ -368,6 +394,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "A2 analysis failed." }
 
       - name: Finalize the retained A2 bundle manifest
+        id: finalize
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
@@ -377,11 +404,14 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "A2 bundle finalization failed." }
 
       - name: Independently validate the complete A2 bundle
+        id: validate
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $bundle = Join-Path $env:RUNNER_TEMP "jet3-a2-bundle"
-          & python -B oracle/windows-dao/scripts/a2_bundle.py validate $bundle
+          & python -B oracle/windows-dao/scripts/a2_bundle.py validate $bundle `
+            --campaign-id "a2-run-$env:GITHUB_RUN_ID" `
+            --producer-commit $env:GITHUB_SHA
           if ($LASTEXITCODE -ne 0) {
             throw "Independent complete A2 bundle validation failed."
           }
@@ -390,12 +420,115 @@ jobs:
             throw "A2 fan-in changed the exact producer checkout."
           }
 
+      - name: Record retained A2 fan-in status
+        id: fan_in_status
+        if: always()
+        shell: powershell
+        env:
+          ASSEMBLE_OUTCOME: ${{ steps.assemble.outcome }}
+          ANALYZE_OUTCOME: ${{ steps.analyze.outcome }}
+          FINALIZE_OUTCOME: ${{ steps.finalize.outcome }}
+          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a2-fanin-diagnostics"
+          New-Item -ItemType Directory -Path $diagnostics -Force | Out-Null
+          $timingRoot = Join-Path $env:RUNNER_TEMP "jet3-a2-replica-diagnostics"
+          $records = @(Get-ChildItem -LiteralPath $timingRoot `
+            -Filter "hosted-replica.json" -File -Recurse -ErrorAction SilentlyContinue)
+          $timingComplete = $records.Count -eq 3
+          $replicas = @()
+          $earliest = $null
+          foreach ($recordPath in $records) {
+            try {
+              if ($recordPath.Length -lt 1 -or $recordPath.Length -gt 4096) {
+                throw "Replica timing record violates its byte bound."
+              }
+              $record = Get-Content -LiteralPath $recordPath.FullName -Raw |
+                ConvertFrom-Json
+              if ($record.document_type -cne "jet3_windows_dao_a2_hosted_replica" -or
+                  $record.producer_commit -cne $env:GITHUB_SHA -or
+                  $record.campaign_id -cne "a2-run-$env:GITHUB_RUN_ID") {
+                throw "Replica timing record binding mismatch."
+              }
+              $started = [DateTimeOffset]::Parse(
+                [string]$record.started_utc,
+                [Globalization.CultureInfo]::InvariantCulture,
+                [Globalization.DateTimeStyles]::RoundtripKind
+              )
+              $replicas += [int]$record.replica
+              if ($null -eq $earliest -or $started -lt $earliest) {
+                $earliest = $started
+              }
+            }
+            catch {
+              $timingComplete = $false
+            }
+          }
+          if ((@($replicas | Sort-Object -Unique) -join ",") -cne "1,2,3") {
+            $timingComplete = $false
+          }
+          $completed = [DateTimeOffset]::UtcNow
+          $campaignElapsed = $null
+          if ($timingComplete) {
+            $campaignElapsed = [Math]::Round(($completed - $earliest).TotalSeconds, 3)
+            if ($campaignElapsed -lt 0) { $timingComplete = $false }
+          }
+          $withinPlan = $timingComplete -and `
+            $campaignElapsed -le [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+          $validationPassed = (
+            $env:ASSEMBLE_OUTCOME -ceq "success" -and
+            $env:ANALYZE_OUTCOME -ceq "success" -and
+            $env:FINALIZE_OUTCOME -ceq "success" -and
+            $env:VALIDATE_OUTCOME -ceq "success"
+          )
+          $status = [ordered]@{
+            document_type = "jet3_windows_dao_a2_fan_in_status"
+            producer_commit = $env:GITHUB_SHA
+            campaign_id = "a2-run-$env:GITHUB_RUN_ID"
+            assemble = $env:ASSEMBLE_OUTCOME
+            analyze = $env:ANALYZE_OUTCOME
+            finalize = $env:FINALIZE_OUTCOME
+            validate = $env:VALIDATE_OUTCOME
+            independent_validation_passed = $validationPassed
+            timing_records_complete = $timingComplete
+            campaign_elapsed_seconds = $campaignElapsed
+            plan_campaign_timeout_seconds = `
+              [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+            within_plan_campaign_timeout = $withinPlan
+            completed_utc = $completed.ToString("o")
+            github_run_id = $env:GITHUB_RUN_ID
+            github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+          }
+          $statusJson = ($status | ConvertTo-Json -Compress) + "`n"
+          $statusBytes = [Text.Encoding]::UTF8.GetBytes($statusJson)
+          if ($statusBytes.Length -gt 4096) {
+            throw "A2 fan-in status exceeds its byte ceiling."
+          }
+          [IO.File]::WriteAllBytes(
+            (Join-Path $diagnostics "fan-in-status.json"),
+            $statusBytes
+          )
+
       - name: Upload retained A2 bundle
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-dao-a2-bundle-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}\jet3-a2-bundle
-          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}\jet3-a2-bundle
+            ${{ runner.temp }}\jet3-a2-fanin-diagnostics\fan-in-status.json
+          if-no-files-found: error
           compression-level: 0
           retention-days: 90
+
+      - name: Upload bounded A2 fan-in diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a2-fanin-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\jet3-a2-fanin-diagnostics
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/.github/workflows/windows-dao-a2.yml
+++ b/.github/workflows/windows-dao-a2.yml
@@ -374,7 +374,8 @@ jobs:
             --replica-root (Join-Path $replicas "replica-01") `
             --replica-root (Join-Path $replicas "replica-02") `
             --replica-root (Join-Path $replicas "replica-03") `
-            --bundle-root $bundle --campaign-id $campaignId
+            --bundle-root $bundle --campaign-id $campaignId `
+            --producer-commit $env:GITHUB_SHA
           if ($LASTEXITCODE -ne 0) { throw "A2 replica assembly failed." }
 
       - name: Freeze derivation, validate holdout separately, and analyze
@@ -400,7 +401,9 @@ jobs:
           $ErrorActionPreference = "Stop"
           $bundle = Join-Path $env:RUNNER_TEMP "jet3-a2-bundle"
           & python -B oracle/windows-dao/scripts/a2_bundle.py finalize `
-            --bundle-root $bundle
+            --bundle-root $bundle `
+            --campaign-id "a2-run-$env:GITHUB_RUN_ID" `
+            --producer-commit $env:GITHUB_SHA
           if ($LASTEXITCODE -ne 0) { throw "A2 bundle finalization failed." }
 
       - name: Independently validate the complete A2 bundle

--- a/.github/workflows/windows-dao-a2.yml
+++ b/.github/workflows/windows-dao-a2.yml
@@ -1,0 +1,401 @@
+name: Windows DAO A2 campaign
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute_a2_campaign:
+        description: Authorize the licensed A2 three-replica acquisition
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-dao-a2-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    name: Validate the checked A2 contract
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13.7"
+
+      - name: Parse checked A2 PowerShell sources without execution
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          if ($PSVersionTable.PSEdition -cne "Desktop" -or
+              $PSVersionTable.PSVersion.Major -ne 5) {
+            throw "A2 contract parsing requires Windows PowerShell 5 Desktop."
+          }
+          $entrypoint = "oracle/windows-dao/scripts/run-a2-replica.ps1"
+          $a2Directory = "oracle/windows-dao/scripts/a2"
+          if (-not (Test-Path -LiteralPath $entrypoint -PathType Leaf) -or
+              -not (Test-Path -LiteralPath $a2Directory -PathType Container)) {
+            throw "The checked A2 PowerShell source inventory is incomplete."
+          }
+          $sourcePaths = @($entrypoint) + @(
+            Get-ChildItem -LiteralPath $a2Directory -Filter "*.ps1" -File |
+              Sort-Object -Property Name |
+              ForEach-Object { $_.FullName }
+          )
+          if ($sourcePaths.Count -lt 2 -or $sourcePaths.Count -gt 32) {
+            throw "The checked A2 PowerShell source count violates its bound."
+          }
+          foreach ($sourcePath in $sourcePaths) {
+            $item = Get-Item -LiteralPath $sourcePath -Force
+            if ($item.PSIsContainer -or $item.Length -lt 1 -or
+                $item.Length -gt 2MB -or
+                ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw "A checked A2 PowerShell source violates its file bound."
+            }
+            $tokens = $null
+            $errors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile(
+              $item.FullName,
+              [ref]$tokens,
+              [ref]$errors
+            )
+            if (@($errors).Count -ne 0) {
+              [string]$detail = [Convert]::ToString((@($errors | ForEach-Object {
+                "line $($_.Extent.StartLineNumber): $($_.Message)"
+              }) -join "; "))
+              if ($detail.Length -gt 2000) {
+                $detail = $detail.Substring(0, 2000)
+              }
+              throw "A2 PowerShell parser errors in $sourcePath`: $detail"
+            }
+          }
+
+      - name: Run the checked A2 Python contract tests
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          & python -B oracle/windows-dao/scripts/a2_spec.py `
+            oracle/windows-dao/experiments/a2/a2-allocation-maps.plan.json
+          if ($LASTEXITCODE -ne 0) { throw "The checked A2 plan failed." }
+          & python -B -m unittest `
+            oracle/windows-dao/tests/test_a2_plan_contract.py `
+            oracle/windows-dao/tests/test_a2_spec_generator.py `
+            oracle/windows-dao/tests/test_a2_dryrun.py `
+            oracle/windows-dao/tests/test_a2_powershell_contract.py `
+            oracle/windows-dao/tests/test_a2_bundle.py `
+            oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
+          if ($LASTEXITCODE -ne 0) {
+            throw "The checked A2 contract tests failed."
+          }
+
+  a2-replica:
+    name: Acquire A2 replica ${{ matrix.replica }}
+    needs: contract
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.execute_a2_campaign
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        replica: [1, 2, 3]
+    runs-on: windows-latest
+    timeout-minutes: 31
+    env:
+      FROZEN_WORKER_TIMEOUT_SECONDS: "1700"
+      HOSTED_REPLICA_TIMEOUT_SECONDS: "1800"
+      FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"
+      REPLICA_MAXIMUM_OUTPUT_BYTES: "1048576"
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13.7"
+
+      - name: Bind the exact clean pushed producer commit
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs") {
+            throw "The workflow repository differs from the canonical repository."
+          }
+          & git remote set-url origin https://github.com/oglassdev/jet3-rs.git
+          if ($LASTEXITCODE -ne 0) { throw "Could not bind the canonical origin." }
+          $head = (& git rev-parse --verify HEAD).Trim()
+          $origin = (& git remote get-url origin).Trim()
+          if ($LASTEXITCODE -ne 0 -or $head -cne $env:GITHUB_SHA -or
+              $origin -cne "https://github.com/oglassdev/jet3-rs.git") {
+            throw "The checkout identity differs from the dispatched commit."
+          }
+          $remoteRows = @(& git ls-remote --exit-code origin refs/heads/main)
+          if ($LASTEXITCODE -ne 0 -or $remoteRows.Count -ne 1) {
+            throw "The pushed main-branch identity is unavailable."
+          }
+          $remoteFields = @($remoteRows[0] -split "\s+")
+          if ($remoteFields.Count -ne 2 -or $remoteFields[0] -cne $env:GITHUB_SHA) {
+            throw "The dispatched producer commit is not the pushed main commit."
+          }
+          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+            throw "The A2 producer checkout is not exact and clean."
+          }
+
+      - name: Run bounded A2 replica ${{ matrix.replica }}
+        id: replica
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          . "oracle/windows-dao/scripts/remote/Remote.Process.ps1"
+
+          function Get-A2LogBytes {
+            param([Parameter(Mandatory = $true)][string[]]$Paths)
+            [long]$total = 0
+            foreach ($path in $Paths) {
+              if (Test-Path -LiteralPath $path -PathType Leaf) {
+                [long]$length = (Get-Item -LiteralPath $path -Force).Length
+                if ($length -gt ([long]::MaxValue - $total)) {
+                  throw "A2 log byte accounting overflowed."
+                }
+                $total += $length
+              }
+            }
+            return $total
+          }
+
+          $repository = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+          $replica = [int]${{ matrix.replica }}
+          $replicaName = $replica.ToString("00")
+          $outputRoot = Join-Path $env:RUNNER_TEMP "jet3-a2-output-$replicaName"
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a2-diagnostics-$replicaName"
+          New-Item -ItemType Directory -Path $outputRoot, $diagnostics | Out-Null
+          $stdoutPath = Join-Path $diagnostics "replica.stdout.log"
+          $stderrPath = Join-Path $diagnostics "replica.stderr.log"
+          $hostedRecord = [ordered]@{
+            document_type = "jet3_windows_dao_a2_hosted_replica"
+            producer_commit = $env:GITHUB_SHA
+            campaign_id = "a2-run-$env:GITHUB_RUN_ID"
+            replica = $replica
+            worker_timeout_seconds = [int]$env:FROZEN_WORKER_TIMEOUT_SECONDS
+            hosted_timeout_seconds = [int]$env:HOSTED_REPLICA_TIMEOUT_SECONDS
+            campaign_timeout_seconds = [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+          }
+          [IO.File]::WriteAllText(
+            (Join-Path $diagnostics "hosted-replica.json"),
+            ($hostedRecord | ConvertTo-Json -Compress),
+            (New-Object Text.UTF8Encoding($false))
+          )
+          $x86PowerShell = Join-Path $env:WINDIR `
+            "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+          $entrypoint = Join-Path $repository `
+            "oracle/windows-dao/scripts/run-a2-replica.ps1"
+          if (-not (Test-Path -LiteralPath $x86PowerShell -PathType Leaf)) {
+            throw "x86 Windows PowerShell 5 is unavailable."
+          }
+          $process = $null
+          $clock = $null
+          $replicaExit = $null
+          $replicaError = $null
+          $cleanupErrors = New-Object Collections.ArrayList
+          try {
+            $process = Start-Process -FilePath $x86PowerShell -PassThru `
+              -RedirectStandardOutput $stdoutPath `
+              -RedirectStandardError $stderrPath `
+              -ArgumentList @(
+                "-NoLogo", "-NoProfile", "-NonInteractive",
+                "-ExecutionPolicy", "Bypass", "-File", $entrypoint,
+                "-RepositoryRoot", $repository,
+                "-OutputRoot", $outputRoot,
+                "-DiagnosticsRoot", $diagnostics,
+                "-GitCommit", $env:GITHUB_SHA,
+                "-RunId", $env:GITHUB_RUN_ID,
+                "-Replica", $replica,
+                "-MatrixJobId", "a2-replica-$replica"
+              )
+            $null = $process.Handle
+            $clock = [Diagnostics.Stopwatch]::StartNew()
+            while (-not $process.WaitForExit(1000)) {
+              if ((Get-A2LogBytes -Paths @($stdoutPath, $stderrPath)) -gt
+                  [long]$env:REPLICA_MAXIMUM_OUTPUT_BYTES) {
+                throw "A2 replica output exceeded its byte ceiling."
+              }
+              if ($clock.Elapsed.TotalSeconds -ge
+                  [int]$env:HOSTED_REPLICA_TIMEOUT_SECONDS) {
+                throw "A2 replica exceeded its hosted wall-clock ceiling."
+              }
+            }
+            if ((Get-A2LogBytes -Paths @($stdoutPath, $stderrPath)) -gt
+                [long]$env:REPLICA_MAXIMUM_OUTPUT_BYTES) {
+              throw "A2 replica output exceeded its byte ceiling."
+            }
+            $process.WaitForExit()
+            $process.Refresh()
+            $exitCode = $process.ExitCode
+            if ($null -eq $exitCode) {
+              throw "A2 replica exit code was unavailable after completion."
+            }
+            $replicaExit = [int]$exitCode
+          }
+          catch {
+            $replicaError = $_
+          }
+          finally {
+            if ($null -ne $process) {
+              try {
+                Stop-Jet3BootstrapProcessTree -Process $process `
+                  -Label "A2 hosted replica $replica"
+              }
+              catch { [void]$cleanupErrors.Add($_) }
+            }
+            if ($null -ne $clock) { $clock.Stop() }
+            if ($null -ne $process) {
+              try { $process.Dispose() }
+              catch { [void]$cleanupErrors.Add($_) }
+            }
+          }
+          if ($null -ne $replicaError) { throw $replicaError }
+          if ($cleanupErrors.Count -ne 0) {
+            throw "A2 hosted replica cleanup failed."
+          }
+          if ($replicaExit -ne 0) {
+            throw "The checked A2 replica worker returned nonzero."
+          }
+          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+            throw "A2 acquisition changed the exact producer checkout."
+          }
+
+      - name: Upload retained A2 replica tree
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a2-replica-${{ matrix.replica }}
+          path: ${{ runner.temp }}\jet3-a2-output-0${{ matrix.replica }}
+          if-no-files-found: warn
+          compression-level: 0
+          retention-days: 90
+
+      - name: Upload bounded A2 replica diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a2-diagnostics-${{ matrix.replica }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\jet3-a2-diagnostics-0${{ matrix.replica }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+  fan-in:
+    name: Assemble and analyze the complete A2 bundle
+    needs: [contract, a2-replica]
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.execute_a2_campaign &&
+      needs.contract.result == 'success' &&
+      needs.a2-replica.result == 'success'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13.7"
+
+      - name: Download A2 replica 1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-dao-a2-replica-1
+          path: ${{ runner.temp }}\jet3-a2-replicas\replica-01
+
+      - name: Download A2 replica 2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-dao-a2-replica-2
+          path: ${{ runner.temp }}\jet3-a2-replicas\replica-02
+
+      - name: Download A2 replica 3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: windows-dao-a2-replica-3
+          path: ${{ runner.temp }}\jet3-a2-replicas\replica-03
+
+      - name: Assemble the three checked replica trees
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $replicas = Join-Path $env:RUNNER_TEMP "jet3-a2-replicas"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a2-bundle"
+          $campaignId = "a2-run-$env:GITHUB_RUN_ID"
+          & python -B oracle/windows-dao/scripts/a2_bundle.py assemble `
+            --replica-root (Join-Path $replicas "replica-01") `
+            --replica-root (Join-Path $replicas "replica-02") `
+            --replica-root (Join-Path $replicas "replica-03") `
+            --bundle-root $bundle --campaign-id $campaignId
+          if ($LASTEXITCODE -ne 0) { throw "A2 replica assembly failed." }
+
+      - name: Freeze derivation, validate holdout separately, and analyze
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a2-bundle"
+          & python -B oracle/windows-dao/scripts/a2_analysis.py `
+            --bundle-root $bundle `
+            --replica (Join-Path $bundle "observations/replica-01.json") `
+            --replica (Join-Path $bundle "observations/replica-02.json") `
+            --replica (Join-Path $bundle "observations/replica-03.json") `
+            --candidate-output (Join-Path $bundle "analysis/derivation-candidates.json") `
+            --holdout-receipt (Join-Path $bundle "analysis/holdout-structure-receipt.json") `
+            --output (Join-Path $bundle "analysis/analysis-report.json")
+          if ($LASTEXITCODE -ne 0) { throw "A2 analysis failed." }
+
+      - name: Finalize the retained A2 bundle manifest
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a2-bundle"
+          & python -B oracle/windows-dao/scripts/a2_bundle.py finalize `
+            --bundle-root $bundle
+          if ($LASTEXITCODE -ne 0) { throw "A2 bundle finalization failed." }
+
+      - name: Independently validate the complete A2 bundle
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a2-bundle"
+          & python -B oracle/windows-dao/scripts/a2_bundle.py validate $bundle
+          if ($LASTEXITCODE -ne 0) {
+            throw "Independent complete A2 bundle validation failed."
+          }
+          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+            throw "A2 fan-in changed the exact producer checkout."
+          }
+
+      - name: Upload retained A2 bundle
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a2-bundle-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\jet3-a2-bundle
+          if-no-files-found: warn
+          compression-level: 0
+          retention-days: 90

--- a/oracle/windows-dao/scripts/a2_analysis.py
+++ b/oracle/windows-dao/scripts/a2_analysis.py
@@ -739,7 +739,8 @@ def _receipt_validator(path: Path, bundle_root: Path, candidate_path: Path,
     def validate(frozen_sha256: str) -> None:
         from a2_holdout import run_holdout_process
 
-        run_holdout_process(bundle_root, candidate_path, frozen_sha256, path)
+        run_holdout_process(bundle_root, candidate_path, frozen_sha256,
+                            replica.campaign_id, replica.producer_commit, path)
         receipt = _bounded_json(path)
         validate_document(receipt, "holdout-structure-receipt.schema.json")
         expected = {

--- a/oracle/windows-dao/scripts/a2_analysis.py
+++ b/oracle/windows-dao/scripts/a2_analysis.py
@@ -734,8 +734,17 @@ def build_analysis(
     return report
 
 
-def _receipt_validator(path: Path, campaign_id: str, producer_commit: str) -> Callable[[str], None]:
+def _receipt_validator(
+    path: Path,
+    bundle_root: Path,
+    candidate_path: Path,
+    campaign_id: str,
+    producer_commit: str,
+) -> Callable[[str], None]:
     def validate(frozen_sha256: str) -> None:
+        from a2_holdout import run_holdout_process
+
+        run_holdout_process(bundle_root, candidate_path, frozen_sha256, path)
         receipt = _bounded_json(path)
         validate_document(receipt, "holdout-structure-receipt.schema.json")
         expected = {
@@ -747,7 +756,11 @@ def _receipt_validator(path: Path, campaign_id: str, producer_commit: str) -> Ca
         for key, value in expected.items():
             if receipt[key] != value:
                 raise ValidationError(f"holdout receipt {key} binding mismatch")
-
+        manifest_path = (
+            bundle_root / "replica-artifacts" / "replica-03-manifest.json"
+        )
+        if receipt["replica_artifact_manifest_sha256"] != _sha256(manifest_path):
+            raise ValidationError("holdout receipt replica manifest binding mismatch")
     return validate
 
 
@@ -760,25 +773,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", type=Path)
     arguments = parser.parse_args(argv)
     root = arguments.bundle_root
-    replicas = arguments.replica or [
-        root / relative for relative in PLAN["artifacts"]["replica_observations"]
-    ]
-    candidate_output = (
-        arguments.candidate_output or root / PLAN["artifacts"]["frozen_candidate_set"]
-    )
+    replicas = arguments.replica or [root / relative for relative in PLAN["artifacts"]["replica_observations"]]
+    candidate_output = arguments.candidate_output or root / PLAN["artifacts"]["frozen_candidate_set"]
     output = arguments.output or root / PLAN["artifacts"]["analysis_report"]
-    receipt_path = (
-        arguments.holdout_receipt
-        or root / PLAN["artifacts"]["holdout_structure_receipt"]
-    )
+    receipt_path = arguments.holdout_receipt or root / PLAN["artifacts"]["holdout_structure_receipt"]
     try:
         if len(replicas) != 3:
             raise ValidationError("exactly three A2 replica observations are required")
         sources = [BundleReplicaSource(path, root) for path in replicas]
         first = sources[0].open()
-        validator = _receipt_validator(receipt_path, first.campaign_id, first.producer_commit)
-        # Re-opening replica 1 below is metadata-only and still precedes the freeze;
-        # replica 3 remains unopened until build_analysis persists candidates.
+        validator = _receipt_validator(receipt_path, root, candidate_output, first.campaign_id, first.producer_commit)
         report = build_analysis(sources, candidate_output, validator)
         output.parent.mkdir(parents=True, exist_ok=True)
         with output.open("xb") as handle:
@@ -786,12 +790,7 @@ def main(argv: list[str] | None = None) -> int:
     except (Abort, OSError, ValidationError) as exc:
         print(f"A2 analysis failed: {exc}", file=sys.stderr)
         return 1
-    print(
-        json.dumps(
-            {"output": str(output), "scientific_outcome": report["scientific_outcome"]},
-            sort_keys=True,
-        )
-    )
+    print(json.dumps({"output": str(output), "scientific_outcome": report["scientific_outcome"]}, sort_keys=True))
     return 0
 
 

--- a/oracle/windows-dao/scripts/a2_analysis.py
+++ b/oracle/windows-dao/scripts/a2_analysis.py
@@ -734,13 +734,8 @@ def build_analysis(
     return report
 
 
-def _receipt_validator(
-    path: Path,
-    bundle_root: Path,
-    candidate_path: Path,
-    campaign_id: str,
-    producer_commit: str,
-) -> Callable[[str], None]:
+def _receipt_validator(path: Path, bundle_root: Path, candidate_path: Path,
+                       replica: ReplicaInput) -> Callable[[str], None]:
     def validate(frozen_sha256: str) -> None:
         from a2_holdout import run_holdout_process
 
@@ -749,16 +744,14 @@ def _receipt_validator(
         validate_document(receipt, "holdout-structure-receipt.schema.json")
         expected = {
             "plan_sha256": PLAN_SHA256,
-            "campaign_id": campaign_id,
-            "producer_commit": producer_commit,
+            "campaign_id": replica.campaign_id,
+            "producer_commit": replica.producer_commit,
             "derivation_candidate_set_sha256": frozen_sha256,
         }
         for key, value in expected.items():
             if receipt[key] != value:
                 raise ValidationError(f"holdout receipt {key} binding mismatch")
-        manifest_path = (
-            bundle_root / "replica-artifacts" / "replica-03-manifest.json"
-        )
+        manifest_path = bundle_root / "replica-artifacts" / "replica-03-manifest.json"
         if receipt["replica_artifact_manifest_sha256"] != _sha256(manifest_path):
             raise ValidationError("holdout receipt replica manifest binding mismatch")
     return validate
@@ -773,16 +766,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", type=Path)
     arguments = parser.parse_args(argv)
     root = arguments.bundle_root
-    replicas = arguments.replica or [root / relative for relative in PLAN["artifacts"]["replica_observations"]]
-    candidate_output = arguments.candidate_output or root / PLAN["artifacts"]["frozen_candidate_set"]
-    output = arguments.output or root / PLAN["artifacts"]["analysis_report"]
-    receipt_path = arguments.holdout_receipt or root / PLAN["artifacts"]["holdout_structure_receipt"]
+    artifacts = PLAN["artifacts"]
+    replicas = arguments.replica or [
+        root / relative for relative in artifacts["replica_observations"]
+    ]
+    candidate_output = arguments.candidate_output or root / artifacts["frozen_candidate_set"]
+    output = arguments.output or root / artifacts["analysis_report"]
+    receipt_path = arguments.holdout_receipt or root / artifacts["holdout_structure_receipt"]
     try:
         if len(replicas) != 3:
             raise ValidationError("exactly three A2 replica observations are required")
         sources = [BundleReplicaSource(path, root) for path in replicas]
         first = sources[0].open()
-        validator = _receipt_validator(receipt_path, root, candidate_output, first.campaign_id, first.producer_commit)
+        validator = _receipt_validator(receipt_path, root, candidate_output, first)
+        # Re-opening replica 1 below is metadata-only and still precedes the freeze;
+        # replica 3 remains unopened until build_analysis persists candidates.
         report = build_analysis(sources, candidate_output, validator)
         output.parent.mkdir(parents=True, exist_ok=True)
         with output.open("xb") as handle:
@@ -790,7 +788,8 @@ def main(argv: list[str] | None = None) -> int:
     except (Abort, OSError, ValidationError) as exc:
         print(f"A2 analysis failed: {exc}", file=sys.stderr)
         return 1
-    print(json.dumps({"output": str(output), "scientific_outcome": report["scientific_outcome"]}, sort_keys=True))
+    summary = {"output": str(output), "scientific_outcome": report["scientific_outcome"]}
+    print(json.dumps(summary, sort_keys=True))
     return 0
 
 

--- a/oracle/windows-dao/scripts/a2_bundle.py
+++ b/oracle/windows-dao/scripts/a2_bundle.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""Assemble, finalize, and independently validate DAO A2 bundle trees."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from a2_spec import (
+    BOUNDS,
+    CHECKED_PLAN,
+    CHECKPOINT_IDS,
+    EXPERIMENT_ID,
+    PLAN_SHA256,
+    PREDICATE_REASONS,
+    ROLE_BINDINGS,
+    validate_analysis_report,
+    validate_bundle_manifest,
+    validate_environment,
+    validate_holdout_structure_receipt,
+    validate_page_index,
+    validate_replica_artifact_manifest,
+    validate_replica_observation,
+)
+from protocol_validation import ValidationError, canonical_json_bytes
+
+PAGE_SIZE = 2_048
+REPLICA_COUNT = 3
+CHECKPOINT_COUNT = 25
+MAX_JSON_BYTES = 67_108_864
+MAX_PAGE_BLOBS = 65_536
+MAX_PAGE_STORE_BYTES = 536_870_912
+MAX_BUNDLE_BYTES = 805_306_368
+MAX_TREE_ENTRIES = 65_750
+MAX_TREE_DEPTH = 8
+REPOSITORY_URL = "https://github.com/oglassdev/jet3-rs.git"
+MANIFEST_PATH = "bundle-manifest.json"
+FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+LAYER_KEYS = (
+    "global_map_record",
+    "global_map_conversion_inline",
+    "global_map_extended_base",
+    "tdef_pointer_pair",
+)
+
+_PINNED_BOUNDS = {
+    "page_size": PAGE_SIZE,
+    "replicas": REPLICA_COUNT,
+    "planned_checkpoints_per_replica": CHECKPOINT_COUNT,
+    "max_json_bytes": MAX_JSON_BYTES,
+    "max_unique_page_blobs": MAX_PAGE_BLOBS,
+    "max_retained_page_store_bytes": MAX_PAGE_STORE_BYTES,
+    "max_bundle_bytes": MAX_BUNDLE_BYTES,
+}
+for _bound_name, _bound_value in _PINNED_BOUNDS.items():
+    if BOUNDS[_bound_name] != _bound_value:
+        raise RuntimeError(f"checked A2 bound drifted: {_bound_name}")
+if len(CHECKPOINT_IDS) != CHECKPOINT_COUNT:
+    raise RuntimeError("checked A2 checkpoint count drifted")
+@dataclass(frozen=True)
+class TreeFile:
+    size: int
+    modified_ns: int
+    device: int
+    inode: int
+    links: int
+@dataclass(frozen=True)
+class ReplicaResult:
+    root: Path
+    replica: int
+    manifest_path: str
+    manifest: dict[str, Any]
+    manifest_sha256: str
+    manifest_size: int
+    entries: dict[str, dict[str, Any]]
+    environment: dict[str, Any]
+    environment_sha256: str
+    observation: dict[str, Any]
+    provider_sha256: str
+    producer_commit: str
+    campaign_id: str
+    page_paths: frozenset[str]
+@dataclass(frozen=True)
+class PayloadResult:
+    tree: dict[str, TreeFile]
+    directories: set[str]
+    replicas: tuple[ReplicaResult, ...]
+    expected_paths: frozenset[str]
+    analysis: dict[str, Any] | None
+    receipt: dict[str, Any] | None
+    frozen_sha256: str | None
+def _is_reparse(metadata: os.stat_result) -> bool:
+    return bool(
+        getattr(metadata, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT
+    )
+def _safe_locator(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 512 or "\\" in value:
+        raise ValidationError(f"{label}: unsafe artifact path")
+    candidate = Path(value)
+    if candidate.is_absolute() or any(part in ("", ".", "..") for part in candidate.parts):
+        raise ValidationError(f"{label}: unsafe artifact path")
+    if candidate.as_posix() != value:
+        raise ValidationError(f"{label}: non-canonical artifact path")
+    return value
+def _inventory(root: Path) -> tuple[dict[str, TreeFile], set[str]]:
+    root = root.resolve()
+    try:
+        metadata = root.lstat()
+    except OSError as exc:
+        raise ValidationError(f"{root}: cannot inspect tree root: {exc}") from exc
+    if root.is_symlink() or _is_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValidationError(f"{root}: tree root must be a regular directory")
+    files: dict[str, TreeFile] = {}
+    directories: set[str] = set()
+    folded: dict[str, str] = {}
+    identities: set[tuple[int, int]] = set()
+    pending = [(root, 0)]
+    seen = 0
+    try:
+        while pending:
+            directory, depth = pending.pop()
+            with os.scandir(directory) as children:
+                for child in children:
+                    seen += 1
+                    if seen > MAX_TREE_ENTRIES:
+                        raise ValidationError("A2 tree exceeds its entry ceiling")
+                    child_metadata = child.stat(follow_symlinks=False)
+                    if child.is_symlink() or _is_reparse(child_metadata):
+                        raise ValidationError(f"{child.path}: links are forbidden")
+                    locator = Path(child.path).relative_to(root).as_posix()
+                    _safe_locator(locator, child.path)
+                    prior = folded.get(locator.casefold())
+                    if prior is not None and prior != locator:
+                        raise ValidationError(f"{locator}: case-colliding tree entry")
+                    folded[locator.casefold()] = locator
+                    if stat.S_ISDIR(child_metadata.st_mode):
+                        if depth >= MAX_TREE_DEPTH:
+                            raise ValidationError("A2 tree exceeds its depth ceiling")
+                        directories.add(locator)
+                        pending.append((Path(child.path), depth + 1))
+                    elif stat.S_ISREG(child_metadata.st_mode):
+                        identity = (child_metadata.st_dev, child_metadata.st_ino)
+                        if child_metadata.st_nlink != 1 or identity in identities:
+                            raise ValidationError(f"{locator}: hard links are forbidden")
+                        identities.add(identity)
+                        files[locator] = TreeFile(
+                            child_metadata.st_size,
+                            child_metadata.st_mtime_ns,
+                            child_metadata.st_dev,
+                            child_metadata.st_ino,
+                            child_metadata.st_nlink,
+                        )
+                    else:
+                        raise ValidationError(f"{locator}: non-regular tree entry")
+    except ValidationError:
+        raise
+    except OSError as exc:
+        raise ValidationError(f"{root}: cannot enumerate tree: {exc}") from exc
+    return files, directories
+def _expected_directories(paths: Iterable[str]) -> set[str]:
+    return {
+        parent.as_posix()
+        for locator in paths
+        for parent in Path(locator).parents
+        if parent != Path(".")
+    }
+def _identity(metadata: os.stat_result) -> tuple[int, int, int]:
+    return metadata.st_dev, metadata.st_ino, metadata.st_nlink
+def _read_checked(root: Path, locator: str, tree: dict[str, TreeFile], maximum: int) -> bytes:
+    try:
+        expected = tree[locator]
+    except KeyError as exc:
+        raise ValidationError(f"{locator}: missing artifact") from exc
+    if expected.size < 1 or expected.size > maximum:
+        raise ValidationError(f"{locator}: artifact violates its byte ceiling")
+    path = root.joinpath(*locator.split("/"))
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        before = path.lstat()
+        expected_identity = (expected.device, expected.inode, expected.links)
+        if (
+            path.is_symlink() or _is_reparse(before) or not stat.S_ISREG(before.st_mode)
+            or before.st_size != expected.size
+            or before.st_mtime_ns != expected.modified_ns
+            or _identity(before) != expected_identity
+        ):
+            raise ValidationError(f"{locator}: artifact identity changed before read")
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as handle:
+            opened = os.fstat(handle.fileno())
+            if _identity(opened) != expected_identity:
+                raise ValidationError(f"{locator}: artifact identity changed while opening")
+            payload = handle.read(maximum + 1)
+            after_open = os.fstat(handle.fileno())
+        after = path.lstat()
+    except ValidationError:
+        raise
+    except OSError as exc:
+        raise ValidationError(f"{locator}: cannot read artifact: {exc}") from exc
+    if (
+        len(payload) != expected.size or len(payload) > maximum
+        or _identity(after_open) != expected_identity
+        or path.is_symlink() or _is_reparse(after) or not stat.S_ISREG(after.st_mode)
+        or after.st_size != expected.size
+        or after.st_mtime_ns != expected.modified_ns
+        or _identity(after) != expected_identity
+    ):
+        raise ValidationError(f"{locator}: artifact changed during read")
+    return payload
+def _parse_json(payload: bytes, locator: str) -> dict[str, Any]:
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise ValidationError(f"{locator}: UTF-8 byte-order marks are forbidden")
+
+    def unique(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    def reject(value: str) -> None:
+        raise ValueError(f"non-finite JSON number {value}")
+
+    try:
+        document = json.loads(payload.decode("utf-8"), object_pairs_hook=unique,
+                              parse_constant=reject)
+    except (UnicodeError, json.JSONDecodeError, ValueError, RecursionError) as exc:
+        raise ValidationError(f"{locator}: invalid JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValidationError(f"{locator}: JSON root must be an object")
+    return document
+def _json_artifact(root: Path, locator: str, tree: dict[str, TreeFile]) -> tuple[dict[str, Any], bytes]:
+    payload = _read_checked(root, locator, tree, MAX_JSON_BYTES)
+    return _parse_json(payload, locator), payload
+def _require(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{label}: binding mismatch")
+def _entry_map(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    folded: set[str] = set()
+    for index, entry in enumerate(manifest["files"]):
+        locator = _safe_locator(entry["path"], f"$.files[{index}].path")
+        if locator in entries or locator.casefold() in folded:
+            raise ValidationError(f"$.files: duplicate path {locator!r}")
+        entries[locator] = entry
+        folded.add(locator.casefold())
+    return entries
+def _entry_payload(root: Path, tree: dict[str, TreeFile],
+                   entry: dict[str, Any]) -> tuple[bytes, dict[str, Any] | None]:
+    maximum = PAGE_SIZE if entry["role"] == "page_blob" else MAX_JSON_BYTES
+    payload = _read_checked(root, entry["path"], tree, maximum)
+    _require(len(payload), entry["size_bytes"], f"{entry['path']} size")
+    _require(hashlib.sha256(payload).hexdigest(), entry["sha256"], f"{entry['path']} sha256")
+    expected_media = "application/octet-stream" if entry["role"] == "page_blob" else "application/json"
+    _require(entry["media_type"], expected_media, f"{entry['path']} media type")
+    return payload, None if expected_media != "application/json" else _parse_json(payload, entry["path"])
+def _validate_replica(
+    root: Path,
+    tree: dict[str, TreeFile],
+    directories: set[str],
+    replica: int,
+    campaign_id: str | None,
+    *,
+    closed: bool,
+) -> ReplicaResult:
+    manifest_path = f"replica-artifacts/replica-{replica:02d}-manifest.json"
+    manifest, manifest_payload = _json_artifact(root, manifest_path, tree)
+    validate_replica_artifact_manifest(manifest)
+    _require(manifest["replica"], replica, f"replica {replica} manifest replica")
+    if campaign_id is not None:
+        _require(manifest["campaign_id"], campaign_id, f"replica {replica} campaign")
+    entries = _entry_map(manifest)
+    if any(entry["role"] == "acquisition_log" for entry in entries.values()):
+        raise ValidationError("replica outputs may not contain acquisition logs")
+    expected_files = set(entries) | {manifest_path}
+    if closed:
+        _require(set(tree), expected_files, f"replica {replica} closed inventory")
+        _require(directories, _expected_directories(expected_files), f"replica {replica} directory closure")
+
+    documents: dict[str, dict[str, Any]] = {}
+    for entry in entries.values():
+        _, document = _entry_payload(root, tree, entry)
+        if document is not None:
+            documents[entry["path"]] = document
+
+    environment_path = f"environment/replica-{replica:02d}.json"
+    observation_path = f"observations/replica-{replica:02d}.json"
+    environment_entry = entries.get(environment_path)
+    observation_entry = entries.get(observation_path)
+    if environment_entry is None or environment_entry["role"] != "environment":
+        raise ValidationError(f"{environment_path}: missing environment role")
+    if observation_entry is None or observation_entry["role"] != "replica_observation":
+        raise ValidationError(f"{observation_path}: missing observation role")
+    environment = documents[environment_path]
+    observation = documents[observation_path]
+    validate_environment(environment)
+    validate_replica_observation(observation)
+    expected_binding = {
+        "plan_sha256": PLAN_SHA256,
+        "producer_commit": manifest["producer_commit"],
+        "campaign_id": manifest["campaign_id"],
+        "replica": replica,
+    }
+    for key, expected in expected_binding.items():
+        _require(environment[key], expected, f"{environment_path} {key}")
+        _require(observation[key], expected, f"{observation_path} {key}")
+    _require(environment["matrix_job_id"], manifest["matrix_job_id"], "environment matrix job")
+    _require(observation["matrix_job"]["job_id"], manifest["matrix_job_id"], "observation matrix job")
+    _require(environment_entry["sha256"], manifest["environment_sha256"], "environment manifest hash")
+    _require(observation["environment_sha256"], environment_entry["sha256"], "observation environment hash")
+    provider_sha256 = environment["provider"]["server_sha256"]
+    _require(provider_sha256, manifest["provider_sha256"], "manifest provider hash")
+    _require(observation["provider_sha256"], provider_sha256, "observation provider hash")
+    _require(observation["repository_url"], REPOSITORY_URL, "observation repository URL")
+    _require(observation["role_binding"], dict(ROLE_BINDINGS[replica - 1]), "observation role binding")
+
+    referenced_pages: set[str] = set()
+    prior_hashes: list[str] = []
+    for ordinal, checkpoint in enumerate(observation["checkpoints"]):
+        checkpoint_id = CHECKPOINT_IDS[ordinal]
+        expected_path = f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint_id}.json"
+        reference = checkpoint["page_index"]
+        _require(reference["path"], expected_path, f"replica {replica} page index path")
+        entry = entries.get(expected_path)
+        if entry is None or entry["role"] != "page_index":
+            raise ValidationError(f"{expected_path}: missing page-index role")
+        _require(reference["sha256"], entry["sha256"], f"{expected_path} reference hash")
+        _require(reference["size_bytes"], entry["size_bytes"], f"{expected_path} reference size")
+        index = documents[expected_path]
+        hashes = validate_page_index(index, observation, checkpoint, prior_hashes)
+        reconstruction = hashlib.sha256()
+        for digest in hashes:
+            page_path = f"page-store/{digest}.page"
+            page_entry = entries.get(page_path)
+            if page_entry is None or page_entry["role"] != "page_blob":
+                raise ValidationError(f"{page_path}: referenced blob is absent")
+            payload = _read_checked(root, page_path, tree, PAGE_SIZE)
+            _require(len(payload), PAGE_SIZE, f"{page_path} page size")
+            _require(hashlib.sha256(payload).hexdigest(), digest, f"{page_path} content address")
+            reconstruction.update(payload)
+            referenced_pages.add(page_path)
+        _require(reconstruction.hexdigest(), index["database_sha256"], f"{expected_path} database hash")
+        prior_hashes = hashes
+    page_paths = {path for path, entry in entries.items() if entry["role"] == "page_blob"}
+    _require(page_paths, referenced_pages, f"replica {replica} page-store closure")
+    if len(page_paths) > MAX_PAGE_BLOBS or len(page_paths) * PAGE_SIZE > MAX_PAGE_STORE_BYTES:
+        raise ValidationError(f"replica {replica}: page-store bound exceeded")
+    return ReplicaResult(
+        root,
+        replica,
+        manifest_path,
+        manifest,
+        hashlib.sha256(manifest_payload).hexdigest(),
+        len(manifest_payload),
+        entries,
+        environment,
+        environment_entry["sha256"],
+        observation,
+        provider_sha256,
+        manifest["producer_commit"],
+        manifest["campaign_id"],
+        frozenset(page_paths),
+    )
+def _validate_environments(replicas: Iterable[ReplicaResult]) -> None:
+    rows = tuple(replicas)
+    for attribute in ("campaign_id", "producer_commit", "provider_sha256"):
+        if len({getattr(row, attribute) for row in rows}) != 1:
+            raise ValidationError(f"cross-replica {attribute} differs")
+    exact = (
+        lambda row: row.environment["provider"]["prog_id"],
+        lambda row: row.environment["provider"]["clsid"],
+        lambda row: row.environment["provider"]["server_sha256"],
+        lambda row: row.environment["host"]["process_architecture"],
+        lambda row: int(row.environment["host"]["powershell_version"].split(".", 1)[0]),
+    )
+    for projection in exact:
+        if len({projection(row) for row in rows}) != 1:
+            raise ValidationError("cross-replica exact environment field differs")
+def _validate_frozen(document: dict[str, Any], campaign_id: str) -> None:
+    expected_keys = {
+        "protocol_version", "document_type", "experiment_id", "plan_sha256",
+        "campaign_id", "derivation_replicas", "qualified_pages", "layers",
+    }
+    _require(set(document), expected_keys, "frozen candidate keys")
+    bindings = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_frozen_derivation_candidates",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "campaign_id": campaign_id,
+        "derivation_replicas": [1, 2],
+    }
+    for key, expected in bindings.items():
+        _require(document[key], expected, f"frozen candidate {key}")
+    qualified = document["qualified_pages"]
+    if set(qualified) != {"global_map", "tdef"}:
+        raise ValidationError("frozen candidate qualified-page keys differ")
+    for pages in qualified.values():
+        if (
+            not isinstance(pages, list)
+            or len(pages) > 16
+            or pages != sorted(set(pages))
+            or any(type(page) is not int or not 0 <= page < 65_536 for page in pages)
+        ):
+            raise ValidationError("frozen candidate qualified pages are malformed")
+    if set(document["layers"]) != set(LAYER_KEYS):
+        raise ValidationError("frozen candidate layer inventory differs")
+    for layer in document["layers"].values():
+        if set(layer) != {
+            "applicable", "derivation_survivor_count", "terminal_predicate_id",
+            "no_outcome_reason", "model",
+        }:
+            raise ValidationError("frozen candidate layer shape differs")
+        predicate = layer["terminal_predicate_id"]
+        reason = layer["no_outcome_reason"]
+        if predicate is None:
+            if reason is not None:
+                raise ValidationError("frozen candidate reason lacks a predicate")
+        elif PREDICATE_REASONS.get(predicate) != reason:
+            raise ValidationError("frozen candidate predicate mapping differs")
+        if type(layer["applicable"]) is not bool:
+            raise ValidationError("frozen candidate applicability is not boolean")
+        count = layer["derivation_survivor_count"]
+        if type(count) is not int or not 0 <= count <= 1_000_000:
+            raise ValidationError("frozen candidate survivor count is out of bounds")
+        if layer["model"] is not None and not isinstance(layer["model"], dict):
+            raise ValidationError("frozen candidate model is malformed")
+def _validate_analysis_payload(root: Path, tree: dict[str, TreeFile],
+                               replicas: tuple[ReplicaResult, ...]) -> tuple[dict[str, Any], dict[str, Any], str]:
+    frozen_path = "analysis/derivation-candidates.json"
+    analysis_path = "analysis/analysis-report.json"
+    receipt_path = "analysis/holdout-structure-receipt.json"
+    frozen, frozen_payload = _json_artifact(root, frozen_path, tree)
+    report, _ = _json_artifact(root, analysis_path, tree)
+    receipt, _ = _json_artifact(root, receipt_path, tree)
+    campaign_id = replicas[0].campaign_id
+    frozen_sha256 = hashlib.sha256(frozen_payload).hexdigest()
+    _validate_frozen(frozen, campaign_id)
+    validate_analysis_report(report)
+    validate_holdout_structure_receipt(receipt)
+    bindings = {
+        "campaign_id": campaign_id,
+        "producer_commit": replicas[0].producer_commit,
+        "derivation_candidate_set_sha256": frozen_sha256,
+    }
+    for key, expected in bindings.items():
+        _require(report[key], expected, f"analysis {key}")
+        _require(receipt[key], expected, f"holdout receipt {key}")
+    _require(
+        receipt["replica_artifact_manifest_sha256"],
+        replicas[2].manifest_sha256,
+        "holdout receipt replica manifest hash",
+    )
+    return report, receipt, frozen_sha256
+def _validate_payload(root: Path, *, require_analysis: bool,
+                      allow_manifest: bool = False) -> PayloadResult:
+    root = root.resolve()
+    tree, directories = _inventory(root)
+    plan_payload = _read_checked(root, "plan/a2-allocation-maps.plan.json", tree, MAX_JSON_BYTES)
+    _require(hashlib.sha256(plan_payload).hexdigest(), PLAN_SHA256, "retained plan hash")
+    _require(plan_payload, CHECKED_PLAN.read_bytes(), "retained checked plan")
+    replicas = tuple(
+        _validate_replica(root, tree, directories, replica, None, closed=False)
+        for replica in range(1, REPLICA_COUNT + 1)
+    )
+    _validate_environments(replicas)
+    expected = {"plan/a2-allocation-maps.plan.json"}
+    for replica in replicas:
+        expected.add(replica.manifest_path)
+        expected.update(replica.entries)
+    report = None
+    receipt = None
+    frozen_sha256 = None
+    if require_analysis:
+        analysis_paths = {
+            "analysis/derivation-candidates.json",
+            "analysis/analysis-report.json",
+            "analysis/holdout-structure-receipt.json",
+        }
+        expected.update(analysis_paths)
+        report, receipt, frozen_sha256 = _validate_analysis_payload(root, tree, replicas)
+    complete_expected = expected | ({MANIFEST_PATH} if allow_manifest else set())
+    _require(set(tree), complete_expected, "A2 payload closed inventory")
+    _require(directories, _expected_directories(complete_expected),
+             "A2 payload directory closure")
+    page_paths = set().union(*(row.page_paths for row in replicas))
+    if len(page_paths) > MAX_PAGE_BLOBS or len(page_paths) * PAGE_SIZE > MAX_PAGE_STORE_BYTES:
+        raise ValidationError("A2 merged page store exceeds its fixed bound")
+    if sum(item.size for item in tree.values()) > MAX_BUNDLE_BYTES:
+        raise ValidationError("A2 bundle exceeds its fixed byte bound")
+    return PayloadResult(tree, directories, replicas, frozenset(expected),
+                         report, receipt, frozen_sha256)
+def _copy_verified(
+    source_root: Path,
+    destination_root: Path,
+    locator: str,
+    size: int,
+    digest: str,
+) -> None:
+    source = source_root.joinpath(*locator.split("/"))
+    destination = destination_root.joinpath(*locator.split("/"))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if not destination.is_file() or destination.is_symlink():
+            raise ValidationError(f"{locator}: merge collision is not a regular file")
+        payload_digest = hashlib.sha256(destination.read_bytes()).hexdigest()
+        if destination.stat().st_size != size or payload_digest != digest:
+            raise ValidationError(f"{locator}: merge collision differs")
+        return
+    source_metadata = source.lstat()
+    if source.is_symlink() or _is_reparse(source_metadata) or not stat.S_ISREG(source_metadata.st_mode):
+        raise ValidationError(f"{locator}: copy source is unsafe")
+    observed = hashlib.sha256()
+    total = 0
+    try:
+        with source.open("rb") as reader, destination.open("xb") as writer:
+            for chunk in iter(lambda: reader.read(65_536), b""):
+                total += len(chunk)
+                if total > size:
+                    raise ValidationError(f"{locator}: copy source grew")
+                observed.update(chunk)
+                writer.write(chunk)
+    except Exception:
+        if destination.exists():
+            destination.unlink()
+        raise
+    if total != size or observed.hexdigest() != digest:
+        destination.unlink()
+        raise ValidationError(f"{locator}: copy source binding failed")
+
+
+def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
+                    campaign_id: str) -> dict[str, Any]:
+    roots = tuple(Path(root).resolve() for root in replica_roots)
+    if len(roots) != REPLICA_COUNT:
+        raise ValidationError("assemble requires exactly three replica roots")
+    if bundle_root.exists():
+        raise ValidationError("bundle root already exists")
+    validated = []
+    for replica, root in enumerate(roots, start=1):
+        tree, directories = _inventory(root)
+        validated.append(_validate_replica(
+            root, tree, directories, replica, campaign_id, closed=True))
+    replicas = tuple(validated)
+    _validate_environments(replicas)
+    github_sha = os.environ.get("GITHUB_SHA")
+    if github_sha is not None:
+        _require(replicas[0].producer_commit, github_sha, "checked-out producer commit")
+    bundle_parent = bundle_root.resolve().parent
+    bundle_parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".a2-assemble-", dir=bundle_parent))
+    try:
+        plan_path = staging / "plan" / "a2-allocation-maps.plan.json"
+        plan_path.parent.mkdir(parents=True)
+        plan_path.write_bytes(CHECKED_PLAN.read_bytes())
+        for replica in replicas:
+            _copy_verified(
+                replica.root,
+                staging,
+                replica.manifest_path,
+                replica.manifest_size,
+                replica.manifest_sha256,
+            )
+            for entry in replica.entries.values():
+                _copy_verified(
+                    replica.root,
+                    staging,
+                    entry["path"],
+                    entry["size_bytes"],
+                    entry["sha256"],
+                )
+        result = _validate_payload(staging, require_analysis=False)
+        os.replace(staging, bundle_root)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return {
+        "bundle_root": str(bundle_root),
+        "campaign_id": campaign_id,
+        "producer_commit": result.replicas[0].producer_commit,
+        "provider_sha256": result.replicas[0].provider_sha256,
+    }
+
+
+def validate_holdout_replica(bundle_root: Path, candidate_path: Path,
+                             candidate_sha256: str) -> ReplicaResult:
+    tree, directories = _inventory(bundle_root.resolve())
+    replica = _validate_replica(bundle_root.resolve(), tree, directories,
+                                REPLICA_COUNT, None, closed=False)
+    payload = _read_checked(
+        bundle_root.resolve(),
+        candidate_path.resolve().relative_to(bundle_root.resolve()).as_posix(),
+        tree,
+        MAX_JSON_BYTES,
+    )
+    _require(hashlib.sha256(payload).hexdigest(), candidate_sha256, "frozen candidate hash")
+    frozen = _parse_json(payload, candidate_path.as_posix())
+    _validate_frozen(frozen, replica.campaign_id)
+    return replica
+
+
+def _role_for_path(path: str, replicas: tuple[ReplicaResult, ...]) -> str:
+    fixed = {
+        "plan/a2-allocation-maps.plan.json": "plan",
+        "analysis/derivation-candidates.json": "frozen_candidate_set",
+        "analysis/analysis-report.json": "analysis_report",
+        "analysis/holdout-structure-receipt.json": "holdout_structure_receipt",
+    }
+    if path in fixed:
+        return fixed[path]
+    for replica in replicas:
+        if path == replica.manifest_path:
+            return "replica_artifact_manifest"
+        if path in replica.entries:
+            return replica.entries[path]["role"]
+    raise ValidationError(f"{path}: cannot assign bundle role")
+
+
+def finalize_bundle(bundle_root: Path) -> dict[str, Any]:
+    bundle_root = bundle_root.resolve()
+    if (bundle_root / MANIFEST_PATH).exists():
+        raise ValidationError("bundle manifest already exists")
+    payload = _validate_payload(bundle_root, require_analysis=True)
+    assert payload.analysis is not None and payload.receipt is not None
+    files = []
+    for path in sorted(payload.expected_paths):
+        item = payload.tree[path]
+        role = _role_for_path(path, payload.replicas)
+        maximum = PAGE_SIZE if role == "page_blob" else MAX_JSON_BYTES
+        retained = _read_checked(bundle_root, path, payload.tree, maximum)
+        digest = hashlib.sha256(retained).hexdigest()
+        files.append(
+            {
+                "path": path,
+                "role": role,
+                "sha256": digest,
+                "size_bytes": item.size,
+                "media_type": "application/octet-stream" if role == "page_blob" else "application/json",
+            }
+        )
+    decisive = payload.analysis["scientific_outcome"] == "one_or_more_submodels_predict_holdout"
+    manifest = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_bundle_manifest",
+        "experiment_id": EXPERIMENT_ID,
+        "campaign_id": payload.replicas[0].campaign_id,
+        "producer_commit": payload.replicas[0].producer_commit,
+        "repository_url": REPOSITORY_URL,
+        "created_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "plan_sha256": PLAN_SHA256,
+        "replica_environment_sha256": [row.environment_sha256 for row in payload.replicas],
+        "provider_sha256": payload.replicas[0].provider_sha256,
+        "replica_count": REPLICA_COUNT,
+        "replica_artifact_manifest_sha256": [row.manifest_sha256 for row in payload.replicas],
+        "checkpoint_count": REPLICA_COUNT * CHECKPOINT_COUNT,
+        "page_blob_count": sum(1 for row in files if row["role"] == "page_blob"),
+        "bundle_size_bytes_excluding_manifest": sum(row["size_bytes"] for row in files),
+        "inventory_closed": True,
+        "hashes_verified": True,
+        "paths_closed": True,
+        "execution_status": "analysis_complete",
+        "campaign_failed": False,
+        "holdout_structure_receipt_sha256": hashlib.sha256(_read_checked(
+            bundle_root, "analysis/holdout-structure-receipt.json",
+            payload.tree, MAX_JSON_BYTES)).hexdigest(),
+        "analysis_report_retained": True,
+        "analysis_scientific_outcome": payload.analysis["scientific_outcome"],
+        "bundle_status": (
+            "decisive_pending_independent_validation"
+            if decisive
+            else "complete_no_scientific_outcome"
+        ),
+        "independent_validation_status": "not_independently_validated",
+        "files": files,
+    }
+    validate_bundle_manifest(manifest)
+    manifest_bytes = canonical_json_bytes(manifest)
+    if len(manifest_bytes) > MAX_JSON_BYTES:
+        raise ValidationError("bundle manifest exceeds its fixed JSON bound")
+    if manifest["bundle_size_bytes_excluding_manifest"] + len(manifest_bytes) > MAX_BUNDLE_BYTES:
+        raise ValidationError("complete A2 bundle exceeds its fixed byte bound")
+    with (bundle_root / MANIFEST_PATH).open("xb") as handle:
+        handle.write(manifest_bytes)
+    return manifest
+
+
+def validate_bundle(bundle_root: Path) -> dict[str, Any]:
+    bundle_root = bundle_root.resolve()
+    tree, directories = _inventory(bundle_root)
+    manifest, manifest_payload = _json_artifact(bundle_root, MANIFEST_PATH, tree)
+    validate_bundle_manifest(manifest)
+    entries = _entry_map(manifest)
+    _require(set(tree), set(entries) | {MANIFEST_PATH}, "complete bundle inventory")
+    _require(directories, _expected_directories(entries), "complete bundle directories")
+    for entry in entries.values():
+        _entry_payload(bundle_root, tree, entry)
+    payload = _validate_payload(bundle_root, require_analysis=True,
+                                allow_manifest=True)
+    assert payload.analysis is not None and payload.receipt is not None
+    expected = {
+        "experiment_id": EXPERIMENT_ID,
+        "campaign_id": payload.replicas[0].campaign_id,
+        "producer_commit": payload.replicas[0].producer_commit,
+        "repository_url": REPOSITORY_URL,
+        "plan_sha256": PLAN_SHA256,
+        "replica_environment_sha256": [row.environment_sha256 for row in payload.replicas],
+        "provider_sha256": payload.replicas[0].provider_sha256,
+        "replica_artifact_manifest_sha256": [row.manifest_sha256 for row in payload.replicas],
+        "holdout_structure_receipt_sha256": entries["analysis/holdout-structure-receipt.json"]["sha256"],
+        "analysis_scientific_outcome": payload.analysis["scientific_outcome"],
+    }
+    for key, value in expected.items():
+        _require(manifest[key], value, f"bundle manifest {key}")
+    _require(
+        manifest["bundle_size_bytes_excluding_manifest"],
+        sum(entry["size_bytes"] for entry in entries.values()),
+        "bundle manifest retained bytes",
+    )
+    _require(
+        manifest["page_blob_count"],
+        sum(entry["role"] == "page_blob" for entry in entries.values()),
+        "bundle manifest page count",
+    )
+    observed_tree, observed_directories = _inventory(bundle_root)
+    _require(observed_tree, tree, "bundle stability")
+    _require(observed_directories, directories, "bundle directory stability")
+    return {
+        "manifest": manifest,
+        "manifest_sha256": hashlib.sha256(manifest_payload).hexdigest(),
+        "analysis": payload.analysis,
+        "replicas": [row.observation for row in payload.replicas],
+    }
+
+
+def _bundle_argument(parser: argparse.ArgumentParser, *, positional: bool = False) -> None:
+    if positional:
+        parser.add_argument("bundle", nargs="?", type=Path)
+        parser.add_argument("--bundle-root", type=Path)
+    else:
+        parser.add_argument("--bundle-root", type=Path, required=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    assemble = subparsers.add_parser("assemble")
+    assemble.add_argument("--replica-root", action="append", type=Path, required=True)
+    _bundle_argument(assemble)
+    assemble.add_argument("--campaign-id", required=True)
+    finalize = subparsers.add_parser("finalize")
+    _bundle_argument(finalize)
+    validate = subparsers.add_parser("validate")
+    _bundle_argument(validate, positional=True)
+    arguments = parser.parse_args(argv)
+    try:
+        if arguments.command == "assemble":
+            result = assemble_bundle(arguments.replica_root, arguments.bundle_root, arguments.campaign_id)
+        elif arguments.command == "finalize":
+            manifest = finalize_bundle(arguments.bundle_root)
+            result = {
+                "bundle_root": str(arguments.bundle_root),
+                "campaign_id": manifest["campaign_id"],
+                "bundle_status": manifest["bundle_status"],
+                "file_count": len(manifest["files"]),
+            }
+        else:
+            bundle_root = arguments.bundle_root or arguments.bundle
+            if bundle_root is None:
+                raise ValidationError("validate requires a bundle root")
+            validation = validate_bundle(bundle_root)
+            result = {
+                "bundle_root": str(bundle_root),
+                "campaign_id": validation["manifest"]["campaign_id"],
+                "bundle_status": validation["manifest"]["bundle_status"],
+                "manifest_sha256": validation["manifest_sha256"],
+            }
+    except (OSError, ValidationError) as exc:
+        print(f"A2 bundle {arguments.command} failed: {exc}", file=os.sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a2_bundle.py
+++ b/oracle/windows-dao/scripts/a2_bundle.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Assemble, finalize, and independently validate DAO A2 bundle trees."""
+"""Assemble, finalize, and separately validate DAO A2 bundle trees.
+
+This is not the plan's separately provenanced independent validation rule.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +12,7 @@ import json
 import os
 import shutil
 import stat
+import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -111,6 +115,17 @@ def _safe_locator(value: Any, label: str) -> str:
     if candidate.as_posix() != value:
         raise ValidationError(f"{label}: non-canonical artifact path")
     return value
+def _identity(metadata: os.stat_result) -> tuple[int, int, int]:
+    return metadata.st_dev, metadata.st_ino, metadata.st_nlink
+def _path_identity(path: Path, metadata: os.stat_result) -> tuple[int, int, int]:
+    if os.name != "nt":
+        return _identity(metadata)
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        return _identity(os.fstat(descriptor))
+    finally:
+        os.close(descriptor)
 def _inventory(root: Path) -> tuple[dict[str, TreeFile], set[str]]:
     root = root.resolve()
     try:
@@ -148,16 +163,15 @@ def _inventory(root: Path) -> tuple[dict[str, TreeFile], set[str]]:
                         directories.add(locator)
                         pending.append((Path(child.path), depth + 1))
                     elif stat.S_ISREG(child_metadata.st_mode):
-                        identity = (child_metadata.st_dev, child_metadata.st_ino)
-                        if child_metadata.st_nlink != 1 or identity in identities:
+                        file_identity = _path_identity(Path(child.path), child_metadata)
+                        identity = file_identity[:2]
+                        if file_identity[2] != 1 or identity in identities:
                             raise ValidationError(f"{locator}: hard links are forbidden")
                         identities.add(identity)
                         files[locator] = TreeFile(
                             child_metadata.st_size,
                             child_metadata.st_mtime_ns,
-                            child_metadata.st_dev,
-                            child_metadata.st_ino,
-                            child_metadata.st_nlink,
+                            *file_identity,
                         )
                     else:
                         raise ValidationError(f"{locator}: non-regular tree entry")
@@ -173,8 +187,6 @@ def _expected_directories(paths: Iterable[str]) -> set[str]:
         for parent in Path(locator).parents
         if parent != Path(".")
     }
-def _identity(metadata: os.stat_result) -> tuple[int, int, int]:
-    return metadata.st_dev, metadata.st_ino, metadata.st_nlink
 def _read_checked(root: Path, locator: str, tree: dict[str, TreeFile], maximum: int) -> bytes:
     try:
         expected = tree[locator]
@@ -537,8 +549,6 @@ def _copy_verified(
     if total != size or observed.hexdigest() != digest:
         destination.unlink()
         raise ValidationError(f"{locator}: copy source binding failed")
-
-
 def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
                     campaign_id: str) -> dict[str, Any]:
     roots = tuple(Path(root).resolve() for root in replica_roots)
@@ -590,8 +600,6 @@ def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
         "producer_commit": result.replicas[0].producer_commit,
         "provider_sha256": result.replicas[0].provider_sha256,
     }
-
-
 def validate_holdout_replica(bundle_root: Path, candidate_path: Path,
                              candidate_sha256: str) -> ReplicaResult:
     tree, directories = _inventory(bundle_root.resolve())
@@ -624,8 +632,6 @@ def _role_for_path(path: str, replicas: tuple[ReplicaResult, ...]) -> str:
         if path in replica.entries:
             return replica.entries[path]["role"]
     raise ValidationError(f"{path}: cannot assign bundle role")
-
-
 def finalize_bundle(bundle_root: Path) -> dict[str, Any]:
     bundle_root = bundle_root.resolve()
     if (bundle_root / MANIFEST_PATH).exists():
@@ -656,7 +662,7 @@ def finalize_bundle(bundle_root: Path) -> dict[str, Any]:
         "campaign_id": payload.replicas[0].campaign_id,
         "producer_commit": payload.replicas[0].producer_commit,
         "repository_url": REPOSITORY_URL,
-        "created_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "created_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         "plan_sha256": PLAN_SHA256,
         "replica_environment_sha256": [row.environment_sha256 for row in payload.replicas],
         "provider_sha256": payload.replicas[0].provider_sha256,
@@ -692,9 +698,8 @@ def finalize_bundle(bundle_root: Path) -> dict[str, Any]:
     with (bundle_root / MANIFEST_PATH).open("xb") as handle:
         handle.write(manifest_bytes)
     return manifest
-
-
-def validate_bundle(bundle_root: Path) -> dict[str, Any]:
+def validate_bundle(bundle_root: Path, campaign_id: str | None = None,
+                    producer_commit: str | None = None) -> dict[str, Any]:
     bundle_root = bundle_root.resolve()
     tree, directories = _inventory(bundle_root)
     manifest, manifest_payload = _json_artifact(bundle_root, MANIFEST_PATH, tree)
@@ -707,6 +712,10 @@ def validate_bundle(bundle_root: Path) -> dict[str, Any]:
     payload = _validate_payload(bundle_root, require_analysis=True,
                                 allow_manifest=True)
     assert payload.analysis is not None and payload.receipt is not None
+    if campaign_id is not None:
+        _require(manifest["campaign_id"], campaign_id, "expected campaign")
+    if producer_commit is not None:
+        _require(manifest["producer_commit"], producer_commit, "expected producer commit")
     expected = {
         "experiment_id": EXPERIMENT_ID,
         "campaign_id": payload.replicas[0].campaign_id,
@@ -740,27 +749,19 @@ def validate_bundle(bundle_root: Path) -> dict[str, Any]:
         "analysis": payload.analysis,
         "replicas": [row.observation for row in payload.replicas],
     }
-
-
-def _bundle_argument(parser: argparse.ArgumentParser, *, positional: bool = False) -> None:
-    if positional:
-        parser.add_argument("bundle", nargs="?", type=Path)
-        parser.add_argument("--bundle-root", type=Path)
-    else:
-        parser.add_argument("--bundle-root", type=Path, required=True)
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     assemble = subparsers.add_parser("assemble")
     assemble.add_argument("--replica-root", action="append", type=Path, required=True)
-    _bundle_argument(assemble)
+    assemble.add_argument("--bundle-root", type=Path, required=True)
     assemble.add_argument("--campaign-id", required=True)
     finalize = subparsers.add_parser("finalize")
-    _bundle_argument(finalize)
+    finalize.add_argument("--bundle-root", type=Path, required=True)
     validate = subparsers.add_parser("validate")
-    _bundle_argument(validate, positional=True)
+    validate.add_argument("bundle", type=Path)
+    validate.add_argument("--campaign-id", required=True)
+    validate.add_argument("--producer-commit", required=True)
     arguments = parser.parse_args(argv)
     try:
         if arguments.command == "assemble":
@@ -774,10 +775,9 @@ def main(argv: list[str] | None = None) -> int:
                 "file_count": len(manifest["files"]),
             }
         else:
-            bundle_root = arguments.bundle_root or arguments.bundle
-            if bundle_root is None:
-                raise ValidationError("validate requires a bundle root")
-            validation = validate_bundle(bundle_root)
+            bundle_root = arguments.bundle
+            validation = validate_bundle(
+                bundle_root, arguments.campaign_id, arguments.producer_commit)
             result = {
                 "bundle_root": str(bundle_root),
                 "campaign_id": validation["manifest"]["campaign_id"],
@@ -785,7 +785,7 @@ def main(argv: list[str] | None = None) -> int:
                 "manifest_sha256": validation["manifest_sha256"],
             }
     except (OSError, ValidationError) as exc:
-        print(f"A2 bundle {arguments.command} failed: {exc}", file=os.sys.stderr)
+        print(f"A2 bundle {arguments.command} failed: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(result, sort_keys=True, default=str))
     return 0

--- a/oracle/windows-dao/scripts/a2_bundle.py
+++ b/oracle/windows-dao/scripts/a2_bundle.py
@@ -550,7 +550,7 @@ def _copy_verified(
         destination.unlink()
         raise ValidationError(f"{locator}: copy source binding failed")
 def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
-                    campaign_id: str) -> dict[str, Any]:
+                    campaign_id: str, producer_commit: str) -> dict[str, Any]:
     roots = tuple(Path(root).resolve() for root in replica_roots)
     if len(roots) != REPLICA_COUNT:
         raise ValidationError("assemble requires exactly three replica roots")
@@ -563,9 +563,7 @@ def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
             root, tree, directories, replica, campaign_id, closed=True))
     replicas = tuple(validated)
     _validate_environments(replicas)
-    github_sha = os.environ.get("GITHUB_SHA")
-    if github_sha is not None:
-        _require(replicas[0].producer_commit, github_sha, "checked-out producer commit")
+    _require(replicas[0].producer_commit, producer_commit, "expected producer commit")
     bundle_parent = bundle_root.resolve().parent
     bundle_parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=".a2-assemble-", dir=bundle_parent))
@@ -601,10 +599,13 @@ def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
         "provider_sha256": result.replicas[0].provider_sha256,
     }
 def validate_holdout_replica(bundle_root: Path, candidate_path: Path,
-                             candidate_sha256: str) -> ReplicaResult:
+                             candidate_sha256: str, campaign_id: str,
+                             producer_commit: str) -> ReplicaResult:
     tree, directories = _inventory(bundle_root.resolve())
     replica = _validate_replica(bundle_root.resolve(), tree, directories,
                                 REPLICA_COUNT, None, closed=False)
+    _require(replica.campaign_id, campaign_id, "expected holdout campaign")
+    _require(replica.producer_commit, producer_commit, "expected holdout producer")
     payload = _read_checked(
         bundle_root.resolve(),
         candidate_path.resolve().relative_to(bundle_root.resolve()).as_posix(),
@@ -615,8 +616,6 @@ def validate_holdout_replica(bundle_root: Path, candidate_path: Path,
     frozen = _parse_json(payload, candidate_path.as_posix())
     _validate_frozen(frozen, replica.campaign_id)
     return replica
-
-
 def _role_for_path(path: str, replicas: tuple[ReplicaResult, ...]) -> str:
     fixed = {
         "plan/a2-allocation-maps.plan.json": "plan",
@@ -632,12 +631,15 @@ def _role_for_path(path: str, replicas: tuple[ReplicaResult, ...]) -> str:
         if path in replica.entries:
             return replica.entries[path]["role"]
     raise ValidationError(f"{path}: cannot assign bundle role")
-def finalize_bundle(bundle_root: Path) -> dict[str, Any]:
+def finalize_bundle(bundle_root: Path, campaign_id: str,
+                    producer_commit: str) -> dict[str, Any]:
     bundle_root = bundle_root.resolve()
     if (bundle_root / MANIFEST_PATH).exists():
         raise ValidationError("bundle manifest already exists")
     payload = _validate_payload(bundle_root, require_analysis=True)
     assert payload.analysis is not None and payload.receipt is not None
+    _require(payload.replicas[0].campaign_id, campaign_id, "expected campaign")
+    _require(payload.replicas[0].producer_commit, producer_commit, "expected producer")
     files = []
     for path in sorted(payload.expected_paths):
         item = payload.tree[path]
@@ -698,8 +700,8 @@ def finalize_bundle(bundle_root: Path) -> dict[str, Any]:
     with (bundle_root / MANIFEST_PATH).open("xb") as handle:
         handle.write(manifest_bytes)
     return manifest
-def validate_bundle(bundle_root: Path, campaign_id: str | None = None,
-                    producer_commit: str | None = None) -> dict[str, Any]:
+def validate_bundle(bundle_root: Path, campaign_id: str,
+                    producer_commit: str) -> dict[str, Any]:
     bundle_root = bundle_root.resolve()
     tree, directories = _inventory(bundle_root)
     manifest, manifest_payload = _json_artifact(bundle_root, MANIFEST_PATH, tree)
@@ -712,10 +714,8 @@ def validate_bundle(bundle_root: Path, campaign_id: str | None = None,
     payload = _validate_payload(bundle_root, require_analysis=True,
                                 allow_manifest=True)
     assert payload.analysis is not None and payload.receipt is not None
-    if campaign_id is not None:
-        _require(manifest["campaign_id"], campaign_id, "expected campaign")
-    if producer_commit is not None:
-        _require(manifest["producer_commit"], producer_commit, "expected producer commit")
+    _require(manifest["campaign_id"], campaign_id, "expected campaign")
+    _require(manifest["producer_commit"], producer_commit, "expected producer commit")
     expected = {
         "experiment_id": EXPERIMENT_ID,
         "campaign_id": payload.replicas[0].campaign_id,
@@ -756,8 +756,11 @@ def main(argv: list[str] | None = None) -> int:
     assemble.add_argument("--replica-root", action="append", type=Path, required=True)
     assemble.add_argument("--bundle-root", type=Path, required=True)
     assemble.add_argument("--campaign-id", required=True)
+    assemble.add_argument("--producer-commit", required=True)
     finalize = subparsers.add_parser("finalize")
     finalize.add_argument("--bundle-root", type=Path, required=True)
+    finalize.add_argument("--campaign-id", required=True)
+    finalize.add_argument("--producer-commit", required=True)
     validate = subparsers.add_parser("validate")
     validate.add_argument("bundle", type=Path)
     validate.add_argument("--campaign-id", required=True)
@@ -765,9 +768,11 @@ def main(argv: list[str] | None = None) -> int:
     arguments = parser.parse_args(argv)
     try:
         if arguments.command == "assemble":
-            result = assemble_bundle(arguments.replica_root, arguments.bundle_root, arguments.campaign_id)
+            result = assemble_bundle(arguments.replica_root, arguments.bundle_root,
+                                     arguments.campaign_id, arguments.producer_commit)
         elif arguments.command == "finalize":
-            manifest = finalize_bundle(arguments.bundle_root)
+            manifest = finalize_bundle(
+                arguments.bundle_root, arguments.campaign_id, arguments.producer_commit)
             result = {
                 "bundle_root": str(arguments.bundle_root),
                 "campaign_id": manifest["campaign_id"],
@@ -789,7 +794,5 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     print(json.dumps(result, sort_keys=True, default=str))
     return 0
-
-
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a2_holdout.py
+++ b/oracle/windows-dao/scripts/a2_holdout.py
@@ -14,6 +14,7 @@ from a2_spec import BOUNDS, EXPERIMENT_ID, PLAN_SHA256, validate_holdout_structu
 from protocol_validation import ValidationError, canonical_json_bytes
 
 FAN_IN_TIMEOUT_SECONDS = 900
+HOLDOUT_TIMEOUT_SECONDS = 300
 if BOUNDS["fan_in_timeout_seconds"] != FAN_IN_TIMEOUT_SECONDS:
     raise RuntimeError("checked A2 fan-in bound drifted")
 
@@ -30,8 +31,6 @@ def run_holdout_process(
         str(Path(__file__)),
         "--bundle-root",
         str(bundle_root),
-        "--replica",
-        "3",
         "--candidate-set",
         str(candidate_set),
         "--candidate-sha256",
@@ -41,7 +40,7 @@ def run_holdout_process(
     ]
     try:
         completed = subprocess.run(
-            command, check=False, timeout=FAN_IN_TIMEOUT_SECONDS
+            command, check=False, timeout=HOLDOUT_TIMEOUT_SECONDS
         )
     except (OSError, subprocess.SubprocessError) as exc:
         raise ValidationError(f"holdout structural validator failed: {exc}") from exc
@@ -83,7 +82,6 @@ def write_receipt(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--bundle-root", type=Path, required=True)
-    parser.add_argument("--replica", type=int, choices=(3,), default=3)
     parser.add_argument("--candidate-set", type=Path, required=True)
     parser.add_argument("--candidate-sha256", required=True)
     parser.add_argument("--output", type=Path, required=True)

--- a/oracle/windows-dao/scripts/a2_holdout.py
+++ b/oracle/windows-dao/scripts/a2_holdout.py
@@ -23,6 +23,8 @@ def run_holdout_process(
     bundle_root: Path,
     candidate_set: Path,
     candidate_sha256: str,
+    campaign_id: str,
+    producer_commit: str,
     output: Path,
 ) -> None:
     command = [
@@ -35,6 +37,10 @@ def run_holdout_process(
         str(candidate_set),
         "--candidate-sha256",
         candidate_sha256,
+        "--campaign-id",
+        campaign_id,
+        "--producer-commit",
+        producer_commit,
         "--output",
         str(output),
     ]
@@ -52,9 +58,12 @@ def write_receipt(
     bundle_root: Path,
     candidate_set: Path,
     candidate_sha256: str,
+    campaign_id: str,
+    producer_commit: str,
     output: Path,
 ) -> dict[str, object]:
-    replica = validate_holdout_replica(bundle_root, candidate_set, candidate_sha256)
+    replica = validate_holdout_replica(
+        bundle_root, candidate_set, candidate_sha256, campaign_id, producer_commit)
     receipt: dict[str, object] = {
         "protocol_version": "1.0.0",
         "document_type": "dao_a2_holdout_structure_receipt",
@@ -84,6 +93,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--bundle-root", type=Path, required=True)
     parser.add_argument("--candidate-set", type=Path, required=True)
     parser.add_argument("--candidate-sha256", required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--producer-commit", required=True)
     parser.add_argument("--output", type=Path, required=True)
     arguments = parser.parse_args(argv)
     try:
@@ -96,6 +107,8 @@ def main(argv: list[str] | None = None) -> int:
             arguments.bundle_root,
             arguments.candidate_set,
             arguments.candidate_sha256,
+            arguments.campaign_id,
+            arguments.producer_commit,
             arguments.output,
         )
     except (OSError, ValidationError, ValueError) as exc:

--- a/oracle/windows-dao/scripts/a2_holdout.py
+++ b/oracle/windows-dao/scripts/a2_holdout.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Post-freeze structural validation for the DAO A2 holdout replica."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from a2_bundle import MAX_JSON_BYTES, validate_holdout_replica
+from a2_spec import BOUNDS, EXPERIMENT_ID, PLAN_SHA256, validate_holdout_structure_receipt
+from protocol_validation import ValidationError, canonical_json_bytes
+
+FAN_IN_TIMEOUT_SECONDS = 900
+if BOUNDS["fan_in_timeout_seconds"] != FAN_IN_TIMEOUT_SECONDS:
+    raise RuntimeError("checked A2 fan-in bound drifted")
+
+
+def run_holdout_process(
+    bundle_root: Path,
+    candidate_set: Path,
+    candidate_sha256: str,
+    output: Path,
+) -> None:
+    command = [
+        sys.executable,
+        "-B",
+        str(Path(__file__)),
+        "--bundle-root",
+        str(bundle_root),
+        "--replica",
+        "3",
+        "--candidate-set",
+        str(candidate_set),
+        "--candidate-sha256",
+        candidate_sha256,
+        "--output",
+        str(output),
+    ]
+    try:
+        completed = subprocess.run(
+            command, check=False, timeout=FAN_IN_TIMEOUT_SECONDS
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ValidationError(f"holdout structural validator failed: {exc}") from exc
+    if completed.returncode != 0:
+        raise ValidationError("holdout structural validator returned nonzero")
+
+
+def write_receipt(
+    bundle_root: Path,
+    candidate_set: Path,
+    candidate_sha256: str,
+    output: Path,
+) -> dict[str, object]:
+    replica = validate_holdout_replica(bundle_root, candidate_set, candidate_sha256)
+    receipt: dict[str, object] = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a2_holdout_structure_receipt",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "producer_commit": replica.producer_commit,
+        "campaign_id": replica.campaign_id,
+        "derivation_candidate_set_sha256": candidate_sha256,
+        "replica": replica.replica,
+        "replica_artifact_manifest_sha256": replica.manifest_sha256,
+        "validated_after_candidate_freeze": True,
+        "page_bytes_exposed_to_analyzer": False,
+        "result": "pass",
+    }
+    validate_holdout_structure_receipt(receipt)
+    payload = canonical_json_bytes(receipt)
+    if len(payload) > MAX_JSON_BYTES:
+        raise ValidationError("holdout receipt exceeds its fixed JSON bound")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("xb") as handle:
+        handle.write(payload)
+    return receipt
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--replica", type=int, choices=(3,), default=3)
+    parser.add_argument("--candidate-set", type=Path, required=True)
+    parser.add_argument("--candidate-sha256", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        if len(arguments.candidate_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in arguments.candidate_sha256
+        ):
+            raise ValidationError("candidate SHA-256 is not lowercase hexadecimal")
+        receipt = write_receipt(
+            arguments.bundle_root,
+            arguments.candidate_set,
+            arguments.candidate_sha256,
+            arguments.output,
+        )
+    except (OSError, ValidationError, ValueError) as exc:
+        print(f"A2 holdout validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "output": str(arguments.output),
+                "replica_artifact_manifest_sha256": receipt[
+                    "replica_artifact_manifest_sha256"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/tests/test_a2_bundle.py
+++ b/oracle/windows-dao/tests/test_a2_bundle.py
@@ -53,15 +53,18 @@ class A2BundleTests(unittest.TestCase):
             write_synthetic_bundle(root, bundle)
         observation = cls.synthetic[0].documents["observations/replica-01.json"]
         cls.campaign_id = observation["campaign_id"]
+        cls.producer_commit = observation["producer_commit"]
         cls.bundle = cls.root / "complete-bundle"
         cls.assembly = assemble_bundle(
-            cls.replica_roots, cls.bundle, cls.campaign_id
+            cls.replica_roots, cls.bundle, cls.campaign_id, cls.producer_commit
         )
         analysis_exit = analysis_main(["--bundle-root", str(cls.bundle)])
         if analysis_exit != 0:
             raise AssertionError("synthetic A2 analysis did not complete")
-        cls.manifest = finalize_bundle(cls.bundle)
-        cls.validation = validate_bundle(cls.bundle)
+        cls.manifest = finalize_bundle(
+            cls.bundle, cls.campaign_id, cls.producer_commit)
+        cls.validation = validate_bundle(
+            cls.bundle, cls.campaign_id, cls.producer_commit)
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -93,6 +96,12 @@ class A2BundleTests(unittest.TestCase):
                 "max_retained_page_store_bytes", "max_bundle_bytes",
             )},
         )
+
+    def test_bundle_and_holdout_never_read_ci_bindings_from_environment(self) -> None:
+        for script in ("a2_bundle.py", "a2_holdout.py"):
+            source = (SCRIPTS / script).read_text(encoding="utf-8")
+            self.assertNotIn("os.environ", source)
+            self.assertNotIn("os.getenv", source)
 
     def test_complete_bundle_is_closed_bound_and_decisive(self) -> None:
         manifest = self.validation["manifest"]
@@ -145,7 +154,16 @@ class A2BundleTests(unittest.TestCase):
     def test_assemble_rejects_wrong_campaign_without_publication(self) -> None:
         destination = self.root / "wrong-campaign"
         with self.assertRaisesRegex(ValidationError, "campaign"):
-            assemble_bundle(self.replica_roots, destination, "a2-wrong-campaign")
+            assemble_bundle(
+                self.replica_roots, destination, "a2-wrong-campaign",
+                self.producer_commit)
+        self.assertFalse(destination.exists())
+
+    def test_assemble_rejects_wrong_explicit_producer_without_publication(self) -> None:
+        destination = self.root / "wrong-producer"
+        with self.assertRaisesRegex(ValidationError, "expected producer commit"):
+            assemble_bundle(
+                self.replica_roots, destination, self.campaign_id, "f" * 40)
         self.assertFalse(destination.exists())
 
     def test_assemble_rejects_extra_replica_inventory(self) -> None:
@@ -158,6 +176,7 @@ class A2BundleTests(unittest.TestCase):
                 (replica_copy, *self.replica_roots[1:]),
                 destination,
                 self.campaign_id,
+                self.producer_commit,
             )
         self.assertFalse(destination.exists())
 
@@ -226,18 +245,19 @@ class A2BundleTests(unittest.TestCase):
         report = corrupted / "analysis" / "analysis-report.json"
         report.write_bytes(report.read_bytes() + b" ")
         with self.assertRaisesRegex(ValidationError, "size|sha256"):
-            validate_bundle(corrupted)
+            validate_bundle(corrupted, self.campaign_id, self.producer_commit)
 
     def test_complete_validator_rejects_explicit_binding_mismatch(self) -> None:
-        producer_commit = self.manifest["producer_commit"]
         with self.assertRaisesRegex(ValidationError, "expected campaign"):
-            validate_bundle(self.bundle, "a2-wrong-campaign", producer_commit)
+            validate_bundle(
+                self.bundle, "a2-wrong-campaign", self.producer_commit)
         with self.assertRaisesRegex(ValidationError, "expected producer commit"):
             validate_bundle(self.bundle, self.campaign_id, "f" * 40)
 
     def test_finalize_refuses_manifest_replacement(self) -> None:
         with self.assertRaisesRegex(ValidationError, "already exists"):
-            finalize_bundle(self.bundle)
+            finalize_bundle(
+                self.bundle, self.campaign_id, self.producer_commit)
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_a2_bundle.py
+++ b/oracle/windows-dao/tests/test_a2_bundle.py
@@ -1,0 +1,172 @@
+"""Synthetic fan-in contracts for DAO A2 bundle assembly and validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from a2_analysis import main as analysis_main  # noqa: E402
+from a2_bundle import (  # noqa: E402
+    CHECKPOINT_COUNT,
+    MAX_BUNDLE_BYTES,
+    MAX_JSON_BYTES,
+    MAX_PAGE_BLOBS,
+    MAX_PAGE_STORE_BYTES,
+    PAGE_SIZE,
+    REPLICA_COUNT,
+    assemble_bundle,
+    finalize_bundle,
+    validate_bundle,
+)
+from a2_generator import (  # noqa: E402
+    generate_synthetic_bundles,
+    write_synthetic_bundle,
+)
+from a2_spec import BOUNDS, PLAN_SHA256  # noqa: E402
+from protocol_validation import ValidationError  # noqa: E402
+
+
+class A2BundleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.temporary.name)
+        cls.replica_roots = tuple(
+            cls.root / f"replica-{replica:02d}"
+            for replica in range(1, REPLICA_COUNT + 1)
+        )
+        cls.synthetic = generate_synthetic_bundles()
+        for root, bundle in zip(cls.replica_roots, cls.synthetic, strict=True):
+            write_synthetic_bundle(root, bundle)
+        observation = cls.synthetic[0].documents["observations/replica-01.json"]
+        cls.campaign_id = observation["campaign_id"]
+        cls.bundle = cls.root / "complete-bundle"
+        cls.assembly = assemble_bundle(
+            cls.replica_roots, cls.bundle, cls.campaign_id
+        )
+        analysis_exit = analysis_main(["--bundle-root", str(cls.bundle)])
+        if analysis_exit != 0:
+            raise AssertionError("synthetic A2 analysis did not complete")
+        cls.manifest = finalize_bundle(cls.bundle)
+        cls.validation = validate_bundle(cls.bundle)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_fixed_bounds_are_not_cli_reparsed_defaults(self) -> None:
+        self.assertEqual(PAGE_SIZE, 2_048)
+        self.assertEqual(REPLICA_COUNT, 3)
+        self.assertEqual(CHECKPOINT_COUNT, 25)
+        self.assertEqual(MAX_JSON_BYTES, 67_108_864)
+        self.assertEqual(MAX_PAGE_BLOBS, 65_536)
+        self.assertEqual(MAX_PAGE_STORE_BYTES, 536_870_912)
+        self.assertEqual(MAX_BUNDLE_BYTES, 805_306_368)
+        self.assertEqual(
+            {
+                "page_size": PAGE_SIZE,
+                "replicas": REPLICA_COUNT,
+                "planned_checkpoints_per_replica": CHECKPOINT_COUNT,
+                "max_json_bytes": MAX_JSON_BYTES,
+                "max_unique_page_blobs": MAX_PAGE_BLOBS,
+                "max_retained_page_store_bytes": MAX_PAGE_STORE_BYTES,
+                "max_bundle_bytes": MAX_BUNDLE_BYTES,
+            },
+            {key: BOUNDS[key] for key in (
+                "page_size", "replicas", "planned_checkpoints_per_replica",
+                "max_json_bytes", "max_unique_page_blobs",
+                "max_retained_page_store_bytes", "max_bundle_bytes",
+            )},
+        )
+
+    def test_complete_bundle_is_closed_bound_and_decisive(self) -> None:
+        manifest = self.validation["manifest"]
+        self.assertEqual(self.assembly["campaign_id"], self.campaign_id)
+        self.assertEqual(manifest, self.manifest)
+        self.assertEqual(manifest["plan_sha256"], PLAN_SHA256)
+        self.assertEqual(manifest["replica_count"], REPLICA_COUNT)
+        self.assertEqual(manifest["checkpoint_count"], 75)
+        self.assertEqual(
+            manifest["bundle_status"],
+            "decisive_pending_independent_validation",
+        )
+        self.assertEqual(
+            manifest["independent_validation_status"],
+            "not_independently_validated",
+        )
+        paths = {entry["path"] for entry in manifest["files"]}
+        discovered = {
+            path.relative_to(self.bundle).as_posix()
+            for path in self.bundle.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(discovered, paths | {"bundle-manifest.json"})
+        page_entries = [
+            entry for entry in manifest["files"] if entry["role"] == "page_blob"
+        ]
+        self.assertEqual(len(page_entries), manifest["page_blob_count"])
+        self.assertLessEqual(len(page_entries), MAX_PAGE_BLOBS)
+
+    def test_holdout_receipt_is_post_freeze_and_manifest_bound(self) -> None:
+        candidate = self.bundle / "analysis" / "derivation-candidates.json"
+        receipt = json.loads(
+            (self.bundle / "analysis" / "holdout-structure-receipt.json").read_bytes()
+        )
+        replica_manifest = (
+            self.bundle / "replica-artifacts" / "replica-03-manifest.json"
+        )
+        self.assertEqual(
+            receipt["derivation_candidate_set_sha256"],
+            hashlib.sha256(candidate.read_bytes()).hexdigest(),
+        )
+        self.assertEqual(
+            receipt["replica_artifact_manifest_sha256"],
+            hashlib.sha256(replica_manifest.read_bytes()).hexdigest(),
+        )
+        self.assertTrue(receipt["validated_after_candidate_freeze"])
+        self.assertFalse(receipt["page_bytes_exposed_to_analyzer"])
+
+    def test_assemble_rejects_wrong_campaign_without_publication(self) -> None:
+        destination = self.root / "wrong-campaign"
+        with self.assertRaisesRegex(ValidationError, "campaign"):
+            assemble_bundle(self.replica_roots, destination, "a2-wrong-campaign")
+        self.assertFalse(destination.exists())
+
+    def test_assemble_rejects_extra_replica_inventory(self) -> None:
+        replica_copy = self.root / "replica-extra"
+        shutil.copytree(self.replica_roots[0], replica_copy)
+        (replica_copy / "unexpected.json").write_text("{}\n", encoding="utf-8")
+        destination = self.root / "extra-inventory-bundle"
+        with self.assertRaisesRegex(ValidationError, "closed inventory"):
+            assemble_bundle(
+                (replica_copy, *self.replica_roots[1:]),
+                destination,
+                self.campaign_id,
+            )
+        self.assertFalse(destination.exists())
+
+    def test_complete_validator_rejects_modified_artifact(self) -> None:
+        corrupted = self.root / "corrupted-bundle"
+        shutil.copytree(self.bundle, corrupted)
+        report = corrupted / "analysis" / "analysis-report.json"
+        report.write_bytes(report.read_bytes() + b" ")
+        with self.assertRaisesRegex(ValidationError, "size|sha256"):
+            validate_bundle(corrupted)
+
+    def test_finalize_refuses_manifest_replacement(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "already exists"):
+            finalize_bundle(self.bundle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a2_bundle.py
+++ b/oracle/windows-dao/tests/test_a2_bundle.py
@@ -9,12 +9,14 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+import a2_bundle  # noqa: E402
 from a2_analysis import main as analysis_main  # noqa: E402
 from a2_bundle import (  # noqa: E402
     CHECKPOINT_COUNT,
@@ -32,6 +34,7 @@ from a2_generator import (  # noqa: E402
     generate_synthetic_bundles,
     write_synthetic_bundle,
 )
+from a2_holdout import FAN_IN_TIMEOUT_SECONDS, HOLDOUT_TIMEOUT_SECONDS  # noqa: E402
 from a2_spec import BOUNDS, PLAN_SHA256  # noqa: E402
 from protocol_validation import ValidationError  # noqa: E402
 
@@ -72,6 +75,8 @@ class A2BundleTests(unittest.TestCase):
         self.assertEqual(MAX_PAGE_BLOBS, 65_536)
         self.assertEqual(MAX_PAGE_STORE_BYTES, 536_870_912)
         self.assertEqual(MAX_BUNDLE_BYTES, 805_306_368)
+        self.assertEqual(FAN_IN_TIMEOUT_SECONDS, 900)
+        self.assertEqual(HOLDOUT_TIMEOUT_SECONDS, 300)
         self.assertEqual(
             {
                 "page_size": PAGE_SIZE,
@@ -96,6 +101,7 @@ class A2BundleTests(unittest.TestCase):
         self.assertEqual(manifest["plan_sha256"], PLAN_SHA256)
         self.assertEqual(manifest["replica_count"], REPLICA_COUNT)
         self.assertEqual(manifest["checkpoint_count"], 75)
+        self.assertRegex(manifest["created_utc"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
         self.assertEqual(
             manifest["bundle_status"],
             "decisive_pending_independent_validation",
@@ -155,6 +161,65 @@ class A2BundleTests(unittest.TestCase):
             )
         self.assertFalse(destination.exists())
 
+    def test_inventory_uses_descriptor_identity_when_direntry_zeros_it(self) -> None:
+        root = self.root / "zeroed-direntry"
+        root.mkdir()
+        artifact = root / "artifact.json"
+        artifact.write_text("{}\n", encoding="utf-8")
+        actual = artifact.stat()
+        real_scandir = a2_bundle.os.scandir
+        real_path_identity = a2_bundle._path_identity
+
+        class ZeroedMetadata:
+            def __init__(self, metadata: object) -> None:
+                self._metadata = metadata
+                self.st_dev = 0
+                self.st_ino = 0
+                self.st_nlink = 0
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._metadata, name)
+
+        class ZeroedEntry:
+            def __init__(self, entry: object) -> None:
+                self._entry = entry
+                self.path = entry.path
+
+            def stat(self, *, follow_symlinks: bool = True) -> ZeroedMetadata:
+                return ZeroedMetadata(
+                    self._entry.stat(follow_symlinks=follow_symlinks)
+                )
+
+            def is_symlink(self) -> bool:
+                return self._entry.is_symlink()
+
+        class ZeroedScan:
+            def __init__(self, path: object) -> None:
+                self._scan = real_scandir(path)
+
+            def __enter__(self) -> object:
+                return (ZeroedEntry(entry) for entry in self._scan.__enter__())
+
+            def __exit__(self, *arguments: object) -> object:
+                return self._scan.__exit__(*arguments)
+
+        def windows_path_identity(path: Path, metadata: object) -> tuple[int, int, int]:
+            with mock.patch.object(a2_bundle.os, "name", "nt"):
+                return real_path_identity(path, metadata)
+
+        with mock.patch.object(a2_bundle.os, "scandir", ZeroedScan), mock.patch.object(
+            a2_bundle, "_path_identity", side_effect=windows_path_identity
+        ) as identity:
+            tree, directories = a2_bundle._inventory(root)
+
+        self.assertEqual(directories, set())
+        self.assertEqual(
+            (tree["artifact.json"].device, tree["artifact.json"].inode),
+            (actual.st_dev, actual.st_ino),
+        )
+        self.assertEqual(tree["artifact.json"].links, actual.st_nlink)
+        identity.assert_called_once()
+
     def test_complete_validator_rejects_modified_artifact(self) -> None:
         corrupted = self.root / "corrupted-bundle"
         shutil.copytree(self.bundle, corrupted)
@@ -162,6 +227,13 @@ class A2BundleTests(unittest.TestCase):
         report.write_bytes(report.read_bytes() + b" ")
         with self.assertRaisesRegex(ValidationError, "size|sha256"):
             validate_bundle(corrupted)
+
+    def test_complete_validator_rejects_explicit_binding_mismatch(self) -> None:
+        producer_commit = self.manifest["producer_commit"]
+        with self.assertRaisesRegex(ValidationError, "expected campaign"):
+            validate_bundle(self.bundle, "a2-wrong-campaign", producer_commit)
+        with self.assertRaisesRegex(ValidationError, "expected producer commit"):
+            validate_bundle(self.bundle, self.campaign_id, "f" * 40)
 
     def test_finalize_refuses_manifest_replacement(self) -> None:
         with self.assertRaisesRegex(ValidationError, "already exists"):

--- a/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
@@ -173,7 +173,9 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
         self.assertIn('$campaignId = "a2-run-$env:GITHUB_RUN_ID"', self.fan_in)
         self.assertIn("--holdout-receipt", self.fan_in)
         self.assertIn('--campaign-id "a2-run-$env:GITHUB_RUN_ID"', self.fan_in)
-        self.assertIn("--producer-commit $env:GITHUB_SHA", self.fan_in)
+        self.assertEqual(
+            self.fan_in.count("--producer-commit $env:GITHUB_SHA"), 3
+        )
         upload = self.fan_in.split("      - name: Upload retained A2 bundle", 1)[1]
         self.assertIn("if: always()", upload)
         self.assertIn("fan-in-status.json", upload)

--- a/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
@@ -1,0 +1,187 @@
+"""Fail-closed source contract for the manual DAO A2 workflow."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "windows-dao-a2.yml"
+
+
+class WindowsDaoA2WorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.contract, remainder = cls.workflow.split("  a2-replica:", 1)
+        cls.replica, cls.fan_in = remainder.split("  fan-in:", 1)
+        cls.parse_step = cls.contract.split(
+            "- name: Parse checked A2 PowerShell sources without execution", 1
+        )[1].split("- name: Run the checked A2 Python contract tests", 1)[0]
+        cls.run_step = cls.replica.split(
+            "      - name: Run bounded A2 replica", 1
+        )[1].split("      - name: Upload retained A2 replica tree", 1)[0]
+
+    def test_dispatch_is_manual_only_and_explicitly_gated(self) -> None:
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertIn("execute_a2_campaign:", self.workflow)
+        self.assertIn("type: boolean", self.workflow)
+        self.assertIn("default: false", self.workflow)
+        for trigger in ("push:", "pull_request:", "schedule:"):
+            self.assertNotIn(trigger, self.workflow)
+        gate = (
+            r"github\.event_name == 'workflow_dispatch' &&\s+"
+            r"github\.ref == 'refs/heads/main' &&\s+"
+            r"inputs\.execute_a2_campaign"
+        )
+        self.assertRegex(self.replica, gate)
+        self.assertRegex(self.fan_in, gate)
+        self.assertNotIn("Start-Process", self.contract)
+
+    def test_contract_parses_a2_powershell_without_execution(self) -> None:
+        self.assertIn("shell: powershell", self.parse_step)
+        self.assertIn('$PSVersionTable.PSEdition -cne "Desktop"', self.parse_step)
+        self.assertIn("$PSVersionTable.PSVersion.Major -ne 5", self.parse_step)
+        self.assertIn("$item.Length -gt 2MB", self.parse_step)
+        self.assertIn(
+            "[System.Management.Automation.Language.Parser]::ParseFile",
+            self.parse_step,
+        )
+        self.assertEqual(
+            self.parse_step.count(
+                "oracle/windows-dao/scripts/run-a2-replica.ps1"
+            ),
+            1,
+        )
+        self.assertEqual(
+            self.parse_step.count("oracle/windows-dao/scripts/a2"), 1
+        )
+        for forbidden in ("Start-Process", "Invoke-A2", "& python"):
+            self.assertNotIn(forbidden, self.parse_step)
+        for test in (
+            "test_a2_plan_contract.py",
+            "test_a2_spec_generator.py",
+            "test_a2_dryrun.py",
+            "test_a2_powershell_contract.py",
+            "test_a2_bundle.py",
+            "test_windows_dao_a2_workflow.py",
+        ):
+            self.assertEqual(self.contract.count(test), 1)
+
+    def test_three_job_matrix_and_bounds_are_frozen(self) -> None:
+        self.assertIn("replica: [1, 2, 3]", self.replica)
+        self.assertIn("max-parallel: 3", self.replica)
+        self.assertIn("fail-fast: false", self.replica)
+        self.assertIn("runs-on: windows-latest", self.replica)
+        self.assertIn("timeout-minutes: 31", self.replica)
+        self.assertIn('FROZEN_WORKER_TIMEOUT_SECONDS: "1700"', self.replica)
+        self.assertIn('HOSTED_REPLICA_TIMEOUT_SECONDS: "1800"', self.replica)
+        self.assertIn('FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"', self.replica)
+        self.assertIn('REPLICA_MAXIMUM_OUTPUT_BYTES: "1048576"', self.replica)
+        self.assertIn("timeout-minutes: 15", self.fan_in)
+        self.assertEqual(1_800 + 15 * 60, 2_700)
+
+    def test_replica_launch_is_x86_waited_bounded_and_null_safe(self) -> None:
+        self.assertIn(
+            '"SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"',
+            self.run_step,
+        )
+        launch = self.run_step.index(
+            "$process = Start-Process -FilePath $x86PowerShell -PassThru"
+        )
+        handle = self.run_step.index("$null = $process.Handle", launch)
+        clock = self.run_step.index(
+            "$clock = [Diagnostics.Stopwatch]::StartNew()", handle
+        )
+        monitored_wait = self.run_step.index(
+            "while (-not $process.WaitForExit(1000))", clock
+        )
+        completed_wait = self.run_step.index("$process.WaitForExit()", monitored_wait)
+        refresh = self.run_step.index("$process.Refresh()", completed_wait)
+        null_guard = self.run_step.index("if ($null -eq $exitCode)", refresh)
+        assignment = self.run_step.index("$replicaExit = [int]$exitCode", null_guard)
+        comparison = self.run_step.index("if ($replicaExit -ne 0)", assignment)
+        self.assertLess(launch, handle)
+        self.assertLess(handle, clock)
+        self.assertLess(clock, monitored_wait)
+        self.assertLess(completed_wait, refresh)
+        self.assertLess(refresh, null_guard)
+        self.assertLess(null_guard, assignment)
+        self.assertLess(assignment, comparison)
+        self.assertIn("Get-A2LogBytes", self.run_step)
+        self.assertIn("REPLICA_MAXIMUM_OUTPUT_BYTES", self.run_step)
+        self.assertIn("HOSTED_REPLICA_TIMEOUT_SECONDS", self.run_step)
+        self.assertIn("Stop-Jet3BootstrapProcessTree -Process $process", self.run_step)
+        for argument in (
+            '"-RepositoryRoot", $repository',
+            '"-OutputRoot", $outputRoot',
+            '"-DiagnosticsRoot", $diagnostics',
+            '"-GitCommit", $env:GITHUB_SHA',
+            '"-RunId", $env:GITHUB_RUN_ID',
+            '"-Replica", $replica',
+            '"-MatrixJobId", "a2-replica-$replica"',
+        ):
+            self.assertIn(argument, self.run_step)
+
+    def test_exact_clean_pushed_checkout_is_required(self) -> None:
+        self.assertIn('$env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs"', self.replica)
+        self.assertIn("git remote set-url origin https://github.com/oglassdev/jet3-rs.git", self.replica)
+        self.assertIn("$head -cne $env:GITHUB_SHA", self.replica)
+        self.assertIn("git ls-remote --exit-code origin refs/heads/main", self.replica)
+        self.assertGreaterEqual(
+            self.workflow.count("status --porcelain=v1 --untracked-files=all"),
+            2,
+        )
+        self.assertIn("fetch-depth: 0", self.replica)
+
+    def test_replica_and_diagnostic_uploads_are_always_retained(self) -> None:
+        retained = self.replica.split(
+            "      - name: Upload retained A2 replica tree", 1
+        )[1].split("      - name: Upload bounded A2 replica diagnostics", 1)[0]
+        diagnostics = self.replica.split(
+            "      - name: Upload bounded A2 replica diagnostics", 1
+        )[1]
+        self.assertIn("if: always()", retained)
+        self.assertIn("if: always()", diagnostics)
+        self.assertIn("if-no-files-found: warn", retained)
+        self.assertIn("if-no-files-found: error", diagnostics)
+        self.assertIn("compression-level: 0", retained)
+        self.assertIn("compression-level: 0", diagnostics)
+        self.assertIn("retention-days: 90", retained)
+        self.assertIn("retention-days: 14", diagnostics)
+
+    def test_fan_in_downloads_exactly_three_and_runs_contract_order(self) -> None:
+        self.assertEqual(self.fan_in.count("actions/download-artifact@"), 3)
+        for replica in (1, 2, 3):
+            self.assertIn(f"name: windows-dao-a2-replica-{replica}", self.fan_in)
+            self.assertIn(f"replica-0{replica}", self.fan_in)
+        assemble = self.fan_in.index("a2_bundle.py assemble")
+        analysis = self.fan_in.index("a2_analysis.py", assemble)
+        finalize = self.fan_in.index("a2_bundle.py finalize", analysis)
+        validate = self.fan_in.index("a2_bundle.py validate", finalize)
+        self.assertLess(assemble, analysis)
+        self.assertLess(analysis, finalize)
+        self.assertLess(finalize, validate)
+        self.assertEqual(self.fan_in.count("--replica-root"), 3)
+        self.assertEqual(self.fan_in.count("--replica (Join-Path"), 3)
+        self.assertIn('$campaignId = "a2-run-$env:GITHUB_RUN_ID"', self.fan_in)
+        self.assertIn("--holdout-receipt", self.fan_in)
+        upload = self.fan_in.split("      - name: Upload retained A2 bundle", 1)[1]
+        self.assertIn("if: always()", upload)
+        self.assertIn("compression-level: 0", upload)
+        self.assertIn("retention-days: 90", upload)
+
+    def test_all_actions_are_commit_pinned(self) -> None:
+        actions = re.findall(
+            r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE
+        )
+        self.assertEqual(len(actions), 12)
+        for action in actions:
+            self.assertRegex(action, r"^[^@]+@[0-9a-f]{40}$")
+        self.assertEqual(self.workflow.count("persist-credentials: false"), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
@@ -75,13 +75,13 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
         self.assertIn("max-parallel: 3", self.replica)
         self.assertIn("fail-fast: false", self.replica)
         self.assertIn("runs-on: windows-latest", self.replica)
-        self.assertIn("timeout-minutes: 31", self.replica)
+        self.assertIn("timeout-minutes: 37", self.replica)
         self.assertIn('FROZEN_WORKER_TIMEOUT_SECONDS: "1700"', self.replica)
-        self.assertIn('HOSTED_REPLICA_TIMEOUT_SECONDS: "1800"', self.replica)
+        self.assertIn('HOSTED_REPLICA_TIMEOUT_SECONDS: "2120"', self.replica)
         self.assertIn('FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"', self.replica)
         self.assertIn('REPLICA_MAXIMUM_OUTPUT_BYTES: "1048576"', self.replica)
-        self.assertIn("timeout-minutes: 15", self.fan_in)
-        self.assertEqual(1_800 + 15 * 60, 2_700)
+        self.assertIn("timeout-minutes: 20", self.fan_in)
+        self.assertEqual(1_700 + 120 + 300, 2_120)
 
     def test_replica_launch_is_x86_waited_bounded_and_null_safe(self) -> None:
         self.assertIn(
@@ -114,6 +114,9 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
         self.assertIn("REPLICA_MAXIMUM_OUTPUT_BYTES", self.run_step)
         self.assertIn("HOSTED_REPLICA_TIMEOUT_SECONDS", self.run_step)
         self.assertIn("Stop-Jet3BootstrapProcessTree -Process $process", self.run_step)
+        self.assertIn('started_utc = [DateTimeOffset]::UtcNow.ToString("o")', self.run_step)
+        self.assertIn('completed_utc = [DateTimeOffset]::UtcNow.ToString("o")', self.run_step)
+        self.assertIn("elapsed_seconds = [Math]::Round($elapsedSeconds, 3)", self.run_step)
         for argument in (
             '"-RepositoryRoot", $repository',
             '"-OutputRoot", $outputRoot',
@@ -134,7 +137,8 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
             self.workflow.count("status --porcelain=v1 --untracked-files=all"),
             2,
         )
-        self.assertIn("fetch-depth: 0", self.replica)
+        self.assertIn("fetch-depth: 1", self.replica)
+        self.assertIn("needs.contract.result == 'success'", self.replica)
 
     def test_replica_and_diagnostic_uploads_are_always_retained(self) -> None:
         retained = self.replica.split(
@@ -153,7 +157,7 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
         self.assertIn("retention-days: 14", diagnostics)
 
     def test_fan_in_downloads_exactly_three_and_runs_contract_order(self) -> None:
-        self.assertEqual(self.fan_in.count("actions/download-artifact@"), 3)
+        self.assertEqual(self.fan_in.count("actions/download-artifact@"), 4)
         for replica in (1, 2, 3):
             self.assertIn(f"name: windows-dao-a2-replica-{replica}", self.fan_in)
             self.assertIn(f"replica-0{replica}", self.fan_in)
@@ -168,16 +172,45 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
         self.assertEqual(self.fan_in.count("--replica (Join-Path"), 3)
         self.assertIn('$campaignId = "a2-run-$env:GITHUB_RUN_ID"', self.fan_in)
         self.assertIn("--holdout-receipt", self.fan_in)
+        self.assertIn('--campaign-id "a2-run-$env:GITHUB_RUN_ID"', self.fan_in)
+        self.assertIn("--producer-commit $env:GITHUB_SHA", self.fan_in)
         upload = self.fan_in.split("      - name: Upload retained A2 bundle", 1)[1]
         self.assertIn("if: always()", upload)
+        self.assertIn("fan-in-status.json", upload)
+        self.assertIn("if-no-files-found: error", upload)
         self.assertIn("compression-level: 0", upload)
         self.assertIn("retention-days: 90", upload)
+
+    def test_fan_in_status_is_bounded_timed_and_always_retained(self) -> None:
+        for step_id in ("assemble", "analyze", "finalize", "validate"):
+            self.assertIn(f"id: {step_id}", self.fan_in)
+            self.assertIn(f"steps.{step_id}.outcome", self.fan_in)
+        status = self.fan_in.split(
+            "      - name: Record retained A2 fan-in status", 1
+        )[1].split("      - name: Upload retained A2 bundle", 1)[0]
+        self.assertIn("if: always()", status)
+        for field in (
+            "independent_validation_passed",
+            "campaign_elapsed_seconds",
+            "within_plan_campaign_timeout",
+            "timing_records_complete",
+        ):
+            self.assertIn(field, status)
+        self.assertIn("$statusBytes.Length -gt 4096", status)
+        self.assertIn("hosted-replica.json", self.fan_in)
+        self.assertIn("started_utc", self.fan_in)
+        diagnostics = self.fan_in.split(
+            "      - name: Upload bounded A2 fan-in diagnostics", 1
+        )[1]
+        self.assertIn("if: always()", diagnostics)
+        self.assertIn("if-no-files-found: error", diagnostics)
+        self.assertIn("retention-days: 14", diagnostics)
 
     def test_all_actions_are_commit_pinned(self) -> None:
         actions = re.findall(
             r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE
         )
-        self.assertEqual(len(actions), 12)
+        self.assertEqual(len(actions), 14)
         for action in actions:
             self.assertRegex(action, r"^[^@]+@[0-9a-f]{40}$")
         self.assertEqual(self.workflow.count("persist-credentials: false"), 3)


### PR DESCRIPTION
## Summary

- add the manual-only three-replica Windows DAO A2 matrix and bounded fan-in workflow
- add fail-closed replica assembly, holdout subprocess validation, finalization, and separate-process complete-bundle validation
- add synthetic end-to-end bundle tests and workflow source-contract tests
- harden Windows file identity, retained fan-in diagnostics, and elapsed-time reporting from review

## Merge order

- PR #43 must merge before (or together with) PR #44. This workflow intentionally requires the worker entrypoint and contract test added by #43, so #44 is not dispatchable on its own.

## Checks

- `python3 -B -m unittest -v oracle/windows-dao/tests/test_a2_plan_contract.py oracle/windows-dao/tests/test_a2_spec_generator.py oracle/windows-dao/tests/test_a2_integration.py oracle/windows-dao/tests/test_a2_dryrun.py oracle/windows-dao/tests/test_a2_bundle.py oracle/windows-dao/tests/test_windows_dao_a2_workflow.py` (68 passed)
- `python3 tools/reconcile_tests.py`
- Python byte compilation and Ruby YAML parse

## Interface assumptions

- The lane contract's `tests/` shorthand maps to `oracle/windows-dao/tests/`, matching the existing A1 oracle tests and CI discovery path.
- `tests/manifest.json` remains unchanged because its schema-v2 contract inventories Cargo/libtest runtimes only; adding Python unittest entries makes reconciliation fail as stale runtime tests.
- The worker lane may choose any bounded set of files under `oracle/windows-dao/scripts/a2/*.ps1`; the contract job parses that closed directory plus `run-a2-replica.ps1` without execution.