### PR TITLE
docs: pin A3 survivor-count and replay blob bound (R4, EXP-0047)

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -3814,8 +3814,8 @@ Use `not applicable` explicitly rather than omitting a field.
   (SHA-256 `b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1`),
   R2 (`3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1`), and
   R3 (`bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a`),
-  inherits their sequences and rules unchanged, and pins `R4-S01`, `R4-B01`,
-  and `R4-B02`. Acquisition has not started, so the revision is permitted by
+  inherits their sequences and rules unchanged except the two sentences
+  `R4-C01` supersedes, and pins `R4-S01`, `R4-B01`, `R4-B02`, and `R4-C01`. Acquisition has not started, so the revision is permitted by
   the base plan's amendment rule.
 - `R4-S01` survivor count: `decision_rules.freeze_rule` says only that
   `derivation_survivor_counts equals layer counts`; on
@@ -3861,14 +3861,34 @@ Use `not applicable` explicitly rather than omitting a field.
   outcome. The nine evidence schemas and `plan.schema.json` are byte-identical.
   The single sentence of R3's `pair_acceptance_gate` declaring the dry-run
   schema unchanged is superseded for this one field.
-- Not resolved here: the pair gate's remaining disagreements are analyzer
-  defects against existing text, not plan gaps: on 87 of 89 cases the analyzer
-  reports `tdef_pointer_pair` terminal `A3-POINTER-MULTIPLE` with a null model
-  where the validator derives the `u24le_page_then_u8_slot` model (offsets
-  0/2044) under `tdef_no_outcome_ordering` and `R3-G06`; on
-  `sixteen_qualified_pages` the analyzer raises `A3-RESOURCE-BOUND` at exactly
-  `max_qualified_pages_per_submodel = 16` where `bounds_sanity_basis` requires
-  the exact ceiling to be accepted. Both are left to PR #58.
+- `R4-C01` record candidate count: independent review of this revision ruled
+  the `sixteen_qualified_pages` divergence a plan gap, not an analyzer defect.
+  `R3-G08`/`R3-G03` count `record_candidates_examined` per (derivation
+  replica, qualified page), which at 16 + 16 pages in both replicas gives
+  134,283,264, while the immutable base plan's
+  `combined_record_candidate_bound`, `bounds.max_record_candidates`, and the
+  analysis-report schema maximum are all 67,141,632 = 32 x 2,098,176 with no
+  replica factor, and `prefix_sum_work_model` (537,133,056 + 1,049,088 =
+  538,182,144 < 600,000,000) likewise assumes none. R4 supersedes those two
+  sentences: the field and the work units count each union qualified page
+  once across derivation replicas (a TDEF page when the churn precondition
+  passed in at least one replica), so the exact ceiling 67,141,632 is accepted
+  and one page more (69,239,808) is rejected by schema, bound, and
+  `max_qualified_pages_per_submodel`. The independent validator must
+  recompute the field on that basis and must also enforce
+  `bounds.max_record_candidates`, which the validator lane never does today.
+  `EXP-0042` replay value under the rule: 8 union pages, 16,785,408. No bound,
+  `plan.schema.json` const, or evidence schema changes.
+- Not resolved here: the TDEF u24 pointer-layout disagreement (87 of 89
+  cases: analyzer `tdef_pointer_pair` terminal `A3-POINTER-MULTIPLE` with a
+  null model where the validator derives `u24le_page_then_u8_slot`, offsets
+  0/2044, under `tdef_no_outcome_ordering` and `R3-G06`) is an analyzer
+  defect against existing text, not a plan gap, and is left to the analyzer
+  lane.
+- Independent review: `/private/tmp/fable-59-60-review.md` (sections A.6 and
+  C), not committed; it verified additivity, hash pins, the schema-edit
+  justification, the survivor table, and the 81/1800 derivations, and
+  required the `R4-C01` ruling before merge.
 - Plan identities:
   `oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json`, SHA-256
   `b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1`;
@@ -3877,7 +3897,7 @@ Use `not applicable` explicitly rather than omitting a field.
   `oracle/windows-dao/experiments/a3/a3-allocation-maps-r3.plan.json`, SHA-256
   `bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a`;
   `oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json`, SHA-256
-  `167b6e10ca2ff7f90070dfd73957e5ea3dc9b02e54d917be9918b273a0e26ce1`.
+  `939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea`.
 - Observation: `preregistration.acquisition_started` remains `false`; this
   revision records no database, checkpoint, replica observation, candidate
   set, report, validation receipt, evidence bundle, or scientific outcome.
@@ -3893,7 +3913,8 @@ Use `not applicable` explicitly rather than omitting a field.
 - Rights: project-authored revision and tests; no DAO binary, MDB, page blob,
   or retained bundle is committed or redistributed
 - Review: focused A3 plan hash, R4 binding, survivor-count table, blob-bound
-  derivation, schema-hash, and analyzer-defect-exclusion contracts plus
+  derivation, schema-hash, record-candidate-count, and analyzer-defect-exclusion
+  contracts plus
   repository validation must pass
 
 ## Fixtures and black-box results

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -3793,6 +3793,109 @@ Use `not applicable` explicitly rather than omitting a field.
   holdout-semantics, and dry-run-clause contracts plus repository validation
   must pass
 
