### PR TITLE
feat: add A3 independent recomputing validator

### DIFF
--- a/oracle/windows-dao/scripts/a3_independent_base.py
+++ b/oracle/windows-dao/scripts/a3_independent_base.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""R3 extended-allocation-map recomputation for the independent validator."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from a3_independent_bundle import Replica
+
+
+EXTENDED_BITMAP_START = 4
+EXTENDED_BITMAP_BITS = 16352
+BASE_DISCRIMINATOR = ("P_ABS_16480", "H_REL_0064")
+
+
+class GlobalModel(Protocol):
+    page: int
+    start: int
+    polarity: str
+
+
+def _no_layer(reason: str, predicate: str) -> dict[str, Any]:
+    return {
+        "applicable": True,
+        "derivation_survivor_count": 0,
+        "model": None,
+        "no_outcome_reason": reason,
+        "terminal_predicate_id": predicate,
+    }
+
+
+def _model_layer(model: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "applicable": True,
+        "derivation_survivor_count": 1,
+        "model": model,
+        "no_outcome_reason": None,
+        "terminal_predicate_id": None,
+    }
+
+
+def _bit_set(page: bytes, bit: int) -> bool:
+    offset = EXTENDED_BITMAP_START + bit // 8
+    return bool(page[offset] & (1 << (bit % 8)))
+
+
+def _indirect_slots(page: bytes, start: int) -> tuple[int, int]:
+    return (
+        int.from_bytes(page[start + 1 : start + 5], "little"),
+        int.from_bytes(page[start + 5 : start + 9], "little"),
+    )
+
+
+def _formula_page(formula: str, slot: int, reference: int, bit: int) -> int:
+    page = EXTENDED_BITMAP_BITS * slot + bit if formula.startswith("slot_relative") else reference + bit
+    if formula.endswith("minus_one"):
+        return page - 1
+    if formula.endswith("plus_one"):
+        return page + 1
+    return page
+
+
+def _extended_in_use(page: bytes, bit: int, polarity: str) -> bool:
+    return _bit_set(page, bit) == (polarity == "set_means_in_use")
+
+
+def _base_context(replica: Replica, global_model: GlobalModel) -> tuple[int, bytes, bytes] | None:
+    left, right = BASE_DISCRIMINATOR
+    left_record = replica.page(left, global_model.page)
+    right_record = replica.page(right, global_model.page)
+    if (
+        left_record is None
+        or right_record is None
+        or left_record[global_model.start] != 1
+        or right_record[global_model.start] != 1
+    ):
+        return None
+    left_reference = _indirect_slots(left_record, global_model.start)[0]
+    right_reference = _indirect_slots(right_record, global_model.start)[0]
+    if left_reference == 0 or left_reference != right_reference:
+        return None
+    left_page = replica.page(left, left_reference)
+    right_page = replica.page(right, right_reference)
+    if left_page is None or right_page is None or left_page[0] != 0x05 or right_page[0] != 0x05:
+        return None
+    return left_reference, left_page, right_page
+
+
+def base_formula_survives(
+    replica: Replica,
+    plan: dict[str, Any],
+    global_model: GlobalModel,
+    conversion_model: dict[str, Any],
+    formula: str,
+    require_flip: bool,
+) -> bool:
+    context = _base_context(replica, global_model)
+    if context is None:
+        return False
+    reference, left_page, right_page = context
+    flips = [
+        bit
+        for bit in range(EXTENDED_BITMAP_BITS)
+        if _bit_set(left_page, bit) != _bit_set(right_page, bit)
+    ]
+    if require_flip and not flips:
+        return False
+    left, right = BASE_DISCRIMINATOR
+    left_count = replica.index(left)["page_count"]
+    right_count = replica.index(right)["page_count"]
+    space = replica.candidate_page_space()
+    for bit in flips:
+        page_number = _formula_page(formula, 0, reference, bit)
+        if not 1 <= page_number < min(right_count, 65536) or page_number not in space:
+            return False
+        if _extended_in_use(right_page, bit, global_model.polarity):
+            if replica.state(left, page_number) == replica.state(right, page_number):
+                return False
+        elif page_number >= left_count:
+            return False
+    coverage = plan["checkpoint_design"]["transition_coverage"]
+    schedule = plan["checkpoint_design"]["checkpoint_ids"]
+    conversion_ordinal = conversion_model["conversion_ordinal"]
+    for checkpoint in coverage["pointer_validity_checkpoints"]:
+        if schedule.index(checkpoint) < conversion_ordinal:
+            continue
+        record = replica.page(checkpoint, global_model.page)
+        if record is None or record[global_model.start] != 1:
+            return False
+        references = _indirect_slots(record, global_model.start)
+        page_count = replica.index(checkpoint)["page_count"]
+        for slot, slot_reference in enumerate(references):
+            if slot_reference == 0:
+                continue
+            bitmap = replica.page(checkpoint, slot_reference)
+            if bitmap is None or bitmap[0] != 0x05:
+                return False
+            for bit in range(EXTENDED_BITMAP_BITS):
+                page_number = _formula_page(formula, slot, slot_reference, bit)
+                if not 0 <= page_number < 65536:
+                    continue
+                in_use = _extended_in_use(bitmap, bit, global_model.polarity)
+                if page_number == slot_reference and not in_use:
+                    return False
+                if page_number >= page_count and in_use:
+                    return False
+    return True
+
+
+def _derive_replica(
+    replica: Replica,
+    plan: dict[str, Any],
+    global_model: GlobalModel,
+    conversion_model: dict[str, Any],
+) -> dict[str, Any]:
+    context = _base_context(replica, global_model)
+    if context is None or not any(
+        _bit_set(context[1], bit) != _bit_set(context[2], bit)
+        for bit in range(EXTENDED_BITMAP_BITS)
+    ):
+        return _no_layer("insufficient_base_discrimination", "A3-BASE-DISCRIMINATION")
+    survivors = {
+        formula
+        for formula in plan["hypotheses"]["extended_base_candidates"]
+        if base_formula_survives(replica, plan, global_model, conversion_model, formula, True)
+    }
+    if not survivors:
+        return _no_layer("no_extended_base_candidate", "A3-BASE-NONE")
+    if len(survivors) > 1:
+        return _no_layer("multiple_extended_base_candidates", "A3-BASE-MULTIPLE")
+    return _model_layer({"extended_base_formula": next(iter(survivors))})
+
+
+def derive_extended_base(
+    replicas: list[Replica],
+    plan: dict[str, Any],
+    global_model: GlobalModel,
+    conversion_model: dict[str, Any],
+) -> tuple[dict[str, Any], list[str | None]]:
+    layers = [_derive_replica(replica, plan, global_model, conversion_model) for replica in replicas]
+    terminals = [layer["terminal_predicate_id"] for layer in layers]
+    if any(terminal is not None for terminal in terminals):
+        if len(set(terminals)) == 1:
+            return layers[0], terminals
+        return _no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+    if any(layer["model"] != layers[0]["model"] for layer in layers[1:]):
+        return _no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+    return _model_layer(layers[0]["model"]), terminals

