### PR TITLE
docs: pin A3 predicate evaluation sequence (R2, EXP-0045)

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -3594,6 +3594,89 @@ Use `not applicable` explicitly rather than omitting a field.
 - Review: focused A3 plan/schema/hash contracts and repository validation must
   pass; acquisition remains blocked until every listed requirement is met
 
+### EXP-0045 — A3 pre-acquisition predicate evaluation sequence revision
+
+- Recorded: 2026-08-22, OpenAI Codex
+- Kind: additive pre-acquisition reporting-order reconciliation; no A3 worker,
+  workflow, analyzer result, validator result, dry-run result, DAO acquisition,
+  physical-format result, Rust result, or compatibility result
+- Origin: project-authored review of the immutable
+  `DAO-A3-ALLOCATION-MAPS-001` plan after two independent implementations,
+  analyzer PR #54 and validator PR #53, disagreed on whether
+  `A3-TDEF-PAGE-MULTIPLE` and `A3-POINTER-VALIDITY` were `pass` or
+  `not_applicable` on an analyzer-produced synthetic report. No external MDB
+  implementation, Microsoft implementation source, donated MDB, A3 DAO
+  observation, or holdout artifact was inspected.
+- Additive R2 revision: the base plan's
+  `predicate_registry.reporting_rule` states total reporting and terminal
+  projection but leaves the campaign and per-layer predicate evaluation
+  sequence unstated. Revision `DAO-A3-ALLOCATION-MAPS-001-R2` pins the missing
+  order without changing the immutable base plan, schemas, 34-entry registry,
+  mappings, operational rules, scientific models, or blocked execution gate.
+  Acquisition has not started, so this additive revision is permitted by the
+  base plan's amendment rule.
+- Campaign order: evaluate `A3-IDLE-EQUALITY`,
+  `A3-SNAPSHOT-RECONSTRUCTION`, and `A3-RESOURCE-BOUND`, in that order, before
+  any layer.
+- Layer orders: `global_map.record` evaluates `A3-GLOBAL-PAGE-NONE`,
+  `A3-GLOBAL-RECORD-NONE`, `A3-D-SET-RELATION`, `A3-GLOBAL-RECORD-END`,
+  `A3-POLARITY-NONE`, `A3-POLARITY-MULTIPLE`, `A3-GLOBAL-PAGE-MULTIPLE`,
+  `A3-GLOBAL-RECORD-MULTIPLE`, `A3-STRUCTURAL-EXCLUSION`, and
+  `A3-REPLICA-DISAGREEMENT`; `global_map.conversion_inline` evaluates
+  `A3-POLARITY-CROSSCHECK`, `A3-CONVERSION-NONE`, `A3-CONVERSION-MULTIPLE`,
+  `A3-SLOT-ACTIVATION`, `A3-SLOT-FINAL`, `A3-POINTER-VALIDITY`,
+  `A3-INLINE-BOUNDARY-NONE`, `A3-INLINE-BOUNDARY-MULTIPLE`,
+  `A3-INLINE-SUFFIX`, `A3-STRUCTURAL-EXCLUSION`, and
+  `A3-REPLICA-DISAGREEMENT`; `global_map.extended_base` evaluates
+  `A3-BASE-DISCRIMINATION`, `A3-BASE-NONE`, `A3-BASE-MULTIPLE`,
+  `A3-POINTER-VALIDITY`, and `A3-REPLICA-DISAGREEMENT`; and
+  `tdef.pointer_pair` evaluates `A3-TDEF-PAGE-NONE`,
+  `A3-CHURN-PRECONDITION`, `A3-GROWTH-POINTER-NONE`,
+  `A3-CHURN-POINTER-NONE`, `A3-TDEF-RECORD-NONE`,
+  `A3-TDEF-PAGE-MULTIPLE`, `A3-TDEF-RECORD-MULTIPLE`,
+  `A3-POINTER-MULTIPLE`, `A3-POINTER-VALIDITY`,
+  `A3-STRUCTURAL-EXCLUSION`, and `A3-REPLICA-DISAGREEMENT`, in those exact
+  orders.
+- Evaluation and status projection: an applicable layer stops at its first
+  terminal. An `applicable_layer` predicate is `pass` iff reached in at least
+  one applicable layer and terminal nowhere, `fail` iff terminal in any layer,
+  and otherwise `not_applicable`. A layer-specific predicate is `pass` iff
+  reached and nonterminal, and is `not_applicable` when unreached or its layer
+  is inapplicable. A terminal layer-specific predicate is `fail`.
+  `A3-HOLDOUT-PREDICTION` retains the base plan's exception unchanged.
+- Base-text consistency review: the supplied sequence is pinned without silent
+  reordering, but four positions appear to conflict with the immutable
+  operational prose. `A3-GLOBAL-RECORD-END` precedes polarity although the
+  record-end rule says D has already selected a unique polarity; the base
+  start-resolution prose is itself internally inconsistent because it also
+  says polarity uniqueness follows end resolution. `A3-POLARITY-CROSSCHECK`
+  precedes conversion, slot, and inline checks although the global-map search
+  and source-contract text list polarity agreement after them.
+  `A3-INLINE-SUFFIX` follows boundary zero/multiplicity although the survival
+  rule makes the quiet suffix a prerequisite to boundary survival. Extended-
+  base `A3-POINTER-VALIDITY` follows every base terminal although the base rule
+  evaluates allocation bitmaps on referenced `0x05` pages whose validity that
+  predicate establishes. These positions remain exactly as supplied in R2.
+- Plan identities:
+  `oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json`, SHA-256
+  `b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1`;
+  `oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json`, SHA-256
+  `3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1`.
+- Observation: `preregistration.acquisition_started` remains `false`; this
+  revision records no database, checkpoint, replica observation, candidate
+  set, report, validation receipt, evidence bundle, or scientific outcome.
+- Interpretation and execution gate: this amendment resolves an implementation
+  contract ambiguity only. It assigns no Jet meaning, proves no Rust behavior
+  or DAO compatibility, changes no support-matrix entry, and authorizes no A3
+  acquisition. The `EXP-0044` execution gate remains `BLOCKED`.
+- Usage: `file:oracle/windows-dao/experiments/a3/README.md`;
+  `file:oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json`;
+  future separately reviewed A3 analyzer and independent validator
+- Rights: project-authored revision and tests; no DAO binary, MDB, page blob,
+  or retained bundle is committed or redistributed
+- Review: focused A3 plan hash, exact sequence, status-projection, amendment,
+  and flagged-position contracts plus repository validation must pass
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/experiments/a3/README.md
+++ b/oracle/windows-dao/experiments/a3/README.md
@@ -6,6 +6,19 @@ started. This lane contains the plan, A3-bound schemas, and hash-pinned design
 input pointers only; it contains no analyzer, independent validator, worker, or
 workflow implementation.
 
