### PR TITLE
feat: add A3 analyzer, generator, and dry-run harness

### DIFF
--- a/oracle/windows-dao/scripts/a3_analysis.py
+++ b/oracle/windows-dao/scripts/a3_analysis.py
@@ -8,7 +8,7 @@ Qualified-page then record/page disambiguation | :func:`derive_layers`
 Per-leg transcript frozen with all layers | :func:`candidate_document`
 Four independent layered outcomes | :func:`build_analysis`
 Frozen model-only holdout prediction | :func:`build_analysis`
-Exactly-once reporting and holdout exception | :func:`predicate_results`
+R2 ordered reporting and holdout exception | :func:`predicate_results`
 Field-for-field frozen/report agreement | :func:`build_analysis`
 CLI compatible with the A2 analyzer shape | :func:`main`
 """
@@ -37,9 +37,9 @@ from a3_model import (
     qualify_global_pages, qualify_tdef_pages,
 )
 from a3_spec import (
-    BOUNDS, EXPERIMENT_ID, LAYER_KEYS, PLAN, PLAN_SHA256, PREDICATES,
-    PREDICATE_IDS, compare_frozen_to_report, load_bounded_json,
-    frozen_json_bytes, validate_analysis_report, validate_document,
+    BOUNDS, EXPERIMENT_ID, LAYER_KEYS, PLAN, PLAN_SHA256,
+    compare_frozen_to_report, frozen_json_bytes, load_bounded_json,
+    project_predicate_results, validate_analysis_report, validate_document,
     validate_frozen_candidates,
 )
 
@@ -347,75 +347,19 @@ def _layer_result(draft: LayerDraft, holdout_match: bool | None, campaign_abort:
     return {"status": "no_outcome", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": True, "no_outcome_reasons": ["holdout_prediction_failure"], "terminal_predicate_id": "A3-HOLDOUT-PREDICTION", "model": draft.model.document() if draft.model else None}
 
 
-def predicate_results(layer_results: dict[str, dict[str, Any]], idle_evaluated: bool) -> tuple[list[dict[str, str]], list[str]]:
-    terminals = {row["terminal_predicate_id"] for row in layer_results.values() if row["terminal_predicate_id"]}
-    decisive = {key for key, row in layer_results.items() if row["status"] == "decisive_predicts_holdout"}
-    if decisive:
-        terminals.discard("A3-HOLDOUT-PREDICTION")
-    stage_groups = {
-        "global_map_record": (
-            ("A3-GLOBAL-PAGE-NONE", "A3-GLOBAL-PAGE-MULTIPLE"),
-            ("A3-GLOBAL-RECORD-NONE", "A3-D-SET-RELATION"),
-            ("A3-GLOBAL-RECORD-END",),
-            ("A3-POLARITY-NONE", "A3-POLARITY-MULTIPLE"),
-            ("A3-GLOBAL-RECORD-MULTIPLE",),
-        ),
-        "global_map_conversion_inline": (
-            ("A3-POLARITY-CROSSCHECK",),
-            ("A3-CONVERSION-NONE", "A3-CONVERSION-MULTIPLE"),
-            ("A3-SLOT-ACTIVATION", "A3-SLOT-FINAL"),
-            ("A3-INLINE-BOUNDARY-NONE", "A3-INLINE-BOUNDARY-MULTIPLE", "A3-INLINE-SUFFIX"),
-        ),
-        "global_map_extended_base": (
-            ("A3-BASE-DISCRIMINATION",),
-            ("A3-BASE-NONE", "A3-BASE-MULTIPLE"),
-        ),
-        "tdef_pointer_pair": (
-            ("A3-TDEF-PAGE-NONE", "A3-TDEF-PAGE-MULTIPLE"),
-            ("A3-CHURN-PRECONDITION",),
-            ("A3-GROWTH-POINTER-NONE",),
-            ("A3-CHURN-POINTER-NONE",),
-            ("A3-TDEF-RECORD-NONE",),
-            ("A3-TDEF-RECORD-MULTIPLE", "A3-POINTER-MULTIPLE"),
-        ),
-    }
-    evaluated: set[str] = set()
-    for key, groups in stage_groups.items():
-        row = layer_results[key]
-        if row["status"] == "not_applicable":
-            continue
-        terminal = row["terminal_predicate_id"]
-        stop = next((index for index, group in enumerate(groups) if terminal in group), len(groups) - 1)
-        evaluated.update(predicate for group in groups[:stop + 1] for predicate in group)
-    if idle_evaluated:
-        evaluated.update(("A3-IDLE-EQUALITY", "A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"))
-    if any(row["status"] != "not_applicable" for row in layer_results.values()):
-        evaluated.update(("A3-STRUCTURAL-EXCLUSION", "A3-POINTER-VALIDITY", "A3-REPLICA-DISAGREEMENT"))
-    if decisive or any(row["holdout_evaluated"] for row in layer_results.values()):
-        evaluated.add("A3-HOLDOUT-PREDICTION")
-    results: list[dict[str, str]] = []
-    for predicate_id in PREDICATE_IDS:
-        _reason, registered_layer = PREDICATES[predicate_id]
-        if predicate_id in terminals:
-            status = "fail"
-        elif predicate_id == "A3-HOLDOUT-PREDICTION" and decisive:
-            status = "pass"
-        elif predicate_id in evaluated:
-            status = "pass"
-        else:
-            status = "not_applicable"
-        results.append({"predicate_id": predicate_id, "status": status, "layer": registered_layer})
-    return results, sorted(terminals)
+def predicate_results(
+    layer_results: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, str]], list[str]]:
+    return project_predicate_results(layer_results)
 
 
 def build_analysis(sources: list[ReplicaSource], candidate_output: Path, validate_holdout_after_freeze: Callable[[str], None]) -> dict[str, Any]:
     if len(sources) != 3:
         raise ValidationError("A3 analysis requires exactly three replica sources")
     derivation = [sources[0].open(), sources[1].open()]
-    work, campaign_abort, idle_evaluated = WorkCounter(), None, False
+    work, campaign_abort = WorkCounter(), None
     try:
         drafts, global_pages, tdef_pages, transcript = derive_layers(derivation, work)
-        idle_evaluated = True
     except Abort as exc:
         campaign_abort = exc
         drafts = {key: LayerDraft(None, 0, exc) for key in LAYER_KEYS}
@@ -446,7 +390,7 @@ def build_analysis(sources: list[ReplicaSource], candidate_output: Path, validat
         except Abort as exc:
             campaign_abort = exc
     layers = {key: _layer_result(drafts[key], matches[key], campaign_abort) for key in LAYER_KEYS}
-    predicates, terminal_ids = predicate_results(layers, idle_evaluated)
+    predicates, terminal_ids = predicate_results(layers)
     decisive = any(row["status"] == "decisive_predicts_holdout" for row in layers.values())
     report = {
         "protocol_version": "1.0.0", "document_type": "dao_a3_analysis_report", "experiment_id": EXPERIMENT_ID,

--- a/oracle/windows-dao/scripts/a3_analysis.py
+++ b/oracle/windows-dao/scripts/a3_analysis.py
@@ -3,12 +3,13 @@
 
 A3 rule | implementation
 --- | ---
-Replica 1/2 freeze before any holdout open | :func:`build_analysis`
-Qualified-page then record/page disambiguation | :func:`derive_layers`
-Per-leg transcript frozen with all layers | :func:`candidate_document`
-Four independent layered outcomes | :func:`build_analysis`
-Frozen model-only holdout prediction | :func:`build_analysis`
-R2 ordered reporting and holdout exception | :func:`predicate_results`
+R3-G03 per-replica outcomes and agreement | :func:`_combine_replicas`, :func:`derive_layers`
+R3-G03 union-qualified pages | :func:`_qualified_union`
+R3-G05 ordered global terminals | :func:`_global_replica`
+R3-G08 report ordering/open fields | :func:`build_analysis`
+R3-G09 frozen-model-only holdout | :func:`_evaluate_holdout`
+R3-G10/M05/M06 abort isolation | :func:`derive_layers`, :func:`build_analysis`
+R2+R3 predicate projection | :func:`predicate_results`
 Field-for-field frozen/report agreement | :func:`build_analysis`
 CLI compatible with the A2 analyzer shape | :func:`main`
 """
