### PR TITLE
feat: rebind independent validator to A3 R4

### DIFF
--- a/oracle/windows-dao/scripts/a3_independent_base.py
+++ b/oracle/windows-dao/scripts/a3_independent_base.py
@@ -19,10 +19,10 @@ class GlobalModel(Protocol):
     polarity: str
 
 
-def _no_layer(reason: str, predicate: str) -> dict[str, Any]:
+def _no_layer(reason: str, predicate: str, survivors: int = 0) -> dict[str, Any]:
     return {
         "applicable": True,
-        "derivation_survivor_count": 0,
+        "derivation_survivor_count": survivors,
         "model": None,
         "no_outcome_reason": reason,
         "terminal_predicate_id": predicate,
@@ -167,7 +167,7 @@ def _derive_replica(
     if not survivors:
         return _no_layer("no_extended_base_candidate", "A3-BASE-NONE")
     if len(survivors) > 1:
-        return _no_layer("multiple_extended_base_candidates", "A3-BASE-MULTIPLE")
+        return _no_layer("multiple_extended_base_candidates", "A3-BASE-MULTIPLE", len(survivors))
     return _model_layer({"extended_base_formula": next(iter(survivors))})
 
 
@@ -182,7 +182,7 @@ def derive_extended_base(
     if any(terminal is not None for terminal in terminals):
         if len(set(terminals)) == 1:
             return layers[0], terminals
-        return _no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+        return _no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT", layers[0]["derivation_survivor_count"]), terminals
     if any(layer["model"] != layers[0]["model"] for layer in layers[1:]):
-        return _no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+        return _no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT", 1), terminals
     return _model_layer(layers[0]["model"]), terminals

--- a/oracle/windows-dao/scripts/a3_independent_core.py
+++ b/oracle/windows-dao/scripts/a3_independent_core.py
@@ -174,14 +174,29 @@ def candidates_for_page(replica: Replica, page_number: int) -> tuple[set[GlobalC
     return candidates, seen
 
 
-def no_layer(reason: str | None, predicate: str | None, applicable: bool = True) -> dict[str, Any]:
+def no_layer(
+    reason: str | None,
+    predicate: str | None,
+    applicable: bool = True,
+    survivors: int = 0,
+) -> dict[str, Any]:
+    """A terminal layer; ``survivors`` is the R4-S01 count of the set the terminal classified."""
     return {
         "applicable": applicable,
-        "derivation_survivor_count": 0,
+        "derivation_survivor_count": survivors,
         "model": None,
         "no_outcome_reason": reason,
         "terminal_predicate_id": predicate,
     }
+
+
+def disagreement_layer(replica_1: dict[str, Any]) -> dict[str, Any]:
+    """A3-REPLICA-DISAGREEMENT carries replica 1's survivor count at its own stop (R4-S01)."""
+    return no_layer(
+        "replica_disagreement",
+        "A3-REPLICA-DISAGREEMENT",
+        survivors=replica_1["derivation_survivor_count"],
+    )
 
 
 def model_layer(model: dict[str, Any]) -> dict[str, Any]:
@@ -220,13 +235,13 @@ def _derive_global_record_replica(
         return no_layer(reason, predicate), None, transcript
     polarities = {candidate.polarity for candidate in found}
     if len(polarities) > 1:
-        return no_layer("multiple_bit_polarities_survive", "A3-POLARITY-MULTIPLE"), None, transcript
+        return no_layer("multiple_bit_polarities_survive", "A3-POLARITY-MULTIPLE", survivors=len(found)), None, transcript
     pages = {candidate.page for candidate in found}
     if len(pages) > 1:
-        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE"), None, transcript
+        return no_layer("multiple_physical_pages_satisfy_global_transition_predicates", "A3-GLOBAL-PAGE-MULTIPLE", survivors=len(found)), None, transcript
     starts = {candidate.start for candidate in found}
     if len(starts) > 1:
-        return no_layer("multiple_global_record_boundaries_survive", "A3-GLOBAL-RECORD-MULTIPLE"), None, transcript
+        return no_layer("multiple_global_record_boundaries_survive", "A3-GLOBAL-RECORD-MULTIPLE", survivors=len(found)), None, transcript
     candidate = next(iter(found))
     return model_layer(candidate.model()), candidate, transcript
 
@@ -248,14 +263,14 @@ def derive_global_record(
     if any(terminal is not None for terminal in terminals):
         if len(set(terminals)) == 1:
             return evaluations[0][0], None, transcript, terminals
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), None, transcript, terminals
+        return disagreement_layer(evaluations[0][0]), None, transcript, terminals
     candidates = [candidate for _, candidate, _ in evaluations]
     concrete = [candidate for candidate in candidates if candidate is not None]
     if len(concrete) != len(replicas) or any(
         _global_comparison_key(candidate) != _global_comparison_key(concrete[0])
         for candidate in concrete[1:]
     ):
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), None, transcript, terminals
+        return disagreement_layer(evaluations[0][0]), None, transcript, terminals
     candidate = GlobalCandidate(
         concrete[0].page,
         concrete[0].start,
@@ -402,15 +417,15 @@ def _derive_conversion_replica(
         return no_layer("missing_inline_to_indirect_conversion", "A3-CONVERSION-NONE"), cross
     class_changes = sum(left != right for left, right in zip(classes, classes[1:]))
     if class_changes != 1:
-        return no_layer("multiple_inline_to_indirect_conversions", "A3-CONVERSION-MULTIPLE"), cross
+        return no_layer("multiple_inline_to_indirect_conversions", "A3-CONVERSION-MULTIPLE", survivors=class_changes), cross
     conversion = window[first_indirect]
     slots = references[conversion]
     if sum(value != 0 for value in slots) == 0:
-        return no_layer("no_active_slot_at_conversion", "A3-SLOT-ACTIVATION"), cross
+        return no_layer("no_active_slot_at_conversion", "A3-SLOT-ACTIVATION", survivors=1), cross
     if sum(value != 0 for value in references["H_REL_0904"]) != 2:
-        return no_layer("final_slot_activation_not_two", "A3-SLOT-FINAL"), cross
+        return no_layer("final_slot_activation_not_two", "A3-SLOT-FINAL", survivors=1), cross
     if not _pointer_valid(replica, plan, references):
-        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY"), cross
+        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY", survivors=1), cross
     inline_phase = window[:first_indirect]
     boundary = _inline_boundary(replica, inline_phase, model)
     expected = 0xFF if model.polarity == "set_means_not_in_use" else 0x00
@@ -418,7 +433,7 @@ def _derive_conversion_replica(
         any(byte != expected for byte in _record_page(replica, checkpoint, model)[boundary:])
         for checkpoint in inline_phase
     ):
-        return no_layer("unexplained_nonzero_inline_suffix", "A3-INLINE-SUFFIX"), cross
+        return no_layer("unexplained_nonzero_inline_suffix", "A3-INLINE-SUFFIX", survivors=1), cross
     conversion_model = {
         "conversion_checkpoint_id": conversion,
         "conversion_ordinal": plan["checkpoint_design"]["checkpoint_ids"].index(conversion),
@@ -449,11 +464,11 @@ def derive_conversion(
     if any(terminal is not None for terminal in terminals):
         if len(set(terminals)) == 1:
             return evaluations[0][0], frozen_cross, terminals
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), frozen_cross, terminals
+        return disagreement_layer(evaluations[0][0]), frozen_cross, terminals
     models = [layer["model"] for layer, _ in evaluations]
     crosses = [cross for _, cross in evaluations]
     if any(value != models[0] for value in models[1:]) or any(value != crosses[0] for value in crosses[1:]):
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), frozen_cross, terminals
+        return disagreement_layer(evaluations[0][0]), frozen_cross, terminals
     return model_layer(models[0]), frozen_cross, terminals
 
 
@@ -628,19 +643,19 @@ def _derive_tdef_replica(replica: Replica, plan: dict[str, Any], qualified: list
     for page, start, _ in record_keys:
         starts_by_page.setdefault(page, set()).add(start)
     if len(starts_by_page) > 1:
-        return no_layer("multiple_physical_pages_satisfy_tdef_transition_predicates", "A3-TDEF-PAGE-MULTIPLE")
+        return no_layer("multiple_physical_pages_satisfy_tdef_transition_predicates", "A3-TDEF-PAGE-MULTIPLE", survivors=len(record_keys))
     if len(record_keys) > 1:
-        return no_layer("multiple_tdef_record_boundaries_survive", "A3-TDEF-RECORD-MULTIPLE")
+        return no_layer("multiple_tdef_record_boundaries_survive", "A3-TDEF-RECORD-MULTIPLE", survivors=len(record_keys))
     if len(models) > 1:
-        return no_layer("multiple_pointer_models_survive", "A3-POINTER-MULTIPLE")
+        return no_layer("multiple_pointer_models_survive", "A3-POINTER-MULTIPLE", survivors=len(models))
     model = next(iter(models))
     page, start, end, layout, growth_offset, churn_offset = model
     if not _reference_valid(replica, plan, page, growth_offset, layout) or not _reference_valid(
         replica, plan, page, churn_offset, layout
     ):
-        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY")
+        return no_layer("pointer_validity_failure", "A3-POINTER-VALIDITY", survivors=1)
     if not _tdef_structural_valid(replica, plan, model):
-        return no_layer("structural_field_exclusion_failure", "A3-STRUCTURAL-EXCLUSION")
+        return no_layer("structural_field_exclusion_failure", "A3-STRUCTURAL-EXCLUSION", survivors=1)
     return model_layer(
         {
             "record": {"page": page, "start": start, "end": end},
@@ -664,9 +679,9 @@ def derive_tdef(
     if any(terminal is not None for terminal in terminals):
         if len(set(terminals)) == 1:
             return layers[0], terminals
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+        return disagreement_layer(layers[0]), terminals
     if any(layer["model"] != layers[0]["model"] for layer in layers[1:]):
-        return no_layer("replica_disagreement", "A3-REPLICA-DISAGREEMENT"), terminals
+        return disagreement_layer(layers[0]), terminals
     return model_layer(layers[0]["model"]), terminals
 
 
@@ -717,12 +732,11 @@ def recompute_derivation(bundle: LoadedBundle) -> dict[str, Any]:
     else:
         base_layer, base_terminals = derive_extended_base(replicas, plan, global_model, conversion_layer["model"])
     tdef_layer, tdef_terminals = derive_tdef(replicas, plan, qualifications)
-    enumerations = sum(len(value["global_map"]) for value in qualifications.values())
-    enumerations += sum(
-        len(qualifications[replica.number]["tdef"])
-        for replica in replicas
-        if _tdef_precondition(replica)
-    )
+    # R4-C01: each union qualified page is counted once across derivation replicas;
+    # TDEF pages count when the churn precondition passed in at least one replica.
+    enumerations = len(union_qualified["global_map"])
+    if any(_tdef_precondition(replica) for replica in replicas):
+        enumerations += len(union_qualified["tdef"])
     return {
         "qualified_pages": union_qualified,
         "per_replica_qualified_pages": qualifications,

--- a/oracle/windows-dao/scripts/a3_independent_validator.py
+++ b/oracle/windows-dao/scripts/a3_independent_validator.py
@@ -42,6 +42,11 @@ LAYER_PATHS = {
 
 R2_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
 R3_SHA256 = "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a"
+R4_SHA256 = "939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea"
+REVISION_PATHS = {
+    "DAO-A3-ALLOCATION-MAPS-001-R2": "oracle/windows-dao/experiments/a3/a3-allocation-maps-r2.plan.json",
+    "DAO-A3-ALLOCATION-MAPS-001-R3": "oracle/windows-dao/experiments/a3/a3-allocation-maps-r3.plan.json",
+}
 R2_LAYER_NAME_MAP = {
     "global_map.record": "global_map_record",
     "global_map.conversion_inline": "global_map_conversion_inline",
@@ -61,7 +66,7 @@ def _repo_plan_path() -> Path:
 
 
 def _repo_revision_path() -> Path:
-    return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps-r3.plan.json"
+    return Path(__file__).resolve().parents[1] / "experiments" / "a3" / "a3-allocation-maps-r4.plan.json"
 
 
 def _load_predicate_sequences(
@@ -70,14 +75,17 @@ def _load_predicate_sequences(
     predicate_ids: list[str],
 ) -> tuple[list[str], dict[str, list[str]]]:
     revision, raw = load_json(revision_path, 67_108_864)
-    if sha256_bytes(raw) != R3_SHA256:
+    if sha256_bytes(raw) != R4_SHA256:
         raise ValidationError("predicate_revision_hash_mismatch")
+    original_path = "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json"
     try:
         original = revision["preregistration"]["original_plan"]
-        prior = revision["preregistration"]["prior_revision"]
-        prior_path = revision_path.with_name(Path(prior["path"]).name)
-        r2, r2_raw = load_json(prior_path, 67_108_864)
-        r2_original = r2["preregistration"]["original_plan"]
+        priors = {row["revision_id"]: row for row in revision["preregistration"]["prior_revisions"]}
+        r3_row = priors["DAO-A3-ALLOCATION-MAPS-001-R3"]
+        r2_row = priors["DAO-A3-ALLOCATION-MAPS-001-R2"]
+        r3, r3_raw = load_json(revision_path.with_name(Path(r3_row["path"]).name), 67_108_864)
+        r2, r2_raw = load_json(revision_path.with_name(Path(r2_row["path"]).name), 67_108_864)
+        r3_prior = r3["preregistration"]["prior_revision"]
         reconciliation = r2["predicate_evaluation_sequence_reconciliation"]
         campaign = reconciliation["campaign_evaluated_before_any_layer"]
         published_layers = reconciliation["per_layer_ordered_predicates"]
@@ -85,14 +93,22 @@ def _load_predicate_sequences(
         raise ValidationError("predicate_revision_contract_mismatch") from exc
     if (
         revision.get("document_type") != "dao_a3_allocation_maps_plan_revision"
-        or revision.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R3"
-        or original.get("path") != "oracle/windows-dao/experiments/a3/a3-allocation-maps.plan.json"
+        or revision.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R4"
+        or original.get("path") != original_path
         or original.get("sha256") != plan_sha256
-        or prior.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
-        or prior.get("sha256") != R2_SHA256
+        or len(priors) != 2
+        or r3_row.get("path") != REVISION_PATHS["DAO-A3-ALLOCATION-MAPS-001-R3"]
+        or r3_row.get("sha256") != R3_SHA256
+        or sha256_bytes(r3_raw) != R3_SHA256
+        or r3.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R3"
+        or r3["preregistration"].get("original_plan") != original
+        or r3_prior.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
+        or r3_prior.get("sha256") != R2_SHA256
+        or r2_row.get("path") != REVISION_PATHS["DAO-A3-ALLOCATION-MAPS-001-R2"]
+        or r2_row.get("sha256") != R2_SHA256
         or sha256_bytes(r2_raw) != R2_SHA256
         or r2.get("revision_id") != "DAO-A3-ALLOCATION-MAPS-001-R2"
-        or r2_original != original
+        or r2["preregistration"].get("original_plan") != original
         or not isinstance(campaign, list)
         or not all(isinstance(predicate, str) for predicate in campaign)
         or len(campaign) != len(set(campaign))
@@ -515,15 +531,22 @@ def verify_report_bounds(bundle: LoadedBundle, derivation: dict[str, Any]) -> No
     if bundle.report is None:
         raise ValidationError("analysis_report_missing")
     report = bundle.report
-    expected_records = (
-        derivation["record_candidate_enumerations"]
-        * bundle.plan["bounds"]["max_record_candidates_per_page"]
-    )
+    bounds = bundle.plan["bounds"]
+    # R4-C01: each union qualified page is charged once across derivation replicas.
+    pages = derivation["record_candidate_enumerations"]
+    expected_records = pages * bounds["max_record_candidates_per_page"]
+    if expected_records > bounds["max_record_candidates"]:
+        raise ValidationError("record_candidate_bound")
     if report["record_candidates_examined"] != expected_records:
         raise ValidationError("record_candidate_count_mismatch")
-    if report["candidate_models_examined"] > bundle.plan["bounds"]["max_candidate_models"]:
+    if report["candidate_models_examined"] > bounds["max_candidate_models"]:
         raise ValidationError("candidate_model_bound")
-    if report["analysis_work_units"] > bundle.plan["bounds"]["max_analysis_work_units"]:
+    # prefix_sum_work_model: at most eight units per enumerated interval and at most
+    # sixteen 2049-cell prefix arrays per union qualified page, charged once.
+    work_ceiling = 8 * expected_records + 16 * (bounds["page_size"] + 1) * pages
+    if work_ceiling > bounds["max_analysis_work_units"]:
+        raise ValidationError("analysis_work_bound")
+    if report["analysis_work_units"] > min(work_ceiling, bounds["max_analysis_work_units"]):
         raise ValidationError("analysis_work_bound")
 
 

--- a/oracle/windows-dao/tests/test_a3_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a3_independent_validator.py
@@ -14,13 +14,14 @@ from typing import Any, Callable
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 PLAN_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps.plan.json"
-R3_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps-r3.plan.json"
+R4_PATH = ROOT / "oracle" / "windows-dao" / "experiments" / "a3" / "a3-allocation-maps-r4.plan.json"
 sys.path.insert(0, str(SCRIPTS))
 
 from a3_independent_bundle import BundleLoader, ValidationError, canonical_json_bytes  # noqa: E402
 from a3_independent_core import recompute_derivation  # noqa: E402
 from a3_independent_validator import (  # noqa: E402
-    R3_SHA256,
+    R4_SHA256,
+    verify_report_bounds,
     _expected_predicate_statuses,
     _load_predicate_sequences,
     _validate_terminal_predicate_ids,
@@ -223,7 +224,7 @@ def _report(plan: dict[str, Any], plan_sha: str, frozen: dict[str, Any], frozen_
         "campaign_id": CAMPAIGN, "producer_commit": PRODUCER, "derivation_replicas": [1, 2],
         "holdout_replica": 3, "input_checkpoint_count": 75,
         "qualified_page_counts": {"global_map": 1, "tdef": 1}, "qualified_pages": frozen["qualified_pages"],
-        "record_candidates_examined": 4 * 2_098_176, "candidate_models_examined": 10,
+        "record_candidates_examined": 2 * 2_098_176, "candidate_models_examined": 10,
         "derivation_survivor_counts": {name: layer["derivation_survivor_count"] for name, layer in layers.items()},
         "derivation_candidate_set_sha256": frozen_sha, "polarity_cross_check": frozen["polarity_cross_check"],
         "analysis_work_units": 10_000_000, "holdout_structurally_validated_after_freeze": True,
@@ -476,16 +477,16 @@ class IndependentValidatorTests(unittest.TestCase):
             {"A3-POLARITY-CROSSCHECK", "A3-TDEF-RECORD-NONE"},
         )
 
-    def test_binds_published_r3_by_hash(self) -> None:
+    def test_binds_published_r4_by_hash(self) -> None:
         plan_raw = PLAN_PATH.read_bytes()
         plan_sha256 = hashlib.sha256(plan_raw).hexdigest()
         plan = json.loads(plan_raw)
         campaign, sequences = _load_predicate_sequences(
-            R3_PATH,
+            R4_PATH,
             plan_sha256,
             plan["predicate_registry"]["ids"],
         )
-        self.assertEqual(hashlib.sha256(R3_PATH.read_bytes()).hexdigest(), R3_SHA256)
+        self.assertEqual(hashlib.sha256(R4_PATH.read_bytes()).hexdigest(), R4_SHA256)
         self.assertEqual(campaign, ["A3-IDLE-EQUALITY", "A3-SNAPSHOT-RECONSTRUCTION", "A3-RESOURCE-BOUND"])
         self.assertEqual(
             set(sequences),
@@ -497,8 +498,8 @@ class IndependentValidatorTests(unittest.TestCase):
             },
         )
         with tempfile.TemporaryDirectory(prefix="a3-r2-") as directory:
-            mutated = Path(directory) / R3_PATH.name
-            mutated.write_bytes(R3_PATH.read_bytes() + b" ")
+            mutated = Path(directory) / R4_PATH.name
+            mutated.write_bytes(R4_PATH.read_bytes() + b" ")
             with self.assertRaisesRegex(ValidationError, "predicate_revision_hash_mismatch"):
                 _load_predicate_sequences(
                     mutated,
@@ -506,13 +507,52 @@ class IndependentValidatorTests(unittest.TestCase):
                     plan["predicate_registry"]["ids"],
                 )
 
+    def test_r4_c01_counts_each_union_page_once_and_enforces_record_bound(self) -> None:
+        bundle = BundleLoader(self.synthetic_bundle, PLAN_PATH).load()
+        derivation = recompute_derivation(bundle)
+        per_replica = derivation["per_replica_qualified_pages"]
+        self.assertEqual(per_replica[1], per_replica[2])
+        self.assertEqual(derivation["record_candidate_enumerations"], 2)
+        per_page = bundle.plan["bounds"]["max_record_candidates_per_page"]
+        verify_report_bounds(bundle, derivation)
+        bundle.report["record_candidates_examined"] = 4 * per_page
+        with self.assertRaisesRegex(ValidationError, "record_candidate_count_mismatch"):
+            verify_report_bounds(bundle, derivation)
+        bundle.report["record_candidates_examined"] = 2 * per_page
+        bundle.report["analysis_work_units"] = 8 * 2 * per_page + 16 * 2049 * 2 + 1
+        with self.assertRaisesRegex(ValidationError, "analysis_work_bound"):
+            verify_report_bounds(bundle, derivation)
+        ceiling = bundle.plan["bounds"]["max_record_candidates"]
+        self.assertEqual(ceiling, 32 * per_page)
+        derivation["record_candidate_enumerations"] = 32
+        bundle.report["record_candidates_examined"] = ceiling
+        bundle.report["analysis_work_units"] = 8 * ceiling + 16 * 2049 * 32
+        verify_report_bounds(bundle, derivation)
+        derivation["record_candidate_enumerations"] = 33
+        with self.assertRaisesRegex(ValidationError, "record_candidate_bound"):
+            verify_report_bounds(bundle, derivation)
+
+    def test_r4_s01_multiple_terminal_carries_multiplicity(self) -> None:
+        bundle = BundleLoader(self.synthetic_bundle, PLAN_PATH).load()
+        # Qualify a second global page whose record is a byte-identical copy of page 1 at every
+        # checkpoint, so two starts survive on two pages and stage 7 fires with two survivors.
+        for replica in (1, 2):
+            for checkpoint_id in CHECKPOINTS:
+                index = bundle.replicas[replica].indexes[checkpoint_id]["ordered_page_sha256"]
+                index[3] = index[1]
+        derivation = recompute_derivation(bundle)
+        layer = derivation["layers"]["global_map_record"]
+        self.assertEqual(layer["terminal_predicate_id"], "A3-GLOBAL-PAGE-MULTIPLE")
+        self.assertEqual(layer["derivation_survivor_count"], 2)
+        self.assertEqual(derivation["qualified_pages"]["global_map"], [1, 3])
+
     def test_idle_campaign_terminal_skips_all_layers(self) -> None:
         bundle = BundleLoader(self.synthetic_bundle, PLAN_PATH).load()
         idle_index = bundle.replicas[1].indexes["E0R"]["ordered_page_sha256"]
         idle_index[0] = idle_index[1]
         derivation = recompute_derivation(bundle)
         campaign, sequences = _load_predicate_sequences(
-            R3_PATH,
+            R4_PATH,
             hashlib.sha256(PLAN_PATH.read_bytes()).hexdigest(),
             bundle.plan["predicate_registry"]["ids"],
         )


### PR DESCRIPTION
Validator side of A3 R4 (#60), `a3_independent_*` only; stdlib; derived from plan text, no analyzer modules read.

- **R4 binding**: `--revision` defaults to `a3-allocation-maps-r4.plan.json`; loader checks R4 sha `939ce3ce…`, R4's `prior_revisions` paths/hashes for R3 (`bac37116…`) and R2 (`3feca409…`), R3's own `prior_revision` → R2, and still reads the R2 sequences. No dry-run schema hash is checked by the validator (it never loads that schema), so nothing to pin there.
- **R4-C01**: `record_candidate_enumerations` = union global pages + union TDEF pages when the churn precondition passed in ≥1 derivation replica. `verify_report_bounds` now rejects `record_candidate_bound` when the recomputed count exceeds `bounds.max_record_candidates`, and bounds `analysis_work_units` by the union-once `prefix_sum_work_model` ceiling (8 × records + 16 × 2049 × pages) as well as `max_analysis_work_units`.
- **R4-S01**: `no_layer` takes a survivor count; POLARITY/GLOBAL-PAGE/GLOBAL-RECORD-MULTIPLE carry the surviving candidate count, CONVERSION-MULTIPLE the class-change count, BASE-MULTIPLE the surviving formulas, TDEF-PAGE/RECORD-MULTIPLE the surviving records, POINTER-MULTIPLE the models; slot/suffix/validity/structural terminals carry 1; REPLICA-DISAGREEMENT carries replica 1's count at its own stop.
- Tests: fixture report now expects `2 × 2,098,176`; new tests for union-once counting, the exact 32-page ceiling accepted / 33 rejected, work-unit ceiling, and a two-page fixture reaching `A3-GLOBAL-PAGE-MULTIPLE` with `derivation_survivor_count` 2.

Checks: `test_a3_*` 52 passed; `validate_repository_contract.py` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFeGTawS4oZNsiwa136BdG