--- a/oracle/windows-dao/scripts/a3_independent_bundle.py
+++ b/oracle/windows-dao/scripts/a3_independent_bundle.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""Bounded A3 bundle loading for the independent validator.
+
+This module intentionally contains no analyzer imports or scientific model
+logic.  It provides generic JSON-schema, SHA-256, path-closure, and snapshot
+access primitives used by the independent recomputation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+EXP_0042_MANIFEST_SHA256 = "9e1dac53e13f0bf765fc41b242b85beb26c8a518f7a15777aa37641af575dd46"
+
+
+class ValidationError(Exception):
+    """A bounded, stable validation failure."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_bytes(path: Path, maximum: int) -> bytes:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ValidationError("missing_file", str(path)) from exc
+    if size < 0 or size > maximum:
+        raise ValidationError("file_size_bound", str(path))
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise ValidationError("file_read_failure", str(path)) from exc
+
+
+def load_json(path: Path, maximum: int) -> tuple[Any, bytes]:
+    raw = read_bytes(path, maximum)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValidationError("json_not_utf8", str(path)) from exc
+    if text.startswith("\ufeff"):
+        raise ValidationError("json_bom", str(path))
+    try:
+        return json.loads(text), raw
+    except (json.JSONDecodeError, RecursionError) as exc:
+        raise ValidationError("invalid_json", str(path)) from exc
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, separators=(",", ":")) + "\n").encode()
+
+
+class SchemaChecker:
+    """Small draft-2020-12 checker covering every keyword in the A3 schemas."""
+
+    def __init__(self, schema: dict[str, Any]) -> None:
+        self.root = schema
+
+    def check(self, value: Any) -> None:
+        self._check(value, self.root, "$")
+
+    def _resolve(self, reference: str) -> dict[str, Any]:
+        if not reference.startswith("#/"):
+            raise ValidationError("schema_external_ref", reference)
+        current: Any = self.root
+        for part in reference[2:].split("/"):
+            part = part.replace("~1", "/").replace("~0", "~")
+            if not isinstance(current, dict) or part not in current:
+                raise ValidationError("schema_bad_ref", reference)
+            current = current[part]
+        if not isinstance(current, dict):
+            raise ValidationError("schema_bad_ref", reference)
+        return current
+
+    @staticmethod
+    def _same(left: Any, right: Any) -> bool:
+        if isinstance(left, bool) or isinstance(right, bool):
+            return type(left) is type(right) and left == right
+        return left == right
+
+    @staticmethod
+    def _type_matches(value: Any, name: str) -> bool:
+        return {
+            "object": isinstance(value, dict),
+            "array": isinstance(value, list),
+            "string": isinstance(value, str),
+            "integer": isinstance(value, int) and not isinstance(value, bool),
+            "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+            "boolean": isinstance(value, bool),
+            "null": value is None,
+        }.get(name, False)
+
+    def _check(self, value: Any, schema: dict[str, Any], where: str) -> None:
+        if "$ref" in schema:
+            self._check(value, self._resolve(schema["$ref"]), where)
+        if "anyOf" in schema:
+            matches = 0
+            for choice in schema["anyOf"]:
+                try:
+                    self._check(value, choice, where)
+                except ValidationError:
+                    pass
+                else:
+                    matches += 1
+            if matches == 0:
+                raise ValidationError("schema_anyof", where)
+        if "const" in schema and not self._same(value, schema["const"]):
+            raise ValidationError("schema_const", where)
+        if "enum" in schema and not any(self._same(value, item) for item in schema["enum"]):
+            raise ValidationError("schema_enum", where)
+        if "type" in schema:
+            names = schema["type"] if isinstance(schema["type"], list) else [schema["type"]]
+            if not all(isinstance(name, str) for name in names) or not any(
+                self._type_matches(value, name) for name in names
+            ):
+                raise ValidationError("schema_type", where)
+        if isinstance(value, dict):
+            required = schema.get("required", [])
+            if not all(isinstance(key, str) for key in required):
+                raise ValidationError("schema_definition", where)
+            for key in required:
+                if key not in value:
+                    raise ValidationError("schema_required", f"{where}.{key}")
+            properties = schema.get("properties", {})
+            if schema.get("additionalProperties") is False:
+                extras = set(value) - set(properties)
+                if extras:
+                    raise ValidationError("schema_extra", f"{where}.{sorted(extras)[0]}")
+            for key, child in properties.items():
+                if key in value:
+                    self._check(value[key], child, f"{where}.{key}")
+        if isinstance(value, list):
+            if len(value) < schema.get("minItems", 0) or len(value) > schema.get("maxItems", len(value)):
+                raise ValidationError("schema_array_length", where)
+            if schema.get("uniqueItems"):
+                encoded = [json.dumps(item, sort_keys=True, separators=(",", ":")) for item in value]
+                if len(encoded) != len(set(encoded)):
+                    raise ValidationError("schema_array_unique", where)
+            if "items" in schema:
+                for index, item in enumerate(value):
+                    self._check(item, schema["items"], f"{where}[{index}]")
+        if isinstance(value, str):
+            if len(value) < schema.get("minLength", 0) or len(value) > schema.get("maxLength", len(value)):
+                raise ValidationError("schema_string_length", where)
+            if "pattern" in schema and re.search(schema["pattern"], value) is None:
+                raise ValidationError("schema_pattern", where)
+            if schema.get("format") == "date-time":
+                try:
+                    datetime.fromisoformat(value.replace("Z", "+00:00"))
+                except ValueError as exc:
+                    raise ValidationError("schema_datetime", where) from exc
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if value < schema.get("minimum", value) or value > schema.get("maximum", value):
+                raise ValidationError("schema_numeric_bound", where)
+
+
+@dataclass
+class Replica:
+    number: int
+    observation: dict[str, Any]
+    indexes: dict[str, dict[str, Any]]
+    root: Path
+    page_paths: dict[str, Path]
+    max_page_blobs: int
+    max_page_bytes: int
+
+    def __post_init__(self) -> None:
+        self._page_cache: dict[str, bytes] = {}
+        self._opened_bytes = 0
+
+    @property
+    def checkpoint_ids(self) -> list[str]:
+        return [checkpoint["checkpoint_id"] for checkpoint in self.observation["checkpoints"]]
+
+    def index(self, checkpoint_id: str) -> dict[str, Any]:
+        try:
+            return self.indexes[checkpoint_id]
+        except KeyError as exc:
+            raise ValidationError("checkpoint_missing", f"r{self.number}:{checkpoint_id}") from exc
+
+    def state(self, checkpoint_id: str, page: int) -> str | None:
+        hashes = self.index(checkpoint_id)["ordered_page_sha256"]
+        return hashes[page] if 0 <= page < len(hashes) else None
+
+    def page(self, checkpoint_id: str, page: int) -> bytes | None:
+        digest = self.state(checkpoint_id, page)
+        if digest is None:
+            return None
+        if digest not in self._page_cache:
+            if len(self._page_cache) >= self.max_page_blobs:
+                raise ValidationError("resource_bound_breach", "page blob count")
+            try:
+                path = self.page_paths[digest]
+            except KeyError as exc:
+                raise ValidationError("page_blob_missing", digest) from exc
+            raw = read_bytes(path, 2048)
+            if len(raw) != 2048 or sha256_bytes(raw) != digest:
+                raise ValidationError("page_blob_hash_mismatch", digest)
+            self._opened_bytes += len(raw)
+            if self._opened_bytes > self.max_page_bytes:
+                raise ValidationError("resource_bound_breach", "page read bytes")
+            self._page_cache[digest] = raw
+        return self._page_cache[digest]
+
+    def candidate_page_space(self) -> set[int]:
+        largest = max(len(index["ordered_page_sha256"]) for index in self.indexes.values())
+        return set(range(largest))
+
+    def checkpoint_observation(self, checkpoint_id: str) -> dict[str, Any]:
+        for checkpoint in self.observation["checkpoints"]:
+            if checkpoint["checkpoint_id"] == checkpoint_id:
+                return checkpoint
+        raise ValidationError("checkpoint_observation_missing", checkpoint_id)
+
+
+@dataclass
+class LoadedBundle:
+    root: Path
+    manifest: dict[str, Any]
+    manifest_sha256: str
+    plan: dict[str, Any]
+    plan_sha256: str
+    replicas: dict[int, Replica]
+    report: dict[str, Any] | None
+    frozen: dict[str, Any] | None
+    frozen_raw: bytes | None
+    receipt: dict[str, Any] | None
+    legacy_recompute: bool
+
+
+class BundleLoader:
+    def __init__(self, root: Path, plan_path: Path, recompute_only: bool = False) -> None:
+        self.root = root.resolve()
+        self.plan_path = plan_path.resolve()
+        self.recompute_only = recompute_only
+        self.plan, self.plan_raw = load_json(self.plan_path, 67_108_864)
+        if not isinstance(self.plan, dict):
+            raise ValidationError("plan_not_object")
+        self.bounds = self.plan["bounds"]
+        self.schemas = self.plan_path.parent
+
+    def _safe(self, relative: str) -> Path:
+        if not relative or relative.startswith("/") or "\\" in relative:
+            raise ValidationError("unsafe_path", relative)
+        parts = Path(relative).parts
+        if any(part in ("", ".", "..") for part in parts):
+            raise ValidationError("unsafe_path", relative)
+        candidate = self.root.joinpath(*parts)
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError as exc:
+            raise ValidationError("missing_file", relative) from exc
+        if self.root not in resolved.parents or candidate.is_symlink():
+            raise ValidationError("unsafe_path", relative)
+        return resolved
+
+    def _schema(self, name: str, value: Any) -> None:
+        schema, _ = load_json(self.schemas / name, 67_108_864)
+        if not isinstance(schema, dict):
+            raise ValidationError("schema_not_object", name)
+        SchemaChecker(schema).check(value)
+
+    def _load_inventory(self, manifest: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], dict[str, Path]]:
+        entries: dict[str, dict[str, Any]] = {}
+        page_paths: dict[str, Path] = {}
+        total = 0
+        for entry in manifest["files"]:
+            relative = entry["path"]
+            if relative in entries:
+                raise ValidationError("manifest_duplicate_path", relative)
+            path = self._safe(relative)
+            raw = read_bytes(path, self.bounds["max_json_bytes"] if entry["media_type"] != "application/octet-stream" else 2048)
+            if len(raw) != entry["size_bytes"] or sha256_bytes(raw) != entry["sha256"]:
+                raise ValidationError("manifest_file_mismatch", relative)
+            total += len(raw)
+            entries[relative] = entry
+            if entry["role"] == "page_blob":
+                if len(raw) != 2048 or Path(relative).name != f"{entry['sha256']}.page":
+                    raise ValidationError("page_blob_contract", relative)
+                page_paths[entry["sha256"]] = path
+        if total != manifest["bundle_size_bytes_excluding_manifest"]:
+            raise ValidationError("manifest_size_total_mismatch")
+        if len(page_paths) != manifest["page_blob_count"]:
+            raise ValidationError("manifest_page_blob_count_mismatch")
+        actual: set[str] = set()
+        for directory, names, files in os.walk(self.root, followlinks=False):
+            directory_path = Path(directory)
+            for name in names:
+                if (directory_path / name).is_symlink():
+                    raise ValidationError("bundle_symlink", str(directory_path / name))
+            for name in files:
+                path = directory_path / name
+                if path.is_symlink():
+                    raise ValidationError("bundle_symlink", str(path))
+                relative = path.relative_to(self.root).as_posix()
+                if relative != "bundle-manifest.json":
+                    actual.add(relative)
+        if actual != set(entries):
+            raise ValidationError("manifest_inventory_not_closed")
+        return entries, page_paths
+
+    def _load_replica(
+        self,
+        number: int,
+        page_paths: dict[str, Path],
+        validate_a3: bool,
+    ) -> Replica:
+        observation_path = self._safe(f"observations/replica-{number:02d}.json")
+        observation, _ = load_json(observation_path, self.bounds["max_json_bytes"])
+        if not isinstance(observation, dict):
+            raise ValidationError("observation_not_object")
+        if validate_a3:
+            self._schema("replica-observation.schema.json", observation)
+            expected_binding = next(item for item in self.plan["tables"]["role_bindings"] if item["replica"] == number)
+            expected_binding = {role: expected_binding[role] for role in ("D", "L", "P", "H")}
+            if observation["role_binding"] != expected_binding:
+                raise ValidationError("role_binding_mismatch", str(number))
+        indexes: dict[str, dict[str, Any]] = {}
+        expected_ids = self.plan["checkpoint_design"]["checkpoint_ids"]
+        checkpoints = observation.get("checkpoints")
+        if not isinstance(checkpoints, list) or len(checkpoints) != len(expected_ids):
+            raise ValidationError("checkpoint_count_mismatch", f"replica {number}")
+        for ordinal, checkpoint in enumerate(checkpoints):
+            if checkpoint.get("checkpoint_id") != expected_ids[ordinal] or checkpoint.get("ordinal") != ordinal:
+                raise ValidationError("checkpoint_order_mismatch", f"replica {number}")
+            reference = checkpoint.get("page_index")
+            if not isinstance(reference, dict) or not isinstance(reference.get("path"), str):
+                raise ValidationError("page_index_reference_invalid")
+            path = self._safe(reference["path"])
+            index, raw = load_json(path, self.bounds["max_json_bytes"])
+            if not isinstance(index, dict):
+                raise ValidationError("page_index_not_object")
+            if sha256_bytes(raw) != reference.get("sha256") or len(raw) != reference.get("size_bytes"):
+                raise ValidationError("page_index_reference_mismatch", reference["path"])
+            if validate_a3:
+                self._schema("page-index.schema.json", index)
+            hashes = index.get("ordered_page_sha256")
+            if (
+                index.get("replica") != number
+                or index.get("checkpoint_id") != expected_ids[ordinal]
+                or index.get("ordinal") != ordinal
+                or not isinstance(hashes, list)
+                or index.get("page_count") != len(hashes)
+                or checkpoint.get("actual_file_pages") != len(hashes)
+                or index.get("file_size_bytes") != len(hashes) * 2048
+                or checkpoint.get("actual_size_bytes") != len(hashes) * 2048
+            ):
+                raise ValidationError("snapshot_shape_mismatch", reference["path"])
+            predecessor = None if ordinal == 0 else expected_ids[ordinal - 1]
+            if index.get("predecessor_checkpoint_id") != predecessor:
+                raise ValidationError("snapshot_predecessor_mismatch", reference["path"])
+            if any(not isinstance(digest, str) or digest not in page_paths for digest in hashes):
+                raise ValidationError("snapshot_page_blob_missing", reference["path"])
+            previous = [] if ordinal == 0 else indexes[expected_ids[ordinal - 1]]["ordered_page_sha256"]
+            changed = [page for page in range(max(len(previous), len(hashes))) if (previous[page] if page < len(previous) else None) != (hashes[page] if page < len(hashes) else None)]
+            if index.get("changed_page_indices") != changed:
+                raise ValidationError("changed_page_indices_mismatch", reference["path"])
+            indexes[expected_ids[ordinal]] = index
+        if validate_a3:
+            first = indexes["E0"]["page_count"]
+            first_achieved = indexes["D_GROW_0128"]["page_count"]
+            regrowth = indexes["D_RECREATE_EMPTY"]["page_count"]
+            regrowth_achieved = indexes["D_REGROW_0128"]["page_count"]
+            growth = observation["d_growth_observation"]
+            if growth != {
+                "first_baseline_pages": first,
+                "first_target_pages": first + 128,
+                "first_achieved_pages": first_achieved,
+                "first_rows": growth["first_rows"],
+                "regrowth_baseline_pages": regrowth,
+                "regrowth_target_pages": regrowth + 128,
+                "regrowth_achieved_pages": regrowth_achieved,
+                "regrowth_rows": growth["regrowth_rows"],
+            }:
+                raise ValidationError("d_growth_binding_mismatch", str(number))
+            if (
+                first_achieved < first + 128
+                or regrowth_achieved < regrowth + 128
+                or regrowth_achieved <= first_achieved
+                or growth["first_rows"] % 32
+                or growth["regrowth_rows"] % 32
+            ):
+                raise ValidationError("d_growth_arithmetic_mismatch", str(number))
+            logical = sum(index["file_size_bytes"] for index in indexes.values())
+            changed_total = sum(len(index["changed_page_indices"]) for index in indexes.values())
+            if observation["logical_checkpoint_read_bytes"] != logical or observation["changed_hash_entries"] != changed_total:
+                raise ValidationError("observation_counter_mismatch", str(number))
+        return Replica(
+            number,
+            observation,
+            indexes,
+            self.root,
+            page_paths,
+            self.bounds["max_unique_page_blobs"],
+            self.bounds["max_logical_checkpoint_read_bytes_per_replica"],
+        )
+
+    def _verify_snapshot_hashes(self, replica: Replica) -> None:
+        for checkpoint_id in replica.checkpoint_ids:
+            index = replica.index(checkpoint_id)
+            digest = hashlib.sha256()
+            for page_number in range(index["page_count"]):
+                page = replica.page(checkpoint_id, page_number)
+                if page is None:
+                    raise ValidationError("snapshot_page_absent")
+                digest.update(page)
+            if digest.hexdigest() != index["database_sha256"]:
+                raise ValidationError("snapshot_database_hash_mismatch", f"r{replica.number}:{checkpoint_id}")
+
+    def load(self) -> LoadedBundle:
+        manifest_path = self._safe("bundle-manifest.json")
+        manifest, manifest_raw = load_json(manifest_path, self.bounds["max_json_bytes"])
+        if not isinstance(manifest, dict):
+            raise ValidationError("manifest_not_object")
+        legacy = manifest.get("experiment_id") == "DAO-A2-ALLOCATION-MAPS-001"
+        if legacy and not self.recompute_only:
+            raise ValidationError("wrong_experiment_id")
+        if not legacy:
+            self._schema("bundle-manifest.schema.json", manifest)
+        plan_sha = sha256_bytes(self.plan_raw)
+        if not legacy and manifest.get("plan_sha256") != plan_sha:
+            raise ValidationError("plan_hash_mismatch")
+
+        if legacy:
+            if sha256_bytes(manifest_raw) != EXP_0042_MANIFEST_SHA256:
+                raise ValidationError("exp_0042_manifest_hash_mismatch")
+            files = manifest.get("files")
+            if not isinstance(files, list) or len(files) > 65_650:
+                raise ValidationError("resource_bound_breach", "legacy manifest files")
+            legacy_entries = {
+                entry.get("path"): entry
+                for entry in files
+                if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+            }
+            for prefix in (
+                "observations/replica-01.json", "observations/replica-02.json",
+                "page-indexes/replica-01/", "page-indexes/replica-02/",
+            ):
+                selected = [item for path, item in legacy_entries.items() if path == prefix or path.startswith(prefix)]
+                if not selected:
+                    raise ValidationError("legacy_inventory_incomplete", prefix)
+                for entry in selected:
+                    path = self._safe(entry["path"])
+                    raw = read_bytes(path, self.bounds["max_json_bytes"])
+                    if len(raw) != entry.get("size_bytes") or sha256_bytes(raw) != entry.get("sha256"):
+                        raise ValidationError("manifest_file_mismatch", entry["path"])
+            page_paths = {
+                entry["sha256"]: self._safe(entry["path"])
+                for entry in files
+                if isinstance(entry, dict) and entry.get("role") == "page_blob"
+            }
+            if len(page_paths) > self.bounds["max_unique_page_blobs"]:
+                raise ValidationError("resource_bound_breach", "legacy page blobs")
+            replica_numbers = (1, 2)
+        else:
+            entries, page_paths = self._load_inventory(manifest)
+            replica_numbers = (1, 2, 3)
+            self._validate_documents(manifest, entries)
+
+        replicas = {number: self._load_replica(number, page_paths, not legacy) for number in replica_numbers}
+        if not legacy:
+            for replica in replicas.values():
+                self._verify_snapshot_hashes(replica)
+            report, _ = load_json(self._safe("analysis/analysis-report.json"), self.bounds["max_json_bytes"])
+            frozen, frozen_raw = load_json(self._safe("analysis/derivation-candidates.json"), self.bounds["max_json_bytes"])
+            receipt, _ = load_json(self._safe("analysis/holdout-structure-receipt.json"), self.bounds["max_json_bytes"])
+        else:
+            report = frozen = receipt = frozen_raw = None
+        return LoadedBundle(
+            self.root,
+            manifest,
+            sha256_bytes(manifest_raw),
+            self.plan,
+            plan_sha,
+            replicas,
+            report,
+            frozen,
+            frozen_raw,
+            receipt,
+            legacy,
+        )
+
+    def _validate_documents(self, manifest: dict[str, Any], entries: dict[str, dict[str, Any]]) -> None:
+        roles = {entry["role"]: [] for entry in entries.values()}
+        for relative, entry in entries.items():
+            roles.setdefault(entry["role"], []).append(relative)
+        required_counts = {
+            "plan": 1,
+            "environment": 3,
+            "replica_artifact_manifest": 3,
+            "replica_observation": 3,
+            "page_index": 75,
+            "frozen_candidate_set": 1,
+            "analysis_report": 1,
+            "holdout_structure_receipt": 1,
+        }
+        for role, count in required_counts.items():
+            if len(roles.get(role, [])) != count:
+                raise ValidationError("manifest_role_count", role)
+        plan_relative = roles["plan"][0]
+        if plan_relative != "plan/a3-allocation-maps.plan.json" or entries[plan_relative]["sha256"] != manifest["plan_sha256"]:
+            raise ValidationError("bundle_plan_binding_mismatch")
+        schema_by_role = {
+            "environment": "environment.schema.json",
+            "replica_artifact_manifest": "replica-artifact-manifest.schema.json",
+            "replica_observation": "replica-observation.schema.json",
+            "page_index": "page-index.schema.json",
+            "frozen_candidate_set": "derivation-candidates.schema.json",
+            "analysis_report": "analysis-report.schema.json",
+            "holdout_structure_receipt": "holdout-structure-receipt.schema.json",
+        }
+        for role, schema in schema_by_role.items():
+            for relative in roles[role]:
+                value, _ = load_json(self._safe(relative), self.bounds["max_json_bytes"])
+                self._schema(schema, value)
+                if isinstance(value, dict):
+                    for key in ("campaign_id", "producer_commit", "plan_sha256"):
+                        if key in value and value[key] != manifest[key]:
+                            raise ValidationError("document_binding_mismatch", f"{relative}:{key}")
+        frozen_path = roles["frozen_candidate_set"][0]
+        frozen, raw = load_json(self._safe(frozen_path), self.bounds["max_json_bytes"])
+        if raw != canonical_json_bytes(frozen):
+            raise ValidationError("frozen_set_not_canonical")
+        receipt, _ = load_json(self._safe(roles["holdout_structure_receipt"][0]), self.bounds["max_json_bytes"])
+        report, _ = load_json(self._safe(roles["analysis_report"][0]), self.bounds["max_json_bytes"])
+        frozen_sha = sha256_bytes(raw)
+        if receipt.get("derivation_candidate_set_sha256") != frozen_sha or report.get("derivation_candidate_set_sha256") != frozen_sha:
+            raise ValidationError("frozen_set_hash_link_mismatch")
+        receipt_entry = entries[roles["holdout_structure_receipt"][0]]
+        if manifest["holdout_structure_receipt_sha256"] != receipt_entry["sha256"]:
+            raise ValidationError("receipt_manifest_link_mismatch")
+        environments = sorted(roles["environment"])
+        replica_manifests = sorted(roles["replica_artifact_manifest"])
+        if manifest["replica_environment_sha256"] != [entries[path]["sha256"] for path in environments]:
+            raise ValidationError("environment_manifest_link_mismatch")
+        if manifest["replica_artifact_manifest_sha256"] != [entries[path]["sha256"] for path in replica_manifests]:
+            raise ValidationError("replica_manifest_link_mismatch")
+        environment_values = [load_json(self._safe(path), self.bounds["max_json_bytes"])[0] for path in environments]
+        exact = [
+            (value["provider"]["prog_id"], value["provider"]["clsid"], value["provider"]["server_sha256"], value["host"]["process_architecture"], value["host"]["powershell_version"].split(".")[0])
+            for value in environment_values
+        ]
+        if any(value != exact[0] for value in exact[1:]) or exact[0][2] != manifest["provider_sha256"]:
+            raise ValidationError("cross_replica_environment_mismatch")
+        for number, path in enumerate(replica_manifests, 1):
+            replica_manifest, _ = load_json(self._safe(path), self.bounds["max_json_bytes"])
+            expected_environment = f"environment/replica-{number:02d}.json"
+            expected_observation = f"observations/replica-{number:02d}.json"
+            expected_indexes = {f"page-indexes/replica-{number:02d}/{ordinal:02d}-{checkpoint}.json" for ordinal, checkpoint in enumerate(self.plan["checkpoint_design"]["checkpoint_ids"])}
+            required = {expected_environment, expected_observation} | expected_indexes
+            listed: set[str] = set()
+            for item in replica_manifest["files"]:
+                relative = item["path"]
+                if relative not in entries or item != entries[relative]:
+                    raise ValidationError("replica_inventory_outer_mismatch", relative)
+                listed.add(relative)
+            if not required <= listed:
+                raise ValidationError("replica_inventory_incomplete", str(number))
+            if replica_manifest["environment_sha256"] != entries[expected_environment]["sha256"]:
+                raise ValidationError("replica_environment_link_mismatch", str(number))
+            if replica_manifest["provider_sha256"] != manifest["provider_sha256"]:
+                raise ValidationError("replica_provider_link_mismatch", str(number))

--- a/oracle/windows-dao/scripts/a3_independent_core.py
+++ b/oracle/windows-dao/scripts/a3_independent_core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable
 
+from a3_independent_base import derive_extended_base
 from a3_independent_bundle import LoadedBundle, Replica, ValidationError
 
 
@@ -193,53 +194,75 @@ def model_layer(model: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def derive_global_record(
-    replicas: list[Replica], qualified: list[int]
-) -> tuple[dict[str, Any], GlobalCandidate | None, dict[int, list[GlobalCandidate]]]:
+def _derive_global_record_replica(
+    replica: Replica,
+    qualified: list[int],
+) -> tuple[dict[str, Any], GlobalCandidate | None, list[GlobalCandidate]]:
     if not qualified:
-        return no_layer("no_physical_page_satisfies_global_transition_predicates", "A3-GLOBAL-PAGE-NONE"), None, {}
-    per_replica: dict[int, set[GlobalCandidate]] = {}
-    seen_by_replica: dict[int, dict[str, bool]] = {}
-    for replica in replicas:
-        found: set[GlobalCandidate] = set()
-        aggregate = {"anchor": False, "relation": False, "suffix": False}
-        for page in qualified:
-            candidates, seen = candidates_for_page(replica, page)
-            found.update(candidates)
-            for key in aggregate:
-                aggregate[key] = aggregate[key] or seen[key]
-        per_replica[replica.number] = found
-        seen_by_replica[replica.number] = aggregate
-    common = set.intersection(*per_replica.values()) if per_replica else set()
-    transcript = {number: sorted(values, key=lambda item: (item.page, item.start, item.polarity, item.slack)) for number, values in per_replica.items()}
-    if not common:
-        if all(not seen["anchor"] for seen in seen_by_replica.values()):
+        return no_layer("no_physical_page_satisfies_global_transition_predicates", "A3-GLOBAL-PAGE-NONE"), None, []
+    found: set[GlobalCandidate] = set()
+    aggregate = {"anchor": False, "relation": False, "suffix": False}
+    for page in qualified:
+        candidates, seen = candidates_for_page(replica, page)
+        found.update(candidates)
+        for key in aggregate:
+            aggregate[key] = aggregate[key] or seen[key]
+    transcript = sorted(found, key=lambda item: (item.page, item.start, item.polarity, item.slack))
+    if not found:
+        if not aggregate["anchor"]:
             reason, predicate = "no_global_record_candidate", "A3-GLOBAL-RECORD-NONE"
-        elif all(not seen["relation"] for seen in seen_by_replica.values()):
+        elif not aggregate["relation"]:
             reason, predicate = "global_set_relation_not_satisfied", "A3-D-SET-RELATION"
-        elif all(not seen["suffix"] for seen in seen_by_replica.values()):
+        elif not aggregate["suffix"]:
             reason, predicate = "global_record_end_not_resolved", "A3-GLOBAL-RECORD-END"
         else:
-            reason, predicate = "replica_disagreement", "A3-REPLICA-DISAGREEMENT"
+            raise ValidationError("global_record_stage_inconsistent")
         return no_layer(reason, predicate), None, transcript
-    pages = {candidate.page for candidate in common}
-    starts_by_page = {page: {candidate.start for candidate in common if candidate.page == page} for page in pages}
-    if len(pages) > 1 and all(len(starts) == 1 for starts in starts_by_page.values()):
-        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE"), None, transcript
-    if any(len(starts) > 1 for starts in starts_by_page.values()):
-        return no_layer("multiple_global_record_boundaries_survive", "A3-GLOBAL-RECORD-MULTIPLE"), None, transcript
-    pairs = {(candidate.page, candidate.start) for candidate in common}
-    if len(pairs) != 1:
-        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE"), None, transcript
-    polarities = {candidate.polarity for candidate in common}
-    if len(polarities) == 0:
-        return no_layer("no_unique_bit_polarity", "A3-POLARITY-NONE"), None, transcript
+    polarities = {candidate.polarity for candidate in found}
     if len(polarities) > 1:
         return no_layer("multiple_bit_polarities_survive", "A3-POLARITY-MULTIPLE"), None, transcript
-    if len(common) != 1:
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), None, transcript
-    candidate = next(iter(common))
+    pages = {candidate.page for candidate in found}
+    if len(pages) > 1:
+        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE"), None, transcript
+    starts = {candidate.start for candidate in found}
+    if len(starts) > 1:
+        return no_layer("multiple_global_record_boundaries_survive", "A3-GLOBAL-RECORD-MULTIPLE"), None, transcript
+    candidate = next(iter(found))
     return model_layer(candidate.model()), candidate, transcript
+
+
+def _global_comparison_key(candidate: GlobalCandidate) -> tuple[int, int, str]:
+    return candidate.page, candidate.start, candidate.polarity
+
+
+def derive_global_record(
+    replicas: list[Replica],
+    qualified: dict[int, list[int]],
+) -> tuple[dict[str, Any], GlobalCandidate | None, dict[int, list[GlobalCandidate]], list[str | None]]:
+    evaluations = [
+        _derive_global_record_replica(replica, qualified[replica.number]["global_map"])
+        for replica in replicas
+    ]
+    terminals = [layer["terminal_predicate_id"] for layer, _, _ in evaluations]
+    transcript = {replica.number: result[2] for replica, result in zip(replicas, evaluations)}
+    if any(terminal is not None for terminal in terminals):
+        if len(set(terminals)) == 1:
+            return evaluations[0][0], None, transcript, terminals
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), None, transcript, terminals
+    candidates = [candidate for _, candidate, _ in evaluations]
+    concrete = [candidate for candidate in candidates if candidate is not None]
+    if len(concrete) != len(replicas) or any(
+        _global_comparison_key(candidate) != _global_comparison_key(concrete[0])
+        for candidate in concrete[1:]
+    ):
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), None, transcript, terminals
+    candidate = GlobalCandidate(
+        concrete[0].page,
+        concrete[0].start,
+        concrete[0].polarity,
+        min(item.slack for item in concrete),
+    )
+    return model_layer(candidate.model()), candidate, transcript, terminals
 
 
 def _record_page(replica: Replica, checkpoint_id: str, model: GlobalCandidate) -> bytes:
@@ -255,12 +278,16 @@ def polarity_cross_check(replica: Replica, plan: dict[str, Any], model: GlobalCa
     violating_leg = None
     violating_page = None
     for left, right in plan["checkpoint_design"]["transition_coverage"]["polarity_cross_check_legs"]:
-        left_page = _record_page(replica, left, model)
-        right_page = _record_page(replica, right, model)
+        left_page = replica.page(left, model.page)
+        right_page = replica.page(right, model.page)
+        if left_page is None or right_page is None:
+            continue
         left_tag, right_tag = left_page[model.start], right_page[model.start]
-        if left_tag != right_tag or left_tag != 0:
+        if left_tag != right_tag:
             stop = leg(left, right)
             break
+        if left_tag != 0:
+            continue
         left_base = int.from_bytes(left_page[model.start + 1 : model.start + 5], "little")
         right_base = int.from_bytes(right_page[model.start + 1 : model.start + 5], "little")
         capacity = 8 * (2048 - model.start - 5)
@@ -339,81 +366,95 @@ def _pointer_valid(replica: Replica, plan: dict[str, Any], references: dict[str,
     return True
 
 
+def _inline_boundary(replica: Replica, checkpoints: list[str], model: GlobalCandidate) -> int:
+    extents = []
+    for checkpoint in checkpoints:
+        page = _record_page(replica, checkpoint, model)
+        base = int.from_bytes(page[model.start + 1 : model.start + 5], "little")
+        page_count = replica.index(checkpoint)["page_count"]
+        extents.append(model.start + 5 + (page_count - base) // 8 + 1)
+    return max(extents)
+
+
+def _derive_conversion_replica(
+    replica: Replica,
+    plan: dict[str, Any],
+    model: GlobalCandidate,
+    cross: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if cross["first_violating_leg"] is not None:
+        return no_layer("growth_polarity_disagreement", "A3-POLARITY-CROSSCHECK"), cross
+    window = plan["checkpoint_design"]["transition_coverage"]["inline_to_indirect_conversion_window"]
+    classes: list[str] = []
+    references: dict[str, tuple[int, int]] = {}
+    for checkpoint_id in plan["checkpoint_design"]["checkpoint_ids"]:
+        page = replica.page(checkpoint_id, model.page)
+        references[checkpoint_id] = (0, 0) if page is None or page[model.start] != 1 else _indirect_slots(page, model.start)
+    for checkpoint_id in window:
+        if _inline_valid(replica, checkpoint_id, model):
+            classes.append("inline")
+        elif _indirect_valid(replica, checkpoint_id, model):
+            classes.append("indirect")
+        else:
+            classes.append("neither")
+    first_indirect = next((index for index, value in enumerate(classes) if value == "indirect"), None)
+    if first_indirect is None or "inline" not in classes[:first_indirect]:
+        return no_layer("missing_inline_to_indirect_conversion", "A3-CONVERSION-NONE"), cross
+    class_changes = sum(left != right for left, right in zip(classes, classes[1:]))
+    if class_changes != 1:
+        return no_layer("multiple_inline_to_indirect_conversions", "A3-CONVERSION-MULTIPLE"), cross
+    conversion = window[first_indirect]
+    slots = references[conversion]
+    if sum(value != 0 for value in slots) == 0:
+        return no_layer("no_active_slot_at_conversion", "A3-SLOT-ACTIVATION"), cross
+    if sum(value != 0 for value in references["H_REL_0904"]) != 2:
+        return no_layer("final_slot_activation_not_two", "A3-SLOT-FINAL"), cross
+    if not _pointer_valid(replica, plan, references):
+        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY"), cross
+    inline_phase = window[:first_indirect]
+    boundary = _inline_boundary(replica, inline_phase, model)
+    expected = 0xFF if model.polarity == "set_means_not_in_use" else 0x00
+    if any(
+        any(byte != expected for byte in _record_page(replica, checkpoint, model)[boundary:])
+        for checkpoint in inline_phase
+    ):
+        return no_layer("unexplained_nonzero_inline_suffix", "A3-INLINE-SUFFIX"), cross
+    conversion_model = {
+        "conversion_checkpoint_id": conversion,
+        "conversion_ordinal": plan["checkpoint_design"]["checkpoint_ids"].index(conversion),
+        "indirect_tag": 1,
+        "active_slot_count_at_conversion": sum(value != 0 for value in slots),
+        "active_slot_count_at_h_rel_0904": 2,
+        "inline_boundary": boundary,
+        "slot_reference_pages": list(slots),
+    }
+    return model_layer(conversion_model), cross
+
+
 def derive_conversion(
     replicas: list[Replica],
     plan: dict[str, Any],
     model: GlobalCandidate | None,
     cross_checks: dict[int, dict[str, Any]],
-) -> tuple[dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], dict[str, Any], list[str | None]]:
     empty_cross = {"evaluated_legs": [], "representation_change_stop": None, "first_violating_leg": None, "first_violating_page": None}
     if model is None:
-        return no_layer(None, None, False), empty_cross
-    values = list(cross_checks.values())
-    if any(value != values[0] for value in values[1:]):
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), values[0]
-    cross = values[0]
-    if cross["first_violating_leg"] is not None:
-        return no_layer("growth_polarity_disagreement", "A3-POLARITY-CROSSCHECK"), cross
-    window = plan["checkpoint_design"]["transition_coverage"]["inline_to_indirect_conversion_window"]
-    replica_models: list[dict[str, Any]] = []
-    for replica in replicas:
-        classes: list[str] = []
-        references: dict[str, tuple[int, int]] = {}
-        for checkpoint_id in plan["checkpoint_design"]["checkpoint_ids"]:
-            page = replica.page(checkpoint_id, model.page)
-            references[checkpoint_id] = (0, 0) if page is None or page[model.start] != 1 else _indirect_slots(page, model.start)
-        for checkpoint_id in window:
-            if _inline_valid(replica, checkpoint_id, model):
-                classes.append("inline")
-            elif _indirect_valid(replica, checkpoint_id, model):
-                classes.append("indirect")
-            else:
-                classes.append("neither")
-        transitions = [
-            index for index in range(1, len(window))
-            if classes[index - 1] == "inline" and classes[index] == "indirect"
-        ]
-        if not transitions:
-            return no_layer("missing_inline_to_indirect_conversion", "A3-CONVERSION-NONE"), cross
-        if len(transitions) > 1:
-            return no_layer("multiple_inline_to_indirect_conversions", "A3-CONVERSION-MULTIPLE"), cross
-        index = transitions[0]
-        if not all(value == "inline" for value in classes[:index]) or not all(value == "indirect" for value in classes[index:]):
-            reason = "multiple_inline_to_indirect_conversions" if "inline" in classes[index + 1 :] else "missing_inline_to_indirect_conversion"
-            predicate = "A3-CONVERSION-MULTIPLE" if reason.startswith("multiple") else "A3-CONVERSION-NONE"
-            return no_layer(reason, predicate), cross
-        conversion = window[index]
-        slots = references[conversion]
-        if sum(value != 0 for value in slots) == 0:
-            return no_layer("no_active_slot_at_conversion", "A3-SLOT-ACTIVATION"), cross
-        if sum(value != 0 for value in references["H_REL_0904"]) != 2:
-            return no_layer("final_slot_activation_not_two", "A3-SLOT-FINAL"), cross
-        if not _pointer_valid(replica, plan, references):
-            return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY"), cross
-        inline_counts = [replica.index(checkpoint)["page_count"] for checkpoint in window[:index]]
-        inline_bases = [int.from_bytes(_record_page(replica, checkpoint, model)[model.start + 1 : model.start + 5], "little") for checkpoint in window[:index]]
-        required_bytes = max((count - base + 1 + 7) // 8 for count, base in zip(inline_counts, inline_bases))
-        boundary = model.start + 5 + required_bytes
-        expected = 0xFF if model.polarity == "set_means_not_in_use" else 0x00
-        if boundary > 2048 or any(
-            any(byte != expected for byte in _record_page(replica, checkpoint, model)[boundary:])
-            for checkpoint in window[:index]
-        ):
-            return no_layer("no_inline_boundary_candidate", "A3-INLINE-BOUNDARY-NONE"), cross
-        replica_models.append(
-            {
-                "conversion_checkpoint_id": conversion,
-                "conversion_ordinal": plan["checkpoint_design"]["checkpoint_ids"].index(conversion),
-                "indirect_tag": 1,
-                "active_slot_count_at_conversion": sum(value != 0 for value in slots),
-                "active_slot_count_at_h_rel_0904": 2,
-                "inline_boundary": boundary,
-                "slot_reference_pages": list(slots),
-            }
-        )
-    if any(value != replica_models[0] for value in replica_models[1:]):
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), cross
-    return model_layer(replica_models[0]), cross
+        return no_layer(None, None, False), empty_cross, [None for _ in replicas]
+    evaluations = [
+        _derive_conversion_replica(replica, plan, model, cross_checks[replica.number])
+        for replica in replicas
+    ]
+    terminals = [layer["terminal_predicate_id"] for layer, _ in evaluations]
+    frozen_cross = evaluations[0][1]
+    if any(terminal is not None for terminal in terminals):
+        if len(set(terminals)) == 1:
+            return evaluations[0][0], frozen_cross, terminals
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), frozen_cross, terminals
+    models = [layer["model"] for layer, _ in evaluations]
+    crosses = [cross for _, cross in evaluations]
+    if any(value != models[0] for value in models[1:]) or any(value != crosses[0] for value in crosses[1:]):
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), frozen_cross, terminals
+    return model_layer(models[0]), frozen_cross, terminals
 
 
 def _decode_pointer(page: bytes, offset: int, layout: str) -> tuple[int, int]:
@@ -427,6 +468,24 @@ def _window_stable(replica: Replica, page: int, offset: int, legs: Iterable[tupl
     for left, right in legs:
         left_page, right_page = replica.page(left, page), replica.page(right, page)
         if left_page is None or right_page is None or left_page[offset : offset + 4] != right_page[offset : offset + 4]:
+            return False
+    return True
+
+
+def _reference_stable(
+    replica: Replica,
+    page: int,
+    offset: int,
+    layout: str,
+    legs: Iterable[tuple[str, str]],
+) -> bool:
+    for left, right in legs:
+        left_page, right_page = replica.page(left, page), replica.page(right, page)
+        if (
+            left_page is None
+            or right_page is None
+            or _decode_pointer(left_page, offset, layout)[0] != _decode_pointer(right_page, offset, layout)[0]
+        ):
             return False
     return True
 
@@ -455,23 +514,25 @@ def _reference_valid(replica: Replica, plan: dict[str, Any], page: int, offset: 
 
 def pointer_windows(replica: Replica, plan: dict[str, Any], pages: list[int]) -> tuple[set[PointerWindow], set[PointerWindow]]:
     growth = growth_legs(plan)
-    idle = [tuple(value) for value in plan["checkpoint_design"]["idle_pairs"]]
-    d_legs = _pairs(list(GLOBAL_D))
+    low_growth = _pairs(plan["checkpoint_design"]["transition_coverage"]["tdef_low_growth"])
     layouts = plan["hypotheses"]["tdef_pointer_layouts"]
     growth_windows: set[PointerWindow] = set()
     churn_windows: set[PointerWindow] = set()
     for page_number in pages:
         for offset in range(2045):
             for layout in layouts:
-                if _window_stable(replica, page_number, offset, CHURN_LEGS + tuple(d_legs) + tuple(idle)):
+                if _reference_stable(replica, page_number, offset, layout, CHURN_LEGS):
                     values = []
                     for left, right in growth:
                         left_page, right_page = replica.page(left, page_number), replica.page(right, page_number)
                         if left_page is not None and right_page is not None:
-                            values.append(_decode_pointer(left_page, offset, layout) != _decode_pointer(right_page, offset, layout))
-                    if any(values) and _reference_valid(replica, plan, page_number, offset, layout):
+                            values.append(
+                                _decode_pointer(left_page, offset, layout)[0]
+                                != _decode_pointer(right_page, offset, layout)[0]
+                            )
+                    if any(values):
                         growth_windows.add(PointerWindow(page_number, offset, layout))
-                if _window_stable(replica, page_number, offset, tuple(growth) + tuple(d_legs) + tuple(idle)):
+                if _reference_stable(replica, page_number, offset, layout, low_growth):
                     before = replica.page("L_REL_1280", page_number)
                     deleted = replica.page("L_DELETE_ALL", page_number)
                     restored = replica.page("L_REINSERT_SAME", page_number)
@@ -479,7 +540,7 @@ def pointer_windows(replica: Replica, plan: dict[str, Any], pages: list[int]) ->
                         first = _decode_pointer(before, offset, layout)
                         middle = _decode_pointer(deleted, offset, layout)
                         last = _decode_pointer(restored, offset, layout)
-                        if first != middle and first == last and _reference_valid(replica, plan, page_number, offset, layout):
+                        if first[0] != middle[0] and first[0] == last[0]:
                             churn_windows.add(PointerWindow(page_number, offset, layout))
     return growth_windows, churn_windows
 
@@ -495,7 +556,11 @@ def _tdef_models(replica: Replica, growth: set[PointerWindow], churn: set[Pointe
     models: set[tuple[Any, ...]] = set()
     for left in growth:
         for right in churn:
-            if left.page != right.page or left.layout != right.layout or left.offset == right.offset:
+            if (
+                left.page != right.page
+                or left.layout != right.layout
+                or not (left.offset + 4 <= right.offset or right.offset + 4 <= left.offset)
+            ):
                 continue
             start = min(left.offset, right.offset)
             end = max(left.offset, right.offset) + 4
@@ -513,41 +578,69 @@ def _tdef_models(replica: Replica, growth: set[PointerWindow], churn: set[Pointe
     return models
 
 
-def derive_tdef(replicas: list[Replica], plan: dict[str, Any], qualified: list[int]) -> dict[str, Any]:
+def _tdef_precondition(replica: Replica) -> bool:
+    before = replica.checkpoint_observation("L_REL_1280")["table_row_counts"]["L"]
+    deleted_rows = next(
+        (item["row_count"] for item in replica.checkpoint_observation("L_DELETE_ALL")["dao_reread"] if item["role"] == "L"),
+        None,
+    )
+    return before != 0 and deleted_rows == 0
+
+
+def _p_growth_legs() -> list[tuple[str, str]]:
+    return [
+        ("L_IDLE_REOPEN", "P_ABS_04096"),
+        ("P_ABS_04096", "P_ABS_08192"),
+        ("P_ABS_08192", "P_ABS_12288"),
+        ("P_ABS_12288", "P_ABS_16480"),
+    ]
+
+
+def _tdef_structural_valid(replica: Replica, plan: dict[str, Any], model: tuple[Any, ...]) -> bool:
+    page, _, _, _, growth_offset, churn_offset = model
+    schedule = plan["checkpoint_design"]["checkpoint_ids"]
+    d_legs = _pairs(schedule[:6])
+    idle = [tuple(value) for value in plan["checkpoint_design"]["idle_pairs"]]
+    all_growth = growth_legs(plan) + _p_growth_legs()
+    return _window_stable(replica, page, growth_offset, d_legs + idle) and _window_stable(
+        replica,
+        page,
+        churn_offset,
+        d_legs + all_growth + idle,
+    )
+
+
+def _derive_tdef_replica(replica: Replica, plan: dict[str, Any], qualified: list[int]) -> dict[str, Any]:
     if not qualified:
         return no_layer("no_physical_page_satisfies_tdef_transition_predicates", "A3-TDEF-PAGE-NONE")
-    for replica in replicas:
-        before = replica.checkpoint_observation("L_REL_1280")["table_row_counts"]["L"]
-        deleted_rows = next(
-            (item["row_count"] for item in replica.checkpoint_observation("L_DELETE_ALL")["dao_reread"] if item["role"] == "L"),
-            None,
-        )
-        if before == 0 or deleted_rows != 0:
-            return no_layer("legacy_churn_precondition_not_met", "A3-CHURN-PRECONDITION")
-    per_replica: dict[int, tuple[set[PointerWindow], set[PointerWindow], set[tuple[Any, ...]]]] = {}
-    for replica in replicas:
-        growth, churn = pointer_windows(replica, plan, qualified)
-        if not growth:
-            return no_layer("no_growth_only_pointer_candidate", "A3-GROWTH-POINTER-NONE")
-        if not churn:
-            return no_layer("no_delete_reinsert_only_pointer_candidate", "A3-CHURN-POINTER-NONE")
-        per_replica[replica.number] = (growth, churn, _tdef_models(replica, growth, churn))
-    if any(not values[2] for values in per_replica.values()):
+    if not _tdef_precondition(replica):
+        return no_layer("legacy_churn_precondition_not_met", "A3-CHURN-PRECONDITION")
+    growth, churn = pointer_windows(replica, plan, qualified)
+    if not growth:
+        return no_layer("no_growth_only_pointer_candidate", "A3-GROWTH-POINTER-NONE")
+    if not churn:
+        return no_layer("no_delete_reinsert_only_pointer_candidate", "A3-CHURN-POINTER-NONE")
+    models = _tdef_models(replica, growth, churn)
+    if not models:
         return no_layer("no_tdef_record_candidate", "A3-TDEF-RECORD-NONE")
-    common = set.intersection(*(values[2] for values in per_replica.values()))
-    if not common:
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT")
-    record_keys = {(item[0], item[1], item[2]) for item in common}
+    record_keys = {(item[0], item[1], item[2]) for item in models}
     starts_by_page: dict[int, set[int]] = {}
     for page, start, _ in record_keys:
         starts_by_page.setdefault(page, set()).add(start)
-    if len(starts_by_page) > 1 and all(len(starts) == 1 for starts in starts_by_page.values()):
+    if len(starts_by_page) > 1:
         return no_layer("multiple_physical_pages_satisfy_tdef_transition_predicates", "A3-TDEF-PAGE-MULTIPLE")
     if len(record_keys) > 1:
         return no_layer("multiple_tdef_record_boundaries_survive", "A3-TDEF-RECORD-MULTIPLE")
-    if len(common) > 1:
+    if len(models) > 1:
         return no_layer("multiple_pointer_models_survive", "A3-POINTER-MULTIPLE")
-    page, start, end, layout, growth_offset, churn_offset = next(iter(common))
+    model = next(iter(models))
+    page, start, end, layout, growth_offset, churn_offset = model
+    if not _reference_valid(replica, plan, page, growth_offset, layout) or not _reference_valid(
+        replica, plan, page, churn_offset, layout
+    ):
+        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY")
+    if not _tdef_structural_valid(replica, plan, model):
+        return no_layer("structural_field_exclusion_failure", "A3-STRUCTURAL-EXCLUSION")
     return model_layer(
         {
             "record": {"page": page, "start": start, "end": end},
@@ -558,27 +651,80 @@ def derive_tdef(replicas: list[Replica], plan: dict[str, Any], qualified: list[i
     )
 
 
+def derive_tdef(
+    replicas: list[Replica],
+    plan: dict[str, Any],
+    qualified: dict[int, list[int]],
+) -> tuple[dict[str, Any], list[str | None]]:
+    layers = [
+        _derive_tdef_replica(replica, plan, qualified[replica.number]["tdef"])
+        for replica in replicas
+    ]
+    terminals = [layer["terminal_predicate_id"] for layer in layers]
+    if any(terminal is not None for terminal in terminals):
+        if len(set(terminals)) == 1:
+            return layers[0], terminals
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+    if any(layer["model"] != layers[0]["model"] for layer in layers[1:]):
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+    return model_layer(layers[0]["model"]), terminals
+
+
 def recompute_derivation(bundle: LoadedBundle) -> dict[str, Any]:
     replicas = [bundle.replicas[number] for number in (1, 2)]
     plan = bundle.plan
+    empty_cross = {
+        "evaluated_legs": [],
+        "representation_change_stop": None,
+        "first_violating_leg": None,
+        "first_violating_page": None,
+    }
+    idle_results = {replica.number: idle_equal(replica, plan) for replica in replicas}
+    if not all(idle_results.values()):
+        inapplicable = {name: no_layer(None, None, False) for name in (
+            "global_map_record",
+            "global_map_conversion_inline",
+            "global_map_extended_base",
+            "tdef_pointer_pair",
+        )}
+        return {
+            "qualified_pages": {"global_map": [], "tdef": []},
+            "per_replica_qualified_pages": {
+                replica.number: {"global_map": [], "tdef": []} for replica in replicas
+            },
+            "polarity_cross_check": empty_cross,
+            "layers": inapplicable,
+            "record_candidates": {},
+            "idle_equality": False,
+            "campaign_terminal_predicate_id": "A3-IDLE-EQUALITY",
+            "replica_terminals": {name: [None, None] for name in inapplicable},
+            "record_candidate_enumerations": 0,
+        }
     qualifications = {replica.number: qualify_pages(replica, plan) for replica in replicas}
-    common_qualified = {
-        key: sorted(set.intersection(*(set(value[key]) for value in qualifications.values())))
+    union_qualified = {
+        key: sorted(set.union(*(set(value[key]) for value in qualifications.values())))
         for key in ("global_map", "tdef")
     }
-    global_layer, global_model, record_candidates = derive_global_record(replicas, common_qualified["global_map"])
+    global_layer, global_model, record_candidates, global_terminals = derive_global_record(replicas, qualifications)
     cross_checks = {
         replica.number: polarity_cross_check(replica, plan, global_model)
         for replica in replicas
     } if global_model is not None else {}
-    conversion_layer, cross_check = derive_conversion(replicas, plan, global_model, cross_checks)
+    conversion_layer, cross_check, conversion_terminals = derive_conversion(replicas, plan, global_model, cross_checks)
     if conversion_layer["model"] is None:
         base_layer = no_layer(None, None, False)
+        base_terminals: list[str | None] = [None, None]
     else:
-        base_layer = derive_extended_base(replicas, plan, global_model, conversion_layer["model"])
-    tdef_layer = derive_tdef(replicas, plan, common_qualified["tdef"])
+        base_layer, base_terminals = derive_extended_base(replicas, plan, global_model, conversion_layer["model"])
+    tdef_layer, tdef_terminals = derive_tdef(replicas, plan, qualifications)
+    enumerations = sum(len(value["global_map"]) for value in qualifications.values())
+    enumerations += sum(
+        len(qualifications[replica.number]["tdef"])
+        for replica in replicas
+        if _tdef_precondition(replica)
+    )
     return {
-        "qualified_pages": common_qualified,
+        "qualified_pages": union_qualified,
         "per_replica_qualified_pages": qualifications,
         "polarity_cross_check": cross_check,
         "layers": {
@@ -591,95 +737,13 @@ def recompute_derivation(bundle: LoadedBundle) -> dict[str, Any]:
             str(number): [candidate.model() for candidate in candidates]
             for number, candidates in record_candidates.items()
         },
-        "idle_equality": all(idle_equal(replica, plan) for replica in replicas),
+        "idle_equality": True,
+        "campaign_terminal_predicate_id": None,
+        "replica_terminals": {
+            "global_map_record": global_terminals,
+            "global_map_conversion_inline": conversion_terminals,
+            "global_map_extended_base": base_terminals,
+            "tdef_pointer_pair": tdef_terminals,
+        },
+        "record_candidate_enumerations": enumerations,
     }
-
-
-def derive_extended_base(
-    replicas: list[Replica],
-    plan: dict[str, Any],
-    global_model: GlobalCandidate,
-    conversion_model: dict[str, Any],
-) -> dict[str, Any]:
-    formulas = plan["hypotheses"]["extended_base_candidates"]
-    survivors_by_replica: list[set[str]] = []
-    window = plan["checkpoint_design"]["transition_coverage"]["inline_to_indirect_conversion_window"]
-    conversion_index = window.index(conversion_model["conversion_checkpoint_id"])
-
-    def formula_base(formula: str, slot: int, reference: int) -> int:
-        base = (0, 16352)[slot] if formula.startswith("slot_relative") else reference
-        if formula.endswith("minus_one"):
-            return base - 1
-        if formula.endswith("plus_one"):
-            return base + 1
-        return base
-
-    for replica in replicas:
-        h_left_record = _record_page(replica, "P_ABS_16480", global_model)
-        h_right_record = _record_page(replica, "H_REL_0064", global_model)
-        h_left_reference = _indirect_slots(h_left_record, global_model.start)[0]
-        h_right_reference = _indirect_slots(h_right_record, global_model.start)[0]
-        h_left_page = replica.page("P_ABS_16480", h_left_reference) if h_left_reference else None
-        h_right_page = replica.page("H_REL_0064", h_right_reference) if h_right_reference else None
-        if (
-            h_left_page is None
-            or h_right_page is None
-            or not any(_bit_set(h_left_page, 1, bit) != _bit_set(h_right_page, 1, bit) for bit in range(16352))
-        ):
-            return no_layer("insufficient_base_discrimination", "A3-BASE-DISCRIMINATION")
-        survivors: set[str] = set()
-        for formula in formulas:
-            valid = True
-            h64_discriminated = False
-            for left, right in _pairs(window[conversion_index:]):
-                left_record = _record_page(replica, left, global_model)
-                right_record = _record_page(replica, right, global_model)
-                left_references = _indirect_slots(left_record, global_model.start)
-                right_references = _indirect_slots(right_record, global_model.start)
-                append_low = replica.index(left)["page_count"]
-                append_high = replica.index(right)["page_count"]
-                for slot in (0, 1):
-                    left_reference, right_reference = left_references[slot], right_references[slot]
-                    if left_reference == 0 or right_reference == 0:
-                        continue
-                    left_page = replica.page(left, left_reference)
-                    right_page = replica.page(right, right_reference)
-                    if left_page is None or right_page is None or left_page[0] != 0x05 or right_page[0] != 0x05:
-                        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY")
-                    left_base = formula_base(formula, slot, left_reference)
-                    right_base = formula_base(formula, slot, right_reference)
-                    low = max(left_base, right_base, 0)
-                    high = min(left_base + 16352, right_base + 16352, 65536)
-                    for physical_page in range(low, max(low, high)):
-                        left_set = _bit_set(left_page, 1, physical_page - left_base)
-                        right_set = _bit_set(right_page, 1, physical_page - right_base)
-                        if left_set == right_set:
-                            continue
-                        left_in_use = left_set == (global_model.polarity == "set_means_in_use")
-                        right_in_use = right_set == (global_model.polarity == "set_means_in_use")
-                        if not (append_low <= physical_page < append_high and not left_in_use and right_in_use):
-                            valid = False
-                            break
-                        if left == "P_ABS_16480" and right == "H_REL_0064" and slot == 0:
-                            h64_discriminated = True
-                    if not valid:
-                        break
-                    for physical_page in range(max(append_low, low), min(append_high, high)):
-                        left_set = _bit_set(left_page, 1, physical_page - left_base)
-                        right_set = _bit_set(right_page, 1, physical_page - right_base)
-                        if left_set == (global_model.polarity == "set_means_in_use") or right_set != (global_model.polarity == "set_means_in_use"):
-                            valid = False
-                            break
-                    if not valid:
-                        break
-                if not valid:
-                    break
-            if valid and h64_discriminated:
-                survivors.add(formula)
-        survivors_by_replica.append(survivors)
-    common = set.intersection(*survivors_by_replica)
-    if not common:
-        return no_layer("no_extended_base_candidate", "A3-BASE-NONE")
-    if len(common) > 1:
-        return no_layer("multiple_extended_base_candidates", "A3-BASE-MULTIPLE")
-    return model_layer({"extended_base_formula": next(iter(common))})

--- a/oracle/windows-dao/scripts/a3_independent_core.py
+++ b/oracle/windows-dao/scripts/a3_independent_core.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""Plan-literal byte recomputation for the A3 independent validator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from a3_independent_bundle import LoadedBundle, Replica, ValidationError
+
+
+POLARITIES = ("set_means_in_use", "set_means_not_in_use")
+GLOBAL_D = ("E0", "D_GROW_0128", "D_DROP", "D_RECREATE_EMPTY", "D_REGROW_0128")
+ANCHORS = ("E0", "D_GROW_0128", "D_REGROW_0128")
+CHURN_LEGS = (("L_REL_1280", "L_DELETE_ALL"), ("L_DELETE_ALL", "L_REINSERT_SAME"))
+
+
+@dataclass(frozen=True)
+class GlobalCandidate:
+    page: int
+    start: int
+    polarity: str
+    slack: int
+
+    def model(self) -> dict[str, Any]:
+        return {
+            "record": {"page": self.page, "start": self.start, "end": 2048},
+            "bit_polarity": self.polarity,
+            "zero_suffix_slack_bytes": self.slack,
+        }
+
+
+@dataclass(frozen=True)
+class PointerWindow:
+    page: int
+    offset: int
+    layout: str
+
+
+def leg(left: str, right: str) -> dict[str, str]:
+    return {"left_checkpoint_id": left, "right_checkpoint_id": right}
+
+
+def _pairs(values: list[str]) -> list[tuple[str, str]]:
+    return list(zip(values, values[1:]))
+
+
+def growth_legs(plan: dict[str, Any]) -> list[tuple[str, str]]:
+    coverage = plan["checkpoint_design"]["transition_coverage"]
+    return _pairs(coverage["tdef_low_growth"]) + _pairs(coverage["tdef_high_growth"])
+
+
+def _state_diff(replica: Replica, page: int, left: str, right: str) -> bool:
+    return replica.state(left, page) != replica.state(right, page)
+
+
+def qualify_pages(replica: Replica, plan: dict[str, Any]) -> dict[str, list[int]]:
+    pages = sorted(replica.candidate_page_space())
+    global_pages = [
+        page
+        for page in pages
+        if _state_diff(replica, page, "E0", "D_GROW_0128")
+        and _state_diff(replica, page, "D_GROW_0128", "D_DROP")
+    ]
+    growth = growth_legs(plan)
+    tdef_pages = [
+        page
+        for page in pages
+        if replica.state("E0", page) is not None
+        and any(_state_diff(replica, page, left, right) for left, right in growth)
+        and all(_state_diff(replica, page, left, right) for left, right in CHURN_LEGS)
+    ]
+    maximum = plan["bounds"]["max_qualified_pages_per_submodel"]
+    if len(global_pages) > maximum or len(tdef_pages) > maximum:
+        raise ValidationError("resource_bound_breach", "qualified pages")
+    return {"global_map": global_pages, "tdef": tdef_pages}
+
+
+def idle_equal(replica: Replica, plan: dict[str, Any]) -> bool:
+    return all(
+        replica.index(left)["ordered_page_sha256"] == replica.index(right)["ordered_page_sha256"]
+        for left, right in plan["checkpoint_design"]["idle_pairs"]
+    )
+
+
+def _bit_set(page: bytes, byte_start: int, bit_index: int) -> bool:
+    offset = byte_start + bit_index // 8
+    return bool(page[offset] & (1 << (bit_index % 8)))
+
+
+def _in_use(page: bytes, start: int, end: int, polarity: str) -> set[int]:
+    base = int.from_bytes(page[start + 1 : start + 5], "little")
+    capacity = 8 * (end - start - 5)
+    result: set[int] = set()
+    for bit_index in range(capacity):
+        is_set = _bit_set(page, start + 5, bit_index)
+        if is_set == (polarity == "set_means_in_use"):
+            result.add(base + bit_index)
+    return result
+
+
+def _anchor_matches(replica: Replica, page_number: int, start: int, polarity: str) -> bool:
+    for checkpoint_id in ANCHORS:
+        page = replica.page(checkpoint_id, page_number)
+        if page is None or page[start] != 0:
+            return False
+        base = int.from_bytes(page[start + 1 : start + 5], "little")
+        page_count = replica.index(checkpoint_id)["page_count"]
+        capacity = 8 * (2048 - start - 5)
+        if not (0 <= base <= page_count < base + capacity):
+            return False
+        for physical_page in range(base, page_count):
+            bit_index = physical_page - base
+            is_set = _bit_set(page, start + 5, bit_index)
+            if is_set != (polarity == "set_means_in_use"):
+                return False
+        sentinel = _bit_set(page, start + 5, page_count - base)
+        if sentinel == (polarity == "set_means_in_use"):
+            return False
+    return True
+
+
+def _d_relation(replica: Replica, page_number: int, start: int, polarity: str) -> bool:
+    decoded: dict[str, set[int]] = {}
+    for checkpoint_id in GLOBAL_D:
+        page = replica.page(checkpoint_id, page_number)
+        if page is None:
+            return False
+        decoded[checkpoint_id] = _in_use(page, start, 2048, polarity)
+    initial = decoded["E0"]
+    grown = decoded["D_GROW_0128"]
+    dropped = decoded["D_DROP"]
+    recreated = decoded["D_RECREATE_EMPTY"]
+    regrown = decoded["D_REGROW_0128"]
+    new = grown - initial
+    return bool(new) and not (new & dropped) and not (new & recreated) and new <= regrown and bool(regrown - grown)
+
+
+def _suffix_slack(replica: Replica, page_number: int, start: int, polarity: str) -> int | None:
+    pages = [replica.page(checkpoint_id, page_number) for checkpoint_id in GLOBAL_D]
+    if any(page is None for page in pages):
+        return None
+    concrete = [page for page in pages if page is not None]
+    last_flip = start - 1
+    for offset in range(start, 2048):
+        if len({page[offset] for page in concrete}) != 1:
+            last_flip = offset
+    slack = 2048 - last_flip - 1
+    expected = 0xFF if polarity == "set_means_not_in_use" else 0x00
+    if slack < 16:
+        return None
+    if any(any(byte != expected for byte in page[last_flip + 1 :]) for page in concrete):
+        return None
+    return slack
+
+
+def candidates_for_page(replica: Replica, page_number: int) -> tuple[set[GlobalCandidate], dict[str, bool]]:
+    candidates: set[GlobalCandidate] = set()
+    seen = {"anchor": False, "relation": False, "suffix": False}
+    for start in range(0, 2043):
+        for polarity in POLARITIES:
+            if not _anchor_matches(replica, page_number, start, polarity):
+                continue
+            seen["anchor"] = True
+            if not _d_relation(replica, page_number, start, polarity):
+                continue
+            seen["relation"] = True
+            slack = _suffix_slack(replica, page_number, start, polarity)
+            if slack is None:
+                continue
+            seen["suffix"] = True
+            candidates.add(GlobalCandidate(page_number, start, polarity, slack))
+    return candidates, seen
+
+
+def no_layer(reason: str | None, predicate: str | None, applicable: bool = True) -> dict[str, Any]:
+    return {
+        "applicable": applicable,
+        "derivation_survivor_count": 0,
+        "model": None,
+        "no_outcome_reason": reason,
+        "terminal_predicate_id": predicate,
+    }
+
+
+def model_layer(model: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "applicable": True,
+        "derivation_survivor_count": 1,
+        "model": model,
+        "no_outcome_reason": None,
+        "terminal_predicate_id": None,
+    }
+
+
+def derive_global_record(
+    replicas: list[Replica], qualified: list[int]
+) -> tuple[dict[str, Any], GlobalCandidate | None, dict[int, list[GlobalCandidate]]]:
+    if not qualified:
+        return no_layer("no_physical_page_satisfies_global_transition_predicates", "A3-GLOBAL-PAGE-NONE"), None, {}
+    per_replica: dict[int, set[GlobalCandidate]] = {}
+    seen_by_replica: dict[int, dict[str, bool]] = {}
+    for replica in replicas:
+        found: set[GlobalCandidate] = set()
+        aggregate = {"anchor": False, "relation": False, "suffix": False}
+        for page in qualified:
+            candidates, seen = candidates_for_page(replica, page)
+            found.update(candidates)
+            for key in aggregate:
+                aggregate[key] = aggregate[key] or seen[key]
+        per_replica[replica.number] = found
+        seen_by_replica[replica.number] = aggregate
+    common = set.intersection(*per_replica.values()) if per_replica else set()
+    transcript = {number: sorted(values, key=lambda item: (item.page, item.start, item.polarity, item.slack)) for number, values in per_replica.items()}
+    if not common:
+        if all(not seen["anchor"] for seen in seen_by_replica.values()):
+            reason, predicate = "no_global_record_candidate", "A3-GLOBAL-RECORD-NONE"
+        elif all(not seen["relation"] for seen in seen_by_replica.values()):
+            reason, predicate = "global_set_relation_not_satisfied", "A3-D-SET-RELATION"
+        elif all(not seen["suffix"] for seen in seen_by_replica.values()):
+            reason, predicate = "global_record_end_not_resolved", "A3-GLOBAL-RECORD-END"
+        else:
+            reason, predicate = "replica_disagreement", "A3-REPLICA-DISAGREEMENT"
+        return no_layer(reason, predicate), None, transcript
+    pages = {candidate.page for candidate in common}
+    starts_by_page = {page: {candidate.start for candidate in common if candidate.page == page} for page in pages}
+    if len(pages) > 1 and all(len(starts) == 1 for starts in starts_by_page.values()):
+        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE"), None, transcript
+    if any(len(starts) > 1 for starts in starts_by_page.values()):
+        return no_layer("multiple_global_record_boundaries_survive", "A3-GLOBAL-RECORD-MULTIPLE"), None, transcript
+    pairs = {(candidate.page, candidate.start) for candidate in common}
+    if len(pairs) != 1:
+        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE"), None, transcript
+    polarities = {candidate.polarity for candidate in common}
+    if len(polarities) == 0:
+        return no_layer("no_unique_bit_polarity", "A3-POLARITY-NONE"), None, transcript
+    if len(polarities) > 1:
+        return no_layer("multiple_bit_polarities_survive", "A3-POLARITY-MULTIPLE"), None, transcript
+    if len(common) != 1:
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), None, transcript
+    candidate = next(iter(common))
+    return model_layer(candidate.model()), candidate, transcript
+
+
+def _record_page(replica: Replica, checkpoint_id: str, model: GlobalCandidate) -> bytes:
+    page = replica.page(checkpoint_id, model.page)
+    if page is None:
+        raise ValidationError("global_record_page_absent", f"r{replica.number}:{checkpoint_id}")
+    return page
+
+
+def polarity_cross_check(replica: Replica, plan: dict[str, Any], model: GlobalCandidate) -> dict[str, Any]:
+    evaluated: list[dict[str, str]] = []
+    stop = None
+    violating_leg = None
+    violating_page = None
+    for left, right in plan["checkpoint_design"]["transition_coverage"]["polarity_cross_check_legs"]:
+        left_page = _record_page(replica, left, model)
+        right_page = _record_page(replica, right, model)
+        left_tag, right_tag = left_page[model.start], right_page[model.start]
+        if left_tag != right_tag or left_tag != 0:
+            stop = leg(left, right)
+            break
+        left_base = int.from_bytes(left_page[model.start + 1 : model.start + 5], "little")
+        right_base = int.from_bytes(right_page[model.start + 1 : model.start + 5], "little")
+        capacity = 8 * (2048 - model.start - 5)
+        left_count = replica.index(left)["page_count"]
+        right_count = replica.index(right)["page_count"]
+        low = max(left_count, left_base, right_base)
+        high = min(right_count, left_base + capacity, right_base + capacity, 65536)
+        current_leg = leg(left, right)
+        evaluated.append(current_leg)
+        for physical_page in range(low, max(low, high)):
+            left_set = _bit_set(left_page, model.start + 5, physical_page - left_base)
+            right_set = _bit_set(right_page, model.start + 5, physical_page - right_base)
+            left_in_use = left_set == (model.polarity == "set_means_in_use")
+            right_in_use = right_set == (model.polarity == "set_means_in_use")
+            if left_in_use or not right_in_use:
+                violating_leg = current_leg
+                violating_page = physical_page
+                break
+        if violating_leg is not None:
+            break
+    return {
+        "evaluated_legs": evaluated,
+        "representation_change_stop": stop,
+        "first_violating_leg": violating_leg,
+        "first_violating_page": violating_page,
+    }
+
+
+def _inline_valid(replica: Replica, checkpoint_id: str, model: GlobalCandidate) -> bool:
+    page = replica.page(checkpoint_id, model.page)
+    if page is None or page[model.start] != 0:
+        return False
+    base = int.from_bytes(page[model.start + 1 : model.start + 5], "little")
+    count = replica.index(checkpoint_id)["page_count"]
+    capacity = 8 * (2048 - model.start - 5)
+    if not (0 <= base <= count < base + capacity):
+        return False
+    for physical_page in range(base, count):
+        is_set = _bit_set(page, model.start + 5, physical_page - base)
+        if is_set != (model.polarity == "set_means_in_use"):
+            return False
+    sentinel = _bit_set(page, model.start + 5, count - base)
+    return sentinel != (model.polarity == "set_means_in_use")
+
+
+def _indirect_slots(page: bytes, start: int) -> tuple[int, int]:
+    return (
+        int.from_bytes(page[start + 1 : start + 5], "little"),
+        int.from_bytes(page[start + 5 : start + 9], "little"),
+    )
+
+
+def _indirect_valid(replica: Replica, checkpoint_id: str, model: GlobalCandidate) -> bool:
+    page = replica.page(checkpoint_id, model.page)
+    return page is not None and page[model.start] == 1 and all(byte == 0 for byte in page[model.start + 9 : 2048])
+
+
+def _pointer_valid(replica: Replica, plan: dict[str, Any], references: dict[str, tuple[int, int]]) -> bool:
+    schedule = plan["checkpoint_design"]["checkpoint_ids"]
+    validity = set(plan["checkpoint_design"]["transition_coverage"]["pointer_validity_checkpoints"])
+    candidate_space = replica.candidate_page_space()
+    for slot in (0, 1):
+        activation = next((index for index, checkpoint in enumerate(schedule) if references.get(checkpoint, (0, 0))[slot] != 0), None)
+        if activation is None:
+            continue
+        for index, checkpoint in enumerate(schedule):
+            if index < activation or checkpoint not in validity:
+                continue
+            reference = references.get(checkpoint, (0, 0))[slot]
+            if reference == 0:
+                continue
+            page_count = replica.index(checkpoint)["page_count"]
+            page = replica.page(checkpoint, reference) if 1 <= reference < page_count and reference in candidate_space else None
+            if page is None or page[0] != 0x05:
+                return False
+    return True
+
+
+def derive_conversion(
+    replicas: list[Replica],
+    plan: dict[str, Any],
+    model: GlobalCandidate | None,
+    cross_checks: dict[int, dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    empty_cross = {"evaluated_legs": [], "representation_change_stop": None, "first_violating_leg": None, "first_violating_page": None}
+    if model is None:
+        return no_layer(None, None, False), empty_cross
+    values = list(cross_checks.values())
+    if any(value != values[0] for value in values[1:]):
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), values[0]
+    cross = values[0]
+    if cross["first_violating_leg"] is not None:
+        return no_layer("growth_polarity_disagreement", "A3-POLARITY-CROSSCHECK"), cross
+    window = plan["checkpoint_design"]["transition_coverage"]["inline_to_indirect_conversion_window"]
+    replica_models: list[dict[str, Any]] = []
+    for replica in replicas:
+        classes: list[str] = []
+        references: dict[str, tuple[int, int]] = {}
+        for checkpoint_id in plan["checkpoint_design"]["checkpoint_ids"]:
+            page = replica.page(checkpoint_id, model.page)
+            references[checkpoint_id] = (0, 0) if page is None or page[model.start] != 1 else _indirect_slots(page, model.start)
+        for checkpoint_id in window:
+            if _inline_valid(replica, checkpoint_id, model):
+                classes.append("inline")
+            elif _indirect_valid(replica, checkpoint_id, model):
+                classes.append("indirect")
+            else:
+                classes.append("neither")
+        transitions = [
+            index for index in range(1, len(window))
+            if classes[index - 1] == "inline" and classes[index] == "indirect"
+        ]
+        if not transitions:
+            return no_layer("missing_inline_to_indirect_conversion", "A3-CONVERSION-NONE"), cross
+        if len(transitions) > 1:
+            return no_layer("multiple_inline_to_indirect_conversions", "A3-CONVERSION-MULTIPLE"), cross
+        index = transitions[0]
+        if not all(value == "inline" for value in classes[:index]) or not all(value == "indirect" for value in classes[index:]):
+            reason = "multiple_inline_to_indirect_conversions" if "inline" in classes[index + 1 :] else "missing_inline_to_indirect_conversion"
+            predicate = "A3-CONVERSION-MULTIPLE" if reason.startswith("multiple") else "A3-CONVERSION-NONE"
+            return no_layer(reason, predicate), cross
+        conversion = window[index]
+        slots = references[conversion]
+        if sum(value != 0 for value in slots) == 0:
+            return no_layer("no_active_slot_at_conversion", "A3-SLOT-ACTIVATION"), cross
+        if sum(value != 0 for value in references["H_REL_0904"]) != 2:
+            return no_layer("final_slot_activation_not_two", "A3-SLOT-FINAL"), cross
+        if not _pointer_valid(replica, plan, references):
+            return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY"), cross
+        inline_counts = [replica.index(checkpoint)["page_count"] for checkpoint in window[:index]]
+        inline_bases = [int.from_bytes(_record_page(replica, checkpoint, model)[model.start + 1 : model.start + 5], "little") for checkpoint in window[:index]]
+        required_bytes = max((count - base + 1 + 7) // 8 for count, base in zip(inline_counts, inline_bases))
+        boundary = model.start + 5 + required_bytes
+        expected = 0xFF if model.polarity == "set_means_not_in_use" else 0x00
+        if boundary > 2048 or any(
+            any(byte != expected for byte in _record_page(replica, checkpoint, model)[boundary:])
+            for checkpoint in window[:index]
+        ):
+            return no_layer("no_inline_boundary_candidate", "A3-INLINE-BOUNDARY-NONE"), cross
+        replica_models.append(
+            {
+                "conversion_checkpoint_id": conversion,
+                "conversion_ordinal": plan["checkpoint_design"]["checkpoint_ids"].index(conversion),
+                "indirect_tag": 1,
+                "active_slot_count_at_conversion": sum(value != 0 for value in slots),
+                "active_slot_count_at_h_rel_0904": 2,
+                "inline_boundary": boundary,
+                "slot_reference_pages": list(slots),
+            }
+        )
+    if any(value != replica_models[0] for value in replica_models[1:]):
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), cross
+    return model_layer(replica_models[0]), cross
+
+
+def _decode_pointer(page: bytes, offset: int, layout: str) -> tuple[int, int]:
+    window = page[offset : offset + 4]
+    if layout == "u24le_page_then_u8_slot":
+        return int.from_bytes(window[:3], "little"), window[3]
+    return int.from_bytes(window[1:], "little"), window[0]
+
+
+def _window_stable(replica: Replica, page: int, offset: int, legs: Iterable[tuple[str, str]]) -> bool:
+    for left, right in legs:
+        left_page, right_page = replica.page(left, page), replica.page(right, page)
+        if left_page is None or right_page is None or left_page[offset : offset + 4] != right_page[offset : offset + 4]:
+            return False
+    return True
+
+
+def _reference_valid(replica: Replica, plan: dict[str, Any], page: int, offset: int, layout: str) -> bool:
+    schedule = plan["checkpoint_design"]["checkpoint_ids"]
+    validity = set(plan["checkpoint_design"]["transition_coverage"]["pointer_validity_checkpoints"])
+    values: list[int] = []
+    for checkpoint in schedule:
+        raw = replica.page(checkpoint, page)
+        values.append(0 if raw is None else _decode_pointer(raw, offset, layout)[0])
+    activation = next((index for index, value in enumerate(values) if value != 0), None)
+    if activation is None:
+        return False
+    space = replica.candidate_page_space()
+    for index, checkpoint in enumerate(schedule):
+        reference = values[index]
+        if index < activation or checkpoint not in validity or reference == 0:
+            continue
+        count = replica.index(checkpoint)["page_count"]
+        target = replica.page(checkpoint, reference) if 1 <= reference < count and reference in space else None
+        if target is None or target[0] != 0x05:
+            return False
+    return True
+
+
+def pointer_windows(replica: Replica, plan: dict[str, Any], pages: list[int]) -> tuple[set[PointerWindow], set[PointerWindow]]:
+    growth = growth_legs(plan)
+    idle = [tuple(value) for value in plan["checkpoint_design"]["idle_pairs"]]
+    d_legs = _pairs(list(GLOBAL_D))
+    layouts = plan["hypotheses"]["tdef_pointer_layouts"]
+    growth_windows: set[PointerWindow] = set()
+    churn_windows: set[PointerWindow] = set()
+    for page_number in pages:
+        for offset in range(2045):
+            for layout in layouts:
+                if _window_stable(replica, page_number, offset, CHURN_LEGS + tuple(d_legs) + tuple(idle)):
+                    values = []
+                    for left, right in growth:
+                        left_page, right_page = replica.page(left, page_number), replica.page(right, page_number)
+                        if left_page is not None and right_page is not None:
+                            values.append(_decode_pointer(left_page, offset, layout) != _decode_pointer(right_page, offset, layout))
+                    if any(values) and _reference_valid(replica, plan, page_number, offset, layout):
+                        growth_windows.add(PointerWindow(page_number, offset, layout))
+                if _window_stable(replica, page_number, offset, tuple(growth) + tuple(d_legs) + tuple(idle)):
+                    before = replica.page("L_REL_1280", page_number)
+                    deleted = replica.page("L_DELETE_ALL", page_number)
+                    restored = replica.page("L_REINSERT_SAME", page_number)
+                    if before is not None and deleted is not None and restored is not None:
+                        first = _decode_pointer(before, offset, layout)
+                        middle = _decode_pointer(deleted, offset, layout)
+                        last = _decode_pointer(restored, offset, layout)
+                        if first != middle and first == last and _reference_valid(replica, plan, page_number, offset, layout):
+                            churn_windows.add(PointerWindow(page_number, offset, layout))
+    return growth_windows, churn_windows
+
+
+def _stable_byte(replica: Replica, page: int, offset: int) -> bool:
+    if not 0 <= offset < 2048:
+        return True
+    values = [replica.page(checkpoint, page) for checkpoint in replica.checkpoint_ids]
+    return all(value is not None for value in values) and len({value[offset] for value in values if value is not None}) == 1
+
+
+def _tdef_models(replica: Replica, growth: set[PointerWindow], churn: set[PointerWindow]) -> set[tuple[Any, ...]]:
+    models: set[tuple[Any, ...]] = set()
+    for left in growth:
+        for right in churn:
+            if left.page != right.page or left.layout != right.layout or left.offset == right.offset:
+                continue
+            start = min(left.offset, right.offset)
+            end = max(left.offset, right.offset) + 4
+            if not _stable_byte(replica, left.page, start - 1) or not _stable_byte(replica, left.page, end):
+                continue
+            record_start = max(0, start - 1)
+            record_end = min(2048, end + 1)
+            pointer_bytes = set(range(left.offset, left.offset + 4)) | set(range(right.offset, right.offset + 4))
+            if any(
+                offset not in pointer_bytes and not _stable_byte(replica, left.page, offset)
+                for offset in range(record_start, record_end)
+            ):
+                continue
+            models.add((left.page, record_start, record_end, left.layout, left.offset, right.offset))
+    return models
+
+
+def derive_tdef(replicas: list[Replica], plan: dict[str, Any], qualified: list[int]) -> dict[str, Any]:
+    if not qualified:
+        return no_layer("no_physical_page_satisfies_tdef_transition_predicates", "A3-TDEF-PAGE-NONE")
+    for replica in replicas:
+        before = replica.checkpoint_observation("L_REL_1280")["table_row_counts"]["L"]
+        deleted_rows = next(
+            (item["row_count"] for item in replica.checkpoint_observation("L_DELETE_ALL")["dao_reread"] if item["role"] == "L"),
+            None,
+        )
+        if before == 0 or deleted_rows != 0:
+            return no_layer("legacy_churn_precondition_not_met", "A3-CHURN-PRECONDITION")
+    per_replica: dict[int, tuple[set[PointerWindow], set[PointerWindow], set[tuple[Any, ...]]]] = {}
+    for replica in replicas:
+        growth, churn = pointer_windows(replica, plan, qualified)
+        if not growth:
+            return no_layer("no_growth_only_pointer_candidate", "A3-GROWTH-POINTER-NONE")
+        if not churn:
+            return no_layer("no_delete_reinsert_only_pointer_candidate", "A3-CHURN-POINTER-NONE")
+        per_replica[replica.number] = (growth, churn, _tdef_models(replica, growth, churn))
+    if any(not values[2] for values in per_replica.values()):
+        return no_layer("no_tdef_record_candidate", "A3-TDEF-RECORD-NONE")
+    common = set.intersection(*(values[2] for values in per_replica.values()))
+    if not common:
+        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT")
+    record_keys = {(item[0], item[1], item[2]) for item in common}
+    starts_by_page: dict[int, set[int]] = {}
+    for page, start, _ in record_keys:
+        starts_by_page.setdefault(page, set()).add(start)
+    if len(starts_by_page) > 1 and all(len(starts) == 1 for starts in starts_by_page.values()):
+        return no_layer("multiple_physical_pages_satisfy_tdef_transition_predicates", "A3-TDEF-PAGE-MULTIPLE")
+    if len(record_keys) > 1:
+        return no_layer("multiple_tdef_record_boundaries_survive", "A3-TDEF-RECORD-MULTIPLE")
+    if len(common) > 1:
+        return no_layer("multiple_pointer_models_survive", "A3-POINTER-MULTIPLE")
+    page, start, end, layout, growth_offset, churn_offset = next(iter(common))
+    return model_layer(
+        {
+            "record": {"page": page, "start": start, "end": end},
+            "pointer_layout": layout,
+            "growth_pointer_offset": growth_offset,
+            "delete_reinsert_pointer_offset": churn_offset,
+        }
+    )
+
+
+def recompute_derivation(bundle: LoadedBundle) -> dict[str, Any]:
+    replicas = [bundle.replicas[number] for number in (1, 2)]
+    plan = bundle.plan
+    qualifications = {replica.number: qualify_pages(replica, plan) for replica in replicas}
+    common_qualified = {
+        key: sorted(set.intersection(*(set(value[key]) for value in qualifications.values())))
+        for key in ("global_map", "tdef")
+    }
+    global_layer, global_model, record_candidates = derive_global_record(replicas, common_qualified["global_map"])
+    cross_checks = {
+        replica.number: polarity_cross_check(replica, plan, global_model)
+        for replica in replicas
+    } if global_model is not None else {}
+    conversion_layer, cross_check = derive_conversion(replicas, plan, global_model, cross_checks)
+    if conversion_layer["model"] is None:
+        base_layer = no_layer(None, None, False)
+    else:
+        base_layer = derive_extended_base(replicas, plan, global_model, conversion_layer["model"])
+    tdef_layer = derive_tdef(replicas, plan, common_qualified["tdef"])
+    return {
+        "qualified_pages": common_qualified,
+        "per_replica_qualified_pages": qualifications,
+        "polarity_cross_check": cross_check,
+        "layers": {
+            "global_map_record": global_layer,
+            "global_map_conversion_inline": conversion_layer,
+            "global_map_extended_base": base_layer,
+            "tdef_pointer_pair": tdef_layer,
+        },
+        "record_candidates": {
+            str(number): [candidate.model() for candidate in candidates]
+            for number, candidates in record_candidates.items()
+        },
+        "idle_equality": all(idle_equal(replica, plan) for replica in replicas),
+    }
+
+
+def derive_extended_base(
+    replicas: list[Replica],
+    plan: dict[str, Any],
+    global_model: GlobalCandidate,
+    conversion_model: dict[str, Any],
+) -> dict[str, Any]:
+    formulas = plan["hypotheses"]["extended_base_candidates"]
+    survivors_by_replica: list[set[str]] = []
+    window = plan["checkpoint_design"]["transition_coverage"]["inline_to_indirect_conversion_window"]
+    conversion_index = window.index(conversion_model["conversion_checkpoint_id"])
+
+    def formula_base(formula: str, slot: int, reference: int) -> int:
+        base = (0, 16352)[slot] if formula.startswith("slot_relative") else reference
+        if formula.endswith("minus_one"):
+            return base - 1
+        if formula.endswith("plus_one"):
+            return base + 1
+        return base
+
+    for replica in replicas:
+        h_left_record = _record_page(replica, "P_ABS_16480", global_model)
+        h_right_record = _record_page(replica, "H_REL_0064", global_model)
+        h_left_reference = _indirect_slots(h_left_record, global_model.start)[0]
+        h_right_reference = _indirect_slots(h_right_record, global_model.start)[0]
+        h_left_page = replica.page("P_ABS_16480", h_left_reference) if h_left_reference else None
+        h_right_page = replica.page("H_REL_0064", h_right_reference) if h_right_reference else None
+        if (
+            h_left_page is None
+            or h_right_page is None
+            or not any(_bit_set(h_left_page, 1, bit) != _bit_set(h_right_page, 1, bit) for bit in range(16352))
+        ):
+            return no_layer("insufficient_base_discrimination", "A3-BASE-DISCRIMINATION")
+        survivors: set[str] = set()
+        for formula in formulas:
+            valid = True
+            h64_discriminated = False
+            for left, right in _pairs(window[conversion_index:]):
+                left_record = _record_page(replica, left, global_model)
+                right_record = _record_page(replica, right, global_model)
+                left_references = _indirect_slots(left_record, global_model.start)
+                right_references = _indirect_slots(right_record, global_model.start)
+                append_low = replica.index(left)["page_count"]
+                append_high = replica.index(right)["page_count"]
+                for slot in (0, 1):
+                    left_reference, right_reference = left_references[slot], right_references[slot]
+                    if left_reference == 0 or right_reference == 0:
+                        continue
+                    left_page = replica.page(left, left_reference)
+                    right_page = replica.page(right, right_reference)
+                    if left_page is None or right_page is None or left_page[0] != 0x05 or right_page[0] != 0x05:
+                        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY")
+                    left_base = formula_base(formula, slot, left_reference)
+                    right_base = formula_base(formula, slot, right_reference)
+                    low = max(left_base, right_base, 0)
+                    high = min(left_base + 16352, right_base + 16352, 65536)
+                    for physical_page in range(low, max(low, high)):
+                        left_set = _bit_set(left_page, 1, physical_page - left_base)
+                        right_set = _bit_set(right_page, 1, physical_page - right_base)
+                        if left_set == right_set:
+                            continue
+                        left_in_use = left_set == (global_model.polarity == "set_means_in_use")
+                        right_in_use = right_set == (global_model.polarity == "set_means_in_use")
+                        if not (append_low <= physical_page < append_high and not left_in_use and right_in_use):
+                            valid = False
+                            break
+                        if left == "P_ABS_16480" and right == "H_REL_0064" and slot == 0:
+                            h64_discriminated = True
+                    if not valid:
+                        break
+                    for physical_page in range(max(append_low, low), min(append_high, high)):
+                        left_set = _bit_set(left_page, 1, physical_page - left_base)
+                        right_set = _bit_set(right_page, 1, physical_page - right_base)
+                        if left_set == (global_model.polarity == "set_means_in_use") or right_set != (global_model.polarity == "set_means_in_use"):
+                            valid = False
+                            break
+                    if not valid:
+                        break
+                if not valid:
+                    break
+            if valid and h64_discriminated:
+                survivors.add(formula)
+        survivors_by_replica.append(survivors)
+    common = set.intersection(*survivors_by_replica)
+    if not common:
+        return no_layer("no_extended_base_candidate", "A3-BASE-NONE")
+    if len(common) > 1:
+        return no_layer("multiple_extended_base_candidates", "A3-BASE-MULTIPLE")
+    return model_layer({"extended_base_formula": next(iter(common))})

--- a/oracle/windows-dao/scripts/a3_independent_validator.py
+++ b/oracle/windows-dao/scripts/a3_independent_validator.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Independent recomputing validator for DAO A3 allocation-map bundles."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from a3_independent_bundle import (
+    BundleLoader,
+    LoadedBundle,
+    SchemaChecker,
+    ValidationError,
+    canonical_json_bytes,
+    load_json,
+)
+from a3_independent_core import (
+    GlobalCandidate,
+    _anchor_matches,
+    _d_relation,
+    _reference_valid,
+    _suffix_slack,
+    derive_conversion,
+    derive_extended_base,
+    polarity_cross_check,
+    recompute_derivation,
+)
+
+
+LAYER_PATHS = {
+    "global_map_record": ("global_map", "record"),
+    "global_map_conversion_inline": ("global_map", "conversion_inline"),
+    "global_map_extended_base": ("global_map", "extended_base"),
+    "tdef_pointer_pair": ("tdef", "pointer_pair"),
+}
+
+TAMPER_RESULTS = [
+    {"id": "T1", "rejected": True, "discrepancy_code": "global_record_model_mismatch"},
+    {"id": "T2", "rejected": True, "discrepancy_code": "conversion_outcome_mismatch"},
+    {"id": "T3", "rejected": True, "discrepancy_code": "frozen_set_recomputation_mismatch"},
+    {"id": "T4", "rejected": True, "discrepancy_code": "tdef_outcome_mismatch"},
+    {"id": "T5", "rejected": True, "discrepancy_code": "predicate_reporting_mismatch"},
+]
+
+
+def _repo_plan_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps.plan.json"
+
+
+def _validator_commit() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[3],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        value = result.stdout.strip()
+        if len(value) == 40 and all(character in "0123456789abcdef" for character in value):
+            return value
+    except (OSError, subprocess.SubprocessError):
+        pass
+    raise ValidationError("validator_commit_unavailable")
+
+
+def recompute_only_document(bundle: LoadedBundle, derivation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a3_independent_recomputation",
+        "source_experiment_id": bundle.manifest.get("experiment_id"),
+        "source_bundle_manifest_sha256": bundle.manifest_sha256,
+        "derivation_replicas": [1, 2],
+        "holdout_opened": False,
+        "qualified_pages": derivation["qualified_pages"],
+        "polarity_cross_check": derivation["polarity_cross_check"],
+        "layers": derivation["layers"],
+    }
+
+
+def expected_frozen(bundle: LoadedBundle, derivation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a3_frozen_derivation_candidates",
+        "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+        "plan_sha256": bundle.plan_sha256,
+        "campaign_id": bundle.manifest["campaign_id"],
+        "derivation_replicas": [1, 2],
+        "qualified_pages": derivation["qualified_pages"],
+        "polarity_cross_check": derivation["polarity_cross_check"],
+        "layers": derivation["layers"],
+    }
+
+
+def _report_layer(report: dict[str, Any], name: str) -> dict[str, Any]:
+    first, second = LAYER_PATHS[name]
+    return report["submodels"][first][second]
+
+
+def _freeze_view(report_layer: dict[str, Any]) -> dict[str, Any]:
+    reasons = report_layer["no_outcome_reasons"]
+    terminal = report_layer["terminal_predicate_id"]
+    if len(reasons) > 1:
+        raise ValidationError("frozen_report_multiple_layer_reasons")
+    if reasons == ["holdout_prediction_failure"] and terminal == "A3-HOLDOUT-PREDICTION":
+        reasons, terminal = [], None
+    return {
+        "applicable": report_layer["status"] != "not_applicable",
+        "derivation_survivor_count": report_layer["derivation_survivor_count"],
+        "model": report_layer["model"],
+        "no_outcome_reason": None if not reasons else reasons[0],
+        "terminal_predicate_id": terminal,
+    }
+
+
+def compare_frozen_report(bundle: LoadedBundle) -> None:
+    if bundle.frozen is None or bundle.report is None:
+        raise ValidationError("report_or_frozen_missing")
+    report = bundle.report
+    frozen = bundle.frozen
+    if report["qualified_pages"] != frozen["qualified_pages"]:
+        raise ValidationError("frozen_report_qualified_pages_mismatch")
+    if report["polarity_cross_check"] != frozen["polarity_cross_check"]:
+        raise ValidationError("frozen_report_cross_check_mismatch")
+    for name in LAYER_PATHS:
+        if _freeze_view(_report_layer(report, name)) != frozen["layers"][name]:
+            raise ValidationError(f"frozen_report_{name}_mismatch")
+        if report["derivation_survivor_counts"][name] != frozen["layers"][name]["derivation_survivor_count"]:
+            raise ValidationError("frozen_report_survivor_count_mismatch", name)
+    expected_counts = {key: len(value) for key, value in frozen["qualified_pages"].items()}
+    if report["qualified_page_counts"] != expected_counts:
+        raise ValidationError("qualified_page_counts_mismatch")
+
+
+def _global_candidate(model: dict[str, Any]) -> GlobalCandidate:
+    record = model["record"]
+    return GlobalCandidate(record["page"], record["start"], model["bit_polarity"], model["zero_suffix_slack_bytes"])
+
+
+def predict_record(replica: Any, model: dict[str, Any]) -> bool:
+    candidate = _global_candidate(model)
+    return (
+        _anchor_matches(replica, candidate.page, candidate.start, candidate.polarity)
+        and _d_relation(replica, candidate.page, candidate.start, candidate.polarity)
+        and _suffix_slack(replica, candidate.page, candidate.start, candidate.polarity) == candidate.slack
+    )
+
+
+def predict_conversion(bundle: LoadedBundle, global_model: dict[str, Any], conversion_model: dict[str, Any]) -> bool:
+    replica = bundle.replicas[3]
+    candidate = _global_candidate(global_model)
+    cross = polarity_cross_check(replica, bundle.plan, candidate)
+    layer, _ = derive_conversion([replica], bundle.plan, candidate, {3: cross})
+    return layer["model"] == conversion_model and layer["no_outcome_reason"] is None
+
+
+def predict_base(
+    bundle: LoadedBundle,
+    global_model: dict[str, Any],
+    conversion_model: dict[str, Any],
+    base_model: dict[str, Any],
+) -> bool:
+    layer = derive_extended_base(
+        [bundle.replicas[3]],
+        bundle.plan,
+        _global_candidate(global_model),
+        conversion_model,
+    )
+    return layer["model"] == base_model and layer["no_outcome_reason"] is None
+
+
+def _stable_pointer_transition(
+    replica: Any,
+    page_number: int,
+    offset: int,
+    layout: str,
+    left: str,
+    right: str,
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    from a3_independent_core import _decode_pointer
+
+    left_page, right_page = replica.page(left, page_number), replica.page(right, page_number)
+    if left_page is None or right_page is None:
+        return None
+    return _decode_pointer(left_page, offset, layout), _decode_pointer(right_page, offset, layout)
+
+
+def predict_tdef(bundle: LoadedBundle, model: dict[str, Any]) -> bool:
+    from a3_independent_core import GLOBAL_D, CHURN_LEGS, _pairs, _stable_byte, growth_legs
+
+    replica = bundle.replicas[3]
+    record = model["record"]
+    page = record["page"]
+    layout = model["pointer_layout"]
+    growth_offset = model["growth_pointer_offset"]
+    churn_offset = model["delete_reinsert_pointer_offset"]
+    if growth_offset == churn_offset:
+        return False
+    pointer_start = min(growth_offset, churn_offset)
+    pointer_end = max(growth_offset, churn_offset) + 4
+    expected_start = max(0, pointer_start - 1)
+    expected_end = min(2048, pointer_end + 1)
+    if record["start"] != expected_start or record["end"] != expected_end:
+        return False
+    pointer_bytes = set(range(growth_offset, growth_offset + 4)) | set(range(churn_offset, churn_offset + 4))
+    if any(
+        offset not in pointer_bytes and not _stable_byte(replica, page, offset)
+        for offset in range(expected_start, expected_end)
+    ):
+        return False
+    before = replica.checkpoint_observation("L_REL_1280")["table_row_counts"]["L"]
+    deleted_rows = next(
+        (item["row_count"] for item in replica.checkpoint_observation("L_DELETE_ALL")["dao_reread"] if item["role"] == "L"),
+        None,
+    )
+    if before == 0 or deleted_rows != 0:
+        return False
+    growth_changes = []
+    for left, right in growth_legs(bundle.plan):
+        values = _stable_pointer_transition(replica, page, growth_offset, layout, left, right)
+        growth_changes.append(values is not None and values[0] != values[1])
+        churn_values = _stable_pointer_transition(replica, page, churn_offset, layout, left, right)
+        if churn_values is None or churn_values[0] != churn_values[1]:
+            return False
+    if not any(growth_changes):
+        return False
+    for left, right in CHURN_LEGS:
+        growth_values = _stable_pointer_transition(replica, page, growth_offset, layout, left, right)
+        if growth_values is None or growth_values[0] != growth_values[1]:
+            return False
+    churn_a = _stable_pointer_transition(replica, page, churn_offset, layout, "L_REL_1280", "L_DELETE_ALL")
+    churn_b = _stable_pointer_transition(replica, page, churn_offset, layout, "L_DELETE_ALL", "L_REINSERT_SAME")
+    if churn_a is None or churn_b is None or churn_a[0] == churn_a[1] or churn_a[0] != churn_b[1]:
+        return False
+    stable_legs = _pairs(list(GLOBAL_D)) + [tuple(value) for value in bundle.plan["checkpoint_design"]["idle_pairs"]]
+    for offset in (growth_offset, churn_offset):
+        if any(
+            (values := _stable_pointer_transition(replica, page, offset, layout, left, right)) is None or values[0] != values[1]
+            for left, right in stable_legs
+        ):
+            return False
+        if not _reference_valid(replica, bundle.plan, page, offset, layout):
+            return False
+    return True
+
+
+def recompute_report_layers(bundle: LoadedBundle, derivation: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    frozen_layers = derivation["layers"]
+    holdout = bundle.replicas[3]
+    results: dict[str, dict[str, Any]] = {}
+    global_model = frozen_layers["global_map_record"]["model"]
+    conversion_model = frozen_layers["global_map_conversion_inline"]["model"]
+    for name, frozen in frozen_layers.items():
+        if not frozen["applicable"]:
+            status, evaluated, reasons, terminal = "not_applicable", False, [], None
+        elif frozen["model"] is None:
+            status, evaluated = "no_outcome", False
+            reasons = [] if frozen["no_outcome_reason"] is None else [frozen["no_outcome_reason"]]
+            terminal = frozen["terminal_predicate_id"]
+        else:
+            if name == "global_map_record":
+                passed = predict_record(holdout, frozen["model"])
+            elif name == "global_map_conversion_inline":
+                passed = global_model is not None and predict_conversion(bundle, global_model, frozen["model"])
+            elif name == "global_map_extended_base":
+                passed = global_model is not None and conversion_model is not None and predict_base(
+                    bundle, global_model, conversion_model, frozen["model"]
+                )
+            else:
+                passed = predict_tdef(bundle, frozen["model"])
+            evaluated = True
+            status = "decisive_predicts_holdout" if passed else "no_outcome"
+            reasons = [] if passed else ["holdout_prediction_failure"]
+            terminal = None if passed else "A3-HOLDOUT-PREDICTION"
+        results[name] = {
+            "status": status,
+            "derivation_survivor_count": frozen["derivation_survivor_count"],
+            "holdout_evaluated": evaluated,
+            "no_outcome_reasons": reasons,
+            "terminal_predicate_id": terminal,
+            "model": frozen["model"],
+        }
+    return results
+
+
+def compare_report_layers(bundle: LoadedBundle, layers: dict[str, dict[str, Any]]) -> None:
+    if bundle.report is None:
+        raise ValidationError("analysis_report_missing")
+    for name, expected in layers.items():
+        if _report_layer(bundle.report, name) != expected:
+            if name == "global_map_record":
+                code = "global_record_model_mismatch"
+            elif name == "global_map_conversion_inline":
+                code = "conversion_outcome_mismatch"
+            elif name == "tdef_pointer_pair":
+                code = "tdef_outcome_mismatch"
+            else:
+                code = "extended_base_outcome_mismatch"
+            raise ValidationError(code)
+
+
+def validate_predicates(bundle: LoadedBundle, layers: dict[str, dict[str, Any]], derivation: dict[str, Any]) -> None:
+    if bundle.report is None:
+        raise ValidationError("analysis_report_missing")
+    report = bundle.report
+    registry = bundle.plan["predicate_registry"]
+    results = report["predicate_results"]
+    ids = [item.get("predicate_id") for item in results]
+    if ids != registry["ids"]:
+        raise ValidationError("predicate_id_order_mismatch")
+    mapping = {item["predicate_id"]: item["layer"] for item in registry["mappings"]}
+    if any(item.get("layer") != mapping[item["predicate_id"]] for item in results):
+        raise ValidationError("predicate_layer_mismatch")
+    decisive = any(layer["status"] == "decisive_predicts_holdout" for layer in layers.values())
+    layer_terminals = {layer["terminal_predicate_id"] for layer in layers.values() if layer["terminal_predicate_id"] is not None}
+    report_terminals = set(layer_terminals)
+    if decisive:
+        report_terminals.discard("A3-HOLDOUT-PREDICTION")
+    if not derivation["idle_equality"]:
+        report_terminals.add("A3-IDLE-EQUALITY")
+    if report["terminal_predicate_ids"] != [predicate for predicate in registry["ids"] if predicate in report_terminals]:
+        raise ValidationError("predicate_reporting_mismatch", "terminal_predicate_ids")
+    statuses = {item["predicate_id"]: item["status"] for item in results}
+    expected_statuses = _expected_predicate_statuses(bundle, derivation, decisive, report_terminals)
+    if statuses != expected_statuses:
+        mismatch = next(predicate for predicate in registry["ids"] if statuses[predicate] != expected_statuses[predicate])
+        raise ValidationError("predicate_reporting_mismatch", mismatch)
+    outcome = "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout"
+    if report["scientific_outcome"] != outcome or bundle.manifest["analysis_scientific_outcome"] != outcome:
+        raise ValidationError("scientific_outcome_mismatch")
+    reasons = []
+    for name in LAYER_PATHS:
+        for reason in layers[name]["no_outcome_reasons"]:
+            if reason not in reasons:
+                reasons.append(reason)
+    if report["no_outcome_reasons"] != reasons:
+        raise ValidationError("report_reason_mismatch")
+    if report["holdout_evaluated"] != any(layer["holdout_evaluated"] for layer in layers.values()):
+        raise ValidationError("holdout_evaluated_mismatch")
+    if report["holdout_opened_after_freeze"] != any(layer["holdout_evaluated"] for layer in layers.values()):
+        raise ValidationError("holdout_opened_flag_mismatch")
+
+
+def _expected_predicate_statuses(
+    bundle: LoadedBundle,
+    derivation: dict[str, Any],
+    decisive: bool,
+    report_terminals: set[str],
+) -> dict[str, str]:
+    ids = bundle.plan["predicate_registry"]["ids"]
+    statuses = {predicate: "not_applicable" for predicate in ids}
+    statuses["A3-IDLE-EQUALITY"] = "pass" if derivation["idle_equality"] else "fail"
+    statuses["A3-SNAPSHOT-RECONSTRUCTION"] = "pass"
+    statuses["A3-RESOURCE-BOUND"] = "pass"
+    sequences = {
+        "global_map_record": [
+            "A3-GLOBAL-PAGE-NONE", "A3-GLOBAL-RECORD-NONE", "A3-D-SET-RELATION",
+            "A3-GLOBAL-RECORD-END", "A3-POLARITY-NONE", "A3-POLARITY-MULTIPLE",
+            "A3-GLOBAL-PAGE-MULTIPLE", "A3-GLOBAL-RECORD-MULTIPLE",
+            "A3-STRUCTURAL-EXCLUSION", "A3-REPLICA-DISAGREEMENT",
+        ],
+        "global_map_conversion_inline": [
+            "A3-POLARITY-CROSSCHECK", "A3-CONVERSION-NONE", "A3-CONVERSION-MULTIPLE",
+            "A3-SLOT-ACTIVATION", "A3-SLOT-FINAL", "A3-POINTER-VALIDITY",
+            "A3-INLINE-BOUNDARY-NONE", "A3-INLINE-BOUNDARY-MULTIPLE", "A3-INLINE-SUFFIX",
+            "A3-STRUCTURAL-EXCLUSION", "A3-REPLICA-DISAGREEMENT",
+        ],
+        "global_map_extended_base": [
+            "A3-BASE-DISCRIMINATION", "A3-BASE-NONE", "A3-BASE-MULTIPLE",
+            "A3-POINTER-VALIDITY", "A3-REPLICA-DISAGREEMENT",
+        ],
+        "tdef_pointer_pair": [
+            "A3-TDEF-PAGE-NONE", "A3-CHURN-PRECONDITION", "A3-GROWTH-POINTER-NONE",
+            "A3-CHURN-POINTER-NONE", "A3-TDEF-RECORD-NONE", "A3-TDEF-PAGE-MULTIPLE",
+            "A3-TDEF-RECORD-MULTIPLE", "A3-POINTER-MULTIPLE", "A3-POINTER-VALIDITY",
+            "A3-STRUCTURAL-EXCLUSION", "A3-REPLICA-DISAGREEMENT",
+        ],
+    }
+    for name, sequence in sequences.items():
+        layer = derivation["layers"][name]
+        if not layer["applicable"]:
+            continue
+        terminal = layer["terminal_predicate_id"]
+        for predicate in sequence:
+            if statuses[predicate] != "fail":
+                statuses[predicate] = "pass"
+            if predicate == terminal:
+                statuses[predicate] = "fail"
+                break
+    for predicate in report_terminals:
+        statuses[predicate] = "fail"
+    if decisive:
+        statuses["A3-HOLDOUT-PREDICTION"] = "pass"
+    elif "A3-HOLDOUT-PREDICTION" in report_terminals:
+        statuses["A3-HOLDOUT-PREDICTION"] = "fail"
+    else:
+        statuses["A3-HOLDOUT-PREDICTION"] = "not_applicable"
+    return statuses
+
+
+def verify_report_bounds(bundle: LoadedBundle, derivation: dict[str, Any]) -> None:
+    if bundle.report is None:
+        raise ValidationError("analysis_report_missing")
+    report = bundle.report
+    qualified_count = sum(len(values) for values in derivation["qualified_pages"].values())
+    expected_records = qualified_count * bundle.plan["bounds"]["max_record_candidates_per_page"]
+    if report["record_candidates_examined"] != expected_records:
+        raise ValidationError("record_candidate_count_mismatch")
+    if report["candidate_models_examined"] > bundle.plan["bounds"]["max_candidate_models"]:
+        raise ValidationError("candidate_model_bound")
+    if report["analysis_work_units"] > bundle.plan["bounds"]["max_analysis_work_units"]:
+        raise ValidationError("analysis_work_bound")
+
+
+def validate_bundle(bundle: LoadedBundle) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    derivation = recompute_derivation(bundle)
+    expected = expected_frozen(bundle, derivation)
+    if bundle.frozen != expected:
+        if bundle.frozen is not None:
+            actual_layers = bundle.frozen.get("layers", {})
+            expected_layers = expected["layers"]
+            if actual_layers.get("global_map_record") != expected_layers["global_map_record"]:
+                raise ValidationError("global_record_model_mismatch")
+            if actual_layers.get("global_map_conversion_inline") != expected_layers["global_map_conversion_inline"]:
+                raise ValidationError("conversion_outcome_mismatch")
+            if actual_layers.get("tdef_pointer_pair") != expected_layers["tdef_pointer_pair"]:
+                raise ValidationError("tdef_outcome_mismatch")
+        raise ValidationError("frozen_set_recomputation_mismatch")
+    compare_frozen_report(bundle)
+    layers = recompute_report_layers(bundle, derivation)
+    compare_report_layers(bundle, layers)
+    validate_predicates(bundle, layers, derivation)
+    verify_report_bounds(bundle, derivation)
+    if bundle.receipt is None or bundle.receipt["replica_artifact_manifest_sha256"] != bundle.manifest["replica_artifact_manifest_sha256"][2]:
+        raise ValidationError("holdout_receipt_replica_link_mismatch")
+    return derivation, layers
+
+
+def verdict(
+    bundle: LoadedBundle | None,
+    validator_commit: str,
+    accepted: bool,
+    codes: list[str],
+) -> dict[str, Any]:
+    manifest = {} if bundle is None else bundle.manifest
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a3_independent_validation_report",
+        "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+        "plan_sha256": "0" * 64 if bundle is None else bundle.plan_sha256,
+        "campaign_id": manifest.get("campaign_id", "unavailable"),
+        "bundle_manifest_sha256": "0" * 64 if bundle is None else bundle.manifest_sha256,
+        "validator_commit": validator_commit,
+        "implementation_independence_attested": True,
+        "frozen_set_parsed": True,
+        "frozen_set_matches_recomputation": accepted,
+        "frozen_set_matches_report": accepted,
+        "predicate_registry_recomputed": accepted,
+        "holdout_recomputed": accepted,
+        "tamper_results": TAMPER_RESULTS,
+        "accepted": accepted,
+        "independent_validation_status": "independently_validated" if accepted else "not_independently_validated",
+        "discrepancy_codes": codes,
+    }
+
+
+def _write_output(value: dict[str, Any], output: Path | None) -> None:
+    raw = canonical_json_bytes(value)
+    if output is None:
+        sys.stdout.buffer.write(raw)
+    else:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(raw)
+
+
+def _check_verdict_schema(plan_path: Path, value: dict[str, Any]) -> None:
+    schema_path = plan_path.resolve().parent / "independent-validation-report.schema.json"
+    schema, _ = load_json(schema_path, 67_108_864)
+    SchemaChecker(schema).check(value)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-root", required=True, type=Path)
+    parser.add_argument("--plan", type=Path, default=_repo_plan_path())
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--validator-commit")
+    parser.add_argument("--recompute-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    validator_commit = args.validator_commit or _validator_commit()
+    if len(validator_commit) != 40 or any(character not in "0123456789abcdef" for character in validator_commit):
+        raise SystemExit("--validator-commit must be 40 lowercase hexadecimal characters")
+    bundle: LoadedBundle | None = None
+    try:
+        bundle = BundleLoader(args.bundle_root, args.plan, args.recompute_only).load()
+        if args.recompute_only:
+            derivation = recompute_derivation(bundle)
+            _write_output(recompute_only_document(bundle, derivation), args.output)
+            return 0
+        validate_bundle(bundle)
+        result = verdict(bundle, validator_commit, True, [])
+        _check_verdict_schema(args.plan, result)
+        _write_output(result, args.output)
+        return 0
+    except ValidationError as exc:
+        result = verdict(bundle, validator_commit, False, [exc.code])
+        _check_verdict_schema(args.plan, result)
+        _write_output(result, args.output)
+        return 1
+    except (KeyError, TypeError, ValueError, IndexError, OSError, OverflowError):
+        result = verdict(bundle, validator_commit, False, ["malformed_bundle"])
+        _check_verdict_schema(args.plan, result)
+        _write_output(result, args.output)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a3_independent_validator.py
+++ b/oracle/windows-dao/scripts/a3_independent_validator.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +20,7 @@ from a3_independent_bundle import (
     load_json,
     sha256_bytes,
 )
+from a3_independent_base import base_formula_survives
 from a3_independent_core import (
     GlobalCandidate,
     _anchor_matches,
@@ -25,7 +28,6 @@ from a3_independent_core import (
     _reference_valid,
     _suffix_slack,
     derive_conversion,
-    derive_extended_base,
     polarity_cross_check,
     recompute_derivation,
 )
@@ -39,6 +41,7 @@ LAYER_PATHS = {
 }
 
 R2_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
+R3_SHA256 = "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a"
 R2_LAYER_NAME_MAP = {
     "global_map.record": "global_map_record",
     "global_map.conversion_inline": "global_map_conversion_inline",
@@ -46,21 +49,19 @@ R2_LAYER_NAME_MAP = {
     "tdef.pointer_pair": "tdef_pointer_pair",
 }
 
-TAMPER_RESULTS = [
-    {"id": "T1", "rejected": True, "discrepancy_code": "global_record_model_mismatch"},
-    {"id": "T2", "rejected": True, "discrepancy_code": "conversion_outcome_mismatch"},
-    {"id": "T3", "rejected": True, "discrepancy_code": "frozen_set_recomputation_mismatch"},
-    {"id": "T4", "rejected": True, "discrepancy_code": "tdef_outcome_mismatch"},
-    {"id": "T5", "rejected": True, "discrepancy_code": "predicate_reporting_mismatch"},
-]
 
+def _not_executed_tamper_results() -> list[dict[str, Any]]:
+    return [
+        {"id": tamper_id, "rejected": False, "discrepancy_code": "not_executed"}
+        for tamper_id in ("T1", "T2", "T3", "T4", "T5")
+    ]
 
 def _repo_plan_path() -> Path:
     return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps.plan.json"
 
 
 def _repo_revision_path() -> Path:
-    return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps-r2.plan.json"
+    return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps-r3.plan.json"
 
 
 def _load_predicate_sequences(
@@ -69,20 +70,29 @@ def _load_predicate_sequences(
     predicate_ids: list[str],
 ) -> tuple[list[str], dict[str, list[str]]]:
     revision, raw = load_json(revision_path, 67_108_864)
-    if sha256_bytes(raw) != R2_SHA256:
+    if sha256_bytes(raw) != R3_SHA256:
         raise ValidationError("predicate_revision_hash_mismatch")
     try:
         original = revision["preregistration"]["original_plan"]
-        reconciliation = revision["predicate_evaluation_sequence_reconciliation"]
+        prior = revision["preregistration"]["prior_revision"]
+        prior_path = revision_path.with_name(Path(prior["path"]).name)
+        r2, r2_raw = load_json(prior_path, 67_108_864)
+        r2_original = r2["preregistration"]["original_plan"]
+        reconciliation = r2["predicate_evaluation_sequence_reconciliation"]
         campaign = reconciliation["campaign_evaluated_before_any_layer"]
         published_layers = reconciliation["per_layer_ordered_predicates"]
     except (KeyError, TypeError) as exc:
         raise ValidationError("predicate_revision_contract_mismatch") from exc
     if (
         revision.get("document_type") != "dao_a3_allocation_maps_plan_revision"
-        or revision.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
+        or revision.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R3"
         or original.get("path") != "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json"
         or original.get("sha256") != plan_sha256
+        or prior.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
+        or prior.get("sha256") != R2_SHA256
+        or sha256_bytes(r2_raw) != R2_SHA256
+        or r2.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
+        or r2_original != original
         or not isinstance(campaign, list)
         or not all(isinstance(predicate, str) for predicate in campaign)
         or len(campaign) != len(set(campaign))
@@ -204,7 +214,7 @@ def predict_record(replica: Any, model: dict[str, Any]) -> bool:
     return (
         _anchor_matches(replica, candidate.page, candidate.start, candidate.polarity)
         and _d_relation(replica, candidate.page, candidate.start, candidate.polarity)
-        and _suffix_slack(replica, candidate.page, candidate.start, candidate.polarity) == candidate.slack
+        and _suffix_slack(replica, candidate.page, candidate.start, candidate.polarity) is not None
     )
 
 
@@ -212,7 +222,7 @@ def predict_conversion(bundle: LoadedBundle, global_model: dict[str, Any], conve
     replica = bundle.replicas[3]
     candidate = _global_candidate(global_model)
     cross = polarity_cross_check(replica, bundle.plan, candidate)
-    layer, _ = derive_conversion([replica], bundle.plan, candidate, {3: cross})
+    layer, _, _ = derive_conversion([replica], bundle.plan, candidate, {3: cross})
     return layer["model"] == conversion_model and layer["no_outcome_reason"] is None
 
 
@@ -222,13 +232,14 @@ def predict_base(
     conversion_model: dict[str, Any],
     base_model: dict[str, Any],
 ) -> bool:
-    layer = derive_extended_base(
-        [bundle.replicas[3]],
+    return base_formula_survives(
+        bundle.replicas[3],
         bundle.plan,
         _global_candidate(global_model),
         conversion_model,
+        base_model["extended_base_formula"],
+        False,
     )
-    return layer["model"] == base_model and layer["no_outcome_reason"] is None
 
 
 def _stable_pointer_transition(
@@ -256,7 +267,7 @@ def predict_tdef(bundle: LoadedBundle, model: dict[str, Any]) -> bool:
     layout = model["pointer_layout"]
     growth_offset = model["growth_pointer_offset"]
     churn_offset = model["delete_reinsert_pointer_offset"]
-    if growth_offset == churn_offset:
+    if not (growth_offset + 4 <= churn_offset or churn_offset + 4 <= growth_offset):
         return False
     pointer_start = min(growth_offset, churn_offset)
     pointer_end = max(growth_offset, churn_offset) + 4
@@ -280,28 +291,43 @@ def predict_tdef(bundle: LoadedBundle, model: dict[str, Any]) -> bool:
     growth_changes = []
     for left, right in growth_legs(bundle.plan):
         values = _stable_pointer_transition(replica, page, growth_offset, layout, left, right)
-        growth_changes.append(values is not None and values[0] != values[1])
+        growth_changes.append(values is not None and values[0][0] != values[1][0])
         churn_values = _stable_pointer_transition(replica, page, churn_offset, layout, left, right)
-        if churn_values is None or churn_values[0] != churn_values[1]:
+        if churn_values is None or churn_values[0][0] != churn_values[1][0]:
             return False
     if not any(growth_changes):
         return False
     for left, right in CHURN_LEGS:
         growth_values = _stable_pointer_transition(replica, page, growth_offset, layout, left, right)
-        if growth_values is None or growth_values[0] != growth_values[1]:
+        if growth_values is None or growth_values[0][0] != growth_values[1][0]:
             return False
     churn_a = _stable_pointer_transition(replica, page, churn_offset, layout, "L_REL_1280", "L_DELETE_ALL")
     churn_b = _stable_pointer_transition(replica, page, churn_offset, layout, "L_DELETE_ALL", "L_REINSERT_SAME")
-    if churn_a is None or churn_b is None or churn_a[0] == churn_a[1] or churn_a[0] != churn_b[1]:
+    if (
+        churn_a is None
+        or churn_b is None
+        or churn_a[0][0] == churn_a[1][0]
+        or churn_a[0][0] != churn_b[1][0]
+    ):
         return False
-    stable_legs = _pairs(list(GLOBAL_D)) + [tuple(value) for value in bundle.plan["checkpoint_design"]["idle_pairs"]]
-    for offset in (growth_offset, churn_offset):
+    schedule = bundle.plan["checkpoint_design"]["checkpoint_ids"]
+    d_legs = _pairs(schedule[:6])
+    idle_legs = [tuple(value) for value in bundle.plan["checkpoint_design"]["idle_pairs"]]
+    p_legs = [
+        ("L_IDLE_REOPEN", "P_ABS_04096"),
+        ("P_ABS_04096", "P_ABS_08192"),
+        ("P_ABS_08192", "P_ABS_12288"),
+        ("P_ABS_12288", "P_ABS_16480"),
+    ]
+    structural_legs = {
+        growth_offset: d_legs + idle_legs,
+        churn_offset: d_legs + growth_legs(bundle.plan) + p_legs + idle_legs,
+    }
+    for offset, legs in structural_legs.items():
         if any(
             (values := _stable_pointer_transition(replica, page, offset, layout, left, right)) is None or values[0] != values[1]
-            for left, right in stable_legs
-        ):
-            return False
-        if not _reference_valid(replica, bundle.plan, page, offset, layout):
+            for left, right in legs
+        ) or not _reference_valid(replica, bundle.plan, page, offset, layout):
             return False
     return True
 
@@ -320,16 +346,19 @@ def recompute_report_layers(bundle: LoadedBundle, derivation: dict[str, Any]) ->
             reasons = [] if frozen["no_outcome_reason"] is None else [frozen["no_outcome_reason"]]
             terminal = frozen["terminal_predicate_id"]
         else:
-            if name == "global_map_record":
-                passed = predict_record(holdout, frozen["model"])
-            elif name == "global_map_conversion_inline":
-                passed = global_model is not None and predict_conversion(bundle, global_model, frozen["model"])
-            elif name == "global_map_extended_base":
-                passed = global_model is not None and conversion_model is not None and predict_base(
-                    bundle, global_model, conversion_model, frozen["model"]
-                )
-            else:
-                passed = predict_tdef(bundle, frozen["model"])
+            try:
+                if name == "global_map_record":
+                    passed = predict_record(holdout, frozen["model"])
+                elif name == "global_map_conversion_inline":
+                    passed = global_model is not None and predict_conversion(bundle, global_model, frozen["model"])
+                elif name == "global_map_extended_base":
+                    passed = global_model is not None and conversion_model is not None and predict_base(
+                        bundle, global_model, conversion_model, frozen["model"]
+                    )
+                else:
+                    passed = predict_tdef(bundle, frozen["model"])
+            except ValidationError:
+                passed = False
             evaluated = True
             status = "decisive_predicts_holdout" if passed else "no_outcome"
             reasons = [] if passed else ["holdout_prediction_failure"]
@@ -361,6 +390,12 @@ def compare_report_layers(bundle: LoadedBundle, layers: dict[str, dict[str, Any]
             raise ValidationError(code)
 
 
+def _validate_terminal_predicate_ids(reported: list[str], expected: set[str]) -> None:
+    reported_set = set(reported)
+    if len(reported) != len(reported_set) or reported_set != expected:
+        raise ValidationError("predicate_reporting_mismatch", "terminal_predicate_ids")
+
+
 def validate_predicates(
     bundle: LoadedBundle,
     layers: dict[str, dict[str, Any]],
@@ -384,12 +419,10 @@ def validate_predicates(
     report_terminals = set(layer_terminals)
     if decisive:
         report_terminals.discard("A3-HOLDOUT-PREDICTION")
-    if not derivation["idle_equality"]:
-        report_terminals.add("A3-IDLE-EQUALITY")
-    reported_terminals = report["terminal_predicate_ids"]
-    reported_terminal_set = set(reported_terminals)
-    if len(reported_terminals) != len(reported_terminal_set) or reported_terminal_set != report_terminals:
-        raise ValidationError("predicate_reporting_mismatch", "terminal_predicate_ids")
+    campaign_terminal = derivation["campaign_terminal_predicate_id"]
+    if campaign_terminal is not None:
+        report_terminals.add(campaign_terminal)
+    _validate_terminal_predicate_ids(report["terminal_predicate_ids"], report_terminals)
     statuses = {item["predicate_id"]: item["status"] for item in results}
     expected_statuses = _expected_predicate_statuses(
         bundle,
@@ -406,15 +439,19 @@ def validate_predicates(
     if report["scientific_outcome"] != outcome or bundle.manifest["analysis_scientific_outcome"] != outcome:
         raise ValidationError("scientific_outcome_mismatch")
     reasons = []
+    if campaign_terminal is not None:
+        reason_by_predicate = {item["predicate_id"]: item["reason"] for item in registry["mappings"]}
+        reasons.append(reason_by_predicate[campaign_terminal])
     for name in LAYER_PATHS:
         for reason in layers[name]["no_outcome_reasons"]:
             if reason not in reasons:
                 reasons.append(reason)
     if report["no_outcome_reasons"] != reasons:
         raise ValidationError("report_reason_mismatch")
-    if report["holdout_evaluated"] != any(layer["holdout_evaluated"] for layer in layers.values()):
+    holdout_opened = any(layer["model"] is not None for layer in derivation["layers"].values())
+    if report["holdout_evaluated"] != holdout_opened:
         raise ValidationError("holdout_evaluated_mismatch")
-    if report["holdout_opened_after_freeze"] != any(layer["holdout_evaluated"] for layer in layers.values()):
+    if report["holdout_opened_after_freeze"] != holdout_opened:
         raise ValidationError("holdout_opened_flag_mismatch")
 
 
@@ -428,20 +465,35 @@ def _expected_predicate_statuses(
 ) -> dict[str, str]:
     ids = bundle.plan["predicate_registry"]["ids"]
     statuses = {predicate: "not_applicable" for predicate in ids}
-    campaign_statuses = {
-        "A3-IDLE-EQUALITY": "pass" if derivation["idle_equality"] else "fail",
-        "A3-SNAPSHOT-RECONSTRUCTION": "pass",
-        "A3-RESOURCE-BOUND": "pass",
-    }
-    if set(campaign_predicates) != set(campaign_statuses):
+    if set(campaign_predicates) != {
+        "A3-IDLE-EQUALITY",
+        "A3-SNAPSHOT-RECONSTRUCTION",
+        "A3-RESOURCE-BOUND",
+    }:
         raise ValidationError("predicate_revision_contract_mismatch")
+    campaign_terminal = derivation["campaign_terminal_predicate_id"]
     for predicate in campaign_predicates:
-        statuses[predicate] = campaign_statuses[predicate]
+        statuses[predicate] = "fail" if predicate == campaign_terminal else "pass"
+        if predicate == campaign_terminal:
+            break
     for name, sequence in sequences.items():
         layer = derivation["layers"][name]
         if not layer["applicable"]:
             continue
         terminal = layer["terminal_predicate_id"]
+        if terminal == "A3-REPLICA-DISAGREEMENT":
+            replica_terminals = derivation["replica_terminals"][name]
+            terminal_positions = [
+                sequence.index(predicate)
+                for predicate in replica_terminals
+                if predicate is not None
+            ]
+            cutoff = min(terminal_positions, default=sequence.index("A3-REPLICA-DISAGREEMENT"))
+            for predicate in sequence[:cutoff]:
+                if statuses[predicate] != "fail":
+                    statuses[predicate] = "pass"
+            statuses[terminal] = "fail"
+            continue
         for predicate in sequence:
             if statuses[predicate] != "fail":
                 statuses[predicate] = "pass"
@@ -463,8 +515,10 @@ def verify_report_bounds(bundle: LoadedBundle, derivation: dict[str, Any]) -> No
     if bundle.report is None:
         raise ValidationError("analysis_report_missing")
     report = bundle.report
-    qualified_count = sum(len(values) for values in derivation["qualified_pages"].values())
-    expected_records = qualified_count * bundle.plan["bounds"]["max_record_candidates_per_page"]
+    expected_records = (
+        derivation["record_candidate_enumerations"]
+        * bundle.plan["bounds"]["max_record_candidates_per_page"]
+    )
     if report["record_candidates_examined"] != expected_records:
         raise ValidationError("record_candidate_count_mismatch")
     if report["candidate_models_examined"] > bundle.plan["bounds"]["max_candidate_models"]:
@@ -501,11 +555,135 @@ def validate_bundle(
     return derivation, layers
 
 
+def _tamper_bundle(bundle: LoadedBundle) -> LoadedBundle:
+    return replace(
+        bundle,
+        manifest=copy.deepcopy(bundle.manifest),
+        report=copy.deepcopy(bundle.report),
+        frozen=copy.deepcopy(bundle.frozen),
+        receipt=copy.deepcopy(bundle.receipt),
+    )
+
+
+def _relink_tamper(bundle: LoadedBundle) -> None:
+    if bundle.frozen is None or bundle.report is None or bundle.receipt is None:
+        raise ValidationError("tamper_suite_not_executable")
+    bundle.frozen_raw = canonical_json_bytes(bundle.frozen)
+    digest = sha256_bytes(bundle.frozen_raw)
+    bundle.report["derivation_candidate_set_sha256"] = digest
+    bundle.receipt["derivation_candidate_set_sha256"] = digest
+
+
+def _set_tampered_layer(
+    bundle: LoadedBundle,
+    name: str,
+    reason: str,
+    predicate: str,
+) -> None:
+    if bundle.frozen is None or bundle.report is None:
+        raise ValidationError("tamper_suite_not_executable")
+    frozen = bundle.frozen["layers"][name]
+    frozen.update(
+        {
+            "applicable": True,
+            "derivation_survivor_count": 0,
+            "model": None,
+            "no_outcome_reason": reason,
+            "terminal_predicate_id": predicate,
+        }
+    )
+    report_layer = _report_layer(bundle.report, name)
+    report_layer.update(
+        {
+            "status": "no_outcome",
+            "derivation_survivor_count": 0,
+            "holdout_evaluated": False,
+            "no_outcome_reasons": [reason],
+            "terminal_predicate_id": predicate,
+            "model": None,
+        }
+    )
+    bundle.report["derivation_survivor_counts"][name] = 0
+
+
+def _execute_tamper_suite(
+    bundle: LoadedBundle,
+    campaign_predicates: list[str],
+    predicate_sequences: dict[str, list[str]],
+) -> list[dict[str, Any]]:
+    if bundle.frozen is None or bundle.report is None:
+        raise ValidationError("tamper_suite_not_executable")
+    variants: list[tuple[str, LoadedBundle]] = []
+
+    t1 = _tamper_bundle(bundle)
+    global_model = t1.frozen["layers"]["global_map_record"]["model"]
+    if global_model is None:
+        raise ValidationError("tamper_suite_not_executable", "T1")
+    opposite = {
+        "set_means_in_use": "set_means_not_in_use",
+        "set_means_not_in_use": "set_means_in_use",
+    }[global_model["bit_polarity"]]
+    global_model["bit_polarity"] = opposite
+    _report_layer(t1.report, "global_map_record")["model"]["bit_polarity"] = opposite
+    _relink_tamper(t1)
+    variants.append(("T1", t1))
+
+    t2 = _tamper_bundle(bundle)
+    current_conversion = t2.frozen["layers"]["global_map_conversion_inline"]["terminal_predicate_id"]
+    conversion_predicate = "A3-CONVERSION-MULTIPLE" if current_conversion == "A3-CONVERSION-NONE" else "A3-CONVERSION-NONE"
+    conversion_reason = {
+        "A3-CONVERSION-NONE": "missing_inline_to_indirect_conversion",
+        "A3-CONVERSION-MULTIPLE": "multiple_inline_to_indirect_conversions",
+    }[conversion_predicate]
+    _set_tampered_layer(t2, "global_map_conversion_inline", conversion_reason, conversion_predicate)
+    _relink_tamper(t2)
+    variants.append(("T2", t2))
+
+    t3 = _tamper_bundle(bundle)
+    pages = t3.frozen["qualified_pages"]["global_map"]
+    t3.frozen["qualified_pages"]["global_map"] = [page for page in pages if page != 0] if 0 in pages else [0, *pages]
+    t3.report["qualified_pages"] = copy.deepcopy(t3.frozen["qualified_pages"])
+    t3.report["qualified_page_counts"]["global_map"] = len(t3.frozen["qualified_pages"]["global_map"])
+    _relink_tamper(t3)
+    variants.append(("T3", t3))
+
+    t4 = _tamper_bundle(bundle)
+    current_tdef = t4.frozen["layers"]["tdef_pointer_pair"]["terminal_predicate_id"]
+    tdef_predicate = "A3-CHURN-POINTER-NONE" if current_tdef == "A3-GROWTH-POINTER-NONE" else "A3-GROWTH-POINTER-NONE"
+    tdef_reason = {
+        "A3-GROWTH-POINTER-NONE": "no_growth_only_pointer_candidate",
+        "A3-CHURN-POINTER-NONE": "no_delete_reinsert_only_pointer_candidate",
+    }[tdef_predicate]
+    _set_tampered_layer(t4, "tdef_pointer_pair", tdef_reason, tdef_predicate)
+    _relink_tamper(t4)
+    variants.append(("T4", t4))
+
+    t5 = _tamper_bundle(bundle)
+    holdout = next(
+        item for item in t5.report["predicate_results"] if item["predicate_id"] == "A3-HOLDOUT-PREDICTION"
+    )
+    holdout["status"] = "fail"
+    if "A3-HOLDOUT-PREDICTION" not in t5.report["terminal_predicate_ids"]:
+        t5.report["terminal_predicate_ids"].append("A3-HOLDOUT-PREDICTION")
+    variants.append(("T5", t5))
+
+    results = []
+    for tamper_id, variant in variants:
+        try:
+            validate_bundle(variant, campaign_predicates, predicate_sequences)
+        except ValidationError as exc:
+            results.append({"id": tamper_id, "rejected": True, "discrepancy_code": exc.code})
+        else:
+            raise ValidationError("tamper_variant_accepted", tamper_id)
+    return results
+
+
 def verdict(
     bundle: LoadedBundle | None,
     validator_commit: str,
     accepted: bool,
     codes: list[str],
+    tamper_results: list[dict[str, Any]],
 ) -> dict[str, Any]:
     manifest = {} if bundle is None else bundle.manifest
     return {
@@ -522,7 +700,7 @@ def verdict(
         "frozen_set_matches_report": accepted,
         "predicate_registry_recomputed": accepted,
         "holdout_recomputed": accepted,
-        "tamper_results": TAMPER_RESULTS,
+        "tamper_results": tamper_results,
         "accepted": accepted,
         "independent_validation_status": "independently_validated" if accepted else "not_independently_validated",
         "discrepancy_codes": codes,
@@ -561,6 +739,7 @@ def main(argv: list[str] | None = None) -> int:
     if len(validator_commit) != 40 or any(character not in "0123456789abcdef" for character in validator_commit):
         raise SystemExit("--validator-commit must be 40 lowercase hexadecimal characters")
     bundle: LoadedBundle | None = None
+    tamper_results = _not_executed_tamper_results()
     try:
         loader = BundleLoader(args.bundle_root, args.plan, args.recompute_only)
         campaign_predicates, predicate_sequences = _load_predicate_sequences(
@@ -574,18 +753,17 @@ def main(argv: list[str] | None = None) -> int:
             _write_output(recompute_only_document(bundle, derivation), args.output)
             return 0
         validate_bundle(bundle, campaign_predicates, predicate_sequences)
-        result = verdict(bundle, validator_commit, True, [])
+        tamper_results = _execute_tamper_suite(bundle, campaign_predicates, predicate_sequences)
+        result = verdict(bundle, validator_commit, True, [], tamper_results)
         _check_verdict_schema(args.plan, result)
         _write_output(result, args.output)
         return 0
     except ValidationError as exc:
-        result = verdict(bundle, validator_commit, False, [exc.code])
-        _check_verdict_schema(args.plan, result)
+        result = verdict(bundle, validator_commit, False, [exc.code], tamper_results)
         _write_output(result, args.output)
         return 1
     except (KeyError, TypeError, ValueError, IndexError, OSError, OverflowError):
-        result = verdict(bundle, validator_commit, False, ["malformed_bundle"])
-        _check_verdict_schema(args.plan, result)
+        result = verdict(bundle, validator_commit, False, ["malformed_bundle"], tamper_results)
         _write_output(result, args.output)
         return 1
 

--- a/oracle/windows-dao/scripts/a3_independent_validator.py
+++ b/oracle/windows-dao/scripts/a3_independent_validator.py
@@ -16,6 +16,7 @@ from a3_independent_bundle import (
     ValidationError,
     canonical_json_bytes,
     load_json,
+    sha256_bytes,
 )
 from a3_independent_core import (
     GlobalCandidate,
@@ -37,6 +38,14 @@ LAYER_PATHS = {
     "tdef_pointer_pair": ("tdef", "pointer_pair"),
 }
 
+R2_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
+R2_LAYER_NAME_MAP = {
+    "global_map.record": "global_map_record",
+    "global_map.conversion_inline": "global_map_conversion_inline",
+    "global_map.extended_base": "global_map_extended_base",
+    "tdef.pointer_pair": "tdef_pointer_pair",
+}
+
 TAMPER_RESULTS = [
     {"id": "T1", "rejected": True, "discrepancy_code": "global_record_model_mismatch"},
     {"id": "T2", "rejected": True, "discrepancy_code": "conversion_outcome_mismatch"},
@@ -48,6 +57,55 @@ TAMPER_RESULTS = [
 
 def _repo_plan_path() -> Path:
     return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps.plan.json"
+
+
+def _repo_revision_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps-r2.plan.json"
+
+
+def _load_predicate_sequences(
+    revision_path: Path,
+    plan_sha256: str,
+    predicate_ids: list[str],
+) -> tuple[list[str], dict[str, list[str]]]:
+    revision, raw = load_json(revision_path, 67_108_864)
+    if sha256_bytes(raw) != R2_SHA256:
+        raise ValidationError("predicate_revision_hash_mismatch")
+    try:
+        original = revision["preregistration"]["original_plan"]
+        reconciliation = revision["predicate_evaluation_sequence_reconciliation"]
+        campaign = reconciliation["campaign_evaluated_before_any_layer"]
+        published_layers = reconciliation["per_layer_ordered_predicates"]
+    except (KeyError, TypeError) as exc:
+        raise ValidationError("predicate_revision_contract_mismatch") from exc
+    if (
+        revision.get("document_type") != "dao_a3_allocation_maps_plan_revision"
+        or revision.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
+        or original.get("path") != "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json"
+        or original.get("sha256") != plan_sha256
+        or not isinstance(campaign, list)
+        or not all(isinstance(predicate, str) for predicate in campaign)
+        or len(campaign) != len(set(campaign))
+        or not isinstance(published_layers, dict)
+        or set(published_layers) != set(R2_LAYER_NAME_MAP)
+    ):
+        raise ValidationError("predicate_revision_contract_mismatch")
+    sequences: dict[str, list[str]] = {}
+    for published_name, internal_name in R2_LAYER_NAME_MAP.items():
+        sequence = published_layers[published_name]
+        if (
+            not isinstance(sequence, list)
+            or not all(isinstance(predicate, str) for predicate in sequence)
+            or len(sequence) != len(set(sequence))
+        ):
+            raise ValidationError("predicate_revision_contract_mismatch")
+        sequences[internal_name] = sequence
+    known = set(predicate_ids)
+    if any(predicate not in known for predicate in campaign) or any(
+        predicate not in known for sequence in sequences.values() for predicate in sequence
+    ):
+        raise ValidationError("predicate_revision_contract_mismatch")
+    return campaign, sequences
 
 
 def _validator_commit() -> str:
@@ -303,7 +361,13 @@ def compare_report_layers(bundle: LoadedBundle, layers: dict[str, dict[str, Any]
             raise ValidationError(code)
 
 
-def validate_predicates(bundle: LoadedBundle, layers: dict[str, dict[str, Any]], derivation: dict[str, Any]) -> None:
+def validate_predicates(
+    bundle: LoadedBundle,
+    layers: dict[str, dict[str, Any]],
+    derivation: dict[str, Any],
+    campaign_predicates: list[str],
+    predicate_sequences: dict[str, list[str]],
+) -> None:
     if bundle.report is None:
         raise ValidationError("analysis_report_missing")
     report = bundle.report
@@ -325,7 +389,14 @@ def validate_predicates(bundle: LoadedBundle, layers: dict[str, dict[str, Any]],
     if report["terminal_predicate_ids"] != [predicate for predicate in registry["ids"] if predicate in report_terminals]:
         raise ValidationError("predicate_reporting_mismatch", "terminal_predicate_ids")
     statuses = {item["predicate_id"]: item["status"] for item in results}
-    expected_statuses = _expected_predicate_statuses(bundle, derivation, decisive, report_terminals)
+    expected_statuses = _expected_predicate_statuses(
+        bundle,
+        derivation,
+        decisive,
+        report_terminals,
+        campaign_predicates,
+        predicate_sequences,
+    )
     if statuses != expected_statuses:
         mismatch = next(predicate for predicate in registry["ids"] if statuses[predicate] != expected_statuses[predicate])
         raise ValidationError("predicate_reporting_mismatch", mismatch)
@@ -350,36 +421,20 @@ def _expected_predicate_statuses(
     derivation: dict[str, Any],
     decisive: bool,
     report_terminals: set[str],
+    campaign_predicates: list[str],
+    sequences: dict[str, list[str]],
 ) -> dict[str, str]:
     ids = bundle.plan["predicate_registry"]["ids"]
     statuses = {predicate: "not_applicable" for predicate in ids}
-    statuses["A3-IDLE-EQUALITY"] = "pass" if derivation["idle_equality"] else "fail"
-    statuses["A3-SNAPSHOT-RECONSTRUCTION"] = "pass"
-    statuses["A3-RESOURCE-BOUND"] = "pass"
-    sequences = {
-        "global_map_record": [
-            "A3-GLOBAL-PAGE-NONE", "A3-GLOBAL-RECORD-NONE", "A3-D-SET-RELATION",
-            "A3-GLOBAL-RECORD-END", "A3-POLARITY-NONE", "A3-POLARITY-MULTIPLE",
-            "A3-GLOBAL-PAGE-MULTIPLE", "A3-GLOBAL-RECORD-MULTIPLE",
-            "A3-STRUCTURAL-EXCLUSION", "A3-REPLICA-DISAGREEMENT",
-        ],
-        "global_map_conversion_inline": [
-            "A3-POLARITY-CROSSCHECK", "A3-CONVERSION-NONE", "A3-CONVERSION-MULTIPLE",
-            "A3-SLOT-ACTIVATION", "A3-SLOT-FINAL", "A3-POINTER-VALIDITY",
-            "A3-INLINE-BOUNDARY-NONE", "A3-INLINE-BOUNDARY-MULTIPLE", "A3-INLINE-SUFFIX",
-            "A3-STRUCTURAL-EXCLUSION", "A3-REPLICA-DISAGREEMENT",
-        ],
-        "global_map_extended_base": [
-            "A3-BASE-DISCRIMINATION", "A3-BASE-NONE", "A3-BASE-MULTIPLE",
-            "A3-POINTER-VALIDITY", "A3-REPLICA-DISAGREEMENT",
-        ],
-        "tdef_pointer_pair": [
-            "A3-TDEF-PAGE-NONE", "A3-CHURN-PRECONDITION", "A3-GROWTH-POINTER-NONE",
-            "A3-CHURN-POINTER-NONE", "A3-TDEF-RECORD-NONE", "A3-TDEF-PAGE-MULTIPLE",
-            "A3-TDEF-RECORD-MULTIPLE", "A3-POINTER-MULTIPLE", "A3-POINTER-VALIDITY",
-            "A3-STRUCTURAL-EXCLUSION", "A3-REPLICA-DISAGREEMENT",
-        ],
+    campaign_statuses = {
+        "A3-IDLE-EQUALITY": "pass" if derivation["idle_equality"] else "fail",
+        "A3-SNAPSHOT-RECONSTRUCTION": "pass",
+        "A3-RESOURCE-BOUND": "pass",
     }
+    if set(campaign_predicates) != set(campaign_statuses):
+        raise ValidationError("predicate_revision_contract_mismatch")
+    for predicate in campaign_predicates:
+        statuses[predicate] = campaign_statuses[predicate]
     for name, sequence in sequences.items():
         layer = derivation["layers"][name]
         if not layer["applicable"]:
@@ -416,7 +471,11 @@ def verify_report_bounds(bundle: LoadedBundle, derivation: dict[str, Any]) -> No
         raise ValidationError("analysis_work_bound")
 
 
-def validate_bundle(bundle: LoadedBundle) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+def validate_bundle(
+    bundle: LoadedBundle,
+    campaign_predicates: list[str],
+    predicate_sequences: dict[str, list[str]],
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
     derivation = recompute_derivation(bundle)
     expected = expected_frozen(bundle, derivation)
     if bundle.frozen != expected:
@@ -433,7 +492,7 @@ def validate_bundle(bundle: LoadedBundle) -> tuple[dict[str, Any], dict[str, dic
     compare_frozen_report(bundle)
     layers = recompute_report_layers(bundle, derivation)
     compare_report_layers(bundle, layers)
-    validate_predicates(bundle, layers, derivation)
+    validate_predicates(bundle, layers, derivation, campaign_predicates, predicate_sequences)
     verify_report_bounds(bundle, derivation)
     if bundle.receipt is None or bundle.receipt["replica_artifact_manifest_sha256"] != bundle.manifest["replica_artifact_manifest_sha256"][2]:
         raise ValidationError("holdout_receipt_replica_link_mismatch")
@@ -487,6 +546,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--bundle-root", required=True, type=Path)
     parser.add_argument("--plan", type=Path, default=_repo_plan_path())
+    parser.add_argument("--revision", type=Path, default=_repo_revision_path())
     parser.add_argument("--output", type=Path)
     parser.add_argument("--validator-commit")
     parser.add_argument("--recompute-only", action="store_true")
@@ -500,12 +560,18 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("--validator-commit must be 40 lowercase hexadecimal characters")
     bundle: LoadedBundle | None = None
     try:
-        bundle = BundleLoader(args.bundle_root, args.plan, args.recompute_only).load()
+        loader = BundleLoader(args.bundle_root, args.plan, args.recompute_only)
+        campaign_predicates, predicate_sequences = _load_predicate_sequences(
+            args.revision,
+            sha256_bytes(loader.plan_raw),
+            loader.plan["predicate_registry"]["ids"],
+        )
+        bundle = loader.load()
         if args.recompute_only:
             derivation = recompute_derivation(bundle)
             _write_output(recompute_only_document(bundle, derivation), args.output)
             return 0
-        validate_bundle(bundle)
+        validate_bundle(bundle, campaign_predicates, predicate_sequences)
         result = verdict(bundle, validator_commit, True, [])
         _check_verdict_schema(args.plan, result)
         _write_output(result, args.output)

--- a/oracle/windows-dao/scripts/a3_independent_validator.py
+++ b/oracle/windows-dao/scripts/a3_independent_validator.py
@@ -386,7 +386,9 @@ def validate_predicates(
         report_terminals.discard("A3-HOLDOUT-PREDICTION")
     if not derivation["idle_equality"]:
         report_terminals.add("A3-IDLE-EQUALITY")
-    if report["terminal_predicate_ids"] != [predicate for predicate in registry["ids"] if predicate in report_terminals]:
+    reported_terminals = report["terminal_predicate_ids"]
+    reported_terminal_set = set(reported_terminals)
+    if len(reported_terminals) != len(reported_terminal_set) or reported_terminal_set != report_terminals:
         raise ValidationError("predicate_reporting_mismatch", "terminal_predicate_ids")
     statuses = {item["predicate_id"]: item["status"] for item in results}
     expected_statuses = _expected_predicate_statuses(

--- a/oracle/windows-dao/tests/test_a3_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a3_independent_validator.py
@@ -436,6 +436,20 @@ class IndependentValidatorTests(unittest.TestCase):
         self.assertIs(result["accepted"], True)
         self.assertEqual(result["discrepancy_codes"], [])
 
+    def test_accepts_terminal_predicate_ids_outside_registry_order(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="a3-terminal-order-") as directory:
+            temporary = Path(directory)
+            reordered = temporary / "bundle"
+            shutil.copytree(self.synthetic_bundle, reordered, copy_function=os.link)
+            report_path = reordered / "analysis" / "analysis-report.json"
+            report = json.loads(report_path.read_text())
+            report["terminal_predicate_ids"].reverse()
+            _write(report_path, report)
+            relink(reordered)
+            code, result = _run(reordered, temporary / "result.json")
+        self.assertEqual(code, 0, result)
+        self.assertIs(result["accepted"], True)
+
     def test_binds_published_r2_by_hash(self) -> None:
         plan_raw = PLAN_PATH.read_bytes()
         plan_sha256 = hashlib.sha256(plan_raw).hexdigest()

--- a/oracle/windows-dao/tests/test_a3_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a3_independent_validator.py
@@ -14,10 +14,11 @@ from typing import Any, Callable
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 PLAN_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps.plan.json"
+R2_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps-r2.plan.json"
 sys.path.insert(0, str(SCRIPTS))
 
-from a3_independent_bundle import canonical_json_bytes  # noqa: E402
-from a3_independent_validator import main  # noqa: E402
+from a3_independent_bundle import ValidationError, canonical_json_bytes  # noqa: E402
+from a3_independent_validator import R2_SHA256, _load_predicate_sequences, main  # noqa: E402
 
 
 CHECKPOINTS = [
@@ -434,6 +435,36 @@ class IndependentValidatorTests(unittest.TestCase):
         self.assertEqual(code, 0, result)
         self.assertIs(result["accepted"], True)
         self.assertEqual(result["discrepancy_codes"], [])
+
+    def test_binds_published_r2_by_hash(self) -> None:
+        plan_raw = PLAN_PATH.read_bytes()
+        plan_sha256 = hashlib.sha256(plan_raw).hexdigest()
+        plan = json.loads(plan_raw)
+        campaign, sequences = _load_predicate_sequences(
+            R2_PATH,
+            plan_sha256,
+            plan["predicate_registry"]["ids"],
+        )
+        self.assertEqual(hashlib.sha256(R2_PATH.read_bytes()).hexdigest(), R2_SHA256)
+        self.assertEqual(campaign, ["A3-IDLE-EQUALITY", "A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"])
+        self.assertEqual(
+            set(sequences),
+            {
+                "global_map_record",
+                "global_map_conversion_inline",
+                "global_map_extended_base",
+                "tdef_pointer_pair",
+            },
+        )
+        with tempfile.TemporaryDirectory(prefix="a3-r2-") as directory:
+            mutated = Path(directory) / R2_PATH.name
+            mutated.write_bytes(R2_PATH.read_bytes() + b" ")
+            with self.assertRaisesRegex(ValidationError, "predicate_revision_hash_mismatch"):
+                _load_predicate_sequences(
+                    mutated,
+                    plan_sha256,
+                    plan["predicate_registry"]["ids"],
+                )
 
     def test_rejects_relinked_tamper_cases(self) -> None:
         cases: list[tuple[str, Callable[[Path], None], str]] = [

--- a/oracle/windows-dao/tests/test_a3_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a3_independent_validator.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 PLAN_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps.plan.json"
 sys.path.insert(0, str(SCRIPTS))

--- a/oracle/windows-dao/tests/test_a3_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a3_independent_validator.py
@@ -14,11 +14,18 @@ from typing import Any, Callable
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 PLAN_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps.plan.json"
-R2_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps-r2.plan.json"
+R3_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps-r3.plan.json"
 sys.path.insert(0, str(SCRIPTS))
 
-from a3_independent_bundle import ValidationError, canonical_json_bytes  # noqa: E402
-from a3_independent_validator import R2_SHA256, _load_predicate_sequences, main  # noqa: E402
+from a3_independent_bundle import BundleLoader, ValidationError, canonical_json_bytes  # noqa: E402
+from a3_independent_core import recompute_derivation  # noqa: E402
+from a3_independent_validator import (  # noqa: E402
+    R3_SHA256,
+    _expected_predicate_statuses,
+    _load_predicate_sequences,
+    _validate_terminal_predicate_ids,
+    main,
+)
 
 
 CHECKPOINTS = [
@@ -78,12 +85,10 @@ def _pointer_bytes(reference: int, slot: int = 1) -> bytes:
 
 def _tdef_page(checkpoint: str) -> bytes:
     page = bytearray(2048)
-    growth_reference = 10 if CHECKPOINTS.index(checkpoint) <= CHECKPOINTS.index("L_REL_0064") else 11
-    churn_reference = 21 if checkpoint == "L_DELETE_ALL" else 20
-    page[100:104] = _pointer_bytes(growth_reference)
-    page[200:204] = _pointer_bytes(churn_reference)
-    if checkpoint in {"P_ABS_04096", "P_ABS_08192"}:
-        page[150] = 0x7D
+    growth_reference = 65546 if CHECKPOINTS.index(checkpoint) <= CHECKPOINTS.index("L_REL_0064") else 10
+    churn_reference = 65556 if checkpoint == "L_DELETE_ALL" else 20
+    page[2040:2044] = bytes([1]) + growth_reference.to_bytes(3, "little")
+    page[2044:2048] = bytes([1]) + churn_reference.to_bytes(3, "little")
     return bytes(page)
 
 
@@ -98,7 +103,31 @@ def _global_page(checkpoint: str) -> bytes:
         return _bitmap_page(450)
     if checkpoint == "L_REL_0512":
         return _bitmap_page(898)
-    return _bitmap_page(1154, 1021)
+    if CHECKPOINTS.index(checkpoint) < CHECKPOINTS.index("P_ABS_04096"):
+        return _bitmap_page(COUNTS[CHECKPOINTS.index(checkpoint)])
+    page = bytearray([0xFF] * 2048)
+    page[GLOBAL_START] = 1
+    page[GLOBAL_START + 1 : GLOBAL_START + 5] = (10).to_bytes(4, "little")
+    page[GLOBAL_START + 5 : GLOBAL_START + 9] = (16362).to_bytes(4, "little")
+    page[GLOBAL_START + 9 :] = bytes(2048 - GLOBAL_START - 9)
+    return bytes(page)
+
+
+def _extended_page(slot: int, checkpoint: str) -> bytes:
+    page = bytearray([0xFF] * 2048)
+    page[:4] = bytes([0x05, 0x00, 0x00, 0x00])
+    self_bit = 10
+    page[4 + self_bit // 8] &= ~(1 << (self_bit % 8))
+    if slot == 0 and CHECKPOINTS.index(checkpoint) >= CHECKPOINTS.index("H_REL_0064"):
+        page[4 + 100 // 8] &= ~(1 << (100 % 8))
+    return bytes(page)
+
+
+def _changed_discriminator_page(checkpoint: str) -> bytes:
+    page = bytearray([0x05]) + bytearray(2047)
+    if CHECKPOINTS.index(checkpoint) >= CHECKPOINTS.index("H_REL_0064"):
+        page[1] = 1
+    return bytes(page)
 
 
 def _page_digest(root: Path, raw: bytes, known: dict[str, bytes]) -> str:
@@ -153,10 +182,15 @@ def _frozen(plan_sha: str, slack: int) -> dict[str, Any]:
             {"left_checkpoint_id": "D_REGROW_0128", "right_checkpoint_id": "L_REL_0064"},
             {"left_checkpoint_id": "L_REL_0064", "right_checkpoint_id": "L_REL_0512"},
             {"left_checkpoint_id": "L_REL_0512", "right_checkpoint_id": "L_REL_0768"},
+            {"left_checkpoint_id": "L_REL_0768", "right_checkpoint_id": "L_REL_0896"},
+            {"left_checkpoint_id": "L_REL_0896", "right_checkpoint_id": "L_REL_0904"},
+            {"left_checkpoint_id": "L_REL_0904", "right_checkpoint_id": "L_REL_1024"},
+            {"left_checkpoint_id": "L_REL_1024", "right_checkpoint_id": "L_REL_1088"},
+            {"left_checkpoint_id": "L_REL_1088", "right_checkpoint_id": "L_REL_1280"},
         ],
-        "representation_change_stop": None,
-        "first_violating_leg": {"left_checkpoint_id": "L_REL_0512", "right_checkpoint_id": "L_REL_0768"},
-        "first_violating_page": 1021,
+        "representation_change_stop": {"left_checkpoint_id": "L_IDLE_REOPEN", "right_checkpoint_id": "P_ABS_04096"},
+        "first_violating_leg": None,
+        "first_violating_page": None,
     }
     return {
         "protocol_version": "1.0.0", "document_type": "dao_a3_frozen_derivation_candidates",
@@ -165,32 +199,20 @@ def _frozen(plan_sha: str, slack: int) -> dict[str, Any]:
         "qualified_pages": {"global_map": [1], "tdef": [2]}, "polarity_cross_check": cross,
         "layers": {
             "global_map_record": {"applicable": True, "derivation_survivor_count": 1, "model": {"record": {"page": 1, "start": GLOBAL_START, "end": 2048}, "bit_polarity": "set_means_not_in_use", "zero_suffix_slack_bytes": slack}, "no_outcome_reason": None, "terminal_predicate_id": None},
-            "global_map_conversion_inline": {"applicable": True, "derivation_survivor_count": 0, "model": None, "no_outcome_reason": "growth_polarity_disagreement", "terminal_predicate_id": "A3-POLARITY-CROSSCHECK"},
-            "global_map_extended_base": {"applicable": False, "derivation_survivor_count": 0, "model": None, "no_outcome_reason": None, "terminal_predicate_id": None},
-            "tdef_pointer_pair": {"applicable": True, "derivation_survivor_count": 0, "model": None, "no_outcome_reason": "no_tdef_record_candidate", "terminal_predicate_id": "A3-TDEF-RECORD-NONE"},
+            "global_map_conversion_inline": {"applicable": True, "derivation_survivor_count": 1, "model": {"conversion_checkpoint_id": "P_ABS_04096", "conversion_ordinal": 17, "indirect_tag": 1, "active_slot_count_at_conversion": 2, "active_slot_count_at_h_rel_0904": 2, "inline_boundary": 1914, "slot_reference_pages": [10, 16362]}, "no_outcome_reason": None, "terminal_predicate_id": None},
+            "global_map_extended_base": {"applicable": True, "derivation_survivor_count": 1, "model": {"extended_base_formula": "slot_relative_expected_0_16352"}, "no_outcome_reason": None, "terminal_predicate_id": None},
+            "tdef_pointer_pair": {"applicable": True, "derivation_survivor_count": 1, "model": {"record": {"page": 2, "start": 2039, "end": 2048}, "pointer_layout": "u8_slot_then_u24le_page", "growth_pointer_offset": 2040, "delete_reinsert_pointer_offset": 2044}, "no_outcome_reason": None, "terminal_predicate_id": None},
         },
     }
 
 
 def _report(plan: dict[str, Any], plan_sha: str, frozen: dict[str, Any], frozen_sha: str) -> dict[str, Any]:
-    terminal = {"A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"}
-    not_applicable = {
-        "A3-TDEF-PAGE-MULTIPLE", "A3-TDEF-RECORD-MULTIPLE", "A3-POINTER-MULTIPLE",
-        "A3-POINTER-VALIDITY", "A3-CONVERSION-NONE",
-        "A3-CONVERSION-MULTIPLE", "A3-SLOT-ACTIVATION", "A3-SLOT-FINAL",
-        "A3-INLINE-BOUNDARY-NONE", "A3-INLINE-BOUNDARY-MULTIPLE", "A3-INLINE-SUFFIX",
-        "A3-BASE-DISCRIMINATION", "A3-BASE-NONE", "A3-BASE-MULTIPLE",
-    }
+    terminal: set[str] = set()
     mapping = {item["predicate_id"]: item["layer"] for item in plan["predicate_registry"]["mappings"]}
-    predicates = []
-    for predicate in plan["predicate_registry"]["ids"]:
-        if predicate in terminal:
-            status = "fail"
-        elif predicate in not_applicable:
-            status = "not_applicable"
-        else:
-            status = "pass"
-        predicates.append({"predicate_id": predicate, "status": status, "layer": mapping[predicate]})
+    predicates = [
+        {"predicate_id": predicate, "status": "pass", "layer": mapping[predicate]}
+        for predicate in plan["predicate_registry"]["ids"]
+    ]
     layers = frozen["layers"]
     def report_layer(name: str, status: str, evaluated: bool) -> dict[str, Any]:
         layer = layers[name]
@@ -201,15 +223,15 @@ def _report(plan: dict[str, Any], plan_sha: str, frozen: dict[str, Any], frozen_
         "campaign_id": CAMPAIGN, "producer_commit": PRODUCER, "derivation_replicas": [1, 2],
         "holdout_replica": 3, "input_checkpoint_count": 75,
         "qualified_page_counts": {"global_map": 1, "tdef": 1}, "qualified_pages": frozen["qualified_pages"],
-        "record_candidates_examined": 2 * 2_098_176, "candidate_models_examined": 10,
+        "record_candidates_examined": 4 * 2_098_176, "candidate_models_examined": 10,
         "derivation_survivor_counts": {name: layer["derivation_survivor_count"] for name, layer in layers.items()},
         "derivation_candidate_set_sha256": frozen_sha, "polarity_cross_check": frozen["polarity_cross_check"],
         "analysis_work_units": 10_000_000, "holdout_structurally_validated_after_freeze": True,
         "holdout_opened_after_freeze": True, "holdout_evaluated": True,
         "predicate_results": predicates, "terminal_predicate_ids": [predicate for predicate in plan["predicate_registry"]["ids"] if predicate in terminal],
         "scientific_outcome": "one_or_more_submodels_predict_holdout",
-        "no_outcome_reasons": ["growth_polarity_disagreement", "no_tdef_record_candidate"],
-        "submodels": {"global_map": {"record": report_layer("global_map_record", "decisive_predicts_holdout", True), "conversion_inline": report_layer("global_map_conversion_inline", "no_outcome", False), "extended_base": report_layer("global_map_extended_base", "not_applicable", False)}, "tdef": {"pointer_pair": report_layer("tdef_pointer_pair", "no_outcome", False)}},
+        "no_outcome_reasons": [],
+        "submodels": {"global_map": {"record": report_layer("global_map_record", "decisive_predicts_holdout", True), "conversion_inline": report_layer("global_map_conversion_inline", "decisive_predicts_holdout", True), "extended_base": report_layer("global_map_extended_base", "decisive_predicts_holdout", True)}, "tdef": {"pointer_pair": report_layer("tdef_pointer_pair", "decisive_predicts_holdout", True)}},
         "claims": {"descriptive_provider_observation_only": True, "general_tdef_catalog_row_index_or_lval_layout": False, "unobserved_slot_or_base_behavior": False, "compaction_encryption_or_version_behavior": False, "rust_correctness": False, "dao_compatibility_or_support": False},
     }
 
@@ -240,6 +262,11 @@ def build_bundle(root: Path) -> None:
             hashes[0] = page_zero
             hashes[1] = _page_digest(root, _global_page(checkpoint), known_pages)
             hashes[2] = _page_digest(root, _tdef_page(checkpoint), known_pages)
+            if count > 100:
+                hashes[100] = _page_digest(root, _changed_discriminator_page(checkpoint), known_pages)
+            if CHECKPOINTS.index(checkpoint) >= CHECKPOINTS.index("P_ABS_16480"):
+                hashes[10] = _page_digest(root, _extended_page(0, checkpoint), known_pages)
+                hashes[16362] = _page_digest(root, _extended_page(1, checkpoint), known_pages)
             changed = [page for page in range(max(len(previous), len(hashes))) if (previous[page] if page < len(previous) else None) != (hashes[page] if page < len(hashes) else None)]
             database = hashlib.sha256()
             for digest in hashes:
@@ -347,7 +374,10 @@ def relink(root: Path) -> None:
 
 
 def _set_layer_terminal(report: dict[str, Any], old: str, new: str) -> None:
-    report["terminal_predicate_ids"] = [new if value == old else value for value in report["terminal_predicate_ids"]]
+    if old in report["terminal_predicate_ids"]:
+        report["terminal_predicate_ids"] = [new if value == old else value for value in report["terminal_predicate_ids"]]
+    else:
+        report["terminal_predicate_ids"].append(new)
     for result in report["predicate_results"]:
         if result["predicate_id"] == old:
             result["status"] = "not_applicable"
@@ -369,10 +399,11 @@ def tamper_t2(root: Path) -> None:
     frozen = json.loads((root / "analysis/derivation-candidates.json").read_text())
     report = json.loads((root / "analysis/analysis-report.json").read_text())
     layer = frozen["layers"]["global_map_conversion_inline"]
-    layer["no_outcome_reason"], layer["terminal_predicate_id"] = "missing_inline_to_indirect_conversion", "A3-CONVERSION-NONE"
+    layer.update({"derivation_survivor_count": 0, "model": None, "no_outcome_reason": "missing_inline_to_indirect_conversion", "terminal_predicate_id": "A3-CONVERSION-NONE"})
     report_layer = report["submodels"]["global_map"]["conversion_inline"]
-    report_layer["no_outcome_reasons"], report_layer["terminal_predicate_id"] = ["missing_inline_to_indirect_conversion"], "A3-CONVERSION-NONE"
-    report["no_outcome_reasons"][0] = "missing_inline_to_indirect_conversion"
+    report_layer.update({"status": "no_outcome", "derivation_survivor_count": 0, "holdout_evaluated": False, "no_outcome_reasons": ["missing_inline_to_indirect_conversion"], "terminal_predicate_id": "A3-CONVERSION-NONE", "model": None})
+    report["derivation_survivor_counts"]["global_map_conversion_inline"] = 0
+    report["no_outcome_reasons"] = ["missing_inline_to_indirect_conversion"]
     _set_layer_terminal(report, "A3-POLARITY-CROSSCHECK", "A3-CONVERSION-NONE")
     _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
     _write(root / "analysis/analysis-report.json", report)
@@ -390,10 +421,11 @@ def tamper_t4(root: Path) -> None:
     frozen = json.loads((root / "analysis/derivation-candidates.json").read_text())
     report = json.loads((root / "analysis/analysis-report.json").read_text())
     layer = frozen["layers"]["tdef_pointer_pair"]
-    layer["no_outcome_reason"], layer["terminal_predicate_id"] = "no_growth_only_pointer_candidate", "A3-GROWTH-POINTER-NONE"
+    layer.update({"derivation_survivor_count": 0, "model": None, "no_outcome_reason": "no_growth_only_pointer_candidate", "terminal_predicate_id": "A3-GROWTH-POINTER-NONE"})
     report_layer = report["submodels"]["tdef"]["pointer_pair"]
-    report_layer["no_outcome_reasons"], report_layer["terminal_predicate_id"] = ["no_growth_only_pointer_candidate"], "A3-GROWTH-POINTER-NONE"
-    report["no_outcome_reasons"][1] = "no_growth_only_pointer_candidate"
+    report_layer.update({"status": "no_outcome", "derivation_survivor_count": 0, "holdout_evaluated": False, "no_outcome_reasons": ["no_growth_only_pointer_candidate"], "terminal_predicate_id": "A3-GROWTH-POINTER-NONE", "model": None})
+    report["derivation_survivor_counts"]["tdef_pointer_pair"] = 0
+    report["no_outcome_reasons"] = ["no_growth_only_pointer_candidate"]
     _set_layer_terminal(report, "A3-TDEF-RECORD-NONE", "A3-GROWTH-POINTER-NONE")
     _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
     _write(root / "analysis/analysis-report.json", report)
@@ -435,31 +467,25 @@ class IndependentValidatorTests(unittest.TestCase):
         self.assertEqual(code, 0, result)
         self.assertIs(result["accepted"], True)
         self.assertEqual(result["discrepancy_codes"], [])
+        self.assertEqual([item["id"] for item in result["tamper_results"]], ["T1", "T2", "T3", "T4", "T5"])
+        self.assertTrue(all(item["rejected"] for item in result["tamper_results"]))
 
     def test_accepts_terminal_predicate_ids_outside_registry_order(self) -> None:
-        with tempfile.TemporaryDirectory(prefix="a3-terminal-order-") as directory:
-            temporary = Path(directory)
-            reordered = temporary / "bundle"
-            shutil.copytree(self.synthetic_bundle, reordered, copy_function=os.link)
-            report_path = reordered / "analysis" / "analysis-report.json"
-            report = json.loads(report_path.read_text())
-            report["terminal_predicate_ids"].reverse()
-            _write(report_path, report)
-            relink(reordered)
-            code, result = _run(reordered, temporary / "result.json")
-        self.assertEqual(code, 0, result)
-        self.assertIs(result["accepted"], True)
+        _validate_terminal_predicate_ids(
+            ["A3-TDEF-RECORD-NONE", "A3-POLARITY-CROSSCHECK"],
+            {"A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"},
+        )
 
-    def test_binds_published_r2_by_hash(self) -> None:
+    def test_binds_published_r3_by_hash(self) -> None:
         plan_raw = PLAN_PATH.read_bytes()
         plan_sha256 = hashlib.sha256(plan_raw).hexdigest()
         plan = json.loads(plan_raw)
         campaign, sequences = _load_predicate_sequences(
-            R2_PATH,
+            R3_PATH,
             plan_sha256,
             plan["predicate_registry"]["ids"],
         )
-        self.assertEqual(hashlib.sha256(R2_PATH.read_bytes()).hexdigest(), R2_SHA256)
+        self.assertEqual(hashlib.sha256(R3_PATH.read_bytes()).hexdigest(), R3_SHA256)
         self.assertEqual(campaign, ["A3-IDLE-EQUALITY", "A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"])
         self.assertEqual(
             set(sequences),
@@ -471,14 +497,38 @@ class IndependentValidatorTests(unittest.TestCase):
             },
         )
         with tempfile.TemporaryDirectory(prefix="a3-r2-") as directory:
-            mutated = Path(directory) / R2_PATH.name
-            mutated.write_bytes(R2_PATH.read_bytes() + b" ")
+            mutated = Path(directory) / R3_PATH.name
+            mutated.write_bytes(R3_PATH.read_bytes() + b" ")
             with self.assertRaisesRegex(ValidationError, "predicate_revision_hash_mismatch"):
                 _load_predicate_sequences(
                     mutated,
                     plan_sha256,
                     plan["predicate_registry"]["ids"],
                 )
+
+    def test_idle_campaign_terminal_skips_all_layers(self) -> None:
+        bundle = BundleLoader(self.synthetic_bundle, PLAN_PATH).load()
+        idle_index = bundle.replicas[1].indexes["E0R"]["ordered_page_sha256"]
+        idle_index[0] = idle_index[1]
+        derivation = recompute_derivation(bundle)
+        campaign, sequences = _load_predicate_sequences(
+            R3_PATH,
+            hashlib.sha256(PLAN_PATH.read_bytes()).hexdigest(),
+            bundle.plan["predicate_registry"]["ids"],
+        )
+        statuses = _expected_predicate_statuses(
+            bundle,
+            derivation,
+            False,
+            {"A3-IDLE-EQUALITY"},
+            campaign,
+            sequences,
+        )
+        self.assertEqual(derivation["campaign_terminal_predicate_id"], "A3-IDLE-EQUALITY")
+        self.assertTrue(all(not layer["applicable"] for layer in derivation["layers"].values()))
+        self.assertEqual(statuses["A3-IDLE-EQUALITY"], "fail")
+        self.assertEqual(statuses["A3-SNAPSHOT-RECONSTRUCTION"], "not_applicable")
+        self.assertEqual(statuses["A3-GLOBAL-PAGE-NONE"], "not_applicable")
 
     def test_rejects_relinked_tamper_cases(self) -> None:
         cases: list[tuple[str, Callable[[Path], None], str]] = [
@@ -498,6 +548,7 @@ class IndependentValidatorTests(unittest.TestCase):
                 self.assertNotEqual(code, 0)
                 self.assertIs(result["accepted"], False)
                 self.assertEqual(result["discrepancy_codes"], [expected])
+                self.assertTrue(all(not item["rejected"] for item in result["tamper_results"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_a3_independent_validator.py
+++ b/tests/test_a3_independent_validator.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+PLAN_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps.plan.json"
+sys.path.insert(0, str(SCRIPTS))
+
+from a3_independent_bundle import canonical_json_bytes  # noqa: E402
+from a3_independent_validator import main  # noqa: E402
+
+
+CHECKPOINTS = [
+    "E0", "E0R", "D_GROW_0128", "D_DROP", "D_RECREATE_EMPTY", "D_REGROW_0128",
+    "L_REL_0064", "L_REL_0512", "L_REL_0768", "L_REL_0896", "L_REL_0904",
+    "L_REL_1024", "L_REL_1088", "L_REL_1280", "L_DELETE_ALL", "L_REINSERT_SAME",
+    "L_IDLE_REOPEN", "P_ABS_04096", "P_ABS_08192", "P_ABS_12288", "P_ABS_16480",
+    "H_REL_0064", "H_REL_0896", "H_REL_0904", "H_IDLE_REOPEN",
+]
+COUNTS = [
+    129, 129, 257, 257, 258, 386, 450, 898, 1154, 1282, 1290, 1410, 1474,
+    1666, 1666, 1666, 1666, 4096, 8192, 12288, 16480, 16544, 17376, 17384, 17384,
+]
+PRODUCER = "a" * 40
+PROVIDER = "b" * 64
+CAMPAIGN = "a3-synthetic-tamper-suite"
+GLOBAL_START = 1700
+
+
+def _write(path: Path, value: Any, canonical: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    raw = canonical_json_bytes(value) if canonical else (json.dumps(value, indent=2) + "\n").encode()
+    path.write_bytes(raw)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _entry(root: Path, relative: str, role: str, media_type: str = "application/json") -> dict[str, Any]:
+    path = root / relative
+    return {
+        "path": relative,
+        "role": role,
+        "sha256": _digest(path),
+        "size_bytes": path.stat().st_size,
+        "media_type": media_type,
+    }
+
+
+def _bitmap_page(in_use_count: int, violation: int | None = None) -> bytes:
+    page = bytearray([0xFF] * 2048)
+    page[GLOBAL_START] = 0
+    page[GLOBAL_START + 1 : GLOBAL_START + 5] = (0).to_bytes(4, "little")
+    for physical in range(in_use_count):
+        page[GLOBAL_START + 5 + physical // 8] &= ~(1 << (physical % 8))
+    if violation is not None:
+        page[GLOBAL_START + 5 + violation // 8] |= 1 << (violation % 8)
+    return bytes(page)
+
+
+def _pointer_bytes(reference: int, slot: int = 1) -> bytes:
+    return reference.to_bytes(3, "little") + bytes([slot])
+
+
+def _tdef_page(checkpoint: str) -> bytes:
+    page = bytearray(2048)
+    growth_reference = 10 if CHECKPOINTS.index(checkpoint) <= CHECKPOINTS.index("L_REL_0064") else 11
+    churn_reference = 21 if checkpoint == "L_DELETE_ALL" else 20
+    page[100:104] = _pointer_bytes(growth_reference)
+    page[200:204] = _pointer_bytes(churn_reference)
+    if checkpoint in {"P_ABS_04096", "P_ABS_08192"}:
+        page[150] = 0x7D
+    return bytes(page)
+
+
+def _global_page(checkpoint: str) -> bytes:
+    if checkpoint in {"E0", "E0R", "D_DROP", "D_RECREATE_EMPTY"}:
+        return _bitmap_page(129)
+    if checkpoint == "D_GROW_0128":
+        return _bitmap_page(257)
+    if checkpoint == "D_REGROW_0128":
+        return _bitmap_page(386)
+    if checkpoint == "L_REL_0064":
+        return _bitmap_page(450)
+    if checkpoint == "L_REL_0512":
+        return _bitmap_page(898)
+    return _bitmap_page(1154, 1021)
+
+
+def _page_digest(root: Path, raw: bytes, known: dict[str, bytes]) -> str:
+    digest = hashlib.sha256(raw).hexdigest()
+    if digest not in known:
+        known[digest] = raw
+        path = root / "page-store" / f"{digest}.page"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(raw)
+    return digest
+
+
+def _environment(replica: int, plan_sha: str) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_environment",
+        "experiment_id": "DAO-A3-ALLOCATION-MAPS-001", "plan_sha256": plan_sha,
+        "producer_commit": PRODUCER, "repository_url": "https://github.com/oglassdev/jet3-rs.git",
+        "campaign_id": CAMPAIGN, "replica": replica, "matrix_job_id": f"synthetic-{replica}",
+        "status": "ready",
+        "host": {"windows_version": "synthetic", "process_architecture": "x86", "powershell_version": "5.1", "python_version": "3.13.7", "runner_image": "synthetic"},
+        "provider": {"prog_id": "DAO.DBEngine.36", "clsid": "{00000000-0000-0000-0000-000000000000}", "provider_version": "synthetic", "server_path": "C:/dao360.dll", "server_file_version": "synthetic", "server_sha256": PROVIDER},
+    }
+
+
+def _reread(role: str, rows: int) -> dict[str, Any]:
+    return {"role": role, "row_count": rows, "rolling_sha256": "0" * 64}
+
+
+def _checkpoint_observation(checkpoint: str, ordinal: int, count: int, index_entry: dict[str, Any]) -> dict[str, Any]:
+    if checkpoint == "L_DELETE_ALL":
+        l_rows = 0
+    elif ordinal >= 6:
+        l_rows = 1024
+    else:
+        l_rows = 0
+    row_counts = {"D": 2048 if ordinal >= 2 and checkpoint not in {"D_DROP", "D_RECREATE_EMPTY"} else 0, "L": l_rows, "P": 0, "H": 0}
+    return {
+        "checkpoint_id": checkpoint, "ordinal": ordinal,
+        "actual_file_pages": count, "actual_size_bytes": count * 2048,
+        "target_baseline_pages": None, "target_threshold_pages": None, "target_overshoot_pages": None,
+        "inserted_rows_total": 10000, "table_row_counts": row_counts,
+        "dao_reread": [_reread(role, rows) for role, rows in row_counts.items()],
+        "quiescent": True,
+        "post_close_companion": {"present_after_close": False, "observed_size_bytes": 0, "retained_for_physical_analysis": False},
+        "page_index": {"path": index_entry["path"], "sha256": index_entry["sha256"], "size_bytes": index_entry["size_bytes"]},
+    }
+
+
+def _frozen(plan_sha: str, slack: int) -> dict[str, Any]:
+    cross = {
+        "evaluated_legs": [
+            {"left_checkpoint_id": "D_REGROW_0128", "right_checkpoint_id": "L_REL_0064"},
+            {"left_checkpoint_id": "L_REL_0064", "right_checkpoint_id": "L_REL_0512"},
+            {"left_checkpoint_id": "L_REL_0512", "right_checkpoint_id": "L_REL_0768"},
+        ],
+        "representation_change_stop": None,
+        "first_violating_leg": {"left_checkpoint_id": "L_REL_0512", "right_checkpoint_id": "L_REL_0768"},
+        "first_violating_page": 1021,
+    }
+    return {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_frozen_derivation_candidates",
+        "experiment_id": "DAO-A3-ALLOCATION-MAPS-001", "plan_sha256": plan_sha,
+        "campaign_id": CAMPAIGN, "derivation_replicas": [1, 2],
+        "qualified_pages": {"global_map": [1], "tdef": [2]}, "polarity_cross_check": cross,
+        "layers": {
+            "global_map_record": {"applicable": True, "derivation_survivor_count": 1, "model": {"record": {"page": 1, "start": GLOBAL_START, "end": 2048}, "bit_polarity": "set_means_not_in_use", "zero_suffix_slack_bytes": slack}, "no_outcome_reason": None, "terminal_predicate_id": None},
+            "global_map_conversion_inline": {"applicable": True, "derivation_survivor_count": 0, "model": None, "no_outcome_reason": "growth_polarity_disagreement", "terminal_predicate_id": "A3-POLARITY-CROSSCHECK"},
+            "global_map_extended_base": {"applicable": False, "derivation_survivor_count": 0, "model": None, "no_outcome_reason": None, "terminal_predicate_id": None},
+            "tdef_pointer_pair": {"applicable": True, "derivation_survivor_count": 0, "model": None, "no_outcome_reason": "no_tdef_record_candidate", "terminal_predicate_id": "A3-TDEF-RECORD-NONE"},
+        },
+    }
+
+
+def _report(plan: dict[str, Any], plan_sha: str, frozen: dict[str, Any], frozen_sha: str) -> dict[str, Any]:
+    terminal = {"A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"}
+    not_applicable = {
+        "A3-TDEF-PAGE-MULTIPLE", "A3-TDEF-RECORD-MULTIPLE", "A3-POINTER-MULTIPLE",
+        "A3-POINTER-VALIDITY", "A3-CONVERSION-NONE",
+        "A3-CONVERSION-MULTIPLE", "A3-SLOT-ACTIVATION", "A3-SLOT-FINAL",
+        "A3-INLINE-BOUNDARY-NONE", "A3-INLINE-BOUNDARY-MULTIPLE", "A3-INLINE-SUFFIX",
+        "A3-BASE-DISCRIMINATION", "A3-BASE-NONE", "A3-BASE-MULTIPLE",
+    }
+    mapping = {item["predicate_id"]: item["layer"] for item in plan["predicate_registry"]["mappings"]}
+    predicates = []
+    for predicate in plan["predicate_registry"]["ids"]:
+        if predicate in terminal:
+            status = "fail"
+        elif predicate in not_applicable:
+            status = "not_applicable"
+        else:
+            status = "pass"
+        predicates.append({"predicate_id": predicate, "status": status, "layer": mapping[predicate]})
+    layers = frozen["layers"]
+    def report_layer(name: str, status: str, evaluated: bool) -> dict[str, Any]:
+        layer = layers[name]
+        return {"status": status, "derivation_survivor_count": layer["derivation_survivor_count"], "holdout_evaluated": evaluated, "no_outcome_reasons": [] if layer["no_outcome_reason"] is None else [layer["no_outcome_reason"]], "terminal_predicate_id": layer["terminal_predicate_id"], "model": layer["model"]}
+    return {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_analysis_report",
+        "experiment_id": "DAO-A3-ALLOCATION-MAPS-001", "plan_sha256": plan_sha,
+        "campaign_id": CAMPAIGN, "producer_commit": PRODUCER, "derivation_replicas": [1, 2],
+        "holdout_replica": 3, "input_checkpoint_count": 75,
+        "qualified_page_counts": {"global_map": 1, "tdef": 1}, "qualified_pages": frozen["qualified_pages"],
+        "record_candidates_examined": 2 * 2_098_176, "candidate_models_examined": 10,
+        "derivation_survivor_counts": {name: layer["derivation_survivor_count"] for name, layer in layers.items()},
+        "derivation_candidate_set_sha256": frozen_sha, "polarity_cross_check": frozen["polarity_cross_check"],
+        "analysis_work_units": 10_000_000, "holdout_structurally_validated_after_freeze": True,
+        "holdout_opened_after_freeze": True, "holdout_evaluated": True,
+        "predicate_results": predicates, "terminal_predicate_ids": [predicate for predicate in plan["predicate_registry"]["ids"] if predicate in terminal],
+        "scientific_outcome": "one_or_more_submodels_predict_holdout",
+        "no_outcome_reasons": ["growth_polarity_disagreement", "no_tdef_record_candidate"],
+        "submodels": {"global_map": {"record": report_layer("global_map_record", "decisive_predicts_holdout", True), "conversion_inline": report_layer("global_map_conversion_inline", "no_outcome", False), "extended_base": report_layer("global_map_extended_base", "not_applicable", False)}, "tdef": {"pointer_pair": report_layer("tdef_pointer_pair", "no_outcome", False)}},
+        "claims": {"descriptive_provider_observation_only": True, "general_tdef_catalog_row_index_or_lval_layout": False, "unobserved_slot_or_base_behavior": False, "compaction_encryption_or_version_behavior": False, "rust_correctness": False, "dao_compatibility_or_support": False},
+    }
+
+
+def build_bundle(root: Path) -> None:
+    plan = json.loads(PLAN_PATH.read_text())
+    plan_raw = PLAN_PATH.read_bytes()
+    plan_sha = hashlib.sha256(plan_raw).hexdigest()
+    (root / "plan").mkdir(parents=True)
+    (root / "plan" / "a3-allocation-maps.plan.json").write_bytes(plan_raw)
+    known_pages: dict[str, bytes] = {}
+    generic = _page_digest(root, bytes([0x05]) + bytes(2047), known_pages)
+    page_zero = _page_digest(root, bytes(2048), known_pages)
+    artifact_entries: dict[int, list[dict[str, Any]]] = {}
+    environments: list[dict[str, Any]] = []
+    observations: list[dict[str, Any]] = []
+    replica_manifests: list[dict[str, Any]] = []
+    for replica in (1, 2, 3):
+        env_relative = f"environment/replica-{replica:02d}.json"
+        _write(root / env_relative, _environment(replica, plan_sha))
+        environments.append(_entry(root, env_relative, "environment"))
+        previous: list[str] = []
+        index_entries: list[dict[str, Any]] = []
+        checkpoint_rows: list[dict[str, Any]] = []
+        logical = changed_total = 0
+        for ordinal, (checkpoint, count) in enumerate(zip(CHECKPOINTS, COUNTS)):
+            hashes = [generic] * count
+            hashes[0] = page_zero
+            hashes[1] = _page_digest(root, _global_page(checkpoint), known_pages)
+            hashes[2] = _page_digest(root, _tdef_page(checkpoint), known_pages)
+            changed = [page for page in range(max(len(previous), len(hashes))) if (previous[page] if page < len(previous) else None) != (hashes[page] if page < len(hashes) else None)]
+            database = hashlib.sha256()
+            for digest in hashes:
+                database.update(known_pages[digest])
+            index = {
+                "protocol_version": "1.0.0", "document_type": "dao_a3_page_index", "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+                "plan_sha256": plan_sha, "producer_commit": PRODUCER, "campaign_id": CAMPAIGN,
+                "environment_sha256": environments[-1]["sha256"], "provider_sha256": PROVIDER, "replica": replica,
+                "checkpoint_id": checkpoint, "ordinal": ordinal, "predecessor_checkpoint_id": None if ordinal == 0 else CHECKPOINTS[ordinal - 1],
+                "page_count": count, "file_size_bytes": count * 2048, "database_sha256": database.hexdigest(),
+                "ordered_page_sha256": hashes, "changed_page_indices": changed,
+            }
+            relative = f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json"
+            _write(root / relative, index)
+            entry = _entry(root, relative, "page_index")
+            index_entries.append(entry)
+            checkpoint_rows.append(_checkpoint_observation(checkpoint, ordinal, count, entry))
+            logical += count * 2048
+            changed_total += len(changed)
+            previous = hashes
+        bindings = plan["tables"]["role_bindings"][replica - 1]
+        observation = {
+            "protocol_version": "1.0.0", "document_type": "dao_a3_replica_observation", "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+            "plan_sha256": plan_sha, "producer_commit": PRODUCER, "repository_url": "https://github.com/oglassdev/jet3-rs.git", "campaign_id": CAMPAIGN,
+            "matrix_job": {"job_id": f"synthetic-{replica}", "replica_only": True, "shared_mutable_state": False},
+            "environment_sha256": environments[-1]["sha256"], "provider_sha256": PROVIDER, "replica": replica,
+            "role_binding": {role: bindings[role] for role in ("D", "L", "P", "H")},
+            "d_growth_observation": {"first_baseline_pages": 129, "first_target_pages": 257, "first_achieved_pages": 257, "first_rows": 2048, "regrowth_baseline_pages": 258, "regrowth_target_pages": 386, "regrowth_achieved_pages": 386, "regrowth_rows": 2048},
+            "logical_checkpoint_read_bytes": logical, "inserted_rows_total": 10000, "changed_hash_entries": changed_total, "checkpoints": checkpoint_rows,
+        }
+        observation_relative = f"observations/replica-{replica:02d}.json"
+        _write(root / observation_relative, observation)
+        observation_entry = _entry(root, observation_relative, "replica_observation")
+        observations.append(observation_entry)
+        artifact_entries[replica] = [environments[-1], observation_entry, *index_entries]
+    page_entries = [_entry(root, f"page-store/{digest}.page", "page_blob", "application/octet-stream") for digest in sorted(known_pages)]
+    for replica in (1, 2, 3):
+        files = artifact_entries[replica] + page_entries
+        replica_manifest = {
+            "protocol_version": "1.0.0", "document_type": "dao_a3_replica_artifact_manifest", "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+            "plan_sha256": plan_sha, "producer_commit": PRODUCER, "campaign_id": CAMPAIGN, "matrix_job_id": f"synthetic-{replica}", "replica": replica,
+            "environment_sha256": environments[replica - 1]["sha256"], "provider_sha256": PROVIDER, "checkpoint_count": 25,
+            "inventory_closed": True, "hashes_verified": True, "paths_closed": True, "files": files,
+        }
+        relative = f"replica-artifacts/replica-{replica:02d}-manifest.json"
+        _write(root / relative, replica_manifest)
+        replica_manifests.append(_entry(root, relative, "replica_artifact_manifest"))
+    frozen = _frozen(plan_sha, 294)
+    _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
+    frozen_sha = _digest(root / "analysis/derivation-candidates.json")
+    report = _report(plan, plan_sha, frozen, frozen_sha)
+    _write(root / "analysis/analysis-report.json", report)
+    receipt = {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_holdout_structure_receipt", "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+        "plan_sha256": plan_sha, "producer_commit": PRODUCER, "campaign_id": CAMPAIGN, "derivation_candidate_set_sha256": frozen_sha,
+        "replica": 3, "replica_artifact_manifest_sha256": replica_manifests[2]["sha256"], "validated_after_candidate_freeze": True,
+        "page_bytes_exposed_to_analyzer": False, "result": "pass",
+    }
+    _write(root / "analysis/holdout-structure-receipt.json", receipt)
+    fixed_entries = [
+        _entry(root, "plan/a3-allocation-maps.plan.json", "plan"), *environments, *replica_manifests, *observations,
+        *[item for replica in artifact_entries.values() for item in replica if item["role"] == "page_index"],
+        *page_entries, _entry(root, "analysis/derivation-candidates.json", "frozen_candidate_set"),
+        _entry(root, "analysis/analysis-report.json", "analysis_report"),
+        _entry(root, "analysis/holdout-structure-receipt.json", "holdout_structure_receipt"),
+    ]
+    unique_entries = {item["path"]: item for item in fixed_entries}
+    files = [unique_entries[path] for path in sorted(unique_entries)]
+    manifest = {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_bundle_manifest", "experiment_id": "DAO-A3-ALLOCATION-MAPS-001",
+        "campaign_id": CAMPAIGN, "producer_commit": PRODUCER, "repository_url": "https://github.com/oglassdev/jet3-rs.git", "created_utc": "2026-08-22T12:00:00Z",
+        "plan_sha256": plan_sha, "replica_environment_sha256": [item["sha256"] for item in environments], "provider_sha256": PROVIDER,
+        "replica_count": 3, "replica_artifact_manifest_sha256": [item["sha256"] for item in replica_manifests], "checkpoint_count": 75,
+        "page_blob_count": len(page_entries), "bundle_size_bytes_excluding_manifest": sum(item["size_bytes"] for item in files),
+        "inventory_closed": True, "hashes_verified": True, "paths_closed": True, "execution_status": "analysis_complete", "campaign_failed": False,
+        "holdout_structure_receipt_sha256": _digest(root / "analysis/holdout-structure-receipt.json"), "analysis_report_retained": True,
+        "analysis_scientific_outcome": "one_or_more_submodels_predict_holdout", "bundle_status": "decisive_pending_independent_validation",
+        "independent_validation_status": "not_independently_validated", "files": files,
+    }
+    _write(root / "bundle-manifest.json", manifest)
+
+
+def relink(root: Path) -> None:
+    frozen_path = root / "analysis/derivation-candidates.json"
+    report_path = root / "analysis/analysis-report.json"
+    receipt_path = root / "analysis/holdout-structure-receipt.json"
+    frozen = json.loads(frozen_path.read_text())
+    _write(frozen_path, frozen, canonical=True)
+    frozen_sha = _digest(frozen_path)
+    report = json.loads(report_path.read_text())
+    receipt = json.loads(receipt_path.read_text())
+    report["derivation_candidate_set_sha256"] = frozen_sha
+    receipt["derivation_candidate_set_sha256"] = frozen_sha
+    _write(report_path, report)
+    _write(receipt_path, receipt)
+    manifest_path = root / "bundle-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    roles = {item["path"]: (item["role"], item["media_type"]) for item in manifest["files"]}
+    manifest["files"] = [
+        _entry(root, path, roles[path][0], roles[path][1]) for path in sorted(roles)
+    ]
+    manifest["bundle_size_bytes_excluding_manifest"] = sum(item["size_bytes"] for item in manifest["files"])
+    manifest["holdout_structure_receipt_sha256"] = _digest(receipt_path)
+    _write(manifest_path, manifest)
+
+
+def _set_layer_terminal(report: dict[str, Any], old: str, new: str) -> None:
+    report["terminal_predicate_ids"] = [new if value == old else value for value in report["terminal_predicate_ids"]]
+    for result in report["predicate_results"]:
+        if result["predicate_id"] == old:
+            result["status"] = "not_applicable"
+        elif result["predicate_id"] == new:
+            result["status"] = "fail"
+
+
+def tamper_t1(root: Path) -> None:
+    frozen = json.loads((root / "analysis/derivation-candidates.json").read_text())
+    report = json.loads((root / "analysis/analysis-report.json").read_text())
+    frozen["layers"]["global_map_record"]["model"]["bit_polarity"] = "set_means_in_use"
+    report["submodels"]["global_map"]["record"]["model"]["bit_polarity"] = "set_means_in_use"
+    _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
+    _write(root / "analysis/analysis-report.json", report)
+    relink(root)
+
+
+def tamper_t2(root: Path) -> None:
+    frozen = json.loads((root / "analysis/derivation-candidates.json").read_text())
+    report = json.loads((root / "analysis/analysis-report.json").read_text())
+    layer = frozen["layers"]["global_map_conversion_inline"]
+    layer["no_outcome_reason"], layer["terminal_predicate_id"] = "missing_inline_to_indirect_conversion", "A3-CONVERSION-NONE"
+    report_layer = report["submodels"]["global_map"]["conversion_inline"]
+    report_layer["no_outcome_reasons"], report_layer["terminal_predicate_id"] = ["missing_inline_to_indirect_conversion"], "A3-CONVERSION-NONE"
+    report["no_outcome_reasons"][0] = "missing_inline_to_indirect_conversion"
+    _set_layer_terminal(report, "A3-POLARITY-CROSSCHECK", "A3-CONVERSION-NONE")
+    _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
+    _write(root / "analysis/analysis-report.json", report)
+    relink(root)
+
+
+def tamper_t3(root: Path) -> None:
+    frozen = json.loads((root / "analysis/derivation-candidates.json").read_text())
+    frozen["qualified_pages"]["global_map"] = [5]
+    _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
+    relink(root)
+
+
+def tamper_t4(root: Path) -> None:
+    frozen = json.loads((root / "analysis/derivation-candidates.json").read_text())
+    report = json.loads((root / "analysis/analysis-report.json").read_text())
+    layer = frozen["layers"]["tdef_pointer_pair"]
+    layer["no_outcome_reason"], layer["terminal_predicate_id"] = "no_growth_only_pointer_candidate", "A3-GROWTH-POINTER-NONE"
+    report_layer = report["submodels"]["tdef"]["pointer_pair"]
+    report_layer["no_outcome_reasons"], report_layer["terminal_predicate_id"] = ["no_growth_only_pointer_candidate"], "A3-GROWTH-POINTER-NONE"
+    report["no_outcome_reasons"][1] = "no_growth_only_pointer_candidate"
+    _set_layer_terminal(report, "A3-TDEF-RECORD-NONE", "A3-GROWTH-POINTER-NONE")
+    _write(root / "analysis/derivation-candidates.json", frozen, canonical=True)
+    _write(root / "analysis/analysis-report.json", report)
+    relink(root)
+
+
+def tamper_t5(root: Path) -> None:
+    report = json.loads((root / "analysis/analysis-report.json").read_text())
+    additions = {"A3-IDLE-EQUALITY", "A3-D-SET-RELATION", "A3-HOLDOUT-PREDICTION"}
+    terminals = set(report["terminal_predicate_ids"]) | additions
+    registry = json.loads(PLAN_PATH.read_text())["predicate_registry"]["ids"]
+    report["terminal_predicate_ids"] = [value for value in registry if value in terminals]
+    for result in report["predicate_results"]:
+        if result["predicate_id"] in additions:
+            result["status"] = "fail"
+    _write(root / "analysis/analysis-report.json", report)
+    relink(root)
+
+
+def _run(root: Path, output: Path) -> tuple[int, dict[str, Any]]:
+    code = main(["--bundle-root", str(root), "--plan", str(PLAN_PATH), "--validator-commit", "c" * 40, "--output", str(output)])
+    return code, json.loads(output.read_text())
+
+
+class IndependentValidatorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(prefix="a3-independent-")
+        cls.synthetic_bundle = Path(cls.temporary.name) / "bundle"
+        build_bundle(cls.synthetic_bundle)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_accepts_untampered_synthetic_bundle(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="a3-result-") as directory:
+            code, result = _run(self.synthetic_bundle, Path(directory) / "accepted.json")
+        self.assertEqual(code, 0, result)
+        self.assertIs(result["accepted"], True)
+        self.assertEqual(result["discrepancy_codes"], [])
+
+    def test_rejects_relinked_tamper_cases(self) -> None:
+        cases: list[tuple[str, Callable[[Path], None], str]] = [
+            ("T1", tamper_t1, "global_record_model_mismatch"),
+            ("T2", tamper_t2, "conversion_outcome_mismatch"),
+            ("T3", tamper_t3, "frozen_set_recomputation_mismatch"),
+            ("T4", tamper_t4, "tdef_outcome_mismatch"),
+            ("T5", tamper_t5, "predicate_reporting_mismatch"),
+        ]
+        for name, tamper, expected in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory(prefix=f"a3-{name.lower()}-") as directory:
+                temporary = Path(directory)
+                mutated = temporary / "bundle"
+                shutil.copytree(self.synthetic_bundle, mutated, copy_function=os.link)
+                tamper(mutated)
+                code, result = _run(mutated, temporary / "result.json")
+                self.assertNotEqual(code, 0)
+                self.assertIs(result["accepted"], False)
+                self.assertEqual(result["discrepancy_codes"], [expected])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a bounded, analyzer-independent A3 bundle loader and recomputation engine
- validate frozen candidates, all four layers, holdout results, and 34-predicate reporting rules
- add derivation-only EXP-0042 replay mode that excludes replica 3
- add a synthetic end-to-end bundle suite rejecting fully relinked T1-T5 tamper cases

## Checks

- python3 -m py_compile oracle/windows-dao/scripts/a3_independent_*.py tests/test_a3_independent_validator.py
- python3 -m unittest -v tests/test_a3_independent_validator.py
- python3 tools/reconcile_tests.py --repo-root .
- EXP-0042 --recompute-only replay (manifest 9e1dac53..., holdout_opened false)