### PR TITLE
fix: pin A2 hosted jobs to the windows-2022 image

### DIFF
--- a/.github/workflows/windows-dao-a2.yml
+++ b/.github/workflows/windows-dao-a2.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   contract:
     name: Validate the checked A2 contract
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -108,7 +108,7 @@ jobs:
       max-parallel: 3
       matrix:
         replica: [1, 2, 3]
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 37
     env:
       FROZEN_WORKER_TIMEOUT_SECONDS: "1700"
@@ -322,7 +322,7 @@ jobs:
       inputs.execute_a2_campaign &&
       needs.contract.result == 'success' &&
       needs.a2-replica.result == 'success'
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 20
     env:
       FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"

--- a/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a2_workflow.py
@@ -75,7 +75,9 @@ class WindowsDaoA2WorkflowTests(unittest.TestCase):
         self.assertIn("replica: [1, 2, 3]", self.replica)
         self.assertIn("max-parallel: 3", self.replica)
         self.assertIn("fail-fast: false", self.replica)
-        self.assertIn("runs-on: windows-latest", self.replica)
+        # EXP-0006 pins the dao360.dll binary shipped by the Server 2022 image.
+        self.assertEqual(self.workflow.count("runs-on: windows-2022"), 3)
+        self.assertNotIn("windows-latest", self.workflow)
         self.assertIn("timeout-minutes: 37", self.replica)
         self.assertIn('FROZEN_WORKER_TIMEOUT_SECONDS: "1700"', self.replica)
         self.assertIn('HOSTED_REPLICA_TIMEOUT_SECONDS: "2120"', self.replica)


### PR DESCRIPTION
A2 run 32584974169: all three replicas failed preflight with `Environment differs from EXP-0006 policy: server_file_version` — `windows-latest` is now Server 2025 (10.0.26100, dao360.dll 10.0.26100.5074) while the policy and A1 run 12 bind the Server 2022 binary (03.60.9765.0). Pin the three A2 jobs to `windows-2022` like A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp6DTLry3q32XBCYyzbo2g