+Before acquisition, additive revision `DAO-A3-ALLOCATION-MAPS-001-R2` was
+recorded as `EXP-0045` to pin the previously unstated campaign and per-layer
+predicate evaluation sequence and status projection. Acquisition has not
+started, so this additive revision is permitted by the base plan's amendment
+rule. The immutable revision file is
+`oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json`, SHA-256
+`3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1`.
+It preserves the base plan and explicitly flags four supplied positions whose
+ordering appears to conflict with its operational prose: global record end
+before polarity resolution, polarity cross-check before conversion/slot/inline
+evaluation, inline suffix after boundary ambiguity, and extended-base pointer
+validity after the base terminals.
+
 The actual `EXP-0042` polarity cross-check outcome is a violation on leg 3,
 `L_REL_0512` to `L_REL_0768`, first at page 1021; the later tag-change leg is
 never reached. On EXP-0042-like data, the `global_map_conversion_inline` and

--- a/oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json
+++ b/oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json
@@ -1,0 +1,134 @@
+{
+  "protocol_version": "1.0.0",
+  "document_type": "dao_a3_allocation_maps_plan_revision",
+  "revision_id": "DAO-A3-ALLOCATION-MAPS-001-R2",
+  "preregistration": {
+    "provenance_entry": "EXP-0045",
+    "recorded_utc_date": "2026-08-22",
+    "acquisition_started": false,
+    "acquisition_start_criterion": "acquisition starts when the first schema-valid A3 replica observation is retained for inspection",
+    "revision_of": "DAO-A3-ALLOCATION-MAPS-001",
+    "original_plan": {
+      "path": "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json",
+      "sha256": "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
+    },
+    "scientific_design_inherited_unchanged": [
+      "question",
+      "replicas",
+      "tables",
+      "checkpoint_design",
+      "page_capture",
+      "record_candidate_procedure",
+      "inline_boundary_procedure",
+      "hypotheses",
+      "predicate_registry",
+      "decision_rules",
+      "decisive_report_handling",
+      "runtime_design",
+      "artifacts",
+      "bounds",
+      "claims"
+    ],
+    "revision_scope": "pin the previously unstated campaign and per-layer predicate evaluation sequence and the resulting total predicate status projection without changing any predicate, operational rule, scientific model, or acquisition gate",
+    "amendment_permitted": "acquisition has not started, so this additive revision is permitted by the original plan's amendment rule",
+    "amendment_rule": "after the first acquisition starts, any change requires a new experiment id, plan file, and provenance entry"
+  },
+  "predicate_evaluation_sequence_reconciliation": {
+    "inherited_contract": "the immutable original plan, schemas, 34-entry predicate registry and mappings, scientific design, operational rules, holdout exception, and blocked acquisition gate remain unchanged; this revision supplies only the missing evaluation sequence and its status projection",
+    "motivation": "predicate_registry.reporting_rule leaves the campaign and per-layer predicate evaluation sequence unstated; independent analyzer PR #54 and validator PR #53 implementations therefore disagreed on whether A3-TDEF-PAGE-MULTIPLE and A3-POINTER-VALIDITY were pass or not_applicable on an analyzer-produced synthetic report",
+    "campaign_evaluated_before_any_layer": [
+      "A3-IDLE-EQUALITY",
+      "A3-SNAPSHOT-RECONSTRUCTION",
+      "A3-RESOURCE-BOUND"
+    ],
+    "per_layer_ordered_predicates": {
+      "global_map.record": [
+        "A3-GLOBAL-PAGE-NONE",
+        "A3-GLOBAL-RECORD-NONE",
+        "A3-D-SET-RELATION",
+        "A3-GLOBAL-RECORD-END",
+        "A3-POLARITY-NONE",
+        "A3-POLARITY-MULTIPLE",
+        "A3-GLOBAL-PAGE-MULTIPLE",
+        "A3-GLOBAL-RECORD-MULTIPLE",
+        "A3-STRUCTURAL-EXCLUSION",
+        "A3-REPLICA-DISAGREEMENT"
+      ],
+      "global_map.conversion_inline": [
+        "A3-POLARITY-CROSSCHECK",
+        "A3-CONVERSION-NONE",
+        "A3-CONVERSION-MULTIPLE",
+        "A3-SLOT-ACTIVATION",
+        "A3-SLOT-FINAL",
+        "A3-POINTER-VALIDITY",
+        "A3-INLINE-BOUNDARY-NONE",
+        "A3-INLINE-BOUNDARY-MULTIPLE",
+        "A3-INLINE-SUFFIX",
+        "A3-STRUCTURAL-EXCLUSION",
+        "A3-REPLICA-DISAGREEMENT"
+      ],
+      "global_map.extended_base": [
+        "A3-BASE-DISCRIMINATION",
+        "A3-BASE-NONE",
+        "A3-BASE-MULTIPLE",
+        "A3-POINTER-VALIDITY",
+        "A3-REPLICA-DISAGREEMENT"
+      ],
+      "tdef.pointer_pair": [
+        "A3-TDEF-PAGE-NONE",
+        "A3-CHURN-PRECONDITION",
+        "A3-GROWTH-POINTER-NONE",
+        "A3-CHURN-POINTER-NONE",
+        "A3-TDEF-RECORD-NONE",
+        "A3-TDEF-PAGE-MULTIPLE",
+        "A3-TDEF-RECORD-MULTIPLE",
+        "A3-POINTER-MULTIPLE",
+        "A3-POINTER-VALIDITY",
+        "A3-STRUCTURAL-EXCLUSION",
+        "A3-REPLICA-DISAGREEMENT"
+      ]
+    },
+    "layer_evaluation_rule": "within an applicable layer, predicates are evaluated in the listed order and evaluation stops at that layer's terminal predicate",
+    "applicable_layer_status_rule": "a predicate registered to applicable_layer is pass iff it is reached and evaluated in at least one applicable layer and is not terminal in any layer; it is fail iff it is terminal in any layer; otherwise it is not_applicable",
+    "layer_specific_status_rule": "a predicate registered to a specific layer is pass iff it is reached and evaluated nonterminally in that layer; it is not_applicable if it is unreached or that layer is inapplicable; it is fail iff it is terminal in that layer",
+    "holdout_exception": "A3-HOLDOUT-PREDICTION retains the immutable original plan's predicate_registry.reporting_rule exception unchanged",
+    "base_text_consistency_review": {
+      "rule": "the ordered sequences above are pinned exactly as preregistered; positions that appear to contradict the immutable original plan's operational prose are retained and explicitly flagged rather than silently moved",
+      "flagged_positions": [
+        {
+          "layer": "global_map.record",
+          "predicate_id": "A3-GLOBAL-RECORD-END",
+          "position": 4,
+          "conflict": "global_record_end_resolution says it runs after D has selected the unique polarity, and global_record_start_resolution first says to apply the unique-polarity rule before the page-terminal suffix rule; this position puts record-end before A3-POLARITY-NONE and A3-POLARITY-MULTIPLE. The same start-resolution text later says polarity uniqueness is evaluated after end resolution, so the base text is internally inconsistent on this dependency."
+        },
+        {
+          "layer": "global_map.conversion_inline",
+          "predicate_id": "A3-POLARITY-CROSSCHECK",
+          "position": 1,
+          "conflict": "hypotheses.global_map_search and analyzer_dry_run_contract.source_contract_checks list conversion, slot activation, inline boundary, then polarity agreement; this position evaluates polarity agreement before those stages."
+        },
+        {
+          "layer": "global_map.conversion_inline",
+          "predicate_id": "A3-INLINE-SUFFIX",
+          "position": 9,
+          "conflict": "inline_boundary_procedure.survival_rule makes the quiet inline suffix a condition for a boundary to survive, and ambiguity_rule then classifies zero or multiple survivors; this position evaluates A3-INLINE-SUFFIX after A3-INLINE-BOUNDARY-NONE and A3-INLINE-BOUNDARY-MULTIPLE."
+        },
+        {
+          "layer": "global_map.extended_base",
+          "predicate_id": "A3-POINTER-VALIDITY",
+          "position": 4,
+          "conflict": "hypotheses.extended_base_rule evaluates formulas against allocation bitmaps on referenced 0x05 pages, while hypotheses.pointer_validity_rule establishes that referenced pages exist in the candidate page space and have byte-zero 0x05; this position evaluates pointer validity after every base terminal."
+        }
+      ]
+    }
+  },
+  "execution_effect": {
+    "original_plan_remains_immutable": true,
+    "original_schemas_remain_immutable": true,
+    "original_predicate_registry_remains_immutable": true,
+    "operational_rules_changed": false,
+    "scientific_projection_changed": false,
+    "acquisition_authorized": false,
+    "support_claim_changed": false
+  }
+}

