### PR TITLE
fix: make validator T5 flip a nonterminal predicate

### DIFF
--- a/oracle/windows-dao/scripts/a3_independent_validator.py
+++ b/oracle/windows-dao/scripts/a3_independent_validator.py
@@ -629,6 +629,29 @@ def _set_tampered_layer(
     bundle.report["derivation_survivor_counts"][name] = 0
 
 
+def _t5_target(report: dict[str, Any]) -> str:
+    """T5 flips a nonterminal predicate result: A3-HOLDOUT-PREDICTION when it is nonterminal
+    (a decisive report), otherwise the first other nonterminal evaluated predicate."""
+    statuses = {item["predicate_id"]: item["status"] for item in report["predicate_results"]}
+    if statuses.get("A3-HOLDOUT-PREDICTION") == "pass":
+        return "A3-HOLDOUT-PREDICTION"
+    for item in report["predicate_results"]:
+        if item["status"] == "pass":
+            return item["predicate_id"]
+    raise ValidationError("tamper_suite_not_executable", "T5")
+
+
+def _tamper_t5(bundle: LoadedBundle) -> tuple[LoadedBundle, str]:
+    if bundle.report is None:
+        raise ValidationError("tamper_suite_not_executable", "T5")
+    t5 = _tamper_bundle(bundle)
+    target = _t5_target(t5.report)
+    next(item for item in t5.report["predicate_results"] if item["predicate_id"] == target)["status"] = "fail"
+    if target not in t5.report["terminal_predicate_ids"]:
+        t5.report["terminal_predicate_ids"].append(target)
+    return t5, target
+
+
 def _execute_tamper_suite(
     bundle: LoadedBundle,
     campaign_predicates: list[str],
@@ -681,13 +704,7 @@ def _execute_tamper_suite(
     _relink_tamper(t4)
     variants.append(("T4", t4))
 
-    t5 = _tamper_bundle(bundle)
-    holdout = next(
-        item for item in t5.report["predicate_results"] if item["predicate_id"] == "A3-HOLDOUT-PREDICTION"
-    )
-    holdout["status"] = "fail"
-    if "A3-HOLDOUT-PREDICTION" not in t5.report["terminal_predicate_ids"]:
-        t5.report["terminal_predicate_ids"].append("A3-HOLDOUT-PREDICTION")
+    t5, _ = _tamper_t5(bundle)
     variants.append(("T5", t5))
 
     results = []

--- a/oracle/windows-dao/tests/test_a3_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a3_independent_validator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import os
@@ -7,6 +8,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
@@ -24,6 +26,8 @@ from a3_independent_validator import (  # noqa: E402
     verify_report_bounds,
     _expected_predicate_statuses,
     _load_predicate_sequences,
+    _t5_target,
+    _tamper_t5,
     _validate_terminal_predicate_ids,
     main,
 )
@@ -545,6 +549,32 @@ class IndependentValidatorTests(unittest.TestCase):
         self.assertEqual(layer["terminal_predicate_id"], "A3-GLOBAL-PAGE-MULTIPLE")
         self.assertEqual(layer["derivation_survivor_count"], 2)
         self.assertEqual(derivation["qualified_pages"]["global_map"], [1, 3])
+
+    def test_t5_targets_a_nonterminal_predicate(self) -> None:
+        bundle = BundleLoader(self.synthetic_bundle, PLAN_PATH).load()
+        self.assertEqual(_t5_target(bundle.report), "A3-HOLDOUT-PREDICTION")
+        variant, target = _tamper_t5(bundle)
+        self.assertEqual(target, "A3-HOLDOUT-PREDICTION")
+        self.assertNotEqual(variant.report, bundle.report)
+        # When every layer fails holdout, A3-HOLDOUT-PREDICTION is the legitimate terminal and
+        # T5 must flip some other nonterminal predicate instead of producing a no-op variant.
+        failed = copy.deepcopy(bundle.report)
+        for item in failed["predicate_results"]:
+            if item["predicate_id"] == "A3-HOLDOUT-PREDICTION":
+                item["status"] = "fail"
+        failed["terminal_predicate_ids"].append("A3-HOLDOUT-PREDICTION")
+        target = _t5_target(failed)
+        self.assertNotEqual(target, "A3-HOLDOUT-PREDICTION")
+        self.assertEqual(next(i["status"] for i in failed["predicate_results"] if i["predicate_id"] == target), "pass")
+        variant, chosen = _tamper_t5(replace(bundle, report=failed))
+        self.assertEqual(chosen, target)
+        self.assertNotEqual(variant.report, failed)
+        self.assertIn(target, variant.report["terminal_predicate_ids"])
+        all_fail = copy.deepcopy(bundle.report)
+        for item in all_fail["predicate_results"]:
+            item["status"] = "fail"
+        with self.assertRaisesRegex(ValidationError, "tamper_suite_not_executable"):
+            _t5_target(all_fail)
 
     def test_idle_campaign_terminal_skips_all_layers(self) -> None:
         bundle = BundleLoader(self.synthetic_bundle, PLAN_PATH).load()


### PR DESCRIPTION
Validator defect from the #58 full sweep (`holdout_contradicts_every_layer`): when all four layers fail holdout, `A3-HOLDOUT-PREDICTION` is the legitimate failing terminal, so T5's unconditional flip to `fail` was a no-op, the variant equalled the original, and the suite failed closed with `tamper_variant_accepted`.

Fix per plan `tamper_cases[T5]` ("set one or more nonterminal predicate_results, including A3-HOLDOUT-PREDICTION on a decisive report"): new `_t5_target` picks `A3-HOLDOUT-PREDICTION` only when its status is `pass` (nonterminal), otherwise the first other `pass` predicate; `tamper_suite_not_executable` if none exists. `_tamper_t5` flips it and appends it to `terminal_predicate_ids` so the variant is self-consistent and must be rejected by the layer projection. Stdlib only; `a3_independent_validator.py` + one focused test.

Checks: `test_a3_independent_validator` 8/8; all `test_a3_*` 53 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFeGTawS4oZNsiwa136BdG