+### EXP-0047 — A3 pre-acquisition survivor-count and replay blob-bound revision
+
+- Recorded: 2026-08-22, Claude Fable 5
+- Kind: additive pre-acquisition operational-rule reconciliation; no A3 worker,
+  workflow, analyzer result, validator result, dry-run result, DAO acquisition,
+  physical-format result, Rust result, or compatibility result
+- Origin: the executed full-sweep analyzer/validator pair gate of PR #58
+  (`origin/fable/a3-dryrun`, `dry-run/a3-pair-agreement.json`, 100 fixtures,
+  89 disagreeing) and its `dry-run/exp-0042-replay-report.json`, which was
+  schema-rejected solely on `input_page_blob_count` 81 > 55. The two results
+  were read only to locate the gaps; neither rule adopts an implementation for
+  convenience. The ceiling and the 81 were re-measured directly from the
+  retained `EXP-0042` bundle's replica 1 and 2 page indexes (manifest SHA-256
+  `9e1dac53e13f0bf765fc41b242b85beb26c8a518f7a15777aa37641af575dd46`);
+  `EXP-0042` replica 3 was not opened. No external MDB implementation,
+  Microsoft implementation source, donated MDB, A3 DAO observation, or holdout
+  artifact was inspected.
+- Additive R4 revision: `DAO-A3-ALLOCATION-MAPS-001-R4` binds the base plan
+  (SHA-256 `b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1`),
+  R2 (`3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1`), and
+  R3 (`bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a`),
+  inherits their sequences and rules unchanged, and pins `R4-S01`, `R4-B01`,
+  and `R4-B02`. Acquisition has not started, so the revision is permitted by
+  the base plan's amendment rule.
+- `R4-S01` survivor count: `decision_rules.freeze_rule` says only that
+  `derivation_survivor_counts equals layer counts`; on
+  `second_global_page_opposite_polarity` the analyzer froze 2 at
+  `A3-POLARITY-MULTIPLE` and the validator expected 0. R4 pins the count as
+  the cardinality, in derivation replica 1, of the candidate set the layer's
+  terminal predicate classified: every MULTIPLE terminal carries its
+  multiplicity (at least 2), every NONE/precondition/discrimination/
+  set-relation/record-end/cross-check terminal carries 0, a model or a
+  single-survivor terminal (slot, inline-suffix, pointer-validity, structural
+  exclusion, holdout prediction) carries 1, `A3-REPLICA-DISAGREEMENT` carries
+  replica 1's count at its own stop, and an inapplicable layer carries 0. The
+  table is written for every terminal of every layer. Rationale: a MULTIPLE
+  terminal is the statement that more than one candidate survived, so
+  freezing 0 there would contradict the terminal and collapse the
+  field-for-field freeze comparison to a constant for every non-decisive layer.
+- `R4-B01` replay blob bound: the base plan's 55 lives in
+  `analyzer_dry_run_contract.historical_a1_input_not_required_by_a3`
+  (`max_input_page_blobs`, and `candidate_bound_assertion`'s 13 qualified
+  pages per replica) and is A1 run-12 calibration text, but
+  `dry-run-report.schema.json` copied it as the maximum of
+  `input_page_blob_count`, which binds every A3 dry-run report. R4 pins the
+  ceiling 1800 = 2 derivation replicas x 25 planned checkpoints x (16 + 16
+  `max_qualified_pages_per_submodel` + 4 referenced pages: two global slots and
+  two TDEF pointers), distinct blobs counted once, synthetic runs reporting 0,
+  replica 3 never opened. Re-measured `EXP-0042` values: global qualified pages
+  `{0,1,20,21}` and TDEF qualified pages `{0,1,23,24}` in both replicas; over
+  25 checkpoints x 2 replicas the global pages yield 50 distinct blobs and the
+  TDEF pages 71, sharing pages 0 and 1, union exactly 81; no referenced page is
+  opened because the conversion layer stops at cross-check leg 3 and TDEF at
+  `A3-TDEF-RECORD-NONE`. The replacement `candidate_bound_assertion` asserts
+  those pages, at most 16 per submodel, exactly 81 blobs, and no more than
+  1800.
+- `R4-B02` schema edit: `oracle/windows-dao/experiments/a3/dry-run-report.schema.json`
+  `properties.input_page_blob_count.maximum` 55 -> 1800, SHA-256
+  `f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593` ->
+  `e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d`, and the
+  matching pin in `oracle/windows-dao/scripts/a3_spec.py`. R3 kept every
+  schema immutable; R4 edits this one because the dry-run report is a
+  pre-acquisition calibration artifact the base plan declares non-evidential
+  (`retained_exp_0042_input.scientific_evidence = false`, `disclosure_rule`),
+  never enters a retained evidence bundle, and validates no scientific
+  outcome. The nine evidence schemas and `plan.schema.json` are byte-identical.
+  The single sentence of R3's `pair_acceptance_gate` declaring the dry-run
+  schema unchanged is superseded for this one field.
+- Not resolved here: the pair gate's remaining disagreements are analyzer
+  defects against existing text, not plan gaps: on 87 of 89 cases the analyzer
+  reports `tdef_pointer_pair` terminal `A3-POINTER-MULTIPLE` with a null model
+  where the validator derives the `u24le_page_then_u8_slot` model (offsets
+  0/2044) under `tdef_no_outcome_ordering` and `R3-G06`; on
+  `sixteen_qualified_pages` the analyzer raises `A3-RESOURCE-BOUND` at exactly
+  `max_qualified_pages_per_submodel = 16` where `bounds_sanity_basis` requires
+  the exact ceiling to be accepted. Both are left to PR #58.
+- Plan identities:
+  `oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json`, SHA-256
+  `b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1`;
+  `oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json`, SHA-256
+  `3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1`;
+  `oracle/windows-dao/experiments/a3/a3-allocation-maps-r3.plan.json`, SHA-256
+  `bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a`;
+  `oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json`, SHA-256
+  `167b6e10ca2ff7f90070dfd73957e5ea3dc9b02e54d917be9918b273a0e26ce1`.
+- Observation: `preregistration.acquisition_started` remains `false`; this
+  revision records no database, checkpoint, replica observation, candidate
+  set, report, validation receipt, evidence bundle, or scientific outcome.
+- Interpretation and execution gate: this amendment resolves implementation
+  contract ambiguities only. It assigns no independently validated Jet
+  meaning, proves no Rust behavior or DAO compatibility, changes no
+  support-matrix entry, and authorizes no A3 acquisition. The `EXP-0044`
+  execution gate remains `BLOCKED`.
+- Usage: `file:oracle/windows-dao/experiments/a3/README.md`;
+  `file:oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json`;
+  `file:oracle/windows-dao/experiments/a3/dry-run-report.schema.json`;
+  the A3 analyzer and independent validator lanes, which must rebind to R4
+- Rights: project-authored revision and tests; no DAO binary, MDB, page blob,
+  or retained bundle is committed or redistributed
+- Review: focused A3 plan hash, R4 binding, survivor-count table, blob-bound
+  derivation, schema-hash, and analyzer-defect-exclusion contracts plus
+  repository validation must pass
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/experiments/a3/README.md
+++ b/oracle/windows-dao/experiments/a3/README.md
@@ -58,12 +58,12 @@ reachable predicates, a replica 3 with independent overshoot, and full-sweep
 analyzer/validator agreement recorded in retained companion documents.
 
 Before acquisition, additive revision `DAO-A3-ALLOCATION-MAPS-001-R4` was
-recorded as `EXP-0047` to pin two items surfaced by the executed full-sweep
+recorded as `EXP-0047` to pin three items surfaced by the executed full-sweep
 analyzer/validator pair gate (PR #58, `dry-run/a3-pair-agreement.json` on
 `origin/fable/a3-dryrun`). Acquisition has not started. The immutable revision
 file is `oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json`,
 SHA-256
-`167b6e10ca2ff7f90070dfd73957e5ea3dc9b02e54d917be9918b273a0e26ce1`; it binds
+`939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea`; it binds
 the base, R2, and R3 hashes and inherits their rules unchanged. R4-S01 pins
 `derivation_survivor_count` as the count of survivors actually found in
 derivation replica 1: every MULTIPLE terminal carries its multiplicity, every
@@ -79,9 +79,16 @@ and 1 shared). R4-B02 is the only schema edit in any A3 revision:
 (SHA-256 `f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593` ->
 `e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d`),
 permitted because the dry-run report is a non-evidential calibration artifact;
-every evidence schema is byte-identical. The TDEF u24 and exact-ceiling
-divergences in the same pair gate are analyzer defects against existing text,
-not plan gaps, and are left to PR #58.
+every evidence schema is byte-identical. R4-C01 supersedes the
+`record_candidates_examined` sentences of R3-G08/R3-G03: the field and the
+work units count each union qualified page once across derivation replicas,
+which is the only reading consistent with `combined_record_candidate_bound`,
+`bounds.max_record_candidates`, the analysis-report schema maximum
+(67,141,632 = 32 x 2,098,176) and the `prefix_sum_work_model` arithmetic; the
+exact 16+16 ceiling is accepted, and the validator must also enforce
+`bounds.max_record_candidates`. The TDEF u24 divergence in the same pair gate
+is an analyzer defect against existing text, not a plan gap, and is left to
+the analyzer lane.
 
 The actual `EXP-0042` polarity cross-check outcome is a violation on leg 3,
 `L_REL_0512` to `L_REL_0768`, first at page 1021; the later tag-change leg is

--- a/oracle/windows-dao/experiments/a3/README.md
+++ b/oracle/windows-dao/experiments/a3/README.md
@@ -57,6 +57,32 @@ dry-run honesty clause requires executed fixture transcripts for all 31
 reachable predicates, a replica 3 with independent overshoot, and full-sweep
 analyzer/validator agreement recorded in retained companion documents.
 
