### PR TITLE
fix: make A3 TDEF reference plan-literal

### DIFF
--- a/oracle/windows-dao/scripts/a3_layers.py
+++ b/oracle/windows-dao/scripts/a3_layers.py
@@ -16,7 +16,7 @@ R3-G10 candidate-local absence | :func:`_window_values`, :func:`_classification`
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, TypeVar
 
 from a3_model import (
     CHECKPOINT_IDS, CHURN_TRANSITIONS, D_TRANSITIONS, HIGH_GROWTH,
@@ -32,6 +32,7 @@ VALIDITY_CHECKPOINTS = tuple(TRANSITIONS["pointer_validity_checkpoints"])
 CROSS_CHECK_LEGS = tuple(tuple(pair) for pair in TRANSITIONS["polarity_cross_check_legs"])
 EXTENDED_HEADER_BYTES = 4
 EXTENDED_BITS = (PAGE_SIZE - EXTENDED_HEADER_BYTES) * 8
+ValueT = TypeVar("ValueT")
 
 
 @dataclass(frozen=True)
@@ -448,8 +449,12 @@ def _window_values(
     return values
 
 
-def _stable(values: Mapping[str, tuple[int, int]], pairs: Sequence[tuple[str, str]]) -> bool:
+def _stable(values: Mapping[str, ValueT], pairs: Sequence[tuple[str, str]]) -> bool:
     return all(values[left] == values[right] for left, right in pairs)
+
+
+def _references(values: Mapping[str, tuple[int, int]]) -> dict[str, int]:
+    return {checkpoint: value[0] for checkpoint, value in values.items()}
 
 
 @dataclass(frozen=True)
@@ -463,9 +468,10 @@ def pointer_windows(view: View, page: int) -> WindowCandidates:
     churn = {layout: [] for layout in POINTER_LAYOUTS}
     for offset in range(PAGE_SIZE - 3):
         for layout in POINTER_LAYOUTS:
-            values = _window_values(view, page, offset, layout)
-            if values is None:
+            window_values = _window_values(view, page, offset, layout)
+            if window_values is None:
                 continue
+            values = _references(window_values)
             grows = any(values[a] != values[b] for a, b in LOW_GROWTH + HIGH_GROWTH)
             churns = values["L_REL_1280"] != values["L_DELETE_ALL"] and values["L_REL_1280"] == values["L_REINSERT_SAME"]
             growth_shape = grows and _stable(values, CHURN_TRANSITIONS)
@@ -620,14 +626,16 @@ def predicts_tdef(view: View, frozen: TdefModel, churn_precondition_met: bool) -
     page = frozen.record.page
     if qualify_tdef_pages(view, (page,)) != (page,):
         return False
-    growth_values = _window_values(
+    growth_window = _window_values(
         view, page, frozen.growth_pointer_offset, frozen.pointer_layout
     )
-    churn_values = _window_values(
+    churn_window = _window_values(
         view, page, frozen.delete_reinsert_pointer_offset, frozen.pointer_layout
     )
-    if growth_values is None or churn_values is None:
+    if growth_window is None or churn_window is None:
         return False
+    growth_values = _references(growth_window)
+    churn_values = _references(churn_window)
     growth_holds = (
         any(
             growth_values[left] != growth_values[right]

--- a/oracle/windows-dao/tests/test_a3_analyzer.py
+++ b/oracle/windows-dao/tests/test_a3_analyzer.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import sys
 import unittest
 from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import MappingProxyType
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
@@ -23,11 +25,11 @@ from a3_generator import (  # noqa: E402
 )
 from a3_layers import (  # noqa: E402
     ConversionModel, conversion_index, derive_tdef_candidates,
-    polarity_cross_check,
+    pointer_windows, polarity_cross_check,
 )
 from a3_model import (  # noqa: E402
-    Abort, GlobalRecordModel, Record, View, WorkCounter, decode_inline,
-    global_start_candidates,
+    CHECKPOINT_IDS, Abort, GlobalRecordModel, Record, View, WorkCounter,
+    decode_inline, global_start_candidates,
 )
 from a3_spec import (  # noqa: E402
     LAYER_PREDICATE_SEQUENCES, PLAN_SHA256, PREDICATES, PREDICATE_IDS,
@@ -96,6 +98,47 @@ class A3AnalyzerTests(unittest.TestCase):
         with self.assertRaises(Abort) as caught:
             derive_tdef_candidates(view, (bundle.tdef_page,), False)
         self.assertEqual(caught.exception.predicate_id, "A3-CHURN-PRECONDITION")
+
+    def test_tdef_signatures_compare_the_layout_page_field(self) -> None:
+        bundle = generate_synthetic_bundle()
+        windows = pointer_windows(View(bundle, WorkCounter()), bundle.tdef_page)
+        self.assertEqual(
+            windows.growth,
+            {
+                "u24le_page_then_u8_slot": (0,),
+                "u8_slot_then_u24le_page": (),
+            },
+        )
+
+    def test_tdef_slot_change_is_structural_exclusion(self) -> None:
+        bundle = generate_synthetic_bundle()
+        payloads = dict(bundle._payloads)
+        ordered = {checkpoint: list(hashes) for checkpoint, hashes in bundle.ordered_page_sha256.items()}
+        for checkpoint in CHECKPOINT_IDS:
+            payload = bytearray(bundle.page_bytes(ordered[checkpoint][bundle.tdef_page]))
+            churn_page = 24 + ((1 << 16) if checkpoint == "L_DELETE_ALL" else 0)
+            payload[2044:2047] = churn_page.to_bytes(3, "little")
+            if checkpoint == "D_DROP":
+                payload[3] += 1
+            encoded = bytes(payload)
+            digest = hashlib.sha256(encoded).hexdigest()
+            payloads[digest] = encoded
+            ordered[checkpoint][bundle.tdef_page] = digest
+        modified = replace(
+            bundle,
+            ordered_page_sha256=MappingProxyType({
+                checkpoint: tuple(hashes) for checkpoint, hashes in ordered.items()
+            }),
+            _payloads=MappingProxyType(payloads),
+        )
+        view = View(modified, WorkCounter())
+        windows = pointer_windows(view, modified.tdef_page)
+        layout = "u24le_page_then_u8_slot"
+        self.assertIn(0, windows.growth[layout])
+        self.assertIn(2044, windows.churn[layout])
+        with self.assertRaises(Abort) as caught:
+            derive_tdef_candidates(view, (modified.tdef_page,), True)
+        self.assertEqual(caught.exception.predicate_id, "A3-STRUCTURAL-EXCLUSION")
 
     def test_holdout_reporting_exception_and_t5_rejection(self) -> None:
         rows = [


### PR DESCRIPTION
## Summary

- compare TDEF signature stages using each declared layout’s u24 page reference
- retain full four-byte window comparison for structural exclusion
- add focused regressions for layout discrimination and a slot-byte-only D-transition structural failure

## Validation

- `python3 -m unittest tests.test_a3_analyzer` — 16 passed

## Scope

Candidate-ceiling behavior remains unchanged pending the binding plan revision. No `a3_independent_*`, `a3_generator*`, or `a3_dryrun*` files changed.