### PR TITLE
ci: add REST fallback for A3 replica artifact downloads

### DIFF
--- a/.github/workflows/windows-dao-a3.yml
+++ b/.github/workflows/windows-dao-a3.yml
@@ -388,6 +388,8 @@ jobs:
             -Encoding utf8 -Append
 
       - name: Download A3 replica 1
+        id: download_replica_1
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-dao-a3-replica-1
@@ -395,13 +397,53 @@ jobs:
           # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
           digest-mismatch: warn
 
+      - name: Download A3 replica 1 through the REST fallback
+        if: steps.download_replica_1.outcome == 'failure'
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          & oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1 `
+            -ArtifactName "windows-dao-a3-replica-1" `
+            -Destination (Join-Path $env:RUNNER_TEMP "jet3-a3-replicas\replica-01")
+
+      - name: Require A3 replica 1 download
+        if: always()
+        shell: powershell
+        run: |
+          $replica = Join-Path $env:RUNNER_TEMP "jet3-a3-replicas\replica-01"
+          if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
+            throw "Neither A3 replica 1 download produced its directory."
+          }
+
       - name: Download A3 replica 2
+        id: download_replica_2
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-dao-a3-replica-2
           path: ${{ runner.temp }}\jet3-a3-replicas\replica-02
           # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
           digest-mismatch: warn
+
+      - name: Download A3 replica 2 through the REST fallback
+        if: steps.download_replica_2.outcome == 'failure'
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          & oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1 `
+            -ArtifactName "windows-dao-a3-replica-2" `
+            -Destination (Join-Path $env:RUNNER_TEMP "jet3-a3-replicas\replica-02")
+
+      - name: Require A3 replica 2 download
+        if: always()
+        shell: powershell
+        run: |
+          $replica = Join-Path $env:RUNNER_TEMP "jet3-a3-replicas\replica-02"
+          if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
+            throw "Neither A3 replica 2 download produced its directory."
+          }
 
       - name: Assemble the two derivation replica trees
         id: assemble
@@ -443,12 +485,33 @@ jobs:
           )
 
       - name: Download A3 holdout replica 3 outside the bundle
+        id: download_replica_3
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-dao-a3-replica-3
           path: ${{ runner.temp }}\jet3-a3-holdout\replica-03
           # The preceding step has retained and recorded the frozen-set digest.
           digest-mismatch: warn
+
+      - name: Download A3 holdout replica 3 through the REST fallback
+        if: steps.download_replica_3.outcome == 'failure'
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          & oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1 `
+            -ArtifactName "windows-dao-a3-replica-3" `
+            -Destination (Join-Path $env:RUNNER_TEMP "jet3-a3-holdout\replica-03")
+
+      - name: Require A3 replica 3 download
+        if: always()
+        shell: powershell
+        run: |
+          $replica = Join-Path $env:RUNNER_TEMP "jet3-a3-holdout\replica-03"
+          if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
+            throw "Neither A3 replica 3 download produced its directory."
+          }
 
       - name: Graft and structurally validate the holdout against retained frozen bytes
         id: holdout

