### PR TITLE
perf: fit A3 fan-in within the 900 s bound

### DIFF
--- a/.github/workflows/windows-dao-a3.yml
+++ b/.github/workflows/windows-dao-a3.yml
@@ -387,18 +387,7 @@ jobs:
           "run_started_at=$started" | Out-File -FilePath $env:GITHUB_OUTPUT `
             -Encoding utf8 -Append
 
-      - name: Download A3 replica 1
-        id: download_replica_1
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: windows-dao-a3-replica-1
-          path: ${{ runner.temp }}\jet3-a3-replicas\replica-01
-          # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
-          digest-mismatch: warn
-
-      - name: Download A3 replica 1 through the REST fallback
-        if: steps.download_replica_1.outcome == 'failure'
+      - name: Download A3 replica 1 through the REST API
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -413,21 +402,10 @@ jobs:
         run: |
           $replica = Join-Path $env:RUNNER_TEMP "jet3-a3-replicas\replica-01"
           if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
-            throw "Neither A3 replica 1 download produced its directory."
+            throw "The A3 replica 1 download did not produce its directory."
           }
 
-      - name: Download A3 replica 2
-        id: download_replica_2
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: windows-dao-a3-replica-2
-          path: ${{ runner.temp }}\jet3-a3-replicas\replica-02
-          # The closed replica manifest is re-hashed by assemble; the zip digest is advisory.
-          digest-mismatch: warn
-
-      - name: Download A3 replica 2 through the REST fallback
-        if: steps.download_replica_2.outcome == 'failure'
+      - name: Download A3 replica 2 through the REST API
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -442,7 +420,7 @@ jobs:
         run: |
           $replica = Join-Path $env:RUNNER_TEMP "jet3-a3-replicas\replica-02"
           if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
-            throw "Neither A3 replica 2 download produced its directory."
+            throw "The A3 replica 2 download did not produce its directory."
           }
 
       - name: Assemble the two derivation replica trees
@@ -484,18 +462,7 @@ jobs:
             (New-Object Text.UTF8Encoding($false))
           )
 
-      - name: Download A3 holdout replica 3 outside the bundle
-        id: download_replica_3
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: windows-dao-a3-replica-3
-          path: ${{ runner.temp }}\jet3-a3-holdout\replica-03
-          # The preceding step has retained and recorded the frozen-set digest.
-          digest-mismatch: warn
-
-      - name: Download A3 holdout replica 3 through the REST fallback
-        if: steps.download_replica_3.outcome == 'failure'
+      - name: Download A3 holdout replica 3 through the REST API
         shell: powershell
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -510,7 +477,7 @@ jobs:
         run: |
           $replica = Join-Path $env:RUNNER_TEMP "jet3-a3-holdout\replica-03"
           if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
-            throw "Neither A3 replica 3 download produced its directory."
+            throw "The A3 replica 3 download did not produce its directory."
           }
 
       - name: Graft and structurally validate the holdout against retained frozen bytes

--- a/oracle/windows-dao/scripts/a3_analysis.py
+++ b/oracle/windows-dao/scripts/a3_analysis.py
@@ -541,7 +541,11 @@ def resume_analysis(
         if any(receipt.get(key) != value for key, value in expected_receipt.items()):
             raise ValidationError("A3 holdout receipt binding mismatch")
     holdout_validated_after_freeze = _holdout_validated_after_freeze(
-        candidate_output, frozen_sha, receipt, analyzer_holdout_opens_before_receipt
+        candidate_output,
+        frozen_sha,
+        receipt,
+        analyzer_holdout_opens_before_receipt,
+        observed_candidate_sha256=frozen_result.observed_candidate_sha256,
     )
     if not holdout_validated_after_freeze:
         raise ValidationError("holdout structural validation is not bound to the frozen candidate set")
@@ -603,9 +607,12 @@ def _holdout_validated_after_freeze(
     frozen_sha: str,
     receipt: dict[str, Any] | None,
     analyzer_holdout_opens_before_receipt: int = 0,
+    *,
+    observed_candidate_sha256: str | None = None,
 ) -> bool:
     """Derive the report flag from observables: the frozen bytes on disk and the receipt's own bindings."""
-    if sha256_file(candidate_output) != frozen_sha:
+    candidate_sha256 = observed_candidate_sha256 or sha256_file(candidate_output)
+    if candidate_sha256 != frozen_sha:
         return False
     if receipt is None:
         return False

--- a/oracle/windows-dao/scripts/a3_analysis_cli.py
+++ b/oracle/windows-dao/scripts/a3_analysis_cli.py
@@ -68,11 +68,11 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if len(replicas) != 1 or arguments.freeze_state is None:
             raise ValidationError("resume requires the holdout replica and --freeze-state")
+        receipt_document = load_bounded_json(receipt, MAX_JSON_BYTES)
         frozen_result, bindings, marker_opens = _load_freeze_state(
             arguments.freeze_state, candidate
         )
         counted_holdout = CountingReplicaSource(BundleReplicaSource(replicas[0], root))
-        receipt_document = load_bounded_json(receipt, MAX_JSON_BYTES)
         if counted_holdout.open_count != marker_opens:
             raise ValidationError("A3 analyzer holdout-open count differs from freeze marker")
         report = resume_analysis(

--- a/oracle/windows-dao/scripts/a3_analysis_input.py
+++ b/oracle/windows-dao/scripts/a3_analysis_input.py
@@ -15,6 +15,7 @@ from a3_spec import (
     PLAN_SHA256,
     REVISION_PLAN_SHA256,
     load_bounded_json,
+    load_bounded_json_with_payload,
     validate_document,
 )
 from protocol_validation import ValidationError
@@ -113,9 +114,12 @@ class BundleReplicaSource:
         for ordinal, checkpoint in enumerate(checkpoints):
             reference = checkpoint["page_index"]
             path = _safe_path(self.bundle_root, reference["path"])
-            if path.stat().st_size != reference["size_bytes"] or sha256_file(path) != reference["sha256"]:
+            index, payload = load_bounded_json_with_payload(path, self.max_json_bytes)
+            if (
+                len(payload) != reference["size_bytes"]
+                or hashlib.sha256(payload).hexdigest() != reference["sha256"]
+            ):
                 raise ValidationError(f"{path}: page-index binding failed")
-            index = load_bounded_json(path, self.max_json_bytes)
             validate_document(index)
             expected_predecessor = CHECKPOINT_IDS[ordinal - 1] if ordinal else None
             bindings = {

--- a/oracle/windows-dao/scripts/a3_analysis_state.py
+++ b/oracle/windows-dao/scripts/a3_analysis_state.py
@@ -15,7 +15,7 @@ from a3_layers import (
 from a3_model import Abort, GlobalRecordModel, PAGE_SIZE, Record, WorkCounter
 from a3_spec import (
     BOUNDS, LAYER_KEYS, LAYER_PREDICATE_SEQUENCES, frozen_json_bytes,
-    load_bounded_json, validate_frozen_candidates,
+    load_bounded_json, load_bounded_json_with_payload, validate_frozen_candidates,
 )
 from protocol_validation import ValidationError
 
@@ -47,6 +47,7 @@ class FreezeResult:
     frozen_sha256: str
     work: WorkCounter
     campaign_abort: Abort | None
+    observed_candidate_sha256: str | None = None
 
 
 def _leg(document: dict[str, str] | None) -> Leg | None:
@@ -98,9 +99,10 @@ def load_freeze_state(
     candidate_output: Path,
 ) -> tuple[FreezeResult, tuple[str, str, str], int]:
     state = load_bounded_json(path, MAX_JSON_BYTES)
-    frozen = load_bounded_json(candidate_output, MAX_JSON_BYTES)
+    frozen, frozen_payload = load_bounded_json_with_payload(
+        candidate_output, MAX_JSON_BYTES
+    )
     validate_frozen_candidates(frozen)
-    frozen_payload = candidate_output.read_bytes()
     if frozen_json_bytes(frozen) != frozen_payload:
         raise ValidationError("A3 frozen candidate bytes are not canonical")
     frozen_sha = hashlib.sha256(frozen_payload).hexdigest()
@@ -181,7 +183,7 @@ def load_freeze_state(
     result = FreezeResult(
         [], drafts, tuple(frozen["qualified_pages"]["global_map"]),
         tuple(frozen["qualified_pages"]["tdef"]), _transcript(frozen["polarity_cross_check"]),
-        frozen, frozen_sha, work, campaign_abort,
+        frozen, frozen_sha, work, campaign_abort, frozen_sha,
     )
     bindings = (state["campaign_id"], state["producer_commit"], state["provider_sha256"])
     return result, bindings, opens

--- a/oracle/windows-dao/scripts/a3_bundle.py
+++ b/oracle/windows-dao/scripts/a3_bundle.py
@@ -11,7 +11,6 @@ import json
 import math
 import os
 import shutil
-import stat
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -20,12 +19,11 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from a3_bundle_io import (
+    ArtifactCache,
     TreeFile,
+    copy_cached as _copy_cached,
     expected_directories as _expected_directories,
     inventory as _inventory,
-    is_reparse as _is_reparse,
-    parse_json as _parse_json,
-    read_checked as _read_checked,
     safe_locator as _safe_locator,
 )
 from a3_spec import (
@@ -82,6 +80,7 @@ if PLAN.document["artifacts"]["plan"] != PLAN_PATH:
 @dataclass(frozen=True)
 class ReplicaResult:
     root: Path
+    cache: ArtifactCache
     replica: int
     manifest_path: str
     manifest: dict[str, Any]
@@ -99,14 +98,16 @@ class ReplicaResult:
 class PayloadResult:
     tree: dict[str, TreeFile]
     directories: set[str]
+    cache: ArtifactCache
     replicas: tuple[ReplicaResult, ...]
     expected_paths: frozenset[str]
     analysis: dict[str, Any] | None
     receipt: dict[str, Any] | None
     frozen_sha256: str | None
-def _json_artifact(root: Path, locator: str, tree: dict[str, TreeFile]) -> tuple[dict[str, Any], bytes]:
-    payload = _read_checked(root, locator, tree, MAX_JSON_BYTES)
-    return _parse_json(payload, locator), payload
+def _json_artifact(
+    cache: ArtifactCache, locator: str
+) -> tuple[dict[str, Any], bytes]:
+    return cache.json(locator, MAX_JSON_BYTES)
 def _require(actual: Any, expected: Any, label: str) -> None:
     if actual != expected:
         raise ValidationError(f"{label}: binding mismatch")
@@ -154,15 +155,19 @@ def _entry_map(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
         entries[locator] = entry
         folded.add(locator.casefold())
     return entries
-def _entry_payload(root: Path, tree: dict[str, TreeFile],
-                   entry: dict[str, Any]) -> tuple[bytes, dict[str, Any] | None]:
+def _entry_payload(
+    cache: ArtifactCache, entry: dict[str, Any]
+) -> tuple[bytes, dict[str, Any] | None]:
     maximum = PAGE_SIZE if entry["role"] == "page_blob" else MAX_JSON_BYTES
-    payload = _read_checked(root, entry["path"], tree, maximum)
+    payload = cache.read(entry["path"], maximum)
     _require(len(payload), entry["size_bytes"], f"{entry['path']} size")
-    _require(hashlib.sha256(payload).hexdigest(), entry["sha256"], f"{entry['path']} sha256")
+    _require(cache.sha256(entry["path"], maximum), entry["sha256"], f"{entry['path']} sha256")
     expected_media = "application/octet-stream" if entry["role"] == "page_blob" else "application/json"
     _require(entry["media_type"], expected_media, f"{entry['path']} media type")
-    return payload, None if expected_media != "application/json" else _parse_json(payload, entry["path"])
+    document = None if expected_media != "application/json" else cache.json(
+        entry["path"], maximum
+    )[0]
+    return payload, document
 
 
 def _validate_plan_entries(entries: dict[str, dict[str, Any]]) -> None:
@@ -183,13 +188,14 @@ def _validate_replica(
     root: Path,
     tree: dict[str, TreeFile],
     directories: set[str],
+    cache: ArtifactCache,
     replica: int,
     campaign_id: str | None,
     *,
     closed: bool,
 ) -> ReplicaResult:
     manifest_path = f"replica-artifacts/replica-{replica:02d}-manifest.json"
-    manifest, manifest_payload = _json_artifact(root, manifest_path, tree)
+    manifest, manifest_payload = _json_artifact(cache, manifest_path)
     _validate_typed(manifest, "dao_a3_replica_artifact_manifest", manifest_path)
     _require(manifest["checkpoint_count"], CHECKPOINT_COUNT, f"replica {replica} checkpoint count")
     _require(manifest["replica"], replica, f"replica {replica} manifest replica")
@@ -205,7 +211,7 @@ def _validate_replica(
 
     documents: dict[str, dict[str, Any]] = {}
     for entry in entries.values():
-        _, document = _entry_payload(root, tree, entry)
+        _, document = _entry_payload(cache, entry)
         if document is not None:
             documents[entry["path"]] = document
 
@@ -263,9 +269,9 @@ def _validate_replica(
             page_entry = entries.get(page_path)
             if page_entry is None or page_entry["role"] != "page_blob":
                 raise ValidationError(f"{page_path}: referenced blob is absent")
-            payload = _read_checked(root, page_path, tree, PAGE_SIZE)
+            payload = cache.read(page_path, PAGE_SIZE)
             _require(len(payload), PAGE_SIZE, f"{page_path} page size")
-            _require(hashlib.sha256(payload).hexdigest(), digest, f"{page_path} content address")
+            _require(cache.sha256(page_path, PAGE_SIZE), digest, f"{page_path} content address")
             reconstruction.update(payload)
             referenced_pages.add(page_path)
         _require(reconstruction.hexdigest(), index["database_sha256"], f"{expected_path} database hash")
@@ -279,10 +285,11 @@ def _validate_replica(
         raise ValidationError(f"replica {replica}: page-store bound exceeded")
     return ReplicaResult(
         root,
+        cache,
         replica,
         manifest_path,
         manifest,
-        hashlib.sha256(manifest_payload).hexdigest(),
+        cache.sha256(manifest_path, MAX_JSON_BYTES),
         len(manifest_payload),
         entries,
         environment,
@@ -349,16 +356,17 @@ def _validate_frozen(document: dict[str, Any], payload: bytes, campaign_id: str)
     }
     for key, expected in bindings.items():
         _require(document[key], expected, f"frozen candidate {key}")
-def _validate_analysis_payload(root: Path, tree: dict[str, TreeFile],
-                               replicas: tuple[ReplicaResult, ...]) -> tuple[dict[str, Any], dict[str, Any], str]:
+def _validate_analysis_payload(
+    cache: ArtifactCache, replicas: tuple[ReplicaResult, ...]
+) -> tuple[dict[str, Any], dict[str, Any], str]:
     frozen_path = "analysis/derivation-candidates.json"
     analysis_path = "analysis/analysis-report.json"
     receipt_path = "analysis/holdout-structure-receipt.json"
-    frozen, frozen_payload = _json_artifact(root, frozen_path, tree)
-    report, _ = _json_artifact(root, analysis_path, tree)
-    receipt, _ = _json_artifact(root, receipt_path, tree)
+    frozen, frozen_payload = _json_artifact(cache, frozen_path)
+    report, _ = _json_artifact(cache, analysis_path)
+    receipt, _ = _json_artifact(cache, receipt_path)
     campaign_id = replicas[0].campaign_id
-    frozen_sha256 = hashlib.sha256(frozen_payload).hexdigest()
+    frozen_sha256 = cache.sha256(frozen_path, MAX_JSON_BYTES)
     _validate_frozen(frozen, frozen_payload, campaign_id)
     _require(report.get("document_type"), "dao_a3_analysis_report", f"{analysis_path} document type")
     validate_analysis_report(report, frozen)
@@ -385,20 +393,32 @@ def _validate_analysis_payload(root: Path, tree: dict[str, TreeFile],
     return report, receipt, frozen_sha256
 def _validate_payload(root: Path, *, require_analysis: bool,
                       allow_manifest: bool = False,
-                      replica_count: int = REPLICA_COUNT) -> PayloadResult:
+                      replica_count: int = REPLICA_COUNT,
+                      tree: dict[str, TreeFile] | None = None,
+                      directories: set[str] | None = None,
+                      cache: ArtifactCache | None = None) -> PayloadResult:
     root = root.resolve()
-    tree, directories = _inventory(root)
+    if tree is None or directories is None:
+        if tree is not None or directories is not None or cache is not None:
+            raise ValidationError("partial A3 validation context")
+        tree, directories = _inventory(root)
+    if cache is None:
+        cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+    elif cache.root != root or cache.tree is not tree:
+        raise ValidationError("A3 validation cache does not match its inventory")
     retained_plans = {PLAN_PATH: (CHECKED_PLAN, PLAN_SHA256)} | {
         locator: (REVISION_PLAN_PATHS[locator], digest)
         for locator, digest in REVISION_CHAIN.items()
     }
     for locator, (checked_path, digest) in retained_plans.items():
-        plan_payload = _read_checked(root, locator, tree, MAX_JSON_BYTES)
-        _require(hashlib.sha256(plan_payload).hexdigest(), digest,
+        plan_payload = cache.read(locator, MAX_JSON_BYTES)
+        _require(cache.sha256(locator, MAX_JSON_BYTES), digest,
                  f"retained {locator} hash")
         _require(plan_payload, checked_path.read_bytes(), f"retained checked {locator}")
     replicas = tuple(
-        _validate_replica(root, tree, directories, replica, None, closed=False)
+        _validate_replica(
+            root, tree, directories, cache, replica, None, closed=False
+        )
         for replica in range(1, replica_count + 1)
     )
     _validate_environments(replicas)
@@ -416,7 +436,7 @@ def _validate_payload(root: Path, *, require_analysis: bool,
             "analysis/holdout-structure-receipt.json",
         }
         expected.update(analysis_paths)
-        report, receipt, frozen_sha256 = _validate_analysis_payload(root, tree, replicas)
+        report, receipt, frozen_sha256 = _validate_analysis_payload(cache, replicas)
     complete_expected = expected | ({MANIFEST_PATH} if allow_manifest else set())
     _require(set(tree), complete_expected, "A3 payload closed inventory")
     _require(directories, _expected_directories(complete_expected),
@@ -426,51 +446,23 @@ def _validate_payload(root: Path, *, require_analysis: bool,
         raise ValidationError("A3 merged page store exceeds its fixed bound")
     if sum(item.size for item in tree.values()) > MAX_BUNDLE_BYTES:
         raise ValidationError("A3 bundle exceeds its fixed byte bound")
-    return PayloadResult(tree, directories, replicas, frozenset(expected),
+    return PayloadResult(tree, directories, cache, replicas, frozenset(expected),
                          report, receipt, frozen_sha256)
-def _copy_verified(
-    source_root: Path,
-    destination_root: Path,
-    locator: str,
-    size: int,
-    digest: str,
+def _copy_replica(
+    replica: ReplicaResult,
+    destination: Path,
+    copied: dict[str, tuple[int, str]],
 ) -> None:
-    source = source_root.joinpath(*locator.split("/"))
-    destination = destination_root.joinpath(*locator.split("/"))
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    if destination.exists():
-        if not destination.is_file() or destination.is_symlink():
-            raise ValidationError(f"{locator}: merge collision is not a regular file")
-        payload_digest = hashlib.sha256(destination.read_bytes()).hexdigest()
-        if destination.stat().st_size != size or payload_digest != digest:
-            raise ValidationError(f"{locator}: merge collision differs")
-        return
-    source_metadata = source.lstat()
-    if source.is_symlink() or _is_reparse(source_metadata) or not stat.S_ISREG(source_metadata.st_mode):
-        raise ValidationError(f"{locator}: copy source is unsafe")
-    observed = hashlib.sha256()
-    total = 0
-    try:
-        with source.open("rb") as reader, destination.open("xb") as writer:
-            for chunk in iter(lambda: reader.read(65_536), b""):
-                total += len(chunk)
-                if total > size:
-                    raise ValidationError(f"{locator}: copy source grew")
-                observed.update(chunk)
-                writer.write(chunk)
-    except Exception:
-        if destination.exists():
-            destination.unlink()
-        raise
-    if total != size or observed.hexdigest() != digest:
-        destination.unlink()
-        raise ValidationError(f"{locator}: copy source binding failed")
-def _copy_replica(replica: ReplicaResult, destination: Path) -> None:
-    _copy_verified(replica.root, destination, replica.manifest_path,
-                   replica.manifest_size, replica.manifest_sha256)
+    _copy_cached(
+        replica.cache, destination, replica.manifest_path,
+        replica.manifest_size, replica.manifest_sha256, MAX_JSON_BYTES, copied,
+    )
     for entry in replica.entries.values():
-        _copy_verified(replica.root, destination, entry["path"],
-                       entry["size_bytes"], entry["sha256"])
+        maximum = PAGE_SIZE if entry["role"] == "page_blob" else MAX_JSON_BYTES
+        _copy_cached(
+            replica.cache, destination, entry["path"],
+            entry["size_bytes"], entry["sha256"], maximum, copied,
+        )
 def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
                     campaign_id: str, producer_commit: str) -> dict[str, Any]:
     """Assemble the derivation replicas only; the holdout is grafted after the freeze."""
@@ -482,8 +474,9 @@ def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
     validated = []
     for replica, root in enumerate(roots, start=1):
         tree, directories = _inventory(root)
+        cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
         validated.append(_validate_replica(
-            root, tree, directories, replica, campaign_id, closed=True))
+            root, tree, directories, cache, replica, campaign_id, closed=True))
     replicas = tuple(validated)
     _validate_environments(replicas)
     _require(replicas[0].producer_commit, producer_commit, "expected producer commit")
@@ -496,8 +489,9 @@ def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
         plan_path.write_bytes(CHECKED_PLAN.read_bytes())
         for locator, checked_path in REVISION_PLAN_PATHS.items():
             staging.joinpath(*locator.split("/")).write_bytes(checked_path.read_bytes())
+        copied: dict[str, tuple[int, str]] = {}
         for replica in replicas:
-            _copy_replica(replica, staging)
+            _copy_replica(replica, staging, copied)
         result = _validate_payload(staging, require_analysis=False,
                                    replica_count=DERIVATION_REPLICA_COUNT)
         os.replace(staging, bundle_root)
@@ -513,19 +507,22 @@ def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
 def validate_holdout_replica(bundle_root: Path, candidate_path: Path,
                              candidate_sha256: str, campaign_id: str,
                              producer_commit: str) -> ReplicaResult:
-    tree, directories = _inventory(bundle_root.resolve())
-    replica = _validate_replica(bundle_root.resolve(), tree, directories,
-                                REPLICA_COUNT, None, closed=False)
+    root = bundle_root.resolve()
+    tree, directories = _inventory(root)
+    cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+    replica = _validate_replica(
+        root, tree, directories, cache, REPLICA_COUNT, None, closed=False
+    )
     _require(replica.campaign_id, campaign_id, "expected holdout campaign")
     _require(replica.producer_commit, producer_commit, "expected holdout producer")
-    payload = _read_checked(
-        bundle_root.resolve(),
-        candidate_path.resolve().relative_to(bundle_root.resolve()).as_posix(),
-        tree,
-        MAX_JSON_BYTES,
+    candidate_locator = candidate_path.resolve().relative_to(root).as_posix()
+    payload = cache.read(candidate_locator, MAX_JSON_BYTES)
+    _require(
+        cache.sha256(candidate_locator, MAX_JSON_BYTES),
+        candidate_sha256,
+        "frozen candidate hash",
     )
-    _require(hashlib.sha256(payload).hexdigest(), candidate_sha256, "frozen candidate hash")
-    frozen = _parse_json(payload, candidate_path.as_posix())
+    frozen = cache.json(candidate_locator, MAX_JSON_BYTES)[0]
     _validate_frozen(frozen, payload, replica.campaign_id)
     return replica
 def _role_for_path(path: str, replicas: tuple[ReplicaResult, ...]) -> str:
@@ -587,8 +584,7 @@ def finalize_bundle(bundle_root: Path, campaign_id: str, producer_commit: str,
         item = payload.tree[path]
         role = _role_for_path(path, payload.replicas)
         maximum = PAGE_SIZE if role == "page_blob" else MAX_JSON_BYTES
-        retained = _read_checked(bundle_root, path, payload.tree, maximum)
-        digest = hashlib.sha256(retained).hexdigest()
+        digest = payload.cache.sha256(path, maximum)
         files.append(
             {
                 "path": path,
@@ -654,7 +650,8 @@ def validate_bundle(bundle_root: Path, campaign_id: str,
                     producer_commit: str) -> dict[str, Any]:
     bundle_root = bundle_root.resolve()
     tree, directories = _inventory(bundle_root)
-    manifest, manifest_payload = _json_artifact(bundle_root, MANIFEST_PATH, tree)
+    cache = ArtifactCache(bundle_root, tree, MAX_BUNDLE_BYTES)
+    manifest, _ = _json_artifact(cache, MANIFEST_PATH)
     _validate_typed(manifest, "dao_a3_bundle_manifest", MANIFEST_PATH)
     _require(
         manifest["campaign_elapsed_seconds"],
@@ -666,9 +663,10 @@ def validate_bundle(bundle_root: Path, campaign_id: str,
     _require(set(tree), set(entries) | {MANIFEST_PATH}, "complete bundle inventory")
     _require(directories, _expected_directories(entries), "complete bundle directories")
     for entry in entries.values():
-        _entry_payload(bundle_root, tree, entry)
+        _entry_payload(cache, entry)
     payload = _validate_payload(bundle_root, require_analysis=True,
-                                allow_manifest=True)
+                                allow_manifest=True, tree=tree,
+                                directories=directories, cache=cache)
     assert payload.analysis is not None and payload.receipt is not None
     _require(manifest["campaign_id"], campaign_id, "expected campaign")
     _require(manifest["producer_commit"], producer_commit, "expected producer commit")
@@ -702,7 +700,7 @@ def validate_bundle(bundle_root: Path, campaign_id: str,
     _require(observed_directories, directories, "bundle directory stability")
     return {
         "manifest": manifest,
-        "manifest_sha256": hashlib.sha256(manifest_payload).hexdigest(),
+        "manifest_sha256": cache.sha256(MANIFEST_PATH, MAX_JSON_BYTES),
         "analysis": payload.analysis,
         "replicas": [row.observation for row in payload.replicas],
     }

--- a/oracle/windows-dao/scripts/a3_bundle_io.py
+++ b/oracle/windows-dao/scripts/a3_bundle_io.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import stat
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -24,6 +25,82 @@ class TreeFile:
     device: int
     inode: int
     links: int
+
+
+@dataclass
+class ArtifactCache:
+    """Process-local retained bytes, digests, and parsed JSON from checked reads."""
+
+    root: Path
+    tree: dict[str, TreeFile]
+    maximum_bytes: int
+    _payloads: dict[str, bytes] = field(default_factory=dict)
+    _digests: dict[str, str] = field(default_factory=dict)
+    _documents: dict[str, dict[str, Any]] = field(default_factory=dict)
+    _retained_bytes: int = 0
+
+    def read(self, locator: str, maximum: int) -> bytes:
+        payload = self._payloads.get(locator)
+        if payload is None:
+            payload = read_checked(self.root, locator, self.tree, maximum)
+            retained = self._retained_bytes + len(payload)
+            if retained > self.maximum_bytes:
+                raise ValidationError("A3 cached artifacts exceed their byte ceiling")
+            self._payloads[locator] = payload
+            self._retained_bytes = retained
+        elif len(payload) > maximum:
+            raise ValidationError(f"{locator}: artifact violates its byte ceiling")
+        return payload
+
+    def sha256(self, locator: str, maximum: int) -> str:
+        digest = self._digests.get(locator)
+        if digest is None:
+            digest = hashlib.sha256(self.read(locator, maximum)).hexdigest()
+            self._digests[locator] = digest
+        return digest
+
+    def json(self, locator: str, maximum: int) -> tuple[dict[str, Any], bytes]:
+        payload = self.read(locator, maximum)
+        document = self._documents.get(locator)
+        if document is None:
+            document = parse_json(payload, locator)
+            self._documents[locator] = document
+        return document, payload
+
+
+def copy_cached(
+    cache: ArtifactCache,
+    destination_root: Path,
+    locator: str,
+    size: int,
+    digest: str,
+    maximum: int,
+    copied: dict[str, tuple[int, str]],
+) -> None:
+    destination = destination_root.joinpath(*locator.split("/"))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = cache.read(locator, maximum)
+    if len(payload) != size or cache.sha256(locator, maximum) != digest:
+        raise ValidationError(f"{locator}: cached copy binding mismatch")
+    if destination.exists():
+        metadata = destination.lstat()
+        if (
+            destination.is_symlink()
+            or is_reparse(metadata)
+            or not stat.S_ISREG(metadata.st_mode)
+        ):
+            raise ValidationError(f"{locator}: merge collision is not a regular file")
+        if metadata.st_size != size or copied.get(locator) != (size, digest):
+            raise ValidationError(f"{locator}: merge collision differs")
+        return
+    try:
+        with destination.open("xb") as writer:
+            writer.write(payload)
+    except Exception:
+        if destination.exists():
+            destination.unlink()
+        raise
+    copied[locator] = (size, digest)
 
 
 def is_reparse(metadata: os.stat_result) -> bool:

--- a/oracle/windows-dao/scripts/a3_holdout.py
+++ b/oracle/windows-dao/scripts/a3_holdout.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import subprocess
 import sys
@@ -12,19 +11,18 @@ from pathlib import Path
 
 from a3_bundle import (
     DERIVATION_REPLICA_COUNT,
+    MAX_BUNDLE_BYTES,
     MAX_JSON_BYTES,
     PLAN_PATH,
     REPLICA_COUNT,
     ReplicaResult,
     _copy_replica,
     _inventory,
-    _parse_json,
-    _read_checked,
     _validate_environments,
     _validate_frozen,
     _validate_replica,
-    validate_holdout_replica,
 )
+from a3_bundle_io import ArtifactCache, TreeFile
 from a3_spec import (
     BOUNDS, EXPERIMENT_ID, PLAN_SHA256, REVISION_CHAIN, REVISION_PLAN_SHA256,
     load_bounded_json, validate_document,
@@ -51,43 +49,85 @@ def graft_holdout_replica(
     candidate_sha256: str,
     campaign_id: str,
     producer_commit: str,
+    *,
+    bundle_tree: dict[str, TreeFile] | None = None,
+    bundle_directories: set[str] | None = None,
+    bundle_cache: ArtifactCache | None = None,
 ) -> ReplicaResult:
     """Copy the closed holdout replica into a bundle that holds only the frozen derivation set.
 
-    The frozen candidate set is re-read and hash-checked on disk before a single
-    holdout byte is inventoried, so the graft itself is the freeze-order observable."""
+    The retained frozen candidate bytes are hash-checked before a single holdout
+    byte is inventoried, so the graft itself is the freeze-order observable."""
     bundle_root = bundle_root.resolve()
-    if not holdout_absent(bundle_root):
+    if bundle_tree is None or bundle_directories is None:
+        if (
+            bundle_tree is not None
+            or bundle_directories is not None
+            or bundle_cache is not None
+        ):
+            raise ValidationError("partial A3 holdout validation context")
+        bundle_tree, bundle_directories = _inventory(bundle_root)
+    if bundle_cache is None:
+        bundle_cache = ArtifactCache(bundle_root, bundle_tree, MAX_BUNDLE_BYTES)
+    elif bundle_cache.root != bundle_root or bundle_cache.tree is not bundle_tree:
+        raise ValidationError("A3 holdout cache does not match its inventory")
+    if any(f"replica-{REPLICA_COUNT:02d}" in path for path in bundle_tree):
         raise ValidationError("holdout replica artifacts already present before graft")
     candidate_locator = candidate_set.resolve().relative_to(bundle_root).as_posix()
-    tree, directories = _inventory(bundle_root)
     derivation = tuple(
-        _validate_replica(bundle_root, tree, directories, replica, campaign_id, closed=False)
+        _validate_replica(
+            bundle_root, bundle_tree, bundle_directories, bundle_cache,
+            replica, campaign_id, closed=False,
+        )
         for replica in range(1, DERIVATION_REPLICA_COUNT + 1)
     )
     expected = {PLAN_PATH, *REVISION_CHAIN, candidate_locator}
     for replica in derivation:
         expected.add(replica.manifest_path)
         expected.update(replica.entries)
-    if set(tree) != expected:
-        raise ValidationError("bundle holds more than the plan, derivation replicas, and frozen set")
-    frozen_payload = _read_checked(bundle_root, candidate_locator, tree, MAX_JSON_BYTES)
-    _require_sha256(frozen_payload, candidate_sha256, "frozen candidate hash")
-    _validate_frozen(
-        _parse_json(frozen_payload, candidate_set.as_posix()), frozen_payload, campaign_id)
+    if set(bundle_tree) != expected:
+        raise ValidationError(
+            "bundle holds more than the plan, derivation replicas, and frozen set"
+        )
+    frozen_payload = bundle_cache.read(candidate_locator, MAX_JSON_BYTES)
+    if bundle_cache.sha256(candidate_locator, MAX_JSON_BYTES) != candidate_sha256:
+        raise ValidationError(f"frozen candidate hash: expected {candidate_sha256}")
+    frozen = bundle_cache.json(candidate_locator, MAX_JSON_BYTES)[0]
+    _validate_frozen(frozen, frozen_payload, campaign_id)
     root = Path(holdout_root).resolve()
     tree, directories = _inventory(root)
-    holdout = _validate_replica(root, tree, directories, REPLICA_COUNT, campaign_id, closed=True)
+    holdout_cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+    holdout = _validate_replica(
+        root, tree, directories, holdout_cache,
+        REPLICA_COUNT, campaign_id, closed=True,
+    )
     _validate_environments((*derivation, holdout))
     if holdout.producer_commit != producer_commit:
         raise ValidationError("expected holdout producer commit")
-    _copy_replica(holdout, bundle_root)
-    return holdout
+    copied = {
+        replica.manifest_path: (replica.manifest_size, replica.manifest_sha256)
+        for replica in derivation
+    }
+    for replica in derivation:
+        copied.update({
+            path: (entry["size_bytes"], entry["sha256"])
+            for path, entry in replica.entries.items()
+        })
+    _copy_replica(holdout, bundle_root, copied)
 
-
-def _require_sha256(payload: bytes, expected: str, label: str) -> None:
-    if hashlib.sha256(payload).hexdigest() != expected:
-        raise ValidationError(f"{label}: expected {expected}")
+    grafted_tree, grafted_directories = _inventory(bundle_root)
+    if any(grafted_tree.get(path) != item for path, item in bundle_tree.items()):
+        raise ValidationError("derivation bundle changed while grafting the holdout")
+    bundle_cache.tree = grafted_tree
+    grafted = _validate_replica(
+        bundle_root, grafted_tree, grafted_directories, bundle_cache,
+        REPLICA_COUNT, campaign_id, closed=False,
+    )
+    if grafted.producer_commit != producer_commit:
+        raise ValidationError("expected grafted holdout producer commit")
+    if grafted.manifest_sha256 != holdout.manifest_sha256:
+        raise ValidationError("grafted holdout replica changed during structural validation")
+    return grafted
 
 
 def run_holdout_process(
@@ -146,14 +186,12 @@ def write_receipt(
     state = load_bounded_json(freeze_state, MAX_JSON_BYTES)
     resolved_bundle = bundle_root.resolve()
     candidate_locator = candidate_set.resolve().relative_to(resolved_bundle).as_posix()
-    bundle_tree, _ = _inventory(resolved_bundle)
+    bundle_tree, bundle_directories = _inventory(resolved_bundle)
+    bundle_cache = ArtifactCache(resolved_bundle, bundle_tree, MAX_BUNDLE_BYTES)
     absent_before_graft = not any(
         f"replica-{REPLICA_COUNT:02d}" in path for path in bundle_tree
     )
-    frozen_bytes = _read_checked(
-        resolved_bundle, candidate_locator, bundle_tree, MAX_JSON_BYTES
-    )
-    frozen_digest = hashlib.sha256(frozen_bytes).hexdigest()
+    frozen_digest = bundle_cache.sha256(candidate_locator, MAX_JSON_BYTES)
     validated_after_candidate_freeze = (
         absent_before_graft
         and frozen_digest == candidate_sha256
@@ -174,12 +212,17 @@ def write_receipt(
         raise ValidationError("holdout replica reached the bundle before the candidate freeze")
     if page_bytes_exposed_to_analyzer or opens != 0:
         raise ValidationError("analyzer opened replica 3 before receipt acceptance")
-    grafted = graft_holdout_replica(
-        holdout_root, bundle_root, candidate_set, candidate_sha256, campaign_id, producer_commit)
-    replica = validate_holdout_replica(
-        bundle_root, candidate_set, candidate_sha256, campaign_id, producer_commit)
-    if replica.manifest_sha256 != grafted.manifest_sha256:
-        raise ValidationError("grafted holdout replica changed during structural validation")
+    replica = graft_holdout_replica(
+        holdout_root,
+        bundle_root,
+        candidate_set,
+        candidate_sha256,
+        campaign_id,
+        producer_commit,
+        bundle_tree=bundle_tree,
+        bundle_directories=bundle_directories,
+        bundle_cache=bundle_cache,
+    )
     receipt: dict[str, object] = {
         "protocol_version": "1.0.0",
         "document_type": "dao_a3_holdout_structure_receipt",

--- a/oracle/windows-dao/scripts/a3_spec.py
+++ b/oracle/windows-dao/scripts/a3_spec.py
@@ -90,7 +90,9 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def load_bounded_json(path: Path, maximum: int = 64 * 1024 * 1024) -> dict[str, Any]:
+def load_bounded_json_with_payload(
+    path: Path, maximum: int = 64 * 1024 * 1024
+) -> tuple[dict[str, Any], bytes]:
     """Load one regular, duplicate-key-free, bounded UTF-8 JSON object."""
     try:
         metadata = path.lstat()
@@ -122,7 +124,11 @@ def load_bounded_json(path: Path, maximum: int = 64 * 1024 * 1024) -> dict[str, 
         raise ValidationError(f"{path}: invalid JSON: {exc}") from exc
     if not isinstance(value, dict):
         raise ValidationError(f"{path}: JSON root must be an object")
-    return value
+    return value, payload
+
+
+def load_bounded_json(path: Path, maximum: int = 64 * 1024 * 1024) -> dict[str, Any]:
+    return load_bounded_json_with_payload(path, maximum)[0]
 
 
 @dataclass(frozen=True)

--- a/oracle/windows-dao/tests/test_a3_bundle.py
+++ b/oracle/windows-dao/tests/test_a3_bundle.py
@@ -36,6 +36,7 @@ from a3_bundle import (  # noqa: E402
     _validate_target_disclosures,
 )
 import a3_bundle  # noqa: E402
+import a3_bundle_io  # noqa: E402
 from a3_holdout import (  # noqa: E402
     FAN_IN_TIMEOUT_SECONDS,
     HOLDOUT_TIMEOUT_SECONDS,
@@ -357,7 +358,7 @@ class A3BundleTests(unittest.TestCase):
         ordered = self.root / "ordered-finalization-bundle"
         shutil.copytree(self.pre_finalization, ordered)
         events = []
-        original_read_checked = a3_bundle._read_checked
+        original_read_checked = a3_bundle_io.read_checked
 
         def instrumented_read(*args, **kwargs):
             events.append(("read", args[1]))
@@ -367,7 +368,7 @@ class A3BundleTests(unittest.TestCase):
             events.append(("clock", None))
             return self.created_utc
 
-        with patch("a3_bundle._read_checked", side_effect=instrumented_read), patch(
+        with patch("a3_bundle_io.read_checked", side_effect=instrumented_read), patch(
             "a3_bundle._created_utc_now", side_effect=instrumented_clock
         ):
             manifest = finalize_bundle(
@@ -381,7 +382,32 @@ class A3BundleTests(unittest.TestCase):
             path for event, path in events[:clock_index] if event == "read"
         }
         self.assertEqual(reads_before_clock, inventory_paths)
+        self.assertEqual(
+            sum(event == "read" for event, _ in events[:clock_index]),
+            len(inventory_paths),
+        )
         self.assertFalse(any(event == "read" for event, _ in events[clock_index + 1:]))
+
+    def test_artifact_cache_reads_and_hashes_each_file_once(self) -> None:
+        cache_root = self.root / "artifact-cache"
+        cache_root.mkdir()
+        artifact = cache_root / "record.json"
+        artifact.write_bytes(b"{}\n")
+        tree, _ = a3_bundle_io.inventory(cache_root)
+        cache = a3_bundle_io.ArtifactCache(cache_root.resolve(), tree, 64)
+        original_sha256 = hashlib.sha256
+        with patch(
+            "a3_bundle_io.read_checked", wraps=a3_bundle_io.read_checked
+        ) as checked, patch(
+            "a3_bundle_io.hashlib.sha256", wraps=original_sha256
+        ) as sha256:
+            self.assertEqual(cache.read("record.json", 64), b"{}\n")
+            self.assertEqual(cache.json("record.json", 64)[0], {})
+            first = cache.sha256("record.json", 64)
+            second = cache.sha256("record.json", 64)
+        self.assertEqual(first, second)
+        self.assertEqual(checked.call_count, 1)
+        self.assertEqual(sha256.call_count, 1)
 
     def test_complete_validator_rejects_non_a3_manifest_identity(self) -> None:
         relabeled = self.root / "relabeled-bundle"

--- a/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a3_workflow.py
@@ -201,14 +201,20 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn("retention-days: 14", diagnostics)
 
     def test_fan_in_downloads_exactly_three_and_runs_contract_order(self) -> None:
-        self.assertEqual(self.fan_in.count("actions/download-artifact@"), 3)
+        self.assertNotIn("actions/download-artifact@", self.fan_in)
+        self.assertEqual(self.fan_in.count("Download-A3Artifact.ps1"), 3)
         for replica in (1, 2, 3):
-            self.assertIn(f"name: windows-dao-a3-replica-{replica}", self.fan_in)
+            self.assertIn(
+                f'-ArtifactName "windows-dao-a3-replica-{replica}"',
+                self.fan_in,
+            )
             self.assertIn(f"replica-0{replica}", self.fan_in)
         assemble = self.fan_in.index("a3_bundle.py assemble")
         campaign_start = self.fan_in.index("Bind the hosted run-attempt start observable")
         freeze = self.fan_in.index("--freeze-only", assemble)
-        holdout_download = self.fan_in.index("name: windows-dao-a3-replica-3")
+        holdout_download = self.fan_in.index(
+            "Download A3 holdout replica 3 through the REST API"
+        )
         holdout = self.fan_in.index("a3_holdout.py", holdout_download)
         analysis = self.fan_in.index("--resume", holdout)
         # Replica 3 is downloaded only after the retained candidate bytes and
@@ -260,7 +266,7 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn("compression-level: 0", upload)
         self.assertIn("retention-days: 90", upload)
 
-    def test_fan_in_downloads_have_fail_closed_rest_fallbacks(self) -> None:
+    def test_fan_in_downloads_use_only_fail_closed_rest_helper(self) -> None:
         permissions = self.workflow.split("permissions:", 1)[1].split(
             "concurrency:", 1
         )[0]
@@ -269,28 +275,20 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
             {"actions: read", "contents: read"},
         )
         for replica in (1, 2, 3):
-            primary = self.fan_in.split(
-                f"      - name: Download A3 "
-                f"{'holdout ' if replica == 3 else ''}replica {replica}", 1
-            )[1].split("      - name:", 1)[0]
-            self.assertIn(f"id: download_replica_{replica}", primary)
-            self.assertIn("continue-on-error: true", primary)
-
-            fallback_name = (
+            download_name = (
                 f"Download A3 {'holdout ' if replica == 3 else ''}replica {replica} "
-                "through the REST fallback"
+                "through the REST API"
             )
-            fallback = self.fan_in.split(
-                f"      - name: {fallback_name}", 1
+            download = self.fan_in.split(
+                f"      - name: {download_name}", 1
             )[1].split("      - name:", 1)[0]
+            self.assertNotIn("continue-on-error", download)
+            self.assertNotIn("uses: actions/download-artifact", download)
+            self.assertIn("shell: powershell", download)
+            self.assertIn("GITHUB_TOKEN: ${{ github.token }}", download)
+            self.assertIn("Download-A3Artifact.ps1", download)
             self.assertIn(
-                f"if: steps.download_replica_{replica}.outcome == 'failure'",
-                fallback,
-            )
-            self.assertIn("GITHUB_TOKEN: ${{ github.token }}", fallback)
-            self.assertIn("Download-A3Artifact.ps1", fallback)
-            self.assertIn(
-                f'-ArtifactName "windows-dao-a3-replica-{replica}"', fallback
+                f'-ArtifactName "windows-dao-a3-replica-{replica}"', download
             )
 
             check = self.fan_in.split(
@@ -315,10 +313,10 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn("Set-StrictMode -Version Latest", source)
 
         freeze = self.fan_in.index("--freeze-only")
-        holdout_fallback = self.fan_in.index(
-            "Download A3 holdout replica 3 through the REST fallback"
+        holdout_download = self.fan_in.index(
+            "Download A3 holdout replica 3 through the REST API"
         )
-        self.assertLess(freeze, holdout_fallback)
+        self.assertLess(freeze, holdout_download)
 
     def test_independent_validator_is_a_separate_recorded_step(self) -> None:
         step = self.fan_in.split(
@@ -338,7 +336,7 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         self.assertIn("rejected the bundle", step)
         # The report lives outside the closed bundle tree.
         self.assertNotIn("jet3-a3-bundle\\validation", step)
-        self.assertEqual(self.fan_in.count("continue-on-error: true"), 3)
+        self.assertNotIn("continue-on-error: true", self.fan_in)
 
     def test_fan_in_status_is_bounded_timed_and_always_retained(self) -> None:
         for step_id in (
@@ -398,7 +396,7 @@ class WindowsDaoA3WorkflowTests(unittest.TestCase):
         actions = re.findall(
             r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE
         )
-        self.assertEqual(len(actions), 13)
+        self.assertEqual(len(actions), 10)
         for action in actions:
             self.assertRegex(action, r"^[^@]+@[0-9a-f]{40}$")
         self.assertEqual(self.workflow.count("persist-credentials: false"), 3)


### PR DESCRIPTION
## Summary

- use `Download-A3Artifact.ps1` as the only fan-in download path for all three replicas, removing the consistently failing `actions/download-artifact` primaries while preserving fail-closed require steps
- keep replica 3 strictly after the derivation freeze
- cache checked artifact bytes, parsed JSON, and locally computed SHA-256 digests within each producer process so retained files are read and hashed once per process
- reuse verified source bytes during assembly/graft, then independently read and validate the retained destination tree in the same process
- load page-index JSON and the resume candidate bytes once instead of separate read/hash/parse passes
- leave every `a3_independent_*` module untouched so independent validation continues to recompute all evidence itself

The workflow change directly removes 123 seconds of observed hosted overhead (three failing 41-second primary downloads) from run 32623259568.

## Local real-tree profile

Measured with `/usr/bin/time -p` against the read-only A3 replica tree from run 32620335712 (18,952 files, 86 MiB). Contract-valid copies exercised replica 2 assembly and replica 3 graft/holdout. Each row is one separate process, matching the workflow phase boundary.

| Phase | Before | After | Change |
| --- | ---: | ---: | ---: |
| Assemble derivation replicas | 22.80 s | 10.26 s | -53.6% |
| Freeze analysis | 1.96 s | 1.96 s | 0.0% |
| Graft + holdout structural validation | 22.43 s | 6.21 s | -72.3% |
| Resume analysis | 0.25 s | 0.25 s | 0.0% |
| Finalize producer bundle | 15.00 s | 2.77 s | -81.5% |
| Producer bundle validation | 15.82 s | 3.15 s | -80.1% |
| **Producer phase subtotal** | **78.26 s** | **24.60 s** | **-68.6%** |
| Independent recompute (untouched) | 8.26 s | 8.16 s | noise (-1.2%) |
| **All measured Python phases** | **86.52 s** | **32.76 s** | **-62.1%** |

The before/after bundles had identical 19,017-file inventories. All retained bytes matched except `bundle-manifest.json`; its only differences were the expected `campaign_started_utc`, `created_utc`, and reduced `campaign_elapsed_seconds` timing observables.

## Verification

- `python3 -m py_compile` for all changed A3 Python modules
- `python3 -m unittest oracle/windows-dao/tests/test_a3_*.py oracle/windows-dao/tests/test_windows_dao_a3_workflow.py` — 127 tests passed
- `git diff --check`
