### PR TITLE
fix: treat A2 replica artifact zip digests as advisory

### DIFF
--- a/.github/workflows/windows-dao-a2.yml
+++ b/.github/workflows/windows-dao-a2.yml
@@ -341,18 +341,24 @@ jobs:
         with:
           name: windows-dao-a2-replica-1
           path: ${{ runner.temp }}\jet3-a2-replicas\replica-01
+          # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
+          digest-mismatch: warn
 
       - name: Download A2 replica 2
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-dao-a2-replica-2
           path: ${{ runner.temp }}\jet3-a2-replicas\replica-02
+          # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
+          digest-mismatch: warn
 
       - name: Download A2 replica 3
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-dao-a2-replica-3
           path: ${{ runner.temp }}\jet3-a2-replicas\replica-03
+          # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
+          digest-mismatch: warn
 
       - name: Download bounded A2 replica timing diagnostics
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Run 32586156614 acquired all three replicas (469 s / ~540 s / ~300 s) but the fan-in failed on both attempts with `digest-mismatch` from actions/download-artifact on replica 1. The artifact downloads intact via `gh` and all 18,947 manifest hashes verify, so the zip digest is a false alarm; `assemble` performs the real closed-manifest re-hash. Set `digest-mismatch: warn` for the three replica downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp6DTLry3q32XBCYyzbo2g