### PR TITLE
feat: add independent recomputing validator for A2 reports

### DIFF
--- a/oracle/windows-dao/scripts/a2_independent_bundle.py
+++ b/oracle/windows-dao/scripts/a2_independent_bundle.py
@@ -1,0 +1,563 @@
+"""Fail-closed A2 bundle closure, schema, linkage, and snapshot validation.
+
+This code shares no implementation with the A2 producer or analyzer.  Its only
+repository inputs are the preregistered plan/revision and the adjacent schemas.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from a2_independent_core import PAGE_SIZE, ReplicaView
+
+PLAN_SHA256 = "804e84dace5c423938f32dd350ebc778d43084d41db1da93f26f1777984480c2"
+REVISION_SHA256 = "977d352b6b7c042cf4d0f0cab793086842b3ad2b7da13b9c217020f00c5193c4"
+SCHEMA_FILES = {
+    "plan": "plan.schema.json",
+    "bundle": "bundle-manifest.schema.json",
+    "environment": "environment.schema.json",
+    "observation": "replica-observation.schema.json",
+    "replica_manifest": "replica-artifact-manifest.schema.json",
+    "page_index": "page-index.schema.json",
+    "report": "analysis-report.schema.json",
+    "receipt": "holdout-structure-receipt.schema.json",
+}
+
+
+class BundleError(Exception):
+    """A deterministic validation failure."""
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise BundleError(f"duplicate JSON member: {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path, maximum: int) -> Any:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise BundleError(f"cannot stat {path}: {exc}") from exc
+    if size < 1 or size > maximum:
+        raise BundleError(f"JSON size outside 1..{maximum}: {path} ({size})")
+    try:
+        return json.loads(path.read_bytes(), object_pairs_hook=_unique_object)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BundleError(f"invalid JSON {path}: {exc}") from exc
+
+
+class SchemaChecker:
+    """Small Draft 2020-12 checker for the constructs used by A2 schemas."""
+
+    def __init__(self, schema: dict[str, Any]):
+        self.schema = schema
+
+    def check(self, value: Any) -> None:
+        self._check(value, self.schema, "$")
+
+    def _resolve(self, reference: str) -> dict[str, Any]:
+        if not reference.startswith("#/"):
+            raise BundleError(f"external schema reference is forbidden: {reference}")
+        value: Any = self.schema
+        for part in reference[2:].split("/"):
+            value = value[part.replace("~1", "/").replace("~0", "~")]
+        if not isinstance(value, dict):
+            raise BundleError(f"schema reference is not an object: {reference}")
+        return value
+
+    def _fail(self, location: str, message: str) -> None:
+        raise BundleError(f"schema violation at {location}: {message}")
+
+    def _check(self, value: Any, schema: dict[str, Any], location: str) -> None:
+        if "$ref" in schema:
+            self._check(value, self._resolve(schema["$ref"]), location)
+            return
+        if "anyOf" in schema:
+            failures = []
+            for option in schema["anyOf"]:
+                try:
+                    self._check(value, option, location)
+                    break
+                except BundleError as exc:
+                    failures.append(str(exc))
+            else:
+                self._fail(location, "no anyOf branch matched: " + " | ".join(failures))
+        expected = schema.get("type")
+        if expected is not None and not self._type_matches(value, expected):
+            self._fail(location, f"expected {expected}, got {type(value).__name__}")
+        if "const" in schema and value != schema["const"]:
+            self._fail(location, f"expected constant {schema['const']!r}")
+        if "enum" in schema and value not in schema["enum"]:
+            self._fail(location, f"value {value!r} is not registered")
+        if isinstance(value, dict):
+            required = schema.get("required", [])
+            missing = [key for key in required if key not in value]
+            if missing:
+                self._fail(location, f"missing members {missing}")
+            properties = schema.get("properties", {})
+            if schema.get("additionalProperties") is False:
+                extras = sorted(set(value) - set(properties))
+                if extras:
+                    self._fail(location, f"unexpected members {extras}")
+            for key, child in value.items():
+                if key in properties:
+                    self._check(child, properties[key], f"{location}.{key}")
+        elif isinstance(value, list):
+            if len(value) < schema.get("minItems", 0):
+                self._fail(location, "array is too short")
+            if "maxItems" in schema and len(value) > schema["maxItems"]:
+                self._fail(location, "array is too long")
+            if schema.get("uniqueItems"):
+                encoded = [
+                    json.dumps(item, sort_keys=True, separators=(",", ":"))
+                    for item in value
+                ]
+                if len(encoded) != len(set(encoded)):
+                    self._fail(location, "array items are not unique")
+            if isinstance(schema.get("items"), dict):
+                for index, child in enumerate(value):
+                    self._check(child, schema["items"], f"{location}[{index}]")
+        elif isinstance(value, str):
+            if len(value) < schema.get("minLength", 0):
+                self._fail(location, "string is too short")
+            if "maxLength" in schema and len(value) > schema["maxLength"]:
+                self._fail(location, "string is too long")
+            if "pattern" in schema and re.search(schema["pattern"], value) is None:
+                self._fail(location, f"string does not match {schema['pattern']}")
+            if schema.get("format") == "date-time":
+                try:
+                    datetime.fromisoformat(value.replace("Z", "+00:00"))
+                except ValueError as exc:
+                    self._fail(location, f"invalid date-time: {exc}")
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            if "minimum" in schema and value < schema["minimum"]:
+                self._fail(location, f"value is below {schema['minimum']}")
+            if "maximum" in schema and value > schema["maximum"]:
+                self._fail(location, f"value is above {schema['maximum']}")
+
+    @staticmethod
+    def _type_matches(value: Any, expected: str) -> bool:
+        return {
+            "object": isinstance(value, dict),
+            "array": isinstance(value, list),
+            "string": isinstance(value, str),
+            "integer": isinstance(value, int) and not isinstance(value, bool),
+            "boolean": isinstance(value, bool),
+            "null": value is None,
+        }.get(expected, False)
+
+
+@dataclass(frozen=True)
+class Contract:
+    plan: dict[str, Any]
+    plan_bytes: bytes
+    schemas: dict[str, SchemaChecker]
+    directory: Path
+
+    @classmethod
+    def load(cls, scripts_directory: Path) -> Contract:
+        directory = scripts_directory.parent / "experiments" / "a2"
+        plan_path = directory / "a2-allocation-maps.plan.json"
+        revision_path = directory / "a2-allocation-maps-r2.plan.json"
+        plan_bytes = plan_path.read_bytes()
+        revision_bytes = revision_path.read_bytes()
+        if sha256_bytes(plan_bytes) != PLAN_SHA256:
+            raise BundleError("repository A2 plan hash does not match EXP-0040")
+        if sha256_bytes(revision_bytes) != REVISION_SHA256:
+            raise BundleError("repository A2 R2 hash does not match EXP-0041")
+        plan = json.loads(plan_bytes, object_pairs_hook=_unique_object)
+        revision = json.loads(revision_bytes, object_pairs_hook=_unique_object)
+        if revision["preregistration"]["original_plan"]["sha256"] != PLAN_SHA256:
+            raise BundleError("R2 does not pin the loaded original plan")
+        schemas = {
+            name: SchemaChecker(load_json(directory / filename, 1_000_000))
+            for name, filename in SCHEMA_FILES.items()
+        }
+        schemas["plan"].check(plan)
+        return cls(plan, plan_bytes, schemas, directory)
+
+
+@dataclass
+class VerifiedBundle:
+    root: Path
+    contract: Contract
+    manifest: dict[str, Any]
+    report: dict[str, Any]
+    observations: dict[int, dict[str, Any]]
+    indexes: dict[int, dict[str, dict[str, Any]]]
+    blobs: dict[str, bytes]
+
+    def views(self, replicas: tuple[int, ...]) -> tuple[ReplicaView, ...]:
+        checkpoint_ids = tuple(
+            self.contract.plan["checkpoint_design"]["checkpoint_ids"]
+        )
+        return tuple(
+            ReplicaView(
+                replica,
+                checkpoint_ids,
+                {
+                    checkpoint: tuple(
+                        self.indexes[replica][checkpoint]["ordered_page_sha256"]
+                    )
+                    for checkpoint in checkpoint_ids
+                },
+                {
+                    checkpoint: self.indexes[replica][checkpoint]["page_count"]
+                    for checkpoint in checkpoint_ids
+                },
+                self.blobs.__getitem__,
+            )
+            for replica in replicas
+        )
+
+
+def _safe_path(text: str) -> PurePosixPath:
+    path = PurePosixPath(text)
+    if (
+        path.is_absolute()
+        or ".." in path.parts
+        or "." in path.parts
+        or str(path) != text
+    ):
+        raise BundleError(f"unsafe or noncanonical manifest path: {text}")
+    return path
+
+
+def _walk_regular_files(root: Path) -> set[str]:
+    files: set[str] = set()
+    for directory, names, filenames in os.walk(root, followlinks=False):
+        base = Path(directory)
+        for name in names:
+            if (base / name).is_symlink():
+                raise BundleError(f"symlinked directory is forbidden: {base / name}")
+        for name in filenames:
+            path = base / name
+            if path.is_symlink() or not path.is_file():
+                raise BundleError(f"non-regular bundle entry is forbidden: {path}")
+            files.add(path.relative_to(root).as_posix())
+    return files
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(1 << 20):
+                digest.update(chunk)
+    except OSError as exc:
+        raise BundleError(f"cannot hash {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+def _same_identity(
+    document: dict[str, Any],
+    manifest: dict[str, Any],
+    *,
+    environment: str | None = None,
+) -> None:
+    for key in ("plan_sha256", "producer_commit", "campaign_id", "provider_sha256"):
+        if key in document and document[key] != manifest[key]:
+            raise BundleError(f"identity mismatch for {key}")
+    if environment is not None and document.get("environment_sha256") != environment:
+        raise BundleError("environment hash linkage mismatch")
+
+
+def verify_bundle(root: Path, contract: Contract) -> VerifiedBundle:
+    root = root.resolve(strict=True)
+    if not root.is_dir() or root.is_symlink():
+        raise BundleError("bundle root must be a real directory")
+    max_json = contract.plan["bounds"]["max_json_bytes"]
+    manifest_path = root / "bundle-manifest.json"
+    manifest = load_json(manifest_path, max_json)
+    contract.schemas["bundle"].check(manifest)
+    if manifest["plan_sha256"] != PLAN_SHA256:
+        raise BundleError("bundle is not bound to the frozen A2 plan")
+
+    entries: dict[str, dict[str, Any]] = {}
+    blobs: dict[str, bytes] = {}
+    for entry in manifest["files"]:
+        path_text = str(_safe_path(entry["path"]))
+        if path_text in entries:
+            raise BundleError(f"duplicate manifest path: {path_text}")
+        entries[path_text] = entry
+    actual = _walk_regular_files(root)
+    expected = set(entries) | {"bundle-manifest.json"}
+    if actual != expected:
+        missing = sorted(expected - actual)[:8]
+        extra = sorted(actual - expected)[:8]
+        raise BundleError(f"bundle closure mismatch; missing={missing}, extra={extra}")
+
+    total_size = 0
+    for path_text, entry in sorted(entries.items()):
+        path = root / path_text
+        size = path.stat().st_size
+        total_size += size
+        if size != entry["size_bytes"]:
+            raise BundleError(f"size mismatch: {path_text}")
+        digest = _hash_file(path)
+        if digest != entry["sha256"]:
+            raise BundleError(f"SHA-256 mismatch: {path_text}")
+        if entry["role"] == "page_blob":
+            match = re.fullmatch(r"page-store/([0-9a-f]{64})\.page", path_text)
+            if match is None or match.group(1) != digest or size != PAGE_SIZE:
+                raise BundleError(f"invalid content-addressed page blob: {path_text}")
+            blobs[digest] = path.read_bytes()
+    if total_size != manifest["bundle_size_bytes_excluding_manifest"]:
+        raise BundleError("bundle size total does not match manifest")
+    if len(blobs) != manifest["page_blob_count"]:
+        raise BundleError("page blob count does not match manifest")
+    if len(blobs) > contract.plan["bounds"]["max_unique_page_blobs"]:
+        raise BundleError("page blob count breaches the plan bound")
+    if (
+        sum(map(len, blobs.values()))
+        > contract.plan["bounds"]["max_retained_page_store_bytes"]
+    ):
+        raise BundleError("page store breaches the plan byte bound")
+
+    plan_entry = entries.get("plan/a2-allocation-maps.plan.json")
+    if (
+        plan_entry is None
+        or (root / plan_entry["path"]).read_bytes() != contract.plan_bytes
+    ):
+        raise BundleError("bundled plan is not byte-identical to the frozen plan")
+
+    observations: dict[int, dict[str, Any]] = {}
+    indexes: dict[int, dict[str, dict[str, Any]]] = {}
+    replica_manifests: dict[int, dict[str, Any]] = {}
+    environments: dict[int, dict[str, Any]] = {}
+    checkpoint_ids = tuple(contract.plan["checkpoint_design"]["checkpoint_ids"])
+    referenced_blobs: set[str] = set()
+    nested_paths: set[str] = set()
+
+    for replica in (1, 2, 3):
+        suffix = f"{replica:02d}"
+        environment_path = f"environment/replica-{suffix}.json"
+        observation_path = f"observations/replica-{suffix}.json"
+        replica_manifest_path = f"replica-artifacts/replica-{suffix}-manifest.json"
+        environment = load_json(root / environment_path, max_json)
+        observation = load_json(root / observation_path, max_json)
+        replica_manifest = load_json(root / replica_manifest_path, max_json)
+        contract.schemas["environment"].check(environment)
+        contract.schemas["observation"].check(observation)
+        contract.schemas["replica_manifest"].check(replica_manifest)
+        if environment["replica"] != replica or observation["replica"] != replica:
+            raise BundleError("replica number does not match artifact path")
+        if replica_manifest["replica"] != replica:
+            raise BundleError("replica manifest number does not match path")
+        environment_hash = entries[environment_path]["sha256"]
+        _same_identity(environment, manifest)
+        _same_identity(observation, manifest, environment=environment_hash)
+        _same_identity(replica_manifest, manifest, environment=environment_hash)
+        if replica_manifest["matrix_job_id"] != observation["matrix_job"]["job_id"]:
+            raise BundleError("matrix job linkage mismatch")
+        expected_binding = dict(contract.plan["tables"]["role_bindings"][replica - 1])
+        expected_binding.pop("replica")
+        if observation["role_binding"] != expected_binding:
+            raise BundleError("role binding differs from plan")
+
+        by_checkpoint: dict[str, dict[str, Any]] = {}
+        previous: dict[str, Any] | None = None
+        changed_total = 0
+        logical_bytes = 0
+        for ordinal, checkpoint in enumerate(checkpoint_ids):
+            index_path = (
+                f"page-indexes/replica-{suffix}/{ordinal:02d}-{checkpoint}.json"
+            )
+            index = load_json(root / index_path, max_json)
+            contract.schemas["page_index"].check(index)
+            _same_identity(index, manifest, environment=environment_hash)
+            if (
+                index["replica"] != replica
+                or index["checkpoint_id"] != checkpoint
+                or index["ordinal"] != ordinal
+            ):
+                raise BundleError(f"page-index schedule mismatch: {index_path}")
+            predecessor = None if ordinal == 0 else checkpoint_ids[ordinal - 1]
+            if index["predecessor_checkpoint_id"] != predecessor:
+                raise BundleError(f"page-index predecessor mismatch: {index_path}")
+            hashes = index["ordered_page_sha256"]
+            if (
+                len(hashes) != index["page_count"]
+                or index["file_size_bytes"] != len(hashes) * PAGE_SIZE
+            ):
+                raise BundleError(f"page-index extent mismatch: {index_path}")
+            if any(digest not in blobs for digest in hashes):
+                raise BundleError(f"page-index references a missing blob: {index_path}")
+            expected_changed = []
+            if previous is None:
+                expected_changed = list(range(len(hashes)))
+            else:
+                old = previous["ordered_page_sha256"]
+                expected_changed = [
+                    page
+                    for page in range(max(len(old), len(hashes)))
+                    if (old[page] if page < len(old) else None)
+                    != (hashes[page] if page < len(hashes) else None)
+                ]
+            if index["changed_page_indices"] != expected_changed:
+                raise BundleError(f"changed-page list is not exact: {index_path}")
+            database = hashlib.sha256()
+            for digest in hashes:
+                database.update(blobs[digest])
+            if database.hexdigest() != index["database_sha256"]:
+                raise BundleError(
+                    f"snapshot reconstruction hash mismatch: {index_path}"
+                )
+            observation_checkpoint = observation["checkpoints"][ordinal]
+            reference = observation_checkpoint["page_index"]
+            if reference != {
+                "path": index_path,
+                "sha256": entries[index_path]["sha256"],
+                "size_bytes": entries[index_path]["size_bytes"],
+            }:
+                raise BundleError(
+                    f"observation page-index reference mismatch: {index_path}"
+                )
+            if (
+                observation_checkpoint["checkpoint_id"] != checkpoint
+                or observation_checkpoint["ordinal"] != ordinal
+            ):
+                raise BundleError("observation checkpoint schedule mismatch")
+            if (
+                observation_checkpoint["actual_file_pages"] != len(hashes)
+                or observation_checkpoint["actual_size_bytes"]
+                != len(hashes) * PAGE_SIZE
+            ):
+                raise BundleError("observation extent differs from page index")
+            referenced_blobs.update(hashes)
+            changed_total += len(expected_changed)
+            logical_bytes += len(hashes) * PAGE_SIZE
+            by_checkpoint[checkpoint] = index
+            previous = index
+        if changed_total != observation["changed_hash_entries"]:
+            raise BundleError("observation changed-hash total is not recomputable")
+        if logical_bytes != observation["logical_checkpoint_read_bytes"]:
+            raise BundleError("observation logical-read total is not recomputable")
+        if (
+            logical_bytes
+            > contract.plan["bounds"]["max_logical_checkpoint_read_bytes_per_replica"]
+        ):
+            raise BundleError("logical checkpoint reads breach the plan bound")
+        growth = observation["d_growth_observation"]
+        if growth["first_target_pages"] != growth["first_baseline_pages"] + 128:
+            raise BundleError("first D target is not baseline + 128")
+        if growth["regrowth_target_pages"] != growth["regrowth_baseline_pages"] + 128:
+            raise BundleError("D regrowth target is not baseline + 128")
+        if growth["first_achieved_pages"] < growth["first_target_pages"]:
+            raise BundleError("first D growth did not reach target")
+        if growth["regrowth_achieved_pages"] < growth["regrowth_target_pages"]:
+            raise BundleError("D regrowth did not reach target")
+        if growth["regrowth_achieved_pages"] <= growth["first_achieved_pages"]:
+            raise BundleError("D regrowth is not strictly larger")
+
+        nested = {item["path"]: item for item in replica_manifest["files"]}
+        for path_text, item in nested.items():
+            if path_text not in entries or item != entries[path_text]:
+                raise BundleError(
+                    f"replica manifest entry differs from outer manifest: {path_text}"
+                )
+        fixed = {environment_path, observation_path} | {
+            f"page-indexes/replica-{suffix}/{ordinal:02d}-{checkpoint}.json"
+            for ordinal, checkpoint in enumerate(checkpoint_ids)
+        }
+        expected_nested = fixed | {
+            f"page-store/{digest}.page"
+            for index in by_checkpoint.values()
+            for digest in index["ordered_page_sha256"]
+        }
+        expected_nested |= {
+            path for path, item in nested.items() if item["role"] == "acquisition_log"
+        }
+        if set(nested) != expected_nested:
+            raise BundleError(
+                f"replica manifest closure mismatch for replica {replica}"
+            )
+        nested_paths.update(nested)
+        observations[replica] = observation
+        indexes[replica] = by_checkpoint
+        replica_manifests[replica] = replica_manifest
+        environments[replica] = environment
+
+    if set(blobs) != referenced_blobs:
+        raise BundleError("page store contains an unreferenced or missing blob")
+    provider_fields = [
+        (
+            environments[replica]["provider"]["prog_id"],
+            environments[replica]["provider"]["clsid"],
+            environments[replica]["provider"]["server_sha256"],
+            environments[replica]["host"]["process_architecture"],
+            environments[replica]["host"]["powershell_version"].split(".")[0],
+        )
+        for replica in (1, 2, 3)
+    ]
+    if len(set(provider_fields)) != 1:
+        raise BundleError("cross-replica provider identity differs")
+
+    report_path = "analysis/analysis-report.json"
+    candidates_path = "analysis/derivation-candidates.json"
+    receipt_path = "analysis/holdout-structure-receipt.json"
+    report = load_json(root / report_path, max_json)
+    receipt = load_json(root / receipt_path, max_json)
+    contract.schemas["report"].check(report)
+    contract.schemas["receipt"].check(receipt)
+    _same_identity(report, manifest)
+    _same_identity(receipt, manifest)
+    if report["derivation_candidate_set_sha256"] != entries[candidates_path]["sha256"]:
+        raise BundleError("report candidate-set hash linkage mismatch")
+    if receipt["derivation_candidate_set_sha256"] != entries[candidates_path]["sha256"]:
+        raise BundleError("receipt candidate-set hash linkage mismatch")
+    if (
+        receipt["replica_artifact_manifest_sha256"]
+        != entries["replica-artifacts/replica-03-manifest.json"]["sha256"]
+    ):
+        raise BundleError("receipt holdout-manifest linkage mismatch")
+    if manifest["holdout_structure_receipt_sha256"] != entries[receipt_path]["sha256"]:
+        raise BundleError("bundle receipt hash linkage mismatch")
+    manifest_hashes = [
+        entries[f"replica-artifacts/replica-{replica:02d}-manifest.json"]["sha256"]
+        for replica in (1, 2, 3)
+    ]
+    if manifest["replica_artifact_manifest_sha256"] != manifest_hashes:
+        raise BundleError("bundle replica-manifest hash linkage mismatch")
+    environment_hashes = [
+        entries[f"environment/replica-{replica:02d}.json"]["sha256"]
+        for replica in (1, 2, 3)
+    ]
+    if manifest["replica_environment_sha256"] != environment_hashes:
+        raise BundleError("bundle environment hash linkage mismatch")
+    if report["scientific_outcome"] != manifest["analysis_scientific_outcome"]:
+        raise BundleError("bundle/report scientific outcome mismatch")
+    if report["input_checkpoint_count"] != len(checkpoint_ids) * 3:
+        raise BundleError("report checkpoint count is not recomputable")
+
+    outer_fixed = {
+        "plan/a2-allocation-maps.plan.json",
+        report_path,
+        candidates_path,
+        receipt_path,
+    } | {
+        f"replica-artifacts/replica-{replica:02d}-manifest.json"
+        for replica in (1, 2, 3)
+    }
+    if set(entries) != nested_paths | outer_fixed:
+        raise BundleError(
+            "outer manifest has files outside the nested and analysis closure"
+        )
+    return VerifiedBundle(
+        root, contract, manifest, report, observations, indexes, blobs
+    )

--- a/oracle/windows-dao/scripts/a2_independent_core.py
+++ b/oracle/windows-dao/scripts/a2_independent_core.py
@@ -1,0 +1,414 @@
+"""Independent A2 record and pointer recomputation primitives.
+
+This module is intentionally standalone.  It was derived only from the frozen
+A2 plan, its R2 revision, README, schemas, and EXP-0040/EXP-0041.  It does not
+import ``a2_spec.py`` or any analyzer, layer, model, dry-run, or generator code.
+
+The plan fixes a five-byte prefix before an inline bitmap by making every
+inline-boundary candidate start at ``global_map.start + 5``.  Bitmap page
+ordinals are decoded least-significant bit first.  A candidate start is tied to
+the closed E0 extent by requiring exactly the E0 physical-page prefix to decode
+in-use and the remaining capacity to decode not-in-use.  This is the direct,
+independent allocation-sequence interpretation of the plan's represented-page
+set relation; no changed-byte envelope supplies either record boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from itertools import pairwise
+
+PAGE_SIZE = 2048
+GLOBAL_PREFIX_BYTES = 5
+D_CHECKPOINTS = (
+    "E0",
+    "D_GROW_0128",
+    "D_DROP",
+    "D_RECREATE_EMPTY",
+    "D_REGROW_0128",
+)
+POLARITIES = ("set_means_in_use", "set_means_not_in_use")
+
+
+@dataclass(frozen=True)
+class ReplicaView:
+    replica: int
+    checkpoint_ids: tuple[str, ...]
+    page_hashes: dict[str, tuple[str, ...]]
+    page_counts: dict[str, int]
+    load_page: Callable[[str], bytes]
+
+    def state(self, checkpoint: str, page: int) -> str | None:
+        hashes = self.page_hashes[checkpoint]
+        return hashes[page] if page < len(hashes) else None
+
+    def page(self, checkpoint: str, page: int) -> bytes | None:
+        digest = self.state(checkpoint, page)
+        return None if digest is None else self.load_page(digest)
+
+
+@dataclass(frozen=True, order=True)
+class GlobalModel:
+    page: int
+    start: int
+    end: int
+    bit_polarity: str
+    zero_suffix_slack_bytes: int
+
+    def report_value(self) -> dict[str, object]:
+        return {
+            "record": {"page": self.page, "start": self.start, "end": self.end},
+            "bit_polarity": self.bit_polarity,
+            "zero_suffix_slack_bytes": self.zero_suffix_slack_bytes,
+        }
+
+
+@dataclass(frozen=True, order=True)
+class TdefModel:
+    page: int
+    start: int
+    end: int
+    pointer_layout: str
+    growth_pointer_offset: int
+    delete_reinsert_pointer_offset: int
+
+
+def candidate_page_space(views: Iterable[ReplicaView]) -> range:
+    maximum = 0
+    for view in views:
+        maximum = max(maximum, max(map(len, view.page_hashes.values()), default=0))
+    return range(maximum)
+
+
+def _different(view: ReplicaView, page: int, left: str, right: str) -> bool:
+    return view.state(left, page) != view.state(right, page)
+
+
+def global_qualifying_pages(views: tuple[ReplicaView, ...]) -> tuple[int, ...]:
+    """Apply the plan's hash-only global qualification before byte access."""
+    return tuple(
+        page
+        for page in candidate_page_space(views)
+        if all(
+            _different(view, page, "E0", "D_GROW_0128")
+            and _different(view, page, "D_GROW_0128", "D_DROP")
+            for view in views
+        )
+    )
+
+
+def growth_pairs(
+    checkpoint_ids: tuple[str, ...], *, include_p: bool
+) -> tuple[tuple[str, str], ...]:
+    prefixes = ("L_REL_", "H_REL_") + (("P_ABS_",) if include_p else ())
+    result: list[tuple[str, str]] = []
+    for left, right in pairwise(checkpoint_ids):
+        if right.startswith(prefixes):
+            result.append((left, right))
+    return tuple(result)
+
+
+def tdef_qualifying_pages(views: tuple[ReplicaView, ...]) -> tuple[int, ...]:
+    """Apply the separate TDEF hash qualification from the plan."""
+    pairs = growth_pairs(views[0].checkpoint_ids, include_p=False)
+    return tuple(
+        page
+        for page in candidate_page_space(views)
+        if all(
+            view.state("E0", page) is not None
+            and any(_different(view, page, left, right) for left, right in pairs)
+            and _different(view, page, "L_REL_1280", "L_DELETE_ALL")
+            and _different(view, page, "L_DELETE_ALL", "L_REINSERT_SAME")
+            for view in views
+        )
+    )
+
+
+def _is_in_use(bit: int, polarity: str) -> bool:
+    if polarity == "set_means_in_use":
+        return bit == 1
+    if polarity == "set_means_not_in_use":
+        return bit == 0
+    raise ValueError(f"unknown polarity: {polarity}")
+
+
+def _raw_values(polarity: str) -> tuple[int, int]:
+    """Return (in-use byte, not-in-use byte) for a uniform byte."""
+    return (0xFF, 0x00) if polarity == "set_means_in_use" else (0x00, 0xFF)
+
+
+def _initial_extent_matches(
+    data: bytes, offset: int, pages: int, polarity: str
+) -> bool:
+    capacity = (PAGE_SIZE - offset) * 8
+    if pages >= capacity:
+        return False
+    used, free = _raw_values(polarity)
+    full, remainder = divmod(pages, 8)
+    if data[offset : offset + full] != bytes((used,)) * full:
+        return False
+    cursor = offset + full
+    if remainder:
+        mask = (1 << remainder) - 1
+        expected = mask if polarity == "set_means_in_use" else 0xFF ^ mask
+        if data[cursor] != expected:
+            return False
+        cursor += 1
+    return data[cursor:] == bytes((free,)) * (PAGE_SIZE - cursor)
+
+
+def _decode_set(data: bytes, offset: int, polarity: str) -> set[int]:
+    decoded: set[int] = set()
+    for byte_ordinal, value in enumerate(data[offset:]):
+        for bit in range(8):
+            if _is_in_use((value >> bit) & 1, polarity):
+                decoded.add(byte_ordinal * 8 + bit)
+    return decoded
+
+
+def _last_d_flip(pages: dict[str, bytes], start: int) -> int | None:
+    changed = [
+        offset
+        for offset in range(start, PAGE_SIZE)
+        if len({pages[checkpoint][offset] for checkpoint in D_CHECKPOINTS}) > 1
+    ]
+    return max(changed) if changed else None
+
+
+def _global_candidate_at(
+    view: ReplicaView, page: int, start: int, polarity: str
+) -> GlobalModel | None:
+    pages = {checkpoint: view.page(checkpoint, page) for checkpoint in D_CHECKPOINTS}
+    if any(value is None for value in pages.values()):
+        return None
+    present = {key: value for key, value in pages.items() if value is not None}
+    offset = start + GLOBAL_PREFIX_BYTES
+    if offset >= PAGE_SIZE or not _initial_extent_matches(
+        present["E0"], offset, view.page_counts["E0"], polarity
+    ):
+        return None
+
+    decoded = {
+        key: _decode_set(value, offset, polarity) for key, value in present.items()
+    }
+    first_growth = decoded["D_GROW_0128"] - decoded["E0"]
+    if not first_growth:
+        return None
+    if first_growth & decoded["D_DROP"] or first_growth & decoded["D_RECREATE_EMPTY"]:
+        return None
+    if not first_growth <= decoded["D_REGROW_0128"]:
+        return None
+    beyond = decoded["D_REGROW_0128"] - decoded["D_GROW_0128"]
+    if not any(index >= view.page_counts["D_GROW_0128"] for index in beyond):
+        return None
+
+    last_flip = _last_d_flip(present, start)
+    if last_flip is None:
+        return None
+    slack = PAGE_SIZE - last_flip - 1
+    if slack < 16:
+        return None
+    free = _raw_values(polarity)[1]
+    if any(
+        value[last_flip + 1 :] != bytes((free,)) * slack for value in present.values()
+    ):
+        return None
+    return GlobalModel(page, start, PAGE_SIZE, polarity, slack)
+
+
+def global_page_models(view: ReplicaView, page: int) -> tuple[GlobalModel, ...]:
+    """Resolve page-terminal candidates after testing every fixed start."""
+    models = {
+        model
+        for start in range(PAGE_SIZE - GLOBAL_PREFIX_BYTES)
+        for polarity in POLARITIES
+        if (model := _global_candidate_at(view, page, start, polarity)) is not None
+    }
+    return tuple(sorted(models))
+
+
+def derive_global_models(
+    views: tuple[ReplicaView, ...], qualified_pages: tuple[int, ...]
+) -> tuple[GlobalModel, ...]:
+    """Intersect independently derived replica models without majority voting."""
+    per_replica: list[set[GlobalModel]] = []
+    for view in views:
+        models = {
+            model
+            for page in qualified_pages
+            for model in global_page_models(view, page)
+        }
+        per_replica.append(models)
+    return tuple(sorted(set.intersection(*per_replica))) if per_replica else ()
+
+
+def global_model_predicts(view: ReplicaView, model: GlobalModel) -> bool:
+    candidate = _global_candidate_at(view, model.page, model.start, model.bit_polarity)
+    return candidate == model
+
+
+def growth_polarity_violations(
+    view: ReplicaView, model: GlobalModel
+) -> tuple[tuple[str, str], ...]:
+    """Return growth legs containing an in-use to not-in-use record-bit flip."""
+    violations: list[tuple[str, str]] = []
+    offset = model.start + GLOBAL_PREFIX_BYTES
+    for left, right in growth_pairs(view.checkpoint_ids, include_p=True):
+        before = view.page(left, model.page)
+        after = view.page(right, model.page)
+        if before is None or after is None:
+            violations.append((left, right))
+            continue
+        disagrees = False
+        for old, new in zip(before[offset : model.end], after[offset : model.end]):
+            for bit in range(8):
+                was = _is_in_use((old >> bit) & 1, model.bit_polarity)
+                now = _is_in_use((new >> bit) & 1, model.bit_polarity)
+                if was and not now:
+                    disagrees = True
+                    break
+            if disagrees:
+                break
+        if disagrees:
+            violations.append((left, right))
+    return tuple(violations)
+
+
+def _decode_pointer(raw: bytes, layout: str) -> tuple[int, int]:
+    if len(raw) != 4:
+        raise ValueError("pointer window must be four bytes")
+    if layout == "u24le_page_then_u8_slot":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    if layout == "u8_slot_then_u24le_page":
+        return int.from_bytes(raw[1:], "little"), raw[0]
+    raise ValueError(f"unknown pointer layout: {layout}")
+
+
+def _reference_valid(view: ReplicaView, checkpoint: str, page: int) -> bool:
+    if page == 0:
+        return True
+    target = view.page(checkpoint, page)
+    return target is not None and target[0] == 0x05
+
+
+def _window_series(
+    view: ReplicaView, page: int, offset: int
+) -> dict[str, bytes] | None:
+    result: dict[str, bytes] = {}
+    for checkpoint in view.checkpoint_ids:
+        data = view.page(checkpoint, page)
+        if data is None:
+            return None
+        result[checkpoint] = data[offset : offset + 4]
+    return result
+
+
+def _window_changes(series: dict[str, bytes], pairs: Iterable[tuple[str, str]]) -> bool:
+    return any(series[left] != series[right] for left, right in pairs)
+
+
+def _valid_growth_window(
+    view: ReplicaView, page: int, offset: int, layout: str
+) -> bool:
+    series = _window_series(view, page, offset)
+    if series is None:
+        return False
+    permitted = set(growth_pairs(view.checkpoint_ids, include_p=False))
+    transitions = tuple(zip(view.checkpoint_ids, view.checkpoint_ids[1:]))
+    if not _window_changes(series, permitted):
+        return False
+    if any(series[a] != series[b] for a, b in transitions if (a, b) not in permitted):
+        return False
+    return all(
+        _reference_valid(view, checkpoint, _decode_pointer(raw, layout)[0])
+        for checkpoint, raw in series.items()
+    )
+
+
+def _valid_churn_window(view: ReplicaView, page: int, offset: int, layout: str) -> bool:
+    series = _window_series(view, page, offset)
+    if series is None:
+        return False
+    before = series["L_REL_1280"]
+    deleted = series["L_DELETE_ALL"]
+    reinserted = series["L_REINSERT_SAME"]
+    if before == deleted or reinserted != before:
+        return False
+    churn = {
+        ("L_REL_1280", "L_DELETE_ALL"),
+        ("L_DELETE_ALL", "L_REINSERT_SAME"),
+    }
+    transitions = tuple(zip(view.checkpoint_ids, view.checkpoint_ids[1:]))
+    if any(series[a] != series[b] for a, b in transitions if (a, b) not in churn):
+        return False
+    return all(
+        _reference_valid(view, checkpoint, _decode_pointer(raw, layout)[0])
+        for checkpoint, raw in series.items()
+    )
+
+
+def _stable_byte(view: ReplicaView, page: int, offset: int) -> bool:
+    values = {view.page(checkpoint, page)[offset] for checkpoint in view.checkpoint_ids}  # type: ignore[index]
+    return len(values) == 1
+
+
+def _minimal_tdef_record(
+    view: ReplicaView, page: int, growth: int, churn: int
+) -> tuple[int, int] | None:
+    low = min(growth, churn)
+    high = max(growth + 4, churn + 4)
+    start = low - 1 if low else 0
+    end = high + 1 if high < PAGE_SIZE else PAGE_SIZE
+    pointer_offsets = set(range(growth, growth + 4)) | set(range(churn, churn + 4))
+    for offset in range(start, end):
+        if offset not in pointer_offsets and not _stable_byte(view, page, offset):
+            return None
+    if low and not _stable_byte(view, page, low - 1):
+        return None
+    if high < PAGE_SIZE and not _stable_byte(view, page, high):
+        return None
+    return start, end
+
+
+def tdef_page_models(view: ReplicaView, page: int) -> tuple[TdefModel, ...]:
+    layouts = ("u24le_page_then_u8_slot", "u8_slot_then_u24le_page")
+    models: set[TdefModel] = set()
+    for layout in layouts:
+        growth = [
+            offset
+            for offset in range(PAGE_SIZE - 3)
+            if _valid_growth_window(view, page, offset, layout)
+        ]
+        churn = [
+            offset
+            for offset in range(PAGE_SIZE - 3)
+            if _valid_churn_window(view, page, offset, layout)
+        ]
+        for growth_offset in growth:
+            for churn_offset in churn:
+                if abs(growth_offset - churn_offset) < 4:
+                    continue
+                record = _minimal_tdef_record(view, page, growth_offset, churn_offset)
+                if record is not None:
+                    models.add(
+                        TdefModel(
+                            page,
+                            record[0],
+                            record[1],
+                            layout,
+                            growth_offset,
+                            churn_offset,
+                        )
+                    )
+    return tuple(sorted(models))
+
+
+def derive_tdef_models(
+    views: tuple[ReplicaView, ...], qualified_pages: tuple[int, ...]
+) -> tuple[TdefModel, ...]:
+    per_replica = [
+        {model for page in qualified_pages for model in tdef_page_models(view, page)}
+        for view in views
+    ]
+    return tuple(sorted(set.intersection(*per_replica))) if per_replica else ()