+Before acquisition, additive revision `DAO-A3-ALLOCATION-MAPS-001-R4` was
+recorded as `EXP-0047` to pin two items surfaced by the executed full-sweep
+analyzer/validator pair gate (PR #58, `dry-run/a3-pair-agreement.json` on
+`origin/fable/a3-dryrun`). Acquisition has not started. The immutable revision
+file is `oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json`,
+SHA-256
+`167b6e10ca2ff7f90070dfd73957e5ea3dc9b02e54d917be9918b273a0e26ce1`; it binds
+the base, R2, and R3 hashes and inherits their rules unchanged. R4-S01 pins
+`derivation_survivor_count` as the count of survivors actually found in
+derivation replica 1: every MULTIPLE terminal carries its multiplicity, every
+NONE terminal carries 0, a model or a single-survivor terminal carries 1, and
+the table is written out for every terminal of every layer. R4-B01 replaces
+the A1 run-12 carry-over blob bound (55, with its 13-page
+`candidate_bound_assertion`) by the derived ceiling 1800 = 2 derivation
+replicas x 25 checkpoints x (16 + 16 qualified + 4 referenced pages), and
+pins the EXP-0042 replay re-measurement: global pages `{0,1,20,21}`, TDEF
+pages `{0,1,23,24}`, exactly 81 distinct blobs (50 global, 71 TDEF, pages 0
+and 1 shared). R4-B02 is the only schema edit in any A3 revision:
+`dry-run-report.schema.json` `input_page_blob_count.maximum` 55 -> 1800
+(SHA-256 `f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593` ->
+`e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d`),
+permitted because the dry-run report is a non-evidential calibration artifact;
+every evidence schema is byte-identical. The TDEF u24 and exact-ceiling
+divergences in the same pair gate are analyzer defects against existing text,
+not plan gaps, and are left to PR #58.
+
 The actual `EXP-0042` polarity cross-check outcome is a violation on leg 3,
 `L_REL_0512` to `L_REL_0768`, first at page 1021; the later tag-change leg is
 never reached. On EXP-0042-like data, the `global_map_conversion_inline` and

--- a/oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json
+++ b/oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json
@@ -23,7 +23,7 @@
         "revision_id": "DAO-A3-ALLOCATION-MAPS-001-R3",
         "path": "oracle/windows-dao/experiments/a3/a3-allocation-maps-r3.plan.json",
         "sha256": "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a",
-        "inherited": "gap rules R3-G01 through R3-G10, minor readings R3-M01 through R3-M06, the predicate reachability classification, and the dry-run honesty clause are inherited unchanged except for the single sentence of dry_run_honesty_clause.pair_acceptance_gate that declares the dry-run report schema unchanged, which R4-B02 supersedes"
+        "inherited": "gap rules R3-G01 through R3-G10, minor readings R3-M01 through R3-M06, the predicate reachability classification, and the dry-run honesty clause are inherited unchanged except for (i) the single sentence of dry_run_honesty_clause.pair_acceptance_gate that declares the dry-run report schema unchanged, which R4-B02 supersedes, and (ii) the record_candidates_examined counting sentences of R3-G08 and R3-G03, which R4-C01 supersedes"
       }
     ],
     "design_inputs": [
@@ -36,6 +36,11 @@
         "path": "oracle/windows-dao/experiments/a3/dry-run/exp-0042-replay-report.json",
         "location": "origin/fable/a3-dryrun (PR #58), not yet merged",
         "role": "executed_exp_0042_replay_whose_input_page_blob_count_81_was_rejected_by_the_schema_maximum_55"
+      },
+      {
+        "path": "/private/tmp/fable-59-60-review.md",
+        "location": "independent review of PR #60 and PR #59, sections A.6 and C, not committed",
+        "role": "ruling_that_the_sixteen_qualified_pages_divergence_is_a_plan_gap_in_record_candidates_examined_counting"
       }
     ],
     "scientific_design_inherited_unchanged": [
@@ -55,8 +60,8 @@
       "bounds",
       "claims"
     ],
-    "revision_scope": "pin two items that the executed full-sweep analyzer/validator pair gate (PR #58) showed the base text leaves open: the meaning of derivation_survivor_count when a layer terminates at a MULTIPLE predicate, and the input_page_blob_count ceiling of the EXP-0042 derivation-only replay, which the base plan and dry-run report schema inherited from the A1 run-12 calibration (55) rather than deriving from A3's own bounds. No predicate id, mapping, sequence, scientific model, acquisition gate, or evidence schema changes",
-    "derivation_basis": "R4-S01 is derived from the immutable base plan's freeze_rule (frozen and report derivation_survivor_count are identical and the frozen set is compared field-for-field), its no_outcome reporting (every terminal predicate names the classification its stage made), and R3-G03's per-replica evaluation. R4-B01 is derived from bounds.max_qualified_pages_per_submodel, bounds.planned_checkpoints_per_replica, the two-replica derivation rule, and the four pointer references a model can hold, and its EXP-0042 value was re-measured directly from the retained EXP-0042 bundle's replica 1 and 2 page indexes (manifest SHA-256 9e1dac53e13f0bf765fc41b242b85beb26c8a518f7a15777aa37641af575dd46). The PR #58 analyzer and validator results were read only to locate the two divergences; neither rule adopts an implementation because it is convenient. EXP-0042 replica 3 was not opened",
+    "revision_scope": "pin three items that the executed full-sweep analyzer/validator pair gate (PR #58) showed the base text leaves open or in conflict: the meaning of derivation_survivor_count when a layer terminates at a MULTIPLE predicate; the input_page_blob_count ceiling of the EXP-0042 derivation-only replay, which the base plan and dry-run report schema inherited from the A1 run-12 calibration (55) rather than deriving from A3's own bounds; and the replica factor in record_candidates_examined, where R3-G08's per-(replica, page) counting contradicts the base plan's combined_record_candidate_bound, bounds.max_record_candidates, the analysis-report schema maximum, and the prefix_sum_work_model arithmetic. No predicate id, mapping, sequence, scientific model, bound, acquisition gate, or evidence schema changes",
+    "derivation_basis": "R4-S01 is derived from the immutable base plan's freeze_rule (frozen and report derivation_survivor_count are identical and the frozen set is compared field-for-field), its no_outcome reporting (every terminal predicate names the classification its stage made), and R3-G03's per-replica evaluation. R4-B01 is derived from bounds.max_qualified_pages_per_submodel, bounds.planned_checkpoints_per_replica, the two-replica derivation rule, and the four pointer references a model can hold, and its EXP-0042 value was re-measured directly from the retained EXP-0042 bundle's replica 1 and 2 page indexes (manifest SHA-256 9e1dac53e13f0bf765fc41b242b85beb26c8a518f7a15777aa37641af575dd46). The PR #58 analyzer and validator results were read only to locate the two divergences; neither rule adopts an implementation because it is convenient. EXP-0042 replica 3 was not opened. R4-C01 is derived from the immutable base plan's record_candidate_procedure.combined_record_candidate_bound, bounds.max_record_candidates, bounds.max_analysis_work_units, prefix_sum_work_model arithmetic, and the analysis-report schema maximum, all of which presuppose no replica factor",
     "amendment_permitted": "acquisition has not started, so this additive revision is permitted by the original plan's amendment rule",
     "amendment_rule": "after the first acquisition starts, any change requires a new experiment id, plan file, and provenance entry"
   },
@@ -247,18 +252,23 @@
       }
     ]
   },