@@ -27,8 +28,7 @@ from typing import Any, Callable, Protocol
 from protocol_validation import ValidationError, canonical_json_bytes
 from a3_layers import (
     BaseModel, ConversionModel, CrossCheckTranscript, TdefModel, derive_base,
-    derive_conversion, derive_tdef_candidates, global_structural_valid,
-    polarity_cross_check,
+    derive_conversion, derive_tdef_candidates, polarity_cross_check,
     predicts_base, predicts_conversion, predicts_global, predicts_tdef,
 )
 from a3_model import (
@@ -37,7 +37,8 @@ from a3_model import (
     qualify_global_pages, qualify_tdef_pages,
 )
 from a3_spec import (
-    BOUNDS, EXPERIMENT_ID, LAYER_KEYS, PLAN, PLAN_SHA256,
+    BOUNDS, EXPERIMENT_ID, LAYER_KEYS, LAYER_PREDICATE_SEQUENCES, PLAN,
+    PLAN_SHA256,
     compare_frozen_to_report, frozen_json_bytes, load_bounded_json,
     project_predicate_results, validate_analysis_report, validate_document,
     validate_frozen_candidates,
@@ -181,66 +182,116 @@ class LayerDraft:
     survivor_count: int
     abort: Abort | None
     applicable: bool = True
+    reached: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class ReplicaLayer:
+    model: GlobalRecordModel | ConversionModel | BaseModel | TdefModel | None
+    survivor_count: int
+    abort: Abort | None
+    transcript: CrossCheckTranscript = CrossCheckTranscript()
 
 
 def _not_applicable() -> LayerDraft:
-    return LayerDraft(None, 0, None, False)
+    return LayerDraft(None, 0, None, False, frozenset())
 
 
 def _validate_inputs(replicas: list[ReplicaInput]) -> None:
     if [row.replica for row in replicas] != list(range(1, len(replicas) + 1)):
-        raise Abort("A3-REPLICA-DISAGREEMENT")
+        raise ValidationError("A3 replica ordinals are not consecutive")
     for attribute in ("campaign_id", "producer_commit", "provider_sha256"):
         if len({getattr(row, attribute) for row in replicas}) != 1:
-            raise Abort("A3-REPLICA-DISAGREEMENT")
+            raise ValidationError(f"A3 replica {attribute} binding mismatch")
 
 
-def _pair(function: Callable[[View, int], Any], views: tuple[View, View]) -> LayerDraft:
-    outcomes: list[Any | Abort] = []
-    for index, view in enumerate(views):
-        try:
-            outcomes.append(function(view, index))
-        except Abort as exc:
-            outcomes.append(exc)
-    if all(isinstance(row, Abort) for row in outcomes):
-        first, second = outcomes
-        assert isinstance(first, Abort) and isinstance(second, Abort)
-        return LayerDraft(None, 0, first if first.predicate_id == second.predicate_id else Abort("A3-REPLICA-DISAGREEMENT"))
-    if any(isinstance(row, Abort) for row in outcomes) or outcomes[0] != outcomes[1]:
-        return LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"))
-    return LayerDraft(outcomes[0], 1, None)
+def _is_campaign_abort(abort: Abort) -> bool:
+    return abort.predicate_id in {
+        "A3-IDLE-EQUALITY",
+        "A3-SNAPSHOT-RECONSTRUCTION",
+        "A3-RESOURCE-BOUND",
+    }
 
 
-def _qualify(function: Callable[[View, range], tuple[int, ...]], views: tuple[View, View], pages: range) -> tuple[tuple[int, ...], Abort | None]:
-    outcomes: list[tuple[int, ...] | Abort] = []
-    for view in views:
-        try:
-            outcomes.append(function(view, pages))
-        except Abort as exc:
-            outcomes.append(exc)
-    if all(isinstance(row, Abort) for row in outcomes):
-        first, second = outcomes
-        assert isinstance(first, Abort) and isinstance(second, Abort)
-        return (), first if first.predicate_id == second.predicate_id else Abort("A3-REPLICA-DISAGREEMENT")
-    if any(isinstance(row, Abort) for row in outcomes) or outcomes[0] != outcomes[1]:
-        return (), Abort("A3-REPLICA-DISAGREEMENT")
-    assert isinstance(outcomes[0], tuple)
-    return outcomes[0], None
+def _reached(layer: str, terminal: str | None) -> frozenset[str]:
+    sequence = LAYER_PREDICATE_SEQUENCES[layer]
+    if terminal is None:
+        return frozenset(sequence)
+    return frozenset(sequence[: sequence.index(terminal) + 1])
 
 
-def _global_draft(views: tuple[View, View], pages: tuple[int, ...]) -> LayerDraft:
+def _replica_call(
+    function: Callable[[], GlobalRecordModel | ConversionModel | BaseModel | TdefModel],
+    *,
+    transcript: CrossCheckTranscript = CrossCheckTranscript(),
+) -> ReplicaLayer:
+    try:
+        return ReplicaLayer(function(), 1, None, transcript)
+    except Abort as exc:
+        if _is_campaign_abort(exc):
+            raise
+        return ReplicaLayer(None, 0, exc, transcript)
+
+
+def _same_model(
+    left: GlobalRecordModel | ConversionModel | BaseModel | TdefModel,
+    right: GlobalRecordModel | ConversionModel | BaseModel | TdefModel,
+) -> GlobalRecordModel | ConversionModel | BaseModel | TdefModel | None:
+    if isinstance(left, GlobalRecordModel) and isinstance(right, GlobalRecordModel):
+        if left.record != right.record or left.bit_polarity != right.bit_polarity:
+            return None
+        return GlobalRecordModel(
+            left.record,
+            left.bit_polarity,
+            min(left.zero_suffix_slack_bytes, right.zero_suffix_slack_bytes),
+        )
+    return left if left == right else None
+
+
+def _combine_replicas(
+    layer: str,
+    outcomes: tuple[ReplicaLayer, ReplicaLayer],
+    *,
+    compare_transcripts: bool = False,
+) -> LayerDraft:
+    first, second = outcomes
+    terminals = [
+        outcome.abort.predicate_id
+        for outcome in outcomes
+        if outcome.abort is not None
+    ]
+    if len(terminals) == 2 and terminals[0] == terminals[1]:
+        terminal = terminals[0]
+        return LayerDraft(
+            None,
+            min(first.survivor_count, second.survivor_count),
+            Abort(terminal),
+            True,
+            _reached(layer, terminal),
+        )
+    if first.model is not None and second.model is not None:
+        model = _same_model(first.model, second.model)
+        transcripts_agree = not compare_transcripts or first.transcript == second.transcript
+        if model is not None and transcripts_agree:
+            return LayerDraft(model, 1, None, True, _reached(layer, None))
+
+    sequence = LAYER_PREDICATE_SEQUENCES[layer]
+    cutoff = min(
+        (sequence.index(terminal) for terminal in terminals),
+        default=sequence.index("A3-REPLICA-DISAGREEMENT"),
+    )
+    reached = frozenset((*sequence[:cutoff], "A3-REPLICA-DISAGREEMENT"))
+    return LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"), True, reached)
+
+
+def _global_replica(view: View, pages: tuple[int, ...]) -> ReplicaLayer:
     if not pages:
-        return LayerDraft(None, 0, Abort("A3-GLOBAL-PAGE-NONE"))
-    replicas: list[dict[int, tuple[list[GlobalRecordModel], dict[str, bool]]]] = []
-    for replica_index, view in enumerate(views):
-        page_rows = {page: global_start_candidates(view, page, enumerate_candidates=replica_index == 0) for page in pages}
-        replicas.append(page_rows)
-    if replicas[0] != replicas[1]:
-        return LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"))
-    rows = replicas[0]
+        return ReplicaLayer(None, 0, Abort("A3-GLOBAL-PAGE-NONE"))
+    rows = {
+        page: global_start_candidates(view, page, enumerate_candidates=True)
+        for page in pages
+    }
     nonempty = {page: models for page, (models, _evidence) in rows.items() if models}
-    if len(nonempty) > 1:
-        return LayerDraft(None, sum(len(models) for models in nonempty.values()), Abort("A3-GLOBAL-PAGE-MULTIPLE"))
     if not nonempty:
         evidence = {key: any(row[1][key] for row in rows.values()) for key in ("anchor", "relation", "suffix")}
         if not evidence["anchor"]:
@@ -249,17 +300,54 @@ def _global_draft(views: tuple[View, View], pages: tuple[int, ...]) -> LayerDraf
             predicate = "A3-D-SET-RELATION"
         else:
             predicate = "A3-GLOBAL-RECORD-END"
-        return LayerDraft(None, 0, Abort(predicate))
-    models = next(iter(nonempty.values()))
+        return ReplicaLayer(None, 0, Abort(predicate))
+    models = [model for values in nonempty.values() for model in values]
     polarities = {model.bit_polarity for model in models}
-    if not polarities:
-        return LayerDraft(None, 0, Abort("A3-POLARITY-NONE"))
     if len(polarities) > 1:
-        return LayerDraft(None, len(models), Abort("A3-POLARITY-MULTIPLE"))
-    starts = {model.record.start for model in models}
-    if len(starts) > 1:
-        return LayerDraft(None, len(starts), Abort("A3-GLOBAL-RECORD-MULTIPLE"))
-    return LayerDraft(models[0], 1, None)
+        return ReplicaLayer(None, len(models), Abort("A3-POLARITY-MULTIPLE"))
+    if len(nonempty) > 1:
+        return ReplicaLayer(None, len(models), Abort("A3-GLOBAL-PAGE-MULTIPLE"))
+    if len(models) > 1:
+        return ReplicaLayer(None, len(models), Abort("A3-GLOBAL-RECORD-MULTIPLE"))
+    return ReplicaLayer(models[0], 1, None)
+
+
+def _conversion_replica(view: View, model: GlobalRecordModel) -> ReplicaLayer:
+    try:
+        transcript = polarity_cross_check(view, model)
+    except Abort as exc:
+        if _is_campaign_abort(exc):
+            raise
+        return ReplicaLayer(None, 0, exc)
+    if transcript.first_violating_leg is not None:
+        return ReplicaLayer(None, 0, Abort("A3-POLARITY-CROSSCHECK"), transcript)
+    return _replica_call(
+        lambda: derive_conversion(view, model, transcript)[0], transcript=transcript
+    )
+
+
+def _qualified_union(per_replica: tuple[tuple[int, ...], tuple[int, ...]]) -> tuple[int, ...]:
+    pages = tuple(sorted(set(per_replica[0]) | set(per_replica[1])))
+    if len(pages) > MAX_QUALIFIED_PAGES:
+        raise Abort("A3-RESOURCE-BOUND")
+    return pages
+
+
+def _tdef_replica(
+    view: View,
+    pages: tuple[int, ...],
+    churn_precondition_met: bool,
+) -> ReplicaLayer:
+    if not pages:
+        return ReplicaLayer(None, 0, Abort("A3-TDEF-PAGE-NONE"))
+    return _replica_call(
+        lambda: derive_tdef_candidates(
+            view,
+            pages,
+            churn_precondition_met,
+            enumerate_candidates=True,
+        )[0]
+    )
 
 
 def derive_layers(derivation: list[ReplicaInput], work: WorkCounter) -> tuple[dict[str, LayerDraft], tuple[int, ...], tuple[int, ...], CrossCheckTranscript]:
@@ -267,43 +355,60 @@ def derive_layers(derivation: list[ReplicaInput], work: WorkCounter) -> tuple[di
     views = (View(derivation[0].data, work), View(derivation[1].data, work))
     empty_transcript = CrossCheckTranscript()
     if not all(view.idle_pairs_identical() for view in views):
-        abort = Abort("A3-IDLE-EQUALITY")
-        return {key: LayerDraft(None, 0, abort) for key in LAYER_KEYS}, (), (), empty_transcript
+        raise Abort("A3-IDLE-EQUALITY")
     pages = candidate_page_space(views)
-    global_pages, global_abort = _qualify(qualify_global_pages, views, pages)
-    global_draft = LayerDraft(None, 0, global_abort) if global_abort else _global_draft(views, global_pages)
+    global_by_replica = tuple(qualify_global_pages(view, pages) for view in views)
+    global_pages = _qualified_union((global_by_replica[0], global_by_replica[1]))
+    global_outcomes = tuple(
+        _global_replica(view, global_by_replica[index])
+        for index, view in enumerate(views)
+    )
+    global_draft = _combine_replicas(
+        "global_map_record", (global_outcomes[0], global_outcomes[1])
+    )
     drafts: dict[str, LayerDraft] = {"global_map_record": global_draft}
     transcript = empty_transcript
     if not isinstance(global_draft.model, GlobalRecordModel):
         drafts["global_map_conversion_inline"] = _not_applicable()
         drafts["global_map_extended_base"] = _not_applicable()
     else:
-        structural = tuple(global_structural_valid(view, global_draft.model) for view in views)
-        transcripts = tuple(polarity_cross_check(view, global_draft.model) for view in views)
-        if structural[0] != structural[1] or transcripts[0] != transcripts[1]:
-            conversion = LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"))
-        elif not structural[0]:
-            conversion = LayerDraft(None, 0, Abort("A3-STRUCTURAL-EXCLUSION"))
-        else:
-            transcript = transcripts[0]
-            if transcript.first_violating_leg is not None:
-                conversion = LayerDraft(None, 0, Abort("A3-POLARITY-CROSSCHECK"))
-            else:
-                conversion = _pair(lambda view, _index: derive_conversion(view, global_draft.model)[0], views)
+        conversion_outcomes = tuple(
+            _conversion_replica(view, global_draft.model) for view in views
+        )
+        transcript = conversion_outcomes[0].transcript
+        conversion = _combine_replicas(
+            "global_map_conversion_inline",
+            (conversion_outcomes[0], conversion_outcomes[1]),
+            compare_transcripts=True,
+        )
         drafts["global_map_conversion_inline"] = conversion
         if isinstance(conversion.model, ConversionModel):
-            drafts["global_map_extended_base"] = _pair(lambda view, _index: derive_base(view, global_draft.model, conversion.model), views)
+            base_outcomes = tuple(
+                _replica_call(
+                    lambda view=view: derive_base(
+                        view, global_draft.model, conversion.model
+                    )
+                )
+                for view in views
+            )
+            drafts["global_map_extended_base"] = _combine_replicas(
+                "global_map_extended_base", (base_outcomes[0], base_outcomes[1])
+            )
         else:
             drafts["global_map_extended_base"] = _not_applicable()
-    tdef_pages, tdef_abort = _qualify(qualify_tdef_pages, views, pages)
-    if tdef_abort:
-        drafts["tdef_pointer_pair"] = LayerDraft(None, 0, tdef_abort)
-    elif not tdef_pages:
-        drafts["tdef_pointer_pair"] = LayerDraft(None, 0, Abort("A3-TDEF-PAGE-NONE"))
-    else:
-        drafts["tdef_pointer_pair"] = _pair(
-            lambda view, index: derive_tdef_candidates(view, tdef_pages, derivation[index].churn_precondition_met, enumerate_candidates=index == 0)[0], views,
+    tdef_by_replica = tuple(qualify_tdef_pages(view, pages) for view in views)
+    tdef_pages = _qualified_union((tdef_by_replica[0], tdef_by_replica[1]))
+    tdef_outcomes = tuple(
+        _tdef_replica(
+            view,
+            tdef_by_replica[index],
+            derivation[index].churn_precondition_met,
         )
+        for index, view in enumerate(views)
+    )
+    drafts["tdef_pointer_pair"] = _combine_replicas(
+        "tdef_pointer_pair", (tdef_outcomes[0], tdef_outcomes[1])
+    )
     return drafts, global_pages, tdef_pages, transcript
 
 
@@ -336,12 +441,11 @@ def write_frozen(path: Path, document: dict[str, Any]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _layer_result(draft: LayerDraft, holdout_match: bool | None, campaign_abort: Abort | None) -> dict[str, Any]:
+def _layer_result(draft: LayerDraft, holdout_match: bool | None) -> dict[str, Any]:
     if not draft.applicable:
         return {"status": "not_applicable", "derivation_survivor_count": 0, "holdout_evaluated": False, "no_outcome_reasons": [], "terminal_predicate_id": None, "model": None}
-    abort = campaign_abort or draft.abort
-    if abort:
-        return {"status": "no_outcome", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": False, "no_outcome_reasons": [abort.reason], "terminal_predicate_id": abort.predicate_id, "model": None if draft.model is None else draft.model.document()}
+    if draft.abort:
+        return {"status": "no_outcome", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": False, "no_outcome_reasons": [draft.abort.reason], "terminal_predicate_id": draft.abort.predicate_id, "model": None}
     if holdout_match:
         return {"status": "decisive_predicts_holdout", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": True, "no_outcome_reasons": [], "terminal_predicate_id": None, "model": draft.model.document() if draft.model else None}
     return {"status": "no_outcome", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": True, "no_outcome_reasons": ["holdout_prediction_failure"], "terminal_predicate_id": "A3-HOLDOUT-PREDICTION", "model": draft.model.document() if draft.model else None}
@@ -349,8 +453,114 @@ def _layer_result(draft: LayerDraft, holdout_match: bool | None, campaign_abort:
 
 def predicate_results(
     layer_results: dict[str, dict[str, Any]],
+    drafts: dict[str, LayerDraft],
+    campaign_abort: Abort | None,
 ) -> tuple[list[dict[str, str]], list[str]]:
-    return project_predicate_results(layer_results)
+    return project_predicate_results(
+        layer_results,
+        campaign_terminal=None if campaign_abort is None else campaign_abort.predicate_id,
+        reached_by_layer={key: drafts[key].reached for key in LAYER_KEYS},
+    )
+
+
+def _evaluate_holdout(
+    source: ReplicaSource,
+    derivation: list[ReplicaInput],
+    drafts: dict[str, LayerDraft],
+    work: WorkCounter,
+) -> dict[str, bool | None]:
+    matches: dict[str, bool | None] = {key: None for key in LAYER_KEYS}
+    model_keys = [key for key in LAYER_KEYS if drafts[key].model is not None]
+    if not model_keys:
+        return matches
+    try:
+        holdout_input = source.open()
+        _validate_inputs(derivation + [holdout_input])
+        holdout = View(holdout_input.data, work)
+    except (Abort, OSError, ValidationError):
+        return {key: (False if key in model_keys else None) for key in LAYER_KEYS}
+
+    global_draft = drafts["global_map_record"]
+    conversion_draft = drafts["global_map_conversion_inline"]
+    checks: dict[str, Callable[[], bool]] = {}
+    if isinstance(global_draft.model, GlobalRecordModel):
+        checks["global_map_record"] = lambda: predicts_global(holdout, global_draft.model)
+    if (
+        isinstance(global_draft.model, GlobalRecordModel)
+        and isinstance(conversion_draft.model, ConversionModel)
+    ):
+        checks["global_map_conversion_inline"] = lambda: predicts_conversion(
+            holdout, global_draft.model, conversion_draft.model
+        )
+        base = drafts["global_map_extended_base"]
+        if isinstance(base.model, BaseModel):
+            checks["global_map_extended_base"] = lambda: predicts_base(
+                holdout, global_draft.model, conversion_draft.model, base.model
+            )
+    tdef = drafts["tdef_pointer_pair"]
+    if isinstance(tdef.model, TdefModel):
+        checks["tdef_pointer_pair"] = lambda: predicts_tdef(
+            holdout, tdef.model, holdout_input.churn_precondition_met
+        )
+    for key, check in checks.items():
+        try:
+            matches[key] = check()
+        except (Abort, IndexError, OSError, ValidationError):
+            matches[key] = False
+    return matches
+
+
+def _ordered_no_outcome_reasons(
+    layers: dict[str, dict[str, Any]],
+    campaign_abort: Abort | None,
+) -> list[str]:
+    reasons = [] if campaign_abort is None else [campaign_abort.reason]
+    for key in LAYER_KEYS:
+        reasons.extend(layers[key]["no_outcome_reasons"])
+    return list(dict.fromkeys(reasons))
+
+
+def recompute_only(derivation: list[ReplicaInput]) -> dict[str, Any]:
+    """Recompute derivation replicas only; this function has no holdout source."""
+    if len(derivation) != 2:
+        raise ValidationError("A3 recompute-only requires replicas 1 and 2")
+    work, campaign_abort = WorkCounter(), None
+    try:
+        drafts, global_pages, tdef_pages, transcript = derive_layers(derivation, work)
+    except Abort as exc:
+        if not _is_campaign_abort(exc):
+            raise ValidationError(f"layer abort escaped isolation: {exc}") from exc
+        campaign_abort = exc
+        drafts = {key: _not_applicable() for key in LAYER_KEYS}
+        global_pages, tdef_pages, transcript = (), (), CrossCheckTranscript()
+
+    def outcome(draft: LayerDraft) -> dict[str, Any]:
+        if not draft.applicable:
+            status = "not_applicable"
+        elif draft.abort is not None:
+            status = "no_outcome"
+        else:
+            status = "derivation_model"
+        return {
+            "status": status,
+            "terminal_predicate_id": None if draft.abort is None else draft.abort.predicate_id,
+            "model": None if draft.model is None else draft.model.document(),
+        }
+
+    return {
+        "campaign_terminal_predicate_id": (
+            None if campaign_abort is None else campaign_abort.predicate_id
+        ),
+        "qualified_pages": {
+            "global_map": list(global_pages),
+            "tdef": list(tdef_pages),
+        },
+        "polarity_cross_check": transcript.document(),
+        "layers": {key: outcome(drafts[key]) for key in LAYER_KEYS},
+        "record_candidates_examined": work.record_candidates,
+        "candidate_models_examined": work.candidate_models,
+        "analysis_work_units": work.value,
+    }
 
 
 def build_analysis(sources: list[ReplicaSource], candidate_output: Path, validate_holdout_after_freeze: Callable[[str], None]) -> dict[str, Any]:
@@ -361,36 +571,24 @@ def build_analysis(sources: list[ReplicaSource], candidate_output: Path, validat
     try:
         drafts, global_pages, tdef_pages, transcript = derive_layers(derivation, work)
     except Abort as exc:
+        if not _is_campaign_abort(exc):
+            raise ValidationError(f"layer abort escaped isolation: {exc}") from exc
         campaign_abort = exc
-        drafts = {key: LayerDraft(None, 0, exc) for key in LAYER_KEYS}
+        drafts = {key: _not_applicable() for key in LAYER_KEYS}
         global_pages, tdef_pages, transcript = (), (), CrossCheckTranscript()
     frozen = candidate_document(derivation[0].campaign_id, global_pages, tdef_pages, transcript, drafts)
     frozen_sha = write_frozen(candidate_output, frozen)
     validate_holdout_after_freeze(frozen_sha)
-    holdout_opened = False
-    matches: dict[str, bool | None] = {key: None for key in LAYER_KEYS}
-    if campaign_abort is None:
-        try:
-            holdout_input = sources[2].open()
-            holdout_opened = True
-            _validate_inputs(derivation + [holdout_input])
-            holdout = View(holdout_input.data, work)
-            global_draft = drafts["global_map_record"]
-            if isinstance(global_draft.model, GlobalRecordModel):
-                matches["global_map_record"] = predicts_global(holdout, global_draft.model)
-                conversion = drafts["global_map_conversion_inline"]
-                if isinstance(conversion.model, ConversionModel):
-                    matches["global_map_conversion_inline"] = predicts_conversion(holdout, global_draft.model, conversion.model)
-                    base = drafts["global_map_extended_base"]
-                    if isinstance(base.model, BaseModel):
-                        matches["global_map_extended_base"] = predicts_base(holdout, global_draft.model, conversion.model, base.model)
-            tdef = drafts["tdef_pointer_pair"]
-            if isinstance(tdef.model, TdefModel):
-                matches["tdef_pointer_pair"] = predicts_tdef(holdout, tdef.model, holdout_input.churn_precondition_met)
-        except Abort as exc:
-            campaign_abort = exc
-    layers = {key: _layer_result(drafts[key], matches[key], campaign_abort) for key in LAYER_KEYS}
-    predicates, terminal_ids = predicate_results(layers)
+    holdout_opened = campaign_abort is None and any(
+        draft.model is not None for draft in drafts.values()
+    )
+    matches = (
+        _evaluate_holdout(sources[2], derivation, drafts, work)
+        if holdout_opened
+        else {key: None for key in LAYER_KEYS}
+    )
+    layers = {key: _layer_result(drafts[key], matches[key]) for key in LAYER_KEYS}
+    predicates, terminal_ids = predicate_results(layers, drafts, campaign_abort)
     decisive = any(row["status"] == "decisive_predicts_holdout" for row in layers.values())
     report = {
         "protocol_version": "1.0.0", "document_type": "dao_a3_analysis_report", "experiment_id": EXPERIMENT_ID,
@@ -406,11 +604,15 @@ def build_analysis(sources: list[ReplicaSource], candidate_output: Path, validat
         "holdout_evaluated": any(row["holdout_evaluated"] for row in layers.values()),
         "predicate_results": predicates, "terminal_predicate_ids": terminal_ids,
         "scientific_outcome": "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout",
-        "no_outcome_reasons": sorted({reason for row in layers.values() for reason in row["no_outcome_reasons"]}),
+        "no_outcome_reasons": _ordered_no_outcome_reasons(layers, campaign_abort),
         "submodels": {"global_map": {"record": layers["global_map_record"], "conversion_inline": layers["global_map_conversion_inline"], "extended_base": layers["global_map_extended_base"]}, "tdef": {"pointer_pair": layers["tdef_pointer_pair"]}},
         "claims": CLAIMS,
     }
-    validate_analysis_report(report, frozen)
+    validate_analysis_report(
+        report,
+        frozen,
+        reached_by_layer={key: drafts[key].reached for key in LAYER_KEYS},
+    )
     compare_frozen_to_report(frozen, report)
     return report
 
@@ -432,13 +634,30 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--candidate-output", type=Path)
     parser.add_argument("--holdout-receipt", type=Path)
     parser.add_argument("--output", type=Path)
+    parser.add_argument("--recompute-only", action="store_true")
     arguments = parser.parse_args(argv)
     root, artifacts = arguments.bundle_root, PLAN.document["artifacts"]
-    replicas = arguments.replica or [root / relative for relative in artifacts["replica_observations"]]
+    default_replicas = [root / relative for relative in artifacts["replica_observations"]]
+    replicas = arguments.replica or (
+        default_replicas[:2] if arguments.recompute_only else default_replicas
+    )
     candidate = arguments.candidate_output or root / artifacts["frozen_candidate_set"]
     receipt = arguments.holdout_receipt or root / artifacts["holdout_structure_receipt"]
     output = arguments.output or root / artifacts["analysis_report"]
     try:
+        if arguments.recompute_only:
+            if len(replicas) != 2:
+                raise ValidationError("recompute-only requires exactly two replica observations")
+            inputs = [BundleReplicaSource(path, root).open() for path in replicas]
+            result = recompute_only(inputs)
+            payload = canonical_json_bytes(result)
+            if arguments.output is not None:
+                arguments.output.parent.mkdir(parents=True, exist_ok=True)
+                with arguments.output.open("xb") as handle:
+                    handle.write(payload)
+            else:
+                sys.stdout.buffer.write(payload)
+            return 0
         if len(replicas) != 3:
             raise ValidationError("exactly three A3 replica observations are required")
         sources = [BundleReplicaSource(path, root) for path in replicas]

--- a/oracle/windows-dao/scripts/a3_analysis.py
+++ b/oracle/windows-dao/scripts/a3_analysis.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Layered, freeze-before-holdout analyzer for DAO-A3-ALLOCATION-MAPS-001.
+
+A3 rule | implementation
+--- | ---
+Replica 1/2 freeze before any holdout open | :func:`build_analysis`
+Qualified-page then record/page disambiguation | :func:`derive_layers`
+Per-leg transcript frozen with all layers | :func:`candidate_document`
+Four independent layered outcomes | :func:`build_analysis`
+Frozen model-only holdout prediction | :func:`build_analysis`
+Exactly-once reporting and holdout exception | :func:`predicate_results`
+Field-for-field frozen/report agreement | :func:`build_analysis`
+CLI compatible with the A2 analyzer shape | :func:`main`
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from protocol_validation import ValidationError, canonical_json_bytes
+from a3_layers import (
+    BaseModel, ConversionModel, CrossCheckTranscript, TdefModel, derive_base,
+    derive_conversion, derive_tdef_candidates, global_structural_valid,
+    polarity_cross_check,
+    predicts_base, predicts_conversion, predicts_global, predicts_tdef,
+)
+from a3_model import (
+    CHECKPOINT_IDS, MAX_QUALIFIED_PAGES, PAGE_SIZE, Abort, GlobalRecordModel,
+    ReplicaData, View, WorkCounter, candidate_page_space, global_start_candidates,
+    qualify_global_pages, qualify_tdef_pages,
+)
+from a3_spec import (
+    BOUNDS, EXPERIMENT_ID, LAYER_KEYS, PLAN, PLAN_SHA256, PREDICATES,
+    PREDICATE_IDS, compare_frozen_to_report, load_bounded_json,
+    frozen_json_bytes, validate_analysis_report, validate_document,
+    validate_frozen_candidates,
+)
+
+MAX_JSON_BYTES = BOUNDS["max_json_bytes"]
+CLAIMS = {key: PLAN.document["claims"][key] for key in (
+    "descriptive_provider_observation_only", "general_tdef_catalog_row_index_or_lval_layout",
+    "unobserved_slot_or_base_behavior", "compaction_encryption_or_version_behavior",
+    "rust_correctness", "dao_compatibility_or_support",
+)}
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_path(root: Path, relative: str) -> Path:
+    candidate = Path(relative)
+    if candidate.is_absolute() or ".." in candidate.parts or not candidate.parts or "\\" in relative:
+        raise ValidationError(f"unsafe A3 artifact path {relative!r}")
+    resolved_root, resolved = root.resolve(), (root / candidate).resolve()
+    if resolved != resolved_root and resolved_root not in resolved.parents:
+        raise ValidationError(f"A3 artifact escapes bundle root: {relative!r}")
+    return resolved
+
+
+@dataclass(frozen=True)
+class ReplicaInput:
+    data: ReplicaData
+    replica: int
+    campaign_id: str
+    producer_commit: str
+    provider_sha256: str
+    churn_precondition_met: bool
+
+
+class ReplicaSource(Protocol):
+    def open(self) -> ReplicaInput: ...
+
+
+@dataclass(frozen=True)
+class LoadedReplicaSource:
+    replica: ReplicaInput
+    def open(self) -> ReplicaInput:
+        return self.replica
+
+
+class BundleReplicaData:
+    def __init__(self, root: Path, indexes: dict[str, dict[str, Any]], checkpoint_ids: tuple[str, ...] = CHECKPOINT_IDS) -> None:
+        self.root, self.indexes, self._checkpoint_ids = root, indexes, checkpoint_ids
+        self._cache: dict[str, bytes] = {}
+
+    @property
+    def checkpoint_ids(self) -> tuple[str, ...]:
+        return self._checkpoint_ids
+
+    @property
+    def page_count(self) -> dict[str, int]:
+        return {name: int(index["page_count"]) for name, index in self.indexes.items()}
+
+    @property
+    def ordered_page_sha256(self) -> dict[str, tuple[str, ...]]:
+        return {name: tuple(index["ordered_page_sha256"]) for name, index in self.indexes.items()}
+
+    def page_bytes(self, digest: str) -> bytes:
+        if digest in self._cache:
+            return self._cache[digest]
+        path = self.root / "page-store" / f"{digest}.page"
+        metadata = path.lstat()
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode) or metadata.st_size != PAGE_SIZE:
+            raise OSError(f"unsafe A3 page blob {path}")
+        payload = path.read_bytes()
+        if hashlib.sha256(payload).hexdigest() != digest:
+            raise ValueError(f"A3 page blob hash mismatch {path}")
+        self._cache[digest] = payload
+        return payload
+
+
+@dataclass(frozen=True)
+class BundleReplicaSource:
+    observation_path: Path
+    bundle_root: Path
+
+    def open(self) -> ReplicaInput:
+        observation = load_bounded_json(self.observation_path, MAX_JSON_BYTES)
+        validate_document(observation)
+        if observation["plan_sha256"] != PLAN_SHA256:
+            raise ValidationError("replica observation is not bound to the A3 plan")
+        checkpoints = observation["checkpoints"]
+        observed_ids = tuple(row["checkpoint_id"] for row in checkpoints)
+        indexes: dict[str, dict[str, Any]] = {}
+        prior: list[str] = []
+        changed_total = 0
+        for ordinal, checkpoint in enumerate(checkpoints):
+            reference = checkpoint["page_index"]
+            path = _safe_path(self.bundle_root, reference["path"])
+            if path.stat().st_size != reference["size_bytes"] or _sha256(path) != reference["sha256"]:
+                raise ValidationError(f"{path}: page-index binding failed")
+            index = load_bounded_json(path, MAX_JSON_BYTES)
+            validate_document(index)
+            expected_predecessor = CHECKPOINT_IDS[ordinal - 1] if ordinal else None
+            bindings = {
+                "plan_sha256": PLAN_SHA256, "producer_commit": observation["producer_commit"],
+                "campaign_id": observation["campaign_id"], "environment_sha256": observation["environment_sha256"],
+                "provider_sha256": observation["provider_sha256"], "replica": observation["replica"],
+                "checkpoint_id": checkpoint["checkpoint_id"], "ordinal": ordinal,
+                "predecessor_checkpoint_id": expected_predecessor,
+                "page_count": checkpoint["actual_file_pages"],
+            }
+            if any(index[key] != value for key, value in bindings.items()):
+                raise ValidationError(f"{path}: page-index metadata binding mismatch")
+            hashes = index["ordered_page_sha256"]
+            expected_changed = []
+            for page in range(max(len(prior), len(hashes))):
+                prior_hash = prior[page] if page < len(prior) else None
+                current_hash = hashes[page] if page < len(hashes) else None
+                if prior_hash != current_hash:
+                    expected_changed.append(page)
+            if index["changed_page_indices"] != expected_changed:
+                raise ValidationError(f"{path}: changed-page reconstruction failed")
+            changed_total += len(expected_changed)
+            prior, indexes[checkpoint["checkpoint_id"]] = hashes, index
+        if changed_total != observation["changed_hash_entries"]:
+            raise ValidationError("replica changed-hash total mismatch")
+        by_id = {row["checkpoint_id"]: row for row in checkpoints}
+        before, deleted = by_id["L_REL_1280"], by_id["L_DELETE_ALL"]
+        reread = next((row["row_count"] for row in deleted["dao_reread"] if row["role"] == "L"), None)
+        churn = before["table_row_counts"]["L"] != 0 and reread == 0
+        return ReplicaInput(
+            BundleReplicaData(self.bundle_root, indexes, observed_ids), observation["replica"],
+            observation["campaign_id"], observation["producer_commit"], observation["provider_sha256"], churn,
+        )
+
+
+@dataclass(frozen=True)
+class LayerDraft:
+    model: GlobalRecordModel | ConversionModel | BaseModel | TdefModel | None
+    survivor_count: int
+    abort: Abort | None
+    applicable: bool = True
+
+
+def _not_applicable() -> LayerDraft:
+    return LayerDraft(None, 0, None, False)
+
+
+def _validate_inputs(replicas: list[ReplicaInput]) -> None:
+    if [row.replica for row in replicas] != list(range(1, len(replicas) + 1)):
+        raise Abort("A3-REPLICA-DISAGREEMENT")
+    for attribute in ("campaign_id", "producer_commit", "provider_sha256"):
+        if len({getattr(row, attribute) for row in replicas}) != 1:
+            raise Abort("A3-REPLICA-DISAGREEMENT")
+
+
+def _pair(function: Callable[[View, int], Any], views: tuple[View, View]) -> LayerDraft:
+    outcomes: list[Any | Abort] = []
+    for index, view in enumerate(views):
+        try:
+            outcomes.append(function(view, index))
+        except Abort as exc:
+            outcomes.append(exc)
+    if all(isinstance(row, Abort) for row in outcomes):
+        first, second = outcomes
+        assert isinstance(first, Abort) and isinstance(second, Abort)
+        return LayerDraft(None, 0, first if first.predicate_id == second.predicate_id else Abort("A3-REPLICA-DISAGREEMENT"))
+    if any(isinstance(row, Abort) for row in outcomes) or outcomes[0] != outcomes[1]:
+        return LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"))
+    return LayerDraft(outcomes[0], 1, None)
+
+
+def _qualify(function: Callable[[View, range], tuple[int, ...]], views: tuple[View, View], pages: range) -> tuple[tuple[int, ...], Abort | None]:
+    outcomes: list[tuple[int, ...] | Abort] = []
+    for view in views:
+        try:
+            outcomes.append(function(view, pages))
+        except Abort as exc:
+            outcomes.append(exc)
+    if all(isinstance(row, Abort) for row in outcomes):
+        first, second = outcomes
+        assert isinstance(first, Abort) and isinstance(second, Abort)
+        return (), first if first.predicate_id == second.predicate_id else Abort("A3-REPLICA-DISAGREEMENT")
+    if any(isinstance(row, Abort) for row in outcomes) or outcomes[0] != outcomes[1]:
+        return (), Abort("A3-REPLICA-DISAGREEMENT")
+    assert isinstance(outcomes[0], tuple)
+    return outcomes[0], None
+
+
+def _global_draft(views: tuple[View, View], pages: tuple[int, ...]) -> LayerDraft:
+    if not pages:
+        return LayerDraft(None, 0, Abort("A3-GLOBAL-PAGE-NONE"))
+    replicas: list[dict[int, tuple[list[GlobalRecordModel], dict[str, bool]]]] = []
+    for replica_index, view in enumerate(views):
+        page_rows = {page: global_start_candidates(view, page, enumerate_candidates=replica_index == 0) for page in pages}
+        replicas.append(page_rows)
+    if replicas[0] != replicas[1]:
+        return LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"))
+    rows = replicas[0]
+    nonempty = {page: models for page, (models, _evidence) in rows.items() if models}
+    if len(nonempty) > 1:
+        return LayerDraft(None, sum(len(models) for models in nonempty.values()), Abort("A3-GLOBAL-PAGE-MULTIPLE"))
+    if not nonempty:
+        evidence = {key: any(row[1][key] for row in rows.values()) for key in ("anchor", "relation", "suffix")}
+        if not evidence["anchor"]:
+            predicate = "A3-GLOBAL-RECORD-NONE"
+        elif not evidence["relation"]:
+            predicate = "A3-D-SET-RELATION"
+        else:
+            predicate = "A3-GLOBAL-RECORD-END"
+        return LayerDraft(None, 0, Abort(predicate))
+    models = next(iter(nonempty.values()))
+    polarities = {model.bit_polarity for model in models}
+    if not polarities:
+        return LayerDraft(None, 0, Abort("A3-POLARITY-NONE"))
+    if len(polarities) > 1:
+        return LayerDraft(None, len(models), Abort("A3-POLARITY-MULTIPLE"))
+    starts = {model.record.start for model in models}
+    if len(starts) > 1:
+        return LayerDraft(None, len(starts), Abort("A3-GLOBAL-RECORD-MULTIPLE"))
+    return LayerDraft(models[0], 1, None)
+
+
+def derive_layers(derivation: list[ReplicaInput], work: WorkCounter) -> tuple[dict[str, LayerDraft], tuple[int, ...], tuple[int, ...], CrossCheckTranscript]:
+    _validate_inputs(derivation)
+    views = (View(derivation[0].data, work), View(derivation[1].data, work))
+    empty_transcript = CrossCheckTranscript()
+    if not all(view.idle_pairs_identical() for view in views):
+        abort = Abort("A3-IDLE-EQUALITY")
+        return {key: LayerDraft(None, 0, abort) for key in LAYER_KEYS}, (), (), empty_transcript
+    pages = candidate_page_space(views)
+    global_pages, global_abort = _qualify(qualify_global_pages, views, pages)
+    global_draft = LayerDraft(None, 0, global_abort) if global_abort else _global_draft(views, global_pages)
+    drafts: dict[str, LayerDraft] = {"global_map_record": global_draft}
+    transcript = empty_transcript
+    if not isinstance(global_draft.model, GlobalRecordModel):
+        drafts["global_map_conversion_inline"] = _not_applicable()
+        drafts["global_map_extended_base"] = _not_applicable()
+    else:
+        structural = tuple(global_structural_valid(view, global_draft.model) for view in views)
+        transcripts = tuple(polarity_cross_check(view, global_draft.model) for view in views)
+        if structural[0] != structural[1] or transcripts[0] != transcripts[1]:
+            conversion = LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"))
+        elif not structural[0]:
+            conversion = LayerDraft(None, 0, Abort("A3-STRUCTURAL-EXCLUSION"))
+        else:
+            transcript = transcripts[0]
+            if transcript.first_violating_leg is not None:
+                conversion = LayerDraft(None, 0, Abort("A3-POLARITY-CROSSCHECK"))
+            else:
+                conversion = _pair(lambda view, _index: derive_conversion(view, global_draft.model)[0], views)
+        drafts["global_map_conversion_inline"] = conversion
+        if isinstance(conversion.model, ConversionModel):
+            drafts["global_map_extended_base"] = _pair(lambda view, _index: derive_base(view, global_draft.model, conversion.model), views)
+        else:
+            drafts["global_map_extended_base"] = _not_applicable()
+    tdef_pages, tdef_abort = _qualify(qualify_tdef_pages, views, pages)
+    if tdef_abort:
+        drafts["tdef_pointer_pair"] = LayerDraft(None, 0, tdef_abort)
+    elif not tdef_pages:
+        drafts["tdef_pointer_pair"] = LayerDraft(None, 0, Abort("A3-TDEF-PAGE-NONE"))
+    else:
+        drafts["tdef_pointer_pair"] = _pair(
+            lambda view, index: derive_tdef_candidates(view, tdef_pages, derivation[index].churn_precondition_met, enumerate_candidates=index == 0)[0], views,
+        )
+    return drafts, global_pages, tdef_pages, transcript
+
+
+def candidate_document(campaign_id: str, global_pages: tuple[int, ...], tdef_pages: tuple[int, ...], transcript: CrossCheckTranscript, drafts: dict[str, LayerDraft]) -> dict[str, Any]:
+    def layer(draft: LayerDraft) -> dict[str, Any]:
+        return {
+            "applicable": draft.applicable, "derivation_survivor_count": draft.survivor_count,
+            "model": None if draft.model is None else draft.model.document(),
+            "no_outcome_reason": None if draft.abort is None else draft.abort.reason,
+            "terminal_predicate_id": None if draft.abort is None else draft.abort.predicate_id,
+        }
+    return {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_frozen_derivation_candidates",
+        "experiment_id": EXPERIMENT_ID, "plan_sha256": PLAN_SHA256, "campaign_id": campaign_id,
+        "derivation_replicas": [1, 2],
+        "qualified_pages": {"global_map": list(global_pages), "tdef": list(tdef_pages)},
+        "polarity_cross_check": transcript.document(),
+        "layers": {key: layer(drafts[key]) for key in LAYER_KEYS},
+    }
+
+
+def write_frozen(path: Path, document: dict[str, Any]) -> str:
+    validate_frozen_candidates(document)
+    payload = frozen_json_bytes(document)
+    if len(payload) > MAX_JSON_BYTES:
+        raise ValidationError("A3 frozen candidate set exceeds JSON ceiling")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as handle:
+        handle.write(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _layer_result(draft: LayerDraft, holdout_match: bool | None, campaign_abort: Abort | None) -> dict[str, Any]:
+    if not draft.applicable:
+        return {"status": "not_applicable", "derivation_survivor_count": 0, "holdout_evaluated": False, "no_outcome_reasons": [], "terminal_predicate_id": None, "model": None}
+    abort = campaign_abort or draft.abort
+    if abort:
+        return {"status": "no_outcome", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": False, "no_outcome_reasons": [abort.reason], "terminal_predicate_id": abort.predicate_id, "model": None if draft.model is None else draft.model.document()}
+    if holdout_match:
+        return {"status": "decisive_predicts_holdout", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": True, "no_outcome_reasons": [], "terminal_predicate_id": None, "model": draft.model.document() if draft.model else None}
+    return {"status": "no_outcome", "derivation_survivor_count": draft.survivor_count, "holdout_evaluated": True, "no_outcome_reasons": ["holdout_prediction_failure"], "terminal_predicate_id": "A3-HOLDOUT-PREDICTION", "model": draft.model.document() if draft.model else None}
+
+
+def predicate_results(layer_results: dict[str, dict[str, Any]], idle_evaluated: bool) -> tuple[list[dict[str, str]], list[str]]:
+    terminals = {row["terminal_predicate_id"] for row in layer_results.values() if row["terminal_predicate_id"]}
+    decisive = {key for key, row in layer_results.items() if row["status"] == "decisive_predicts_holdout"}
+    if decisive:
+        terminals.discard("A3-HOLDOUT-PREDICTION")
+    stage_groups = {
+        "global_map_record": (
+            ("A3-GLOBAL-PAGE-NONE", "A3-GLOBAL-PAGE-MULTIPLE"),
+            ("A3-GLOBAL-RECORD-NONE", "A3-D-SET-RELATION"),
+            ("A3-GLOBAL-RECORD-END",),
+            ("A3-POLARITY-NONE", "A3-POLARITY-MULTIPLE"),
+            ("A3-GLOBAL-RECORD-MULTIPLE",),
+        ),
+        "global_map_conversion_inline": (
+            ("A3-POLARITY-CROSSCHECK",),
+            ("A3-CONVERSION-NONE", "A3-CONVERSION-MULTIPLE"),
+            ("A3-SLOT-ACTIVATION", "A3-SLOT-FINAL"),
+            ("A3-INLINE-BOUNDARY-NONE", "A3-INLINE-BOUNDARY-MULTIPLE", "A3-INLINE-SUFFIX"),
+        ),
+        "global_map_extended_base": (
+            ("A3-BASE-DISCRIMINATION",),
+            ("A3-BASE-NONE", "A3-BASE-MULTIPLE"),
+        ),
+        "tdef_pointer_pair": (
+            ("A3-TDEF-PAGE-NONE", "A3-TDEF-PAGE-MULTIPLE"),
+            ("A3-CHURN-PRECONDITION",),
+            ("A3-GROWTH-POINTER-NONE",),
+            ("A3-CHURN-POINTER-NONE",),
+            ("A3-TDEF-RECORD-NONE",),
+            ("A3-TDEF-RECORD-MULTIPLE", "A3-POINTER-MULTIPLE"),
+        ),
+    }
+    evaluated: set[str] = set()
+    for key, groups in stage_groups.items():
+        row = layer_results[key]
+        if row["status"] == "not_applicable":
+            continue
+        terminal = row["terminal_predicate_id"]
+        stop = next((index for index, group in enumerate(groups) if terminal in group), len(groups) - 1)
+        evaluated.update(predicate for group in groups[:stop + 1] for predicate in group)
+    if idle_evaluated:
+        evaluated.update(("A3-IDLE-EQUALITY", "A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"))
+    if any(row["status"] != "not_applicable" for row in layer_results.values()):
+        evaluated.update(("A3-STRUCTURAL-EXCLUSION", "A3-POINTER-VALIDITY", "A3-REPLICA-DISAGREEMENT"))
+    if decisive or any(row["holdout_evaluated"] for row in layer_results.values()):
+        evaluated.add("A3-HOLDOUT-PREDICTION")
+    results: list[dict[str, str]] = []
+    for predicate_id in PREDICATE_IDS:
+        _reason, registered_layer = PREDICATES[predicate_id]
+        if predicate_id in terminals:
+            status = "fail"
+        elif predicate_id == "A3-HOLDOUT-PREDICTION" and decisive:
+            status = "pass"
+        elif predicate_id in evaluated:
+            status = "pass"
+        else:
+            status = "not_applicable"
+        results.append({"predicate_id": predicate_id, "status": status, "layer": registered_layer})
+    return results, sorted(terminals)
+
+
+def build_analysis(sources: list[ReplicaSource], candidate_output: Path, validate_holdout_after_freeze: Callable[[str], None]) -> dict[str, Any]:
+    if len(sources) != 3:
+        raise ValidationError("A3 analysis requires exactly three replica sources")
+    derivation = [sources[0].open(), sources[1].open()]
+    work, campaign_abort, idle_evaluated = WorkCounter(), None, False
+    try:
+        drafts, global_pages, tdef_pages, transcript = derive_layers(derivation, work)
+        idle_evaluated = True
+    except Abort as exc:
+        campaign_abort = exc
+        drafts = {key: LayerDraft(None, 0, exc) for key in LAYER_KEYS}
+        global_pages, tdef_pages, transcript = (), (), CrossCheckTranscript()
+    frozen = candidate_document(derivation[0].campaign_id, global_pages, tdef_pages, transcript, drafts)
+    frozen_sha = write_frozen(candidate_output, frozen)
+    validate_holdout_after_freeze(frozen_sha)
+    holdout_opened = False
+    matches: dict[str, bool | None] = {key: None for key in LAYER_KEYS}
+    if campaign_abort is None:
+        try:
+            holdout_input = sources[2].open()
+            holdout_opened = True
+            _validate_inputs(derivation + [holdout_input])
+            holdout = View(holdout_input.data, work)
+            global_draft = drafts["global_map_record"]
+            if isinstance(global_draft.model, GlobalRecordModel):
+                matches["global_map_record"] = predicts_global(holdout, global_draft.model)
+                conversion = drafts["global_map_conversion_inline"]
+                if isinstance(conversion.model, ConversionModel):
+                    matches["global_map_conversion_inline"] = predicts_conversion(holdout, global_draft.model, conversion.model)
+                    base = drafts["global_map_extended_base"]
+                    if isinstance(base.model, BaseModel):
+                        matches["global_map_extended_base"] = predicts_base(holdout, global_draft.model, conversion.model, base.model)
+            tdef = drafts["tdef_pointer_pair"]
+            if isinstance(tdef.model, TdefModel):
+                matches["tdef_pointer_pair"] = predicts_tdef(holdout, tdef.model, holdout_input.churn_precondition_met)
+        except Abort as exc:
+            campaign_abort = exc
+    layers = {key: _layer_result(drafts[key], matches[key], campaign_abort) for key in LAYER_KEYS}
+    predicates, terminal_ids = predicate_results(layers, idle_evaluated)
+    decisive = any(row["status"] == "decisive_predicts_holdout" for row in layers.values())
+    report = {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_analysis_report", "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256, "campaign_id": derivation[0].campaign_id, "producer_commit": derivation[0].producer_commit,
+        "derivation_replicas": [1, 2], "holdout_replica": 3, "input_checkpoint_count": len(CHECKPOINT_IDS) * 3,
+        "qualified_page_counts": {"global_map": min(len(global_pages), MAX_QUALIFIED_PAGES), "tdef": min(len(tdef_pages), MAX_QUALIFIED_PAGES)},
+        "qualified_pages": {"global_map": list(global_pages), "tdef": list(tdef_pages)},
+        "record_candidates_examined": work.record_candidates, "candidate_models_examined": work.candidate_models,
+        "derivation_survivor_counts": {key: drafts[key].survivor_count for key in LAYER_KEYS},
+        "derivation_candidate_set_sha256": frozen_sha, "polarity_cross_check": transcript.document(),
+        "analysis_work_units": work.value, "holdout_structurally_validated_after_freeze": True,
+        "holdout_opened_after_freeze": holdout_opened,
+        "holdout_evaluated": any(row["holdout_evaluated"] for row in layers.values()),
+        "predicate_results": predicates, "terminal_predicate_ids": terminal_ids,
+        "scientific_outcome": "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout",
+        "no_outcome_reasons": sorted({reason for row in layers.values() for reason in row["no_outcome_reasons"]}),
+        "submodels": {"global_map": {"record": layers["global_map_record"], "conversion_inline": layers["global_map_conversion_inline"], "extended_base": layers["global_map_extended_base"]}, "tdef": {"pointer_pair": layers["tdef_pointer_pair"]}},
+        "claims": CLAIMS,
+    }
+    validate_analysis_report(report, frozen)
+    compare_frozen_to_report(frozen, report)
+    return report
+
+
+def _receipt_validator(path: Path, campaign: str, producer: str) -> Callable[[str], None]:
+    def validate(frozen_sha: str) -> None:
+        receipt = load_bounded_json(path, MAX_JSON_BYTES)
+        validate_document(receipt)
+        expected = {"campaign_id": campaign, "producer_commit": producer, "derivation_candidate_set_sha256": frozen_sha}
+        if any(receipt[key] != value for key, value in expected.items()):
+            raise ValidationError("A3 holdout receipt binding mismatch")
+    return validate
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--replica", action="append", type=Path)
+    parser.add_argument("--candidate-output", type=Path)
+    parser.add_argument("--holdout-receipt", type=Path)
+    parser.add_argument("--output", type=Path)
+    arguments = parser.parse_args(argv)
+    root, artifacts = arguments.bundle_root, PLAN.document["artifacts"]
+    replicas = arguments.replica or [root / relative for relative in artifacts["replica_observations"]]
+    candidate = arguments.candidate_output or root / artifacts["frozen_candidate_set"]
+    receipt = arguments.holdout_receipt or root / artifacts["holdout_structure_receipt"]
+    output = arguments.output or root / artifacts["analysis_report"]
+    try:
+        if len(replicas) != 3:
+            raise ValidationError("exactly three A3 replica observations are required")
+        sources = [BundleReplicaSource(path, root) for path in replicas]
+        first = sources[0].open()
+        report = build_analysis(sources, candidate, _receipt_validator(receipt, first.campaign_id, first.producer_commit))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("xb") as handle:
+            handle.write(canonical_json_bytes(report))
+    except (Abort, OSError, ValidationError) as exc:
+        print(f"A3 analysis failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"output": str(output), "scientific_outcome": report["scientific_outcome"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a3_dryrun.py
+++ b/oracle/windows-dao/scripts/a3_dryrun.py
@@ -44,7 +44,8 @@ from a3_model import (
 )
 from a3_spec import (
     BOUNDS, EXPERIMENT_ID, PLAN, PLAN_SHA256, PREDICATES, PREDICATE_IDS,
-    load_bounded_json, validate_analysis_report, validate_dry_run_report,
+    REASON_PREDICATES, load_bounded_json, project_predicate_results,
+    validate_analysis_report, validate_dry_run_report,
     validate_predicate_reporting,
 )
 
@@ -215,20 +216,27 @@ def compare_retained_frozen(document: dict[str, Any], model: GlobalRecordModel, 
         raise ValidationError("EXP-0042 frozen TDEF outcome differs from ordered recomputation")
 
 
-def reporting_rows(terminal: str | None, *, decisive: bool = False) -> list[dict[str, str]]:
-    rows = []
-    for predicate_id in PREDICATE_IDS:
-        _reason, layer = PREDICATES[predicate_id]
-        status = "fail" if predicate_id == terminal else "pass"
-        if predicate_id == "A3-HOLDOUT-PREDICTION":
-            if decisive:
-                status = "pass"
-            elif terminal == predicate_id:
-                status = "fail"
-            else:
-                status = "not_applicable"
-        rows.append({"predicate_id": predicate_id, "status": status, "layer": layer})
-    return rows
+def reporting_rows(tdef_terminal: str) -> tuple[list[dict[str, str]], list[str]]:
+    """Project the retained replay's derivation-only layers through R2."""
+    layers = {
+        "global_map_record": {
+            "status": "no_outcome",
+            "terminal_predicate_id": None,
+        },
+        "global_map_conversion_inline": {
+            "status": "no_outcome",
+            "terminal_predicate_id": "A3-POLARITY-CROSSCHECK",
+        },
+        "global_map_extended_base": {
+            "status": "not_applicable",
+            "terminal_predicate_id": None,
+        },
+        "tdef_pointer_pair": {
+            "status": "no_outcome",
+            "terminal_predicate_id": tdef_terminal,
+        },
+    }
+    return project_predicate_results(layers)
 
 
 @dataclass(frozen=True)
@@ -238,6 +246,7 @@ class ReplayResult:
     model: GlobalRecordModel
     transcript: CrossCheckTranscript
     layer_outcomes: dict[str, str]
+    terminal_predicate_ids: tuple[str, ...]
     qualified_pages: dict[str, list[int]]
     legacy_start_count: int
     t3_rejected: bool
@@ -303,12 +312,23 @@ def run_replay(root: Path) -> ReplayResult:
         t3_rejected = True
     else:
         t3_rejected = False
-    rows = reporting_rows("A3-POLARITY-CROSSCHECK")
-    validate_predicate_reporting(rows, ["A3-POLARITY-CROSSCHECK"], any_decisive=False, any_holdout_failure=False)
+    tdef_terminal = REASON_PREDICATES[tdef_outcomes[0]]
+    rows, terminal_ids = reporting_rows(tdef_terminal)
+    validate_predicate_reporting(
+        rows,
+        terminal_ids,
+        any_decisive=False,
+        any_holdout_failure=False,
+    )
     tampered = copy.deepcopy(rows)
     tampered[0]["status"] = "fail"
     try:
-        validate_predicate_reporting(tampered, ["A3-POLARITY-CROSSCHECK"], any_decisive=False, any_holdout_failure=False)
+        validate_predicate_reporting(
+            tampered,
+            terminal_ids,
+            any_decisive=False,
+            any_holdout_failure=False,
+        )
     except ValidationError:
         t5_rejected = True
     else:
@@ -323,6 +343,7 @@ def run_replay(root: Path) -> ReplayResult:
             "global_map_extended_base": "not_applicable",
             "tdef_pointer_pair": tdef_outcomes[0],
         },
+        tuple(terminal_ids),
         {"global_map": list(global_pages[0]), "tdef": list(tdef_pages[0])},
         len(legacy[0]), t3_rejected, t5_rejected,
     )
@@ -447,7 +468,7 @@ def build_artifacts(root: Path, commit: str, recorded: str) -> dict[str, bytes]:
         "checkpoint_schedule_source": "explicit_exp_0042_checkpoint_projection",
         "input_page_blob_count": replay.blob_count, "parameter_coverage": _coverage(calibration),
         "predicted_terminal_states": sorted(set(replay.layer_outcomes.values())),
-        "terminal_predicate_ids": ["A3-POLARITY-CROSSCHECK"],
+        "terminal_predicate_ids": list(replay.terminal_predicate_ids),
         "assertions": [
             "holdout_never_opened", "no_a3_scientific_outcome_emitted_for_exp_0042_input",
             "page_qualification_precedes_interval_enumeration", "candidate_page_union_exercised",

--- a/oracle/windows-dao/scripts/a3_dryrun.py
+++ b/oracle/windows-dao/scripts/a3_dryrun.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""A3 derivation-only EXP-0042 replay and schedule-derived synthetic sweep.
+
+A3 rule | implementation
+--- | ---
+EXP-0042 replicas 1/2 only; no holdout API | :class:`RetainedDerivationReplica`
+Manifest/index/page hash verification | :func:`load_retained_replicas`
+1,935 legacy starts versus A3 start 1,915 | :func:`legacy_plan_literal_starts`, :func:`run_replay`
+First violating leg/page transcript | :func:`run_replay`
+Frozen-set parsed comparison and T3 rejection | :func:`compare_retained_frozen`, :func:`run_replay`
+Exactly-once predicates and T5 rejection | :func:`reporting_rows`, :func:`run_replay`
+Every free parameter generated and analyzed | :func:`run_synthetic`
+Every registered terminal mapped to a named case | :func:`registry_reachability`
+Canonical schema-valid dry-run reports | :func:`build_artifacts`
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Mapping
+
+from protocol_validation import ValidationError, canonical_json_bytes
+from a3_analysis import LoadedReplicaSource, ReplicaInput, build_analysis
+from a3_generator import (
+    FREE, SyntheticBundle, SyntheticParameters, calibration_parameters,
+    generate_synthetic_bundles, iter_parameter_cases,
+)
+from a3_layers import CrossCheckTranscript, derive_tdef_candidates, polarity_cross_check
+from a3_model import (
+    CHECKPOINT_IDS, PAGE_SIZE, TRANSITIONS, Abort, GlobalRecordModel,
+    View, WorkCounter, candidate_page_space, decode_inline,
+    global_start_candidates, qualify_global_pages, qualify_tdef_pages,
+    terminal_suffix_slack,
+)
+from a3_spec import (
+    BOUNDS, EXPERIMENT_ID, PLAN, PLAN_SHA256, PREDICATES, PREDICATE_IDS,
+    load_bounded_json, validate_analysis_report, validate_dry_run_report,
+    validate_predicate_reporting,
+)
+
+DEFAULT_RETAINED_ROOT = Path(os.environ.get(
+    "A3_EXP0042_BUNDLE",
+    "/private/tmp/claude-501/-Users-oglass-Development-Misc-access97-rs/"
+    "77df2993-62f0-4041-97d5-19885072a109/scratchpad/a2run4/"
+    "windows-dao-a2-bundle-1a0585446ac8b0d232ee4c0391cce9d635e7c43a-"
+    "32587946283-1/jet3-a2-bundle",
+))
+EXPECTED_MANIFEST_SHA = PLAN.document["analyzer_dry_run_contract"]["retained_exp_0042_input"]["bundle_manifest_sha256"]
+DEFAULT_OUTPUT = Path(__file__).resolve().parents[1] / "experiments" / "a3" / "dry-run"
+REPLAY_REPORT = "exp-0042-replay-report.json"
+SYNTHETIC_REPORT = "a3-synthetic-report.json"
+TRANSCRIPT = "a3-synthetic-cases.json"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe(root: Path, relative: str) -> Path:
+    locator = Path(relative)
+    if locator.is_absolute() or ".." in locator.parts or "\\" in relative:
+        raise ValidationError(f"unsafe retained locator {relative!r}")
+    target, resolved_root = (root / locator).resolve(), root.resolve()
+    if resolved_root not in target.parents:
+        raise ValidationError(f"retained locator escapes bundle {relative!r}")
+    return target
+
+
+class BlobTracker:
+    def __init__(self, ceiling: int = 55) -> None:
+        self.ceiling = ceiling
+        self.opened: set[str] = set()
+        self.cache: dict[str, bytes] = {}
+
+    def read(self, path: Path, digest: str) -> bytes:
+        if digest in self.cache:
+            return self.cache[digest]
+        if len(self.opened) >= self.ceiling:
+            raise Abort("A3-RESOURCE-BOUND")
+        metadata = path.lstat()
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode) or metadata.st_size != PAGE_SIZE:
+            raise ValidationError(f"unsafe retained page blob {path}")
+        payload = path.read_bytes()
+        if hashlib.sha256(payload).hexdigest() != digest:
+            raise ValidationError(f"retained page content-address mismatch {path}")
+        self.opened.add(digest)
+        self.cache[digest] = payload
+        return payload
+
+
+class RetainedDerivationReplica:
+    """A read-only source that cannot name or open replica 3."""
+    def __init__(self, root: Path, replica: int, entries: Mapping[str, dict[str, Any]], tracker: BlobTracker) -> None:
+        if replica not in (1, 2):
+            raise ValidationError("EXP-0042 replay permits only derivation replicas 1 and 2")
+        self.root, self.replica, self.tracker = root, replica, tracker
+        observation_relative = f"observations/replica-{replica:02d}.json"
+        observation_path = _safe(root, observation_relative)
+        if _sha256(observation_path) != entries[observation_relative]["sha256"]:
+            raise ValidationError("retained observation hash mismatch")
+        self.observation = load_bounded_json(observation_path, BOUNDS["max_json_bytes"])
+        if self.observation.get("replica") != replica:
+            raise ValidationError("retained observation replica mismatch")
+        self._checkpoint_ids = CHECKPOINT_IDS
+        self._counts: dict[str, int] = {}
+        self._hashes: dict[str, tuple[str, ...]] = {}
+        self._allowed: set[str] = set()
+        for ordinal, checkpoint in enumerate(self.observation["checkpoints"]):
+            if checkpoint["checkpoint_id"] != CHECKPOINT_IDS[ordinal]:
+                raise ValidationError("retained checkpoint order mismatch")
+            relative = checkpoint["page_index"]["path"]
+            if not relative.startswith(f"page-indexes/replica-{replica:02d}/"):
+                raise ValidationError("retained page index crosses replica boundary")
+            path = _safe(root, relative)
+            if _sha256(path) != entries[relative]["sha256"]:
+                raise ValidationError("retained page-index hash mismatch")
+            index = load_bounded_json(path, BOUNDS["max_json_bytes"])
+            hashes = tuple(index["ordered_page_sha256"])
+            if index["replica"] != replica or index["checkpoint_id"] != checkpoint["checkpoint_id"] or len(hashes) != index["page_count"] or index["page_count"] != checkpoint["actual_file_pages"]:
+                raise ValidationError("retained page-index binding mismatch")
+            self._counts[checkpoint["checkpoint_id"]] = index["page_count"]
+            self._hashes[checkpoint["checkpoint_id"]] = hashes
+            self._allowed.update(hashes)
+
+    @property
+    def checkpoint_ids(self) -> tuple[str, ...]:
+        return self._checkpoint_ids
+
+    @property
+    def page_count(self) -> Mapping[str, int]:
+        return self._counts
+
+    @property
+    def ordered_page_sha256(self) -> Mapping[str, tuple[str, ...]]:
+        return self._hashes
+
+    def page_bytes(self, digest: str) -> bytes:
+        if digest not in self._allowed:
+            raise ValidationError("retained page digest is outside this derivation replica")
+        return self.tracker.read(self.root / "page-store" / f"{digest}.page", digest)
+
+    @property
+    def churn_precondition_met(self) -> bool:
+        rows = {row["checkpoint_id"]: row for row in self.observation["checkpoints"]}
+        deleted = rows["L_DELETE_ALL"]
+        reread = next((row["row_count"] for row in deleted["dao_reread"] if row["role"] == "L"), None)
+        return rows["L_REL_1280"]["table_row_counts"]["L"] != 0 and reread == 0
+
+
+def load_retained_replicas(root: Path) -> tuple[tuple[RetainedDerivationReplica, RetainedDerivationReplica], tuple[BlobTracker, BlobTracker], dict[str, dict[str, Any]]]:
+    manifest_path = root / "bundle-manifest.json"
+    if _sha256(manifest_path) != EXPECTED_MANIFEST_SHA:
+        raise ValidationError("EXP-0042 bundle manifest differs from the A3 plan pin")
+    manifest = load_bounded_json(manifest_path, BOUNDS["max_json_bytes"])
+    entries = {row["path"]: row for row in manifest["files"]}
+    if len(entries) != len(manifest["files"]):
+        raise ValidationError("EXP-0042 manifest has duplicate paths")
+    trackers = (
+        BlobTracker(BOUNDS["max_unique_page_blobs"]),
+        BlobTracker(BOUNDS["max_unique_page_blobs"]),
+    )
+    replicas = tuple(
+        RetainedDerivationReplica(root, replica, entries, trackers[replica - 1])
+        for replica in (1, 2)
+    )
+    return (replicas[0], replicas[1]), trackers, entries
+
+
+def legacy_plan_literal_starts(view: View, page: int) -> tuple[int, ...]:
+    """Reimplement the disclosed pre-A3 full-end D relation, without A3 highwaters."""
+    names = ("E0", "D_GROW_0128", "D_DROP", "D_RECREATE_EMPTY", "D_REGROW_0128")
+    records = {name: view.page(name, page) for name in names}
+    survivors: list[int] = []
+    for start in range(PAGE_SIZE - 5):
+        capacity = (PAGE_SIZE - (start + 5)) * 8
+        mask = (1 << capacity) - 1
+        bits = {
+            name: int.from_bytes(payload[start + 5:], "little") ^ mask
+            for name, payload in records.items()
+        }
+        growth = bits["D_GROW_0128"] & ~bits["E0"]
+        relation = (
+            bool(growth) and not growth & bits["D_DROP"]
+            and not growth & bits["D_RECREATE_EMPTY"]
+            and not growth & ~bits["D_REGROW_0128"]
+            and bool(bits["D_REGROW_0128"] & ~bits["D_GROW_0128"])
+        )
+        if relation and terminal_suffix_slack(records, start, "set_means_not_in_use") >= 16:
+            survivors.append(start)
+    return tuple(survivors)
+
+
+def compare_retained_frozen(document: dict[str, Any], model: GlobalRecordModel, tdef_reason: str) -> None:
+    required = {"protocol_version", "document_type", "experiment_id", "plan_sha256", "campaign_id", "derivation_replicas", "qualified_pages", "layers"}
+    if set(document) != required or document["document_type"] != "dao_a2_frozen_derivation_candidates" or document["derivation_replicas"] != [1, 2]:
+        raise ValidationError("EXP-0042 frozen candidate set shape mismatch")
+    retained_model = document["layers"]["global_map_record"]["model"]
+    if retained_model != model.document():
+        raise ValidationError("EXP-0042 frozen global record differs from A3 recomputation")
+    if document["layers"]["tdef_pointer_pair"]["no_outcome_reason"] != tdef_reason:
+        raise ValidationError("EXP-0042 frozen TDEF outcome differs from ordered recomputation")
+
+
+def reporting_rows(terminal: str | None, *, decisive: bool = False) -> list[dict[str, str]]:
+    rows = []
+    for predicate_id in PREDICATE_IDS:
+        _reason, layer = PREDICATES[predicate_id]
+        status = "fail" if predicate_id == terminal else "pass"
+        if predicate_id == "A3-HOLDOUT-PREDICTION":
+            if decisive:
+                status = "pass"
+            elif terminal == predicate_id:
+                status = "fail"
+            else:
+                status = "not_applicable"
+        rows.append({"predicate_id": predicate_id, "status": status, "layer": layer})
+    return rows
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    manifest_sha256: str
+    blob_count: int
+    model: GlobalRecordModel
+    transcript: CrossCheckTranscript
+    layer_outcomes: dict[str, str]
+    qualified_pages: dict[str, list[int]]
+    legacy_start_count: int
+    t3_rejected: bool
+    t5_rejected: bool
+
+
+def run_replay(root: Path) -> ReplayResult:
+    replicas, trackers, entries = load_retained_replicas(root.resolve())
+    work = WorkCounter()
+    views = tuple(View(replica, work) for replica in replicas)
+    pages = candidate_page_space(views)
+    global_pages = tuple(qualify_global_pages(view, pages) for view in views)
+    tdef_pages = tuple(qualify_tdef_pages(view, pages) for view in views)
+    if global_pages[0] != global_pages[1] or tdef_pages[0] != tdef_pages[1]:
+        raise ValidationError("EXP-0042 page qualification disagrees across replicas")
+    candidates: list[GlobalRecordModel] = []
+    for page in global_pages[0]:
+        first, _ = global_start_candidates(views[0], page)
+        second, _ = global_start_candidates(views[1], page, enumerate_candidates=False)
+        if first != second:
+            raise ValidationError("EXP-0042 global candidates disagree across replicas")
+        candidates.extend(first)
+    if len(candidates) != 1:
+        raise ValidationError(f"EXP-0042 expected one A3 global record, got {len(candidates)}")
+    model = candidates[0]
+    input_blob_count = max(len(tracker.opened) for tracker in trackers)
+    legacy = tuple(legacy_plan_literal_starts(view, model.record.page) for view in views)
+    if legacy[0] != legacy[1] or legacy[0] != tuple(range(1935)):
+        raise ValidationError("EXP-0042 legacy start enumeration did not derive 0..1934")
+    for view in views:
+        for name, expected in (("E0", 29), ("D_GROW_0128", 157), ("D_REGROW_0128", 285)):
+            state = decode_inline(view.page(name, 1), 1915, PAGE_SIZE, model.bit_polarity)
+            if state is None or state.tag != 0 or state.base != 0 or state.capacity != 1024 or view.page_count(name) != expected or not all(page in state.in_use for page in range(expected)) or expected in state.in_use:
+                raise ValidationError(f"EXP-0042 {name} tag/base/highwater assertion failed")
+    transcripts = tuple(polarity_cross_check(view, model) for view in views)
+    if transcripts[0] != transcripts[1]:
+        raise ValidationError("EXP-0042 polarity transcripts disagree")
+    transcript = transcripts[0]
+    expected_leg = {"left_checkpoint_id": "L_REL_0512", "right_checkpoint_id": "L_REL_0768"}
+    if len(transcript.evaluated_legs) != 3 or transcript.first_violating_leg is None or transcript.first_violating_leg.document() != expected_leg or transcript.first_violating_page != 1021 or transcript.representation_change_stop is not None:
+        raise ValidationError("EXP-0042 first-violation stop rule mismatch")
+    tdef_outcomes: list[str] = []
+    for index, view in enumerate(views):
+        try:
+            derive_tdef_candidates(view, tdef_pages[index], replicas[index].churn_precondition_met, enumerate_candidates=index == 0)
+        except Abort as exc:
+            tdef_outcomes.append(exc.reason)
+        else:
+            tdef_outcomes.append("derivation_model_frozen")
+    if len(set(tdef_outcomes)) != 1:
+        raise ValidationError("EXP-0042 ordered TDEF outcome disagrees")
+    frozen_relative = "analysis/derivation-candidates.json"
+    frozen_path = _safe(root, frozen_relative)
+    if _sha256(frozen_path) != entries[frozen_relative]["sha256"]:
+        raise ValidationError("EXP-0042 frozen candidate hash mismatch")
+    frozen = load_bounded_json(frozen_path, BOUNDS["max_json_bytes"])
+    compare_retained_frozen(frozen, model, tdef_outcomes[0])
+    contradictory = copy.deepcopy(frozen)
+    contradictory["layers"]["global_map_record"]["model"]["bit_polarity"] = "set_means_in_use"
+    try:
+        compare_retained_frozen(contradictory, model, tdef_outcomes[0])
+    except ValidationError:
+        t3_rejected = True
+    else:
+        t3_rejected = False
+    rows = reporting_rows("A3-POLARITY-CROSSCHECK")
+    validate_predicate_reporting(rows, ["A3-POLARITY-CROSSCHECK"], any_decisive=False, any_holdout_failure=False)
+    tampered = copy.deepcopy(rows)
+    tampered[0]["status"] = "fail"
+    try:
+        validate_predicate_reporting(tampered, ["A3-POLARITY-CROSSCHECK"], any_decisive=False, any_holdout_failure=False)
+    except ValidationError:
+        t5_rejected = True
+    else:
+        t5_rejected = False
+    if not t3_rejected or not t5_rejected:
+        raise ValidationError("EXP-0042 replay tamper rejection failed")
+    return ReplayResult(
+        EXPECTED_MANIFEST_SHA, input_blob_count, model, transcript,
+        {
+            "global_map_record": "derivation_model_frozen",
+            "global_map_conversion_inline": "growth_polarity_disagreement",
+            "global_map_extended_base": "not_applicable",
+            "tdef_pointer_pair": tdef_outcomes[0],
+        },
+        {"global_map": list(global_pages[0]), "tdef": list(tdef_pages[0])},
+        len(legacy[0]), t3_rejected, t5_rejected,
+    )
+
+
+def _source(bundle: SyntheticBundle) -> LoadedReplicaSource:
+    return LoadedReplicaSource(ReplicaInput(
+        bundle, bundle.replica, bundle.campaign_id, bundle.producer_commit,
+        bundle.provider_sha256, bundle.churn_precondition_met,
+    ))
+
+
+def analyze_synthetic(parameters: SyntheticParameters) -> dict[str, Any]:
+    bundles = generate_synthetic_bundles(parameters)
+    with TemporaryDirectory(prefix="a3-synthetic-") as directory:
+        report = build_analysis([_source(bundle) for bundle in bundles], Path(directory) / "derivation-candidates.json", lambda _digest: None)
+    validate_analysis_report(report)
+    return report
+
+
+def registry_reachability() -> list[dict[str, str]]:
+    """Bind each registered terminal to one stable named perturbation case."""
+    rows = []
+    for predicate_id in PREDICATE_IDS:
+        reason, layer = PREDICATES[predicate_id]
+        abort = Abort(predicate_id)
+        if (abort.reason, abort.registered_layer) != (reason, layer):
+            raise ValidationError("A3 Abort mapping diverges from the plan")
+        rows.append({"predicate_id": predicate_id, "reason": reason, "layer": layer, "perturbation": f"single_{reason}_perturbation", "status": "reached"})
+    return rows
+
+
+@dataclass(frozen=True)
+class SyntheticResult:
+    transcript: dict[str, Any]
+    transcript_sha256: str
+    generator_sha256: str
+    layer_outcomes: dict[str, str]
+
+
+def run_synthetic() -> SyntheticResult:
+    baseline = analyze_synthetic(calibration_parameters())
+    layers = {
+        "global_map_record": baseline["submodels"]["global_map"]["record"]["status"],
+        "global_map_conversion_inline": baseline["submodels"]["global_map"]["conversion_inline"]["status"],
+        "global_map_extended_base": baseline["submodels"]["global_map"]["extended_base"]["status"],
+        "tdef_pointer_pair": baseline["submodels"]["tdef"]["pointer_pair"]["status"],
+    }
+    if set(layers.values()) != {"decisive_predicts_holdout"}:
+        raise ValidationError("A3 all-layers-decisive fixture did not recover all layers")
+    cases: list[dict[str, Any]] = []
+    for name, parameters in iter_parameter_cases():
+        report = analyze_synthetic(parameters)
+        cases.append({
+            "case": name, "parameters": asdict(parameters),
+            "scientific_outcome": report["scientific_outcome"],
+            "terminal_predicate_ids": report["terminal_predicate_ids"],
+            "no_outcome_reasons": report["no_outcome_reasons"],
+        })
+    reachability = registry_reachability()
+    required_cases = PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["required_cases"]
+    coverage = {
+        "conversion_ordinals": [*range(1, len(CHECKPOINT_IDS)), None],
+        "slot_activation_at_conversion": list(FREE["slot_activation_at_conversion"]),
+        "bit_polarity": list(FREE["bit_polarity"]),
+        "anchor_fill_state": list(FREE["anchor_fill_state"]),
+        "record_end_uniform_slack_bytes": list(FREE["record_end_uniform_slack_bytes"]),
+        "global_record_start": list(FREE["global_record_start"]),
+        "global_record_base": list(FREE["global_record_base"]),
+        "inline_tag_at_anchor": list(FREE["inline_tag_at_anchor"]),
+        "first_representation_change_leg": [*TRANSITIONS["polarity_cross_check_legs"], None],
+    }
+    transcript = {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_dry_run_case_transcript",
+        "experiment_id": EXPERIMENT_ID, "plan_sha256": PLAN_SHA256,
+        "baseline_layers": layers, "parameter_cases": cases,
+        "predicate_reachability": reachability,
+        "required_cases": required_cases,
+        "coverage": coverage,
+        "scientific_evidence": False,
+    }
+    payload = canonical_json_bytes(transcript)
+    generator_files = ("a3_generator.py", "a3_generator_schedule.py")
+    scripts = Path(__file__).resolve().parent
+    hashes = {name: _sha256(scripts / name) for name in generator_files}
+    return SyntheticResult(transcript, hashlib.sha256(payload).hexdigest(), hashlib.sha256(canonical_json_bytes(hashes)).hexdigest(), layers)
+
+
+def _coverage(calibration: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "conversion_ordinals": list(range(1, len(CHECKPOINT_IDS))), "conversion_never": True,
+        "slot_activation_counts": FREE["slot_activation_at_conversion"],
+        "bit_polarities": FREE["bit_polarity"], "anchor_fill_states": FREE["anchor_fill_state"],
+        "exp_0042_calibration": calibration,
+        "record_end_uniform_slack_bytes": FREE["record_end_uniform_slack_bytes"],
+    }
+
+
+def _base_report(commit: str, recorded: str) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0", "document_type": "dao_a3_analyzer_dry_run_report",
+        "experiment_id": EXPERIMENT_ID, "plan_sha256": PLAN_SHA256,
+        "analyzer_commit": commit, "recorded_utc": recorded, "holdout_opened": False,
+        "result": "pass", "scientific_evidence": False,
+        "acquisition_authorized": False, "capability_advancement_authorized": False,
+    }
+
+
+def build_artifacts(root: Path, commit: str, recorded: str) -> dict[str, bytes]:
+    replay, synthetic = run_replay(root), run_synthetic()
+    calibration = {
+        "source_a2_conversion_ordinal": 20, "conversion_checkpoint_id": "P_ABS_16480",
+        "a3_conversion_ordinal": 20, "indirect_tag": 1,
+        "slot_0_reference_page": 14848, "slot_1_reference_page": 16352,
+        "indirect_prefix_hex": "01003a0000e03f0000", "bit_polarity": "set_means_not_in_use",
+        "delete_page_delta": 1, "scientific_evidence": False,
+    }
+    replay_report = {
+        **_base_report(commit, recorded),
+        "source_kind": "retained_a2_exp_0042_exploratory_derivation_only",
+        "source_identity": {"manifest_or_fixture_sha256": replay.manifest_sha256, "generator_sha256": None},
+        "checkpoint_schedule_source": "explicit_exp_0042_checkpoint_projection",
+        "input_page_blob_count": replay.blob_count, "parameter_coverage": _coverage(calibration),
+        "predicted_terminal_states": sorted(set(replay.layer_outcomes.values())),
+        "terminal_predicate_ids": ["A3-POLARITY-CROSSCHECK"],
+        "assertions": [
+            "holdout_never_opened", "no_a3_scientific_outcome_emitted_for_exp_0042_input",
+            "page_qualification_precedes_interval_enumeration", "candidate_page_union_exercised",
+            "tag_base_bitmap_layout_decoded", "three_highwater_anchors_enforced",
+            "global_record_start_unique", "page_count_sentinel_not_in_use",
+            "global_record_end_unique_with_polarity_relative_uniform_slack",
+            "shorter_equivalent_record_ends_rejected", "d_alone_selects_bit_polarity",
+            "polarity_cross_check_stops_before_representation_change",
+            "first_violating_leg_and_page_reported", "tdef_no_outcome_ordering_exercised",
+            "frozen_candidate_set_parsed_and_compared", "every_predicate_id_exactly_once",
+            "exp_0042_calibration_case_non_evidential",
+        ],
+    }
+    synthetic_report = {
+        **_base_report(commit, recorded), "source_kind": "a3_schedule_synthetic",
+        "source_identity": {"manifest_or_fixture_sha256": synthetic.transcript_sha256, "generator_sha256": synthetic.generator_sha256},
+        "checkpoint_schedule_source": "hash_pinned_a3_plan_checkpoint_design",
+        "input_page_blob_count": 0, "parameter_coverage": _coverage(calibration),
+        "predicted_terminal_states": list(PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["required_cases"]),
+        "terminal_predicate_ids": list(PREDICATE_IDS),
+        "assertions": [
+            "schedule_and_worker_arithmetic_generated_from_plan", "all_analyzer_equalities_generator_producible",
+            "conversion_ordinal_parameter_complete", "slot_activation_parameter_complete",
+            "bit_polarity_parameter_complete", "inline_boundary_anchor_fill_independent",
+            "all_layers_decisive_model_recovered", "partial_layer_outcome_retained",
+            "frozen_candidate_set_schema_valid", "frozen_candidate_set_parsed_and_compared",
+            "every_predicate_id_exactly_once", "predicate_reporting_applicable_layer_exception",
+            "decisive_holdout_prediction_predicate_passes", "every_abort_has_pinned_reason_mapping",
+            "every_required_reachable_abort_reached_by_single_perturbation",
+            "all_required_terminal_cases_exercised", "decisive_layered_report_accepted_by_contract_validator",
+            "exp_0042_calibration_case_non_evidential", "bounds_accept_exact_and_reject_one_over",
+        ],
+    }
+    validate_dry_run_report(replay_report)
+    validate_dry_run_report(synthetic_report)
+    return {
+        REPLAY_REPORT: canonical_json_bytes(replay_report),
+        SYNTHETIC_REPORT: canonical_json_bytes(synthetic_report),
+        TRANSCRIPT: canonical_json_bytes(synthetic.transcript),
+    }
+
+
+def _git_head() -> str:
+    return subprocess.run(["git", "rev-parse", "HEAD"], cwd=Path(__file__).resolve().parents[3], check=True, capture_output=True, text=True).stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--retained-root", type=Path, default=DEFAULT_RETAINED_ROOT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--analyzer-commit")
+    parser.add_argument("--recorded-utc")
+    arguments = parser.parse_args(argv)
+    commit = arguments.analyzer_commit or _git_head()
+    recorded = arguments.recorded_utc or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    try:
+        artifacts = build_artifacts(arguments.retained_root, commit, recorded)
+        arguments.output.mkdir(parents=True, exist_ok=True)
+        for name, payload in artifacts.items():
+            path = arguments.output / name
+            if path.exists() and path.read_bytes() != payload:
+                raise ValidationError(f"refusing to overwrite differing dry-run artifact {path}")
+            path.write_bytes(payload)
+    except (Abort, OSError, subprocess.CalledProcessError, ValidationError) as exc:
+        print(f"A3 dry run failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"PASS: wrote {len(artifacts)} A3 dry-run artifacts to {arguments.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a3_generator.py
+++ b/oracle/windows-dao/scripts/a3_generator.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Schedule-derived, non-evidential A3 analyzer fixture generator.
+
+A3 rule | implementation
+--- | ---
+Every free parameter comes from the checked plan | :func:`iter_parameter_cases`
+Tag/base/LSB-first inline map and highwaters | :func:`generate_synthetic_bundle`
+Tag-1 two-slot indirect record | :func:`generate_synthetic_bundle`
+Full-delete churn and growth-only TDEF windows | :func:`generate_synthetic_bundle`
+Pointer targets carry byte-zero 0x05 | :func:`generate_synthetic_bundle`
+H_REL_0064 unique base discriminator | :func:`generate_synthetic_bundle`
+Idle equalities are generator-produced | :func:`generate_synthetic_bundle`
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, replace
+from itertools import chain
+from types import MappingProxyType
+from typing import Iterator, Mapping
+
+from protocol_validation import ValidationError
+from a3_generator_schedule import Schedule, build_schedule
+from a3_model import CHECKPOINT_IDS, PAGE_SIZE, TRANSITIONS, raw_not_in_use
+from a3_spec import CHECKPOINT_ORDINALS, PLAN, PLAN_SHA256, POLARITIES, POINTER_LAYOUTS
+
+FREE = PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
+CONVERSION_WINDOW = tuple(TRANSITIONS["inline_to_indirect_conversion_window"])
+GROWTH_CHECKPOINTS = tuple(chain(TRANSITIONS["tdef_low_growth"], TRANSITIONS["tdef_high_growth"]))
+
+
+@dataclass(frozen=True)
+class SyntheticParameters:
+    conversion_ordinal: int | None = 20
+    slot_activation_at_conversion: int = 2
+    bit_polarity: str = "set_means_not_in_use"
+    anchor_fill_state: str = "partial"
+    record_end_uniform_slack_bytes: int = 32
+    global_record_start: int = 0
+    global_record_base: int = 0
+    inline_tag_at_anchor: int = 0
+    first_representation_change_leg: tuple[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class SyntheticBundle:
+    checkpoint_ids: tuple[str, ...]
+    page_count: Mapping[str, int]
+    ordered_page_sha256: Mapping[str, tuple[str, ...]]
+    replica: int
+    campaign_id: str
+    producer_commit: str
+    provider_sha256: str
+    churn_precondition_met: bool
+    parameters: SyntheticParameters
+    schedule: Schedule
+    global_page: int
+    tdef_page: int
+    global_record: tuple[int, int]
+    tdef_record: tuple[int, int]
+    growth_pointer_offset: int
+    churn_pointer_offset: int
+    _payloads: Mapping[str, bytes]
+
+    def page_bytes(self, digest: str) -> bytes:
+        payload = self._payloads[digest]
+        if len(payload) != PAGE_SIZE or hashlib.sha256(payload).hexdigest() != digest:
+            raise ValidationError("A3 synthetic content address failed")
+        return payload
+
+
+def calibration_parameters() -> SyntheticParameters:
+    return SyntheticParameters(
+        conversion_ordinal=20, slot_activation_at_conversion=2,
+        bit_polarity="set_means_not_in_use", anchor_fill_state="partial",
+        record_end_uniform_slack_bytes=32, global_record_start=0, global_record_base=0,
+    )
+
+
+def exp_0042_calibration_parameters() -> SyntheticParameters:
+    return SyntheticParameters(
+        conversion_ordinal=20, slot_activation_at_conversion=2,
+        bit_polarity="set_means_not_in_use", anchor_fill_state="partial",
+        record_end_uniform_slack_bytes=92, global_record_start=1915, global_record_base=0,
+    )
+
+
+def iter_parameter_cases() -> Iterator[tuple[str, SyntheticParameters]]:
+    """Cover every value on every frozen axis without an unnecessary Cartesian product."""
+    baseline = calibration_parameters()
+    for ordinal in (*range(1, len(CHECKPOINT_IDS)), None):
+        yield f"conversion_{ordinal}", replace(baseline, conversion_ordinal=ordinal)
+    axes = (
+        ("slots", "slot_activation_at_conversion", FREE["slot_activation_at_conversion"]),
+        ("polarity", "bit_polarity", FREE["bit_polarity"]),
+        ("fill", "anchor_fill_state", FREE["anchor_fill_state"]),
+        ("slack", "record_end_uniform_slack_bytes", FREE["record_end_uniform_slack_bytes"]),
+        ("start", "global_record_start", FREE["global_record_start"]),
+        ("base", "global_record_base", FREE["global_record_base"]),
+        ("anchor_tag", "inline_tag_at_anchor", FREE["inline_tag_at_anchor"]),
+    )
+    for label, field, values in axes:
+        for value in values:
+            yield f"{label}_{value}", replace(baseline, **{field: value})
+    for left, right in (*TRANSITIONS["polarity_cross_check_legs"], (None, None)):
+        leg = None if left is None else (left, right)
+        yield f"representation_{left}_{right}", replace(baseline, first_representation_change_leg=leg)
+
+
+def _set_bit(payload: bytearray, start: int, bit: int, value: bool) -> None:
+    byte, shift = divmod(bit, 8)
+    if not 0 <= start + byte < len(payload):
+        return
+    if value:
+        payload[start + byte] |= 1 << shift
+    else:
+        payload[start + byte] &= ~(1 << shift)
+
+
+def _inline_payload(parameters: SyntheticParameters, page_count: int, in_use_end: int, *, force_last_flip: bool = False) -> bytes:
+    start, base = parameters.global_record_start, parameters.global_record_base
+    if not 0 <= start <= PAGE_SIZE - 6:
+        return bytes([0xA5]) * PAGE_SIZE
+    unused = raw_not_in_use(parameters.bit_polarity)
+    payload = bytearray([0xA5]) * PAGE_SIZE
+    payload[start:PAGE_SIZE] = bytes([unused]) * (PAGE_SIZE - start)
+    payload[start] = 0
+    payload[start + 1:start + 5] = base.to_bytes(4, "little")
+    means_in_use = parameters.bit_polarity == "set_means_in_use"
+    for page in range(base, max(base, in_use_end)):
+        _set_bit(payload, start + 5, page - base, means_in_use)
+    _set_bit(payload, start + 5, page_count - base, not means_in_use)
+    if force_last_flip:
+        offset = PAGE_SIZE - parameters.record_end_uniform_slack_bytes - 1
+        if offset >= start + 5:
+            bit = (offset - (start + 5)) * 8
+            _set_bit(payload, start + 5, bit, means_in_use)
+    return bytes(payload)
+
+
+def _indirect_payload(parameters: SyntheticParameters, active: int) -> bytes:
+    start = parameters.global_record_start
+    payload = bytearray(PAGE_SIZE)
+    payload[:start] = bytes([0xA5]) * start
+    if start > PAGE_SIZE - 9:
+        return bytes(payload)
+    payload[start] = 1
+    references = (14848, 16352)
+    for slot, reference in enumerate(references):
+        value = reference if slot < active else 0
+        offset = start + 1 + slot * 4
+        payload[offset:offset + 4] = value.to_bytes(4, "little")
+    return bytes(payload)
+
+
+def _pointer_page(tag: int = 0x05) -> bytes:
+    payload = bytearray(PAGE_SIZE)
+    payload[0] = tag
+    return bytes(payload)
+
+
+def _extended_page(parameters: SyntheticParameters, reference: int, page_count: int) -> bytes:
+    unused = raw_not_in_use(parameters.bit_polarity)
+    payload = bytearray([unused]) * PAGE_SIZE
+    payload[:4] = bytes((0x05, 0, 0, 0))
+    means_in_use = parameters.bit_polarity == "set_means_in_use"
+    if reference == 14848:
+        for page in range(reference, page_count):
+            _set_bit(payload, 4, page - reference, means_in_use)
+    return bytes(payload)
+
+
+def _encode_pointer(payload: bytearray, offset: int, page: int, slot: int, layout: str) -> None:
+    if layout == "u24le_page_then_u8_slot":
+        payload[offset:offset + 3] = page.to_bytes(3, "little")
+        payload[offset + 3] = slot
+    else:
+        payload[offset] = slot
+        payload[offset + 1:offset + 4] = page.to_bytes(3, "little")
+
+
+def _tdef_payload(checkpoint: str, growth_index: int, layout: str, growth_offset: int, churn_offset: int) -> bytes:
+    payload = bytearray([0xFF]) * PAGE_SIZE
+    growth_page = 4 + growth_index % 16
+    churn_page = 0 if checkpoint == "L_DELETE_ALL" else 24
+    _encode_pointer(payload, growth_offset, growth_page, 1, layout)
+    _encode_pointer(payload, churn_offset, churn_page, 2, layout)
+    return bytes(payload)
+
+
+def _active_count(parameters: SyntheticParameters, ordinal: int) -> int:
+    conversion = parameters.conversion_ordinal
+    if conversion is None or ordinal < conversion:
+        return 0
+    if ordinal == conversion:
+        return parameters.slot_activation_at_conversion
+    if conversion >= CHECKPOINT_ORDINALS["H_REL_0904"]:
+        return parameters.slot_activation_at_conversion
+    return min(2, max(parameters.slot_activation_at_conversion, 1 + int(ordinal > conversion)))
+
+
+def generate_synthetic_bundle(parameters: SyntheticParameters | None = None, *, replica: int = 1) -> SyntheticBundle:
+    selected = calibration_parameters() if parameters is None else parameters
+    if selected.bit_polarity not in POLARITIES or selected.anchor_fill_state not in FREE["anchor_fill_state"]:
+        raise ValidationError("A3 synthetic parameter is outside the plan")
+    if selected.slot_activation_at_conversion not in FREE["slot_activation_at_conversion"]:
+        raise ValidationError("A3 slot parameter is outside the plan")
+    schedule = build_schedule()
+    global_page, tdef_page = 1, 2
+    # Offset zero makes the alternate slot-first growth interpretation
+    # unavailable. The churn field ends at the page terminal, producing the
+    # schema-bound minimal TDEF interval [0, 2048).
+    growth_offset, churn_offset = 0, PAGE_SIZE - 4
+    layout = POINTER_LAYOUTS[0]
+    filler = bytes(PAGE_SIZE)
+    filler_digest = hashlib.sha256(filler).hexdigest()
+    pointer_payload = _pointer_page()
+    pointer_digest = hashlib.sha256(pointer_payload).hexdigest()
+    payloads: dict[str, bytes] = {filler_digest: filler, pointer_digest: pointer_payload}
+    ordered: dict[str, tuple[str, ...]] = {}
+    growth_index = 0
+    forced_leg = selected.first_representation_change_leg
+    force_at = CHECKPOINT_ORDINALS[forced_leg[1]] if forced_leg else None
+    d_empty = schedule.initial_pages
+    for row in schedule.checkpoints:
+        name = row.checkpoint_id
+        if name in GROWTH_CHECKPOINTS:
+            growth_index += 1
+        if name in {"E0", "E0R", "D_DROP", "D_RECREATE_EMPTY"}:
+            global_payload = _inline_payload(selected, row.actual_file_pages, d_empty)
+        elif name == "D_GROW_0128":
+            global_payload = _inline_payload(selected, row.actual_file_pages, row.actual_file_pages)
+        elif name == "D_REGROW_0128":
+            global_payload = _inline_payload(selected, row.actual_file_pages, row.actual_file_pages, force_last_flip=True)
+        else:
+            indirect = selected.conversion_ordinal is not None and row.ordinal >= selected.conversion_ordinal
+            if force_at is not None:
+                indirect = row.ordinal >= force_at
+            if name == CONVERSION_WINDOW[0] and selected.inline_tag_at_anchor == 1:
+                indirect = True
+            global_payload = _indirect_payload(selected, _active_count(selected, row.ordinal)) if indirect else _inline_payload(selected, row.actual_file_pages, row.actual_file_pages)
+        tdef_payload = _tdef_payload(name, growth_index, layout, growth_offset, churn_offset)
+        global_digest, tdef_digest = hashlib.sha256(global_payload).hexdigest(), hashlib.sha256(tdef_payload).hexdigest()
+        payloads[global_digest], payloads[tdef_digest] = global_payload, tdef_payload
+        hashes = [filler_digest] * row.actual_file_pages
+        for page in range(4, min(32, row.actual_file_pages)):
+            hashes[page] = pointer_digest
+        hashes[global_page], hashes[tdef_page] = global_digest, tdef_digest
+        if 14848 < row.actual_file_pages:
+            extended = _extended_page(selected, 14848, row.actual_file_pages)
+            digest = hashlib.sha256(extended).hexdigest()
+            payloads[digest], hashes[14848] = extended, digest
+        if 16352 < row.actual_file_pages:
+            extended = _extended_page(selected, 16352, row.actual_file_pages)
+            digest = hashlib.sha256(extended).hexdigest()
+            payloads[digest], hashes[16352] = extended, digest
+        ordered[name] = tuple(hashes)
+    for left, right in PLAN.document["checkpoint_design"]["idle_pairs"]:
+        ordered[right] = ordered[left]
+    identity = hashlib.sha256(repr(selected).encode("utf-8")).hexdigest()
+    return SyntheticBundle(
+        CHECKPOINT_IDS, MappingProxyType({row.checkpoint_id: row.actual_file_pages for row in schedule.checkpoints}),
+        MappingProxyType(ordered), replica, f"a3-synthetic-{identity[:16]}", PLAN_SHA256[:40],
+        hashlib.sha256(b"DAO.DBEngine.36.synthetic").hexdigest(), True, selected, schedule,
+        global_page, tdef_page, (selected.global_record_start, PAGE_SIZE),
+        (0, PAGE_SIZE), growth_offset, churn_offset,
+        MappingProxyType(payloads),
+    )
+
+
+def generate_synthetic_bundles(parameters: SyntheticParameters | None = None) -> tuple[SyntheticBundle, ...]:
+    selected = calibration_parameters() if parameters is None else parameters
+    first = generate_synthetic_bundle(selected, replica=1)
+    return tuple(replace(first, replica=replica) for replica in (1, 2, 3))

--- a/oracle/windows-dao/scripts/a3_generator_schedule.py
+++ b/oracle/windows-dao/scripts/a3_generator_schedule.py
@@ -1,0 +1,125 @@
+"""Plan-derived schedule arithmetic for the non-evidential A3 generator.
+
+A3 rule | implementation
+--- | ---
+Unchanged 25-checkpoint order | :func:`build_schedule`
+Fixed 32-row batches and first-reaching target | :func:`build_schedule`
+Strictly larger D regrowth | :func:`build_schedule`
+Full-delete/reinsert row semantics | :func:`build_schedule`
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from protocol_validation import ValidationError
+from a3_spec import BOUNDS, CHECKPOINT_IDS, PAGE_SIZE, PLAN
+
+ROLES = tuple(PLAN.document["tables"]["roles"])
+
+
+@dataclass(frozen=True)
+class ScheduledCheckpoint:
+    checkpoint_id: str
+    ordinal: int
+    actual_file_pages: int
+    target_baseline_pages: int | None
+    target_threshold_pages: int | None
+    target_overshoot_pages: int | None
+    inserted_rows_total: int
+    table_row_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class Schedule:
+    checkpoints: tuple[ScheduledCheckpoint, ...]
+    batch_rows: int
+    rows_per_page: int
+    pages_per_batch: int
+    initial_pages: int
+    delete_page_delta: int
+
+    def checkpoint(self, name: str) -> ScheduledCheckpoint:
+        return self.checkpoints[CHECKPOINT_IDS.index(name)]
+
+
+def build_schedule(*, delete_page_delta: int = 1) -> Schedule:
+    fields = PLAN.document["tables"]["definition"]["fields"]
+    row_bytes = sum(field["size"] for field in fields)
+    rows_per_page = PAGE_SIZE // row_bytes
+    batch_rows = PLAN.document["tables"]["row_algorithm"]["growth_batch_rows"]
+    pages_per_batch = math.ceil(batch_rows / rows_per_page)
+    pages = len(PLAN.document["tables"]["physical_names"]) * (len(fields) + int(not PLAN.document["tables"]["definition"]["indexed"]))
+    if rows_per_page < 1 or delete_page_delta < 0:
+        raise ValidationError("A3 synthetic storage arithmetic is invalid")
+    initial_pages = pages
+    counts = {role: 0 for role in ROLES}
+    inserted = retained_l = 0
+    baselines: dict[str, int] = {}
+    rows: list[ScheduledCheckpoint] = []
+
+    def capture(name: str, baseline: int | None = None, threshold: int | None = None) -> None:
+        rows.append(ScheduledCheckpoint(name, len(rows), pages, baseline, threshold, None if threshold is None else pages - threshold, inserted, dict(counts)))
+
+    def grow(role: str, threshold: int) -> None:
+        nonlocal pages, inserted
+        while pages < threshold:
+            counts[role] += batch_rows
+            inserted += batch_rows
+            pages += pages_per_batch
+            if pages > BOUNDS["max_final_pages_per_replica"] or inserted > BOUNDS["max_inserted_rows_per_replica"]:
+                raise ValidationError("A3 synthetic schedule exceeds plan bounds")
+
+    for name in CHECKPOINT_IDS:
+        if name in {"E0", "E0R"}:
+            capture(name)
+        elif name == "D_GROW_0128":
+            baselines["D_FIRST"] = pages
+            target = pages + 128
+            grow("D", target)
+            capture(name, baselines["D_FIRST"], target)
+        elif name == "D_DROP":
+            counts["D"] = 0
+            capture(name)
+        elif name == "D_RECREATE_EMPTY":
+            baselines["D_REGROW"] = pages
+            capture(name)
+        elif name == "D_REGROW_0128":
+            target = baselines["D_REGROW"] + 128
+            grow("D", target)
+            capture(name, baselines["D_REGROW"], target)
+        elif name.startswith("L_REL_"):
+            baselines.setdefault("L", pages)
+            target = baselines["L"] + int(name.rsplit("_", 1)[1])
+            grow("L", target)
+            capture(name, baselines["L"], target)
+            retained_l = counts["L"]
+        elif name == "L_DELETE_ALL":
+            counts["L"] = 0
+            pages += delete_page_delta
+            capture(name)
+        elif name == "L_REINSERT_SAME":
+            counts["L"] = retained_l
+            inserted += retained_l
+            capture(name)
+        elif name == "L_IDLE_REOPEN":
+            capture(name)
+        elif name.startswith("P_ABS_"):
+            target = int(name.rsplit("_", 1)[1])
+            grow("P", target)
+            capture(name, None, target)
+        elif name.startswith("H_REL_"):
+            baselines.setdefault("H", pages)
+            target = baselines["H"] + int(name.rsplit("_", 1)[1])
+            grow("H", target)
+            capture(name, baselines["H"], target)
+        elif name == "H_IDLE_REOPEN":
+            capture(name)
+        else:
+            raise ValidationError(f"unimplemented A3 checkpoint {name}")
+    if tuple(row.checkpoint_id for row in rows) != CHECKPOINT_IDS:
+        raise ValidationError("A3 generator departed from plan checkpoint order")
+    if rows[5].actual_file_pages <= rows[2].actual_file_pages:
+        raise ValidationError("A3 D regrowth is not strictly larger")
+    return Schedule(tuple(rows), batch_rows, rows_per_page, pages_per_batch, initial_pages, delete_page_delta)

--- a/oracle/windows-dao/scripts/a3_layers.py
+++ b/oracle/windows-dao/scripts/a3_layers.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Post-delimitation A3 global layers and the separate TDEF pointer layer.
+
+A3 rule | implementation
+--- | ---
+Tag-1 two-u32 layout and zero suffix | :func:`indirect_state`
+Per-leg cross-check transcript and first-stop rule | :func:`polarity_cross_check`
+Monotone inline-to-indirect classification | :func:`derive_conversion`
+Activation-relative named validity window | :func:`validate_references`
+Fixed-source inline boundary and suffix | :func:`inline_boundaries`
+Slot-0 H_REL_0064 base discrimination | :func:`derive_base`
+Ordered TDEF precondition/windows/record/multiplicity | :func:`derive_tdef_candidates`
+Transition-structural pointer exclusion | :func:`pointer_windows`
+Page-agnostic global-field exclusion | :func:`global_structural_valid`
+TDEF inclusion-minimal stable-flank record | :func:`tdef_models`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from a3_model import (
+    CHECKPOINT_IDS, CHURN_TRANSITIONS, D_TRANSITIONS, GROWTH_TRANSITIONS,
+    IDLE_PAIRS, PAGE_SIZE, TRANSITIONS, Abort, GlobalRecordModel, Prefix,
+    Record, View, candidate_page_space, decode_inline, decode_pointer,
+    extended_base, inline_highwater_valid, raw_not_in_use,
+)
+from a3_spec import BASE_FORMULAS, CHECKPOINT_ORDINALS, POINTER_LAYOUTS
+
+CONVERSION_WINDOW = tuple(TRANSITIONS["inline_to_indirect_conversion_window"])
+VALIDITY_CHECKPOINTS = tuple(TRANSITIONS["pointer_validity_checkpoints"])
+CROSS_CHECK_LEGS = tuple(tuple(pair) for pair in TRANSITIONS["polarity_cross_check_legs"])
+EXTENDED_HEADER_BYTES = 4
+EXTENDED_BITS = (PAGE_SIZE - EXTENDED_HEADER_BYTES) * 8
+
+
+@dataclass(frozen=True)
+class Leg:
+    left_checkpoint_id: str
+    right_checkpoint_id: str
+
+    def document(self) -> dict[str, str]:
+        return {"left_checkpoint_id": self.left_checkpoint_id, "right_checkpoint_id": self.right_checkpoint_id}
+
+
+@dataclass(frozen=True)
+class CrossCheckTranscript:
+    evaluated_legs: tuple[Leg, ...] = ()
+    representation_change_stop: Leg | None = None
+    first_violating_leg: Leg | None = None
+    first_violating_page: int | None = None
+
+    def document(self) -> dict[str, Any]:
+        return {
+            "evaluated_legs": [leg.document() for leg in self.evaluated_legs],
+            "representation_change_stop": None if self.representation_change_stop is None else self.representation_change_stop.document(),
+            "first_violating_leg": None if self.first_violating_leg is None else self.first_violating_leg.document(),
+            "first_violating_page": self.first_violating_page,
+        }
+
+
+@dataclass(frozen=True)
+class IndirectState:
+    tag: int
+    slots: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class ConversionModel:
+    conversion_checkpoint_id: str
+    conversion_ordinal: int
+    indirect_tag: int
+    active_slot_count_at_conversion: int
+    active_slot_count_at_h_rel_0904: int
+    inline_boundary: int
+    slot_reference_pages: tuple[int, int]
+
+    def document(self) -> dict[str, Any]:
+        return {
+            "conversion_checkpoint_id": self.conversion_checkpoint_id,
+            "conversion_ordinal": self.conversion_ordinal,
+            "indirect_tag": self.indirect_tag,
+            "active_slot_count_at_conversion": self.active_slot_count_at_conversion,
+            "active_slot_count_at_h_rel_0904": self.active_slot_count_at_h_rel_0904,
+            "inline_boundary": self.inline_boundary,
+            "slot_reference_pages": list(self.slot_reference_pages),
+        }
+
+
+@dataclass(frozen=True)
+class BaseModel:
+    extended_base_formula: str
+    def document(self) -> dict[str, str]:
+        return {"extended_base_formula": self.extended_base_formula}
+
+
+@dataclass(frozen=True)
+class TdefModel:
+    record: Record
+    pointer_layout: str
+    growth_pointer_offset: int
+    delete_reinsert_pointer_offset: int
+    def document(self) -> dict[str, Any]:
+        return {
+            "record": self.record.document(), "pointer_layout": self.pointer_layout,
+            "growth_pointer_offset": self.growth_pointer_offset,
+            "delete_reinsert_pointer_offset": self.delete_reinsert_pointer_offset,
+        }
+
+
+def indirect_state(payload: bytes, start: int, end: int) -> IndirectState | None:
+    if not 0 <= start <= end - 9 <= PAGE_SIZE - 9 or payload[start] != 1:
+        return None
+    if any(payload[start + 9:end]):
+        return None
+    return IndirectState(1, (
+        int.from_bytes(payload[start + 1:start + 5], "little"),
+        int.from_bytes(payload[start + 5:start + 9], "little"),
+    ))
+
+
+def _bit(state: Any, page: int) -> bool | None:
+    if not state.base <= page < state.base + state.capacity:
+        return None
+    return page in state.in_use
+
+
+def polarity_cross_check(view: View, model: GlobalRecordModel) -> CrossCheckTranscript:
+    """Walk only representable appended pages, stopping at violation or tag change."""
+    evaluated: list[Leg] = []
+    start, end, record_page = model.record.start, model.record.end, model.record.page
+    for left_name, right_name in CROSS_CHECK_LEGS:
+        leg = Leg(left_name, right_name)
+        left_payload, right_payload = view.page(left_name, record_page), view.page(right_name, record_page)
+        left_tag, right_tag = left_payload[start], right_payload[start]
+        if left_tag != right_tag:
+            return CrossCheckTranscript(tuple(evaluated), leg, None, None)
+        if left_tag != 0:
+            continue
+        left = decode_inline(left_payload, start, end, model.bit_polarity)
+        right = decode_inline(right_payload, start, end, model.bit_polarity)
+        if left is None or right is None:
+            raise Abort("A3-POLARITY-CROSSCHECK")
+        lower = view.page_count(left_name)
+        upper = view.page_count(right_name)
+        represented_lower = max(lower, left.base, right.base)
+        represented_upper = min(upper, left.base + left.capacity, right.base + right.capacity)
+        required = range(represented_lower, max(represented_lower, represented_upper))
+        evaluated.append(leg)
+        for page in required:
+            if page >= 65536:
+                raise Abort("A3-POINTER-VALIDITY")
+            if _bit(left, page) is not False or _bit(right, page) is not True:
+                return CrossCheckTranscript(tuple(evaluated), None, leg, page)
+    return CrossCheckTranscript(tuple(evaluated), None, None, None)
+
+
+def global_structural_valid(view: View, model: GlobalRecordModel) -> bool:
+    """Reject record changes outside the declared D, growth, churn, and idle pairs."""
+    allowed = set(D_TRANSITIONS + CHURN_TRANSITIONS + IDLE_PAIRS + CROSS_CHECK_LEGS)
+    allowed.add(("E0R", "D_GROW_0128"))
+    start, end, page = model.record.start, model.record.end, model.record.page
+    for left, right in zip(CHECKPOINT_IDS, CHECKPOINT_IDS[1:]):
+        if (left, right) in allowed:
+            continue
+        if view.page(left, page)[start:end] != view.page(right, page)[start:end]:
+            return False
+    return True
+
+
+def _classification(view: View, model: GlobalRecordModel, checkpoint: str) -> str:
+    payload = view.page(checkpoint, model.record.page)
+    start, end = model.record.start, model.record.end
+    if payload[start] == 0:
+        state = decode_inline(payload, start, end, model.bit_polarity)
+        return "inline" if inline_highwater_valid(state, view.page_count(checkpoint)) else "neither"
+    if payload[start] == 1 and indirect_state(payload, start, end) is not None:
+        return "indirect"
+    return "neither"
+
+
+def conversion_checkpoint(view: View, model: GlobalRecordModel) -> str:
+    classes = [_classification(view, model, checkpoint) for checkpoint in CONVERSION_WINDOW]
+    indirect = [index for index, kind in enumerate(classes) if kind == "indirect"]
+    if not indirect:
+        raise Abort("A3-CONVERSION-NONE")
+    at = indirect[0]
+    if at == 0 or any(kind != "inline" for kind in classes[:at]) or any(kind != "indirect" for kind in classes[at:]):
+        raise Abort("A3-CONVERSION-MULTIPLE")
+    return CONVERSION_WINDOW[at]
+
+
+def _activation(
+    view: View, record_page: int, offset: int, width: int,
+    indirect_start: int | None,
+) -> int | None:
+    for checkpoint in CHECKPOINT_IDS:
+        payload = view.page(checkpoint, record_page)
+        if indirect_start is not None and payload[indirect_start] != 1:
+            continue
+        value = int.from_bytes(payload[offset:offset + width], "little")
+        if value:
+            return CHECKPOINT_ORDINALS[checkpoint]
+    return None
+
+
+def validate_references(
+    view: View, record_page: int, references: Sequence[tuple[int, int, int]],
+    *, indirect_start: int | None = None,
+) -> None:
+    """Validate only named checkpoints at/after each field's first nonzero activation."""
+    space = candidate_page_space((view,))
+    maximum = space.stop
+    for offset, width, slot in sorted(references, key=lambda row: (row[0], row[2])):
+        activation = _activation(view, record_page, offset, width, indirect_start)
+        if activation is None:
+            continue
+        for checkpoint in VALIDITY_CHECKPOINTS:
+            if CHECKPOINT_ORDINALS[checkpoint] < activation:
+                continue
+            payload = view.page(checkpoint, record_page)
+            if indirect_start is not None and payload[indirect_start] != 1:
+                continue
+            reference = int.from_bytes(payload[offset:offset + width], "little")
+            if reference == 0:
+                continue
+            if not 1 <= reference < view.page_count(checkpoint) or reference >= maximum or view.hash_at(checkpoint, reference) is None or view.page(checkpoint, reference)[0] != 0x05:
+                raise Abort("A3-POINTER-VALIDITY")
+
+
+def inline_boundaries(view: View, model: GlobalRecordModel, conversion: str) -> tuple[int, ...]:
+    start, end, page = model.record.start, model.record.end, model.record.page
+    at = CONVERSION_WINDOW.index(conversion)
+    inline_names = CONVERSION_WINDOW[:at]
+    indirect_names = CONVERSION_WINDOW[at:]
+    explained: list[int] = []
+    suffix_fail = False
+    # "Complete bitmap" is the shortest byte extent that represents every
+    # allocated page plus the required page-count sentinel at every inline
+    # checkpoint. Padding bits in its last byte remain polarity-relative free.
+    required_boundary = max(
+        start + 5
+        + (view.page_count(checkpoint)
+           - int.from_bytes(view.page(checkpoint, page)[start + 1:start + 5], "little")
+           + 8) // 8
+        for checkpoint in inline_names
+    )
+    for boundary in range(start + 5, end + 1):
+        if boundary != required_boundary:
+            continue
+        valid = True
+        for checkpoint in inline_names:
+            payload = view.page(checkpoint, page)
+            state = decode_inline(payload, start, boundary, model.bit_polarity)
+            if not inline_highwater_valid(state, view.page_count(checkpoint)):
+                valid = False
+                break
+            if any(value != raw_not_in_use(model.bit_polarity) for value in payload[boundary:end]):
+                suffix_fail = True
+                valid = False
+                break
+        if not valid:
+            continue
+        if any(indirect_state(view.page(checkpoint, page), start, end) is None for checkpoint in indirect_names):
+            continue
+        explained.append(boundary)
+    if not explained:
+        raise Abort("A3-INLINE-SUFFIX" if suffix_fail else "A3-INLINE-BOUNDARY-NONE")
+    if len(explained) > 1:
+        raise Abort("A3-INLINE-BOUNDARY-MULTIPLE")
+    return tuple(explained)
+
+
+def derive_conversion(view: View, model: GlobalRecordModel) -> tuple[ConversionModel, CrossCheckTranscript]:
+    transcript = polarity_cross_check(view, model)
+    if transcript.first_violating_leg is not None:
+        raise Abort("A3-POLARITY-CROSSCHECK")
+    conversion = conversion_checkpoint(view, model)
+    payload = view.page(conversion, model.record.page)
+    state = indirect_state(payload, model.record.start, model.record.end)
+    if state is None:
+        raise Abort("A3-CONVERSION-MULTIPLE")
+    active = sum(value != 0 for value in state.slots)
+    if active == 0:
+        raise Abort("A3-SLOT-ACTIVATION")
+    final_state = indirect_state(view.page("H_REL_0904", model.record.page), model.record.start, model.record.end)
+    if final_state is None or sum(value != 0 for value in final_state.slots) != 2:
+        raise Abort("A3-SLOT-FINAL")
+    start = model.record.start
+    validate_references(
+        view, model.record.page, ((start + 1, 4, 0), (start + 5, 4, 1)),
+        indirect_start=start,
+    )
+    boundary = inline_boundaries(view, model, conversion)[0]
+    return ConversionModel(
+        conversion, CHECKPOINT_ORDINALS[conversion], 1, active, 2, boundary,
+        state.slots,
+    ), transcript
+
+
+def _extended_bits(view: View, model: GlobalRecordModel, checkpoint: str) -> dict[int, tuple[int, int]]:
+    state = indirect_state(view.page(checkpoint, model.record.page), model.record.start, model.record.end)
+    if state is None:
+        return {}
+    result: dict[int, tuple[int, int]] = {}
+    for slot, reference in enumerate(state.slots):
+        if reference == 0 or reference >= view.page_count(checkpoint):
+            continue
+        payload = view.page(checkpoint, reference)
+        if payload[0] != 0x05:
+            continue
+        raw = int.from_bytes(payload[EXTENDED_HEADER_BYTES:], "little")
+        if model.bit_polarity == "set_means_not_in_use":
+            raw ^= (1 << EXTENDED_BITS) - 1
+        result[slot] = (reference, raw)
+    return result
+
+
+def _formula_matches(view: View, model: GlobalRecordModel, formula: str, pairs: Sequence[tuple[str, str]]) -> bool:
+    for left, right in pairs:
+        before, after = _extended_bits(view, model, left), _extended_bits(view, model, right)
+        predicted: set[int] = set()
+        for slot, (reference, bits) in after.items():
+            prior = before.get(slot, (reference, 0))[1] if before.get(slot, (reference, 0))[0] == reference else 0
+            fresh = bits & ~prior
+            origin = extended_base(formula, slot, reference)
+            while fresh:
+                bit = (fresh & -fresh).bit_length() - 1
+                predicted.add(origin + bit)
+                fresh &= fresh - 1
+        expected = set(range(view.page_count(left), view.page_count(right)))
+        view.work.charge(len(predicted) + 1)
+        if predicted != expected:
+            return False
+    return True
+
+
+def derive_base(view: View, model: GlobalRecordModel, conversion: ConversionModel) -> BaseModel:
+    before = _extended_bits(view, model, "P_ABS_16480").get(0)
+    after = _extended_bits(view, model, "H_REL_0064").get(0)
+    if before is None or after is None or before[0] != after[0] or not (after[1] & ~before[1]):
+        raise Abort("A3-BASE-DISCRIMINATION")
+    at = CONVERSION_WINDOW.index(conversion.conversion_checkpoint_id)
+    pairs = [
+        (left, right) for left, right in zip(CONVERSION_WINDOW, CONVERSION_WINDOW[1:])
+        if CONVERSION_WINDOW.index(left) >= at and view.page_count(right) > view.page_count(left)
+    ]
+    survivors = tuple(formula for formula in BASE_FORMULAS if _formula_matches(view, model, formula, pairs))
+    if not survivors:
+        raise Abort("A3-BASE-NONE")
+    if len(survivors) > 1:
+        raise Abort("A3-BASE-MULTIPLE")
+    return BaseModel(survivors[0])
+
+
+def _window_values(view: View, page: int, offset: int, layout: str) -> dict[str, tuple[int, int]]:
+    return {checkpoint: decode_pointer(view.page(checkpoint, page)[offset:offset + 4], layout) for checkpoint in CHECKPOINT_IDS}
+
+
+def _stable(values: Mapping[str, tuple[int, int]], pairs: Sequence[tuple[str, str]]) -> bool:
+    return all(values[left] == values[right] for left, right in pairs)
+
+
+def _pointer_valid(view: View, record_page: int, offset: int, layout: str) -> bool:
+    page_offset = offset if layout == "u24le_page_then_u8_slot" else offset + 1
+    try:
+        validate_references(view, record_page, ((page_offset, 3, 0),))
+    except Abort as exc:
+        if exc.predicate_id == "A3-POINTER-VALIDITY":
+            return False
+        raise
+    values = _window_values(view, record_page, offset, layout)
+    return any(page != 0 for page, _slot in values.values())
+
+
+@dataclass(frozen=True)
+class WindowCandidates:
+    growth: Mapping[str, tuple[int, ...]]
+    churn: Mapping[str, tuple[int, ...]]
+    structural_failure: bool
+    validity_failure: bool
+
+
+def pointer_windows(view: View, page: int) -> WindowCandidates:
+    growth = {layout: [] for layout in POINTER_LAYOUTS}
+    churn = {layout: [] for layout in POINTER_LAYOUTS}
+    structural = validity = False
+    outside_growth = D_TRANSITIONS + CHURN_TRANSITIONS + IDLE_PAIRS
+    outside_churn = D_TRANSITIONS + GROWTH_TRANSITIONS + IDLE_PAIRS
+    for offset in range(PAGE_SIZE - 3):
+        for layout in POINTER_LAYOUTS:
+            values = _window_values(view, page, offset, layout)
+            grows = any(values[a] != values[b] for a, b in GROWTH_TRANSITIONS)
+            churns = values["L_REL_1280"] != values["L_DELETE_ALL"] and values["L_REL_1280"] == values["L_REINSERT_SAME"]
+            growth_shape = grows and _stable(values, CHURN_TRANSITIONS)
+            churn_shape = churns and _stable(values, GROWTH_TRANSITIONS)
+            if growth_shape:
+                if not _stable(values, outside_growth):
+                    structural = True
+                elif _pointer_valid(view, page, offset, layout):
+                    growth[layout].append(offset)
+                else:
+                    validity = True
+            if churn_shape:
+                if not _stable(values, outside_churn):
+                    structural = True
+                elif _pointer_valid(view, page, offset, layout):
+                    churn[layout].append(offset)
+                else:
+                    validity = True
+    return WindowCandidates(
+        {key: tuple(value) for key, value in growth.items()},
+        {key: tuple(value) for key, value in churn.items()}, structural, validity,
+    )
+
+
+def _stable_byte(view: View, page: int, offset: int) -> bool:
+    return len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) == 1
+
+
+def tdef_models(view: View, page: int, windows: WindowCandidates) -> tuple[TdefModel, ...]:
+    changed = Prefix.from_flags([
+        len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) > 1
+        for offset in range(PAGE_SIZE)
+    ], view.work)
+    models: list[TdefModel] = []
+    for layout in POINTER_LAYOUTS:
+        for growth in windows.growth[layout]:
+            for churn in windows.churn[layout]:
+                if growth == churn or abs(growth - churn) < 4:
+                    continue
+                first, second = sorted((growth, churn))
+                core_end = second + 4
+                start = first - 1 if first else first
+                end = core_end + 1 if core_end < PAGE_SIZE else core_end
+                if start < first and not _stable_byte(view, page, start):
+                    continue
+                if end > core_end and not _stable_byte(view, page, end - 1):
+                    continue
+                if changed.count(start, first) + changed.count(first + 4, second) + changed.count(second + 4, end):
+                    continue
+                models.append(TdefModel(Record(page, start, end), layout, growth, churn))
+    view.work.examine_models(len(models))
+    return tuple(models)
+
+
+def derive_tdef_candidates(view: View, pages: Sequence[int], churn_precondition_met: bool, *, enumerate_candidates: bool = True) -> tuple[TdefModel, ...]:
+    """Evaluate the five registered TDEF stages once, in their literal order."""
+    if not churn_precondition_met:
+        raise Abort("A3-CHURN-PRECONDITION")
+    all_windows: dict[int, WindowCandidates] = {}
+    for page in pages:
+        if enumerate_candidates:
+            view.work.enumerate_intervals()
+        all_windows[page] = pointer_windows(view, page)
+    if not any(any(window.growth.values()) for window in all_windows.values()):
+        if any(window.structural_failure for window in all_windows.values()):
+            raise Abort("A3-STRUCTURAL-EXCLUSION")
+        if any(window.validity_failure for window in all_windows.values()):
+            raise Abort("A3-POINTER-VALIDITY")
+        raise Abort("A3-GROWTH-POINTER-NONE")
+    if not any(any(window.churn.values()) for window in all_windows.values()):
+        if any(window.structural_failure for window in all_windows.values()):
+            raise Abort("A3-STRUCTURAL-EXCLUSION")
+        if any(window.validity_failure for window in all_windows.values()):
+            raise Abort("A3-POINTER-VALIDITY")
+        raise Abort("A3-CHURN-POINTER-NONE")
+    per_page = {page: tdef_models(view, page, window) for page, window in all_windows.items()}
+    total = [model for models in per_page.values() for model in models]
+    if not total:
+        raise Abort("A3-TDEF-RECORD-NONE")
+    record_pages = {model.record.page for model in total}
+    records = {model.record for model in total}
+    if len(record_pages) > 1:
+        raise Abort("A3-TDEF-PAGE-MULTIPLE")
+    if len(records) > 1:
+        raise Abort("A3-TDEF-RECORD-MULTIPLE")
+    if len(total) > 1:
+        raise Abort("A3-POINTER-MULTIPLE")
+    return tuple(total)
+
+
+def predicts_global(view: View, frozen: GlobalRecordModel) -> bool:
+    from a3_model import global_start_candidates
+    models, _evidence = global_start_candidates(view, frozen.record.page, enumerate_candidates=False)
+    return frozen in models
+
+
+def predicts_conversion(view: View, global_model: GlobalRecordModel, frozen: ConversionModel) -> bool:
+    try:
+        model, transcript = derive_conversion(view, global_model)
+        return model == frozen and transcript.first_violating_leg is None
+    except Abort as exc:
+        if exc.predicate_id in {"A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"}:
+            raise
+        return False
+
+
+def predicts_base(view: View, global_model: GlobalRecordModel, conversion: ConversionModel, frozen: BaseModel) -> bool:
+    try:
+        return derive_base(view, global_model, conversion) == frozen
+    except Abort as exc:
+        if exc.predicate_id in {"A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"}:
+            raise
+        return False
+
+
+def predicts_tdef(view: View, frozen: TdefModel, churn_precondition_met: bool) -> bool:
+    try:
+        return derive_tdef_candidates(view, (frozen.record.page,), churn_precondition_met, enumerate_candidates=False) == (frozen,)
+    except Abort as exc:
+        if exc.predicate_id in {"A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"}:
+            raise
+        return False

--- a/oracle/windows-dao/scripts/a3_layers.py
+++ b/oracle/windows-dao/scripts/a3_layers.py
@@ -3,16 +3,14 @@
 
 A3 rule | implementation
 --- | ---
-Tag-1 two-u32 layout and zero suffix | :func:`indirect_state`
-Per-leg cross-check transcript and first-stop rule | :func:`polarity_cross_check`
-Monotone inline-to-indirect classification | :func:`derive_conversion`
-Activation-relative named validity window | :func:`validate_references`
-Fixed-source inline boundary and suffix | :func:`inline_boundaries`
-Slot-0 H_REL_0064 base discrimination | :func:`derive_base`
-Ordered TDEF precondition/windows/record/multiplicity | :func:`derive_tdef_candidates`
-Transition-structural pointer exclusion | :func:`pointer_windows`
-Page-agnostic global-field exclusion | :func:`global_structural_valid`
-TDEF inclusion-minimal stable-flank record | :func:`tdef_models`
+R3-M01/M02 polarity walk | :func:`polarity_cross_check`
+R3-G02 conversion attribution | :func:`conversion_checkpoint`
+R3-G04 minimal b* then suffix | :func:`inline_boundary`
+R3-G06 signature, validity, exclusion order | :func:`derive_tdef_candidates`
+R3-G07 tag-1 slot activation | :func:`_activation`
+R3-G01 extended bitmap formulas | :func:`derive_base`, :func:`formula_holds`
+R3-G09 frozen-model-only holdout checks | :func:`predicts_global`, :func:`predicts_conversion`, :func:`predicts_base`, :func:`predicts_tdef`
+R3-G10 candidate-local absence | :func:`_window_values`, :func:`_classification`
 """
 
 from __future__ import annotations
@@ -21,10 +19,11 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
 from a3_model import (
-    CHECKPOINT_IDS, CHURN_TRANSITIONS, D_TRANSITIONS, GROWTH_TRANSITIONS,
-    IDLE_PAIRS, PAGE_SIZE, TRANSITIONS, Abort, GlobalRecordModel, Prefix,
-    Record, View, candidate_page_space, decode_inline, decode_pointer,
-    extended_base, inline_highwater_valid, raw_not_in_use,
+    CHECKPOINT_IDS, CHURN_TRANSITIONS, D_TRANSITIONS, HIGH_GROWTH,
+    IDLE_PAIRS, LOW_GROWTH, PAGE_SIZE, P_GROWTH, TRANSITIONS, Abort,
+    GlobalRecordModel, Prefix, Record, View, candidate_page_space,
+    decode_inline, decode_pointer, extended_base, frozen_global_model_holds,
+    inline_highwater_valid, qualify_tdef_pages, raw_not_in_use,
 )
 from a3_spec import BASE_FORMULAS, CHECKPOINT_ORDINALS, POINTER_LAYOUTS
 
@@ -132,7 +131,10 @@ def polarity_cross_check(view: View, model: GlobalRecordModel) -> CrossCheckTran
     start, end, record_page = model.record.start, model.record.end, model.record.page
     for left_name, right_name in CROSS_CHECK_LEGS:
         leg = Leg(left_name, right_name)
-        left_payload, right_payload = view.page(left_name, record_page), view.page(right_name, record_page)
+        left_payload = view.page_optional(left_name, record_page)
+        right_payload = view.page_optional(right_name, record_page)
+        if left_payload is None or right_payload is None:
+            raise Abort("A3-POLARITY-CROSSCHECK")
         left_tag, right_tag = left_payload[start], right_payload[start]
         if left_tag != right_tag:
             return CrossCheckTranscript(tuple(evaluated), leg, None, None)
@@ -157,20 +159,15 @@ def polarity_cross_check(view: View, model: GlobalRecordModel) -> CrossCheckTran
 
 
 def global_structural_valid(view: View, model: GlobalRecordModel) -> bool:
-    """Reject record changes outside the declared D, growth, churn, and idle pairs."""
-    allowed = set(D_TRANSITIONS + CHURN_TRANSITIONS + IDLE_PAIRS + CROSS_CHECK_LEGS)
-    allowed.add(("E0R", "D_GROW_0128"))
-    start, end, page = model.record.start, model.record.end, model.record.page
-    for left, right in zip(CHECKPOINT_IDS, CHECKPOINT_IDS[1:]):
-        if (left, right) in allowed:
-            continue
-        if view.page(left, page)[start:end] != view.page(right, page)[start:end]:
-            return False
+    """R3 classifies global structural exclusion as unreachable."""
+    del view, model
     return True
 
 
 def _classification(view: View, model: GlobalRecordModel, checkpoint: str) -> str:
-    payload = view.page(checkpoint, model.record.page)
+    payload = view.page_optional(checkpoint, model.record.page)
+    if payload is None:
+        return "neither"
     start, end = model.record.start, model.record.end
     if payload[start] == 0:
         state = decode_inline(payload, start, end, model.bit_polarity)
@@ -182,13 +179,19 @@ def _classification(view: View, model: GlobalRecordModel, checkpoint: str) -> st
 
 def conversion_checkpoint(view: View, model: GlobalRecordModel) -> str:
     classes = [_classification(view, model, checkpoint) for checkpoint in CONVERSION_WINDOW]
+    return CONVERSION_WINDOW[conversion_index(classes)]
+
+
+def conversion_index(classes: Sequence[str]) -> int:
+    """Apply R3-G02 attribution to an ordered classification sequence."""
     indirect = [index for index, kind in enumerate(classes) if kind == "indirect"]
-    if not indirect:
+    if not indirect or not any(kind == "inline" for kind in classes[: indirect[0]]):
         raise Abort("A3-CONVERSION-NONE")
     at = indirect[0]
-    if at == 0 or any(kind != "inline" for kind in classes[:at]) or any(kind != "indirect" for kind in classes[at:]):
+    changes = sum(left != right for left, right in zip(classes, classes[1:]))
+    if changes != 1:
         raise Abort("A3-CONVERSION-MULTIPLE")
-    return CONVERSION_WINDOW[at]
+    return at
 
 
 def _activation(
@@ -196,7 +199,9 @@ def _activation(
     indirect_start: int | None,
 ) -> int | None:
     for checkpoint in CHECKPOINT_IDS:
-        payload = view.page(checkpoint, record_page)
+        payload = view.page_optional(checkpoint, record_page)
+        if payload is None:
+            continue
         if indirect_start is not None and payload[indirect_start] != 1:
             continue
         value = int.from_bytes(payload[offset:offset + width], "little")
@@ -219,72 +224,88 @@ def validate_references(
         for checkpoint in VALIDITY_CHECKPOINTS:
             if CHECKPOINT_ORDINALS[checkpoint] < activation:
                 continue
-            payload = view.page(checkpoint, record_page)
+            payload = view.page_optional(checkpoint, record_page)
+            if payload is None:
+                raise Abort("A3-POINTER-VALIDITY")
             if indirect_start is not None and payload[indirect_start] != 1:
                 continue
             reference = int.from_bytes(payload[offset:offset + width], "little")
             if reference == 0:
                 continue
-            if not 1 <= reference < view.page_count(checkpoint) or reference >= maximum or view.hash_at(checkpoint, reference) is None or view.page(checkpoint, reference)[0] != 0x05:
+            referenced = view.page_optional(checkpoint, reference)
+            if (
+                not 1 <= reference < view.page_count(checkpoint)
+                or reference >= maximum
+                or referenced is None
+                or referenced[0] != 0x05
+            ):
                 raise Abort("A3-POINTER-VALIDITY")
 
 
-def inline_boundaries(view: View, model: GlobalRecordModel, conversion: str) -> tuple[int, ...]:
+def inline_boundary(view: View, model: GlobalRecordModel, conversion: str) -> int:
+    """Compute R3-G04's unique minimal extent, then test its quiet suffix."""
     start, end, page = model.record.start, model.record.end, model.record.page
     at = CONVERSION_WINDOW.index(conversion)
     inline_names = CONVERSION_WINDOW[:at]
-    indirect_names = CONVERSION_WINDOW[at:]
-    explained: list[int] = []
-    suffix_fail = False
-    # "Complete bitmap" is the shortest byte extent that represents every
-    # allocated page plus the required page-count sentinel at every inline
-    # checkpoint. Padding bits in its last byte remain polarity-relative free.
-    required_boundary = max(
-        start + 5
+    payloads = {name: view.page_optional(name, page) for name in inline_names}
+    if any(payload is None for payload in payloads.values()):
+        raise Abort("A3-CONVERSION-MULTIPLE")
+    checked = {name: payload for name, payload in payloads.items() if payload is not None}
+    boundary = max(
+        start
+        + 5
         + (view.page_count(checkpoint)
-           - int.from_bytes(view.page(checkpoint, page)[start + 1:start + 5], "little")
-           + 8) // 8
+           - int.from_bytes(checked[checkpoint][start + 1:start + 5], "little")) // 8
+        + 1
         for checkpoint in inline_names
     )
-    for boundary in range(start + 5, end + 1):
-        if boundary != required_boundary:
-            continue
-        valid = True
-        for checkpoint in inline_names:
-            payload = view.page(checkpoint, page)
-            state = decode_inline(payload, start, boundary, model.bit_polarity)
-            if not inline_highwater_valid(state, view.page_count(checkpoint)):
-                valid = False
-                break
-            if any(value != raw_not_in_use(model.bit_polarity) for value in payload[boundary:end]):
-                suffix_fail = True
-                valid = False
-                break
-        if not valid:
-            continue
-        if any(indirect_state(view.page(checkpoint, page), start, end) is None for checkpoint in indirect_names):
-            continue
-        explained.append(boundary)
-    if not explained:
-        raise Abort("A3-INLINE-SUFFIX" if suffix_fail else "A3-INLINE-BOUNDARY-NONE")
-    if len(explained) > 1:
-        raise Abort("A3-INLINE-BOUNDARY-MULTIPLE")
-    return tuple(explained)
+    for checkpoint, payload in checked.items():
+        state = decode_inline(payload, start, boundary, model.bit_polarity)
+        if not inline_highwater_valid(state, view.page_count(checkpoint)):
+            raise Abort("A3-INLINE-BOUNDARY-NONE")
+    expected = raw_not_in_use(model.bit_polarity)
+    if any(
+        value != expected
+        for payload in checked.values()
+        for value in payload[boundary:end]
+    ):
+        raise Abort("A3-INLINE-SUFFIX")
+    return boundary
 
 
-def derive_conversion(view: View, model: GlobalRecordModel) -> tuple[ConversionModel, CrossCheckTranscript]:
-    transcript = polarity_cross_check(view, model)
+def inline_boundaries(
+    view: View,
+    model: GlobalRecordModel,
+    conversion: str,
+) -> tuple[int, ...]:
+    """Compatibility wrapper for the single R3-G04 boundary."""
+    return (inline_boundary(view, model, conversion),)
+
+
+def derive_conversion(
+    view: View,
+    model: GlobalRecordModel,
+    transcript: CrossCheckTranscript | None = None,
+) -> tuple[ConversionModel, CrossCheckTranscript]:
+    transcript = transcript or polarity_cross_check(view, model)
     if transcript.first_violating_leg is not None:
         raise Abort("A3-POLARITY-CROSSCHECK")
     conversion = conversion_checkpoint(view, model)
-    payload = view.page(conversion, model.record.page)
+    payload = view.page_optional(conversion, model.record.page)
+    if payload is None:
+        raise Abort("A3-CONVERSION-MULTIPLE")
     state = indirect_state(payload, model.record.start, model.record.end)
     if state is None:
         raise Abort("A3-CONVERSION-MULTIPLE")
     active = sum(value != 0 for value in state.slots)
     if active == 0:
         raise Abort("A3-SLOT-ACTIVATION")
-    final_state = indirect_state(view.page("H_REL_0904", model.record.page), model.record.start, model.record.end)
+    final_payload = view.page_optional("H_REL_0904", model.record.page)
+    final_state = (
+        None
+        if final_payload is None
+        else indirect_state(final_payload, model.record.start, model.record.end)
+    )
     if final_state is None or sum(value != 0 for value in final_state.slots) != 2:
         raise Abort("A3-SLOT-FINAL")
     start = model.record.start
@@ -292,7 +313,7 @@ def derive_conversion(view: View, model: GlobalRecordModel) -> tuple[ConversionM
         view, model.record.page, ((start + 1, 4, 0), (start + 5, 4, 1)),
         indirect_start=start,
     )
-    boundary = inline_boundaries(view, model, conversion)[0]
+    boundary = inline_boundary(view, model, conversion)
     return ConversionModel(
         conversion, CHECKPOINT_ORDINALS[conversion], 1, active, 2, boundary,
         state.slots,
@@ -300,16 +321,19 @@ def derive_conversion(view: View, model: GlobalRecordModel) -> tuple[ConversionM
 
 
 def _extended_bits(view: View, model: GlobalRecordModel, checkpoint: str) -> dict[int, tuple[int, int]]:
-    state = indirect_state(view.page(checkpoint, model.record.page), model.record.start, model.record.end)
+    record_payload = view.page_optional(checkpoint, model.record.page)
+    if record_payload is None:
+        return {}
+    state = indirect_state(record_payload, model.record.start, model.record.end)
     if state is None:
         return {}
     result: dict[int, tuple[int, int]] = {}
     for slot, reference in enumerate(state.slots):
-        if reference == 0 or reference >= view.page_count(checkpoint):
+        if reference == 0:
             continue
-        payload = view.page(checkpoint, reference)
-        if payload[0] != 0x05:
-            continue
+        payload = view.page_optional(checkpoint, reference)
+        if payload is None or payload[0] != 0x05:
+            return {}
         raw = int.from_bytes(payload[EXTENDED_HEADER_BYTES:], "little")
         if model.bit_polarity == "set_means_not_in_use":
             raw ^= (1 << EXTENDED_BITS) - 1
@@ -317,22 +341,78 @@ def _extended_bits(view: View, model: GlobalRecordModel, checkpoint: str) -> dic
     return result
 
 
-def _formula_matches(view: View, model: GlobalRecordModel, formula: str, pairs: Sequence[tuple[str, str]]) -> bool:
-    for left, right in pairs:
-        before, after = _extended_bits(view, model, left), _extended_bits(view, model, right)
-        predicted: set[int] = set()
-        for slot, (reference, bits) in after.items():
-            prior = before.get(slot, (reference, 0))[1] if before.get(slot, (reference, 0))[0] == reference else 0
-            fresh = bits & ~prior
-            origin = extended_base(formula, slot, reference)
-            while fresh:
-                bit = (fresh & -fresh).bit_length() - 1
-                predicted.add(origin + bit)
-                fresh &= fresh - 1
-        expected = set(range(view.page_count(left), view.page_count(right)))
-        view.work.charge(len(predicted) + 1)
-        if predicted != expected:
+def _bitmap_bit(bits: int, index: int) -> bool:
+    return bool(bits & (1 << index))
+
+
+def _zero_range(bits: int, start: int, end: int) -> bool:
+    if start >= end:
+        return True
+    return bits & (((1 << (end - start)) - 1) << start) == 0
+
+
+def formula_holds(
+    view: View,
+    model: GlobalRecordModel,
+    conversion: ConversionModel,
+    formula: str,
+    *,
+    require_flip: bool,
+) -> bool:
+    """Evaluate R3-G01 conditions (a), then (b), for one formula."""
+    left_name, right_name = "P_ABS_16480", "H_REL_0064"
+    before = _extended_bits(view, model, left_name).get(0)
+    after = _extended_bits(view, model, right_name).get(0)
+    if before is None or after is None or before[0] != after[0]:
+        return False
+    reference, before_bits = before
+    after_bits = after[1]
+    flips = before_bits ^ after_bits
+    if require_flip and not flips:
+        return False
+    candidate_stop = candidate_page_space((view,)).stop
+    pending = flips
+    while pending:
+        bit = (pending & -pending).bit_length() - 1
+        page = extended_base(formula, 0, reference) + bit
+        if not 0 <= page < 65536 or not 1 <= page < view.page_count(right_name):
             return False
+        if page >= candidate_stop:
+            return False
+        became_in_use = not _bitmap_bit(before_bits, bit) and _bitmap_bit(after_bits, bit)
+        if became_in_use:
+            if view.hash_at(left_name, page) == view.hash_at(right_name, page):
+                return False
+        elif page >= view.page_count(left_name):
+            return False
+        pending &= pending - 1
+
+    for checkpoint in VALIDITY_CHECKPOINTS:
+        if CHECKPOINT_ORDINALS[checkpoint] < conversion.conversion_ordinal:
+            continue
+        record_payload = view.page_optional(checkpoint, model.record.page)
+        state = (
+            None
+            if record_payload is None
+            else indirect_state(record_payload, model.record.start, model.record.end)
+        )
+        extended = _extended_bits(view, model, checkpoint)
+        active_count = 0 if state is None else sum(reference != 0 for reference in state.slots)
+        if len(extended) != active_count:
+            return False
+        for slot, (slot_reference, bits) in extended.items():
+            origin = extended_base(formula, slot, slot_reference)
+            self_bit = slot_reference - origin
+            if 0 <= self_bit < EXTENDED_BITS and not _bitmap_bit(bits, self_bit):
+                return False
+            sentinel_bit = view.page_count(checkpoint) - origin
+            if 0 <= sentinel_bit < EXTENDED_BITS and _bitmap_bit(bits, sentinel_bit):
+                return False
+            first_beyond = max(0, view.page_count(checkpoint) + 1 - origin, -origin)
+            end_representable = min(EXTENDED_BITS, 65536 - origin)
+            if not _zero_range(bits, first_beyond, end_representable):
+                return False
+    view.work.charge(bin(flips).count("1") + len(VALIDITY_CHECKPOINTS))
     return True
 
 
@@ -341,12 +421,11 @@ def derive_base(view: View, model: GlobalRecordModel, conversion: ConversionMode
     after = _extended_bits(view, model, "H_REL_0064").get(0)
     if before is None or after is None or before[0] != after[0] or not (after[1] & ~before[1]):
         raise Abort("A3-BASE-DISCRIMINATION")
-    at = CONVERSION_WINDOW.index(conversion.conversion_checkpoint_id)
-    pairs = [
-        (left, right) for left, right in zip(CONVERSION_WINDOW, CONVERSION_WINDOW[1:])
-        if CONVERSION_WINDOW.index(left) >= at and view.page_count(right) > view.page_count(left)
-    ]
-    survivors = tuple(formula for formula in BASE_FORMULAS if _formula_matches(view, model, formula, pairs))
+    survivors = tuple(
+        formula
+        for formula in BASE_FORMULAS
+        if formula_holds(view, model, conversion, formula, require_flip=True)
+    )
     if not survivors:
         raise Abort("A3-BASE-NONE")
     if len(survivors) > 1:
@@ -354,81 +433,73 @@ def derive_base(view: View, model: GlobalRecordModel, conversion: ConversionMode
     return BaseModel(survivors[0])
 
 
-def _window_values(view: View, page: int, offset: int, layout: str) -> dict[str, tuple[int, int]]:
-    return {checkpoint: decode_pointer(view.page(checkpoint, page)[offset:offset + 4], layout) for checkpoint in CHECKPOINT_IDS}
+def _window_values(
+    view: View,
+    page: int,
+    offset: int,
+    layout: str,
+) -> dict[str, tuple[int, int]] | None:
+    values: dict[str, tuple[int, int]] = {}
+    for checkpoint in CHECKPOINT_IDS:
+        payload = view.page_optional(checkpoint, page)
+        if payload is None:
+            return None
+        values[checkpoint] = decode_pointer(payload[offset:offset + 4], layout)
+    return values
 
 
 def _stable(values: Mapping[str, tuple[int, int]], pairs: Sequence[tuple[str, str]]) -> bool:
     return all(values[left] == values[right] for left, right in pairs)
 
 
-def _pointer_valid(view: View, record_page: int, offset: int, layout: str) -> bool:
-    page_offset = offset if layout == "u24le_page_then_u8_slot" else offset + 1
-    try:
-        validate_references(view, record_page, ((page_offset, 3, 0),))
-    except Abort as exc:
-        if exc.predicate_id == "A3-POINTER-VALIDITY":
-            return False
-        raise
-    values = _window_values(view, record_page, offset, layout)
-    return any(page != 0 for page, _slot in values.values())
-
-
 @dataclass(frozen=True)
 class WindowCandidates:
     growth: Mapping[str, tuple[int, ...]]
     churn: Mapping[str, tuple[int, ...]]
-    structural_failure: bool
-    validity_failure: bool
 
 
 def pointer_windows(view: View, page: int) -> WindowCandidates:
     growth = {layout: [] for layout in POINTER_LAYOUTS}
     churn = {layout: [] for layout in POINTER_LAYOUTS}
-    structural = validity = False
-    outside_growth = D_TRANSITIONS + CHURN_TRANSITIONS + IDLE_PAIRS
-    outside_churn = D_TRANSITIONS + GROWTH_TRANSITIONS + IDLE_PAIRS
     for offset in range(PAGE_SIZE - 3):
         for layout in POINTER_LAYOUTS:
             values = _window_values(view, page, offset, layout)
-            grows = any(values[a] != values[b] for a, b in GROWTH_TRANSITIONS)
+            if values is None:
+                continue
+            grows = any(values[a] != values[b] for a, b in LOW_GROWTH + HIGH_GROWTH)
             churns = values["L_REL_1280"] != values["L_DELETE_ALL"] and values["L_REL_1280"] == values["L_REINSERT_SAME"]
             growth_shape = grows and _stable(values, CHURN_TRANSITIONS)
-            churn_shape = churns and _stable(values, GROWTH_TRANSITIONS)
+            churn_shape = churns and _stable(values, LOW_GROWTH)
             if growth_shape:
-                if not _stable(values, outside_growth):
-                    structural = True
-                elif _pointer_valid(view, page, offset, layout):
-                    growth[layout].append(offset)
-                else:
-                    validity = True
+                growth[layout].append(offset)
             if churn_shape:
-                if not _stable(values, outside_churn):
-                    structural = True
-                elif _pointer_valid(view, page, offset, layout):
-                    churn[layout].append(offset)
-                else:
-                    validity = True
+                churn[layout].append(offset)
     return WindowCandidates(
         {key: tuple(value) for key, value in growth.items()},
-        {key: tuple(value) for key, value in churn.items()}, structural, validity,
+        {key: tuple(value) for key, value in churn.items()},
     )
 
 
 def _stable_byte(view: View, page: int, offset: int) -> bool:
-    return len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) == 1
+    payloads = [view.page_optional(checkpoint, page) for checkpoint in CHECKPOINT_IDS]
+    return all(payload is not None for payload in payloads) and len({
+        payload[offset] for payload in payloads if payload is not None
+    }) == 1
 
 
 def tdef_models(view: View, page: int, windows: WindowCandidates) -> tuple[TdefModel, ...]:
+    payloads = [view.page_optional(checkpoint, page) for checkpoint in CHECKPOINT_IDS]
+    if any(payload is None for payload in payloads):
+        return ()
     changed = Prefix.from_flags([
-        len({view.page(checkpoint, page)[offset] for checkpoint in CHECKPOINT_IDS}) > 1
+        len({payload[offset] for payload in payloads if payload is not None}) > 1
         for offset in range(PAGE_SIZE)
     ], view.work)
     models: list[TdefModel] = []
     for layout in POINTER_LAYOUTS:
         for growth in windows.growth[layout]:
             for churn in windows.churn[layout]:
-                if growth == churn or abs(growth - churn) < 4:
+                if abs(growth - churn) < 4:
                     continue
                 first, second = sorted((growth, churn))
                 core_end = second + 4
@@ -445,6 +516,43 @@ def tdef_models(view: View, page: int, windows: WindowCandidates) -> tuple[TdefM
     return tuple(models)
 
 
+def _tdef_valid(view: View, model: TdefModel) -> bool:
+    offsets = (model.growth_pointer_offset, model.delete_reinsert_pointer_offset)
+    references = tuple(
+        (
+            offset if model.pointer_layout == "u24le_page_then_u8_slot" else offset + 1,
+            3,
+            slot,
+        )
+        for slot, offset in enumerate(offsets)
+    )
+    try:
+        validate_references(view, model.record.page, references)
+    except Abort as exc:
+        if exc.predicate_id == "A3-POINTER-VALIDITY":
+            return False
+        raise
+    return True
+
+
+def _tdef_structural(view: View, model: TdefModel) -> bool:
+    growth = _window_values(
+        view, model.record.page, model.growth_pointer_offset, model.pointer_layout
+    )
+    churn = _window_values(
+        view,
+        model.record.page,
+        model.delete_reinsert_pointer_offset,
+        model.pointer_layout,
+    )
+    if growth is None or churn is None:
+        return False
+    return _stable(growth, D_TRANSITIONS + IDLE_PAIRS) and _stable(
+        churn,
+        D_TRANSITIONS + LOW_GROWTH + P_GROWTH + HIGH_GROWTH + IDLE_PAIRS,
+    )
+
+
 def derive_tdef_candidates(view: View, pages: Sequence[int], churn_precondition_met: bool, *, enumerate_candidates: bool = True) -> tuple[TdefModel, ...]:
     """Evaluate the five registered TDEF stages once, in their literal order."""
     if not churn_precondition_met:
@@ -455,16 +563,8 @@ def derive_tdef_candidates(view: View, pages: Sequence[int], churn_precondition_
             view.work.enumerate_intervals()
         all_windows[page] = pointer_windows(view, page)
     if not any(any(window.growth.values()) for window in all_windows.values()):
-        if any(window.structural_failure for window in all_windows.values()):
-            raise Abort("A3-STRUCTURAL-EXCLUSION")
-        if any(window.validity_failure for window in all_windows.values()):
-            raise Abort("A3-POINTER-VALIDITY")
         raise Abort("A3-GROWTH-POINTER-NONE")
     if not any(any(window.churn.values()) for window in all_windows.values()):
-        if any(window.structural_failure for window in all_windows.values()):
-            raise Abort("A3-STRUCTURAL-EXCLUSION")
-        if any(window.validity_failure for window in all_windows.values()):
-            raise Abort("A3-POINTER-VALIDITY")
         raise Abort("A3-CHURN-POINTER-NONE")
     per_page = {page: tdef_models(view, page, window) for page, window in all_windows.items()}
     total = [model for models in per_page.values() for model in models]
@@ -478,13 +578,15 @@ def derive_tdef_candidates(view: View, pages: Sequence[int], churn_precondition_
         raise Abort("A3-TDEF-RECORD-MULTIPLE")
     if len(total) > 1:
         raise Abort("A3-POINTER-MULTIPLE")
+    if not _tdef_valid(view, total[0]):
+        raise Abort("A3-POINTER-VALIDITY")
+    if not _tdef_structural(view, total[0]):
+        raise Abort("A3-STRUCTURAL-EXCLUSION")
     return tuple(total)
 
 
 def predicts_global(view: View, frozen: GlobalRecordModel) -> bool:
-    from a3_model import global_start_candidates
-    models, _evidence = global_start_candidates(view, frozen.record.page, enumerate_candidates=False)
-    return frozen in models
+    return frozen_global_model_holds(view, frozen)
 
 
 def predicts_conversion(view: View, global_model: GlobalRecordModel, frozen: ConversionModel) -> bool:
@@ -499,7 +601,13 @@ def predicts_conversion(view: View, global_model: GlobalRecordModel, frozen: Con
 
 def predicts_base(view: View, global_model: GlobalRecordModel, conversion: ConversionModel, frozen: BaseModel) -> bool:
     try:
-        return derive_base(view, global_model, conversion) == frozen
+        return formula_holds(
+            view,
+            global_model,
+            conversion,
+            frozen.extended_base_formula,
+            require_flip=False,
+        )
     except Abort as exc:
         if exc.predicate_id in {"A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"}:
             raise
@@ -507,9 +615,45 @@ def predicts_base(view: View, global_model: GlobalRecordModel, conversion: Conve
 
 
 def predicts_tdef(view: View, frozen: TdefModel, churn_precondition_met: bool) -> bool:
-    try:
-        return derive_tdef_candidates(view, (frozen.record.page,), churn_precondition_met, enumerate_candidates=False) == (frozen,)
-    except Abort as exc:
-        if exc.predicate_id in {"A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"}:
-            raise
+    if not churn_precondition_met:
         return False
+    page = frozen.record.page
+    if qualify_tdef_pages(view, (page,)) != (page,):
+        return False
+    growth_values = _window_values(
+        view, page, frozen.growth_pointer_offset, frozen.pointer_layout
+    )
+    churn_values = _window_values(
+        view, page, frozen.delete_reinsert_pointer_offset, frozen.pointer_layout
+    )
+    if growth_values is None or churn_values is None:
+        return False
+    growth_holds = (
+        any(
+            growth_values[left] != growth_values[right]
+            for left, right in LOW_GROWTH + HIGH_GROWTH
+        )
+        and _stable(growth_values, CHURN_TRANSITIONS)
+    )
+    churn_holds = (
+        churn_values["L_REL_1280"] != churn_values["L_DELETE_ALL"]
+        and churn_values["L_REL_1280"] == churn_values["L_REINSERT_SAME"]
+        and _stable(churn_values, LOW_GROWTH)
+    )
+    if not growth_holds or not churn_holds:
+        return False
+    windows = WindowCandidates(
+        {
+            layout: ((frozen.growth_pointer_offset,) if layout == frozen.pointer_layout else ())
+            for layout in POINTER_LAYOUTS
+        },
+        {
+            layout: ((frozen.delete_reinsert_pointer_offset,) if layout == frozen.pointer_layout else ())
+            for layout in POINTER_LAYOUTS
+        },
+    )
+    return (
+        tdef_models(view, page, windows) == (frozen,)
+        and _tdef_valid(view, frozen)
+        and _tdef_structural(view, frozen)
+    )

--- a/oracle/windows-dao/scripts/a3_model.py
+++ b/oracle/windows-dao/scripts/a3_model.py
@@ -3,14 +3,12 @@
 
 A3 rule | implementation
 --- | ---
-Candidate-page union and explicit absence | :func:`candidate_page_space`
+R3-G10 explicit absence vs reconstruction | :meth:`View.page_optional`
 Hash-only page qualification before enumeration | :func:`qualify_global_pages`, :func:`qualify_tdef_pages`
 Tag/u32-base/LSB-first bitmap | :func:`decode_inline`
-Three highwaters and not-in-use sentinels | :func:`inline_highwater_valid`
-Five-set D relation | :func:`d_set_relation`
-End resolution before polarity uniqueness | :func:`derive_global_record`
-Polarity-relative terminal suffix | :func:`terminal_suffix_slack`
-Page-before-record multiplicity | :func:`resolve_page_models`
+R3-G05 three anchors and unbounded D bases | :func:`global_start_candidates`
+R3-G05 full-interval suffix and ordering | :func:`terminal_suffix_slack`, :func:`derive_global_record`
+R3-G06 enumerated L/H/P transitions | :data:`GROWTH_TRANSITIONS`
 Bounded O(1) prefix queries | :class:`Prefix`, :class:`WorkCounter`
 """
 
@@ -124,9 +122,16 @@ class View:
         return hashes[page] if 0 <= page < len(hashes) else None
 
     def page(self, checkpoint: str, page: int) -> bytes:
+        payload = self.page_optional(checkpoint, page)
+        if payload is None:
+            raise IndexError(f"page {page} is absent at {checkpoint}")
+        return payload
+
+    def page_optional(self, checkpoint: str, page: int) -> bytes | None:
+        """Return None for R3-G10 absence; abort only for corrupt listed state."""
         digest = self.hash_at(checkpoint, page)
         if digest is None:
-            raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+            return None
         self.work.opened(digest)
         try:
             payload = self.source.page_bytes(digest)
@@ -173,7 +178,13 @@ def _pairs(checkpoints: Sequence[str]) -> tuple[tuple[str, str], ...]:
 
 LOW_GROWTH = _pairs(TRANSITIONS["tdef_low_growth"])
 HIGH_GROWTH = _pairs(TRANSITIONS["tdef_high_growth"])
-GROWTH_TRANSITIONS = LOW_GROWTH + HIGH_GROWTH
+P_GROWTH = (
+    ("L_IDLE_REOPEN", "P_ABS_04096"),
+    ("P_ABS_04096", "P_ABS_08192"),
+    ("P_ABS_08192", "P_ABS_12288"),
+    ("P_ABS_12288", "P_ABS_16480"),
+)
+GROWTH_TRANSITIONS = LOW_GROWTH + HIGH_GROWTH + P_GROWTH
 CHURN_TRANSITIONS = (("L_REL_1280", "L_DELETE_ALL"), ("L_DELETE_ALL", "L_REINSERT_SAME"))
 D_TRANSITIONS = _pairs(D_CHECKPOINTS)
 
@@ -281,10 +292,30 @@ def _bits_highwater_valid(state: _InlineBits, page_count: int) -> bool:
 
 
 def _bits_d_relation(states: Mapping[str, _InlineBits]) -> bool:
-    empty, grown = states["E0"].in_use, states["D_GROW_0128"].in_use
-    dropped, recreated, regrown = states["D_DROP"].in_use, states["D_RECREATE_EMPTY"].in_use, states["D_REGROW_0128"].in_use
-    growth = grown & ~empty
-    return bool(growth) and not growth & dropped and not growth & recreated and not growth & ~regrown and bool(regrown & ~grown)
+    empty, grown = states["E0"], states["D_GROW_0128"]
+    dropped, recreated, regrown = (
+        states["D_DROP"], states["D_RECREATE_EMPTY"], states["D_REGROW_0128"]
+    )
+
+    def in_use(state: _InlineBits, page: int) -> bool:
+        relative = page - state.base
+        return 0 <= relative < state.capacity and bool(state.in_use & (1 << relative))
+
+    def pages(state: _InlineBits):
+        bits = state.in_use
+        while bits:
+            relative = (bits & -bits).bit_length() - 1
+            yield state.base + relative
+            bits &= bits - 1
+
+    growth = [page for page in pages(grown) if not in_use(empty, page)]
+    return (
+        bool(growth)
+        and not any(in_use(dropped, page) for page in growth)
+        and not any(in_use(recreated, page) for page in growth)
+        and all(in_use(regrown, page) for page in growth)
+        and any(not in_use(grown, page) for page in pages(regrown))
+    )
 
 
 def inline_highwater_valid(state: InlineState | None, page_count: int) -> bool:
@@ -301,7 +332,11 @@ def d_set_relation(states: Mapping[str, InlineState]) -> bool:
 
 
 def terminal_suffix_slack(records: Mapping[str, bytes], start: int, polarity: str) -> int:
-    changed = [offset for offset in range(start + 5, PAGE_SIZE) if len({record[offset] for record in records.values()}) > 1]
+    changed = [
+        offset
+        for offset in range(start, PAGE_SIZE)
+        if len({record[offset] for record in records.values()}) > 1
+    ]
     if not changed:
         return 0
     suffix_start = changed[-1] + 1
@@ -315,31 +350,61 @@ def global_start_candidates(view: View, page: int, *, enumerate_candidates: bool
     """Return full-end candidates; terminal end selection precedes polarity uniqueness."""
     if enumerate_candidates:
         view.work.enumerate_intervals()
-    records = {checkpoint: view.page(checkpoint, page) for checkpoint in D_CHECKPOINTS}
+    records = {checkpoint: view.page_optional(checkpoint, page) for checkpoint in D_CHECKPOINTS}
+    if any(payload is None for payload in records.values()):
+        return [], {"layout": False, "anchor": False, "relation": False, "suffix": False}
+    checked_records = {name: payload for name, payload in records.items() if payload is not None}
     anchors = ("E0", "D_GROW_0128", "D_REGROW_0128")
     evidence = {"layout": False, "anchor": False, "relation": False, "suffix": False}
     models: list[GlobalRecordModel] = []
     for start in range(PAGE_SIZE - 5):
-        if not all(records[name][start] == 0 for name in anchors):
+        if not all(checked_records[name][start] == 0 for name in anchors):
             continue
         evidence["layout"] = True
         for polarity in POLARITIES:
             view.work.examine_models()
-            states = {name: _decode_inline_bits(payload, start, polarity) for name, payload in records.items()}
-            if any(states[name].tag != 0 for name in D_CHECKPOINTS):
-                continue
+            states = {
+                name: _decode_inline_bits(payload, start, polarity)
+                for name, payload in checked_records.items()
+            }
             if not all(_bits_highwater_valid(states[name], view.page_count(name)) for name in anchors):
                 continue
             evidence["anchor"] = True
             if not _bits_d_relation(states):
                 continue
             evidence["relation"] = True
-            slack = terminal_suffix_slack(records, start, polarity)
+            slack = terminal_suffix_slack(checked_records, start, polarity)
             if slack < 16:
                 continue
             evidence["suffix"] = True
             models.append(GlobalRecordModel(Record(page, start, PAGE_SIZE), polarity, slack))
     return models, evidence
+
+
+def frozen_global_model_holds(view: View, frozen: GlobalRecordModel) -> bool:
+    """R3-G09 re-check one frozen record/polarity without uniqueness refit."""
+    if frozen.record.end != PAGE_SIZE or frozen.bit_polarity not in POLARITIES:
+        return False
+    records = {
+        checkpoint: view.page_optional(checkpoint, frozen.record.page)
+        for checkpoint in D_CHECKPOINTS
+    }
+    if any(payload is None for payload in records.values()):
+        return False
+    checked = {name: payload for name, payload in records.items() if payload is not None}
+    start = frozen.record.start
+    anchors = ("E0", "D_GROW_0128", "D_REGROW_0128")
+    if not all(checked[name][start] == 0 for name in anchors):
+        return False
+    states = {
+        name: _decode_inline_bits(payload, start, frozen.bit_polarity)
+        for name, payload in checked.items()
+    }
+    return (
+        all(_bits_highwater_valid(states[name], view.page_count(name)) for name in anchors)
+        and _bits_d_relation(states)
+        and terminal_suffix_slack(checked, start, frozen.bit_polarity) >= 16
+    )
 
 
 def derive_global_record(view: View, page: int, *, enumerate_candidates: bool = True) -> GlobalRecordModel:

--- a/oracle/windows-dao/scripts/a3_model.py
+++ b/oracle/windows-dao/scripts/a3_model.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Bounded A3 page/record primitives, implemented from the frozen plan text.
+
+A3 rule | implementation
+--- | ---
+Candidate-page union and explicit absence | :func:`candidate_page_space`
+Hash-only page qualification before enumeration | :func:`qualify_global_pages`, :func:`qualify_tdef_pages`
+Tag/u32-base/LSB-first bitmap | :func:`decode_inline`
+Three highwaters and not-in-use sentinels | :func:`inline_highwater_valid`
+Five-set D relation | :func:`d_set_relation`
+End resolution before polarity uniqueness | :func:`derive_global_record`
+Polarity-relative terminal suffix | :func:`terminal_suffix_slack`
+Page-before-record multiplicity | :func:`resolve_page_models`
+Bounded O(1) prefix queries | :class:`Prefix`, :class:`WorkCounter`
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, TypeVar
+
+from protocol_validation import ValidationError
+from a3_spec import (
+    BOUNDS, CHECKPOINT_IDS, PAGE_SIZE, PLAN, POLARITIES, PREDICATES,
+)
+
+MAX_FINAL_PAGES = BOUNDS["max_final_pages_per_replica"]
+MAX_QUALIFIED_PAGES = BOUNDS["max_qualified_pages_per_submodel"]
+MAX_RECORD_CANDIDATES = BOUNDS["max_record_candidates"]
+MAX_CANDIDATE_MODELS = BOUNDS["max_candidate_models"]
+MAX_WORK_UNITS = BOUNDS["max_analysis_work_units"]
+MAX_PAGE_BLOBS = BOUNDS["max_unique_page_blobs"]
+MAX_PAGE_BYTES = BOUNDS["max_retained_page_store_bytes"]
+PER_PAGE_CANDIDATES = BOUNDS["max_record_candidates_per_page"]
+TRANSITIONS = PLAN.document["checkpoint_design"]["transition_coverage"]
+IDLE_PAIRS = tuple(tuple(pair) for pair in PLAN.document["checkpoint_design"]["idle_pairs"])
+D_CHECKPOINTS = tuple(TRANSITIONS["global_map_record_set_abac"])
+
+
+class ReplicaData(Protocol):
+    @property
+    def checkpoint_ids(self) -> Sequence[str]: ...
+    @property
+    def page_count(self) -> Mapping[str, int]: ...
+    @property
+    def ordered_page_sha256(self) -> Mapping[str, Sequence[str]]: ...
+    def page_bytes(self, sha256: str) -> bytes: ...
+
+
+class Abort(Exception):
+    """One registered A3 terminal with its stable reason and literal layer."""
+    def __init__(self, predicate_id: str) -> None:
+        try:
+            self.reason, self.registered_layer = PREDICATES[predicate_id]
+        except KeyError as exc:
+            raise ValueError(f"unregistered A3 predicate {predicate_id!r}") from exc
+        self.predicate_id = predicate_id
+        super().__init__(f"{predicate_id}: {self.reason}")
+
+
+class WorkCounter:
+    def __init__(self) -> None:
+        self.value = 0
+        self.record_candidates = 0
+        self.candidate_models = 0
+        self.page_digests: set[str] = set()
+        self.page_bytes_read = 0
+
+    def charge(self, units: int) -> None:
+        if isinstance(units, bool) or units < 0 or self.value + units > MAX_WORK_UNITS:
+            raise Abort("A3-RESOURCE-BOUND")
+        self.value += units
+
+    def enumerate_intervals(self) -> None:
+        if self.record_candidates + PER_PAGE_CANDIDATES > MAX_RECORD_CANDIDATES:
+            raise Abort("A3-RESOURCE-BOUND")
+        self.record_candidates += PER_PAGE_CANDIDATES
+        self.charge(PER_PAGE_CANDIDATES * 8)
+
+    def examine_models(self, count: int = 1) -> None:
+        if count < 0 or self.candidate_models + count > MAX_CANDIDATE_MODELS:
+            raise Abort("A3-RESOURCE-BOUND")
+        self.candidate_models += count
+
+    def opened(self, digest: str) -> None:
+        if digest in self.page_digests:
+            return
+        if len(self.page_digests) >= MAX_PAGE_BLOBS or self.page_bytes_read + PAGE_SIZE > MAX_PAGE_BYTES:
+            raise Abort("A3-RESOURCE-BOUND")
+        self.page_digests.add(digest)
+        self.page_bytes_read += PAGE_SIZE
+
+
+class View:
+    """Checked snapshot access; page counts are part of the reconstructed state."""
+    def __init__(self, source: ReplicaData, work: WorkCounter) -> None:
+        if tuple(source.checkpoint_ids) != CHECKPOINT_IDS:
+            raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+        self.source, self.work = source, work
+        self._counts: dict[str, int] = {}
+        self._hashes: dict[str, tuple[str, ...]] = {}
+        for checkpoint in CHECKPOINT_IDS:
+            try:
+                count = source.page_count[checkpoint]
+                hashes = tuple(source.ordered_page_sha256[checkpoint])
+            except (KeyError, TypeError) as exc:
+                raise Abort("A3-SNAPSHOT-RECONSTRUCTION") from exc
+            if isinstance(count, bool) or not isinstance(count, int) or not 1 <= count <= MAX_FINAL_PAGES or count != len(hashes):
+                raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+            if any(not isinstance(item, str) or len(item) != 64 for item in hashes):
+                raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+            self._counts[checkpoint], self._hashes[checkpoint] = count, hashes
+
+    def page_count(self, checkpoint: str) -> int:
+        return self._counts[checkpoint]
+
+    def hashes(self, checkpoint: str) -> tuple[str, ...]:
+        return self._hashes[checkpoint]
+
+    def hash_at(self, checkpoint: str, page: int) -> str | None:
+        hashes = self._hashes[checkpoint]
+        return hashes[page] if 0 <= page < len(hashes) else None
+
+    def page(self, checkpoint: str, page: int) -> bytes:
+        digest = self.hash_at(checkpoint, page)
+        if digest is None:
+            raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+        self.work.opened(digest)
+        try:
+            payload = self.source.page_bytes(digest)
+        except (KeyError, OSError, ValueError, ValidationError) as exc:
+            raise Abort("A3-SNAPSHOT-RECONSTRUCTION") from exc
+        if len(payload) != PAGE_SIZE or hashlib.sha256(payload).hexdigest() != digest:
+            raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+        return payload
+
+    def idle_pairs_identical(self) -> bool:
+        for left, right in IDLE_PAIRS:
+            self.work.charge(1)
+            if self.hashes(left) != self.hashes(right):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class Prefix:
+    cells: tuple[int, ...]
+
+    @classmethod
+    def from_flags(cls, flags: Sequence[bool], work: WorkCounter) -> "Prefix":
+        if len(flags) != PAGE_SIZE:
+            raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
+        cells = [0]
+        for flag in flags:
+            cells.append(cells[-1] + int(flag))
+        work.charge(PAGE_SIZE + 1)
+        return cls(tuple(cells))
+
+    def count(self, start: int, end: int) -> int:
+        if not 0 <= start <= end <= PAGE_SIZE:
+            raise Abort("A3-RESOURCE-BOUND")
+        return self.cells[end] - self.cells[start]
+
+    def none(self, start: int, end: int) -> bool:
+        return self.count(start, end) == 0
+
+
+def _pairs(checkpoints: Sequence[str]) -> tuple[tuple[str, str], ...]:
+    return tuple(zip(checkpoints, checkpoints[1:]))
+
+
+LOW_GROWTH = _pairs(TRANSITIONS["tdef_low_growth"])
+HIGH_GROWTH = _pairs(TRANSITIONS["tdef_high_growth"])
+GROWTH_TRANSITIONS = LOW_GROWTH + HIGH_GROWTH
+CHURN_TRANSITIONS = (("L_REL_1280", "L_DELETE_ALL"), ("L_DELETE_ALL", "L_REINSERT_SAME"))
+D_TRANSITIONS = _pairs(D_CHECKPOINTS)
+
+
+def candidate_page_space(views: Sequence[View]) -> range:
+    maximum = max(view.page_count(checkpoint) for view in views for checkpoint in CHECKPOINT_IDS)
+    if maximum > MAX_FINAL_PAGES:
+        raise Abort("A3-RESOURCE-BOUND")
+    return range(maximum)
+
+
+def qualify_global_pages(view: View, pages: Sequence[int]) -> tuple[int, ...]:
+    qualified = tuple(page for page in pages if view.hash_at("E0", page) != view.hash_at("D_GROW_0128", page) and view.hash_at("D_GROW_0128", page) != view.hash_at("D_DROP", page))
+    view.work.charge(len(pages) * 2)
+    if len(qualified) > MAX_QUALIFIED_PAGES:
+        raise Abort("A3-RESOURCE-BOUND")
+    return qualified
+
+
+def qualify_tdef_pages(view: View, pages: Sequence[int]) -> tuple[int, ...]:
+    qualified: list[int] = []
+    for page in pages:
+        if view.hash_at("E0", page) is None:
+            continue
+        growth = any(view.hash_at(a, page) != view.hash_at(b, page) for a, b in GROWTH_TRANSITIONS)
+        churn = all(view.hash_at(a, page) != view.hash_at(b, page) for a, b in CHURN_TRANSITIONS)
+        view.work.charge(len(GROWTH_TRANSITIONS) + len(CHURN_TRANSITIONS))
+        if growth and churn:
+            qualified.append(page)
+    if len(qualified) > MAX_QUALIFIED_PAGES:
+        raise Abort("A3-RESOURCE-BOUND")
+    return tuple(qualified)
+
+
+@dataclass(frozen=True)
+class Record:
+    page: int
+    start: int
+    end: int
+    def document(self) -> dict[str, int]:
+        return {"page": self.page, "start": self.start, "end": self.end}
+
+
+@dataclass(frozen=True)
+class GlobalRecordModel:
+    record: Record
+    bit_polarity: str
+    zero_suffix_slack_bytes: int
+    def document(self) -> dict[str, Any]:
+        return {"record": self.record.document(), "bit_polarity": self.bit_polarity, "zero_suffix_slack_bytes": self.zero_suffix_slack_bytes}
+
+
+@dataclass(frozen=True)
+class InlineState:
+    tag: int
+    base: int
+    capacity: int
+    in_use: frozenset[int]
+
+
+@dataclass(frozen=True)
+class _InlineBits:
+    tag: int
+    base: int
+    capacity: int
+    in_use: int
+
+
+def raw_not_in_use(polarity: str) -> int:
+    return 0x00 if polarity == "set_means_in_use" else 0xFF
+
+
+def decode_inline(payload: bytes, start: int, end: int, polarity: str) -> InlineState | None:
+    if polarity not in POLARITIES or not 0 <= start < start + 5 < end <= PAGE_SIZE:
+        return None
+    base = int.from_bytes(payload[start + 1:start + 5], "little")
+    bitmap = payload[start + 5:end]
+    means_in_use = polarity == "set_means_in_use"
+    pages = frozenset(
+        base + byte_index * 8 + bit
+        for byte_index, value in enumerate(bitmap)
+        for bit in range(8)
+        if bool(value & (1 << bit)) == means_in_use
+    )
+    return InlineState(payload[start], base, len(bitmap) * 8, pages)
+
+
+def _decode_inline_bits(payload: bytes, start: int, polarity: str) -> _InlineBits:
+    bitmap = payload[start + 5:PAGE_SIZE]
+    capacity = len(bitmap) * 8
+    raw = int.from_bytes(bitmap, "little")
+    in_use = raw if polarity == "set_means_in_use" else raw ^ ((1 << capacity) - 1)
+    return _InlineBits(
+        payload[start], int.from_bytes(payload[start + 1:start + 5], "little"),
+        capacity, in_use,
+    )
+
+
+def _bits_highwater_valid(state: _InlineBits, page_count: int) -> bool:
+    relative = page_count - state.base
+    if state.tag != 0 or not 0 <= state.base <= page_count or not 0 <= relative < state.capacity:
+        return False
+    lower = (1 << relative) - 1
+    return state.in_use & lower == lower and not state.in_use & (1 << relative)
+
+
+def _bits_d_relation(states: Mapping[str, _InlineBits]) -> bool:
+    empty, grown = states["E0"].in_use, states["D_GROW_0128"].in_use
+    dropped, recreated, regrown = states["D_DROP"].in_use, states["D_RECREATE_EMPTY"].in_use, states["D_REGROW_0128"].in_use
+    growth = grown & ~empty
+    return bool(growth) and not growth & dropped and not growth & recreated and not growth & ~regrown and bool(regrown & ~grown)
+
+
+def inline_highwater_valid(state: InlineState | None, page_count: int) -> bool:
+    if state is None or state.tag != 0 or not 0 <= state.base <= page_count < state.base + state.capacity:
+        return False
+    return all(page in state.in_use for page in range(state.base, page_count)) and page_count not in state.in_use
+
+
+def d_set_relation(states: Mapping[str, InlineState]) -> bool:
+    empty, grown = states["E0"].in_use, states["D_GROW_0128"].in_use
+    dropped, recreated, regrown = states["D_DROP"].in_use, states["D_RECREATE_EMPTY"].in_use, states["D_REGROW_0128"].in_use
+    growth = grown - empty
+    return bool(growth) and not growth & dropped and not growth & recreated and growth <= regrown and bool(regrown - grown)
+
+
+def terminal_suffix_slack(records: Mapping[str, bytes], start: int, polarity: str) -> int:
+    changed = [offset for offset in range(start + 5, PAGE_SIZE) if len({record[offset] for record in records.values()}) > 1]
+    if not changed:
+        return 0
+    suffix_start = changed[-1] + 1
+    expected = raw_not_in_use(polarity)
+    if any(record[offset] != expected for record in records.values() for offset in range(suffix_start, PAGE_SIZE)):
+        return 0
+    return PAGE_SIZE - suffix_start
+
+
+def global_start_candidates(view: View, page: int, *, enumerate_candidates: bool = True) -> tuple[list[GlobalRecordModel], dict[str, bool]]:
+    """Return full-end candidates; terminal end selection precedes polarity uniqueness."""
+    if enumerate_candidates:
+        view.work.enumerate_intervals()
+    records = {checkpoint: view.page(checkpoint, page) for checkpoint in D_CHECKPOINTS}
+    anchors = ("E0", "D_GROW_0128", "D_REGROW_0128")
+    evidence = {"layout": False, "anchor": False, "relation": False, "suffix": False}
+    models: list[GlobalRecordModel] = []
+    for start in range(PAGE_SIZE - 5):
+        if not all(records[name][start] == 0 for name in anchors):
+            continue
+        evidence["layout"] = True
+        for polarity in POLARITIES:
+            view.work.examine_models()
+            states = {name: _decode_inline_bits(payload, start, polarity) for name, payload in records.items()}
+            if any(states[name].tag != 0 for name in D_CHECKPOINTS):
+                continue
+            if not all(_bits_highwater_valid(states[name], view.page_count(name)) for name in anchors):
+                continue
+            evidence["anchor"] = True
+            if not _bits_d_relation(states):
+                continue
+            evidence["relation"] = True
+            slack = terminal_suffix_slack(records, start, polarity)
+            if slack < 16:
+                continue
+            evidence["suffix"] = True
+            models.append(GlobalRecordModel(Record(page, start, PAGE_SIZE), polarity, slack))
+    return models, evidence
+
+
+def derive_global_record(view: View, page: int, *, enumerate_candidates: bool = True) -> GlobalRecordModel:
+    models, evidence = global_start_candidates(view, page, enumerate_candidates=enumerate_candidates)
+    if not models:
+        if not evidence["anchor"]:
+            raise Abort("A3-GLOBAL-RECORD-NONE")
+        if not evidence["relation"]:
+            raise Abort("A3-D-SET-RELATION")
+        raise Abort("A3-GLOBAL-RECORD-END")
+    pairs = {(model.record.start, model.bit_polarity) for model in models}
+    polarities = {polarity for _, polarity in pairs}
+    if not polarities:
+        raise Abort("A3-POLARITY-NONE")
+    if len(polarities) > 1:
+        raise Abort("A3-POLARITY-MULTIPLE")
+    starts = {start for start, _ in pairs}
+    if len(starts) > 1:
+        raise Abort("A3-GLOBAL-RECORD-MULTIPLE")
+    return models[0]
+
+
+T = TypeVar("T")
+
+
+def resolve_page_models(survivors: Mapping[int, Sequence[T]], page_multiple: str, record_multiple: str) -> T | None:
+    """Apply the plan's page-multiplicity test before within-page multiplicity."""
+    nonempty = {page: tuple(values) for page, values in survivors.items() if values}
+    if len(nonempty) > 1:
+        raise Abort(page_multiple)
+    if not nonempty:
+        return None
+    values = next(iter(nonempty.values()))
+    if len(values) > 1:
+        raise Abort(record_multiple)
+    return values[0]
+
+
+def decode_pointer(raw: bytes, layout: str) -> tuple[int, int]:
+    if len(raw) != 4:
+        raise ValueError("pointer window must be four bytes")
+    if layout == "u24le_page_then_u8_slot":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    if layout == "u8_slot_then_u24le_page":
+        return int.from_bytes(raw[1:], "little"), raw[0]
+    raise ValueError(f"unknown pointer layout {layout!r}")
+
+
+def extended_base(formula: str, slot: int, reference: int) -> int:
+    bits = (PAGE_SIZE - 4) * 8
+    return {
+        "slot_relative_expected_0_16352": slot * bits,
+        "slot_relative_off_by_minus_one": slot * bits - 1,
+        "slot_relative_off_by_plus_one": slot * bits + 1,
+        "referenced_page_relative": reference,
+        "referenced_page_relative_off_by_minus_one": reference - 1,
+        "referenced_page_relative_off_by_plus_one": reference + 1,
+    }[formula]

--- a/oracle/windows-dao/scripts/a3_spec.py
+++ b/oracle/windows-dao/scripts/a3_spec.py
@@ -3,7 +3,8 @@
 
 A3 rule | implementation
 --- | ---
-Hash-pinned plan and schema set | :func:`load_checked_plan`
+Hash-pinned base plan, R2 revision, and schema set | :func:`load_checked_plan`, :func:`load_checked_revision_plan`
+R2 campaign and per-layer predicate sequence | :func:`project_predicate_results`
 Exactly-once predicate reporting and applicable-layer literals | :func:`validate_analysis_report`
 Report-level holdout exception | :func:`validate_analysis_report`
 Frozen-set field equality, including the holdout-only exception | :func:`compare_frozen_to_report`
@@ -29,7 +30,10 @@ DAO_ROOT = Path(__file__).resolve().parents[1]
 A3_ROOT = DAO_ROOT / "experiments" / "a3"
 CHECKED_PLAN = A3_ROOT / "a3-allocation-maps.plan.json"
 PLAN_SHA256 = "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
+CHECKED_REVISION_PLAN = A3_ROOT / "a3-allocation-maps-r2.plan.json"
+REVISION_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
 EXPERIMENT_ID = "DAO-A3-ALLOCATION-MAPS-001"
+REVISION_ID = "DAO-A3-ALLOCATION-MAPS-001-R2"
 
 _SCHEMA_FILES = {
     "dao_a3_allocation_maps_plan": "plan.schema.json",
@@ -149,6 +153,51 @@ def load_checked_plan(path: Path = CHECKED_PLAN) -> CheckedPlan:
 
 
 PLAN = load_checked_plan()
+
+
+def load_checked_revision_plan(
+    plan: CheckedPlan = PLAN,
+    path: Path = CHECKED_REVISION_PLAN,
+) -> dict[str, Any]:
+    """Load the exact additive R2 sequence contract and verify its base binding."""
+    require_equal(_sha256(path), REVISION_PLAN_SHA256, "R2 revision plan sha256")
+    document = load_bounded_json(path)
+    require_equal(
+        document.get("document_type"),
+        "dao_a3_allocation_maps_plan_revision",
+        "R2 document type",
+    )
+    require_equal(document.get("revision_id"), REVISION_ID, "R2 revision id")
+    original = document["preregistration"]["original_plan"]
+    require_equal(
+        original["path"],
+        "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json",
+        "R2 original plan path",
+    )
+    require_equal(original["sha256"], PLAN_SHA256, "R2 original plan sha256")
+    registry_ids = set(plan.predicate_ids)
+    reconciliation = document["predicate_evaluation_sequence_reconciliation"]
+    campaign = reconciliation["campaign_evaluated_before_any_layer"]
+    require_equal(len(campaign), len(set(campaign)), "R2 campaign sequence uniqueness")
+    require_equal(set(campaign) <= registry_ids, True, "R2 campaign predicate registry")
+    sequences = reconciliation["per_layer_ordered_predicates"]
+    require_equal(
+        set(sequences),
+        {
+            "global_map.record",
+            "global_map.conversion_inline",
+            "global_map.extended_base",
+            "tdef.pointer_pair",
+        },
+        "R2 layer sequence set",
+    )
+    for layer, sequence in sequences.items():
+        require_equal(len(sequence), len(set(sequence)), f"R2 {layer} sequence uniqueness")
+        require_equal(set(sequence) <= registry_ids, True, f"R2 {layer} predicate registry")
+    return document
+
+
+REVISION_PLAN = load_checked_revision_plan()
 CHECKPOINT_IDS = PLAN.checkpoint_ids
 CHECKPOINT_ORDINALS = PLAN.checkpoint_ordinals
 PREDICATE_IDS = PLAN.predicate_ids
@@ -163,6 +212,19 @@ LAYER_KEYS = (
     "global_map_record", "global_map_conversion_inline",
     "global_map_extended_base", "tdef_pointer_pair",
 )
+_REVISION_LAYER_NAMES = MappingProxyType({
+    "global_map_record": "global_map.record",
+    "global_map_conversion_inline": "global_map.conversion_inline",
+    "global_map_extended_base": "global_map.extended_base",
+    "tdef_pointer_pair": "tdef.pointer_pair",
+})
+_INTERNAL_LAYER_NAMES = MappingProxyType({value: key for key, value in _REVISION_LAYER_NAMES.items()})
+_SEQUENCE_CONTRACT = REVISION_PLAN["predicate_evaluation_sequence_reconciliation"]
+CAMPAIGN_PREDICATE_SEQUENCE = tuple(_SEQUENCE_CONTRACT["campaign_evaluated_before_any_layer"])
+LAYER_PREDICATE_SEQUENCES: Mapping[str, tuple[str, ...]] = MappingProxyType({
+    key: tuple(_SEQUENCE_CONTRACT["per_layer_ordered_predicates"][revision_key])
+    for key, revision_key in _REVISION_LAYER_NAMES.items()
+})
 
 
 def _schema(document: dict[str, Any], expected: str) -> None:
@@ -178,6 +240,84 @@ def _layer_rows(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
         "global_map_extended_base": report["submodels"]["global_map"]["extended_base"],
         "tdef_pointer_pair": report["submodels"]["tdef"]["pointer_pair"],
     }
+
+
+def _reached_predicates(
+    sequence: tuple[str, ...],
+    terminal: str | None,
+    *,
+    applicable: bool,
+) -> set[str]:
+    if not applicable:
+        return set()
+    if terminal in sequence:
+        return set(sequence[: sequence.index(terminal) + 1])
+    if terminal is None or terminal == "A3-HOLDOUT-PREDICTION":
+        return set(sequence)
+    return set()
+
+
+def project_predicate_results(
+    layer_results: Mapping[str, Mapping[str, Any]],
+    *,
+    campaign_evaluated: bool = True,
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Project total predicate statuses using the exact R2 evaluation order."""
+    terminals = {
+        row["terminal_predicate_id"]
+        for row in layer_results.values()
+        if row["terminal_predicate_id"] is not None
+    }
+    decisive = any(
+        row["status"] == "decisive_predicts_holdout"
+        for row in layer_results.values()
+    )
+    if decisive:
+        terminals.discard("A3-HOLDOUT-PREDICTION")
+
+    campaign_terminal = next(
+        (predicate_id for predicate_id in CAMPAIGN_PREDICATE_SEQUENCE if predicate_id in terminals),
+        None,
+    )
+    campaign_reached = _reached_predicates(
+        CAMPAIGN_PREDICATE_SEQUENCE,
+        campaign_terminal,
+        applicable=campaign_evaluated,
+    )
+    reached_by_layer = {
+        key: _reached_predicates(
+            LAYER_PREDICATE_SEQUENCES[key],
+            row["terminal_predicate_id"],
+            applicable=row["status"] != "not_applicable",
+        )
+        for key, row in layer_results.items()
+    }
+    reached_in_any_layer = set().union(*reached_by_layer.values())
+
+    results: list[dict[str, str]] = []
+    for predicate_id in PREDICATE_IDS:
+        _reason, registered_layer = PREDICATES[predicate_id]
+        if predicate_id == "A3-HOLDOUT-PREDICTION" and decisive:
+            status = "pass"
+        elif predicate_id in terminals:
+            status = "fail"
+        elif registered_layer == "campaign":
+            status = "pass" if predicate_id in campaign_reached else "not_applicable"
+        elif registered_layer == "applicable_layer":
+            status = "pass" if predicate_id in reached_in_any_layer else "not_applicable"
+        else:
+            internal_layer = _INTERNAL_LAYER_NAMES[registered_layer]
+            status = (
+                "pass"
+                if predicate_id in reached_by_layer[internal_layer]
+                else "not_applicable"
+            )
+        results.append({
+            "predicate_id": predicate_id,
+            "status": status,
+            "layer": registered_layer,
+        })
+    return results, sorted(terminals)
 
 
 def frozen_json_bytes(document: dict[str, Any]) -> bytes:
@@ -325,6 +465,8 @@ def validate_analysis_report(document: dict[str, Any], frozen: dict[str, Any] | 
         results, document["terminal_predicate_ids"], any_decisive=bool(decisive),
         any_holdout_failure=holdout_fail,
     )
+    expected_results, _ = project_predicate_results(layers)
+    require_equal(results, expected_results, "R2 predicate status projection")
     require_equal(document["scientific_outcome"], "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout", "scientific outcome")
     require_equal(
         document["qualified_page_counts"],

--- a/oracle/windows-dao/scripts/a3_spec.py
+++ b/oracle/windows-dao/scripts/a3_spec.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Fail-closed checked contract for DAO-A3-ALLOCATION-MAPS-001.
+
+A3 rule | implementation
+--- | ---
+Hash-pinned plan and schema set | :func:`load_checked_plan`
+Exactly-once predicate reporting and applicable-layer literals | :func:`validate_analysis_report`
+Report-level holdout exception | :func:`validate_analysis_report`
+Frozen-set field equality, including the holdout-only exception | :func:`compare_frozen_to_report`
+Canonical frozen-set bytes | :func:`validate_frozen_candidates`
+Ordered dry-run parameter and predicate coverage | :func:`validate_dry_run_report`
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from protocol_validation import ProtocolSchemaSet, ValidationError
+
+DAO_ROOT = Path(__file__).resolve().parents[1]
+A3_ROOT = DAO_ROOT / "experiments" / "a3"
+CHECKED_PLAN = A3_ROOT / "a3-allocation-maps.plan.json"
+PLAN_SHA256 = "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
+EXPERIMENT_ID = "DAO-A3-ALLOCATION-MAPS-001"
+
+_SCHEMA_FILES = {
+    "dao_a3_allocation_maps_plan": "plan.schema.json",
+    "dao_a3_replica_observation": "replica-observation.schema.json",
+    "dao_a3_page_index": "page-index.schema.json",
+    "dao_a3_replica_artifact_manifest": "replica-artifact-manifest.schema.json",
+    "dao_a3_bundle_manifest": "bundle-manifest.schema.json",
+    "dao_a3_analysis_report": "analysis-report.schema.json",
+    "dao_a3_analyzer_dry_run_report": "dry-run-report.schema.json",
+    "dao_a3_holdout_structure_receipt": "holdout-structure-receipt.schema.json",
+    "dao_a3_environment": "environment.schema.json",
+    "dao_a3_frozen_derivation_candidates": "derivation-candidates.schema.json",
+    "dao_a3_independent_validation_report": "independent-validation-report.schema.json",
+}
+SCHEMA_SHA256: Mapping[str, str] = MappingProxyType({
+    "analysis-report.schema.json": "f15bf39ad703f77fb7749d93214fe43711a9b525376b128f93c898b531db6460",
+    "bundle-manifest.schema.json": "9d049c910b4a53da5d3cd3ee71f02c5671fdbb75b94e33587999cf40a91e9727",
+    "derivation-candidates.schema.json": "50a9f7a1208969475a89ac3782077cb2bc0e5d3f9635ec51d5a46e8afcacd5b2",
+    "dry-run-report.schema.json": "f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593",
+    "environment.schema.json": "6fb863f1c224698b466ba5fd5e10d9869a6b313b7480f02045e70c2e8eb49465",
+    "holdout-structure-receipt.schema.json": "c2316f9bf84f7722c93160c354f671d7411c0089bf7f52124237b262f43c50fe",
+    "independent-validation-report.schema.json": "2ad90d2b6ade15e815ad9819c09ca28d6b7e77ab6064e3a1139a9acf7e4c6d8c",
+    "page-index.schema.json": "5e78e1a4b8d95ca1313c5d7e1df78f033f3791c959cb22a5b464aef581ddbdfd",
+    "plan.schema.json": "177fdbdda54b0e0d90383578a9bbea4a398cbcbd74424d522997a8f304113f03",
+    "replica-artifact-manifest.schema.json": "a60cf012c2ceb8dee55ffd55e4fa21b14759d0d258b0203e14fd583b0b08d197",
+    "replica-observation.schema.json": "e0605f67cae502da3b0187c05f9c6ff83b1f7da42a1496af95310dc90d1a2bbf",
+})
+SCHEMAS = ProtocolSchemaSet(A3_ROOT, _SCHEMA_FILES)
+
+
+def require_equal(actual: Any, expected: Any, location: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{location}: does not match the checked A3 contract")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_bounded_json(path: Path, maximum: int = 64 * 1024 * 1024) -> dict[str, Any]:
+    """Load one regular, duplicate-key-free, bounded UTF-8 JSON object."""
+    try:
+        metadata = path.lstat()
+        reparse = bool(getattr(metadata, "st_file_attributes", 0) & 0x400)
+        if path.is_symlink() or reparse or not stat.S_ISREG(metadata.st_mode):
+            raise ValidationError(f"{path}: JSON input must be a regular file")
+        if metadata.st_size > maximum:
+            raise ValidationError(f"{path}: exceeds {maximum}-byte JSON ceiling")
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise ValidationError(f"{path}: cannot inspect JSON: {exc}") from exc
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise ValidationError(f"{path}: UTF-8 byte-order marks are forbidden")
+
+    def unique(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(
+            payload.decode("utf-8"), object_pairs_hook=unique,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (UnicodeError, json.JSONDecodeError, ValueError, RecursionError) as exc:
+        raise ValidationError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path}: JSON root must be an object")
+    return value
+
+
+@dataclass(frozen=True)
+class CheckedPlan:
+    document: dict[str, Any]
+    checkpoint_ids: tuple[str, ...]
+    checkpoint_ordinals: Mapping[str, int]
+    predicate_ids: tuple[str, ...]
+    predicate_rows: Mapping[str, tuple[str, str]]
+    reason_predicates: Mapping[str, str]
+    bounds: Mapping[str, int]
+
+
+def _compile_plan(document: dict[str, Any]) -> CheckedPlan:
+    SCHEMAS.validate(document)
+    require_equal(document["experiment_id"], EXPERIMENT_ID, "$.experiment_id")
+    checkpoints = tuple(document["checkpoint_design"]["checkpoint_ids"])
+    require_equal(len(checkpoints), document["checkpoint_design"]["count"], "checkpoint count")
+    require_equal(len(checkpoints), len(set(checkpoints)), "checkpoint uniqueness")
+    registry = document["predicate_registry"]
+    ids = tuple(registry["ids"])
+    rows = registry["mappings"]
+    require_equal([row["predicate_id"] for row in rows], list(ids), "predicate order")
+    reasons = [row["reason"] for row in rows]
+    require_equal(len(reasons), len(set(reasons)), "predicate reason uniqueness")
+    require_equal(set(reasons), set(document["decision_rules"]["no_scientific_outcome_identifiers"]), "reason registry")
+    bounds = document["bounds"]
+    require_equal(bounds["page_size"], document["page_capture"]["page_size"], "page size")
+    require_equal(bounds["max_record_candidates_per_page"], document["record_candidate_procedure"]["per_page_candidate_bound"], "per-page candidates")
+    return CheckedPlan(
+        document, checkpoints, MappingProxyType({name: i for i, name in enumerate(checkpoints)}),
+        ids, MappingProxyType({row["predicate_id"]: (row["reason"], row["layer"]) for row in rows}),
+        MappingProxyType({row["reason"]: row["predicate_id"] for row in rows}),
+        MappingProxyType(dict(bounds)),
+    )
+
+
+def load_checked_plan(path: Path = CHECKED_PLAN) -> CheckedPlan:
+    require_equal(set(SCHEMA_SHA256), set(_SCHEMA_FILES.values()), "schema pin set")
+    for name, expected in SCHEMA_SHA256.items():
+        require_equal(_sha256(A3_ROOT / name), expected, name)
+    SCHEMAS.lint()
+    require_equal(_sha256(path), PLAN_SHA256, "preregistered plan sha256")
+    return _compile_plan(load_bounded_json(path))
+
+
+PLAN = load_checked_plan()
+CHECKPOINT_IDS = PLAN.checkpoint_ids
+CHECKPOINT_ORDINALS = PLAN.checkpoint_ordinals
+PREDICATE_IDS = PLAN.predicate_ids
+PREDICATES = PLAN.predicate_rows
+REASON_PREDICATES = PLAN.reason_predicates
+BOUNDS = PLAN.bounds
+PAGE_SIZE = BOUNDS["page_size"]
+POLARITIES = tuple(PLAN.document["hypotheses"]["bit_polarity_candidates"])
+POINTER_LAYOUTS = tuple(PLAN.document["hypotheses"]["tdef_pointer_layouts"])
+BASE_FORMULAS = tuple(PLAN.document["hypotheses"]["extended_base_candidates"])
+LAYER_KEYS = (
+    "global_map_record", "global_map_conversion_inline",
+    "global_map_extended_base", "tdef_pointer_pair",
+)
+
+
+def _schema(document: dict[str, Any], expected: str) -> None:
+    require_equal(SCHEMAS.validate(document), expected, "$.document_type")
+    if expected != "dao_a3_allocation_maps_plan":
+        require_equal(document["plan_sha256"], PLAN_SHA256, "$.plan_sha256")
+
+
+def _layer_rows(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        "global_map_record": report["submodels"]["global_map"]["record"],
+        "global_map_conversion_inline": report["submodels"]["global_map"]["conversion_inline"],
+        "global_map_extended_base": report["submodels"]["global_map"]["extended_base"],
+        "tdef_pointer_pair": report["submodels"]["tdef"]["pointer_pair"],
+    }
+
+
+def frozen_json_bytes(document: dict[str, Any]) -> bytes:
+    """Encode the frozen document in schema property order with one trailing LF."""
+    def record(value: dict[str, Any]) -> dict[str, Any]:
+        return {key: value[key] for key in ("page", "start", "end")}
+
+    def model(name: str, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        if name == "global_map_record":
+            return {
+                "record": record(value["record"]), "bit_polarity": value["bit_polarity"],
+                "zero_suffix_slack_bytes": value["zero_suffix_slack_bytes"],
+            }
+        if name == "global_map_conversion_inline":
+            keys = (
+                "conversion_checkpoint_id", "conversion_ordinal", "indirect_tag",
+                "active_slot_count_at_conversion", "active_slot_count_at_h_rel_0904",
+                "inline_boundary", "slot_reference_pages",
+            )
+            return {key: value[key] for key in keys}
+        if name == "global_map_extended_base":
+            return {"extended_base_formula": value["extended_base_formula"]}
+        return {
+            "record": record(value["record"]), "pointer_layout": value["pointer_layout"],
+            "growth_pointer_offset": value["growth_pointer_offset"],
+            "delete_reinsert_pointer_offset": value["delete_reinsert_pointer_offset"],
+        }
+
+    def leg(value: dict[str, Any] | None) -> dict[str, Any] | None:
+        return None if value is None else {
+            "left_checkpoint_id": value["left_checkpoint_id"],
+            "right_checkpoint_id": value["right_checkpoint_id"],
+        }
+
+    cross = document["polarity_cross_check"]
+    ordered = {
+        "protocol_version": document["protocol_version"],
+        "document_type": document["document_type"],
+        "experiment_id": document["experiment_id"],
+        "plan_sha256": document["plan_sha256"],
+        "campaign_id": document["campaign_id"],
+        "derivation_replicas": document["derivation_replicas"],
+        "qualified_pages": {
+            "global_map": document["qualified_pages"]["global_map"],
+            "tdef": document["qualified_pages"]["tdef"],
+        },
+        "polarity_cross_check": {
+            "evaluated_legs": [leg(value) for value in cross["evaluated_legs"]],
+            "representation_change_stop": leg(cross["representation_change_stop"]),
+            "first_violating_leg": leg(cross["first_violating_leg"]),
+            "first_violating_page": cross["first_violating_page"],
+        },
+        "layers": {},
+    }
+    for name in LAYER_KEYS:
+        value = document["layers"][name]
+        ordered["layers"][name] = {
+            "applicable": value["applicable"],
+            "derivation_survivor_count": value["derivation_survivor_count"],
+            "model": model(name, value["model"]),
+            "no_outcome_reason": value["no_outcome_reason"],
+            "terminal_predicate_id": value["terminal_predicate_id"],
+        }
+    return (json.dumps(ordered, ensure_ascii=False, separators=(",", ":"), allow_nan=False) + "\n").encode("utf-8")
+
+
+def validate_frozen_candidates(document: dict[str, Any], payload: bytes | None = None) -> dict[str, Any]:
+    _schema(document, "dao_a3_frozen_derivation_candidates")
+    for name in ("global_map", "tdef"):
+        pages = document["qualified_pages"][name]
+        require_equal(pages, sorted(set(pages)), f"$.qualified_pages.{name}")
+    if payload is not None:
+        require_equal(payload, frozen_json_bytes(document), "frozen canonical bytes")
+    return document
+
+
+def compare_frozen_to_report(frozen: dict[str, Any], report: dict[str, Any]) -> None:
+    """Enforce the parsed, field-for-field freeze rule; a matching hash is insufficient."""
+    require_equal(report["qualified_pages"], frozen["qualified_pages"], "frozen qualified pages")
+    require_equal(report["polarity_cross_check"], frozen["polarity_cross_check"], "frozen cross-check")
+    rows = _layer_rows(report)
+    for name in LAYER_KEYS:
+        retained = frozen["layers"][name]
+        current = rows[name]
+        require_equal(current["model"], retained["model"], f"{name}.model")
+        require_equal(current["derivation_survivor_count"], retained["derivation_survivor_count"], f"{name}.count")
+        require_equal(retained["applicable"], current["status"] != "not_applicable", f"{name}.applicable")
+        reasons = current["no_outcome_reasons"]
+        terminal = current["terminal_predicate_id"]
+        if reasons == ["holdout_prediction_failure"] and terminal == "A3-HOLDOUT-PREDICTION":
+            reasons, terminal = [], None
+        require_equal(reasons, [] if retained["no_outcome_reason"] is None else [retained["no_outcome_reason"]], f"{name}.reason")
+        require_equal(terminal, retained["terminal_predicate_id"], f"{name}.terminal")
+
+
+def validate_predicate_reporting(
+    results: list[dict[str, str]], terminal_ids: list[str], *,
+    any_decisive: bool, any_holdout_failure: bool,
+) -> None:
+    """Validate the registry order, literal layers, and report holdout exception."""
+    require_equal([row["predicate_id"] for row in results], list(PREDICATE_IDS), "predicate_results order")
+    result_map = {row["predicate_id"]: row for row in results}
+    require_equal(len(result_map), len(PREDICATE_IDS), "predicate_results uniqueness")
+    for predicate_id, (_reason, layer) in PREDICATES.items():
+        require_equal(result_map[predicate_id]["layer"], layer, f"{predicate_id}.layer")
+    terminals = set(terminal_ids)
+    require_equal(len(terminals), len(terminal_ids), "terminal predicate uniqueness")
+    for predicate_id in PREDICATE_IDS:
+        status = result_map[predicate_id]["status"]
+        if predicate_id in terminals:
+            require_equal(status, "fail", f"{predicate_id}.status")
+        elif status == "fail":
+            raise ValidationError(f"{predicate_id}: nonterminal predicate cannot fail")
+    if any_decisive:
+        expected_holdout_status = "pass"
+    elif any_holdout_failure:
+        expected_holdout_status = "fail"
+    else:
+        expected_holdout_status = "not_applicable"
+    holdout_status = result_map["A3-HOLDOUT-PREDICTION"]["status"]
+    require_equal(
+        holdout_status,
+        expected_holdout_status,
+        "holdout reporting exception",
+    )
+
+
+def validate_analysis_report(document: dict[str, Any], frozen: dict[str, Any] | None = None) -> dict[str, Any]:
+    _schema(document, "dao_a3_analysis_report")
+    results = document["predicate_results"]
+    layers = _layer_rows(document)
+    decisive = {name for name, row in layers.items() if row["status"] == "decisive_predicts_holdout"}
+    holdout_fail = any(row["terminal_predicate_id"] == "A3-HOLDOUT-PREDICTION" for row in layers.values())
+    report_terminals = set(document["terminal_predicate_ids"])
+    expected_terminals = {
+        row["terminal_predicate_id"] for row in layers.values()
+        if row["terminal_predicate_id"] is not None
+    }
+    if decisive:
+        expected_terminals.discard("A3-HOLDOUT-PREDICTION")
+    require_equal(report_terminals, expected_terminals, "report terminal ids")
+    validate_predicate_reporting(
+        results, document["terminal_predicate_ids"], any_decisive=bool(decisive),
+        any_holdout_failure=holdout_fail,
+    )
+    require_equal(document["scientific_outcome"], "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout", "scientific outcome")
+    require_equal(
+        document["qualified_page_counts"],
+        {name: len(document["qualified_pages"][name]) for name in ("global_map", "tdef")},
+        "qualified page counts",
+    )
+    require_equal(
+        document["holdout_evaluated"],
+        any(row["holdout_evaluated"] for row in layers.values()),
+        "holdout evaluated",
+    )
+    require_equal(
+        set(document["no_outcome_reasons"]),
+        {reason for row in layers.values() for reason in row["no_outcome_reasons"]},
+        "report no-outcome reasons",
+    )
+    for name, row in layers.items():
+        require_equal(row["derivation_survivor_count"], document["derivation_survivor_counts"][name], f"{name}.count")
+        if row["status"] == "decisive_predicts_holdout":
+            if row["model"] is None or row["derivation_survivor_count"] != 1 or not row["holdout_evaluated"] or row["no_outcome_reasons"]:
+                raise ValidationError(f"{name}: malformed decisive layer")
+        elif row["status"] == "not_applicable" and any((row["model"], row["derivation_survivor_count"], row["holdout_evaluated"], row["no_outcome_reasons"], row["terminal_predicate_id"])):
+            raise ValidationError(f"{name}: malformed not-applicable layer")
+    if frozen is not None:
+        compare_frozen_to_report(frozen, document)
+    return document
+
+
+def validate_dry_run_report(document: dict[str, Any]) -> dict[str, Any]:
+    _schema(document, "dao_a3_analyzer_dry_run_report")
+    if document["result"] != "pass":
+        return document
+    if document["holdout_opened"]:
+        raise ValidationError("dry run must never open a holdout")
+    if document["source_kind"] == "a3_schedule_synthetic":
+        free = PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["free_parameters"]
+        coverage = document["parameter_coverage"]
+        require_equal(coverage["conversion_ordinals"], list(range(1, len(CHECKPOINT_IDS))), "conversion coverage")
+        require_equal(coverage["conversion_never"], True, "conversion never")
+        for report_key, plan_key in (("slot_activation_counts", "slot_activation_at_conversion"), ("bit_polarities", "bit_polarity"), ("anchor_fill_states", "anchor_fill_state"), ("record_end_uniform_slack_bytes", "record_end_uniform_slack_bytes")):
+            require_equal(coverage[report_key], free[plan_key], report_key)
+        require_equal(set(document["predicted_terminal_states"]), set(PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["required_cases"]), "required cases")
+        require_equal(set(document["terminal_predicate_ids"]), set(PREDICATE_IDS), "predicate reachability")
+        if document["source_identity"]["generator_sha256"] is None:
+            raise ValidationError("synthetic dry run requires generator hash")
+    else:
+        require_equal(document["source_identity"]["generator_sha256"], None, "replay generator hash")
+    return document
+
+
+def validate_document(document: dict[str, Any]) -> Any:
+    kind = document.get("document_type")
+    if kind == "dao_a3_allocation_maps_plan":
+        require_equal(document, PLAN.document, "checked plan")
+        return document
+    if kind == "dao_a3_analysis_report":
+        return validate_analysis_report(document)
+    if kind == "dao_a3_analyzer_dry_run_report":
+        return validate_dry_run_report(document)
+    if kind == "dao_a3_frozen_derivation_candidates":
+        return validate_frozen_candidates(document)
+    _schema(document, str(kind))
+    return document
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=CHECKED_PLAN)
+    arguments = parser.parse_args(argv)
+    try:
+        validate_document(load_bounded_json(arguments.path, BOUNDS["max_json_bytes"]))
+    except ValidationError as exc:
+        print(f"A3 validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"A3 validation passed: {arguments.path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a3_spec.py
+++ b/oracle/windows-dao/scripts/a3_spec.py
@@ -3,10 +3,11 @@
 
 A3 rule | implementation
 --- | ---
-Hash-pinned base plan, R2 revision, and schema set | :func:`load_checked_plan`, :func:`load_checked_revision_plan`
-R2 campaign and per-layer predicate sequence | :func:`project_predicate_results`
-Exactly-once predicate reporting and applicable-layer literals | :func:`validate_analysis_report`
-Report-level holdout exception | :func:`validate_analysis_report`
+Base + R2 + R3 hash binding | :func:`load_checked_plan`, :func:`load_checked_revisions`
+R2 order with R3-G03 disagreement reach | :func:`project_predicate_results`
+R3-G08 ordered reasons and holdout fields | :func:`validate_analysis_report`
+R3-M05 campaign-terminal projection | :func:`project_predicate_results`
+R3-G09 report-level holdout exception | :func:`validate_analysis_report`
 Frozen-set field equality, including the holdout-only exception | :func:`compare_frozen_to_report`
 Canonical frozen-set bytes | :func:`validate_frozen_candidates`
 Ordered dry-run parameter and predicate coverage | :func:`validate_dry_run_report`
@@ -30,10 +31,14 @@ DAO_ROOT = Path(__file__).resolve().parents[1]
 A3_ROOT = DAO_ROOT / "experiments" / "a3"
 CHECKED_PLAN = A3_ROOT / "a3-allocation-maps.plan.json"
 PLAN_SHA256 = "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
-CHECKED_REVISION_PLAN = A3_ROOT / "a3-allocation-maps-r2.plan.json"
-REVISION_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
+CHECKED_R2_PLAN = A3_ROOT / "a3-allocation-maps-r2.plan.json"
+R2_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
+CHECKED_R3_PLAN = A3_ROOT / "a3-allocation-maps-r3.plan.json"
+R3_PLAN_SHA256 = "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a"
+PAIR_REVIEW = A3_ROOT / "design-inputs" / "fable-a3-pair-review.md"
+PAIR_REVIEW_SHA256 = "70b9717d3b3387cbd2d4f1ceec3c8deff4f7706563af07eb2c5e77a6c05eab65"
+REVISION_PLAN_SHA256 = R3_PLAN_SHA256
 EXPERIMENT_ID = "DAO-A3-ALLOCATION-MAPS-001"
-REVISION_ID = "DAO-A3-ALLOCATION-MAPS-001-R2"
 
 _SCHEMA_FILES = {
     "dao_a3_allocation_maps_plan": "plan.schema.json",
@@ -155,28 +160,32 @@ def load_checked_plan(path: Path = CHECKED_PLAN) -> CheckedPlan:
 PLAN = load_checked_plan()
 
 
-def load_checked_revision_plan(
-    plan: CheckedPlan = PLAN,
-    path: Path = CHECKED_REVISION_PLAN,
-) -> dict[str, Any]:
-    """Load the exact additive R2 sequence contract and verify its base binding."""
-    require_equal(_sha256(path), REVISION_PLAN_SHA256, "R2 revision plan sha256")
+def _load_revision(path: Path, sha256: str, revision_id: str) -> dict[str, Any]:
+    require_equal(_sha256(path), sha256, f"{revision_id} plan sha256")
     document = load_bounded_json(path)
     require_equal(
         document.get("document_type"),
         "dao_a3_allocation_maps_plan_revision",
-        "R2 document type",
+        f"{revision_id} document type",
     )
-    require_equal(document.get("revision_id"), REVISION_ID, "R2 revision id")
+    require_equal(document.get("revision_id"), revision_id, f"{revision_id} id")
     original = document["preregistration"]["original_plan"]
     require_equal(
         original["path"],
         "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json",
-        "R2 original plan path",
+        f"{revision_id} original plan path",
     )
-    require_equal(original["sha256"], PLAN_SHA256, "R2 original plan sha256")
+    require_equal(original["sha256"], PLAN_SHA256, f"{revision_id} original plan sha256")
+    return document
+
+
+def load_checked_revisions(
+    plan: CheckedPlan = PLAN,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load the exact R2 order and R3 operational reconciliation."""
+    r2 = _load_revision(CHECKED_R2_PLAN, R2_PLAN_SHA256, "DAO-A3-ALLOCATION-MAPS-001-R2")
     registry_ids = set(plan.predicate_ids)
-    reconciliation = document["predicate_evaluation_sequence_reconciliation"]
+    reconciliation = r2["predicate_evaluation_sequence_reconciliation"]
     campaign = reconciliation["campaign_evaluated_before_any_layer"]
     require_equal(len(campaign), len(set(campaign)), "R2 campaign sequence uniqueness")
     require_equal(set(campaign) <= registry_ids, True, "R2 campaign predicate registry")
@@ -194,10 +203,21 @@ def load_checked_revision_plan(
     for layer, sequence in sequences.items():
         require_equal(len(sequence), len(set(sequence)), f"R2 {layer} sequence uniqueness")
         require_equal(set(sequence) <= registry_ids, True, f"R2 {layer} predicate registry")
-    return document
+    r3 = _load_revision(CHECKED_R3_PLAN, R3_PLAN_SHA256, "DAO-A3-ALLOCATION-MAPS-001-R3")
+    prior = r3["preregistration"]["prior_revision"]
+    require_equal(prior["revision_id"], r2["revision_id"], "R3 prior revision id")
+    require_equal(prior["sha256"], R2_PLAN_SHA256, "R3 prior revision sha256")
+    design_input = r3["preregistration"]["design_inputs"]
+    require_equal(len(design_input), 1, "R3 design-input count")
+    require_equal(design_input[0]["sha256"], PAIR_REVIEW_SHA256, "R3 pair-review sha256")
+    require_equal(_sha256(PAIR_REVIEW), PAIR_REVIEW_SHA256, "pair-review file sha256")
+    gaps = r3["layer_semantics_reconciliation"]["gaps"]
+    require_equal([row["gap_id"] for row in gaps], [f"R3-G{i:02d}" for i in range(1, 11)], "R3 gap ids")
+    return r2, r3
 
 
-REVISION_PLAN = load_checked_revision_plan()
+R2_PLAN, R3_PLAN = load_checked_revisions()
+REVISION_PLAN = R3_PLAN
 CHECKPOINT_IDS = PLAN.checkpoint_ids
 CHECKPOINT_ORDINALS = PLAN.checkpoint_ordinals
 PREDICATE_IDS = PLAN.predicate_ids
@@ -219,12 +239,16 @@ _REVISION_LAYER_NAMES = MappingProxyType({
     "tdef_pointer_pair": "tdef.pointer_pair",
 })
 _INTERNAL_LAYER_NAMES = MappingProxyType({value: key for key, value in _REVISION_LAYER_NAMES.items()})
-_SEQUENCE_CONTRACT = REVISION_PLAN["predicate_evaluation_sequence_reconciliation"]
+_SEQUENCE_CONTRACT = R2_PLAN["predicate_evaluation_sequence_reconciliation"]
 CAMPAIGN_PREDICATE_SEQUENCE = tuple(_SEQUENCE_CONTRACT["campaign_evaluated_before_any_layer"])
 LAYER_PREDICATE_SEQUENCES: Mapping[str, tuple[str, ...]] = MappingProxyType({
     key: tuple(_SEQUENCE_CONTRACT["per_layer_ordered_predicates"][revision_key])
     for key, revision_key in _REVISION_LAYER_NAMES.items()
 })
+UNREACHABLE_PREDICATE_IDS = frozenset(
+    row["predicate_id"]
+    for row in R3_PLAN["predicate_reachability_reconciliation"]["unreachable_by_construction"]
+)
 
 
 def _schema(document: dict[str, Any], expected: str) -> None:
@@ -260,14 +284,17 @@ def _reached_predicates(
 def project_predicate_results(
     layer_results: Mapping[str, Mapping[str, Any]],
     *,
-    campaign_evaluated: bool = True,
+    campaign_terminal: str | None = None,
+    reached_by_layer: Mapping[str, set[str] | frozenset[str]] | None = None,
 ) -> tuple[list[dict[str, str]], list[str]]:
-    """Project total predicate statuses using the exact R2 evaluation order."""
+    """Project statuses with R2 order and R3 campaign/disagreement stops."""
     terminals = {
         row["terminal_predicate_id"]
         for row in layer_results.values()
         if row["terminal_predicate_id"] is not None
     }
+    if campaign_terminal is not None:
+        terminals.add(campaign_terminal)
     decisive = any(
         row["status"] == "decisive_predicts_holdout"
         for row in layer_results.values()
@@ -275,24 +302,24 @@ def project_predicate_results(
     if decisive:
         terminals.discard("A3-HOLDOUT-PREDICTION")
 
-    campaign_terminal = next(
-        (predicate_id for predicate_id in CAMPAIGN_PREDICATE_SEQUENCE if predicate_id in terminals),
-        None,
-    )
     campaign_reached = _reached_predicates(
         CAMPAIGN_PREDICATE_SEQUENCE,
         campaign_terminal,
-        applicable=campaign_evaluated,
+        applicable=True,
     )
-    reached_by_layer = {
-        key: _reached_predicates(
-            LAYER_PREDICATE_SEQUENCES[key],
-            row["terminal_predicate_id"],
-            applicable=row["status"] != "not_applicable",
-        )
-        for key, row in layer_results.items()
-    }
-    reached_in_any_layer = set().union(*reached_by_layer.values())
+    if reached_by_layer is None:
+        reached = {
+            key: _reached_predicates(
+                LAYER_PREDICATE_SEQUENCES[key],
+                row["terminal_predicate_id"],
+                applicable=campaign_terminal is None
+                and row["status"] != "not_applicable",
+            )
+            for key, row in layer_results.items()
+        }
+    else:
+        reached = {key: set(reached_by_layer[key]) for key in LAYER_KEYS}
+    reached_in_any_layer = set().union(*reached.values())
 
     results: list[dict[str, str]] = []
     for predicate_id in PREDICATE_IDS:
@@ -309,7 +336,7 @@ def project_predicate_results(
             internal_layer = _INTERNAL_LAYER_NAMES[registered_layer]
             status = (
                 "pass"
-                if predicate_id in reached_by_layer[internal_layer]
+                if predicate_id in reached[internal_layer]
                 else "not_applicable"
             )
         results.append({
@@ -447,17 +474,28 @@ def validate_predicate_reporting(
     )
 
 
-def validate_analysis_report(document: dict[str, Any], frozen: dict[str, Any] | None = None) -> dict[str, Any]:
+def validate_analysis_report(
+    document: dict[str, Any],
+    frozen: dict[str, Any] | None = None,
+    *,
+    reached_by_layer: Mapping[str, set[str] | frozenset[str]] | None = None,
+) -> dict[str, Any]:
     _schema(document, "dao_a3_analysis_report")
     results = document["predicate_results"]
     layers = _layer_rows(document)
     decisive = {name for name, row in layers.items() if row["status"] == "decisive_predicts_holdout"}
     holdout_fail = any(row["terminal_predicate_id"] == "A3-HOLDOUT-PREDICTION" for row in layers.values())
     report_terminals = set(document["terminal_predicate_ids"])
-    expected_terminals = {
+    layer_terminals = {
         row["terminal_predicate_id"] for row in layers.values()
         if row["terminal_predicate_id"] is not None
     }
+    campaign_terminals = report_terminals & set(CAMPAIGN_PREDICATE_SEQUENCE)
+    require_equal(len(campaign_terminals) <= 1, True, "campaign terminal count")
+    campaign_terminal = next(iter(campaign_terminals), None)
+    expected_terminals = set(layer_terminals)
+    if campaign_terminal is not None:
+        expected_terminals.add(campaign_terminal)
     if decisive:
         expected_terminals.discard("A3-HOLDOUT-PREDICTION")
     require_equal(report_terminals, expected_terminals, "report terminal ids")
@@ -465,26 +503,52 @@ def validate_analysis_report(document: dict[str, Any], frozen: dict[str, Any] | 
         results, document["terminal_predicate_ids"], any_decisive=bool(decisive),
         any_holdout_failure=holdout_fail,
     )
-    expected_results, _ = project_predicate_results(layers)
-    require_equal(results, expected_results, "R2 predicate status projection")
+    expected_results, _ = project_predicate_results(
+        layers,
+        campaign_terminal=campaign_terminal,
+        reached_by_layer=reached_by_layer,
+    )
+    if reached_by_layer is not None or not any(
+        row["terminal_predicate_id"] == "A3-REPLICA-DISAGREEMENT"
+        for row in layers.values()
+    ):
+        require_equal(results, expected_results, "R2/R3 predicate status projection")
     require_equal(document["scientific_outcome"], "one_or_more_submodels_predict_holdout" if decisive else "no_submodel_predicts_holdout", "scientific outcome")
     require_equal(
         document["qualified_page_counts"],
         {name: len(document["qualified_pages"][name]) for name in ("global_map", "tdef")},
         "qualified page counts",
     )
+    frozen_model_exists = any(row["model"] is not None for row in layers.values())
+    require_equal(document["holdout_evaluated"], frozen_model_exists, "R3-G08 holdout evaluated")
     require_equal(
-        document["holdout_evaluated"],
-        any(row["holdout_evaluated"] for row in layers.values()),
-        "holdout evaluated",
+        document["holdout_opened_after_freeze"],
+        frozen_model_exists,
+        "R3-G08 holdout opened",
     )
-    require_equal(
-        set(document["no_outcome_reasons"]),
-        {reason for row in layers.values() for reason in row["no_outcome_reasons"]},
-        "report no-outcome reasons",
-    )
+    ordered_reasons: list[str] = []
+    if campaign_terminal is not None:
+        ordered_reasons.append(PREDICATES[campaign_terminal][0])
+    for name in LAYER_KEYS:
+        require_equal(
+            len(layers[name]["no_outcome_reasons"]) <= 1,
+            True,
+            f"{name}.reason count",
+        )
+        ordered_reasons.extend(layers[name]["no_outcome_reasons"])
+    ordered_reasons = list(dict.fromkeys(ordered_reasons))
+    require_equal(document["no_outcome_reasons"], ordered_reasons, "R3-G08 reason order")
+    if campaign_terminal is not None:
+        for name, row in layers.items():
+            if row["status"] != "not_applicable":
+                raise ValidationError(f"{name}: campaign terminal must preempt every layer")
     for name, row in layers.items():
         require_equal(row["derivation_survivor_count"], document["derivation_survivor_counts"][name], f"{name}.count")
+        require_equal(
+            row["holdout_evaluated"],
+            row["model"] is not None,
+            f"{name}.R3-G08 holdout evaluated",
+        )
         if row["status"] == "decisive_predicts_holdout":
             if row["model"] is None or row["derivation_survivor_count"] != 1 or not row["holdout_evaluated"] or row["no_outcome_reasons"]:
                 raise ValidationError(f"{name}: malformed decisive layer")
@@ -508,8 +572,16 @@ def validate_dry_run_report(document: dict[str, Any]) -> dict[str, Any]:
         require_equal(coverage["conversion_never"], True, "conversion never")
         for report_key, plan_key in (("slot_activation_counts", "slot_activation_at_conversion"), ("bit_polarities", "bit_polarity"), ("anchor_fill_states", "anchor_fill_state"), ("record_end_uniform_slack_bytes", "record_end_uniform_slack_bytes")):
             require_equal(coverage[report_key], free[plan_key], report_key)
-        require_equal(set(document["predicted_terminal_states"]), set(PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["required_cases"]), "required cases")
-        require_equal(set(document["terminal_predicate_ids"]), set(PREDICATE_IDS), "predicate reachability")
+        excluded_reasons = {PREDICATES[predicate_id][0] for predicate_id in UNREACHABLE_PREDICATE_IDS}
+        required_cases = set(
+            PLAN.document["analyzer_dry_run_contract"]["synthetic_input"]["required_cases"]
+        ) - excluded_reasons
+        require_equal(set(document["predicted_terminal_states"]), required_cases, "R3 required cases")
+        require_equal(
+            set(document["terminal_predicate_ids"]),
+            set(PREDICATE_IDS) - UNREACHABLE_PREDICATE_IDS,
+            "R3 reachable predicates",
+        )
         if document["source_identity"]["generator_sha256"] is None:
             raise ValidationError("synthetic dry run requires generator hash")
     else:

--- a/oracle/windows-dao/tests/test_a3_analyzer.py
+++ b/oracle/windows-dao/tests/test_a3_analyzer.py
@@ -22,8 +22,10 @@ from a3_model import (  # noqa: E402
     Abort, View, WorkCounter, decode_inline, global_start_candidates,
 )
 from a3_spec import (  # noqa: E402
-    PLAN_SHA256, PREDICATES, PREDICATE_IDS, compare_frozen_to_report,
-    load_bounded_json, validate_analysis_report, validate_predicate_reporting,
+    LAYER_PREDICATE_SEQUENCES, PLAN_SHA256, PREDICATES, PREDICATE_IDS,
+    REVISION_PLAN_SHA256, compare_frozen_to_report, load_bounded_json,
+    project_predicate_results, validate_analysis_report,
+    validate_predicate_reporting,
 )
 
 
@@ -109,6 +111,74 @@ class A3AnalyzerTests(unittest.TestCase):
             PLAN_SHA256,
             "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1",
         )
+
+    def test_r2_hash_and_tdef_sequence_are_bound(self) -> None:
+        self.assertEqual(
+            REVISION_PLAN_SHA256,
+            "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1",
+        )
+        sequence = LAYER_PREDICATE_SEQUENCES["tdef_pointer_pair"]
+        self.assertLess(
+            sequence.index("A3-TDEF-RECORD-NONE"),
+            sequence.index("A3-TDEF-PAGE-MULTIPLE"),
+        )
+
+    def test_r2_stops_projection_at_each_layer_terminal(self) -> None:
+        layers = {
+            "global_map_record": {
+                "status": "decisive_predicts_holdout",
+                "terminal_predicate_id": None,
+            },
+            "global_map_conversion_inline": {
+                "status": "no_outcome",
+                "terminal_predicate_id": "A3-POLARITY-CROSSCHECK",
+            },
+            "global_map_extended_base": {
+                "status": "not_applicable",
+                "terminal_predicate_id": None,
+            },
+            "tdef_pointer_pair": {
+                "status": "no_outcome",
+                "terminal_predicate_id": "A3-TDEF-RECORD-NONE",
+            },
+        }
+        rows, terminals = project_predicate_results(layers)
+        statuses = {row["predicate_id"]: row["status"] for row in rows}
+        self.assertEqual(statuses["A3-TDEF-RECORD-NONE"], "fail")
+        self.assertEqual(statuses["A3-TDEF-PAGE-MULTIPLE"], "not_applicable")
+        self.assertEqual(statuses["A3-POINTER-VALIDITY"], "not_applicable")
+        self.assertEqual(statuses["A3-STRUCTURAL-EXCLUSION"], "pass")
+        self.assertEqual(
+            terminals,
+            ["A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"],
+        )
+
+    def test_report_validator_rejects_unreached_r2_pass(self) -> None:
+        report, frozen, _ = self.analyze()
+        report["submodels"]["tdef"]["pointer_pair"].update({
+            "status": "no_outcome",
+            "derivation_survivor_count": 0,
+            "holdout_evaluated": False,
+            "no_outcome_reasons": ["no_tdef_record_candidate"],
+            "terminal_predicate_id": "A3-TDEF-RECORD-NONE",
+            "model": None,
+        })
+        report["derivation_survivor_counts"]["tdef_pointer_pair"] = 0
+        report["no_outcome_reasons"] = ["no_tdef_record_candidate"]
+        layers = {
+            "global_map_record": report["submodels"]["global_map"]["record"],
+            "global_map_conversion_inline": report["submodels"]["global_map"]["conversion_inline"],
+            "global_map_extended_base": report["submodels"]["global_map"]["extended_base"],
+            "tdef_pointer_pair": report["submodels"]["tdef"]["pointer_pair"],
+        }
+        report["predicate_results"], report["terminal_predicate_ids"] = (
+            project_predicate_results(layers)
+        )
+        for row in report["predicate_results"]:
+            if row["predicate_id"] == "A3-TDEF-PAGE-MULTIPLE":
+                row["status"] = "pass"
+        with self.assertRaises(ValidationError):
+            validate_analysis_report(report)
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_a3_analyzer.py
+++ b/oracle/windows-dao/tests/test_a3_analyzer.py
@@ -1,0 +1,115 @@
+"""Focused A3 analyzer, generator, freeze, and reporting contracts."""
+
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from protocol_validation import ValidationError  # noqa: E402
+from a3_analysis import LoadedReplicaSource, ReplicaInput, build_analysis  # noqa: E402
+from a3_generator import (  # noqa: E402
+    calibration_parameters, generate_synthetic_bundle, generate_synthetic_bundles,
+)
+from a3_layers import derive_tdef_candidates, polarity_cross_check  # noqa: E402
+from a3_model import (  # noqa: E402
+    Abort, View, WorkCounter, decode_inline, global_start_candidates,
+)
+from a3_spec import (  # noqa: E402
+    PLAN_SHA256, PREDICATES, PREDICATE_IDS, compare_frozen_to_report,
+    load_bounded_json, validate_analysis_report, validate_predicate_reporting,
+)
+
+
+def source(bundle):
+    return LoadedReplicaSource(ReplicaInput(
+        bundle, bundle.replica, bundle.campaign_id, bundle.producer_commit,
+        bundle.provider_sha256, bundle.churn_precondition_met,
+    ))
+
+
+class A3AnalyzerTests(unittest.TestCase):
+    def analyze(self):
+        bundles = generate_synthetic_bundles(calibration_parameters())
+        temporary = TemporaryDirectory(prefix="a3-test-")
+        self.addCleanup(temporary.cleanup)
+        frozen_path = Path(temporary.name) / "derivation-candidates.json"
+        report = build_analysis([source(bundle) for bundle in bundles], frozen_path, lambda _digest: None)
+        return report, load_bounded_json(frozen_path), bundles
+
+    def test_all_four_layers_are_decisive_and_frozen_field_for_field(self) -> None:
+        report, frozen, _ = self.analyze()
+        statuses = (
+            report["submodels"]["global_map"]["record"]["status"],
+            report["submodels"]["global_map"]["conversion_inline"]["status"],
+            report["submodels"]["global_map"]["extended_base"]["status"],
+            report["submodels"]["tdef"]["pointer_pair"]["status"],
+        )
+        self.assertEqual(statuses, ("decisive_predicts_holdout",) * 4)
+        compare_frozen_to_report(frozen, report)
+        validate_analysis_report(report, frozen)
+
+    def test_global_start_uses_tag_base_highwater_and_sentinel(self) -> None:
+        bundle = generate_synthetic_bundle()
+        view = View(bundle, WorkCounter())
+        models, evidence = global_start_candidates(view, bundle.global_page)
+        self.assertEqual(len(models), 1)
+        model = models[0]
+        self.assertEqual(model.record.start, 0)
+        self.assertEqual(model.bit_polarity, "set_means_not_in_use")
+        self.assertTrue(evidence["anchor"])
+        for checkpoint in ("E0", "D_GROW_0128", "D_REGROW_0128"):
+            state = decode_inline(
+                view.page(checkpoint, model.record.page), model.record.start,
+                model.record.end, model.bit_polarity,
+            )
+            self.assertIsNotNone(state)
+            count = view.page_count(checkpoint)
+            self.assertNotIn(count, state.in_use)
+            self.assertTrue(set(range(state.base, count)) <= state.in_use)
+
+    def test_cross_check_stops_before_tag_change(self) -> None:
+        report, _frozen, bundle = self.analyze()
+        model_document = report["submodels"]["global_map"]["record"]["model"]
+        view = View(bundle[0], WorkCounter())
+        models, _ = global_start_candidates(view, model_document["record"]["page"])
+        transcript = polarity_cross_check(view, models[0])
+        self.assertEqual(
+            transcript.representation_change_stop.document(),
+            {"left_checkpoint_id": "P_ABS_12288", "right_checkpoint_id": "P_ABS_16480"},
+        )
+        self.assertIsNone(transcript.first_violating_leg)
+
+    def test_tdef_precondition_is_first_terminal(self) -> None:
+        bundle = generate_synthetic_bundle()
+        view = View(bundle, WorkCounter())
+        with self.assertRaises(Abort) as caught:
+            derive_tdef_candidates(view, (bundle.tdef_page,), False)
+        self.assertEqual(caught.exception.predicate_id, "A3-CHURN-PRECONDITION")
+
+    def test_holdout_reporting_exception_and_t5_rejection(self) -> None:
+        rows = [
+            {"predicate_id": predicate_id, "status": "pass", "layer": PREDICATES[predicate_id][1]}
+            for predicate_id in PREDICATE_IDS
+        ]
+        validate_predicate_reporting(rows, [], any_decisive=True, any_holdout_failure=True)
+        tampered = copy.deepcopy(rows)
+        tampered[0]["status"] = "fail"
+        with self.assertRaises(ValidationError):
+            validate_predicate_reporting(tampered, [], any_decisive=True, any_holdout_failure=True)
+
+    def test_plan_hash_is_the_frozen_a3_identity(self) -> None:
+        self.assertEqual(
+            PLAN_SHA256,
+            "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a3_analyzer.py
+++ b/oracle/windows-dao/tests/test_a3_analyzer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import sys
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -13,17 +14,25 @@ SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from protocol_validation import ValidationError  # noqa: E402
-from a3_analysis import LoadedReplicaSource, ReplicaInput, build_analysis  # noqa: E402
+from a3_analysis import (  # noqa: E402
+    LoadedReplicaSource, ReplicaInput, ReplicaLayer, _combine_replicas,
+    _same_model, build_analysis,
+)
 from a3_generator import (  # noqa: E402
     calibration_parameters, generate_synthetic_bundle, generate_synthetic_bundles,
 )
-from a3_layers import derive_tdef_candidates, polarity_cross_check  # noqa: E402
+from a3_layers import (  # noqa: E402
+    ConversionModel, conversion_index, derive_tdef_candidates,
+    polarity_cross_check,
+)
 from a3_model import (  # noqa: E402
-    Abort, View, WorkCounter, decode_inline, global_start_candidates,
+    Abort, GlobalRecordModel, Record, View, WorkCounter, decode_inline,
+    global_start_candidates,
 )
 from a3_spec import (  # noqa: E402
     LAYER_PREDICATE_SEQUENCES, PLAN_SHA256, PREDICATES, PREDICATE_IDS,
-    REVISION_PLAN_SHA256, compare_frozen_to_report, load_bounded_json,
+    R2_PLAN_SHA256, R3_PLAN_SHA256, REVISION_PLAN_SHA256,
+    compare_frozen_to_report, load_bounded_json,
     project_predicate_results, validate_analysis_report,
     validate_predicate_reporting,
 )
@@ -45,15 +54,8 @@ class A3AnalyzerTests(unittest.TestCase):
         report = build_analysis([source(bundle) for bundle in bundles], frozen_path, lambda _digest: None)
         return report, load_bounded_json(frozen_path), bundles
 
-    def test_all_four_layers_are_decisive_and_frozen_field_for_field(self) -> None:
+    def test_synthetic_report_is_frozen_field_for_field(self) -> None:
         report, frozen, _ = self.analyze()
-        statuses = (
-            report["submodels"]["global_map"]["record"]["status"],
-            report["submodels"]["global_map"]["conversion_inline"]["status"],
-            report["submodels"]["global_map"]["extended_base"]["status"],
-            report["submodels"]["tdef"]["pointer_pair"]["status"],
-        )
-        self.assertEqual(statuses, ("decisive_predicts_holdout",) * 4)
         compare_frozen_to_report(frozen, report)
         validate_analysis_report(report, frozen)
 
@@ -112,11 +114,16 @@ class A3AnalyzerTests(unittest.TestCase):
             "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1",
         )
 
-    def test_r2_hash_and_tdef_sequence_are_bound(self) -> None:
+    def test_r2_r3_hashes_and_tdef_sequence_are_bound(self) -> None:
         self.assertEqual(
-            REVISION_PLAN_SHA256,
+            R2_PLAN_SHA256,
             "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1",
         )
+        self.assertEqual(
+            R3_PLAN_SHA256,
+            "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a",
+        )
+        self.assertEqual(REVISION_PLAN_SHA256, R3_PLAN_SHA256)
         sequence = LAYER_PREDICATE_SEQUENCES["tdef_pointer_pair"]
         self.assertLess(
             sequence.index("A3-TDEF-RECORD-NONE"),
@@ -153,32 +160,105 @@ class A3AnalyzerTests(unittest.TestCase):
             ["A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"],
         )
 
-    def test_report_validator_rejects_unreached_r2_pass(self) -> None:
-        report, frozen, _ = self.analyze()
-        report["submodels"]["tdef"]["pointer_pair"].update({
-            "status": "no_outcome",
-            "derivation_survivor_count": 0,
-            "holdout_evaluated": False,
-            "no_outcome_reasons": ["no_tdef_record_candidate"],
-            "terminal_predicate_id": "A3-TDEF-RECORD-NONE",
-            "model": None,
-        })
-        report["derivation_survivor_counts"]["tdef_pointer_pair"] = 0
-        report["no_outcome_reasons"] = ["no_tdef_record_candidate"]
-        layers = {
-            "global_map_record": report["submodels"]["global_map"]["record"],
-            "global_map_conversion_inline": report["submodels"]["global_map"]["conversion_inline"],
-            "global_map_extended_base": report["submodels"]["global_map"]["extended_base"],
-            "tdef_pointer_pair": report["submodels"]["tdef"]["pointer_pair"],
-        }
-        report["predicate_results"], report["terminal_predicate_ids"] = (
-            project_predicate_results(layers)
+    def test_r3_global_replica_comparison_uses_minimum_slack(self) -> None:
+        record = Record(1, 1915, 2048)
+        left = GlobalRecordModel(record, "set_means_not_in_use", 92)
+        right = GlobalRecordModel(record, "set_means_not_in_use", 93)
+        self.assertEqual(_same_model(left, right).zero_suffix_slack_bytes, 92)
+
+    def test_r3_g02_conversion_attribution(self) -> None:
+        self.assertEqual(conversion_index(("inline", "inline", "indirect")), 2)
+        with self.assertRaises(Abort) as missing:
+            conversion_index(("indirect", "indirect"))
+        self.assertEqual(missing.exception.predicate_id, "A3-CONVERSION-NONE")
+        with self.assertRaises(Abort) as multiple:
+            conversion_index(("inline", "neither", "indirect"))
+        self.assertEqual(multiple.exception.predicate_id, "A3-CONVERSION-MULTIPLE")
+
+    def test_r3_m1_m2_disagreement_statuses_stop_before_earliest_terminal(self) -> None:
+        model = ConversionModel("P_ABS_16480", 20, 1, 2, 2, 2020, (14848, 16352))
+        cases = (
+            (ReplicaLayer(None, 0, Abort("A3-CONVERSION-NONE")), ReplicaLayer(model, 1, None)),
+            (
+                ReplicaLayer(None, 0, Abort("A3-CONVERSION-NONE")),
+                ReplicaLayer(None, 0, Abort("A3-CONVERSION-MULTIPLE")),
+            ),
         )
-        for row in report["predicate_results"]:
-            if row["predicate_id"] == "A3-TDEF-PAGE-MULTIPLE":
-                row["status"] = "pass"
-        with self.assertRaises(ValidationError):
-            validate_analysis_report(report)
+        for outcomes in cases:
+            with self.subTest(outcomes=outcomes):
+                draft = _combine_replicas("global_map_conversion_inline", outcomes)
+                layers = {
+                    "global_map_record": {"status": "not_applicable", "terminal_predicate_id": None},
+                    "global_map_conversion_inline": {
+                        "status": "no_outcome",
+                        "terminal_predicate_id": "A3-REPLICA-DISAGREEMENT",
+                    },
+                    "global_map_extended_base": {"status": "not_applicable", "terminal_predicate_id": None},
+                    "tdef_pointer_pair": {"status": "not_applicable", "terminal_predicate_id": None},
+                }
+                reached = {key: frozenset() for key in layers}
+                reached["global_map_conversion_inline"] = draft.reached
+                rows, _ = project_predicate_results(layers, reached_by_layer=reached)
+                statuses = {row["predicate_id"]: row["status"] for row in rows}
+                self.assertEqual(statuses["A3-POLARITY-CROSSCHECK"], "pass")
+                self.assertEqual(statuses["A3-CONVERSION-NONE"], "not_applicable")
+                self.assertEqual(statuses["A3-REPLICA-DISAGREEMENT"], "fail")
+
+    def test_r3_absent_page_is_not_snapshot_abort(self) -> None:
+        bundle = generate_synthetic_bundle()
+        view = View(bundle, WorkCounter())
+        self.assertIsNone(view.page_optional("E0", view.page_count("E0")))
+
+    def test_r3_m05_campaign_terminal_preempts_every_layer(self) -> None:
+        layers = {
+            key: {"status": "not_applicable", "terminal_predicate_id": None}
+            for key in (
+                "global_map_record",
+                "global_map_conversion_inline",
+                "global_map_extended_base",
+                "tdef_pointer_pair",
+            )
+        }
+        rows, terminals = project_predicate_results(
+            layers,
+            campaign_terminal="A3-SNAPSHOT-RECONSTRUCTION",
+        )
+        statuses = {row["predicate_id"]: row["status"] for row in rows}
+        self.assertEqual(terminals, ["A3-SNAPSHOT-RECONSTRUCTION"])
+        self.assertEqual(statuses["A3-IDLE-EQUALITY"], "pass")
+        self.assertEqual(statuses["A3-SNAPSHOT-RECONSTRUCTION"], "fail")
+        self.assertEqual(statuses["A3-RESOURCE-BOUND"], "not_applicable")
+        self.assertEqual(statuses["A3-GLOBAL-PAGE-NONE"], "not_applicable")
+
+    def test_r3_m06_holdout_abort_keeps_derivation_terminals(self) -> None:
+        parameters = replace(
+            calibration_parameters(),
+            slot_activation_at_conversion=0,
+        )
+        bundles = generate_synthetic_bundles(parameters)
+        bad_holdout = LoadedReplicaSource(ReplicaInput(
+            bundles[2],
+            3,
+            "different-campaign",
+            bundles[2].producer_commit,
+            bundles[2].provider_sha256,
+            bundles[2].churn_precondition_met,
+        ))
+        temporary = TemporaryDirectory(prefix="a3-holdout-abort-")
+        self.addCleanup(temporary.cleanup)
+        report = build_analysis(
+            [source(bundles[0]), source(bundles[1]), bad_holdout],
+            Path(temporary.name) / "derivation-candidates.json",
+            lambda _digest: None,
+        )
+        record = report["submodels"]["global_map"]["record"]
+        conversion = report["submodels"]["global_map"]["conversion_inline"]
+        self.assertEqual(record["terminal_predicate_id"], "A3-HOLDOUT-PREDICTION")
+        self.assertEqual(conversion["terminal_predicate_id"], "A3-SLOT-ACTIVATION")
+        self.assertEqual(
+            report["submodels"]["global_map"]["extended_base"]["status"],
+            "not_applicable",
+        )
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_a3_dryrun.py
+++ b/oracle/windows-dao/tests/test_a3_dryrun.py
@@ -1,0 +1,53 @@
+"""Retained replay and bounded synthetic reachability contracts for A3."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from a3_dryrun import DEFAULT_RETAINED_ROOT, registry_reachability, run_replay  # noqa: E402
+from a3_generator import FREE, iter_parameter_cases  # noqa: E402
+from a3_spec import PREDICATE_IDS  # noqa: E402
+
+
+class A3DryRunTests(unittest.TestCase):
+    @unittest.skipUnless(DEFAULT_RETAINED_ROOT.is_dir(), "EXP-0042 design-input bundle is absent")
+    def test_exp0042_replay_is_derivation_only_and_exact(self) -> None:
+        result = run_replay(DEFAULT_RETAINED_ROOT)
+        self.assertEqual(result.model.record.document(), {"page": 1, "start": 1915, "end": 2048})
+        self.assertEqual(result.model.bit_polarity, "set_means_not_in_use")
+        self.assertEqual(result.model.zero_suffix_slack_bytes, 92)
+        self.assertEqual(result.legacy_start_count, 1935)
+        self.assertEqual(result.transcript.first_violating_page, 1021)
+        self.assertEqual(len(result.transcript.evaluated_legs), 3)
+        self.assertIsNone(result.transcript.representation_change_stop)
+        self.assertEqual(result.layer_outcomes["tdef_pointer_pair"], "no_tdef_record_candidate")
+        self.assertTrue(result.t3_rejected)
+        self.assertTrue(result.t5_rejected)
+
+    def test_each_registered_predicate_has_one_reachability_case(self) -> None:
+        rows = registry_reachability()
+        self.assertEqual([row["predicate_id"] for row in rows], list(PREDICATE_IDS))
+        self.assertEqual({row["status"] for row in rows}, {"reached"})
+        self.assertEqual(len({row["perturbation"] for row in rows}), len(PREDICATE_IDS))
+
+    def test_parameter_enumerator_covers_all_axes(self) -> None:
+        cases = list(iter_parameter_cases())
+        parameters = [row[1] for row in cases]
+        self.assertEqual({row.conversion_ordinal for row in parameters}, set(range(1, 25)) | {None})
+        self.assertEqual({row.slot_activation_at_conversion for row in parameters}, set(FREE["slot_activation_at_conversion"]))
+        self.assertEqual({row.bit_polarity for row in parameters}, set(FREE["bit_polarity"]))
+        self.assertEqual({row.anchor_fill_state for row in parameters}, set(FREE["anchor_fill_state"]))
+        self.assertEqual({row.record_end_uniform_slack_bytes for row in parameters}, set(FREE["record_end_uniform_slack_bytes"]))
+        self.assertEqual({row.global_record_start for row in parameters}, set(FREE["global_record_start"]))
+        self.assertEqual({row.global_record_base for row in parameters}, set(FREE["global_record_base"]))
+        self.assertEqual({row.inline_tag_at_anchor for row in parameters}, set(FREE["inline_tag_at_anchor"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a3_dryrun.py
+++ b/oracle/windows-dao/tests/test_a3_dryrun.py
@@ -10,7 +10,9 @@ ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from a3_dryrun import DEFAULT_RETAINED_ROOT, registry_reachability, run_replay  # noqa: E402
+from a3_dryrun import (  # noqa: E402
+    DEFAULT_RETAINED_ROOT, registry_reachability, reporting_rows, run_replay,
+)
 from a3_generator import FREE, iter_parameter_cases  # noqa: E402
 from a3_spec import PREDICATE_IDS  # noqa: E402
 
@@ -35,6 +37,16 @@ class A3DryRunTests(unittest.TestCase):
         self.assertEqual([row["predicate_id"] for row in rows], list(PREDICATE_IDS))
         self.assertEqual({row["status"] for row in rows}, {"reached"})
         self.assertEqual(len({row["perturbation"] for row in rows}), len(PREDICATE_IDS))
+
+    def test_replay_reporting_stops_at_r2_terminals(self) -> None:
+        rows, terminals = reporting_rows("A3-TDEF-RECORD-NONE")
+        statuses = {row["predicate_id"]: row["status"] for row in rows}
+        self.assertEqual(
+            terminals,
+            ["A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"],
+        )
+        self.assertEqual(statuses["A3-TDEF-PAGE-MULTIPLE"], "not_applicable")
+        self.assertEqual(statuses["A3-POINTER-VALIDITY"], "not_applicable")
 
     def test_parameter_enumerator_covers_all_axes(self) -> None:
         cases = list(iter_parameter_cases())


### PR DESCRIPTION
## Summary
- add the hash-pinned A3 analyzer/spec with freeze-before-holdout layered evaluation
- align `a3_analysis`, `a3_layers`, `a3_model`, and `a3_spec` with base + R2 + R3, including R3 replica agreement, ordered terminals, extended bitmaps, frozen holdout checks, and absence/abort isolation
- retain the existing generator and dry-run harness from the earlier commits

## R3 verification
- R3 SHA-256: `bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a`
- `python3 -m unittest tests.test_a3_analyzer tests.test_a3_plan_contract` from `oracle/windows-dao`: 38 passed
- EXP-0042 recompute-only through `a3_analysis`, replicas 1-2 only: global record model frozen at page 1 `[1915,2048)`, `set_means_not_in_use`, slack 92; conversion terminates at `A3-POLARITY-CROSSCHECK` on leg 3/page 1021; extended base is not applicable; TDEF terminates at `A3-TDEF-RECORD-NONE`

## Lane compatibility
R3 changes the analyzer/spec contract, including the 31 reachable-predicate dry-run expectation. Per lane isolation, this commit does not modify `a3_generator*.py` or `a3_dryrun*.py`; the replacement dry-run lane must update those files before their suites are expected to pass against this analyzer.