### PR TITLE
ci: extract A3 artifact fallback with .NET ZipFile

### DIFF
--- a/oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1
+++ b/oracle/windows-dao/scripts/a3/Download-A3Artifact.ps1
@@ -69,7 +69,8 @@ try {
         Invoke-WebRequest -UseBasicParsing -Uri $downloadUri -Headers $headers `
             -OutFile $archive
     }
-    Expand-Archive -LiteralPath $archive -DestinationPath $staging
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [IO.Compression.ZipFile]::ExtractToDirectory($archive, $staging)
     Move-Item -LiteralPath $staging -Destination $Destination
 }
 finally {

--- a/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
@@ -309,7 +309,8 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn('"$($artifact[0].id)/zip"', source)
         self.assertIn("Invoke-WebRequest -UseBasicParsing", source)
         self.assertIn("for ($attempt = 1; $attempt -le 5; $attempt++)", source)
-        self.assertIn("Expand-Archive", source)
+        self.assertIn("[IO.Compression.ZipFile]::ExtractToDirectory", source)
+        self.assertNotIn("Expand-Archive", source)
         self.assertIn("Move-Item", source)
         self.assertIn("Set-StrictMode -Version Latest", source)
 


### PR DESCRIPTION
Run 32621896162: REST fallback works but Expand-Archive takes ~400 s per ~19k-file replica, exceeding the 900 s fan-in bound across three replicas. ZipFile::ExtractToDirectory is the same extraction without the per-entry cmdlet overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp6DTLry3q32XBCYyzbo2g