--- a/oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1
+++ b/oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1
@@ -60,7 +60,7 @@ $downloadUri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/artifac
     "$($artifact[0].id)/zip"
 
 try {
-    if (Test-Path -LiteralPath $Destination) {
+    if ((Test-Path -LiteralPath $Destination)) {
         Remove-Item -LiteralPath $Destination -Recurse -Force
     }
     $parent = Split-Path -Parent $Destination
@@ -73,10 +73,10 @@ try {
     Move-Item -LiteralPath $staging -Destination $Destination
 }
 finally {
-    if (Test-Path -LiteralPath $archive) {
+    if ((Test-Path -LiteralPath $archive)) {
         Remove-Item -LiteralPath $archive -Force
     }
-    if (Test-Path -LiteralPath $staging) {
+    if ((Test-Path -LiteralPath $staging)) {
         Remove-Item -LiteralPath $staging -Recurse -Force
     }
 }

--- a/oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1
+++ b/oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ArtifactName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Destination
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-A3ArtifactRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Operation
+    )
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            return & $Operation
+        }
+        catch {
+            if ($attempt -eq 5) {
+                throw
+            }
+            Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 10))
+        }
+    }
+}
+
+$headers = @{
+    Accept = "application/vnd.github+json"
+    Authorization = "Bearer $env:GITHUB_TOKEN"
+    "X-GitHub-Api-Version" = "2022-11-28"
+}
+$encodedName = [Uri]::EscapeDataString($ArtifactName)
+$listUri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/runs/" +
+    "$env:GITHUB_RUN_ID/artifacts?name=$encodedName&per_page=100"
+$response = Invoke-A3ArtifactRequest {
+    Invoke-RestMethod -Method Get -Uri $listUri -Headers $headers
+}
+$artifact = @(
+    $response.artifacts |
+        Where-Object { $_.name -ceq $ArtifactName -and -not $_.expired } |
+        Sort-Object -Property id -Descending |
+        Select-Object -First 1
+)
+if ($artifact.Count -ne 1) {
+    throw "The current run has no unexpired artifact named '$ArtifactName'."
+}
+
+$nonce = [Guid]::NewGuid().ToString("N")
+$archive = Join-Path $env:RUNNER_TEMP "$ArtifactName-$nonce.zip"
+$staging = "$Destination.rest-$nonce"
+$downloadUri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/artifacts/" +
+    "$($artifact[0].id)/zip"
+
+try {
+    if (Test-Path -LiteralPath $Destination) {
+        Remove-Item -LiteralPath $Destination -Recurse -Force
+    }
+    $parent = Split-Path -Parent $Destination
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $null = Invoke-A3ArtifactRequest {
+        Invoke-WebRequest -UseBasicParsing -Uri $downloadUri -Headers $headers `
+            -OutFile $archive
+    }
+    Expand-Archive -LiteralPath $archive -DestinationPath $staging
+    Move-Item -LiteralPath $staging -Destination $Destination
+}
+finally {
+    if (Test-Path -LiteralPath $archive) {
+        Remove-Item -LiteralPath $archive -Force
+    }
+    if (Test-Path -LiteralPath $staging) {
+        Remove-Item -LiteralPath $staging -Recurse -Force
+    }
+}

--- a/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
@@ -302,6 +302,8 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
             self.assertIn("throw", check)
 
         source = REST_FALLBACK.read_text(encoding="utf-8")
+        self.assertNotIn("if (Test-Path", source)
+        self.assertNotIn("$input", source)
         self.assertIn("actions/runs/", source)
         self.assertIn("actions/artifacts/", source)
         self.assertIn('"$($artifact[0].id)/zip"', source)

--- a/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
@@ -11,6 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = ROOT / ".github" / "workflows" / "windows-dao-a3.yml"
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+REST_FALLBACK = SCRIPTS / "a3" / "Download-A3Artifact.ps1"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
@@ -259,6 +260,63 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn("compression-level: 0", upload)
         self.assertIn("retention-days: 90", upload)
 
+    def test_fan_in_downloads_have_fail_closed_rest_fallbacks(self) -> None:
+        permissions = self.workflow.split("permissions:", 1)[1].split(
+            "concurrency:", 1
+        )[0]
+        self.assertEqual(
+            {line.strip() for line in permissions.splitlines() if line.strip()},
+            {"actions: read", "contents: read"},
+        )
+        for replica in (1, 2, 3):
+            primary = self.fan_in.split(
+                f"      - name: Download A3 "
+                f"{'holdout ' if replica == 3 else ''}replica {replica}", 1
+            )[1].split("      - name:", 1)[0]
+            self.assertIn(f"id: download_replica_{replica}", primary)
+            self.assertIn("continue-on-error: true", primary)
+
+            fallback_name = (
+                f"Download A3 {'holdout ' if replica == 3 else ''}replica {replica} "
+                "through the REST fallback"
+            )
+            fallback = self.fan_in.split(
+                f"      - name: {fallback_name}", 1
+            )[1].split("      - name:", 1)[0]
+            self.assertIn(
+                f"if: steps.download_replica_{replica}.outcome == 'failure'",
+                fallback,
+            )
+            self.assertIn("GITHUB_TOKEN: ${{ github.token }}", fallback)
+            self.assertIn("Download-A3Artifact.ps1", fallback)
+            self.assertIn(
+                f'-ArtifactName "windows-dao-a3-replica-{replica}"', fallback
+            )
+
+            check = self.fan_in.split(
+                f"      - name: Require A3 replica {replica} download", 1
+            )[1].split("      - name:", 1)[0]
+            self.assertIn("if: always()", check)
+            self.assertIn("Test-Path", check)
+            self.assertIn("-PathType Container", check)
+            self.assertIn("throw", check)
+
+        source = REST_FALLBACK.read_text(encoding="utf-8")
+        self.assertIn("actions/runs/", source)
+        self.assertIn("actions/artifacts/", source)
+        self.assertIn('"$($artifact[0].id)/zip"', source)
+        self.assertIn("Invoke-WebRequest -UseBasicParsing", source)
+        self.assertIn("for ($attempt = 1; $attempt -le 5; $attempt++)", source)
+        self.assertIn("Expand-Archive", source)
+        self.assertIn("Move-Item", source)
+        self.assertIn("Set-StrictMode -Version Latest", source)
+
+        freeze = self.fan_in.index("--freeze-only")
+        holdout_fallback = self.fan_in.index(
+            "Download A3 holdout replica 3 through the REST fallback"
+        )
+        self.assertLess(freeze, holdout_fallback)
+
     def test_independent_validator_is_a_separate_recorded_step(self) -> None:
         step = self.fan_in.split(
             "      - name: Independently recompute the retained A3 bundle", 1
@@ -277,7 +335,7 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn("rejected the bundle", step)
         # The report lives outside the closed bundle tree.
         self.assertNotIn("jet3-a3-bundle\\validation", step)
-        self.assertNotIn("continue-on-error", self.fan_in)
+        self.assertEqual(self.fan_in.count("continue-on-error: true"), 3)
 
     def test_fan_in_status_is_bounded_timed_and_always_retained(self) -> None:
         for step_id in (


### PR DESCRIPTION
## Summary
- allow each pinned `actions/download-artifact` replica download to fall back after failure
- download the current-run artifact through the GitHub REST API with bounded PowerShell retries and atomic extraction
- fail closed unless each expected replica directory exists, preserving the replica 3 post-freeze ordering
- extend the A3 workflow contract tests for permissions, fallback wiring, retries, extraction, and ordering

## Checks
- `python3 -B -m unittest oracle.windows-dao.tests.test_a3_powershell_contract oracle.windows-dao.tests.test_windows_dao_a3_workflow`
- workflow YAML parse with Ruby Psych
- `git diff --check`