--- a/oracle/windows-dao/tests/test_a3_plan_contract.py
+++ b/oracle/windows-dao/tests/test_a3_plan_contract.py
@@ -12,9 +12,11 @@ ROOT = Path(__file__).resolve().parents[3]
 EXPERIMENT = ROOT / "oracle" / "windows-dao" / "experiments" / "a3"
 A2_EXPERIMENT = ROOT / "oracle" / "windows-dao" / "experiments" / "a2"
 PLAN = EXPERIMENT / "a3-allocation-maps.plan.json"
+REVISION_PLAN = EXPERIMENT / "a3-allocation-maps-r2.plan.json"
 README = EXPERIMENT / "README.md"
 PROVENANCE = ROOT / "docs" / "PROVENANCE.md"
 PLAN_SHA256 = "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
+REVISION_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
 DESIGN_INPUT_HASHES = {
     "a2-preregistration-pointer.md": "8f16e79686620e254b0ba98de4d7cb21611f84a3e9b5c84d9fd6428987f51632",
     "a2-independent-review-pointer.md": "2e89bb60aa5ac99d8f384836c75ce54c078817564d579d5411acd3bba8daae3b",
@@ -43,6 +45,104 @@ class A3PlanContractTests(unittest.TestCase):
         self.assertIn("### EXP-0044", provenance)
         self.assertIn(PLAN_SHA256, provenance)
         self.assertIn(PLAN_SHA256, readme)
+
+    def test_r2_predicate_sequence_is_hash_pinned_and_additive(self) -> None:
+        revision_bytes = REVISION_PLAN.read_bytes()
+        revision = json.loads(revision_bytes)
+        self.assertEqual(
+            hashlib.sha256(revision_bytes).hexdigest(), REVISION_PLAN_SHA256
+        )
+        preregistration = revision["preregistration"]
+        self.assertEqual(preregistration["revision_of"], self.plan["experiment_id"])
+        self.assertEqual(preregistration["original_plan"]["sha256"], PLAN_SHA256)
+        self.assertFalse(preregistration["acquisition_started"])
+        self.assertIn("permitted", preregistration["amendment_permitted"])
+
+        reconciliation = revision["predicate_evaluation_sequence_reconciliation"]
+        self.assertEqual(
+            reconciliation["campaign_evaluated_before_any_layer"],
+            [
+                "A3-IDLE-EQUALITY",
+                "A3-SNAPSHOT-RECONSTRUCTION",
+                "A3-RESOURCE-BOUND",
+            ],
+        )
+        self.assertEqual(
+            reconciliation["per_layer_ordered_predicates"],
+            {
+                "global_map.record": [
+                    "A3-GLOBAL-PAGE-NONE",
+                    "A3-GLOBAL-RECORD-NONE",
+                    "A3-D-SET-RELATION",
+                    "A3-GLOBAL-RECORD-END",
+                    "A3-POLARITY-NONE",
+                    "A3-POLARITY-MULTIPLE",
+                    "A3-GLOBAL-PAGE-MULTIPLE",
+                    "A3-GLOBAL-RECORD-MULTIPLE",
+                    "A3-STRUCTURAL-EXCLUSION",
+                    "A3-REPLICA-DISAGREEMENT",
+                ],
+                "global_map.conversion_inline": [
+                    "A3-POLARITY-CROSSCHECK",
+                    "A3-CONVERSION-NONE",
+                    "A3-CONVERSION-MULTIPLE",
+                    "A3-SLOT-ACTIVATION",
+                    "A3-SLOT-FINAL",
+                    "A3-POINTER-VALIDITY",
+                    "A3-INLINE-BOUNDARY-NONE",
+                    "A3-INLINE-BOUNDARY-MULTIPLE",
+                    "A3-INLINE-SUFFIX",
+                    "A3-STRUCTURAL-EXCLUSION",
+                    "A3-REPLICA-DISAGREEMENT",
+                ],
+                "global_map.extended_base": [
+                    "A3-BASE-DISCRIMINATION",
+                    "A3-BASE-NONE",
+                    "A3-BASE-MULTIPLE",
+                    "A3-POINTER-VALIDITY",
+                    "A3-REPLICA-DISAGREEMENT",
+                ],
+                "tdef.pointer_pair": [
+                    "A3-TDEF-PAGE-NONE",
+                    "A3-CHURN-PRECONDITION",
+                    "A3-GROWTH-POINTER-NONE",
+                    "A3-CHURN-POINTER-NONE",
+                    "A3-TDEF-RECORD-NONE",
+                    "A3-TDEF-PAGE-MULTIPLE",
+                    "A3-TDEF-RECORD-MULTIPLE",
+                    "A3-POINTER-MULTIPLE",
+                    "A3-POINTER-VALIDITY",
+                    "A3-STRUCTURAL-EXCLUSION",
+                    "A3-REPLICA-DISAGREEMENT",
+                ],
+            },
+        )
+        self.assertIn("stops", reconciliation["layer_evaluation_rule"])
+        self.assertIn("reached", reconciliation["applicable_layer_status_rule"])
+        self.assertIn("unreached", reconciliation["layer_specific_status_rule"])
+        self.assertIn("A3-HOLDOUT-PREDICTION", reconciliation["holdout_exception"])
+        self.assertEqual(
+            [
+                (row["layer"], row["predicate_id"], row["position"])
+                for row in reconciliation["base_text_consistency_review"][
+                    "flagged_positions"
+                ]
+            ],
+            [
+                ("global_map.record", "A3-GLOBAL-RECORD-END", 4),
+                ("global_map.conversion_inline", "A3-POLARITY-CROSSCHECK", 1),
+                ("global_map.conversion_inline", "A3-INLINE-SUFFIX", 9),
+                ("global_map.extended_base", "A3-POINTER-VALIDITY", 4),
+            ],
+        )
+        self.assertTrue(revision["execution_effect"]["original_plan_remains_immutable"])
+        self.assertFalse(revision["execution_effect"]["operational_rules_changed"])
+
+        provenance = PROVENANCE.read_text(encoding="utf-8")
+        readme = README.read_text(encoding="utf-8")
+        self.assertIn("### EXP-0045", provenance)
+        self.assertIn(REVISION_PLAN_SHA256, provenance)
+        self.assertIn(REVISION_PLAN_SHA256, readme)
 
     def test_design_input_pointers_and_targets_are_hash_pinned(self) -> None:
         recorded = {
@@ -439,7 +539,7 @@ class A3PlanContractTests(unittest.TestCase):
 
     def test_all_a3_json_documents_parse(self) -> None:
         documents = sorted(EXPERIMENT.glob("*.json"))
-        self.assertEqual(len(documents), 12)
+        self.assertEqual(len(documents), 13)
         for document in documents:
             with self.subTest(document=document.name):
                 json.loads(document.read_bytes())


### PR DESCRIPTION
Pins the additive A3 R2 predicate evaluation sequence and status projection, records EXP-0045, and hash-pins the revision in the README, provenance ledger, and focused contract test. Acquisition has not started, so the additive amendment is permitted. The supplied sequence is retained exactly; four positions that appear to conflict with base-plan operational prose are explicitly flagged in R2. Checks: python3.13 tools/validate_repository_contract.py; python3.13 oracle/windows-dao/tests/test_a3_plan_contract.py.