--- a/oracle/windows-dao/scripts/a2_independent_validator.py
+++ b/oracle/windows-dao/scripts/a2_independent_validator.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Independently recompute and validate an A2 analysis bundle.
+
+The implementation was written from the A2 plan, R2 revision, README, adjacent
+schemas, and provenance entries EXP-0040/EXP-0041 only.  It deliberately does
+not import ``a2_spec.py`` (even for schema loading), and does not read or share
+code with the A2 analyzer, layers, model, dry runs, generators, or their tests.
+
+The sole positional argument is the complete bundle root.  Exactly one
+canonical, compact JSON verdict is written to stdout.  Every structural,
+recomputation, comparison, holdout, and named-no-outcome failure is a
+discrepancy and produces a nonzero exit status.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from a2_independent_bundle import BundleError, Contract, verify_bundle
+from a2_independent_core import (
+    PAGE_SIZE,
+    derive_global_models,
+    derive_tdef_models,
+    global_model_predicts,
+    global_qualifying_pages,
+    growth_polarity_violations,
+    tdef_qualifying_pages,
+)
+
+
+def _discrepancy(code: str, message: str, layer: str = "campaign") -> dict[str, str]:
+    return {"code": code, "layer": layer, "message": message}
+
+
+def _predicate_status(report: dict[str, Any], predicate_id: str) -> str | None:
+    matches = [
+        item["status"]
+        for item in report["predicate_results"]
+        if item["predicate_id"] == predicate_id
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _reason_mapping(plan: dict[str, Any]) -> dict[str, str]:
+    return {
+        item["reason"]: item["predicate_id"]
+        for item in plan["predicate_registry"]["mappings"]
+    }
+
+
+def recompute(bundle_root: Path) -> dict[str, Any]:
+    discrepancies: list[dict[str, str]] = []
+    layer_verdicts: dict[str, dict[str, Any]] = {
+        "global_map.record": {"accepted": False},
+        "global_map.conversion_inline": {"accepted": False},
+        "global_map.extended_base": {"accepted": False},
+        "tdef.pointer_pair": {"accepted": False},
+    }
+    try:
+        contract = Contract.load(Path(__file__).resolve().parent)
+        bundle = verify_bundle(bundle_root, contract)
+    except (BundleError, OSError, KeyError, TypeError, ValueError) as exc:
+        discrepancies.append(_discrepancy("bundle_validation_failed", str(exc)))
+        return {
+            "accepted": False,
+            "layer_verdicts": layer_verdicts,
+            "discrepancies": discrepancies,
+        }
+
+    plan = contract.plan
+    report = bundle.report
+    derivation = bundle.views((1, 2))
+    holdout = bundle.views((3,))[0]
+    bound = plan["bounds"]["max_qualified_pages_per_submodel"]
+
+    for view in (*derivation, holdout):
+        for left, right in plan["checkpoint_design"]["idle_pairs"]:
+            if view.page_hashes[left] != view.page_hashes[right]:
+                discrepancies.append(
+                    _discrepancy(
+                        "idle_volatility",
+                        f"replica {view.replica} differs across {left}/{right}",
+                    )
+                )
+
+    global_pages = global_qualifying_pages(derivation)
+    tdef_pages = tdef_qualifying_pages(derivation)
+    if len(global_pages) > bound or len(tdef_pages) > bound:
+        discrepancies.append(
+            _discrepancy(
+                "resource_bound_breach",
+                f"qualified pages global={len(global_pages)}, tdef={len(tdef_pages)}, bound={bound}",
+            )
+        )
+    if report["qualified_page_counts"] != {
+        "global_map": len(global_pages),
+        "tdef": len(tdef_pages),
+    }:
+        discrepancies.append(
+            _discrepancy(
+                "qualified_page_count_mismatch",
+                "report qualified-page counts differ from hash-only recomputation",
+            )
+        )
+    candidates_per_page = PAGE_SIZE * (PAGE_SIZE + 1) // 2
+    record_candidates = (len(global_pages) + len(tdef_pages)) * candidates_per_page
+    if record_candidates > plan["bounds"]["max_record_candidates"]:
+        discrepancies.append(
+            _discrepancy(
+                "resource_bound_breach", "recomputed interval count exceeds the plan"
+            )
+        )
+    if report["record_candidates_examined"] != record_candidates:
+        discrepancies.append(
+            _discrepancy(
+                "record_candidate_count_mismatch",
+                f"report={report['record_candidates_examined']}, recomputed={record_candidates}",
+            )
+        )
+
+    global_models = (
+        derive_global_models(derivation, global_pages)
+        if len(global_pages) <= bound
+        else ()
+    )
+    record_layer = report["submodels"]["global_map"]["record"]
+    record_discrepancies_before = len(discrepancies)
+    layer_verdicts["global_map.record"].update(
+        {
+            "derived_survivor_count": len(global_models),
+            "qualified_pages": list(global_pages),
+            "report_status": record_layer["status"],
+        }
+    )
+    if len(global_models) != 1:
+        discrepancies.append(
+            _discrepancy(
+                "global_record_not_unique",
+                f"independent derivation retained {len(global_models)} models",
+                "global_map.record",
+            )
+        )
+    else:
+        derived = global_models[0]
+        derived_value = derived.report_value()
+        layer_verdicts["global_map.record"]["derived_model"] = derived_value
+        if record_layer["status"] != "decisive_predicts_holdout":
+            discrepancies.append(
+                _discrepancy(
+                    "global_record_status_mismatch",
+                    "one independent model survived but the report is not decisive",
+                    "global_map.record",
+                )
+            )
+        if record_layer["model"] != derived_value:
+            discrepancies.append(
+                _discrepancy(
+                    "global_record_model_mismatch",
+                    "reported global_map.record differs from independent recomputation",
+                    "global_map.record",
+                )
+            )
+        if (
+            report["derivation_survivor_counts"]["global_map_record"] != 1
+            or record_layer["derivation_survivor_count"] != 1
+        ):
+            discrepancies.append(
+                _discrepancy(
+                    "global_record_survivor_count_mismatch",
+                    "reported global record survivor count is not one",
+                    "global_map.record",
+                )
+            )
+        holdout_pass = global_model_predicts(holdout, derived)
+        layer_verdicts["global_map.record"]["holdout_prediction"] = holdout_pass
+        if not holdout_pass:
+            discrepancies.append(
+                _discrepancy(
+                    "holdout_prediction_failure",
+                    "the frozen derivation model does not predict replica 3",
+                    "global_map.record",
+                )
+            )
+        if not record_layer["holdout_evaluated"] or not report["holdout_evaluated"]:
+            discrepancies.append(
+                _discrepancy(
+                    "holdout_reporting_mismatch",
+                    "report does not record the independently required holdout evaluation",
+                    "global_map.record",
+                )
+            )
+    layer_verdicts["global_map.record"]["accepted"] = (
+        len(discrepancies) == record_discrepancies_before
+    )
+
+    conversion_layer = report["submodels"]["global_map"]["conversion_inline"]
+    conversion_before = len(discrepancies)
+    layer_verdicts["global_map.conversion_inline"].update(
+        {"report_status": conversion_layer["status"], "confirmed_reasons": []}
+    )
+    if conversion_layer["status"] == "no_outcome" and conversion_layer[
+        "no_outcome_reasons"
+    ] == ["growth_polarity_disagreement"]:
+        if len(global_models) != 1:
+            discrepancies.append(
+                _discrepancy(
+                    "polarity_crosscheck_unavailable",
+                    "a frozen global record is required to recompute the cross-check",
+                    "global_map.conversion_inline",
+                )
+            )
+        else:
+            violations = [
+                growth_polarity_violations(view, global_models[0])
+                for view in derivation
+            ]
+            layer_verdicts["global_map.conversion_inline"][
+                "violating_growth_transitions"
+            ] = [
+                [list(pair) for pair in replica_violations]
+                for replica_violations in violations
+            ]
+            if not violations[0] or violations[0] != violations[1]:
+                discrepancies.append(
+                    _discrepancy(
+                        "growth_polarity_reason_not_confirmed",
+                        "derivation replicas do not agree on a nonempty polarity violation set",
+                        "global_map.conversion_inline",
+                    )
+                )
+            else:
+                layer_verdicts["global_map.conversion_inline"]["confirmed_reasons"] = [
+                    "growth_polarity_disagreement"
+                ]
+    else:
+        discrepancies.append(
+            _discrepancy(
+                "unsupported_conversion_outcome",
+                "this independent validator requires the report's conversion no-outcome to be the recomputable growth polarity disagreement",
+                "global_map.conversion_inline",
+            )
+        )
+    layer_verdicts["global_map.conversion_inline"]["accepted"] = (
+        len(discrepancies) == conversion_before
+    )
+
+    base_layer = report["submodels"]["global_map"]["extended_base"]
+    base_before = len(discrepancies)
+    layer_verdicts["global_map.extended_base"].update(
+        {"report_status": base_layer["status"]}
+    )
+    if not (
+        base_layer["status"] == "not_applicable"
+        and base_layer["model"] is None
+        and base_layer["no_outcome_reasons"] == []
+        and conversion_layer["status"] == "no_outcome"
+    ):
+        discrepancies.append(
+            _discrepancy(
+                "extended_base_dependency_mismatch",
+                "extended base must be not-applicable after conversion no-outcome",
+                "global_map.extended_base",
+            )
+        )
+    layer_verdicts["global_map.extended_base"]["accepted"] = (
+        len(discrepancies) == base_before
+    )
+
+    tdef_layer = report["submodels"]["tdef"]["pointer_pair"]
+    tdef_before = len(discrepancies)
+    tdef_models = (
+        derive_tdef_models(derivation, tdef_pages) if len(tdef_pages) <= bound else ()
+    )
+    layer_verdicts["tdef.pointer_pair"].update(
+        {
+            "derived_survivor_count": len(tdef_models),
+            "qualified_pages": list(tdef_pages),
+            "report_status": tdef_layer["status"],
+            "confirmed_reasons": [],
+        }
+    )
+    if not tdef_pages:
+        derived_reason = "no_physical_page_satisfies_tdef_transition_predicates"
+    elif not tdef_models:
+        derived_reason = "no_tdef_record_candidate"
+    elif len(tdef_models) > 1:
+        derived_reason = "multiple_tdef_record_boundaries_survive"
+    else:
+        derived_reason = None
+    if derived_reason is not None:
+        if tdef_layer["status"] != "no_outcome" or tdef_layer["no_outcome_reasons"] != [
+            derived_reason
+        ]:
+            discrepancies.append(
+                _discrepancy(
+                    "tdef_reason_mismatch",
+                    f"report does not name independently derived reason {derived_reason}",
+                    "tdef.pointer_pair",
+                )
+            )
+        else:
+            layer_verdicts["tdef.pointer_pair"]["confirmed_reasons"] = [derived_reason]
+    else:
+        discrepancies.append(
+            _discrepancy(
+                "unsupported_decisive_tdef",
+                "a TDEF model survived; decisive TDEF holdout evaluation is not implemented",
+                "tdef.pointer_pair",
+            )
+        )
+    if report["derivation_survivor_counts"]["tdef_pointer_pair"] != len(
+        tdef_models
+    ) or tdef_layer["derivation_survivor_count"] != len(tdef_models):
+        discrepancies.append(
+            _discrepancy(
+                "tdef_survivor_count_mismatch",
+                "reported TDEF survivor count differs from recomputation",
+                "tdef.pointer_pair",
+            )
+        )
+    layer_verdicts["tdef.pointer_pair"]["accepted"] = len(discrepancies) == tdef_before
+
+    expected_reasons = sorted(
+        reason
+        for layer in (
+            record_layer,
+            conversion_layer,
+            base_layer,
+            tdef_layer,
+        )
+        for reason in layer["no_outcome_reasons"]
+    )
+    if sorted(report["no_outcome_reasons"]) != expected_reasons:
+        discrepancies.append(
+            _discrepancy(
+                "no_outcome_summary_mismatch",
+                "top-level no-outcome reasons differ from layers",
+            )
+        )
+    mapping = _reason_mapping(plan)
+    expected_terminal = sorted(mapping[reason] for reason in expected_reasons)
+    if sorted(report["terminal_predicate_ids"]) != expected_terminal:
+        discrepancies.append(
+            _discrepancy(
+                "terminal_predicate_mismatch",
+                "terminal predicate ids do not match layer reasons",
+            )
+        )
+    for reason in expected_reasons:
+        predicate = mapping[reason]
+        if _predicate_status(report, predicate) != "fail":
+            discrepancies.append(
+                _discrepancy(
+                    "predicate_result_mismatch",
+                    f"terminal predicate {predicate} is not uniquely recorded as fail",
+                )
+            )
+    scientific = any(
+        layer["status"] == "decisive_predicts_holdout"
+        for layer in (record_layer, conversion_layer, base_layer, tdef_layer)
+    )
+    expected_scientific = (
+        "one_or_more_submodels_predict_holdout"
+        if scientific
+        else "no_submodel_predicts_holdout"
+    )
+    if report["scientific_outcome"] != expected_scientific:
+        discrepancies.append(
+            _discrepancy(
+                "scientific_outcome_mismatch",
+                "scientific outcome differs from layer statuses",
+            )
+        )
+
+    discrepancies.sort(key=lambda item: (item["layer"], item["code"], item["message"]))
+    return {
+        "accepted": not discrepancies,
+        "layer_verdicts": layer_verdicts,
+        "discrepancies": discrepancies,
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        verdict = {
+            "accepted": False,
+            "layer_verdicts": {},
+            "discrepancies": [
+                _discrepancy("usage", "usage: a2_independent_validator.py BUNDLE_ROOT")
+            ],
+        }
+    else:
+        try:
+            verdict = recompute(Path(argv[1]))
+        except Exception as exc:  # noqa: BLE001 - the CLI must fail closed on implementation faults.
+            verdict = {
+                "accepted": False,
+                "layer_verdicts": {},
+                "discrepancies": [
+                    _discrepancy(
+                        "internal_validation_error", f"{type(exc).__name__}: {exc}"
+                    )
+                ],
+            }
+    sys.stdout.write(json.dumps(verdict, sort_keys=True, separators=(",", ":")) + "\n")
+    return 0 if verdict["accepted"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/oracle/windows-dao/tests/test_a2_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a2_independent_validator.py
@@ -1,0 +1,201 @@
+"""Focused synthetic tests for the independent A2 validator.
+
+Every page index and page blob below is hand-built from the preregistered plan.
+No analyzer or generator fixture is imported or consulted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from a2_independent_core import (
+    PAGE_SIZE,
+    GlobalModel,
+    ReplicaView,
+    _minimal_tdef_record,
+    derive_global_models,
+    global_model_predicts,
+    global_qualifying_pages,
+    growth_polarity_violations,
+)
+
+CHECKPOINTS = (
+    "E0",
+    "E0R",
+    "D_GROW_0128",
+    "D_DROP",
+    "D_RECREATE_EMPTY",
+    "D_REGROW_0128",
+    "L_REL_0064",
+    "L_REL_0512",
+    "L_REL_0768",
+    "L_REL_0896",
+    "L_REL_0904",
+    "L_REL_1024",
+    "L_REL_1088",
+    "L_REL_1280",
+    "L_DELETE_ALL",
+    "L_REINSERT_SAME",
+    "L_IDLE_REOPEN",
+    "P_ABS_04096",
+    "P_ABS_08192",
+    "P_ABS_12288",
+    "P_ABS_16480",
+    "H_REL_0064",
+    "H_REL_0896",
+    "H_REL_0904",
+    "H_IDLE_REOPEN",
+)
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _map_page(
+    start: int, in_use: set[int], polarity: str = "set_means_not_in_use"
+) -> bytes:
+    free = 0xFF if polarity == "set_means_not_in_use" else 0x00
+    page = bytearray((free,)) * PAGE_SIZE
+    page[start : start + 5] = b"\0" * 5
+    offset = start + 5
+    for represented_page in in_use:
+        byte, bit = divmod(represented_page, 8)
+        if polarity == "set_means_not_in_use":
+            page[offset + byte] &= ~(1 << bit)
+        else:
+            page[offset + byte] |= 1 << bit
+    return bytes(page)
+
+
+def _view(
+    replica: int,
+    checkpoint_pages: dict[str, list[bytes]],
+) -> ReplicaView:
+    blobs: dict[str, bytes] = {}
+    hashes: dict[str, tuple[str, ...]] = {}
+    for checkpoint in CHECKPOINTS:
+        pages = checkpoint_pages[checkpoint]
+        values = []
+        for page in pages:
+            digest = _digest(page)
+            blobs[digest] = page
+            values.append(digest)
+        hashes[checkpoint] = tuple(values)
+    return ReplicaView(
+        replica,
+        CHECKPOINTS,
+        hashes,
+        {checkpoint: len(checkpoint_pages[checkpoint]) for checkpoint in CHECKPOINTS},
+        blobs.__getitem__,
+    )
+
+
+def _global_view(
+    replica: int, *, bad_holdout: bool = False, opposite_growth: bool = False
+) -> ReplicaView:
+    start = 2000
+    stable = bytes(PAGE_SIZE)
+    states = {
+        "E0": _map_page(start, set(range(8))),
+        "E0R": _map_page(start, set(range(8))),
+        "D_GROW_0128": _map_page(start, set(range(16))),
+        "D_DROP": _map_page(start, set(range(8))),
+        "D_RECREATE_EMPTY": _map_page(start, set(range(8))),
+        "D_REGROW_0128": _map_page(start, set(range(16 if bad_holdout else 24))),
+    }
+    if bad_holdout:
+        states["D_REGROW_0128"] = _map_page(start, set(range(16)))
+    current = _map_page(start, set(range(32)))
+    for checkpoint in CHECKPOINTS[6:]:
+        states[checkpoint] = current
+    if opposite_growth:
+        states["L_REL_0512"] = _map_page(start, set(range(24)))
+        for checkpoint in CHECKPOINTS[8:]:
+            states[checkpoint] = states["L_REL_0512"]
+    lengths = {
+        "E0": 8,
+        "E0R": 8,
+        "D_GROW_0128": 16,
+        "D_DROP": 16,
+        "D_RECREATE_EMPTY": 16,
+        "D_REGROW_0128": 24,
+    }
+    pages: dict[str, list[bytes]] = {}
+    for checkpoint in CHECKPOINTS:
+        length = lengths.get(checkpoint, 32)
+        pages[checkpoint] = [states[checkpoint]] + [stable] * (length - 1)
+    return _view(replica, pages)
+
+
+class GlobalRecordTests(unittest.TestCase):
+    def test_hash_qualification_precedes_unique_page_terminal_record(self) -> None:
+        views = (_global_view(1), _global_view(2))
+        qualified = global_qualifying_pages(views)
+        self.assertEqual(qualified, (0,))
+        self.assertEqual(
+            derive_global_models(views, qualified),
+            (
+                GlobalModel(
+                    page=0,
+                    start=2000,
+                    end=2048,
+                    bit_polarity="set_means_not_in_use",
+                    zero_suffix_slack_bytes=40,
+                ),
+            ),
+        )
+
+    def test_absence_is_an_explicit_hash_state_but_not_two_endpoint_differences(
+        self,
+    ) -> None:
+        view = _global_view(1)
+        self.assertEqual(global_qualifying_pages((view,)), (0,))
+        self.assertIsNone(view.state("E0", 12))
+        self.assertIsNotNone(view.state("D_GROW_0128", 12))
+        self.assertEqual(view.state("D_GROW_0128", 12), view.state("D_DROP", 12))
+
+    def test_frozen_model_rejects_holdout_without_additional_regrowth(self) -> None:
+        derivation = (_global_view(1), _global_view(2))
+        model = derive_global_models(derivation, global_qualifying_pages(derivation))[0]
+        self.assertFalse(
+            global_model_predicts(_global_view(3, bad_holdout=True), model)
+        )
+
+    def test_growth_polarity_crosscheck_names_the_opposite_leg(self) -> None:
+        view = _global_view(1, opposite_growth=True)
+        model = GlobalModel(0, 2000, 2048, "set_means_not_in_use", 40)
+        self.assertEqual(
+            growth_polarity_violations(view, model),
+            (("L_REL_0064", "L_REL_0512"),),
+        )
+
+
+class TdefMinimalityTests(unittest.TestCase):
+    def _tdef_view(self, noisy_between_windows: bool) -> ReplicaView:
+        stable = bytes(PAGE_SIZE)
+        pages: dict[str, list[bytes]] = {}
+        for ordinal, checkpoint in enumerate(CHECKPOINTS):
+            tdef = bytearray(PAGE_SIZE)
+            if noisy_between_windows and ordinal == 7:
+                tdef[15] = 1
+            pages[checkpoint] = [stable, bytes(tdef)]
+        return _view(1, pages)
+
+    def test_inclusion_minimal_interval_adds_one_stable_byte_per_side(self) -> None:
+        view = self._tdef_view(False)
+        self.assertEqual(_minimal_tdef_record(view, 1, 10, 20), (9, 25))
+
+    def test_change_between_pointer_signatures_rejects_interval(self) -> None:
+        view = self._tdef_view(True)
+        self.assertIsNone(_minimal_tdef_record(view, 1, 10, 20))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a standalone A2 bundle closure/hash/snapshot validator
- independently recompute the D-qualified global record, polarity, terminal suffix, and replica-3 holdout prediction
- independently confirm growth-polarity and inclusion-minimal TDEF no-outcome reasons
- add hand-built synthetic page-index/blob tests

## Verification
- `uvx ruff check` and `uvx ruff format --check` on the four new files
- `python3 -m py_compile` on the four new files
- `python3 -m unittest oracle/windows-dao/tests/test_a2_independent_validator.py -v` (6 passed)
- real bundle verdict: accepted; page 1, [1915, 2048), set_means_not_in_use, 92-byte suffix slack; holdout prediction passed