+  "record_candidate_count_reconciliation": {
+    "gap_id": "R4-C01",
+    "title": "record_candidates_examined and work units count each union qualified page once across derivation replicas",
+    "plan_gap": "R3-G08 defines record_candidates_examined as 2098176 multiplied by the number of (derivation replica, qualified page) enumerations and R3-G03 repeats that each union page is counted once per replica that enumerated it. The immutable base plan fixes record_candidate_procedure.combined_record_candidate_bound = 67,141,632 = 32 x 2,098,176 (16 + 16 qualified pages with no replica factor), bounds.max_record_candidates = 67,141,632, analysis-report.schema.json record_candidates_examined maximum 67,141,632, and prefix_sum_work_model's ceiling arithmetic (interval queries at most 8 x 67,141,632 = 537,133,056 units, prefix construction at most 32 x 16 x 2049 = 1,049,088 units, total 538,182,144 below bounds.max_analysis_work_units = 600,000,000), none of which carries a replica factor. Under R3-G08 the sixteen_qualified_pages fixture (16 global + 16 tdef qualified pages in both replicas, churn precondition met) yields 64 x 2,098,176 = 134,283,264, which no schema-valid analysis report can carry and which exceeds bounds.max_record_candidates; the main analyzer's A3-RESOURCE-BOUND abort and the validator's acceptance are both literal readings of conflicting text, so this is a plan gap",
+    "rule": "record_candidates_examined = 2,098,176 multiplied by the number of pages in the union qualified_pages of R3-G03 (global_map and tdef unions together) that at least one derivation replica actually enumerated: every qualified global page of the union, plus every qualified TDEF page of the union when stage 1 (churn precondition) passed in at least one derivation replica. A page is counted once however many derivation replicas enumerated it; replica 3 is never counted. Work units are charged on the same basis: interval queries at most 8 units per enumerated interval and prefix construction at most 16 x 2049 cells per union qualified page, each charged once across derivation replicas, so the per-replica enumeration of R3-G03 is an evaluation rule and not a charging rule. The independent validator recomputes record_candidates_examined from the union and the per-replica churn precondition, rejects a report whose value differs, and must additionally enforce bounds.max_record_candidates and bounds.max_analysis_work_units on the recomputed values as fail-closed bound checks (the validator on origin/codex/a3-validator enforces max_qualified_pages_per_submodel, max_candidate_models, and max_analysis_work_units but never max_record_candidates; it must). The analyzer raises A3-RESOURCE-BOUND only when the union count exceeds bounds.max_record_candidates or the charged work exceeds bounds.max_analysis_work_units; at the exact ceiling it proceeds. This supersedes the record_candidates_examined sentence of R3-G08 and the sentence of R3-G03 that reads record_candidates_examined counts each page of the union once per replica that enumerated it; every other sentence of R3-G03 and R3-G08 stands",
+    "single_implementation": "one charge per union qualified page across derivation replicas; validator recomputes and enforces max_record_candidates",
+    "bound_consistency_derivation": "bounds.max_qualified_pages_per_submodel = 16 applies to the frozen union arrays (derivation-candidates.schema.json pages maxItems 16), so a union above 16 pages in either submodel is itself an A3-RESOURCE-BOUND abort before any interval is charged, and an enumerated union holds at most 32 pages. Hence record_candidates_examined <= 32 x 2,098,176 = 67,141,632 = combined_record_candidate_bound = bounds.max_record_candidates = analysis-report schema maximum; interval queries <= 8 x 67,141,632 = 537,133,056; prefix construction <= 32 x 16 x 2049 = 1,049,088; total 538,182,144 < 600,000,000, exactly the prefix_sum_work_model arithmetic. bounds_sanity_basis is therefore satisfiable for this field: the exact ceiling 67,141,632 is accepted, and one more page's worth, 69,239,808, is rejected by the schema, by bounds.max_record_candidates, and by max_qualified_pages_per_submodel. No bound, no plan.schema.json const, and no evidence schema changes",
+    "exp_0042_worked_example": "EXP-0042 replay: union qualified pages are global {0, 1, 20, 21} and tdef {0, 1, 23, 24}; the churn precondition passes in both replicas, so 8 enumerated union pages give record_candidates_examined = 8 x 2,098,176 = 16,785,408, against 33,570,816 under the superseded per-replica counting. sixteen_qualified_pages fixture: 32 union pages give exactly 67,141,632, the accepted ceiling",
+    "pair_gate_disposition": "the sixteen_qualified_pages disagreement (analyzer A3-RESOURCE-BOUND versus validator acceptance) is resolved by this rule in favour of acceptance at the ceiling, with the field value 67,141,632; the PR #59 analyzer's cross-replica dedupe matches this rule for the field but the validator must be brought to it as well"
+  },
   "analyzer_defects_not_resolved_here": {
-    "rule": "the pair gate's remaining disagreements are analyzer defects against text that already exists and are not plan gaps; R4 does not touch them and PR #58 must fix the analyzer to the existing text",
+    "rule": "the pair gate's remaining disagreement is an analyzer defect against text that already exists and is not a plan gap; R4 does not touch it and the analyzer lane (PR #58 / PR #59) must fix the analyzer to the existing text. The sixteen_qualified_pages disagreement, first listed here as a second analyzer defect, was ruled a plan gap by independent review and is resolved by R4-C01 instead",
     "items": [
       {
         "id": "tdef_u24_pointer_layout",
         "symptom": "on 87 of the 89 disagreeing sweep cases (100 fixtures) the analyzer reports tdef_pointer_pair terminal A3-POINTER-MULTIPLE (twice A3-CHURN-POINTER-NONE or another id) with a null model while the validator derives the u24le_page_then_u8_slot model with growth pointer offset 0 and delete/reinsert pointer offset 2044",
         "governing_text": "record_candidate_procedure TDEF layouts, tdef_no_outcome_ordering stages 2-5, and R3-G06 window distinctness"
-      },
-      {
-        "id": "exact_ceiling_bounds_edge",
-        "symptom": "on the sixteen_qualified_pages fixture, which sits exactly at bounds.max_qualified_pages_per_submodel = 16, the analyzer raises the campaign terminal A3-RESOURCE-BOUND and derives no layer while the validator accepts the ceiling and derives all four models",
-        "governing_text": "bounds.max_qualified_pages_per_submodel = 16 and analyzer_dry_run_contract.bounds_sanity_basis: dry-run boundary cases must accept each exact ceiling and reject one over"
       }
     ]
   },
@@ -269,10 +279,12 @@
     "dry_run_report_schema_change": "properties.input_page_blob_count.maximum 55 -> 1800; sha256 f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593 -> e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d; non-evidential dry-run artifact schema only",
     "original_predicate_registry_remains_immutable": true,
     "r2_sequences_remain_immutable": true,
-    "r3_rules_remain_immutable": true,
+    "r3_rules_remain_immutable": false,
     "operational_rules_pinned": true,
     "scientific_projection_changed": false,
     "acquisition_authorized": false,
-    "support_claim_changed": false
+    "support_claim_changed": false,
+    "r3_rules_superseded": "R3-G08 record_candidates_examined sentence and the matching R3-G03 sentence (R4-C01); one sentence of dry_run_honesty_clause.pair_acceptance_gate (R4-B02); everything else in R3 stands",
+    "bounds_changed": false
   }
 }

