### PR TITLE
feat: rebind A3 analyzer to R4

### DIFF
--- a/oracle/windows-dao/scripts/a3_analysis.py
+++ b/oracle/windows-dao/scripts/a3_analysis.py
@@ -230,7 +230,7 @@ def _replica_call(
     except Abort as exc:
         if _is_campaign_abort(exc):
             raise
-        return ReplicaLayer(None, 0, exc, transcript)
+        return ReplicaLayer(None, exc.survivor_count, exc, transcript)
 
 
 def _same_model(
@@ -264,8 +264,8 @@ def _combine_replicas(
         terminal = terminals[0]
         return LayerDraft(
             None,
-            min(first.survivor_count, second.survivor_count),
-            Abort(terminal),
+            first.survivor_count,
+            Abort(terminal, first.survivor_count),
             True,
             _reached(layer, terminal),
         )
@@ -281,14 +281,20 @@ def _combine_replicas(
         default=sequence.index("A3-REPLICA-DISAGREEMENT"),
     )
     reached = frozenset((*sequence[:cutoff], "A3-REPLICA-DISAGREEMENT"))
-    return LayerDraft(None, 0, Abort("A3-REPLICA-DISAGREEMENT"), True, reached)
+    return LayerDraft(
+        None,
+        first.survivor_count,
+        Abort("A3-REPLICA-DISAGREEMENT", first.survivor_count),
+        True,
+        reached,
+    )
 
 
 def _global_replica(view: View, pages: tuple[int, ...]) -> ReplicaLayer:
     if not pages:
         return ReplicaLayer(None, 0, Abort("A3-GLOBAL-PAGE-NONE"))
     rows = {
-        page: global_start_candidates(view, page, enumerate_candidates=True)
+        page: global_start_candidates(view, page, enumerate_candidates=False)
         for page in pages
     }
     nonempty = {page: models for page, (models, _evidence) in rows.items() if models}
@@ -318,7 +324,7 @@ def _conversion_replica(view: View, model: GlobalRecordModel) -> ReplicaLayer:
     except Abort as exc:
         if _is_campaign_abort(exc):
             raise
-        return ReplicaLayer(None, 0, exc)
+        return ReplicaLayer(None, exc.survivor_count, exc)
     if transcript.first_violating_leg is not None:
         return ReplicaLayer(None, 0, Abort("A3-POLARITY-CROSSCHECK"), transcript)
     return _replica_call(
@@ -345,7 +351,7 @@ def _tdef_replica(
             view,
             pages,
             churn_precondition_met,
-            enumerate_candidates=True,
+            enumerate_candidates=False,
         )[0]
     )
 
@@ -359,6 +365,7 @@ def derive_layers(derivation: list[ReplicaInput], work: WorkCounter) -> tuple[di
     pages = candidate_page_space(views)
     global_by_replica = tuple(qualify_global_pages(view, pages) for view in views)
     global_pages = _qualified_union((global_by_replica[0], global_by_replica[1]))
+    work.enumerate_pages(len(global_pages))
     global_outcomes = tuple(
         _global_replica(view, global_by_replica[index])
         for index, view in enumerate(views)
@@ -398,6 +405,8 @@ def derive_layers(derivation: list[ReplicaInput], work: WorkCounter) -> tuple[di
             drafts["global_map_extended_base"] = _not_applicable()
     tdef_by_replica = tuple(qualify_tdef_pages(view, pages) for view in views)
     tdef_pages = _qualified_union((tdef_by_replica[0], tdef_by_replica[1]))
+    if any(row.churn_precondition_met for row in derivation):
+        work.enumerate_pages(len(tdef_pages), prefix_arrays_per_page=1)
     tdef_outcomes = tuple(
         _tdef_replica(
             view,

--- a/oracle/windows-dao/scripts/a3_layers.py
+++ b/oracle/windows-dao/scripts/a3_layers.py
@@ -153,7 +153,7 @@ def polarity_cross_check(view: View, model: GlobalRecordModel) -> CrossCheckTran
         evaluated.append(leg)
         for page in required:
             if page >= 65536:
-                raise Abort("A3-POINTER-VALIDITY")
+                raise Abort("A3-POINTER-VALIDITY", 1)
             if _bit(left, page) is not False or _bit(right, page) is not True:
                 return CrossCheckTranscript(tuple(evaluated), None, leg, page)
     return CrossCheckTranscript(tuple(evaluated), None, None, None)
@@ -179,8 +179,16 @@ def _classification(view: View, model: GlobalRecordModel, checkpoint: str) -> st
 
 
 def conversion_checkpoint(view: View, model: GlobalRecordModel) -> str:
-    classes = [_classification(view, model, checkpoint) for checkpoint in CONVERSION_WINDOW]
+    classes = _conversion_classes(view, model)
     return CONVERSION_WINDOW[conversion_index(classes)]
+
+
+def _conversion_classes(view: View, model: GlobalRecordModel) -> tuple[str, ...]:
+    return tuple(_classification(view, model, checkpoint) for checkpoint in CONVERSION_WINDOW)
+
+
+def _class_change_count(classes: Sequence[str]) -> int:
+    return sum(left != right for left, right in zip(classes, classes[1:]))
 
 
 def conversion_index(classes: Sequence[str]) -> int:
@@ -189,9 +197,9 @@ def conversion_index(classes: Sequence[str]) -> int:
     if not indirect or not any(kind == "inline" for kind in classes[: indirect[0]]):
         raise Abort("A3-CONVERSION-NONE")
     at = indirect[0]
-    changes = sum(left != right for left, right in zip(classes, classes[1:]))
+    changes = _class_change_count(classes)
     if changes != 1:
-        raise Abort("A3-CONVERSION-MULTIPLE")
+        raise Abort("A3-CONVERSION-MULTIPLE", changes)
     return at
 
 
@@ -227,7 +235,7 @@ def validate_references(
                 continue
             payload = view.page_optional(checkpoint, record_page)
             if payload is None:
-                raise Abort("A3-POINTER-VALIDITY")
+                raise Abort("A3-POINTER-VALIDITY", 1)
             if indirect_start is not None and payload[indirect_start] != 1:
                 continue
             reference = int.from_bytes(payload[offset:offset + width], "little")
@@ -240,7 +248,7 @@ def validate_references(
                 or referenced is None
                 or referenced[0] != 0x05
             ):
-                raise Abort("A3-POINTER-VALIDITY")
+                raise Abort("A3-POINTER-VALIDITY", 1)
 
 
 def inline_boundary(view: View, model: GlobalRecordModel, conversion: str) -> int:
@@ -250,7 +258,9 @@ def inline_boundary(view: View, model: GlobalRecordModel, conversion: str) -> in
     inline_names = CONVERSION_WINDOW[:at]
     payloads = {name: view.page_optional(name, page) for name in inline_names}
     if any(payload is None for payload in payloads.values()):
-        raise Abort("A3-CONVERSION-MULTIPLE")
+        classes = [_classification(view, model, checkpoint) for checkpoint in CONVERSION_WINDOW]
+        changes = sum(left != right for left, right in zip(classes, classes[1:]))
+        raise Abort("A3-CONVERSION-MULTIPLE", changes)
     checked = {name: payload for name, payload in payloads.items() if payload is not None}
     boundary = max(
         start
@@ -270,7 +280,7 @@ def inline_boundary(view: View, model: GlobalRecordModel, conversion: str) -> in
         for payload in checked.values()
         for value in payload[boundary:end]
     ):
-        raise Abort("A3-INLINE-SUFFIX")
+        raise Abort("A3-INLINE-SUFFIX", 1)
     return boundary
 
 
@@ -291,16 +301,18 @@ def derive_conversion(
     transcript = transcript or polarity_cross_check(view, model)
     if transcript.first_violating_leg is not None:
         raise Abort("A3-POLARITY-CROSSCHECK")
-    conversion = conversion_checkpoint(view, model)
+    classes = _conversion_classes(view, model)
+    changes = _class_change_count(classes)
+    conversion = CONVERSION_WINDOW[conversion_index(classes)]
     payload = view.page_optional(conversion, model.record.page)
     if payload is None:
-        raise Abort("A3-CONVERSION-MULTIPLE")
+        raise Abort("A3-CONVERSION-MULTIPLE", changes)
     state = indirect_state(payload, model.record.start, model.record.end)
     if state is None:
-        raise Abort("A3-CONVERSION-MULTIPLE")
+        raise Abort("A3-CONVERSION-MULTIPLE", changes)
     active = sum(value != 0 for value in state.slots)
     if active == 0:
-        raise Abort("A3-SLOT-ACTIVATION")
+        raise Abort("A3-SLOT-ACTIVATION", 1)
     final_payload = view.page_optional("H_REL_0904", model.record.page)
     final_state = (
         None
@@ -308,7 +320,7 @@ def derive_conversion(
         else indirect_state(final_payload, model.record.start, model.record.end)
     )
     if final_state is None or sum(value != 0 for value in final_state.slots) != 2:
-        raise Abort("A3-SLOT-FINAL")
+        raise Abort("A3-SLOT-FINAL", 1)
     start = model.record.start
     validate_references(
         view, model.record.page, ((start + 1, 4, 0), (start + 5, 4, 1)),
@@ -413,7 +425,6 @@ def formula_holds(
             end_representable = min(EXTENDED_BITS, 65536 - origin)
             if not _zero_range(bits, first_beyond, end_representable):
                 return False
-    view.work.charge(bin(flips).count("1") + len(VALIDITY_CHECKPOINTS))
     return True
 
 
@@ -430,7 +441,7 @@ def derive_base(view: View, model: GlobalRecordModel, conversion: ConversionMode
     if not survivors:
         raise Abort("A3-BASE-NONE")
     if len(survivors) > 1:
-        raise Abort("A3-BASE-MULTIPLE")
+        raise Abort("A3-BASE-MULTIPLE", len(survivors))
     return BaseModel(survivors[0])
 
 
@@ -493,14 +504,24 @@ def _stable_byte(view: View, page: int, offset: int) -> bool:
     }) == 1
 
 
-def tdef_models(view: View, page: int, windows: WindowCandidates) -> tuple[TdefModel, ...]:
+def tdef_models(
+    view: View,
+    page: int,
+    windows: WindowCandidates,
+    *,
+    charge_work: bool = True,
+) -> tuple[TdefModel, ...]:
     payloads = [view.page_optional(checkpoint, page) for checkpoint in CHECKPOINT_IDS]
     if any(payload is None for payload in payloads):
         return ()
-    changed = Prefix.from_flags([
-        len({payload[offset] for payload in payloads if payload is not None}) > 1
-        for offset in range(PAGE_SIZE)
-    ], view.work)
+    changed = Prefix.from_flags(
+        [
+            len({payload[offset] for payload in payloads if payload is not None}) > 1
+            for offset in range(PAGE_SIZE)
+        ],
+        view.work,
+        charge_work=charge_work,
+    )
     models: list[TdefModel] = []
     for layout in POINTER_LAYOUTS:
         for growth in windows.growth[layout]:
@@ -572,22 +593,30 @@ def derive_tdef_candidates(view: View, pages: Sequence[int], churn_precondition_
         raise Abort("A3-GROWTH-POINTER-NONE")
     if not any(any(window.churn.values()) for window in all_windows.values()):
         raise Abort("A3-CHURN-POINTER-NONE")
-    per_page = {page: tdef_models(view, page, window) for page, window in all_windows.items()}
+    per_page = {
+        page: tdef_models(
+            view,
+            page,
+            window,
+            charge_work=enumerate_candidates,
+        )
+        for page, window in all_windows.items()
+    }
     total = [model for models in per_page.values() for model in models]
     if not total:
         raise Abort("A3-TDEF-RECORD-NONE")
     record_pages = {model.record.page for model in total}
     records = {model.record for model in total}
     if len(record_pages) > 1:
-        raise Abort("A3-TDEF-PAGE-MULTIPLE")
+        raise Abort("A3-TDEF-PAGE-MULTIPLE", len(records))
     if len(records) > 1:
-        raise Abort("A3-TDEF-RECORD-MULTIPLE")
+        raise Abort("A3-TDEF-RECORD-MULTIPLE", len(records))
     if len(total) > 1:
-        raise Abort("A3-POINTER-MULTIPLE")
+        raise Abort("A3-POINTER-MULTIPLE", len(total))
     if not _tdef_valid(view, total[0]):
-        raise Abort("A3-POINTER-VALIDITY")
+        raise Abort("A3-POINTER-VALIDITY", 1)
     if not _tdef_structural(view, total[0]):
-        raise Abort("A3-STRUCTURAL-EXCLUSION")
+        raise Abort("A3-STRUCTURAL-EXCLUSION", 1)
     return tuple(total)
 
 
@@ -661,7 +690,7 @@ def predicts_tdef(view: View, frozen: TdefModel, churn_precondition_met: bool) -
         },
     )
     return (
-        tdef_models(view, page, windows) == (frozen,)
+        tdef_models(view, page, windows, charge_work=False) == (frozen,)
         and _tdef_valid(view, frozen)
         and _tdef_structural(view, frozen)
     )

--- a/oracle/windows-dao/scripts/a3_model.py
+++ b/oracle/windows-dao/scripts/a3_model.py
@@ -49,12 +49,15 @@ class ReplicaData(Protocol):
 
 class Abort(Exception):
     """One registered A3 terminal with its stable reason and literal layer."""
-    def __init__(self, predicate_id: str) -> None:
+    def __init__(self, predicate_id: str, survivor_count: int = 0) -> None:
         try:
             self.reason, self.registered_layer = PREDICATES[predicate_id]
         except KeyError as exc:
             raise ValueError(f"unregistered A3 predicate {predicate_id!r}") from exc
+        if isinstance(survivor_count, bool) or not isinstance(survivor_count, int) or survivor_count < 0:
+            raise ValueError("A3 survivor count must be a nonnegative integer")
         self.predicate_id = predicate_id
+        self.survivor_count = survivor_count
         super().__init__(f"{predicate_id}: {self.reason}")
 
 
@@ -72,10 +75,18 @@ class WorkCounter:
         self.value += units
 
     def enumerate_intervals(self) -> None:
-        if self.record_candidates + PER_PAGE_CANDIDATES > MAX_RECORD_CANDIDATES:
+        self.enumerate_pages(1)
+
+    def enumerate_pages(self, count: int, *, prefix_arrays_per_page: int = 0) -> None:
+        values = (count, prefix_arrays_per_page)
+        if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in values):
             raise Abort("A3-RESOURCE-BOUND")
-        self.record_candidates += PER_PAGE_CANDIDATES
-        self.charge(PER_PAGE_CANDIDATES * 8)
+        candidates = count * PER_PAGE_CANDIDATES
+        if self.record_candidates + candidates > MAX_RECORD_CANDIDATES:
+            raise Abort("A3-RESOURCE-BOUND")
+        prefix_cells = count * prefix_arrays_per_page * (PAGE_SIZE + 1)
+        self.charge(candidates * 8 + prefix_cells)
+        self.record_candidates += candidates
 
     def examine_models(self, count: int = 1) -> None:
         if count < 0 or self.candidate_models + count > MAX_CANDIDATE_MODELS:
@@ -143,7 +154,6 @@ class View:
 
     def idle_pairs_identical(self) -> bool:
         for left, right in IDLE_PAIRS:
-            self.work.charge(1)
             if self.hashes(left) != self.hashes(right):
                 return False
         return True
@@ -154,13 +164,20 @@ class Prefix:
     cells: tuple[int, ...]
 
     @classmethod
-    def from_flags(cls, flags: Sequence[bool], work: WorkCounter) -> "Prefix":
+    def from_flags(
+        cls,
+        flags: Sequence[bool],
+        work: WorkCounter,
+        *,
+        charge_work: bool = True,
+    ) -> "Prefix":
         if len(flags) != PAGE_SIZE:
             raise Abort("A3-SNAPSHOT-RECONSTRUCTION")
         cells = [0]
         for flag in flags:
             cells.append(cells[-1] + int(flag))
-        work.charge(PAGE_SIZE + 1)
+        if charge_work:
+            work.charge(PAGE_SIZE + 1)
         return cls(tuple(cells))
 
     def count(self, start: int, end: int) -> int:
@@ -198,7 +215,6 @@ def candidate_page_space(views: Sequence[View]) -> range:
 
 def qualify_global_pages(view: View, pages: Sequence[int]) -> tuple[int, ...]:
     qualified = tuple(page for page in pages if view.hash_at("E0", page) != view.hash_at("D_GROW_0128", page) and view.hash_at("D_GROW_0128", page) != view.hash_at("D_DROP", page))
-    view.work.charge(len(pages) * 2)
     if len(qualified) > MAX_QUALIFIED_PAGES:
         raise Abort("A3-RESOURCE-BOUND")
     return qualified
@@ -211,7 +227,6 @@ def qualify_tdef_pages(view: View, pages: Sequence[int]) -> tuple[int, ...]:
             continue
         growth = any(view.hash_at(a, page) != view.hash_at(b, page) for a, b in GROWTH_TRANSITIONS)
         churn = all(view.hash_at(a, page) != view.hash_at(b, page) for a, b in CHURN_TRANSITIONS)
-        view.work.charge(len(GROWTH_TRANSITIONS) + len(CHURN_TRANSITIONS))
         if growth and churn:
             qualified.append(page)
     if len(qualified) > MAX_QUALIFIED_PAGES:
@@ -420,10 +435,10 @@ def derive_global_record(view: View, page: int, *, enumerate_candidates: bool = 
     if not polarities:
         raise Abort("A3-POLARITY-NONE")
     if len(polarities) > 1:
-        raise Abort("A3-POLARITY-MULTIPLE")
+        raise Abort("A3-POLARITY-MULTIPLE", len(pairs))
     starts = {start for start, _ in pairs}
     if len(starts) > 1:
-        raise Abort("A3-GLOBAL-RECORD-MULTIPLE")
+        raise Abort("A3-GLOBAL-RECORD-MULTIPLE", len(starts))
     return models[0]
 
 
@@ -434,12 +449,12 @@ def resolve_page_models(survivors: Mapping[int, Sequence[T]], page_multiple: str
     """Apply the plan's page-multiplicity test before within-page multiplicity."""
     nonempty = {page: tuple(values) for page, values in survivors.items() if values}
     if len(nonempty) > 1:
-        raise Abort(page_multiple)
+        raise Abort(page_multiple, sum(len(values) for values in nonempty.values()))
     if not nonempty:
         return None
     values = next(iter(nonempty.values()))
     if len(values) > 1:
-        raise Abort(record_multiple)
+        raise Abort(record_multiple, len(values))
     return values[0]
 
 

--- a/oracle/windows-dao/scripts/a3_spec.py
+++ b/oracle/windows-dao/scripts/a3_spec.py
@@ -3,7 +3,7 @@
 
 A3 rule | implementation
 --- | ---
-Base + R2 + R3 hash binding | :func:`load_checked_plan`, :func:`load_checked_revisions`
+Base + R2 + R3 + R4 hash binding | :func:`load_checked_plan`, :func:`load_checked_revisions`
 R2 order with R3-G03 disagreement reach | :func:`project_predicate_results`
 R3-G08 ordered reasons and holdout fields | :func:`validate_analysis_report`
 R3-M05 campaign-terminal projection | :func:`project_predicate_results`
@@ -35,9 +35,11 @@ CHECKED_R2_PLAN = A3_ROOT / "a3-allocation-maps-r2.plan.json"
 R2_PLAN_SHA256 = "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1"
 CHECKED_R3_PLAN = A3_ROOT / "a3-allocation-maps-r3.plan.json"
 R3_PLAN_SHA256 = "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a"
+CHECKED_R4_PLAN = A3_ROOT / "a3-allocation-maps-r4.plan.json"
+R4_PLAN_SHA256 = "939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea"
 PAIR_REVIEW = A3_ROOT / "design-inputs" / "fable-a3-pair-review.md"
 PAIR_REVIEW_SHA256 = "70b9717d3b3387cbd2d4f1ceec3c8deff4f7706563af07eb2c5e77a6c05eab65"
-REVISION_PLAN_SHA256 = R3_PLAN_SHA256
+REVISION_PLAN_SHA256 = R4_PLAN_SHA256
 EXPERIMENT_ID = "DAO-A3-ALLOCATION-MAPS-001"
 
 _SCHEMA_FILES = {
@@ -181,8 +183,8 @@ def _load_revision(path: Path, sha256: str, revision_id: str) -> dict[str, Any]:
 
 def load_checked_revisions(
     plan: CheckedPlan = PLAN,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Load the exact R2 order and R3 operational reconciliation."""
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load the exact R2 order and R3/R4 operational reconciliations."""
     r2 = _load_revision(CHECKED_R2_PLAN, R2_PLAN_SHA256, "DAO-A3-ALLOCATION-MAPS-001-R2")
     registry_ids = set(plan.predicate_ids)
     reconciliation = r2["predicate_evaluation_sequence_reconciliation"]
@@ -213,11 +215,31 @@ def load_checked_revisions(
     require_equal(_sha256(PAIR_REVIEW), PAIR_REVIEW_SHA256, "pair-review file sha256")
     gaps = r3["layer_semantics_reconciliation"]["gaps"]
     require_equal([row["gap_id"] for row in gaps], [f"R3-G{i:02d}" for i in range(1, 11)], "R3 gap ids")
-    return r2, r3
+    r4 = _load_revision(CHECKED_R4_PLAN, R4_PLAN_SHA256, "DAO-A3-ALLOCATION-MAPS-001-R4")
+    prior_revisions = r4["preregistration"]["prior_revisions"]
+    require_equal(
+        [(row["revision_id"], row["sha256"]) for row in prior_revisions],
+        [(r2["revision_id"], R2_PLAN_SHA256), (r3["revision_id"], R3_PLAN_SHA256)],
+        "R4 prior revisions",
+    )
+    survivor_rows = r4["survivor_count_reconciliation"]["per_terminal_counts"]
+    require_equal(set(survivor_rows), set(sequences), "R4 survivor-count layer set")
+    for layer, rows in survivor_rows.items():
+        require_equal(
+            [row["predicate_id"] for row in rows],
+            sequences[layer],
+            f"R4 {layer} survivor-count sequence",
+        )
+    require_equal(
+        r4["record_candidate_count_reconciliation"]["gap_id"],
+        "R4-C01",
+        "R4 record-candidate reconciliation",
+    )
+    return r2, r3, r4
 
 
-R2_PLAN, R3_PLAN = load_checked_revisions()
-REVISION_PLAN = R3_PLAN
+R2_PLAN, R3_PLAN, R4_PLAN = load_checked_revisions()
+REVISION_PLAN = R4_PLAN
 CHECKPOINT_IDS = PLAN.checkpoint_ids
 CHECKPOINT_ORDINALS = PLAN.checkpoint_ordinals
 PREDICATE_IDS = PLAN.predicate_ids

--- a/oracle/windows-dao/tests/test_a3_analyzer.py
+++ b/oracle/windows-dao/tests/test_a3_analyzer.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(SCRIPTS))
 from protocol_validation import ValidationError  # noqa: E402
 from a3_analysis import (  # noqa: E402
     LoadedReplicaSource, ReplicaInput, ReplicaLayer, _combine_replicas,
-    _same_model, build_analysis,
+    _qualified_union, _same_model, build_analysis, recompute_only,
 )
 from a3_generator import (  # noqa: E402
     calibration_parameters, generate_synthetic_bundle, generate_synthetic_bundles,
@@ -28,12 +28,13 @@ from a3_layers import (  # noqa: E402
     pointer_windows, polarity_cross_check,
 )
 from a3_model import (  # noqa: E402
-    CHECKPOINT_IDS, Abort, GlobalRecordModel, Record, View, WorkCounter,
+    CHECKPOINT_IDS, MAX_QUALIFIED_PAGES, MAX_RECORD_CANDIDATES, PAGE_SIZE,
+    PER_PAGE_CANDIDATES, Abort, GlobalRecordModel, Record, View, WorkCounter,
     decode_inline, global_start_candidates,
 )
 from a3_spec import (  # noqa: E402
     LAYER_PREDICATE_SEQUENCES, PLAN_SHA256, PREDICATES, PREDICATE_IDS,
-    R2_PLAN_SHA256, R3_PLAN_SHA256, REVISION_PLAN_SHA256,
+    R2_PLAN_SHA256, R3_PLAN_SHA256, R4_PLAN_SHA256, REVISION_PLAN_SHA256,
     compare_frozen_to_report, load_bounded_json,
     project_predicate_results, validate_analysis_report,
     validate_predicate_reporting,
@@ -60,6 +61,21 @@ class A3AnalyzerTests(unittest.TestCase):
         report, frozen, _ = self.analyze()
         compare_frozen_to_report(frozen, report)
         validate_analysis_report(report, frozen)
+        union_pages = sum(report["qualified_page_counts"].values())
+        self.assertEqual(
+            report["record_candidates_examined"],
+            union_pages * PER_PAGE_CANDIDATES,
+        )
+        self.assertEqual(
+            report["analysis_work_units"],
+            8 * report["record_candidates_examined"]
+            + (PAGE_SIZE + 1) * report["qualified_page_counts"]["tdef"],
+        )
+        self.assertLessEqual(
+            report["analysis_work_units"],
+            8 * report["record_candidates_examined"]
+            + 16 * (PAGE_SIZE + 1) * union_pages,
+        )
 
     def test_global_start_uses_tag_base_highwater_and_sentinel(self) -> None:
         bundle = generate_synthetic_bundle()
@@ -139,6 +155,52 @@ class A3AnalyzerTests(unittest.TestCase):
         with self.assertRaises(Abort) as caught:
             derive_tdef_candidates(view, (modified.tdef_page,), True)
         self.assertEqual(caught.exception.predicate_id, "A3-STRUCTURAL-EXCLUSION")
+        self.assertEqual(caught.exception.survivor_count, 1)
+
+    def test_r4_candidate_charging_accepts_exact_ceiling_and_rejects_one_over(self) -> None:
+        work = WorkCounter()
+        work.enumerate_pages(MAX_QUALIFIED_PAGES)
+        work.enumerate_pages(MAX_QUALIFIED_PAGES, prefix_arrays_per_page=1)
+        self.assertEqual(work.record_candidates, MAX_RECORD_CANDIDATES)
+        self.assertEqual(
+            work.value,
+            MAX_RECORD_CANDIDATES * 8 + MAX_QUALIFIED_PAGES * (PAGE_SIZE + 1),
+        )
+        with self.assertRaises(Abort) as candidate_bound:
+            work.enumerate_pages(1)
+        self.assertEqual(candidate_bound.exception.predicate_id, "A3-RESOURCE-BOUND")
+        with self.assertRaises(Abort) as qualified_bound:
+            pages = tuple(range(MAX_QUALIFIED_PAGES + 1))
+            _qualified_union((pages, pages))
+        self.assertEqual(qualified_bound.exception.predicate_id, "A3-RESOURCE-BOUND")
+
+    def test_r4_tdef_union_is_charged_when_either_precondition_passes(self) -> None:
+        bundles = generate_synthetic_bundles(calibration_parameters())[:2]
+
+        def inputs(preconditions: tuple[bool, bool]) -> list[ReplicaInput]:
+            return [
+                ReplicaInput(
+                    bundle,
+                    bundle.replica,
+                    bundle.campaign_id,
+                    bundle.producer_commit,
+                    bundle.provider_sha256,
+                    precondition,
+                )
+                for bundle, precondition in zip(bundles, preconditions)
+            ]
+
+        neither = recompute_only(inputs((False, False)))
+        either = recompute_only(inputs((True, False)))
+        self.assertEqual(
+            neither["record_candidates_examined"],
+            len(neither["qualified_pages"]["global_map"]) * PER_PAGE_CANDIDATES,
+        )
+        self.assertEqual(
+            either["record_candidates_examined"],
+            sum(len(pages) for pages in either["qualified_pages"].values())
+            * PER_PAGE_CANDIDATES,
+        )
 
     def test_holdout_reporting_exception_and_t5_rejection(self) -> None:
         rows = [
@@ -157,7 +219,7 @@ class A3AnalyzerTests(unittest.TestCase):
             "b16f78436bdfea701451880a9b761b3e3aaf1b3ea0b62fef32a6afde22e05cb1",
         )
 
-    def test_r2_r3_hashes_and_tdef_sequence_are_bound(self) -> None:
+    def test_r2_r3_r4_hashes_and_tdef_sequence_are_bound(self) -> None:
         self.assertEqual(
             R2_PLAN_SHA256,
             "3feca409d07bd748954902c51c44f85d7c0708c1af9a99a53f96db2d87ea3bc1",
@@ -166,7 +228,11 @@ class A3AnalyzerTests(unittest.TestCase):
             R3_PLAN_SHA256,
             "bac371167fa67e92e87649e3f28c338ccc6ca57a668da496dfa084c42ce1996a",
         )
-        self.assertEqual(REVISION_PLAN_SHA256, R3_PLAN_SHA256)
+        self.assertEqual(
+            R4_PLAN_SHA256,
+            "939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea",
+        )
+        self.assertEqual(REVISION_PLAN_SHA256, R4_PLAN_SHA256)
         sequence = LAYER_PREDICATE_SEQUENCES["tdef_pointer_pair"]
         self.assertLess(
             sequence.index("A3-TDEF-RECORD-NONE"),
@@ -217,6 +283,27 @@ class A3AnalyzerTests(unittest.TestCase):
         with self.assertRaises(Abort) as multiple:
             conversion_index(("inline", "neither", "indirect"))
         self.assertEqual(multiple.exception.predicate_id, "A3-CONVERSION-MULTIPLE")
+        self.assertEqual(multiple.exception.survivor_count, 2)
+
+    def test_r4_survivor_count_uses_replica_one_stopping_set(self) -> None:
+        same_terminal = _combine_replicas(
+            "global_map_record",
+            (
+                ReplicaLayer(None, 3, Abort("A3-GLOBAL-RECORD-MULTIPLE", 3)),
+                ReplicaLayer(None, 2, Abort("A3-GLOBAL-RECORD-MULTIPLE", 2)),
+            ),
+        )
+        self.assertEqual(same_terminal.survivor_count, 3)
+        model = ConversionModel("P_ABS_16480", 20, 1, 2, 2, 2020, (14848, 16352))
+        disagreement = _combine_replicas(
+            "global_map_conversion_inline",
+            (
+                ReplicaLayer(model, 1, None),
+                ReplicaLayer(None, 0, Abort("A3-CONVERSION-NONE")),
+            ),
+        )
+        self.assertEqual(disagreement.abort.predicate_id, "A3-REPLICA-DISAGREEMENT")
+        self.assertEqual(disagreement.survivor_count, 1)
 
     def test_r3_m1_m2_disagreement_statuses_stop_before_earliest_terminal(self) -> None:
         model = ConversionModel("P_ABS_16480", 20, 1, 2, 2, 2020, (14848, 16352))
@@ -224,7 +311,7 @@ class A3AnalyzerTests(unittest.TestCase):
             (ReplicaLayer(None, 0, Abort("A3-CONVERSION-NONE")), ReplicaLayer(model, 1, None)),
             (
                 ReplicaLayer(None, 0, Abort("A3-CONVERSION-NONE")),
-                ReplicaLayer(None, 0, Abort("A3-CONVERSION-MULTIPLE")),
+                ReplicaLayer(None, 2, Abort("A3-CONVERSION-MULTIPLE", 2)),
             ),
         )
         for outcomes in cases:


### PR DESCRIPTION
## Summary

- bind the analyzer to A3 R4 SHA-256 `939ce3ceef035b9da0e4527f1ffd9ddd6b21e23f088f867c56172f84650332ea`
- implement R4-C01 union-qualified-page charging for record candidates and prefix work, including the any-replica TDEF precondition rule
- implement R4-S01 survivor counts from replica 1’s stopping candidate set
- keep campaign bounds fail-closed while accepting the exact 16+16 candidate ceiling

## Validation

- `python3 -m unittest tests.test_a3_analyzer` — 19 passed
- focused probe: 1 global + 1 TDEF union page reports 4,196,352 candidates

## Scope

Production changes are limited to `a3_analysis.py`, `a3_layers.py`, `a3_model.py`, and `a3_spec.py`. No independent validator, generator, or dry-run files changed.