--- a/oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json
+++ b/oracle/windows-dao/experiments/a3/a3-allocation-maps-r4.plan.json
@@ -1,0 +1,278 @@
+{
+  "protocol_version": "1.0.0",
+  "document_type": "dao_a3_allocation_maps_plan_revision",
+  "revision_id": "DAO-A3-ALLOCATION-MAPS-001-R4",
+  "preregistration": {
+    "provenance_entry": "EXP-0047",
+    "recorded_utc_date": "2026-08-22",
+    "acquisition_started": false,
+    "acquisition_start_criterion": "acquisition starts when the first schema-valid A3 replica observation is retained for inspection",
+    "revision_of": "DAO-A3-ALLOCATION-MAPS-001",
+    "original_plan": {
+      "path": "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json",
+      "sha256": "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
+    },
+    "prior_revisions": [
+      {
+        "revision_id": "DAO-A3-ALLOCATION-MAPS-001-R2",
+        "path": "oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json",
+        "sha256": "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1",
+        "inherited": "campaign order, per-layer ordered predicate sequences, layer evaluation rule, and status projection rules are inherited unchanged"
+      },
+      {
+        "revision_id": "DAO-A3-ALLOCATION-MAPS-001-R3",
+        "path": "oracle/windows-dao/experiments/a3/a3-allocation-maps-r3.plan.json",
+        "sha256": "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a",
+        "inherited": "gap rules R3-G01 through R3-G10, minor readings R3-M01 through R3-M06, the predicate reachability classification, and the dry-run honesty clause are inherited unchanged except for the single sentence of dry_run_honesty_clause.pair_acceptance_gate that declares the dry-run report schema unchanged, which R4-B02 supersedes"
+      }
+    ],
+    "design_inputs": [
+      {
+        "path": "oracle/windows-dao/experiments/a3/dry-run/a3-pair-agreement.json",
+        "location": "origin/fable/a3-dryrun (PR #58), not yet merged; read for the two gaps only, its SHA-256 is not pinned here because that lane may still change before merge",
+        "role": "executed_full_sweep_pair_gate_that_surfaced_the_two_gaps"
+      },
+      {
+        "path": "oracle/windows-dao/experiments/a3/dry-run/exp-0042-replay-report.json",
+        "location": "origin/fable/a3-dryrun (PR #58), not yet merged",
+        "role": "executed_exp_0042_replay_whose_input_page_blob_count_81_was_rejected_by_the_schema_maximum_55"
+      }
+    ],
+    "scientific_design_inherited_unchanged": [
+      "question",
+      "replicas",
+      "tables",
+      "checkpoint_design",
+      "page_capture",
+      "record_candidate_procedure",
+      "inline_boundary_procedure",
+      "hypotheses",
+      "predicate_registry",
+      "decision_rules",
+      "decisive_report_handling",
+      "runtime_design",
+      "artifacts",
+      "bounds",
+      "claims"
+    ],
+    "revision_scope": "pin two items that the executed full-sweep analyzer/validator pair gate (PR #58) showed the base text leaves open: the meaning of derivation_survivor_count when a layer terminates at a MULTIPLE predicate, and the input_page_blob_count ceiling of the EXP-0042 derivation-only replay, which the base plan and dry-run report schema inherited from the A1 run-12 calibration (55) rather than deriving from A3's own bounds. No predicate id, mapping, sequence, scientific model, acquisition gate, or evidence schema changes",
+    "derivation_basis": "R4-S01 is derived from the immutable base plan's freeze_rule (frozen and report derivation_survivor_count are identical and the frozen set is compared field-for-field), its no_outcome reporting (every terminal predicate names the classification its stage made), and R3-G03's per-replica evaluation. R4-B01 is derived from bounds.max_qualified_pages_per_submodel, bounds.planned_checkpoints_per_replica, the two-replica derivation rule, and the four pointer references a model can hold, and its EXP-0042 value was re-measured directly from the retained EXP-0042 bundle's replica 1 and 2 page indexes (manifest SHA-256 9e1dac53e13f0bf765fc41b242b85beb26c8a518f7a15777aa37641af575dd46). The PR #58 analyzer and validator results were read only to locate the two divergences; neither rule adopts an implementation because it is convenient. EXP-0042 replica 3 was not opened",
+    "amendment_permitted": "acquisition has not started, so this additive revision is permitted by the original plan's amendment rule",
+    "amendment_rule": "after the first acquisition starts, any change requires a new experiment id, plan file, and provenance entry"
+  },
+  "survivor_count_reconciliation": {
+    "gap_id": "R4-S01",
+    "title": "derivation_survivor_count at a MULTIPLE terminal",
+    "plan_gap": "decision_rules.freeze_rule requires frozen and report derivation_survivor_count to be identical and says only that derivation_survivor_counts equals layer counts; it never says what a layer counts when it stops at a terminal predicate. On the pair gate's second_global_page_opposite_polarity fixtures the analyzer froze 2 at A3-POLARITY-MULTIPLE and the validator expected 0, and the same silence covers every other MULTIPLE terminal",
+    "rule": "derivation_survivor_count of a layer is the cardinality, measured in derivation replica 1, of the candidate set that the layer's evaluation had most recently classified when it stopped. A layer that holds a model counts exactly 1 (its unique survivor). A terminal layer counts the set its terminal predicate classified: 0 for every terminal that fires on an empty set or before any candidate set of that layer exists (every NONE, precondition, discrimination, set-relation, record-end, and polarity-cross-check terminal), the multiplicity (at least 2) for every MULTIPLE terminal, and 1 for every terminal that fires on the single surviving candidate (slot, inline-suffix, pointer-validity, structural-exclusion, and holdout-prediction terminals). A3-REPLICA-DISAGREEMENT counts replica 1's candidate set at replica 1's own stopping point under the same table (1 if replica 1 held a model). An inapplicable layer counts 0. Replica 2's count is computed but, per R3-G03, is not compared across replicas; only the terminal predicate and the model are. The frozen value is the reported value and the independent validator recomputes it from replica 1",
+    "single_implementation": "count of survivors actually found in replica 1; MULTIPLE carries its multiplicity, NONE carries 0, a model or a single-survivor terminal carries 1",
+    "rationale": "the base plan's no_outcome reporting makes every terminal predicate a statement about a classification the stage actually performed; a MULTIPLE terminal is precisely the statement that more than one candidate survived, so the honest count is that multiplicity. Freezing 0 at a MULTIPLE terminal would make the frozen set assert that nothing survived while its terminal asserts the opposite, and would collapse the field-for-field freeze comparison into a constant for every non-decisive layer. Freezing the survivors found also keeps the count monotone with the stage order: it is 0 until candidates exist, greater than 1 exactly at a multiplicity terminal, and 1 from the first single-survivor stage onward",
+    "per_terminal_counts": {
+      "global_map.record": [
+        {
+          "predicate_id": "A3-GLOBAL-PAGE-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-GLOBAL-RECORD-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-D-SET-RELATION",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-GLOBAL-RECORD-END",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-POLARITY-NONE",
+          "count": "0 (unreachable by construction)"
+        },
+        {
+          "predicate_id": "A3-POLARITY-MULTIPLE",
+          "count": "number of stage-4 surviving (page, start, polarity) candidates across every qualified global page, at least 2"
+        },
+        {
+          "predicate_id": "A3-GLOBAL-PAGE-MULTIPLE",
+          "count": "number of stage-6 surviving (page, start) candidates across the two or more pages, at least 2"
+        },
+        {
+          "predicate_id": "A3-GLOBAL-RECORD-MULTIPLE",
+          "count": "number of surviving starts on the single surviving page, at least 2"
+        },
+        {
+          "predicate_id": "A3-STRUCTURAL-EXCLUSION",
+          "count": "1 (unreachable on this layer by construction)"
+        },
+        {
+          "predicate_id": "A3-REPLICA-DISAGREEMENT",
+          "count": "replica 1's count at replica 1's stopping point"
+        }
+      ],
+      "global_map.conversion_inline": [
+        {
+          "predicate_id": "A3-POLARITY-CROSSCHECK",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-CONVERSION-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-CONVERSION-MULTIPLE",
+          "count": "the R3-G02 class-change count, at least 2"
+        },
+        {
+          "predicate_id": "A3-SLOT-ACTIVATION",
+          "count": "1"
+        },
+        {
+          "predicate_id": "A3-SLOT-FINAL",
+          "count": "1"
+        },
+        {
+          "predicate_id": "A3-POINTER-VALIDITY",
+          "count": "1"
+        },
+        {
+          "predicate_id": "A3-INLINE-BOUNDARY-NONE",
+          "count": "0 (unreachable by construction)"
+        },
+        {
+          "predicate_id": "A3-INLINE-BOUNDARY-MULTIPLE",
+          "count": "number of surviving boundaries, at least 2 (unreachable by construction)"
+        },
+        {
+          "predicate_id": "A3-INLINE-SUFFIX",
+          "count": "1"
+        },
+        {
+          "predicate_id": "A3-STRUCTURAL-EXCLUSION",
+          "count": "1 (unreachable on this layer by construction)"
+        },
+        {
+          "predicate_id": "A3-REPLICA-DISAGREEMENT",
+          "count": "replica 1's count at replica 1's stopping point"
+        }
+      ],
+      "global_map.extended_base": [
+        {
+          "predicate_id": "A3-BASE-DISCRIMINATION",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-BASE-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-BASE-MULTIPLE",
+          "count": "number of surviving formulas, at least 2 and at most 6"
+        },
+        {
+          "predicate_id": "A3-POINTER-VALIDITY",
+          "count": "1 (reached, never terminal)"
+        },
+        {
+          "predicate_id": "A3-REPLICA-DISAGREEMENT",
+          "count": "replica 1's count at replica 1's stopping point"
+        }
+      ],
+      "tdef.pointer_pair": [
+        {
+          "predicate_id": "A3-TDEF-PAGE-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-CHURN-PRECONDITION",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-GROWTH-POINTER-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-CHURN-POINTER-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-TDEF-RECORD-NONE",
+          "count": "0"
+        },
+        {
+          "predicate_id": "A3-TDEF-PAGE-MULTIPLE",
+          "count": "number of surviving minimal records across the two or more pages, at least 2"
+        },
+        {
+          "predicate_id": "A3-TDEF-RECORD-MULTIPLE",
+          "count": "number of surviving minimal records on the single surviving page, at least 2"
+        },
+        {
+          "predicate_id": "A3-POINTER-MULTIPLE",
+          "count": "number of pointer-pair models inside the single surviving record, at least 2"
+        },
+        {
+          "predicate_id": "A3-POINTER-VALIDITY",
+          "count": "1"
+        },
+        {
+          "predicate_id": "A3-STRUCTURAL-EXCLUSION",
+          "count": "1"
+        },
+        {
+          "predicate_id": "A3-REPLICA-DISAGREEMENT",
+          "count": "replica 1's count at replica 1's stopping point"
+        }
+      ]
+    },
+    "pair_gate_worked_example": "second_global_page_opposite_polarity: two qualified global pages each carry one stage-4 survivor of opposite polarity, so global_map_record is terminal at A3-POLARITY-MULTIPLE with derivation_survivor_count 2; the frozen count is 2 and the validator must recompute 2, not 0. anchor_highwater_hole: global_map_record is terminal at A3-GLOBAL-RECORD-NONE with count 0. EXP-0042 replay: global_map_record holds a model (count 1), global_map_conversion_inline is terminal at A3-POLARITY-CROSSCHECK (count 0), global_map_extended_base is inapplicable (count 0), tdef_pointer_pair is terminal at A3-TDEF-RECORD-NONE (count 0)"
+  },
+  "replay_blob_bound_reconciliation": {
+    "gaps": [
+      {
+        "gap_id": "R4-B01",
+        "title": "EXP-0042 replay unique page-blob ceiling",
+        "plan_gap": "analyzer_dry_run_contract.historical_a1_input_not_required_by_a3 carries max_input_page_blobs 55 and a candidate_bound_assertion that asserts 13 qualified pages per replica and no more than 55 opened blobs for the A1 run-12 input; dry-run-report.schema.json copied that 55 as the maximum of input_page_blob_count. The base plan marks the A1 section as not required for A3 dispatch, but the schema maximum binds every A3 dry-run report, and analyzer_dry_run_contract.retained_exp_0042_input states no blob bound of its own. The executed EXP-0042 replay (PR #58) opened 81 unique blobs and was rejected by the schema alone",
+        "rule": "A dry-run report's input_page_blob_count is the number of distinct page-blob SHA-256 values the analyzer opened from the page store. Its ceiling is 1800, derived as 2 derivation replicas x 25 planned checkpoints x (16 + 16 + 4) pages per checkpoint: bounds.max_qualified_pages_per_submodel = 16 for the global_map submodel, 16 for the tdef submodel, and at most 4 referenced pages per checkpoint (global slot 0, global slot 1, the TDEF growth pointer, and the TDEF delete/reinsert pointer) read by pointer_validity_rule and R3-G01 on the single surviving model. Replica 3 is never opened in a dry run (holdout_opened is constant false), so it contributes nothing. Every blob counts once however many checkpoints, replicas, or pages share it, and a synthetic run that opens no page store reports 0. A count above 1800 is a dry-run failure and, if reproduced, an analyzer defect against bounds.max_qualified_pages_per_submodel",
+        "single_implementation": "schema maximum 1800; ceiling 2 x 25 x 36",
+        "exp_0042_worked_example": "Re-measured from the retained bundle's replica 1 and 2 page indexes: the global_map qualified pages are {0, 1, 20, 21} and the tdef qualified pages are {0, 1, 23, 24} in both replicas. Over the 25 checkpoints of both replicas the global pages contribute 50 distinct blobs and the tdef pages 71; pages 0 and 1 are shared, so the union is exactly 81 distinct blobs. No referenced page is opened: the conversion layer is terminal at leg 3 of the polarity cross-check before any slot activates, the polarity cross-check itself reads only page 1 at the leg endpoints (already counted), and tdef is terminal at A3-TDEF-RECORD-NONE before pointer validity. 81 exceeds 55 and is below 1800",
+        "exp_0042_candidate_bound_assertion": "The EXP-0042 replay replaces the A1 run-12 figures of candidate_bound_assertion as follows: derive qualification counts from the retained indexes using the plan rule, then assert 4 global qualifying pages {0, 1, 20, 21} and 4 tdef qualifying pages {0, 1, 23, 24} in each of replicas 1 and 2; assert each submodel is at most 16 qualified pages; assert exactly 81 unique page blobs are opened and no more than 1800. The work-unit assertions of the A1 text are not restated: they remain subject to bounds.max_analysis_work_units = 600,000,000 as the plan already requires"
+      },
+      {
+        "gap_id": "R4-B02",
+        "title": "dry-run report schema edit and why it is permitted",
+        "plan_gap": "R3's execution_effect and dry_run_honesty_clause.pair_acceptance_gate state that the dry-run report schema is not changed; the 55 maximum cannot be corrected without editing that file",
+        "rule": "dry-run-report.schema.json is edited in place in exactly one place: properties.input_page_blob_count.maximum changes from 55 to 1800. Before this revision its SHA-256 was f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593; after it, e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d. This is permitted because the dry-run report is a pre-acquisition calibration artifact that the base plan itself declares non-evidential (analyzer_dry_run_contract.retained_exp_0042_input.scientific_evidence = false, disclosure_rule: all are non-evidential); it never enters a retained A3 evidence bundle, carries no DAO observation, and validates no scientific outcome. The evidence schemas (replica-observation, page-index, replica-artifact-manifest, bundle-manifest, analysis-report, holdout-structure-receipt, environment, derivation-candidates, independent-validation-report) and plan.schema.json remain byte-identical. The sentence of R3's pair_acceptance_gate that reads 'The immutable dry-run report schema is not changed' is superseded by this gap for this one field; every other sentence of that clause stands",
+        "single_implementation": "one numeric edit, old and new schema hashes recorded, evidence schemas untouched"
+      }
+    ]
+  },
+  "analyzer_defects_not_resolved_here": {
+    "rule": "the pair gate's remaining disagreements are analyzer defects against text that already exists and are not plan gaps; R4 does not touch them and PR #58 must fix the analyzer to the existing text",
+    "items": [
+      {
+        "id": "tdef_u24_pointer_layout",
+        "symptom": "on 87 of the 89 disagreeing sweep cases (100 fixtures) the analyzer reports tdef_pointer_pair terminal A3-POINTER-MULTIPLE (twice A3-CHURN-POINTER-NONE or another id) with a null model while the validator derives the u24le_page_then_u8_slot model with growth pointer offset 0 and delete/reinsert pointer offset 2044",
+        "governing_text": "record_candidate_procedure TDEF layouts, tdef_no_outcome_ordering stages 2-5, and R3-G06 window distinctness"
+      },
+      {
+        "id": "exact_ceiling_bounds_edge",
+        "symptom": "on the sixteen_qualified_pages fixture, which sits exactly at bounds.max_qualified_pages_per_submodel = 16, the analyzer raises the campaign terminal A3-RESOURCE-BOUND and derives no layer while the validator accepts the ceiling and derives all four models",
+        "governing_text": "bounds.max_qualified_pages_per_submodel = 16 and analyzer_dry_run_contract.bounds_sanity_basis: dry-run boundary cases must accept each exact ceiling and reject one over"
+      }
+    ]
+  },
+  "execution_effect": {
+    "original_plan_remains_immutable": true,
+    "original_evidence_schemas_remain_immutable": true,
+    "dry_run_report_schema_changed": true,
+    "dry_run_report_schema_change": "properties.input_page_blob_count.maximum 55 -> 1800; sha256 f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593 -> e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d; non-evidential dry-run artifact schema only",
+    "original_predicate_registry_remains_immutable": true,
+    "r2_sequences_remain_immutable": true,
+    "r3_rules_remain_immutable": true,
+    "operational_rules_pinned": true,
+    "scientific_projection_changed": false,
+    "acquisition_authorized": false,
+    "support_claim_changed": false
+  }
+}

--- a/oracle/windows-dao/experiments/a3/dry-run-report.schema.json
+++ b/oracle/windows-dao/experiments/a3/dry-run-report.schema.json
@@ -87,7 +87,7 @@
     "input_page_blob_count": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 55
+      "maximum": 1800
     },
     "holdout_opened": {
       "const": false

--- a/oracle/windows-dao/scripts/a3_spec.py
+++ b/oracle/windows-dao/scripts/a3_spec.py
@@ -57,7 +57,7 @@ SCHEMA_SHA256: Mapping[str, str] = MappingProxyType({
     "analysis-report.schema.json": "f15bf39ad703f77fb7749d93214fe43711a9b525376b128f93c898b531db6460",
     "bundle-manifest.schema.json": "9d049c910b4a53da5d3cd3ee71f02c5671fdbb75b94e33587999cf40a91e9727",
     "derivation-candidates.schema.json": "50a9f7a1208969475a89ac3782077cb2bc0e5d3f9635ec51d5a46e8afcacd5b2",
-    "dry-run-report.schema.json": "f88c1f9bf131352311d3e77e70f95d84d015b60c3d50cce40ceed668b390a593",
+    "dry-run-report.schema.json": "e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d",
     "environment.schema.json": "6fb863f1c224698b466ba5fd5e10d9869a6b313b7480f02045e70c2e8eb49465",
     "holdout-structure-receipt.schema.json": "c2316f9bf84f7722c93160c354f671d7411c0089bf7f52124237b262f43c50fe",
     "independent-validation-report.schema.json": "2ad90d2b6ade15e815ad9819c09ca28d6b7e77ab6064e3a1139a9acf7e4c6d8c",

--- a/oracle/windows-dao/tests/test_a3_plan_contract.py
+++ b/oracle/windows-dao/tests/test_a3_plan_contract.py
@@ -19,6 +19,9 @@ PLAN_SHA256 = "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1"
 REVISION_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
 R3_PLAN = EXPERIMENT / "a3-allocation-maps-r3.plan.json"
 R3_PLAN_SHA256 = "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a"
+R4_PLAN = EXPERIMENT / "a3-allocation-maps-r4.plan.json"
+R4_PLAN_SHA256 = "167b6e10ca2ff7f90070dfd73957e5ea3dc9b02e54d917be9918b273a0e26ce1"
+DRY_RUN_SCHEMA_SHA256 = "e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d"
 PAIR_REVIEW_SHA256 = "70b9717d3b3387cbd2d4f1ceec3c8deff4f7706563af07eb2c5e77a6c05eab65"
 DESIGN_INPUT_HASHES = {
     "a2-preregistration-pointer.md": "8f16e79686620e254b0ba98de4d7cb21611f84a3e9b5c84d9fd6428987f51632",
@@ -264,6 +267,95 @@ class A3PlanContractTests(unittest.TestCase):
         readme = README.read_text(encoding="utf-8")
         self.assertIn("### EXP-0046", provenance)
         for digest in (R3_PLAN_SHA256, PAIR_REVIEW_SHA256):
+            self.assertIn(digest, provenance)
+            self.assertIn(digest, readme)
+
+    def test_r4_survivor_count_and_replay_blob_bound_are_hash_pinned(self) -> None:
+        revision_bytes = R4_PLAN.read_bytes()
+        revision = json.loads(revision_bytes)
+        self.assertEqual(hashlib.sha256(revision_bytes).hexdigest(), R4_PLAN_SHA256)
+        preregistration = revision["preregistration"]
+        self.assertEqual(revision["revision_id"], "DAO-A3-ALLOCATION-MAPS-001-R4")
+        self.assertEqual(preregistration["provenance_entry"], "EXP-0047")
+        self.assertEqual(preregistration["revision_of"], self.plan["experiment_id"])
+        self.assertEqual(preregistration["original_plan"]["sha256"], PLAN_SHA256)
+        self.assertEqual(
+            [row["sha256"] for row in preregistration["prior_revisions"]],
+            [REVISION_PLAN_SHA256, R3_PLAN_SHA256],
+        )
+        self.assertFalse(preregistration["acquisition_started"])
+        self.assertIn("permitted", preregistration["amendment_permitted"])
+        self.assertIn("replica 3 was not opened", preregistration["derivation_basis"])
+
+        survivor = revision["survivor_count_reconciliation"]
+        self.assertEqual(survivor["gap_id"], "R4-S01")
+        rule = survivor["rule"]
+        for text in (
+            "measured in derivation replica 1",
+            "the multiplicity (at least 2) for every MULTIPLE terminal",
+            "0 for every terminal that fires on an empty set",
+            "1 for every terminal that fires on the single surviving candidate",
+            "An inapplicable layer counts 0",
+        ):
+            self.assertIn(text, rule)
+        sequences = json.loads(REVISION_PLAN.read_bytes())[
+            "predicate_evaluation_sequence_reconciliation"
+        ]["per_layer_ordered_predicates"]
+        table = survivor["per_terminal_counts"]
+        self.assertEqual(set(table), set(sequences))
+        for layer, ordered in sequences.items():
+            rows = table[layer]
+            self.assertEqual([row["predicate_id"] for row in rows], ordered)
+            for row in rows:
+                if row["predicate_id"].endswith("-MULTIPLE"):
+                    self.assertIn("at least 2", row["count"])
+                elif row["predicate_id"].endswith("-NONE"):
+                    self.assertTrue(row["count"].startswith("0"))
+        self.assertIn("A3-POLARITY-MULTIPLE with derivation_survivor_count 2", survivor["pair_gate_worked_example"])
+
+        gaps = {gap["gap_id"]: gap for gap in revision["replay_blob_bound_reconciliation"]["gaps"]}
+        self.assertEqual(set(gaps), {"R4-B01", "R4-B02"})
+        bound = gaps["R4-B01"]["rule"]
+        self.assertIn("Its ceiling is 1800", bound)
+        self.assertIn("2 derivation replicas x 25 planned checkpoints x (16 + 16 + 4)", bound)
+        self.assertEqual(self.plan["bounds"]["max_qualified_pages_per_submodel"], 16)
+        self.assertEqual(self.plan["bounds"]["planned_checkpoints_per_replica"], 25)
+        self.assertEqual(2 * 25 * (16 + 16 + 4), 1800)
+        example = gaps["R4-B01"]["exp_0042_worked_example"]
+        for text in ("{0, 1, 20, 21}", "{0, 1, 23, 24}", "50 distinct blobs", "71", "exactly 81"):
+            self.assertIn(text, example)
+        self.assertIn("exactly 81 unique page blobs", gaps["R4-B01"]["exp_0042_candidate_bound_assertion"])
+        self.assertEqual(
+            self.plan["analyzer_dry_run_contract"]["historical_a1_input_not_required_by_a3"]["max_input_page_blobs"],
+            55,
+        )
+
+        schema_bytes = (EXPERIMENT / "dry-run-report.schema.json").read_bytes()
+        self.assertEqual(hashlib.sha256(schema_bytes).hexdigest(), DRY_RUN_SCHEMA_SHA256)
+        self.assertEqual(
+            json.loads(schema_bytes)["properties"]["input_page_blob_count"]["maximum"], 1800
+        )
+        schema_rule = gaps["R4-B02"]["rule"]
+        self.assertIn(DRY_RUN_SCHEMA_SHA256, schema_rule)
+        self.assertIn("non-evidential", schema_rule)
+
+        defects = revision["analyzer_defects_not_resolved_here"]
+        self.assertEqual(
+            [row["id"] for row in defects["items"]],
+            ["tdef_u24_pointer_layout", "exact_ceiling_bounds_edge"],
+        )
+
+        effect = revision["execution_effect"]
+        self.assertTrue(effect["original_plan_remains_immutable"])
+        self.assertTrue(effect["original_evidence_schemas_remain_immutable"])
+        self.assertTrue(effect["dry_run_report_schema_changed"])
+        self.assertTrue(effect["r3_rules_remain_immutable"])
+        self.assertFalse(effect["acquisition_authorized"])
+
+        provenance = PROVENANCE.read_text(encoding="utf-8")
+        readme = README.read_text(encoding="utf-8")
+        self.assertIn("### EXP-0047", provenance)
+        for digest in (R4_PLAN_SHA256, DRY_RUN_SCHEMA_SHA256):
             self.assertIn(digest, provenance)
             self.assertIn(digest, readme)
 
@@ -662,7 +754,7 @@ class A3PlanContractTests(unittest.TestCase):
 
     def test_all_a3_json_documents_parse(self) -> None:
         documents = sorted(EXPERIMENT.glob("*.json"))
-        self.assertEqual(len(documents), 14)
+        self.assertEqual(len(documents), 15)
         for document in documents:
             with self.subTest(document=document.name):
                 json.loads(document.read_bytes())

--- a/oracle/windows-dao/tests/test_a3_plan_contract.py
+++ b/oracle/windows-dao/tests/test_a3_plan_contract.py
@@ -20,7 +20,7 @@ REVISION_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d
 R3_PLAN = EXPERIMENT / "a3-allocation-maps-r3.plan.json"
 R3_PLAN_SHA256 = "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a"
 R4_PLAN = EXPERIMENT / "a3-allocation-maps-r4.plan.json"
-R4_PLAN_SHA256 = "167b6e10ca2ff7f90070dfd73957e5ea3dc9b02e54d917be9918b273a0e26ce1"
+R4_PLAN_SHA256 = "939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea"
 DRY_RUN_SCHEMA_SHA256 = "e7b054543529f4b2ac38cda7ae15fac80cf20bd6745f4fcd43cec02eabc9f13d"
 PAIR_REVIEW_SHA256 = "70b9717d3b3387cbd2d4f1ceec3c8deff4f7706563af07eb2c5e77a6c05eab65"
 DESIGN_INPUT_HASHES = {
@@ -339,17 +339,38 @@ class A3PlanContractTests(unittest.TestCase):
         self.assertIn(DRY_RUN_SCHEMA_SHA256, schema_rule)
         self.assertIn("non-evidential", schema_rule)
 
-        defects = revision["analyzer_defects_not_resolved_here"]
+        candidates = revision["record_candidate_count_reconciliation"]
+        self.assertEqual(candidates["gap_id"], "R4-C01")
+        per_page = self.plan["bounds"]["max_record_candidates_per_page"]
+        ceiling = self.plan["bounds"]["max_record_candidates"]
+        self.assertEqual(32 * per_page, ceiling)
         self.assertEqual(
-            [row["id"] for row in defects["items"]],
-            ["tdef_u24_pointer_layout", "exact_ceiling_bounds_edge"],
+            self.plan["record_candidate_procedure"]["combined_record_candidate_bound"], ceiling
         )
+        report_schema = json.loads((EXPERIMENT / "analysis-report.schema.json").read_bytes())
+        self.assertEqual(
+            report_schema["properties"]["record_candidates_examined"]["maximum"], ceiling
+        )
+        self.assertLess(8 * ceiling + 32 * 16 * 2049, self.plan["bounds"]["max_analysis_work_units"])
+        for text in (
+            "counted once however many derivation replicas enumerated it",
+            "supersedes the record_candidates_examined sentence of R3-G08",
+            "must additionally enforce bounds.max_record_candidates",
+        ):
+            self.assertIn(text, candidates["rule"])
+        self.assertIn("67,141,632 = combined_record_candidate_bound", candidates["bound_consistency_derivation"])
+        self.assertIn("16,785,408", candidates["exp_0042_worked_example"])
+
+        defects = revision["analyzer_defects_not_resolved_here"]
+        self.assertEqual([row["id"] for row in defects["items"]], ["tdef_u24_pointer_layout"])
 
         effect = revision["execution_effect"]
         self.assertTrue(effect["original_plan_remains_immutable"])
         self.assertTrue(effect["original_evidence_schemas_remain_immutable"])
         self.assertTrue(effect["dry_run_report_schema_changed"])
-        self.assertTrue(effect["r3_rules_remain_immutable"])
+        self.assertFalse(effect["r3_rules_remain_immutable"])
+        self.assertIn("R4-C01", effect["r3_rules_superseded"])
+        self.assertFalse(effect["bounds_changed"])
         self.assertFalse(effect["acquisition_authorized"])
 
         provenance = PROVENANCE.read_text(encoding="utf-8")


### PR DESCRIPTION
Additive A3 plan revision `DAO-A3-ALLOCATION-MAPS-001-R4` (EXP-0047), SHA-256 `939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea`. Acquisition has not started. Binds base/R2/R3 hashes and inherits their rules unchanged.

Two items surfaced by the executed full-sweep pair gate (PR #58):

- **R4-S01 survivor count** — `derivation_survivor_count` is the cardinality, in derivation replica 1, of the candidate set the layer's terminal predicate classified: every MULTIPLE terminal carries its multiplicity (≥2), every NONE/precondition/cross-check terminal carries 0, a model or single-survivor terminal (slot, suffix, validity, structural, holdout) carries 1, replica-disagreement carries replica 1's count at its own stop, inapplicable layer 0. Table written for every terminal of every layer.
- **R4-B01/B02 replay blob bound** — the 55 is A1 run-12 text (`historical_a1_input_not_required_by_a3`) copied into `dry-run-report.schema.json`. Replaced by derived ceiling **1800** = 2 replicas × 25 checkpoints × (16 + 16 qualified + 4 referenced pages). EXP-0042 re-measured from the bundle page indexes: global `{0,1,20,21}`, TDEF `{0,1,23,24}`, 50 + 71 distinct blobs sharing pages 0/1 → exactly **81**. Schema edited in place for that one field (sha `f88c1f9b…` → `e7b05454…`, pin updated in `a3_spec.py`); permitted because the dry-run report is a non-evidential calibration artifact; the nine evidence schemas and `plan.schema.json` are byte-identical.

- **R4-C01 record candidate count** — per independent review, the `sixteen_qualified_pages` divergence is a plan gap: R3-G08 per-(replica, page) counting gives 134,283,264 at 16+16 while `combined_record_candidate_bound`, `bounds.max_record_candidates`, the analysis-report schema max and `prefix_sum_work_model` are all 67,141,632 = 32 pages with no replica factor. R4-C01 supersedes the R3-G08/G03 sentences: the field and work units count each union qualified page once across derivation replicas; exact ceiling accepted; validator must also enforce `bounds.max_record_candidates`. No bound or evidence schema changes.

Not resolved here (analyzer defect against existing text, left to the analyzer lane): TDEF u24 pointer layout (87/89 cases).

Checks: `unittest discover -p 'test_a3_*.py'` 48 passed; `validate_repository_contract.py` passed; `acceptance.sh quick` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFeGTawS4oZNsiwa136BdG