### PR TITLE
feat: A4 dry-run reachability harness (EXP-0052 dry_run_honesty_clause)

### DIFF
--- a/oracle/windows-dao/experiments/a4/dry-run/a4-reachability-transcript.json
+++ b/oracle/windows-dao/experiments/a4/dry-run/a4-reachability-transcript.json
@@ -1,0 +1,20887 @@
+{
+  "acquisition_authorized": false,
+  "adversarial_cases": [
+    {
+      "accepted": true,
+      "description": "three lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+      "first_failure": "A4-H1-TDEF-MULTIPLE",
+      "fixture_id": "A4-ADV-TDEF-MULTIPLE-3",
+      "measured_count": 3,
+      "rejected": null,
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "description": "four lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+      "first_failure": "A4-H1-TDEF-MULTIPLE",
+      "fixture_id": "A4-ADV-TDEF-MULTIPLE-4",
+      "measured_count": 4,
+      "rejected": null,
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "description": "the É record carries both registered byte occurrences at compatible anchors: two fitting classes",
+      "first_failure": "A4-H4-ENCODING-AMBIGUOUS",
+      "fixture_id": "A4-ADV-ENCODING-2",
+      "measured_count": 2,
+      "rejected": null,
+      "rejection": "",
+      "target_predicate_id": "A4-H4-ENCODING-AMBIGUOUS"
+    },
+    {
+      "accepted": true,
+      "description": "fixture names an unregistered base formula",
+      "first_failure": null,
+      "fixture_id": "A4-ADV-UNREGISTERED-ID",
+      "measured_count": null,
+      "rejected": true,
+      "rejection": "unregistered candidate id for base_formula: 'not-a-registered-formula'",
+      "target_predicate_id": null
+    },
+    {
+      "accepted": true,
+      "description": "one page blob is 2,047 bytes",
+      "first_failure": null,
+      "fixture_id": "A4-ADV-MALFORMED-PAGE",
+      "measured_count": null,
+      "rejected": true,
+      "rejection": "malformed page blob(s): ['61adf02f8358785f99e523ca6e71cb21612fa445b2a332256b291fd88eb6b02a']",
+      "target_predicate_id": null
+    },
+    {
+      "accepted": true,
+      "description": "claims ROW-FLAGS but the same mutation breaks the directory first",
+      "first_failure": "A4-H2-ROW-DIRECTORY-INVALID",
+      "fixture_id": "A4-ADV-EARLIER-PREDICATE",
+      "measured_count": null,
+      "rejected": true,
+      "rejection": "first failure A4-H2-ROW-DIRECTORY-INVALID is not the target A4-H2-ROW-FLAGS-INVALID",
+      "target_predicate_id": "A4-H2-ROW-FLAGS-INVALID"
+    }
+  ],
+  "baseline": {
+    "campaign": {
+      "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+      "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+      "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+      "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+      "replica_page_counts": {
+        "1": {
+          "EMPTY": 8,
+          "EMPTY_R": 8,
+          "T1_ADD_INDEX": 10,
+          "T1_ADD_TEXT": 10,
+          "T1_CREATE_ID": 10,
+          "T1_DELETE_ALL": 1298,
+          "T1_IDLE_R": 1298,
+          "T1_REINSERT_SAME": 1298,
+          "T1_REL_0064": 82,
+          "T1_REL_0512": 530,
+          "T1_REL_0768": 786,
+          "T1_REL_1280": 1298,
+          "T2_CREATE": 12,
+          "T2_DROP": 12,
+          "T2_RECREATE": 14,
+          "T3_ABS_04096": 4098,
+          "T3_ABS_08192": 8194,
+          "T3_ABS_12288": 12290,
+          "T3_ABS_16480": 16484,
+          "T3_CREATE": 16,
+          "T4_CREATE": 18,
+          "T4_IDLE_R": 17390,
+          "T4_REL_0064": 16550,
+          "T4_REL_0896": 17382,
+          "T4_REL_0904": 17390
+        },
+        "2": {
+          "EMPTY": 10,
+          "EMPTY_R": 10,
+          "T1_ADD_INDEX": 12,
+          "T1_ADD_TEXT": 12,
+          "T1_CREATE_ID": 12,
+          "T1_DELETE_ALL": 1300,
+          "T1_IDLE_R": 1300,
+          "T1_REINSERT_SAME": 1300,
+          "T1_REL_0064": 85,
+          "T1_REL_0512": 535,
+          "T1_REL_0768": 790,
+          "T1_REL_1280": 1300,
+          "T2_CREATE": 14,
+          "T2_DROP": 14,
+          "T2_RECREATE": 16,
+          "T3_ABS_04096": 4100,
+          "T3_ABS_08192": 8195,
+          "T3_ABS_12288": 12290,
+          "T3_ABS_16480": 16482,
+          "T3_CREATE": 18,
+          "T4_CREATE": 20,
+          "T4_IDLE_R": 17389,
+          "T4_REL_0064": 16549,
+          "T4_REL_0896": 17379,
+          "T4_REL_0904": 17389
+        },
+        "3": {
+          "EMPTY": 9,
+          "EMPTY_R": 9,
+          "T1_ADD_INDEX": 11,
+          "T1_ADD_TEXT": 11,
+          "T1_CREATE_ID": 11,
+          "T1_DELETE_ALL": 1303,
+          "T1_IDLE_R": 1303,
+          "T1_REINSERT_SAME": 1303,
+          "T1_REL_0064": 85,
+          "T1_REL_0512": 535,
+          "T1_REL_0768": 787,
+          "T1_REL_1280": 1303,
+          "T2_CREATE": 13,
+          "T2_DROP": 13,
+          "T2_RECREATE": 15,
+          "T3_ABS_04096": 4099,
+          "T3_ABS_08192": 8197,
+          "T3_ABS_12288": 12289,
+          "T3_ABS_16480": 16485,
+          "T3_CREATE": 17,
+          "T4_CREATE": 19,
+          "T4_IDLE_R": 17393,
+          "T4_REL_0064": 16553,
+          "T4_REL_0896": 17381,
+          "T4_REL_0904": 17393
+        }
+      },
+      "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+      "unique_page_blob_count": 155
+    },
+    "charges": {
+      "base_formula_evaluations": 579,
+      "candidate_serializations": 12,
+      "catalog_raw_rows": 117,
+      "catalog_root_signatures": 28,
+      "encoding_union_anchor_bytes": 294,
+      "h1_target_validity_checks": 452,
+      "h4_name_length_structural_tuples": 83232,
+      "qualified_tdef_pages": 6,
+      "raw_locator_pairs": 40008968,
+      "raw_locator_windows": 40900,
+      "role_transition_evaluations": 210,
+      "tdef_lifecycle_signatures": 945,
+      "type_0_and_tag_05_bitmap_bits": 3059664,
+      "type_1_slots": 648,
+      "valid_path_row_directory_entries": 1500
+    },
+    "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+    "first_failure": null,
+    "fixture_id": "A4-R00-BASELINE",
+    "models": {
+      "h1_tdef_to_map_row": {
+        "canonical_candidate_id": "ca88782139c6a4edefefb8dd2231bf570602dd044c862db6f37898b98fcfb8ed",
+        "canonical_model_id": "de2dac5cd44bdd92309391fdc93e171bfbd71964ad042f659400b4301cd85532",
+        "model": {
+          "layout": "u8_row_then_u24le_page",
+          "locator_offsets": [
+            35,
+            39
+          ],
+          "table_record_signature_id": "666a379741fb100b573c5347046e2197776735cd46aada90cf3d138c3625da1a",
+          "tdef_lifecycle_signature": "new_tag_02_at_role_create"
+        },
+        "model_type": "h1_locator_model"
+      },
+      "h2_row_identity_map_role": {
+        "canonical_model_id": "03ab9511b00114d4a074af8db469cdf1b89017cc7a6fcd8bfd126272107de851",
+        "model": {
+          "locator_role_assignment": "ordinal_0_owned_ordinal_1_available",
+          "polarity": "set_bit_owned_in_use",
+          "row_masks": [
+            8191,
+            4095
+          ]
+        },
+        "model_type": "h2_role_model"
+      },
+      "h3_indirect_traversal": {
+        "canonical_model_id": "967068dcdfe1f0323dbc3d98b9490732c0ebe8558fdde93a142d609185cc54e0",
+        "model": {
+          "base_formula": "slot_ordinal_times_16352_plus_bit_index",
+          "conversion_candidate": "structural_type_0_to_type_1_with_nonzero_u32_slots",
+          "tag_05_bitmap_polarity": "set_bit_owned_in_use"
+        },
+        "model_type": "h3_traversal_model"
+      },
+      "h4_catalog_bootstrap": {
+        "canonical_model_id": "2a7bbf55f5464b78fc546ef69a1acf740738fc5283788e1be6f559f74efc4ca4",
+        "model": {
+          "fields": {
+            "encoding_length_equivalence_class": "cp1252_single_byte_per_scalar",
+            "field_tuple_members": [
+              {
+                "endianness": "big",
+                "identifier_width": 1,
+                "kind_start_delta": 2,
+                "kind_width": 1,
+                "name_length_endianness": "big",
+                "name_length_start_delta": 1,
+                "name_length_width": 1
+              },
+              {
+                "endianness": "big",
+                "identifier_width": 1,
+                "kind_start_delta": 2,
+                "kind_width": 1,
+                "name_length_endianness": "little",
+                "name_length_start_delta": 1,
+                "name_length_width": 1
+              },
+              {
+                "endianness": "little",
+                "identifier_width": 1,
+                "kind_start_delta": 2,
+                "kind_width": 1,
+                "name_length_endianness": "big",
+                "name_length_start_delta": 1,
+                "name_length_width": 1
+              },
+              {
+                "endianness": "little",
+                "identifier_width": 1,
+                "kind_start_delta": 2,
+                "kind_width": 1,
+                "name_length_endianness": "little",
+                "name_length_start_delta": 1,
+                "name_length_width": 1
+              }
+            ],
+            "identifier_lifecycle_relation": "stable_for_same_operation_instance_and_distinct_for_t2_v1_v2",
+            "kind_mapping": {
+              "field": 34,
+              "index": 51,
+              "table": 17
+            }
+          },
+          "root": {
+            "catalog_root_selection_signature": "operation_delta_non_name_structure",
+            "root_tdef_page": 2
+          }
+        },
+        "model_type": "h4_catalog_model"
+      },
+      "resources": {
+        "qualified_tdef_pages_union": {
+          "bound": 16,
+          "measured": 6
+        },
+        "replica_1_changed_hash_entries": {
+          "bound": 65536,
+          "measured": 17428
+        },
+        "replica_1_checkpoints": {
+          "bound": 25,
+          "measured": 25
+        },
+        "replica_1_final_pages": {
+          "bound": 20480,
+          "measured": 17390
+        },
+        "replica_1_inserted_rows": {
+          "bound": 200000,
+          "measured": 149184
+        },
+        "replica_2_changed_hash_entries": {
+          "bound": 65536,
+          "measured": 17427
+        },
+        "replica_2_checkpoints": {
+          "bound": 25,
+          "measured": 25
+        },
+        "replica_2_final_pages": {
+          "bound": 20480,
+          "measured": 17389
+        },
+        "replica_2_inserted_rows": {
+          "bound": 200000,
+          "measured": 119328
+        },
+        "replica_3_changed_hash_entries": {
+          "bound": 65536,
+          "measured": 17431
+        },
+        "replica_3_checkpoints": {
+          "bound": 25,
+          "measured": 25
+        },
+        "replica_3_final_pages": {
+          "bound": 20480,
+          "measured": 17393
+        },
+        "replica_3_inserted_rows": {
+          "bound": 200000,
+          "measured": 99488
+        },
+        "unique_page_blobs": {
+          "bound": 65536,
+          "measured": 155
+        }
+      }
+    }
+  },
+  "capability_advancement_authorized": false,
+  "document_type": "dao_a4_reachability_transcript",
+  "evaluator_role": "plan-driven reference evaluator decoding fixture bytes; not the production A4 analyzer",
+  "experiment_id": "DAO-A4-ROW-ANCHORED-MAPS-001",
+  "fixtures": [
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 579,
+        "candidate_serializations": 12,
+        "catalog_raw_rows": 117,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 294,
+        "h1_target_validity_checks": 452,
+        "h4_name_length_structural_tuples": 83232,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 210,
+        "tdef_lifecycle_signatures": 945,
+        "type_0_and_tag_05_bitmap_bits": 3059664,
+        "type_1_slots": 648,
+        "valid_path_row_directory_entries": 1500
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "all-pass synthetic campaign; every derivation layer decisive and every holdout predicted",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-HOLDOUT-PREDICTION": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-HOLDOUT-PREDICTION": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-HOLDOUT-FIELDS": 1,
+        "A4-H4-HOLDOUT-ROOT": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": null,
+      "fixture_id": "A4-R00-BASELINE",
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "e0ec771322f103c509fe55e1b5eb01004bcc7d0a3cddf353c8bbc32b4cbf526c",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "pass"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": null
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "eebdfaebf4d4c48ef1ccc61978e6968183a537610dee0c4768314dfa3e0ee556",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "333d900fef17ad5a32c679bf2876c4ed46fc1b732b74bf04da2625b8fa1cb5d1",
+        "page_index_inventory_sha256": "96dd94e72475c458b113433e45ffb137adc4cb7587ecded1340b6f7a4b384252",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "2be7384fca05026fcb3e010249e3de04f0ba65c8b860f7a0c0cc1135a3431692",
+        "unique_page_blob_count": 156
+      },
+      "charges": {},
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": null,
+      "description": "one byte differs in replica 1 EMPTY_R page 1",
+      "evaluated_counts": {
+        "A4-IDLE-EQUALITY": 0
+      },
+      "first_failure": "A4-IDLE-EQUALITY",
+      "fixture_id": "A4-R01-IDLE-EQUALITY",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "flip_empty_r_byte"
+        ]
+      },
+      "mutation_sha256": "009b8d80dea5c924c95beaf929ae926add0513e2f88489810df91fa4d61cd4fb",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "replica 1 EMPTY/EMPTY_R page-index sequence differs",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-IDLE-EQUALITY"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "3595a6942c6a9a372ea80e329c729c5978f266f542df5baf3ed0d051931314a1",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "be2861e6666adf20e50380609b5486fe2dd7fbf01e2eb330114512385a97439e",
+        "unique_page_blob_count": 155
+      },
+      "charges": {},
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": null,
+      "description": "replica 1 T2_CREATE snapshot carries a duplicate table ordinal",
+      "evaluated_counts": {
+        "A4-IDLE-EQUALITY": 0,
+        "A4-SCHEMA-SNAPSHOT": 0
+      },
+      "first_failure": "A4-SCHEMA-SNAPSHOT",
+      "fixture_id": "A4-R02-SCHEMA-SNAPSHOT",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "snapshot_duplicate_ordinal"
+        ]
+      },
+      "mutation_sha256": "63e23734324386223484c7e223043522ff971428524024eba76ea3d47d776bd2",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1 T2_CREATE ordinals are not unique and name-sorted",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-SCHEMA-SNAPSHOT"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "a0f0851f1868cac85062f105a38ab135955f9ccf8fd11ae2bb97f67dc27ee556",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+        "page_index_inventory_sha256": "7413cf05faf4242a88847006c232ecdcb437765ce2ef9348c2bf5c56e08e69a3",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "unique_page_blob_count": 155
+      },
+      "charges": {},
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": null,
+      "description": "replica 1 T1_REL_0064 page index lists another blob's hash at page 5",
+      "evaluated_counts": {
+        "A4-IDLE-EQUALITY": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-SNAPSHOT-RECONSTRUCTION",
+      "fixture_id": "A4-R03-SNAPSHOT-RECONSTRUCTION",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "page_index_hash_swap"
+        ]
+      },
+      "mutation_sha256": "65a41b0e72c599607deb3b4060365171c0ab70ba0bb374b2fd511c87ab15127b",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1 T1_REL_0064 database SHA-256 differs; replica 1 T1_REL_0064 page index differs from observation sequence; replica 1 T1_REL_0064 changed_page_indices differ",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-SNAPSHOT-RECONSTRUCTION"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "cbf96f8a31a63101c0103ccb834d6127b5d2c55cd5ac556a6e70f0a4860f9892",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "e8dea268e636e4b7b380ebf0b3f10c76c6f6a7ac9ab8e0d83e6195a2a85b0162",
+        "page_index_inventory_sha256": "cdcfd1ff5f7453b3db2f450c7f3d8290f97dcc563c803046c2c65546703b8ad4",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1310,
+            "T1_IDLE_R": 1310,
+            "T1_REINSERT_SAME": 1310,
+            "T1_REL_0064": 94,
+            "T1_REL_0512": 542,
+            "T1_REL_0768": 798,
+            "T1_REL_1280": 1310,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 30,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1312,
+            "T1_IDLE_R": 1312,
+            "T1_REINSERT_SAME": 1312,
+            "T1_REL_0064": 97,
+            "T1_REL_0512": 547,
+            "T1_REL_0768": 802,
+            "T1_REL_1280": 1312,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4097,
+            "T3_ABS_08192": 8192,
+            "T3_ABS_12288": 12292,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 18,
+            "T4_CREATE": 32,
+            "T4_IDLE_R": 17391,
+            "T4_REL_0064": 16551,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17391
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1315,
+            "T1_IDLE_R": 1315,
+            "T1_REINSERT_SAME": 1315,
+            "T1_REL_0064": 97,
+            "T1_REL_0512": 547,
+            "T1_REL_0768": 799,
+            "T1_REL_1280": 1315,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 31,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "0d9bba061047f19e226e6bb1a0ca663ced8d25671048624d66c46e1e1d5f68bd",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "qualified_tdef_pages": 19
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": null,
+      "description": "twelve extra tag-02 pages appear at T4_CREATE: 17 qualified pages in the union, one over 16",
+      "evaluated_counts": {
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-RESOURCE-BOUND",
+      "fixture_id": "A4-R04-RESOURCE-BOUND",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {
+            "T4_CREATE": 12
+          },
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "a567141e98628e41e03911eeb9933a8f2d4ccfbe3ec1b64f57c5540ee18f9cb1",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "qualified_tdef_pages_union=19 > 16",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-RESOURCE-BOUND"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "2db648cd472a8f160a4e29d6bfce0ca0e380910f42b497fcb631841e2dd29882",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "c5b986a002a27d5469b0a7cd2699c6c0c18c3e4180c45b56b362099a8c2e1087",
+        "page_index_inventory_sha256": "7ad4f0a62dc97e5e7c2b8e7441cd692ac9e474bd608d8cf9cbdbffda592e4b6b",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "af51143dd52da41f3ba252fcd89d22b26e186efdc1965e0d12d38b0ca63448bb",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "qualified_tdef_pages": 0
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "a5e36fc56a501c7444561bf6fefa9569518b903f5ea40517bbb8f5daa1bca148",
+      "description": "user TDEF pages carry tag 03, so no tag-02 page matches either lifecycle signature",
+      "evaluated_counts": {
+        "A4-H1-TDEF-NONE": 0,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-TDEF-NONE",
+      "fixture_id": "A4-R05-H1-TDEF-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 3
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "c24cd97d1a883550caf54904de666437b7d504e090df2261e15822db5611af46",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: no lifecycle-matching TDEF candidate",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TDEF-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "d3c27dde730538f8d2ae26e50b28f0c5d1c70d000a8bbfe75848ff3f798789ff",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "fa5d5272fc13059f23f4f7b05b23e3ee06dea62a3a8ffd7b3360d56d5e05e499",
+        "page_index_inventory_sha256": "80a392d350d21276bff3a8cee2fab93bba8ac66118ba50327a09f2fc9550f676",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1299,
+            "T1_IDLE_R": 1299,
+            "T1_REINSERT_SAME": 1299,
+            "T1_REL_0064": 83,
+            "T1_REL_0512": 531,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1299,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12291,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17391,
+            "T4_REL_0064": 16551,
+            "T4_REL_0896": 17383,
+            "T4_REL_0904": 17391
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1301,
+            "T1_IDLE_R": 1301,
+            "T1_REINSERT_SAME": 1301,
+            "T1_REL_0064": 86,
+            "T1_REL_0512": 536,
+            "T1_REL_0768": 791,
+            "T1_REL_1280": 1301,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4096,
+            "T3_ABS_08192": 8196,
+            "T3_ABS_12288": 12291,
+            "T3_ABS_16480": 16483,
+            "T3_CREATE": 19,
+            "T4_CREATE": 21,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17380,
+            "T4_REL_0904": 17390
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1304,
+            "T1_IDLE_R": 1304,
+            "T1_REINSERT_SAME": 1304,
+            "T1_REL_0064": 86,
+            "T1_REL_0512": 536,
+            "T1_REL_0768": 788,
+            "T1_REL_1280": 1304,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8192,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16486,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17394,
+            "T4_REL_0064": 16554,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17394
+          }
+        },
+        "schema_snapshot_inventory_sha256": "42395c5ce897413c0d918e9cdf0632d3eee619bb2c1f27bceda9f3ce6b27827d",
+        "unique_page_blob_count": 158
+      },
+      "charges": {
+        "qualified_tdef_pages": 8,
+        "tdef_lifecycle_signatures": 900
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "aa9345df1303735e3c9cae44b2bae73cbee4d6221c27a0ce860b1452eed4ae24",
+      "description": "a second new tag-02 page appears at T3_CREATE: two lifecycle-matching TDEF candidates",
+      "evaluated_counts": {
+        "A4-H1-TDEF-MULTIPLE": 2,
+        "A4-H1-TDEF-NONE": 2,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-TDEF-MULTIPLE",
+      "fixture_id": "A4-R06-H1-TDEF-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {
+            "T3_CREATE": 1
+          },
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "3ed24958b0ca16be5377d565e130315430a68fbeeaa604e3e608d993588a98e5",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple lifecycle-matching TDEF candidates",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "4f1880f47b1f3e201b36931ce6a1d55ee910647f04bfd3f3d105793bf3b035bc",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "1670734bb1a74a9f9ed81eb69ec39e7ac9ae2141c8eb2f6427ad99b4f6891da5",
+        "page_index_inventory_sha256": "269ab0654335199f936dd3a63c38f5c363621c0d8c8113d343c9767a014a0772",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "03b033f8ae9b49a65cfc63666d182dbbba0aa3d21e8826f42bec03f893f57816",
+        "unique_page_blob_count": 139
+      },
+      "charges": {
+        "qualified_tdef_pages": 6,
+        "raw_locator_windows": 40900,
+        "tdef_lifecycle_signatures": 756
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "e349d0c9577bfd02091e39a34df716f9be229ef3ef3375bf6ad2f129f64593fb",
+      "description": "user TDEF bytes after the tag are all 0xA5: no window decodes under either layout",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-NONE": 0,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-LOCATOR-LAYOUT-NONE",
+      "fixture_id": "A4-R07-H1-LAYOUT-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "opaque",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "3a46bf6be97507b7e6cf724aa66d20bfb3bf45f634c64c33f60415c82a67a590",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: no syntactically preserved window under either layout",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "2341f1c4791881999c81681175d94da479abdef4adb63034bd659de3f33c2c16",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "367c886311a63532d5f7ec41664a983ee157f35fe6784d4b001b4c74cd9f1176",
+        "page_index_inventory_sha256": "40f04f1eff294d465bc845134aea3c7dc95f6c71cf591bf452f0c1900d8448a4",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "70df0d24825f4b7968a3a794ffaef3cae4372e101a76d8ae523df140273145e9",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "tdef_lifecycle_signatures": 756
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "42e3c5fbf51a8acce5bbc6e9afd2a4c8670796087ca8efc51efce408e573fa2e",
+      "description": "signature byte 2 differs on every user TDEF: windows preserved, no masked pair",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-NONE": 0,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-LOCATOR-PAIR-NONE",
+      "fixture_id": "A4-R09-H1-PAIR-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "broken_signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "293115392d6912c24a4f01bd0e5397280f3252b23afe5ad0c6536af7dbcb6ae9",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: no masked, nonoverlapping, identity-preserved pair",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-LOCATOR-PAIR-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "61d35e2b2be1b1adde655be1a7463b84af3c1ee08d8c79796f58fdcaee68f604",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "dd65d837649e33522182d1263af951ccb21e97f868a75ecaed466a5eaa260c29",
+        "page_index_inventory_sha256": "dccf531f2ee53fab78caa4013ccf66914faf6eb6e922b2d8f93e6269b9dacbcc",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "6b2884fc904cee2d886364e9b9f7ec8e9ab90259f3b16b3106299c367a571d32",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "h1_target_validity_checks": 4,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "tdef_lifecycle_signatures": 756
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "01743f5f6497c984e1860186fd38f1939cb8d1f3feed804c59cf039388e4a0ab",
+      "description": "locators point at the TDEF page itself (tag 02) under both layouts",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-TARGET-ROW-INVALID": 0,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-TARGET-ROW-INVALID",
+      "fixture_id": "A4-R11-H1-TARGET-INVALID",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "tdef",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "18c035ad1311513e8dbfd6703aeedcf1157216f7722f64a4adae1b74fff7fc0b",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: u24le_page_then_u8_row: target page 2048 absent at T1_CREATE_ID; u8_row_then_u24le_page: target page 8 tag 02 at T1_CREATE_ID",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TARGET-ROW-INVALID"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "bd43e5e5986773f59f333c0201dd6d5d47c594c67c7dd70e0f96105d4d419b62",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "64b955ee8853f9c3075a083f4f55b81c61804225de96c7eb24141862d1a5c18a",
+        "page_index_inventory_sha256": "f21f4a14b99af12925de964327bcffe4b4de6fce493b1dfdf511e2c17bdb933e",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 4628,
+            "EMPTY_R": 4628,
+            "T1_ADD_INDEX": 4628,
+            "T1_ADD_TEXT": 4628,
+            "T1_CREATE_ID": 4628,
+            "T1_DELETE_ALL": 5908,
+            "T1_IDLE_R": 5908,
+            "T1_REINSERT_SAME": 5908,
+            "T1_REL_0064": 4692,
+            "T1_REL_0512": 5140,
+            "T1_REL_0768": 5396,
+            "T1_REL_1280": 5908,
+            "T2_CREATE": 4628,
+            "T2_DROP": 4628,
+            "T2_RECREATE": 4628,
+            "T3_ABS_04096": 5908,
+            "T3_ABS_08192": 8192,
+            "T3_ABS_12288": 12288,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 4628,
+            "T4_CREATE": 4628,
+            "T4_IDLE_R": 17388,
+            "T4_REL_0064": 16548,
+            "T4_REL_0896": 17380,
+            "T4_REL_0904": 17388
+          },
+          "2": {
+            "EMPTY": 4630,
+            "EMPTY_R": 4630,
+            "T1_ADD_INDEX": 4630,
+            "T1_ADD_TEXT": 4630,
+            "T1_CREATE_ID": 4630,
+            "T1_DELETE_ALL": 5910,
+            "T1_IDLE_R": 5910,
+            "T1_REINSERT_SAME": 5910,
+            "T1_REL_0064": 4695,
+            "T1_REL_0512": 5145,
+            "T1_REL_0768": 5400,
+            "T1_REL_1280": 5910,
+            "T2_CREATE": 4630,
+            "T2_DROP": 4630,
+            "T2_RECREATE": 4630,
+            "T3_ABS_04096": 5910,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 4630,
+            "T4_CREATE": 4630,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 4629,
+            "EMPTY_R": 4629,
+            "T1_ADD_INDEX": 4629,
+            "T1_ADD_TEXT": 4629,
+            "T1_CREATE_ID": 4629,
+            "T1_DELETE_ALL": 5913,
+            "T1_IDLE_R": 5913,
+            "T1_REINSERT_SAME": 5913,
+            "T1_REL_0064": 4695,
+            "T1_REL_0512": 5145,
+            "T1_REL_0768": 5397,
+            "T1_REL_1280": 5913,
+            "T2_CREATE": 4629,
+            "T2_DROP": 4629,
+            "T2_RECREATE": 4629,
+            "T3_ABS_04096": 5913,
+            "T3_ABS_08192": 8193,
+            "T3_ABS_12288": 12291,
+            "T3_ABS_16480": 16487,
+            "T3_CREATE": 4629,
+            "T4_CREATE": 4629,
+            "T4_IDLE_R": 17395,
+            "T4_REL_0064": 16555,
+            "T4_REL_0896": 17383,
+            "T4_REL_0904": 17395
+          }
+        },
+        "schema_snapshot_inventory_sha256": "6286e380e77d47aef55f5c937dbd13b9768adced8c745bd6e07fa072ab486d57",
+        "unique_page_blob_count": 132
+      },
+      "charges": {
+        "h1_target_validity_checks": 600,
+        "qualified_tdef_pages": 5,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "tdef_lifecycle_signatures": 756
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "cb7a9ebcfee8980fc2437f1738e44adf0d483d6e5265356da83c492705c70d09",
+      "description": "user pages preallocated below 18 and EMPTY padded past 256*17 so page-then-row targets are extant tag 01 too",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 2,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-TARGET-ROW-INVALID": 2,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+      "fixture_id": "A4-R08-H1-LAYOUT-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 4610,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": true,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "4dea29a768550e53e186cadecce73fee7fb8c9c2cb5216707d76091ecb9c01e0",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: target-valid pairs under more than one layout",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE"
+    },
+    {
+      "accepted": false,
+      "campaign": {
+        "campaign_sha256": "1132387ffdb5097352a73d97c031f8df43edf622f5b03f284ca7deb4bc7800ff",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "b8164c96e2935b2380f566d319e6df94b02ca0aafb2b1d35b20673e1b48c962e",
+        "page_index_inventory_sha256": "b9789f5beaf7ba0827b64c8215a392938b2553b90c6f63fe265852cdd0c9f423",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "7e4c36f6787863aa685c82d0730110edd9ebe8b16c0eef2de90edae7e4f4dd4f",
+        "unique_page_blob_count": 172
+      },
+      "charges": {
+        "base_formula_evaluations": 579,
+        "candidate_serializations": 12,
+        "catalog_raw_rows": 117,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 294,
+        "h1_target_validity_checks": 452,
+        "h4_name_length_structural_tuples": 83232,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 39889186,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 210,
+        "tdef_lifecycle_signatures": 945,
+        "type_0_and_tag_05_bitmap_bits": 3059664,
+        "type_1_slots": 648,
+        "valid_path_row_directory_entries": 1500
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "attempt: the locator pair is copied to [100,108); exact-hole filtering keeps one structural pair (asserted unreachable)",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-HOLDOUT-PREDICTION": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-HOLDOUT-PREDICTION": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-HOLDOUT-FIELDS": 1,
+        "A4-H4-HOLDOUT-ROOT": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": null,
+      "fixture_id": "A4-R10-H1-PAIR-MULTIPLE",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "second_locator_pair_copy"
+        ]
+      },
+      "mutation_sha256": "b1229f9ba301db2f171b8ccfa2c0fa4828e46c3b45cd730fea0935334cc362c2",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "pass"
+        }
+      ],
+      "rejection": "first failure None is not the target; measured count 1 violates {'minimum': 2, 'source': 'measured_candidate_cardinality'}",
+      "target_predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "84d0b1f60aba454c13eda0dcfb93bed889d83e1a917bc22bc13e552974833167",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "42a519fdaff44f956a0ca12b501251291738b6fc990d8ceaaaa7a0b8169f1139",
+        "page_index_inventory_sha256": "a229be553bfced674e56ce6330f6c6963106eaa0d3aefe4c60bd28f17cd8a6ba",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "85f9aacad6d92e8f779e59ed7f031b8f19a19f7f0298a7233b7c14a1db3bb28e",
+        "unique_page_blob_count": 161
+      },
+      "charges": {
+        "h1_target_validity_checks": 301,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008978,
+        "raw_locator_windows": 40900,
+        "tdef_lifecycle_signatures": 756
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "8572aab6b66ffb7cf07531b5c5f6f87945707f02c63b64c474c2ee1bf6e81699",
+      "description": "replica 2 encodes its locators page-then-row",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-REPLICA-DISAGREEMENT",
+      "fixture_id": "A4-R12-H1-REPLICA",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {
+            "2": "u24le_page_then_u8_row"
+          },
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "906c5639fae050f3ce1c5722658f17c13dc34aba5049539520ed8c9356b2b37b",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica models differ: [{'layout': 'u8_row_then_u24le_page', 'table_record_signature_id': '666a379741fb100b573c5347046e2197776735cd46aada90cf3d138c3625da1a', 'locator_offsets': [35, 39], 'tdef_lifecycle_signature': 'new_tag_02_at_role_create'}, {'layout': 'u24le_page_then_u8_row', 'table_record_signature_id': '666a379741fb100b573c5347046e2197776735cd46aada90cf3d138c3625da1a', 'locator_offsets': [35, 39], 'tdef_lifecycle_signature': 'new_tag_02_at_role_create'}]",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-REPLICA-DISAGREEMENT"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "0a69e0c42426f42f7a1804e48d09c0000d620802f02fe51c2c813dd69ad1c347",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "7c18baf67308e387d915abee3a315f591112d9f4fda682efb744141aeb3e31ea",
+        "page_index_inventory_sha256": "1532c30c1144635a34c4fc03c93f8383afaa2beb0a5addbc5d811ed457c81996",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "7fb0735f295faae526e619a0749eb70993fd94b64569bd525349f710ff2209ae",
+        "unique_page_blob_count": 160
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 70,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 104184,
+        "type_1_slots": 297,
+        "valid_path_row_directory_entries": 940
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "c88b71ce5f94a5c56b404d8202141ab03c68c24533ed3c51d83d7c99c11287fc",
+      "description": "replica 1 T3 map page slot 1 starts at 12, inside the directory bytes",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-ROW-DIRECTORY-INVALID",
+      "fixture_id": "A4-R14-H2-DIRECTORY",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "t3_directory_overlap"
+        ]
+      },
+      "mutation_sha256": "7802dc72936b5ea417e5ca34a35c75b98b61d3da4832e34fcf543a4022f4285c",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: T3-v1 page 15 at T3_CREATE: slot 1 start 12 overlaps directory bytes below 14",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-ROW-DIRECTORY-INVALID"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "6eee697e9e3ce0cfc4ca71a80624937da17a5294b9533a8ec76c7d54c758328f",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "442188a5d5032614b97cedd2a7c8981eb6a0d3385cc00f9f23d361180845abe1",
+        "page_index_inventory_sha256": "dcc063bcf430d5dec681d3f82d7a359bee4d09386fce969ca96f1bad04f65e63",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "aae3f9297f581fa56aa3b7c1cb825a4cddf9f57efcf70875c0b7a0ab44cda334",
+        "unique_page_blob_count": 160
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 70,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 104184,
+        "type_1_slots": 297,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "b825a1f325eb2a65abd26d511397498e70fff6c84d7826b3de9c23f389e13066",
+      "description": "replica 1 T3 owned row has the deleted flag set",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-ROW-FLAGS-INVALID",
+      "fixture_id": "A4-R15-H2-FLAGS",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "t3_owned_deleted_flag"
+        ]
+      },
+      "mutation_sha256": "d21f8a0faafa8bbb14cc54954b961297ed65f83742e28e860b87e743fab3b078",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: located row has deleted/overflow set: (('T3-v1', 'T3_CREATE'), 0)",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-ROW-FLAGS-INVALID"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "d6189454c2568f85f0691534f8c1415b1393f2b0c58533f5a76fdcbb6c7412e6",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "1990ddb618572ba0f5150acf3f965b65680bf2f309aa20320bf13130fccad823",
+        "page_index_inventory_sha256": "cafa48e8a99f6a4805030443c58e84af6ed4be87d4616ddbf463b7e126f7f733",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "16cec848be3322578a2c93268ce20c2ec41b7a725d36f01effd777df5a80b1f9",
+        "unique_page_blob_count": 160
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 70,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 104184,
+        "type_1_slots": 297,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "49532357b1ec96a4d56ef32145c6f966088cbb656fa2ec4b57218da0666317ae",
+      "description": "replica 1 T3 owned row begins 02",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-MAP-TAG-UNSUPPORTED",
+      "fixture_id": "A4-R16-H2-TAG",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "t3_owned_tag_02"
+        ]
+      },
+      "mutation_sha256": "b5caa7a1eaa728d64a18e621f39ba7d30a1cbd333f03021aed5ab46128d4728c",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: ('T3-v1', 'T3_CREATE'): row tag 02 is neither 00 nor 01",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "0e82c3942bd3bc5bda6d2405481050175664006c49fdcce2fe400262d8168928",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "2f4eb18a05dc129b04c531c22defe07f6332e17e00edef73a42bb365cc50882a",
+        "page_index_inventory_sha256": "fc5c068896f5cb55b6306970523a6923b8494436bd1c2e6a86153056870d4d93",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "301102fe001019888b30f73bd39feae477b5b75daaa77fe2fbb8338fe83ff008",
+        "unique_page_blob_count": 161
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 70,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 104248,
+        "type_1_slots": 594,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "0fe775edf902f6ab91a31f4b3aa433bbc63975e0ee31bae4fff68aff2042340d",
+      "description": "replica 1 T1 available row admits a page the owned row never admits",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-ROLE-NONE": 0,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-ROLE-NONE",
+      "fixture_id": "A4-R17-H2-ROLE-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "t1_available_outside_owned"
+        ]
+      },
+      "mutation_sha256": "c6bbcf22d1c248cf1d0f309a13b3d4cc336c479a8eedc1d1d1e183e167a1045b",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: set_bit_owned_in_use/ordinal_0_owned_ordinal_1_available: T1-v1 at T1_CREATE_ID: available admits page beyond page_count; set_bit_owned_in_use/ordinal_1_owned_ordinal_0_available: T1-v1 at T1_CREATE_ID: owned/in-use admits page beyond page_count",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-ROLE-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "f1befc3165d7788e84e649272addb746a19419f05400ed7a47736e19595770bf",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "e1d2a397c0d3527133edc730c53eee5d23b957c5802d46e46fcb008022d5e457",
+        "page_index_inventory_sha256": "f5f8b891df3270f092555a771ea4bae09f3a9f066b771c4a7cf5867f5696d6db",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12291,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8196,
+            "T3_ABS_12288": 12291,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8198,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "d1dfc558c4fa08e18c4a4d1bad4ea2589a90e0e25785f5f226edab49f3794591",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 171392,
+        "type_1_slots": 1452,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "7c6cb73d7965734f2c1e48308caaf194bacd5c915939ab35cfcfda17289eb0a8",
+      "description": "available rows equal owned rows everywhere: both role assignments fit",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-ROLE-MULTIPLE": 2,
+        "A4-H2-ROLE-NONE": 2,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-ROLE-MULTIPLE",
+      "fixture_id": "A4-R18-H2-ROLE-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": true,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "979257f92f52e9306fb655cd595d13856f62afaaafc81ca9414f19fef072c5a4",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple static role/polarity/mask candidates",
+          "measured_count": 2,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-ROLE-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "1ff70ff50eb3c0886fbfd9f98351a286ee94ae6285b5a86681362a6127d24761",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "baff60b9c8d86ea602bfe71bac1c4214b6a72178f547ef0d0481f3c5f78df0c7",
+        "page_index_inventory_sha256": "ca3439de11f8b1f0c125f02aa67ff23531819e220350702c8509d78fde3a826b",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "7655affa2f72c7fe24f0f16c79f21c40cb44e7c37cea4ec3c943df5d5c5f6a72",
+        "unique_page_blob_count": 159
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 79,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 148080,
+        "type_1_slots": 594,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "453fb6474104c2bd681c9e6070829b61514a0a87e6aa2963735b56f426962802",
+      "description": "replica 1 T1 owned row drops its first data page on the T1_REL_0064->T1_REL_0512 grow leg (AMB-06)",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-TRANSITION-UNEXPLAINED",
+      "fixture_id": "A4-R19-H2-TRANSITION",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "t1_owned_drops_page_at_0512"
+        ]
+      },
+      "mutation_sha256": "aee4d5ca592f20a8c665b493ed0fd122ffab1aa5d544c89f954971723801a0c3",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: T1-v1 T1_REL_0064->T1_REL_0512 (grow): owned/in-use removed pages [18]",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-TRANSITION-UNEXPLAINED"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "8e83422607b7a4dc742a22cdc5bed65b824b22c6bdf07cb9f3f7873fe0d416ce",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "78375f77c0d0846e2d2dfd2eeab06f4b06c6cd535dd11c954c84e35bdb9ae244",
+        "page_index_inventory_sha256": "c2d3e09f78c47eb5f3b225ed317562594e25f96eb1584eaf34e4a46b9ba6de2d",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "bc3d324f2c539b607a74c421ac9308f9a96bc813511378979997670d47808b60",
+        "unique_page_blob_count": 159
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 208368,
+        "type_1_slots": 594,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "27c0494913b3b6ea049d9513200a1133f500531d1ef69ed9f60bf5aa0af32388",
+      "description": "replica 2 stores the owned row at locator ordinal 1",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-REPLICA-DISAGREEMENT",
+      "fixture_id": "A4-R20-H2-REPLICA",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {
+            "2": 1
+          },
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "6e0babefab39520279adaba90502278463856a320105b4139e3191f3750a6f1d",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "replica models differ: [{'row_masks': [8191, 4095], 'polarity': 'set_bit_owned_in_use', 'locator_role_assignment': 'ordinal_0_owned_ordinal_1_available'}, {'row_masks': [8191, 4095], 'polarity': 'set_bit_owned_in_use', 'locator_role_assignment': 'ordinal_1_owned_ordinal_0_available'}]",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-REPLICA-DISAGREEMENT"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "cabf85763d8e56a93308e9ad077dbc5a77f1d9b737295e2eeb6f3341ea6e29c3",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "df00d109987aa9bca0285ee123041c361fe0d2b76aceb2da0a656c2d8c19db78",
+        "page_index_inventory_sha256": "4e2781e49d08a8339b90d977a4498ce03a47990a3228236f4ea6760665e73946",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17386,
+            "T4_REL_0064": 16546,
+            "T4_REL_0896": 17378,
+            "T4_REL_0904": 17386
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16480,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17385,
+            "T4_REL_0064": 16545,
+            "T4_REL_0896": 17380,
+            "T4_REL_0904": 17385
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16483,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17383,
+            "T4_REL_0904": 17389
+          }
+        },
+        "schema_snapshot_inventory_sha256": "bf05b73108eea6ef148ecea10c69310d25deb5cd86d85b2283127bd419ac842a",
+        "unique_page_blob_count": 134
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 402816,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "031adb2ea9dab2b3203d4741a3c38ed6b3b1d0d22df0b3e3db8e9046688e6f54",
+      "description": "owned rows never convert to type 1",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-CONVERSION-NONE": 0,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-CONVERSION-NONE",
+      "fixture_id": "A4-R22-H3-CONVERSION",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "never",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "f5d7390e20509131ba7844df91e2ae020d162e85f88712bc80e59cdb23c31bf4",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: no structural type-0 to type-1 transition with a nonzero slot",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-CONVERSION-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "baaa0cffa2cd17fc94e96050939e1afa0e7a527a2acda5022ad9d6dd4f04af4d",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "7e9c42db43ceef69fb2dee2a3ee03967d19500ea8611571d0409da419c637fae",
+        "page_index_inventory_sha256": "cdf164229fec7dbb376e269e31049c033c9c25efb5620b22f55c33ff6a3cfa69",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "a5a548ba7a4b2f9c8068654fba0b52d8e680cea1e0a2de49e94c3ea59c3e0e3f",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 208368,
+        "type_1_slots": 36,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "28fd602a66f6a6e0ada7bb3f2c00b4966a5a57735ddd57a3f12ab4abd401b811",
+      "description": "type-1 rows carry exactly their nonzero slots",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-INACTIVE-SLOT-NONE",
+      "fixture_id": "A4-R23-H3-INACTIVE",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": true,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "21fbb43f37ca966ef2d46045bd7b5f0502f69e28df09443989a7c3c9e99f2e08",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: every observed slot is nonzero",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-INACTIVE-SLOT-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "5829041d503d1922a66b376ef0393cce3aefcb8203e1641b20789c7e4e280e25",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "39afc4128e32b1439b37f6998873be42e86a0e3184150537a3c484a72a9f2320",
+        "page_index_inventory_sha256": "2d56b2d5f64059b625934b13d890a1ae5fd4de56de148454f0ae4800a7496d7a",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "fa626696fa34da1eddcb7ac7a8c5efd462ead2990f7fa5c5e522b70183ead573",
+        "unique_page_blob_count": 156
+      },
+      "charges": {
+        "base_formula_evaluations": 252,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 1434768,
+        "type_1_slots": 614,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "0e9cfdc03b2f3c977d17786b3f1bd7bb363ef2b6317a36d6e86cb87cf4c3eb52",
+      "description": "replica 1 T3 slot 1 references a tag-01 data page from T3_ABS_16480",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-REFERENCE-INVALID",
+      "fixture_id": "A4-R24-H3-REFERENCE",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "t3_reference_to_tag01"
+        ]
+      },
+      "mutation_sha256": "2359208fdb56d2c0c3345b072cf5b55b71ddad0785fbbb1658afa91c78faef82",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: T3-v1 at T3_ABS_16480: slot 1 references page 1298 with tag 01",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-REFERENCE-INVALID"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "b9463b9e064fc64c8fade63b37d3057a0e93070311df7b165d433492057b7ca3",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "803c45e042429868be17cc2a754a810dac6d0925a29486c53df4990ed2ed507c",
+        "page_index_inventory_sha256": "82fa3adc8f5d61acc660e88b0d64c1bf035c8eb8b11093067bb52cd68301cd5d",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16483,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17387,
+            "T4_REL_0064": 16547,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17387
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16481,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17386,
+            "T4_REL_0064": 16546,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17386
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17384,
+            "T4_REL_0904": 17390
+          }
+        },
+        "schema_snapshot_inventory_sha256": "21262d3b02c10969c71ccaacfc896d06414d8ab8886c9395ff1cdae6acab6b46",
+        "unique_page_blob_count": 137
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 372032,
+        "type_1_slots": 340,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "7d13a39ca20f0c304e4174beea45a1d2c2051ee4fb532a896cd60301617f1ce8",
+      "description": "owned sets stop below page 16352: no boundary input region",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-BASE-DISCRIMINATION",
+      "fixture_id": "A4-R25-H3-DISCRIMINATION",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": 16352,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "486f981b9f5e70b88d2fc0a6077192fd20410240efa11c95cc71ddb4d1498119",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: unexercised input regions: ['bit_index_zero', 'boundary_last_bit', 'boundary_next_slot_first_bit']",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-BASE-DISCRIMINATION"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "281d7c922e8cc0c7855d8d8b06b86488ae62b4b1dcdfcbd9bdfd4ca83779d821",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "88215565e0abf16af7e627182ca7d325aeda694b765051cb0f2314ea530d5faa",
+        "page_index_inventory_sha256": "7efb48a2df2b4f96b1b4dfd2a9268c8840e9d66408420a2461f831ebc975071f",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "e2c3f7100650b7003882606ba7b4c9dd02439e8529255b0a40439ca4942861f2",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 472,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2399536,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "f25ed52c18b4c334fc9efb6185812e688988f48f5469d455993e779b7d917223",
+      "description": "every owned tag-05 bit is shifted by two (synthetic boundary bits keep every input region exercised): no formula contains the pre-conversion set",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-NONE": 0,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-BASE-NONE",
+      "fixture_id": "A4-R26-H3-BASE-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": true,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 2,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "6e48dd4eb60600921bf2ec5ae1909c88fa0859366e80c902525e10ae047104d7",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: T3-v1 T3_ABS_12288->T3_ABS_16480: conversion drops pages [15, 1298, 1299]; T3-v1 T3_ABS_12288->T3_ABS_16480: conversion drops pages [15, 1298, 1299, 1300]",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-BASE-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "b3ce38a7ad3535df6d6b4d958dce3ebd7ca193d05525ee09b703dfc4670e6101",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "ce699aaa3ceee90dadf78322f01796c7080b713b919f7c83e711a663e7f5c87c",
+        "page_index_inventory_sha256": "7d01f4ae040496e125f0b9c5648b32630204f48cdf01f6980bc79c71ae439631",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 16352,
+            "EMPTY_R": 16352,
+            "T1_ADD_INDEX": 16354,
+            "T1_ADD_TEXT": 16354,
+            "T1_CREATE_ID": 16354,
+            "T1_DELETE_ALL": 17642,
+            "T1_IDLE_R": 17642,
+            "T1_REINSERT_SAME": 17642,
+            "T1_REL_0064": 16426,
+            "T1_REL_0512": 16874,
+            "T1_REL_0768": 17130,
+            "T1_REL_1280": 17642,
+            "T2_CREATE": 16356,
+            "T2_DROP": 16356,
+            "T2_RECREATE": 16358,
+            "T3_ABS_04096": 17642,
+            "T3_ABS_08192": 17642,
+            "T3_ABS_12288": 17642,
+            "T3_ABS_16480": 17642,
+            "T3_CREATE": 16360,
+            "T4_CREATE": 16362,
+            "T4_IDLE_R": 18546,
+            "T4_REL_0064": 17706,
+            "T4_REL_0896": 18538,
+            "T4_REL_0904": 18546
+          },
+          "2": {
+            "EMPTY": 16354,
+            "EMPTY_R": 16354,
+            "T1_ADD_INDEX": 16356,
+            "T1_ADD_TEXT": 16356,
+            "T1_CREATE_ID": 16356,
+            "T1_DELETE_ALL": 17644,
+            "T1_IDLE_R": 17644,
+            "T1_REINSERT_SAME": 17644,
+            "T1_REL_0064": 16429,
+            "T1_REL_0512": 16879,
+            "T1_REL_0768": 17134,
+            "T1_REL_1280": 17644,
+            "T2_CREATE": 16358,
+            "T2_DROP": 16358,
+            "T2_RECREATE": 16360,
+            "T3_ABS_04096": 17644,
+            "T3_ABS_08192": 17644,
+            "T3_ABS_12288": 17644,
+            "T3_ABS_16480": 17644,
+            "T3_CREATE": 16362,
+            "T4_CREATE": 16364,
+            "T4_IDLE_R": 18549,
+            "T4_REL_0064": 17709,
+            "T4_REL_0896": 18544,
+            "T4_REL_0904": 18549
+          },
+          "3": {
+            "EMPTY": 16353,
+            "EMPTY_R": 16353,
+            "T1_ADD_INDEX": 16355,
+            "T1_ADD_TEXT": 16355,
+            "T1_CREATE_ID": 16355,
+            "T1_DELETE_ALL": 17647,
+            "T1_IDLE_R": 17647,
+            "T1_REINSERT_SAME": 17647,
+            "T1_REL_0064": 16429,
+            "T1_REL_0512": 16879,
+            "T1_REL_0768": 17131,
+            "T1_REL_1280": 17647,
+            "T2_CREATE": 16357,
+            "T2_DROP": 16357,
+            "T2_RECREATE": 16359,
+            "T3_ABS_04096": 17647,
+            "T3_ABS_08192": 17647,
+            "T3_ABS_12288": 17647,
+            "T3_ABS_16480": 17647,
+            "T3_CREATE": 16361,
+            "T4_CREATE": 16363,
+            "T4_IDLE_R": 18553,
+            "T4_REL_0064": 17713,
+            "T4_REL_0896": 18547,
+            "T4_REL_0904": 18553
+          }
+        },
+        "schema_snapshot_inventory_sha256": "cf2be924f568dbc3f9448757acd997068213407412e7cd0f886b616cf636a9ed",
+        "unique_page_blob_count": 136
+      },
+      "charges": {
+        "base_formula_evaluations": 536,
+        "h1_target_validity_checks": 300,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 39929000,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2973376,
+        "type_1_slots": 560,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "e9481c771d95c5c57244b9a4352623045ad596051bbd296b198c59e1670c3eef",
+      "description": "reference == slot for every active slot (user pages beyond 16352, forced T3 conversion): slot and referenced-page formulas both fit",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 1,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 2,
+        "A4-H3-BASE-NONE": 2,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-BASE-MULTIPLE",
+      "fixture_id": "A4-R27-H3-BASE-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 16343,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {
+            "T3-v1": "T3_ABS_04096"
+          },
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": true,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {
+            "1": "equals_slot",
+            "2": "equals_slot",
+            "3": "equals_slot"
+          },
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "0ac388797b2948f403e597a78934e6e8679f978897c326153042db8d219febb4",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: more than one base formula fits",
+          "measured_count": 2,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-BASE-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "fba3dff88c42ee827213f227d7213581e5a8c28a0260378f8429e1644e667ff2",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "5ce187594533617ed44f430abec8f2f4558d374c064eee0b41f14667925b6d95",
+        "page_index_inventory_sha256": "9dfbd2cb492c10de2ff92523d071ab25d42aebf3c5cd96b468cede91267ba6cd",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 16351,
+            "EMPTY_R": 16351,
+            "T1_ADD_INDEX": 16353,
+            "T1_ADD_TEXT": 16353,
+            "T1_CREATE_ID": 16353,
+            "T1_DELETE_ALL": 17641,
+            "T1_IDLE_R": 17641,
+            "T1_REINSERT_SAME": 17641,
+            "T1_REL_0064": 16425,
+            "T1_REL_0512": 16873,
+            "T1_REL_0768": 17129,
+            "T1_REL_1280": 17641,
+            "T2_CREATE": 16355,
+            "T2_DROP": 16355,
+            "T2_RECREATE": 16357,
+            "T3_ABS_04096": 17643,
+            "T3_ABS_08192": 17643,
+            "T3_ABS_12288": 17643,
+            "T3_ABS_16480": 17643,
+            "T3_CREATE": 16359,
+            "T4_CREATE": 16361,
+            "T4_IDLE_R": 18547,
+            "T4_REL_0064": 17707,
+            "T4_REL_0896": 18539,
+            "T4_REL_0904": 18547
+          },
+          "2": {
+            "EMPTY": 16354,
+            "EMPTY_R": 16354,
+            "T1_ADD_INDEX": 16356,
+            "T1_ADD_TEXT": 16356,
+            "T1_CREATE_ID": 16356,
+            "T1_DELETE_ALL": 17644,
+            "T1_IDLE_R": 17644,
+            "T1_REINSERT_SAME": 17644,
+            "T1_REL_0064": 16429,
+            "T1_REL_0512": 16879,
+            "T1_REL_0768": 17134,
+            "T1_REL_1280": 17644,
+            "T2_CREATE": 16358,
+            "T2_DROP": 16358,
+            "T2_RECREATE": 16360,
+            "T3_ABS_04096": 17644,
+            "T3_ABS_08192": 17644,
+            "T3_ABS_12288": 17644,
+            "T3_ABS_16480": 17644,
+            "T3_CREATE": 16362,
+            "T4_CREATE": 16364,
+            "T4_IDLE_R": 18549,
+            "T4_REL_0064": 17709,
+            "T4_REL_0896": 18544,
+            "T4_REL_0904": 18549
+          },
+          "3": {
+            "EMPTY": 16352,
+            "EMPTY_R": 16352,
+            "T1_ADD_INDEX": 16354,
+            "T1_ADD_TEXT": 16354,
+            "T1_CREATE_ID": 16354,
+            "T1_DELETE_ALL": 17646,
+            "T1_IDLE_R": 17646,
+            "T1_REINSERT_SAME": 17646,
+            "T1_REL_0064": 16428,
+            "T1_REL_0512": 16878,
+            "T1_REL_0768": 17130,
+            "T1_REL_1280": 17646,
+            "T2_CREATE": 16356,
+            "T2_DROP": 16356,
+            "T2_RECREATE": 16358,
+            "T3_ABS_04096": 17648,
+            "T3_ABS_08192": 17648,
+            "T3_ABS_12288": 17648,
+            "T3_ABS_16480": 17648,
+            "T3_CREATE": 16360,
+            "T4_CREATE": 16362,
+            "T4_IDLE_R": 18554,
+            "T4_REL_0064": 17714,
+            "T4_REL_0896": 18548,
+            "T4_REL_0904": 18554
+          }
+        },
+        "schema_snapshot_inventory_sha256": "93c4fad593f2e4ce02dafcaad091e05d4f5565ba8871d70ff9295694e63b7fea",
+        "unique_page_blob_count": 140
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "h1_target_validity_checks": 300,
+        "qualified_tdef_pages": 10,
+        "raw_locator_pairs": 39929000,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2973376,
+        "type_1_slots": 560,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "15ad14365ae3854463f30bbf1356163d9cba4135bca747bcc7b928b35d684beb",
+      "description": "replica 2 references page k+1 from slot k (referenced-page formula) while replica 1 keeps the slot formula",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 1,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-REPLICA-DISAGREEMENT",
+      "fixture_id": "A4-R28-H3-REPLICA",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 16343,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {
+            "T3-v1": "T3_ABS_04096"
+          },
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": true,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {
+            "2": "referenced"
+          },
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "87afa8ee697140ba8852d1275d73488c60d0fe1000d66b0388a66ff811a759cf",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica models differ: [{'conversion_candidate': 'structural_type_0_to_type_1_with_nonzero_u32_slots', 'base_formula': 'slot_ordinal_times_16352_plus_bit_index', 'tag_05_bitmap_polarity': 'set_bit_owned_in_use'}, {'conversion_candidate': 'structural_type_0_to_type_1_with_nonzero_u32_slots', 'base_formula': 'referenced_page_times_16352_plus_bit_index', 'tag_05_bitmap_polarity': 'set_bit_owned_in_use'}]",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-REPLICA-DISAGREEMENT"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "cd5669e08f8f5acae44da3c171a3ab48fa7c66db94ca8ca67fd0c9cbd60463c8",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "3ee3a3a3f9f75629603bd684251fc7d9bca33f051c2a77480eb5c5fd6a6845bf",
+        "page_index_inventory_sha256": "91948523e60869c529971102ffd466706cb976fe9bfebea88bef7bb4dcff0fa6",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "aee4c535f5f6b6c35ed6eeace32b936377079f84c890f7c01353b0e062f5fb36",
+        "unique_page_blob_count": 156
+      },
+      "charges": {
+        "base_formula_evaluations": 563,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 452,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 210,
+        "tdef_lifecycle_signatures": 945,
+        "type_0_and_tag_05_bitmap_bits": 2928848,
+        "type_1_slots": 648,
+        "valid_path_row_directory_entries": 1500
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "replica 3's slot-0 tag-05 page clears the bit of the T3 map page after conversion",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-HOLDOUT-PREDICTION": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-HOLDOUT-PREDICTION": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H3-HOLDOUT-PREDICTION",
+      "fixture_id": "A4-R29-H3-HOLDOUT",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "holdout_t3_tag05_clears_map_bit"
+        ]
+      },
+      "mutation_sha256": "1246f0e39b0454b9a5a2f41a97151aa4cd79a6a873f37e57d79a5cfbcbf01084",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "T3-v1 T3_ABS_12288->T3_ABS_16480: conversion drops pages [16]",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H3-HOLDOUT-PREDICTION"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "7aeb79c4793f898866c4be410e2349401415e8b70444a63f16e3742c50141a7e",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+        "page_index_inventory_sha256": "171e58d40b3434141420656c2c51fd565ccf16741549c5812e4af9add692347f",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "91d4bdb974cbb8cc739854bf35ee9699f3b7c427542d656f494063ad63f45788",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "catalog_root_signatures": 28,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "f79abe89bcaab6df32a5a8860e76c1a5f023e0cf7e3248129975d8cc346f85f9",
+      "description": "catalog records are written to a page no system stream admits",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 0,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-CATALOG-ROOT-NONE",
+      "fixture_id": "A4-R30-H4-ROOT-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "spare",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "bf13be186e0f2a5323c11bfeda09a49f43453f1977c7f011b49b3ed5ba6ab472",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: page 2: admitted stream follows no listed operation; page 5: admitted stream follows no listed operation",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-CATALOG-ROOT-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "94f85ad26612558fbbd9655924001ca72eb11f8e2c6b4bc3c2a0f8c6d88daf16",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "76de9eae5f6acdaef4c93e99f7c2b897cb7f0cbe4c9954f42f27fec0aa39febb",
+        "page_index_inventory_sha256": "c86f667e9a53731dcc5a56b812c3171f59e40bdb7acabd3e02a31351ef5f998d",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "308211384a46e269bd3eca67ad36e77ba617a2f1573a9a1b4ad4b7e885fcb8ae",
+        "unique_page_blob_count": 164
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "catalog_root_signatures": 28,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "c725b3c0840a7b47d434e2cb002da6da013b2805edd15250f8701c229d4c3750",
+      "description": "the decoy system table owns the spare page and changes it at every operation",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 2,
+        "A4-H4-CATALOG-ROOT-NONE": 2,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-CATALOG-ROOT-MULTIPLE",
+      "fixture_id": "A4-R31-H4-ROOT-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": true,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "20dda44c30732dbff90a770292eadc1ee02696237c8f523371dd7114dfe1c5b1",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple system streams follow the operation deltas",
+          "measured_count": 2,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "a792115a4596189d3c353974c7d68009695fdc04de89aedf3b51c4a025486322",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "5dcd105a4c7f0a69f88856389d6e5e4053ac785fb64d132d8786e8ef78e0e344",
+        "page_index_inventory_sha256": "272f974f65108f2257c9575842a0957a31a886eee446df84f5436364be618307",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "167e172e91b4d0c1ef703e0e9eafa8144282ef082307be66c796855698af6ada",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "catalog_root_signatures": 28,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "68d6ffbacde0fe75ec58980c454252a6458f13e694a57759658b1c29de1f263f",
+      "description": "the T3_CREATE record is written to the unadmitted spare page",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+      "fixture_id": "A4-R34-H4-OUTSIDE",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {
+            "T3_CREATE": "spare"
+          },
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "e3858a51f9ec803fc80aeaff2d740dbc43dc0c783651b954f5374b53c01c21b5",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: T3_CREATE: schema delta on non-admitted page(s) [7]",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "79b691080bfd75955d8df80dbe508023bb2be8a8d245d88eb2a6b45bef3a7bea",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "d47f31bc4408355959a3eefe3e69c0d8f4fc38d79b5978ef2cd3fcb31a962d3b",
+        "page_index_inventory_sha256": "393a6a4a66924651001615c1b4f81a5be5afc606b367d5b6f9de6daf2a165b9e",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "f10d2ba58e4a1b118e515253066beb3bf6f3ced433ce60c32230f0e531089714",
+        "unique_page_blob_count": 140
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "catalog_raw_rows": 74,
+        "catalog_root_signatures": 28,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "02296849e42056f8d288947a96a51bd0ab7e66cd7fa46bd65982b2f4f5cad869",
+      "description": "no record is written at T3_CREATE",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 0,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-CATALOG-RECORD-NONE",
+      "fixture_id": "A4-R32-H4-RECORD-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [
+            "T3_CREATE"
+          ],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "1beabdeb8eaa7bc1da390a9159b2fce8d3998bc4b332369e4c236f8fc9fa0ca4",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: no operation-delta record for ['T3_CREATE']",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-CATALOG-RECORD-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "62e3758d679b703f37ea051c9459330a74a963dca3cdda4c60f3592203c3bcca",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "3286e1dee9af8d07b4923b54f4eb743d7ada897db9444f37164c29a62c7f6403",
+        "page_index_inventory_sha256": "b60359765453756491096015ac226ead21faea32136cdd5cd7a1d0f34821856c",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "9a2b9577aa3fad0756253859269c1f7c7d794c179a56ebb1d9ddb681874630a2",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "catalog_raw_rows": 82,
+        "catalog_root_signatures": 28,
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "6c31122dd0839a65f84ace9131ed9b7b3675a3f17eebadd31d671e585bfd41dc",
+      "description": "two records are written at T3_CREATE",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 2,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-CATALOG-RECORD-MULTIPLE",
+      "fixture_id": "A4-R33-H4-RECORD-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [
+            "T3_CREATE"
+          ],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "c287b9405fc1b0de1109234dfa3e06cc5383416378e32fe8a38aaf4579eb61ac",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple operation-delta records for ['T3_CREATE']",
+          "measured_count": 2,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "5576dcff42c61ccd9eb5069f5b902c8049f4ec435fc07e03d3979af382df65a7",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "4f2962f2e27669d8e8777aecc1892b3f11a913c4c07ad0e313bac1e3cbafb797",
+        "page_index_inventory_sha256": "14451e7e6497de219c962657a08654d05aee8b8acae190ccb4f038a8745c2691",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "5063ff7bb291696248fa057e66dd6f1452f9f2087f21c9aaf5ac8ab3c0e45a73",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 302,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 0
+      },
+      "derivation_candidate_set_sha256": "cef17f8452e510dd80e9ebe4bd98baa3d26d51a734d1cf5c6e24a8bb12a4f2d3",
+      "description": "the T3_CREATE record stores kind 0x44 while other table records store 0x11",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 0,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-FIELD-MODEL-NONE",
+      "fixture_id": "A4-R35-H4-FIELD-NONE",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {
+            "T3_CREATE": 68
+          },
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "8b7f9c42a89f53a4d4beedcf494322a49861743a0bf2ba497a39aac4569e1515",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: no compatible occurrence or disagreeing kind/id within one record x27632; kind mapping x16",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-FIELD-MODEL-NONE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "d3a7d0605bf6d9c10cf26d233ff4aa34a1e1ecd71a85ab5005c4337f63281281",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "2281507bc022d264fb4a838a643ddefd9874b0c360185b0bd4ce54603eddcb17",
+        "page_index_inventory_sha256": "4c5c0b64a5b84b340f7103333e1b01d178bb5ae65a04fbe35aa4b3f22834c354",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "30f61f9861767dff7c1d9b2c7e8e99cc6db31fbfff5817b7eae74ef0ad2a9a35",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "candidate_serializations": 16,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 236,
+        "h1_target_validity_checks": 302,
+        "h4_name_length_structural_tuples": 56352,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "f445f2cac840683b9807ee0ba7c7dac77a3ecbfdfb3821e7d181f4b8f2839673",
+      "description": "records carry two stamp/id/kind prefixes with distinct identifiers before one length byte",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 2,
+        "A4-H4-FIELD-MODEL-NONE": 2,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-FIELD-MODEL-MULTIPLE",
+      "fixture_id": "A4-R36-H4-FIELD-MULTIPLE",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "double",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "b750dad46d06155b3bf1dcf498e796fc3e85e2323fac9db54d00531b357555c4",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple structural field layouts",
+          "measured_count": 2,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "d8e2b9f851f54a6e9fc24a9c4658a1f82157c77f0baf4738d98d8ae8e91121ce",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "0d131d1eef30c1e2c42dc7caa8cc557140a0b2abe4a63e69be5440f5d2e325f8",
+        "page_index_inventory_sha256": "5092de50653d107cc756596aa5dd5950b69b91b4985bb57041e078385ce6baed",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "ea18d7bd3a9936d3192bd1d5134ded904cf8a2837c77b0ed734b3fb695c81a37",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 302,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "allowed_ranges": [
+          {
+            "exact": 0
+          },
+          {
+            "minimum": 2
+          }
+        ],
+        "source": "measured_encoding_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "5e633577672557b1ba54dfc6047b2e6252ae42c01ac2a5a9697bd501561b4323",
+      "description": "the É record stores Windows-1252 bytes with stored length 9: zero fitting classes",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 0,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-ENCODING-AMBIGUOUS",
+      "fixture_id": "A4-R37-H4-ENCODING",
+      "measured_count": 0,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": 9,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "9eb862d9a61f89e49cc9a39e6588b3217a7ed2861b32aa5b8a118593ab180252",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: fitting encoding/length classes: []",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-ENCODING-AMBIGUOUS"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "0e2715aa0e264b01829499cb03e8865b215b8e4554711ba50cbcae55e2117aee",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "1d05ffbcbabc97c634fbaf3305d91392b5a29ad3f9dabd1b1c303efc54aa2d5e",
+        "page_index_inventory_sha256": "ddd4e70a5f861f9dad9f8a30e9992f9b91b05735237f8921e3fa20f8fe4ea867",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "e970a5c4135a44787686d099283b7b7e5885108bff70a6bfe33687a4d137beaf",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 302,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "a3cd3b60e4182b7981a743d4e451e6fe7e20dc785e624c376861ffa348a5e0c1",
+      "description": "replica 2 reuses the T2-v1 identifier for T2-v2",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-REPLICA-DISAGREEMENT",
+      "fixture_id": "A4-R38-H4-REPLICA",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {
+            "2": "same"
+          },
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "5992898fb94526d2dd64ecf2ab5417d94fcba71100d34681cce6216dc137e946",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "replica models differ: [{'root': {'root_tdef_page': 2, 'catalog_root_selection_signature': 'operation_delta_non_name_structure'}, 'fields': {'field_tuple_members': [{'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}], 'kind_mapping': {'table': 17, 'field': 34, 'index': 51}, 'identifier_lifecycle_relation': 'stable_for_same_operation_instance_and_distinct_for_t2_v1_v2', 'encoding_length_equivalence_class': 'cp1252_single_byte_per_scalar'}}, {'root': {'root_tdef_page': 2, 'catalog_root_selection_signature': 'operation_delta_non_name_structure'}, 'fields': {'field_tuple_members': [{'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}], 'kind_mapping': {'table': 17, 'field': 34, 'index': 51}, 'identifier_lifecycle_relation': 'stable_for_same_physical_name_including_t2_v1_v2', 'encoding_length_equivalence_class': 'cp1252_single_byte_per_scalar'}}]",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-REPLICA-DISAGREEMENT"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "b6fa441aa5c6e648543387a77f3b2c25fc334f0b9e60cfeb597547ba2aafe38c",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "5f21930575e7e2a22546922b5379e5926ac02c717f69fae8601d35c6c02a879c",
+        "page_index_inventory_sha256": "7861f579b6407610c92db784553b37219fdd74e01d99b1f3963d82e2b93dbd85",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "7d2f415182659aa0d37a0b10c0906b5cd86db1903825afa3504611c290700ab0",
+        "unique_page_blob_count": 157
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 302,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 783,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "replica 3 stores its locators at offsets 36/40",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-HOLDOUT-PREDICTION",
+      "fixture_id": "A4-R13-H1-HOLDOUT",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {
+            "3": [
+              36,
+              40
+            ]
+          },
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "904348a3d77dbdd2a96bed04e7a1a15017d47fa41cbb5e11ce78125cde3d7baa",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "T1-v1: signature mismatch at T1_CREATE_ID",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-HOLDOUT-PREDICTION"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "c2515c415d0460416804852c4c9318e0fcefe257be4c17c4d1f0f101bdc04a7c",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "f95b239fb71bfe54efd1a1a8bba194daf62bf61cc83d988ebbc56eb7e799ebbf",
+        "page_index_inventory_sha256": "f729fdd25e3dc7869e5f843c6b56c59a873c27e07b6906952e215e9108d55aa5",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "7626ce129035bb8578657f75b4370f866521dc62e424bc59800353d63e00d652",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 452,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 945,
+        "type_0_and_tag_05_bitmap_bits": 2661176,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1500
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "replica 3 stores the owned row at locator ordinal 1",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-HOLDOUT-PREDICTION": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-HOLDOUT-PREDICTION",
+      "fixture_id": "A4-R21-H2-HOLDOUT",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {
+            "3": 1
+          },
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "b5f363a3e26534acd0374ddc8256634c6a77707670b67b46aa1aebe8e2b79d46",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "T1-v1 at T1_CREATE_ID: owned/in-use set is empty",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H2-HOLDOUT-PREDICTION"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "b84d8874b3c6a79aefaa8aee28d7eca81561129fbf46e0c6ac142faaafa7a8e9",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "7567883ae19424e3ff0c69acde0d50a5a5d15c52ae150b1e5ce33cd6afb13e54",
+        "page_index_inventory_sha256": "c5b2c572617efdf475d4476903a2e6f7cfffe42bf03f8fe898007c747dfea128",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "724a18eb648f23c28825fe31192751c785fc2b5e363b6f4c307a767be4fe532e",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 579,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 188,
+        "h1_target_validity_checks": 452,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 210,
+        "tdef_lifecycle_signatures": 945,
+        "type_0_and_tag_05_bitmap_bits": 3059664,
+        "type_1_slots": 648,
+        "valid_path_row_directory_entries": 1500
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "replica 3 writes the T3_CREATE record to the unadmitted spare page",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-HOLDOUT-PREDICTION": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-HOLDOUT-PREDICTION": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-HOLDOUT-ROOT": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-HOLDOUT-ROOT",
+      "fixture_id": "A4-R39-H4-HOLDOUT-ROOT",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {
+            "3": {
+              "T3_CREATE": "spare"
+            }
+          },
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "4e4feca6fea0b30ef5cb86bf34eb4c6b33be1b82a02c1ced3f595893e88c3f31",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "T3_CREATE: schema delta on non-admitted page(s) [7]",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-HOLDOUT-ROOT"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "55179949b65b7c0c0a9ca5d2fecc36ab6da88be0f55a8332aecfdb08c56aedbb",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "2e0b2ed04d8a345439cc4652f4636c090a7008c85f884842692a25ad1e04b37f",
+        "page_index_inventory_sha256": "148d69eb47a19a8f2ea3155bd1ba351d7a7400a02a839a41485aa66299d98df1",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "ded14d86e0bb6fee1ac6fa48e90c1b60a4f4d4489e7f1aedc401b8fcc7a10145",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 579,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 117,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 294,
+        "h1_target_validity_checks": 452,
+        "h4_name_length_structural_tuples": 55488,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 210,
+        "tdef_lifecycle_signatures": 945,
+        "type_0_and_tag_05_bitmap_bits": 3059664,
+        "type_1_slots": 648,
+        "valid_path_row_directory_entries": 1500
+      },
+      "count_contract": {
+        "exact": 1
+      },
+      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "description": "replica 3's É record name ends in '5'",
+      "evaluated_counts": {
+        "A4-H1-HOLDOUT-PREDICTION": 1,
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-HOLDOUT-PREDICTION": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-HOLDOUT-PREDICTION": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 1,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-HOLDOUT-FIELDS": 1,
+        "A4-H4-HOLDOUT-ROOT": 1,
+        "A4-H4-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-HOLDOUT-FIELDS",
+      "fixture_id": "A4-R40-H4-HOLDOUT-FIELDS",
+      "measured_count": 1,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": true,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "5783b9adec8fe3fd146687dc2bc5dc4d8181acc28ca2d75322114c32993b0f3e",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "pass"
+        },
+        {
+          "detail": "frozen structural field tuple does not fit replica 3: T2_CREATE: no registered expected-name occurrence; T2_RECREATE: no registered expected-name occurrence",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "fail"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-HOLDOUT-FIELDS"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "83d5c7ba8ecc3bc97abefb717e2ee6b3d4ba8f52ee6e99d2e3aba30395e3bed0",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "334a8e3b1c11bcb51bb3669fe7df2f36f48b5f50ec7ebed86e590559ccded486",
+        "page_index_inventory_sha256": "a3e9b6f175913eade32bda4c1b91f3899f0522633a2f3ae4784e641dc4db2658",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 84,
+            "T1_REL_0512": 532,
+            "T1_REL_0768": 788,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4096,
+            "T3_ABS_08192": 8192,
+            "T3_ABS_12288": 12288,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17388,
+            "T4_REL_0064": 16548,
+            "T4_REL_0896": 17380,
+            "T4_REL_0904": 17388
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1302,
+            "T1_IDLE_R": 1302,
+            "T1_REINSERT_SAME": 1302,
+            "T1_REL_0064": 87,
+            "T1_REL_0512": 537,
+            "T1_REL_0768": 792,
+            "T1_REL_1280": 1302,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4097,
+            "T3_ABS_08192": 8192,
+            "T3_ABS_12288": 12292,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 20,
+            "T4_CREATE": 22,
+            "T4_IDLE_R": 17391,
+            "T4_REL_0064": 16551,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17391
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1305,
+            "T1_IDLE_R": 1305,
+            "T1_REINSERT_SAME": 1305,
+            "T1_REL_0064": 87,
+            "T1_REL_0512": 537,
+            "T1_REL_0768": 789,
+            "T1_REL_1280": 1305,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4101,
+            "T3_ABS_08192": 8193,
+            "T3_ABS_12288": 12291,
+            "T3_ABS_16480": 16487,
+            "T3_CREATE": 19,
+            "T4_CREATE": 21,
+            "T4_IDLE_R": 17395,
+            "T4_REL_0064": 16555,
+            "T4_REL_0896": 17383,
+            "T4_REL_0904": 17395
+          }
+        },
+        "schema_snapshot_inventory_sha256": "9353994fbc7c1c82dbfa4ab69921f36860ead25124de0d83852e862ccb4835e7",
+        "unique_page_blob_count": 158
+      },
+      "charges": {
+        "qualified_tdef_pages": 9,
+        "tdef_lifecycle_signatures": 1044
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "7bad7105deab420f8895d7bdccf1f83d23c18dad9c3ed6a4311f9f3e336c676d",
+      "description": "three lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+      "evaluated_counts": {
+        "A4-H1-TDEF-MULTIPLE": 3,
+        "A4-H1-TDEF-NONE": 3,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-TDEF-MULTIPLE",
+      "fixture_id": "A4-ADV-TDEF-MULTIPLE-3",
+      "measured_count": 3,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {
+            "T3_CREATE": 2
+          },
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "478266ebdaa34b0f422f35ff3490eea0ce075229de94b1360faba299da56a724",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 3,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple lifecycle-matching TDEF candidates",
+          "measured_count": 3,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "49cf714b51f4d4c3fab5c25e2d57fb1491fcd506df2366fe4928c5bfec6f505a",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "2b7ba1b10092eb458ec26f6e57ab1b51fa1b626d0cc60d07a269dfddf3bd8f0a",
+        "page_index_inventory_sha256": "992ae55d1386ff154aaff0b63235cfacc387bb044cb4d75d0b890956a1b2f799",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1301,
+            "T1_IDLE_R": 1301,
+            "T1_REINSERT_SAME": 1301,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 533,
+            "T1_REL_0768": 789,
+            "T1_REL_1280": 1301,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4097,
+            "T3_ABS_08192": 8193,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16483,
+            "T3_CREATE": 19,
+            "T4_CREATE": 21,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17389
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 88,
+            "T1_REL_0512": 538,
+            "T1_REL_0768": 793,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8193,
+            "T3_ABS_12288": 12288,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 21,
+            "T4_CREATE": 23,
+            "T4_IDLE_R": 17392,
+            "T4_REL_0064": 16552,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17392
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1306,
+            "T1_IDLE_R": 1306,
+            "T1_REINSERT_SAME": 1306,
+            "T1_REL_0064": 88,
+            "T1_REL_0512": 538,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1306,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4096,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12292,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 20,
+            "T4_CREATE": 22,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17378,
+            "T4_REL_0904": 17390
+          }
+        },
+        "schema_snapshot_inventory_sha256": "b73201fdc9682cface03dc3566ef25c437cda8c28051a6a9f37546856b2c1794",
+        "unique_page_blob_count": 158
+      },
+      "charges": {
+        "qualified_tdef_pages": 10,
+        "tdef_lifecycle_signatures": 1188
+      },
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "6ef3fbf6d34ceb9c128ab78a4e91e033459482d46df3a01273e399ca6bdedbee",
+      "description": "four lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+      "evaluated_counts": {
+        "A4-H1-TDEF-MULTIPLE": 4,
+        "A4-H1-TDEF-NONE": 4,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H1-TDEF-MULTIPLE",
+      "fixture_id": "A4-ADV-TDEF-MULTIPLE-4",
+      "measured_count": 4,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {
+            "T3_CREATE": 3
+          },
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "7500714a978c930ced4ee98adc66df897e6aa04db7242dc2e9a46e52d8e4b347",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 4,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: multiple lifecycle-matching TDEF candidates",
+          "measured_count": 4,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "fff8e2767b9c4ac95f7ce5e3d18d7adb7734381fc93052952d4286cec6ba6822",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "7b8dc810f372cb1773bfb6e87db4128bf82a688f58d001a613b9c751807f1056",
+        "page_index_inventory_sha256": "2e22c05c620c7d624e66fecec789feb98112754ad95dc7f3e6858bcbc8d4d426",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "919570dbb454b20a0cfaaa92088cc6bfaaa3f5db2357118e7b80fd0ea4e7c895",
+        "unique_page_blob_count": 155
+      },
+      "charges": {
+        "base_formula_evaluations": 504,
+        "candidate_serializations": 8,
+        "catalog_raw_rows": 78,
+        "catalog_root_signatures": 28,
+        "encoding_union_anchor_bytes": 240,
+        "h1_target_validity_checks": 302,
+        "h4_name_length_structural_tuples": 55520,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 140,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 2661168,
+        "type_1_slots": 630,
+        "valid_path_row_directory_entries": 1200
+      },
+      "count_contract": {
+        "allowed_ranges": [
+          {
+            "exact": 0
+          },
+          {
+            "minimum": 2
+          }
+        ],
+        "source": "measured_encoding_candidate_cardinality"
+      },
+      "derivation_candidate_set_sha256": "2e8e8e724c6ee9fcca181975a5d251efe9509b9a97b52e132ec9a0c4f41bd2d2",
+      "description": "the É record carries both registered byte occurrences at compatible anchors: two fitting classes",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-MAP-TAG-UNSUPPORTED": 1,
+        "A4-H2-REPLICA-DISAGREEMENT": 1,
+        "A4-H2-ROLE-MULTIPLE": 1,
+        "A4-H2-ROLE-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-H2-ROW-FLAGS-INVALID": 1,
+        "A4-H2-TRANSITION-UNEXPLAINED": 1,
+        "A4-H3-BASE-DISCRIMINATION": 1,
+        "A4-H3-BASE-MULTIPLE": 1,
+        "A4-H3-BASE-NONE": 1,
+        "A4-H3-CONVERSION-NONE": 1,
+        "A4-H3-INACTIVE-SLOT-NONE": 1,
+        "A4-H3-REFERENCE-INVALID": 1,
+        "A4-H3-REPLICA-DISAGREEMENT": 1,
+        "A4-H4-CATALOG-RECORD-MULTIPLE": 1,
+        "A4-H4-CATALOG-RECORD-NONE": 1,
+        "A4-H4-CATALOG-ROOT-MULTIPLE": 1,
+        "A4-H4-CATALOG-ROOT-NONE": 1,
+        "A4-H4-ENCODING-AMBIGUOUS": 2,
+        "A4-H4-FIELD-MODEL-MULTIPLE": 1,
+        "A4-H4-FIELD-MODEL-NONE": 1,
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H4-ENCODING-AMBIGUOUS",
+      "fixture_id": "A4-ADV-ENCODING-2",
+      "measured_count": 2,
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": true,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": []
+      },
+      "mutation_sha256": "99770e829afa6724929c5c7b3de437a76cda6b0c0d19798500c415362e20d438",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: fitting encoding/length classes: ['cp1252_single_byte_per_scalar', 'utf8_encoded_byte_count']",
+          "measured_count": 2,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejection": "",
+      "target_predicate_id": "A4-H4-ENCODING-AMBIGUOUS"
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "unique_page_blob_count": 155
+      },
+      "description": "fixture names an unregistered base formula",
+      "fixture_id": "A4-ADV-UNREGISTERED-ID",
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": {
+          "base_formula": [
+            "not-a-registered-formula"
+          ]
+        },
+        "patches": []
+      },
+      "mutation_sha256": "80e730aeac0defc4d6bf06e1699bf114ad2e78e23d9f9265a6fe9d0c6c038c76",
+      "rejected": true,
+      "rejection": "unregistered candidate id for base_formula: 'not-a-registered-formula'",
+      "target_predicate_id": null
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
+        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "unique_page_blob_count": 155
+      },
+      "description": "one page blob is 2,047 bytes",
+      "fixture_id": "A4-ADV-MALFORMED-PAGE",
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "malformed_page"
+        ]
+      },
+      "mutation_sha256": "a97118dd3fd9504a605ddaebad7413d6c032c84ae553ab18c3419cecaa38a88e",
+      "rejected": true,
+      "rejection": "malformed page blob(s): ['61adf02f8358785f99e523ca6e71cb21612fa445b2a332256b291fd88eb6b02a']",
+      "target_predicate_id": null
+    },
+    {
+      "accepted": true,
+      "campaign": {
+        "campaign_sha256": "bb9dcecaae6d74065398c6f50fdc5483d80df96f5e024728e35691a2c572a033",
+        "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
+        "page_blob_inventory_sha256": "4e089a375cb2f19d26de2e528727a14362d233cdd45b839eb9ab4c1f27e9b79e",
+        "page_index_inventory_sha256": "7f503bf252adcd62ffb89a7ea99b69fae8933d3c3b53f7b8e08dc94fce723232",
+        "replica_page_counts": {
+          "1": {
+            "EMPTY": 8,
+            "EMPTY_R": 8,
+            "T1_ADD_INDEX": 10,
+            "T1_ADD_TEXT": 10,
+            "T1_CREATE_ID": 10,
+            "T1_DELETE_ALL": 1298,
+            "T1_IDLE_R": 1298,
+            "T1_REINSERT_SAME": 1298,
+            "T1_REL_0064": 82,
+            "T1_REL_0512": 530,
+            "T1_REL_0768": 786,
+            "T1_REL_1280": 1298,
+            "T2_CREATE": 12,
+            "T2_DROP": 12,
+            "T2_RECREATE": 14,
+            "T3_ABS_04096": 4098,
+            "T3_ABS_08192": 8194,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16484,
+            "T3_CREATE": 16,
+            "T4_CREATE": 18,
+            "T4_IDLE_R": 17390,
+            "T4_REL_0064": 16550,
+            "T4_REL_0896": 17382,
+            "T4_REL_0904": 17390
+          },
+          "2": {
+            "EMPTY": 10,
+            "EMPTY_R": 10,
+            "T1_ADD_INDEX": 12,
+            "T1_ADD_TEXT": 12,
+            "T1_CREATE_ID": 12,
+            "T1_DELETE_ALL": 1300,
+            "T1_IDLE_R": 1300,
+            "T1_REINSERT_SAME": 1300,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 790,
+            "T1_REL_1280": 1300,
+            "T2_CREATE": 14,
+            "T2_DROP": 14,
+            "T2_RECREATE": 16,
+            "T3_ABS_04096": 4100,
+            "T3_ABS_08192": 8195,
+            "T3_ABS_12288": 12290,
+            "T3_ABS_16480": 16482,
+            "T3_CREATE": 18,
+            "T4_CREATE": 20,
+            "T4_IDLE_R": 17389,
+            "T4_REL_0064": 16549,
+            "T4_REL_0896": 17379,
+            "T4_REL_0904": 17389
+          },
+          "3": {
+            "EMPTY": 9,
+            "EMPTY_R": 9,
+            "T1_ADD_INDEX": 11,
+            "T1_ADD_TEXT": 11,
+            "T1_CREATE_ID": 11,
+            "T1_DELETE_ALL": 1303,
+            "T1_IDLE_R": 1303,
+            "T1_REINSERT_SAME": 1303,
+            "T1_REL_0064": 85,
+            "T1_REL_0512": 535,
+            "T1_REL_0768": 787,
+            "T1_REL_1280": 1303,
+            "T2_CREATE": 13,
+            "T2_DROP": 13,
+            "T2_RECREATE": 15,
+            "T3_ABS_04096": 4099,
+            "T3_ABS_08192": 8197,
+            "T3_ABS_12288": 12289,
+            "T3_ABS_16480": 16485,
+            "T3_CREATE": 17,
+            "T4_CREATE": 19,
+            "T4_IDLE_R": 17393,
+            "T4_REL_0064": 16553,
+            "T4_REL_0896": 17381,
+            "T4_REL_0904": 17393
+          }
+        },
+        "schema_snapshot_inventory_sha256": "10b69d7b30aea096cdb1f2e684fd32557fb3a8740534117182dc514553c3edbd",
+        "unique_page_blob_count": 165
+      },
+      "charges": {
+        "h1_target_validity_checks": 302,
+        "qualified_tdef_pages": 6,
+        "raw_locator_pairs": 40008968,
+        "raw_locator_windows": 40900,
+        "role_transition_evaluations": 70,
+        "tdef_lifecycle_signatures": 756,
+        "type_0_and_tag_05_bitmap_bits": 104184,
+        "type_1_slots": 297,
+        "valid_path_row_directory_entries": 940
+      },
+      "derivation_candidate_set_sha256": "c88b71ce5f94a5c56b404d8202141ab03c68c24533ed3c51d83d7c99c11287fc",
+      "description": "claims ROW-FLAGS but the same mutation breaks the directory first",
+      "evaluated_counts": {
+        "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
+        "A4-H1-LOCATOR-LAYOUT-NONE": 2,
+        "A4-H1-LOCATOR-PAIR-MULTIPLE": 1,
+        "A4-H1-LOCATOR-PAIR-NONE": 2,
+        "A4-H1-REPLICA-DISAGREEMENT": 1,
+        "A4-H1-TARGET-ROW-INVALID": 1,
+        "A4-H1-TDEF-MULTIPLE": 1,
+        "A4-H1-TDEF-NONE": 1,
+        "A4-H2-ROW-DIRECTORY-INVALID": 1,
+        "A4-IDLE-EQUALITY": 0,
+        "A4-RESOURCE-BOUND": 0,
+        "A4-SCHEMA-SNAPSHOT": 0,
+        "A4-SNAPSHOT-RECONSTRUCTION": 0
+      },
+      "first_failure": "A4-H2-ROW-DIRECTORY-INVALID",
+      "fixture_id": "A4-ADV-EARLIER-PREDICATE",
+      "mutation": {
+        "generator_params": {
+          "available_equals_owned": false,
+          "conversion": "capacity",
+          "decoy_follows_ops": false,
+          "decoy_tdef_pages": {},
+          "duplicate_record_at": [],
+          "e_acute_double_occurrence": false,
+          "e_acute_length_override": null,
+          "extra_empty_filler": 0,
+          "extra_tag05_bits": {},
+          "force_conversion_at": {},
+          "holdout_name_corruption": false,
+          "kind_override": {},
+          "layout_by_replica": {},
+          "locator_offsets_by_replica": {},
+          "locator_target": "map",
+          "omit_pages_at_or_above": null,
+          "owned_ordinal_by_replica": {},
+          "preallocate_user_pages": false,
+          "profiles": {
+            "1": {
+              "empty_filler": 0,
+              "rows_per_page": 8
+            },
+            "2": {
+              "empty_filler": 2,
+              "rows_per_page": 7
+            },
+            "3": {
+              "empty_filler": 1,
+              "rows_per_page": 6
+            }
+          },
+          "record_layout": "single",
+          "record_page_default": "root",
+          "record_page_override": {},
+          "record_page_override_by_replica": {},
+          "skip_record_at": [],
+          "synthetic_boundary_bits": false,
+          "t2_id_relation_by_replica": {},
+          "tag05_bit_shift": 0,
+          "tag05_mode_by_replica": {},
+          "tdef_style": "signature",
+          "type1_exact_slots": false,
+          "user_tdef_tag": 2
+        },
+        "grammar_selection": null,
+        "patches": [
+          "flags_and_directory"
+        ]
+      },
+      "mutation_sha256": "543e662b2320d4fe681a323e4c2fcb51cf57c064d4a114eb5ec4d435ab057c3e",
+      "notes": [],
+      "ordered_predicates": [
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-IDLE-EQUALITY",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SCHEMA-SNAPSHOT",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-RESOURCE-BOUND",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TDEF-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 2,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+          "status": "pass"
+        },
+        {
+          "detail": "",
+          "measured_count": 1,
+          "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+          "status": "pass"
+        },
+        {
+          "detail": "replica 1: T3-v1 page 15 at T3_CREATE: slot 1 start 12 overlaps directory bytes below 14",
+          "measured_count": 1,
+          "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+          "status": "fail"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-ROLE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-CONVERSION-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REFERENCE-INVALID",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-BASE-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-ROOT",
+          "status": "not_applicable"
+        },
+        {
+          "detail": "",
+          "measured_count": 0,
+          "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+          "status": "not_applicable"
+        }
+      ],
+      "rejected": true,
+      "rejection": "first failure A4-H2-ROW-DIRECTORY-INVALID is not the target A4-H2-ROW-FLAGS-INVALID",
+      "target_predicate_id": "A4-H2-ROW-FLAGS-INVALID"
+    }
+  ],
+  "generator_sha256": "da5fc5e6ef2afe4d5dbac0f23f842bf23439c3e1f7a9061388c1cf089579dee6",
+  "harness_commit": "4286129d3a7562f32afa2f243fd360f9f8ce05f6",
+  "harness_sources_sha256": "239f86e0c4bab68d913912ade8f7ff0ca119f3bc2bb87e4cacbd3f83004817aa",
+  "plan_ambiguities": [
+    {
+      "id": "AMB-01",
+      "plan": "candidate_grammars.h1.layout_candidate_rule / a3_page_23_recomputed_work",
+      "reading": "A four-byte window is syntactically decodable when its u24 page value is <= 65535 (high byte zero). Only this bound reproduces the plan's 1,872 preserved windows per layout on retained A3 page 23; the frozen-model bound 0..20479 yields 1,869.",
+      "topic": "syntactic decodability"
+    },
+    {
+      "id": "AMB-02",
+      "plan": "filter_order.apply_table_record_signature_and_exact_locator_holes",
+      "reading": "A pair is structural only at offsets (35,39). Consequently at most one pair exists per layout and A4-H1-LOCATOR-PAIR-MULTIPLE is unreachable by enumeration, contradicting its claimed fixture.",
+      "topic": "H1 structural pair requires the exact locator holes"
+    },
+    {
+      "id": "AMB-03",
+      "plan": "record_candidate_procedure.qualified_page_rule / union_once_charging",
+      "reading": "Qualified tag-02 pages are identified by page number in the union across derivation replicas; a page exposed by both replicas is charged once.",
+      "topic": "union-once qualified page identity"
+    },
+    {
+      "id": "AMB-04",
+      "plan": "predicate_contracts input_candidate_set (per replica versus union)",
+      "reading": "Each derivation replica is evaluated independently in order 1 then 2; a cardinality predicate fails on the first replica violating it and stores that replica's measured count. REPLICA-DISAGREEMENT compares the two replica-invariant models.",
+      "topic": "NONE/MULTIPLE counts across replicas"
+    },
+    {
+      "id": "AMB-05",
+      "plan": "A4-H2-ROLE-NONE 'fits their static structure' is undefined",
+      "reading": "Static fit at every applicable checkpoint: both type-0 admitted sets lie below page_count, the owned/in-use set is nonempty, and the available set is a subset of the owned set. Type-1 rows are skipped at H2 because their admitted set needs the H3 traversal.",
+      "topic": "H2 static role/polarity fit"
+    },
+    {
+      "id": "AMB-06",
+      "plan": "A4-R19-H2-TRANSITION fixture text 'owned set changes during an idle leg'",
+      "reading": "Every registered idle leg is an idle pair whose bytes must already be equal at A4-IDLE-EQUALITY, so the described fixture cannot first fail at H2. The harness reaches A4-H2-TRANSITION-UNEXPLAINED with a grow-leg violation instead.",
+      "topic": "H2 idle transition versus A4-IDLE-EQUALITY"
+    },
+    {
+      "id": "AMB-07",
+      "plan": "candidate_grammars.h2.transition_signature.grow",
+      "reading": "On a grow leg the owned set may only gain pages and the available set may not gain any page the owned set gained on that leg; unrelated instances are unconstrained on another role's leg.",
+      "topic": "grow signature 'may remove but not add those same pages'"
+    },
+    {
+      "id": "AMB-08",
+      "plan": "A4-H3-BASE-DISCRIMINATION / base_discrimination_rule",
+      "reading": "A formula fits when, at every conversion leg, the type-0 owned set is contained in the formula-decoded type-1 set and later legs obey the H2 transition signatures on formula-decoded sets. No extant-page rule is applied to admitted pages (claims.exact_allocation_set_equality is false). Regions: inactive slot, active slot, bit 0 set, nonzero bit set, bit 16351 set in slot s, bit 0 set in slot s+1 with both slots active.",
+      "topic": "H3 base-formula fit and input regions"
+    },
+    {
+      "id": "AMB-09",
+      "plan": "catalog_root_selection_signature_rules.operation_delta_non_name_structure",
+      "reading": "A root candidate is an EMPTY tag-02 page whose frozen-model traversal is valid at every checkpoint and whose admitted stream (admitted set or admitted page hashes) changes at one or more of the seven listed operations. Requiring all seven would make A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED unreachable. The H1 record signature is not applied to system TDEFs.",
+      "topic": "H4 root selection signature"
+    },
+    {
+      "id": "AMB-10",
+      "plan": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+      "reading": "At an operation transition the isolated delta is changed_page_indices minus the TDEF and map pages of every user instance extant at that checkpoint. Page 0 is assumed unchanged; a real Jet header page that changes on every operation would fail this predicate on every campaign.",
+      "topic": "isolated physical schema delta"
+    },
+    {
+      "id": "AMB-11",
+      "plan": "raw_tuple_filter_order has no test of the name-length field before count_structural_field_layouts",
+      "reading": "A structural tuple's length field must decode to a count some registered encoding/length class could report for the expected name (union of both encodings' byte counts and the scalar count). Without this the length address is a free dimension and A4-H4-FIELD-MODEL-MULTIPLE is the only reachable H4 outcome.",
+      "topic": "H4 structural stage length field"
+    },
+    {
+      "id": "AMB-12",
+      "plan": "deduplicate_identical_byte_address_tuple; endianness of one-byte fields",
+      "reading": "Tuples that decode identical kind, identifier and length values for every operation record at every checkpoint are one canonical model (as row masks with byte-identical bounds are). Endianness is otherwise unidentifiable by equality relations, making decisive H4 impossible.",
+      "topic": "H4 observational equivalence of field tuples"
+    },
+    {
+      "id": "AMB-13",
+      "plan": "A4-SCHEMA-SNAPSHOT input '75 canonical DAO snapshots' versus freeze_rule",
+      "reading": "Campaign predicates are evaluated over every replica present (75 snapshots); derivation layers read replicas 1 and 2 only; holdout predicates read replica 3 only.",
+      "topic": "campaign predicates consume replica 3 before the freeze"
+    },
+    {
+      "id": "AMB-14",
+      "plan": "A4-H3-HOLDOUT-PREDICTION pass_iff 'predicts every replica-3 slot'",
+      "reading": "If replica 3 exposes no type-1 owned row the frozen H3 model is vacuously confirmed; the harness reports this as pass with a note.",
+      "topic": "H3 holdout with no type-1 row"
+    },
+    {
+      "id": "AMB-15",
+      "plan": "h2 locator_role_assignments versus h1_frozen_model_rule",
+      "reading": "The H2 assignment binds locator ordinal (first/second hole) to owned/available; swapping row order in one replica yields a different canonical H2 model while H1 stays replica-invariant.",
+      "topic": "A4-H2-REPLICA-DISAGREEMENT and the H1 role-assignment"
+    }
+  ],
+  "plan_sha256": "12e62b89bda97290f441b78a08902acbfe7e5fd10b9b008b1393800f45345356",
+  "protocol_version": "1.0.0",
+  "reachable_total": 39,
+  "reached_count": 39,
+  "recorded_utc": "2026-08-23T17:36:22Z",
+  "result": "pass",
+  "revision_plan_sha256": "12e62b89bda97290f441b78a08902acbfe7e5fd10b9b008b1393800f45345356",
+  "rows": [
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R01-IDLE-EQUALITY",
+      "fixtures_reaching": [
+        "A4-R01-IDLE-EQUALITY"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-IDLE-EQUALITY",
+      "predicate_id": "A4-IDLE-EQUALITY",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R02-SCHEMA-SNAPSHOT",
+      "fixtures_reaching": [
+        "A4-R02-SCHEMA-SNAPSHOT"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-SCHEMA-SNAPSHOT",
+      "predicate_id": "A4-SCHEMA-SNAPSHOT",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R03-SNAPSHOT-RECONSTRUCTION",
+      "fixtures_reaching": [
+        "A4-R03-SNAPSHOT-RECONSTRUCTION"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-SNAPSHOT-RECONSTRUCTION",
+      "predicate_id": "A4-SNAPSHOT-RECONSTRUCTION",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R04-RESOURCE-BOUND",
+      "fixtures_reaching": [
+        "A4-R04-RESOURCE-BOUND"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-RESOURCE-BOUND",
+      "predicate_id": "A4-RESOURCE-BOUND",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R05-H1-TDEF-NONE",
+      "fixtures_reaching": [
+        "A4-R05-H1-TDEF-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H1-TDEF-NONE",
+      "predicate_id": "A4-H1-TDEF-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R06-H1-TDEF-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-ADV-TDEF-MULTIPLE-3",
+        "A4-ADV-TDEF-MULTIPLE-4",
+        "A4-R06-H1-TDEF-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H1-TDEF-MULTIPLE",
+      "predicate_id": "A4-H1-TDEF-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R07-H1-LAYOUT-NONE",
+      "fixtures_reaching": [
+        "A4-R07-H1-LAYOUT-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H1-LOCATOR-LAYOUT-NONE",
+      "predicate_id": "A4-H1-LOCATOR-LAYOUT-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R09-H1-PAIR-NONE",
+      "fixtures_reaching": [
+        "A4-R09-H1-PAIR-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H1-LOCATOR-PAIR-NONE",
+      "predicate_id": "A4-H1-LOCATOR-PAIR-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R11-H1-TARGET-INVALID",
+      "fixtures_reaching": [
+        "A4-R11-H1-TARGET-INVALID"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H1-TARGET-ROW-INVALID",
+      "predicate_id": "A4-H1-TARGET-ROW-INVALID",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R08-H1-LAYOUT-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-R08-H1-LAYOUT-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+      "predicate_id": "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "attempt_first_failure": null,
+      "attempt_fixture": "A4-R10-H1-PAIR-MULTIPLE",
+      "classification": "unreachable",
+      "fixtures_reaching": [],
+      "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+      "status": "asserted_unreachable"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R12-H1-REPLICA",
+      "fixtures_reaching": [
+        "A4-R12-H1-REPLICA"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H1-REPLICA-DISAGREEMENT",
+      "predicate_id": "A4-H1-REPLICA-DISAGREEMENT",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R14-H2-DIRECTORY",
+      "fixtures_reaching": [
+        "A4-ADV-EARLIER-PREDICATE",
+        "A4-R14-H2-DIRECTORY"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H2-ROW-DIRECTORY-INVALID",
+      "predicate_id": "A4-H2-ROW-DIRECTORY-INVALID",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R15-H2-FLAGS",
+      "fixtures_reaching": [
+        "A4-R15-H2-FLAGS"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H2-ROW-FLAGS-INVALID",
+      "predicate_id": "A4-H2-ROW-FLAGS-INVALID",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R16-H2-TAG",
+      "fixtures_reaching": [
+        "A4-R16-H2-TAG"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H2-MAP-TAG-UNSUPPORTED",
+      "predicate_id": "A4-H2-MAP-TAG-UNSUPPORTED",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R17-H2-ROLE-NONE",
+      "fixtures_reaching": [
+        "A4-R17-H2-ROLE-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H2-ROLE-NONE",
+      "predicate_id": "A4-H2-ROLE-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R18-H2-ROLE-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-R18-H2-ROLE-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H2-ROLE-MULTIPLE",
+      "predicate_id": "A4-H2-ROLE-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R19-H2-TRANSITION",
+      "fixtures_reaching": [
+        "A4-R19-H2-TRANSITION"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H2-TRANSITION-UNEXPLAINED",
+      "predicate_id": "A4-H2-TRANSITION-UNEXPLAINED",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R20-H2-REPLICA",
+      "fixtures_reaching": [
+        "A4-R20-H2-REPLICA"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H2-REPLICA-DISAGREEMENT",
+      "predicate_id": "A4-H2-REPLICA-DISAGREEMENT",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R22-H3-CONVERSION",
+      "fixtures_reaching": [
+        "A4-R22-H3-CONVERSION"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H3-CONVERSION-NONE",
+      "predicate_id": "A4-H3-CONVERSION-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R23-H3-INACTIVE",
+      "fixtures_reaching": [
+        "A4-R23-H3-INACTIVE"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H3-INACTIVE-SLOT-NONE",
+      "predicate_id": "A4-H3-INACTIVE-SLOT-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R24-H3-REFERENCE",
+      "fixtures_reaching": [
+        "A4-R24-H3-REFERENCE"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H3-REFERENCE-INVALID",
+      "predicate_id": "A4-H3-REFERENCE-INVALID",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R25-H3-DISCRIMINATION",
+      "fixtures_reaching": [
+        "A4-R25-H3-DISCRIMINATION"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H3-BASE-DISCRIMINATION",
+      "predicate_id": "A4-H3-BASE-DISCRIMINATION",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R26-H3-BASE-NONE",
+      "fixtures_reaching": [
+        "A4-R26-H3-BASE-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H3-BASE-NONE",
+      "predicate_id": "A4-H3-BASE-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R27-H3-BASE-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-R27-H3-BASE-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H3-BASE-MULTIPLE",
+      "predicate_id": "A4-H3-BASE-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R28-H3-REPLICA",
+      "fixtures_reaching": [
+        "A4-R28-H3-REPLICA"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H3-REPLICA-DISAGREEMENT",
+      "predicate_id": "A4-H3-REPLICA-DISAGREEMENT",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R30-H4-ROOT-NONE",
+      "fixtures_reaching": [
+        "A4-R30-H4-ROOT-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H4-CATALOG-ROOT-NONE",
+      "predicate_id": "A4-H4-CATALOG-ROOT-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R31-H4-ROOT-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-R31-H4-ROOT-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H4-CATALOG-ROOT-MULTIPLE",
+      "predicate_id": "A4-H4-CATALOG-ROOT-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R34-H4-OUTSIDE",
+      "fixtures_reaching": [
+        "A4-R34-H4-OUTSIDE"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+      "predicate_id": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R32-H4-RECORD-NONE",
+      "fixtures_reaching": [
+        "A4-R32-H4-RECORD-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H4-CATALOG-RECORD-NONE",
+      "predicate_id": "A4-H4-CATALOG-RECORD-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R33-H4-RECORD-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-R33-H4-RECORD-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H4-CATALOG-RECORD-MULTIPLE",
+      "predicate_id": "A4-H4-CATALOG-RECORD-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 0
+      },
+      "designated_fixture": "A4-R35-H4-FIELD-NONE",
+      "fixtures_reaching": [
+        "A4-R35-H4-FIELD-NONE"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H4-FIELD-MODEL-NONE",
+      "predicate_id": "A4-H4-FIELD-MODEL-NONE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "minimum": 2,
+        "source": "measured_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R36-H4-FIELD-MULTIPLE",
+      "fixtures_reaching": [
+        "A4-R36-H4-FIELD-MULTIPLE"
+      ],
+      "measured_count": 2,
+      "measured_first_failure": "A4-H4-FIELD-MODEL-MULTIPLE",
+      "predicate_id": "A4-H4-FIELD-MODEL-MULTIPLE",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "allowed_ranges": [
+          {
+            "exact": 0
+          },
+          {
+            "minimum": 2
+          }
+        ],
+        "source": "measured_encoding_candidate_cardinality"
+      },
+      "designated_fixture": "A4-R37-H4-ENCODING",
+      "fixtures_reaching": [
+        "A4-ADV-ENCODING-2",
+        "A4-R37-H4-ENCODING"
+      ],
+      "measured_count": 0,
+      "measured_first_failure": "A4-H4-ENCODING-AMBIGUOUS",
+      "predicate_id": "A4-H4-ENCODING-AMBIGUOUS",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R38-H4-REPLICA",
+      "fixtures_reaching": [
+        "A4-R38-H4-REPLICA"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H4-REPLICA-DISAGREEMENT",
+      "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R13-H1-HOLDOUT",
+      "fixtures_reaching": [
+        "A4-R13-H1-HOLDOUT"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H1-HOLDOUT-PREDICTION",
+      "predicate_id": "A4-H1-HOLDOUT-PREDICTION",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R21-H2-HOLDOUT",
+      "fixtures_reaching": [
+        "A4-R21-H2-HOLDOUT"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H2-HOLDOUT-PREDICTION",
+      "predicate_id": "A4-H2-HOLDOUT-PREDICTION",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R29-H3-HOLDOUT",
+      "fixtures_reaching": [
+        "A4-R29-H3-HOLDOUT"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H3-HOLDOUT-PREDICTION",
+      "predicate_id": "A4-H3-HOLDOUT-PREDICTION",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R39-H4-HOLDOUT-ROOT",
+      "fixtures_reaching": [
+        "A4-R39-H4-HOLDOUT-ROOT"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H4-HOLDOUT-ROOT",
+      "predicate_id": "A4-H4-HOLDOUT-ROOT",
+      "status": "reached"
+    },
+    {
+      "classification": "claimed_reachable",
+      "count_contract": {
+        "exact": 1
+      },
+      "designated_fixture": "A4-R40-H4-HOLDOUT-FIELDS",
+      "fixtures_reaching": [
+        "A4-R40-H4-HOLDOUT-FIELDS"
+      ],
+      "measured_count": 1,
+      "measured_first_failure": "A4-H4-HOLDOUT-FIELDS",
+      "predicate_id": "A4-H4-HOLDOUT-FIELDS",
+      "status": "reached"
+    }
+  ],
+  "scientific_evidence": false,
+  "unreachable_asserted": [
+    {
+      "enumeration_argument": "structural pairs must sit at the exact registered locator holes [35,39)/[39,43); one layout therefore admits at most one canonical pair (a<b, b-a>=4) and the pair count under the unique layout can never exceed one",
+      "fixtures_evaluating_predicate": [
+        "A4-ADV-EARLIER-PREDICATE",
+        "A4-ADV-ENCODING-2",
+        "A4-R00-BASELINE",
+        "A4-R10-H1-PAIR-MULTIPLE",
+        "A4-R12-H1-REPLICA",
+        "A4-R13-H1-HOLDOUT",
+        "A4-R14-H2-DIRECTORY",
+        "A4-R15-H2-FLAGS",
+        "A4-R16-H2-TAG",
+        "A4-R17-H2-ROLE-NONE",
+        "A4-R18-H2-ROLE-MULTIPLE",
+        "A4-R19-H2-TRANSITION",
+        "A4-R20-H2-REPLICA",
+        "A4-R21-H2-HOLDOUT",
+        "A4-R22-H3-CONVERSION",
+        "A4-R23-H3-INACTIVE",
+        "A4-R24-H3-REFERENCE",
+        "A4-R25-H3-DISCRIMINATION",
+        "A4-R26-H3-BASE-NONE",
+        "A4-R27-H3-BASE-MULTIPLE",
+        "A4-R28-H3-REPLICA",
+        "A4-R29-H3-HOLDOUT",
+        "A4-R30-H4-ROOT-NONE",
+        "A4-R31-H4-ROOT-MULTIPLE",
+        "A4-R32-H4-RECORD-NONE",
+        "A4-R33-H4-RECORD-MULTIPLE",
+        "A4-R34-H4-OUTSIDE",
+        "A4-R35-H4-FIELD-NONE",
+        "A4-R36-H4-FIELD-MULTIPLE",
+        "A4-R37-H4-ENCODING",
+        "A4-R38-H4-REPLICA",
+        "A4-R39-H4-HOLDOUT-ROOT",
+        "A4-R40-H4-HOLDOUT-FIELDS"
+      ],
+      "max_measured_count_across_sweep": 1,
+      "predicate_id": "A4-H1-LOCATOR-PAIR-MULTIPLE",
+      "terminal_in_any_fixture": false
+    }
+  ]
+}

--- a/oracle/windows-dao/experiments/a4/dry-run/a4-reference-reachability-transcript.json
+++ b/oracle/windows-dao/experiments/a4/dry-run/a4-reference-reachability-transcript.json
@@ -3,71 +3,99 @@
   "adversarial_cases": [
     {
       "accepted": true,
+      "case_id": "multiple_count_2",
+      "description": "a second new tag-02 page appears at T3_CREATE: two lifecycle-matching TDEF candidates",
+      "expected": "accept",
+      "first_failure": "A4-H1-TDEF-MULTIPLE",
+      "fixture_id": "A4-R06-H1-TDEF-MULTIPLE",
+      "measured_count": 2,
+      "reference_evaluator_result": "accept",
+      "rejection": ""
+    },
+    {
+      "accepted": true,
+      "case_id": "multiple_count_3",
       "description": "three lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+      "expected": "accept",
       "first_failure": "A4-H1-TDEF-MULTIPLE",
       "fixture_id": "A4-ADV-TDEF-MULTIPLE-3",
       "measured_count": 3,
-      "rejected": null,
-      "rejection": "",
-      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+      "reference_evaluator_result": "accept",
+      "rejection": ""
     },
     {
       "accepted": true,
+      "case_id": "multiple_count_4",
       "description": "four lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+      "expected": "accept",
       "first_failure": "A4-H1-TDEF-MULTIPLE",
       "fixture_id": "A4-ADV-TDEF-MULTIPLE-4",
       "measured_count": 4,
-      "rejected": null,
-      "rejection": "",
-      "target_predicate_id": "A4-H1-TDEF-MULTIPLE"
+      "reference_evaluator_result": "accept",
+      "rejection": ""
     },
     {
       "accepted": true,
+      "case_id": "encoding_count_0",
+      "description": "the É record stores Windows-1252 bytes with stored length 9: zero fitting classes",
+      "expected": "accept",
+      "first_failure": "A4-H4-ENCODING-AMBIGUOUS",
+      "fixture_id": "A4-R37-H4-ENCODING",
+      "measured_count": 0,
+      "reference_evaluator_result": "accept",
+      "rejection": ""
+    },
+    {
+      "accepted": true,
+      "case_id": "encoding_count_2",
       "description": "the É record carries both registered byte occurrences at compatible anchors: two fitting classes",
+      "expected": "accept",
       "first_failure": "A4-H4-ENCODING-AMBIGUOUS",
       "fixture_id": "A4-ADV-ENCODING-2",
       "measured_count": 2,
-      "rejected": null,
-      "rejection": "",
-      "target_predicate_id": "A4-H4-ENCODING-AMBIGUOUS"
+      "reference_evaluator_result": "accept",
+      "rejection": ""
     },
     {
       "accepted": true,
+      "case_id": "unregistered_candidate_id",
       "description": "fixture names an unregistered base formula",
+      "expected": "reject",
       "first_failure": null,
       "fixture_id": "A4-ADV-UNREGISTERED-ID",
       "measured_count": null,
-      "rejected": true,
-      "rejection": "unregistered candidate id for base_formula: 'not-a-registered-formula'",
-      "target_predicate_id": null
+      "reference_evaluator_result": "reject",
+      "rejection": "unregistered candidate id for base_formula: 'not-a-registered-formula'"
     },
     {
       "accepted": true,
+      "case_id": "malformed_page",
       "description": "one page blob is 2,047 bytes",
+      "expected": "reject",
       "first_failure": null,
       "fixture_id": "A4-ADV-MALFORMED-PAGE",
       "measured_count": null,
-      "rejected": true,
-      "rejection": "malformed page blob(s): ['61adf02f8358785f99e523ca6e71cb21612fa445b2a332256b291fd88eb6b02a']",
-      "target_predicate_id": null
+      "reference_evaluator_result": "reject",
+      "rejection": "malformed page blob(s): ['61adf02f8358785f99e523ca6e71cb21612fa445b2a332256b291fd88eb6b02a']"
     },
     {
       "accepted": true,
+      "case_id": "earlier_predicate_invalidated",
       "description": "claims ROW-FLAGS but the same mutation breaks the directory first",
+      "expected": "reject",
       "first_failure": "A4-H2-ROW-DIRECTORY-INVALID",
       "fixture_id": "A4-ADV-EARLIER-PREDICATE",
       "measured_count": null,
-      "rejected": true,
-      "rejection": "first failure A4-H2-ROW-DIRECTORY-INVALID is not the target A4-H2-ROW-FLAGS-INVALID",
-      "target_predicate_id": "A4-H2-ROW-FLAGS-INVALID"
+      "reference_evaluator_result": "reject",
+      "rejection": "first failure A4-H2-ROW-DIRECTORY-INVALID is not the target A4-H2-ROW-FLAGS-INVALID"
     }
   ],
   "baseline": {
     "campaign": {
-      "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+      "campaign_sha256": "bf086b37261217ef210f0b4c5048aea89233227566ecb6a9709f63a6b19e2b4b",
       "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
       "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-      "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+      "page_index_inventory_sha256": "b332814e850a9a2c8c1c940fb0db2305e29b68f99a9732202d3a9cf7656952f6",
       "replica_page_counts": {
         "1": {
           "EMPTY": 8,
@@ -151,17 +179,17 @@
           "T4_REL_0904": 17393
         }
       },
-      "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+      "schema_snapshot_inventory_sha256": "de72138f7df4ee6094dbc05c4bae15647930d653cf7829c62c1600dc23ef28fa",
       "unique_page_blob_count": 155
     },
     "charges": {
       "base_formula_evaluations": 579,
-      "candidate_serializations": 12,
+      "candidate_serializations": 6,
       "catalog_raw_rows": 117,
       "catalog_root_signatures": 28,
       "encoding_union_anchor_bytes": 294,
       "h1_target_validity_checks": 452,
-      "h4_name_length_structural_tuples": 83232,
+      "h4_name_length_structural_tuples": 41616,
       "qualified_tdef_pages": 6,
       "raw_locator_pairs": 40008968,
       "raw_locator_windows": 40900,
@@ -171,7 +199,7 @@
       "type_1_slots": 648,
       "valid_path_row_directory_entries": 1500
     },
-    "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+    "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
     "first_failure": null,
     "fixture_id": "A4-R00-BASELINE",
     "models": {
@@ -211,7 +239,7 @@
         "model_type": "h3_traversal_model"
       },
       "h4_catalog_bootstrap": {
-        "canonical_model_id": "2a7bbf55f5464b78fc546ef69a1acf740738fc5283788e1be6f559f74efc4ca4",
+        "canonical_model_id": "5a8226061f6d95330d0d6a9027c28219bedb6a245a868a2d2dabe4f393f14a63",
         "model": {
           "fields": {
             "encoding_length_equivalence_class": "cp1252_single_byte_per_scalar",
@@ -221,16 +249,6 @@
                 "identifier_width": 1,
                 "kind_start_delta": 2,
                 "kind_width": 1,
-                "name_length_endianness": "big",
-                "name_length_start_delta": 1,
-                "name_length_width": 1
-              },
-              {
-                "endianness": "big",
-                "identifier_width": 1,
-                "kind_start_delta": 2,
-                "kind_width": 1,
-                "name_length_endianness": "little",
                 "name_length_start_delta": 1,
                 "name_length_width": 1
               },
@@ -239,16 +257,6 @@
                 "identifier_width": 1,
                 "kind_start_delta": 2,
                 "kind_width": 1,
-                "name_length_endianness": "big",
-                "name_length_start_delta": 1,
-                "name_length_width": 1
-              },
-              {
-                "endianness": "little",
-                "identifier_width": 1,
-                "kind_start_delta": 2,
-                "kind_width": 1,
-                "name_length_endianness": "little",
                 "name_length_start_delta": 1,
                 "name_length_width": 1
               }
@@ -328,17 +336,17 @@
     }
   },
   "capability_advancement_authorized": false,
-  "document_type": "dao_a4_reachability_transcript",
+  "document_type": "dao_a4_reference_reachability_transcript",
   "evaluator_role": "plan-driven reference evaluator decoding fixture bytes; not the production A4 analyzer",
   "experiment_id": "DAO-A4-ROW-ANCHORED-MAPS-001",
   "fixtures": [
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+        "campaign_sha256": "bf086b37261217ef210f0b4c5048aea89233227566ecb6a9709f63a6b19e2b4b",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "page_index_inventory_sha256": "b332814e850a9a2c8c1c940fb0db2305e29b68f99a9732202d3a9cf7656952f6",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -422,17 +430,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "schema_snapshot_inventory_sha256": "de72138f7df4ee6094dbc05c4bae15647930d653cf7829c62c1600dc23ef28fa",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 579,
-        "candidate_serializations": 12,
+        "candidate_serializations": 6,
         "catalog_raw_rows": 117,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 294,
         "h1_target_validity_checks": 452,
-        "h4_name_length_structural_tuples": 83232,
+        "h4_name_length_structural_tuples": 41616,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -442,7 +450,7 @@
         "type_1_slots": 648,
         "valid_path_row_directory_entries": 1500
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "all-pass synthetic campaign; every derivation layer decisive and every holdout predicted",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -788,10 +796,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "eebdfaebf4d4c48ef1ccc61978e6968183a537610dee0c4768314dfa3e0ee556",
+        "campaign_sha256": "857eeda18880e65fe5b41e874460b1d4f6513c08a8e59d0aec9c9f2ce44d37b3",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "333d900fef17ad5a32c679bf2876c4ed46fc1b732b74bf04da2625b8fa1cb5d1",
-        "page_index_inventory_sha256": "96dd94e72475c458b113433e45ffb137adc4cb7587ecded1340b6f7a4b384252",
+        "page_index_inventory_sha256": "7800674c38632ee24fd245d73f4f476a39d66ab159052decf17a7902b1ca15d0",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -875,7 +883,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "2be7384fca05026fcb3e010249e3de04f0ba65c8b860f7a0c0cc1135a3431692",
+        "schema_snapshot_inventory_sha256": "32e12e713fc62dd8a8cd004186efe36ac2fab847a2779da75329216fc0411b68",
         "unique_page_blob_count": 156
       },
       "charges": {},
@@ -1192,10 +1200,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "3595a6942c6a9a372ea80e329c729c5978f266f542df5baf3ed0d051931314a1",
+        "campaign_sha256": "af6fe55712ce485082edd3d738d62dfecb133d6aa652f0b8fa6d00872bc23fb8",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "page_index_inventory_sha256": "b332814e850a9a2c8c1c940fb0db2305e29b68f99a9732202d3a9cf7656952f6",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -1279,7 +1287,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "be2861e6666adf20e50380609b5486fe2dd7fbf01e2eb330114512385a97439e",
+        "schema_snapshot_inventory_sha256": "57c41cda058de09bf3906b62cc0cb6655777fef0fb9921923fe1d16c0a45dbc7",
         "unique_page_blob_count": 155
       },
       "charges": {},
@@ -1597,10 +1605,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "a0f0851f1868cac85062f105a38ab135955f9ccf8fd11ae2bb97f67dc27ee556",
+        "campaign_sha256": "c8baae65747359fff064074aa93d5c6d625a7bd522d5bc6422430bf5452a76a9",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-        "page_index_inventory_sha256": "7413cf05faf4242a88847006c232ecdcb437765ce2ef9348c2bf5c56e08e69a3",
+        "page_index_inventory_sha256": "9c9ddb297e57577054b4190cf46e95a0d11d1d908742fac4233d3966565eeb7d",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -1684,7 +1692,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "schema_snapshot_inventory_sha256": "de72138f7df4ee6094dbc05c4bae15647930d653cf7829c62c1600dc23ef28fa",
         "unique_page_blob_count": 155
       },
       "charges": {},
@@ -2003,10 +2011,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "cbf96f8a31a63101c0103ccb834d6127b5d2c55cd5ac556a6e70f0a4860f9892",
+        "campaign_sha256": "8480fd0001f87d22f9d4c759421b34c9347849c5e6d903ab4720a11ee20aaf4b",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "e8dea268e636e4b7b380ebf0b3f10c76c6f6a7ac9ab8e0d83e6195a2a85b0162",
-        "page_index_inventory_sha256": "cdcfd1ff5f7453b3db2f450c7f3d8290f97dcc563c803046c2c65546703b8ad4",
+        "page_index_inventory_sha256": "54dd1450676b64e501974f67fe9669680c10ae4d541e00f5287a70256225e288",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -2090,7 +2098,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "0d9bba061047f19e226e6bb1a0ca663ced8d25671048624d66c46e1e1d5f68bd",
+        "schema_snapshot_inventory_sha256": "15249509741bef141d5d227630afce0c55992057627042ab596b2de3d41db6cf",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -2412,10 +2420,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "2db648cd472a8f160a4e29d6bfce0ca0e380910f42b497fcb631841e2dd29882",
+        "campaign_sha256": "a81439bde40a4a33d46599fd07fb96abf23d9d76e59aecf397f4910c1f147981",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "c5b986a002a27d5469b0a7cd2699c6c0c18c3e4180c45b56b362099a8c2e1087",
-        "page_index_inventory_sha256": "7ad4f0a62dc97e5e7c2b8e7441cd692ac9e474bd608d8cf9cbdbffda592e4b6b",
+        "page_index_inventory_sha256": "bc2bb698c5d9e71a7e3b2ee7c5b38773f9620c350235d153d99ff2bc19d7d9c1",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -2499,7 +2507,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "af51143dd52da41f3ba252fcd89d22b26e186efdc1965e0d12d38b0ca63448bb",
+        "schema_snapshot_inventory_sha256": "d62f07f057d88eac0e33261de9e9736cec97136037a2e962102ed2af9dc79498",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -2820,10 +2828,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "d3c27dde730538f8d2ae26e50b28f0c5d1c70d000a8bbfe75848ff3f798789ff",
+        "campaign_sha256": "b40d0fe27a30a213cfd1e14759e07e90bd49ef9af44ddf047e843a8ff9af1c64",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "fa5d5272fc13059f23f4f7b05b23e3ee06dea62a3a8ffd7b3360d56d5e05e499",
-        "page_index_inventory_sha256": "80a392d350d21276bff3a8cee2fab93bba8ac66118ba50327a09f2fc9550f676",
+        "page_index_inventory_sha256": "484842e5f3bd4652d1324c723f82ced16fc172e5996ebc29375166ea992d9073",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -2907,7 +2915,7 @@
             "T4_REL_0904": 17394
           }
         },
-        "schema_snapshot_inventory_sha256": "42395c5ce897413c0d918e9cdf0632d3eee619bb2c1f27bceda9f3ce6b27827d",
+        "schema_snapshot_inventory_sha256": "a46a50bf77e174510bfb0e0754a700fab6cecac4d6c7c8f545d79572149b419e",
         "unique_page_blob_count": 158
       },
       "charges": {
@@ -3233,10 +3241,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "4f1880f47b1f3e201b36931ce6a1d55ee910647f04bfd3f3d105793bf3b035bc",
+        "campaign_sha256": "a6b8d64499c5ceba542592361a47bd2443491e1dafb53362f4240f6618676d27",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "1670734bb1a74a9f9ed81eb69ec39e7ac9ae2141c8eb2f6427ad99b4f6891da5",
-        "page_index_inventory_sha256": "269ab0654335199f936dd3a63c38f5c363621c0d8c8113d343c9767a014a0772",
+        "page_index_inventory_sha256": "e46ac72882e57a05669401d6dd7c6880e773b70f57a8b3706ea05602b3f8c80d",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -3320,7 +3328,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "03b033f8ae9b49a65cfc63666d182dbbba0aa3d21e8826f42bec03f893f57816",
+        "schema_snapshot_inventory_sha256": "d97b3b83e91166773385b322ea646bc18c953cc06b2876a1cd4ee1f5f6191767",
         "unique_page_blob_count": 139
       },
       "charges": {
@@ -3645,10 +3653,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "2341f1c4791881999c81681175d94da479abdef4adb63034bd659de3f33c2c16",
+        "campaign_sha256": "0b21bdee64ded49ec483c5ac51f1deb466f20e75f997a2998e499f05e5f61882",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "367c886311a63532d5f7ec41664a983ee157f35fe6784d4b001b4c74cd9f1176",
-        "page_index_inventory_sha256": "40f04f1eff294d465bc845134aea3c7dc95f6c71cf591bf452f0c1900d8448a4",
+        "page_index_inventory_sha256": "5bd42157922cb0ef8c2525b481089396cad915f136671edbb04405bd2cfdc5ec",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -3732,7 +3740,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "70df0d24825f4b7968a3a794ffaef3cae4372e101a76d8ae523df140273145e9",
+        "schema_snapshot_inventory_sha256": "7fd119828e88bed2bd34a243dc66dee374fbb66b1a421eae148e983b37886ac4",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -4059,10 +4067,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "61d35e2b2be1b1adde655be1a7463b84af3c1ee08d8c79796f58fdcaee68f604",
+        "campaign_sha256": "3815a450f501522296478f1311119fa7e1fdf7531eb1aa9e96940eed25dae9b6",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "dd65d837649e33522182d1263af951ccb21e97f868a75ecaed466a5eaa260c29",
-        "page_index_inventory_sha256": "dccf531f2ee53fab78caa4013ccf66914faf6eb6e922b2d8f93e6269b9dacbcc",
+        "page_index_inventory_sha256": "b1338e130a4519802150cf1b398df225708aca142bff131c76503172bc9b696a",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -4146,7 +4154,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "6b2884fc904cee2d886364e9b9f7ec8e9ab90259f3b16b3106299c367a571d32",
+        "schema_snapshot_inventory_sha256": "c37db2b8d17a349350e8d5ce3bbe45228c2650e7d9722dd571da1fc4f4f3627a",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -4475,10 +4483,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "bd43e5e5986773f59f333c0201dd6d5d47c594c67c7dd70e0f96105d4d419b62",
+        "campaign_sha256": "7e90338629f00a0f00d46e2015d497cf3a38281ae1c2259cf5990b1e1a385848",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "64b955ee8853f9c3075a083f4f55b81c61804225de96c7eb24141862d1a5c18a",
-        "page_index_inventory_sha256": "f21f4a14b99af12925de964327bcffe4b4de6fce493b1dfdf511e2c17bdb933e",
+        "page_index_inventory_sha256": "a695bc8597e3fb7a2105eb9dbf85336ea5bd99a7bfc35f19b36673fa5825a4eb",
         "replica_page_counts": {
           "1": {
             "EMPTY": 4628,
@@ -4562,7 +4570,7 @@
             "T4_REL_0904": 17395
           }
         },
-        "schema_snapshot_inventory_sha256": "6286e380e77d47aef55f5c937dbd13b9768adced8c745bd6e07fa072ab486d57",
+        "schema_snapshot_inventory_sha256": "b53320cb750b83f3b50e972413bc3c08884babfc5045d21cdc2a79918b0c84ff",
         "unique_page_blob_count": 132
       },
       "charges": {
@@ -4893,10 +4901,10 @@
     {
       "accepted": false,
       "campaign": {
-        "campaign_sha256": "1132387ffdb5097352a73d97c031f8df43edf622f5b03f284ca7deb4bc7800ff",
+        "campaign_sha256": "551102f0280c5dd77b76b1e868e07a0502b68bf4b90a083882103699e5a2373e",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "b8164c96e2935b2380f566d319e6df94b02ca0aafb2b1d35b20673e1b48c962e",
-        "page_index_inventory_sha256": "b9789f5beaf7ba0827b64c8215a392938b2553b90c6f63fe265852cdd0c9f423",
+        "page_index_inventory_sha256": "0ff898ce42f3c2d9e9fb2f687eab0f9146f35ba2227eb839b55819077ce8d928",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -4980,17 +4988,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "7e4c36f6787863aa685c82d0730110edd9ebe8b16c0eef2de90edae7e4f4dd4f",
+        "schema_snapshot_inventory_sha256": "5163fcb2811e9c3e589e7f6bd3e6f0136c44e3201bd760412de6ab37e1a94515",
         "unique_page_blob_count": 172
       },
       "charges": {
         "base_formula_evaluations": 579,
-        "candidate_serializations": 12,
+        "candidate_serializations": 6,
         "catalog_raw_rows": 117,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 294,
         "h1_target_validity_checks": 452,
-        "h4_name_length_structural_tuples": 83232,
+        "h4_name_length_structural_tuples": 41616,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 39889186,
         "raw_locator_windows": 40900,
@@ -5004,7 +5012,7 @@
         "minimum": 2,
         "source": "measured_candidate_cardinality"
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "attempt: the locator pair is copied to [100,108); exact-hole filtering keeps one structural pair (asserted unreachable)",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -5353,10 +5361,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "84d0b1f60aba454c13eda0dcfb93bed889d83e1a917bc22bc13e552974833167",
+        "campaign_sha256": "7dcf962068855e25019d9c6facc1cf0e4da0afbee22ec1274f590806db002267",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "42a519fdaff44f956a0ca12b501251291738b6fc990d8ceaaaa7a0b8169f1139",
-        "page_index_inventory_sha256": "a229be553bfced674e56ce6330f6c6963106eaa0d3aefe4c60bd28f17cd8a6ba",
+        "page_index_inventory_sha256": "714a1f9110188f467c232c2cb9117bb4d26f095b934cd22b324495b104e6c27a",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -5440,7 +5448,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "85f9aacad6d92e8f779e59ed7f031b8f19a19f7f0298a7233b7c14a1db3bb28e",
+        "schema_snapshot_inventory_sha256": "37923e9dbcfdf62dbeb79e524698326bb3af86893ccc0cebd1d8b8c85385cb9e",
         "unique_page_blob_count": 161
       },
       "charges": {
@@ -5774,10 +5782,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "0a69e0c42426f42f7a1804e48d09c0000d620802f02fe51c2c813dd69ad1c347",
+        "campaign_sha256": "a4349d939a24ef17544cb33a537698750d5c1cc2ef1639ba6b5290789b78a2e8",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "7c18baf67308e387d915abee3a315f591112d9f4fda682efb744141aeb3e31ea",
-        "page_index_inventory_sha256": "1532c30c1144635a34c4fc03c93f8383afaa2beb0a5addbc5d811ed457c81996",
+        "page_index_inventory_sha256": "00bc6530cce865f4ec661c662d560833dd2c7ddd082f266670c49c0b3701be64",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -5861,7 +5869,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "7fb0735f295faae526e619a0749eb70993fd94b64569bd525349f710ff2209ae",
+        "schema_snapshot_inventory_sha256": "1bfeb96c9b446b8510234b66d2eb444f18b4dcc481ef66133258fcb9f5b356ad",
         "unique_page_blob_count": 160
       },
       "charges": {
@@ -6200,10 +6208,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "6eee697e9e3ce0cfc4ca71a80624937da17a5294b9533a8ec76c7d54c758328f",
+        "campaign_sha256": "661ea5a53dca3b44ccb5decdfc9476c549679ce966ebd8ef27b23aa1fe60cff8",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "442188a5d5032614b97cedd2a7c8981eb6a0d3385cc00f9f23d361180845abe1",
-        "page_index_inventory_sha256": "dcc063bcf430d5dec681d3f82d7a359bee4d09386fce969ca96f1bad04f65e63",
+        "page_index_inventory_sha256": "828c62ad08c6f123e2155422423fe9b329893960db8cf99f7b1f891a9b391465",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -6287,7 +6295,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "aae3f9297f581fa56aa3b7c1cb825a4cddf9f57efcf70875c0b7a0ab44cda334",
+        "schema_snapshot_inventory_sha256": "992314ac2670465afeed258725b27929f83f6ec203dc9b9ef77a1f6575525660",
         "unique_page_blob_count": 160
       },
       "charges": {
@@ -6627,10 +6635,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "d6189454c2568f85f0691534f8c1415b1393f2b0c58533f5a76fdcbb6c7412e6",
+        "campaign_sha256": "70f310679098bcfb407cc483253a05b7c4863dfc7e223b4e2691995c186acf4d",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "1990ddb618572ba0f5150acf3f965b65680bf2f309aa20320bf13130fccad823",
-        "page_index_inventory_sha256": "cafa48e8a99f6a4805030443c58e84af6ed4be87d4616ddbf463b7e126f7f733",
+        "page_index_inventory_sha256": "d67050cae2e681abc64b72d094163292e2d298520925976ccbf2fd05d89ffc3a",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -6714,7 +6722,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "16cec848be3322578a2c93268ce20c2ec41b7a725d36f01effd777df5a80b1f9",
+        "schema_snapshot_inventory_sha256": "28d266e772f1e32ca5d39420bc0ab9ef6c6f328ba46c99c01fe2a6370066b583",
         "unique_page_blob_count": 160
       },
       "charges": {
@@ -7055,10 +7063,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "0e82c3942bd3bc5bda6d2405481050175664006c49fdcce2fe400262d8168928",
+        "campaign_sha256": "5bc7c6732944192edbdc98ed7511652eaae39741ab494346fc14ff36ee537d33",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "2f4eb18a05dc129b04c531c22defe07f6332e17e00edef73a42bb365cc50882a",
-        "page_index_inventory_sha256": "fc5c068896f5cb55b6306970523a6923b8494436bd1c2e6a86153056870d4d93",
+        "page_index_inventory_sha256": "2affbf73cfe0a8ba24647ba836f58f664f27ada0a5639948145513dfbd240476",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -7142,7 +7150,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "301102fe001019888b30f73bd39feae477b5b75daaa77fe2fbb8338fe83ff008",
+        "schema_snapshot_inventory_sha256": "62167bb4d1aca617be9b39698cb535004f6af4d8c6933b0c1bf1f265fadda589",
         "unique_page_blob_count": 161
       },
       "charges": {
@@ -7484,10 +7492,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "f1befc3165d7788e84e649272addb746a19419f05400ed7a47736e19595770bf",
+        "campaign_sha256": "09364d942ec42887c0ebad7a4285a31f67e740239ba40d3ef6239672f7ed6a89",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "e1d2a397c0d3527133edc730c53eee5d23b957c5802d46e46fcb008022d5e457",
-        "page_index_inventory_sha256": "f5f8b891df3270f092555a771ea4bae09f3a9f066b771c4a7cf5867f5696d6db",
+        "page_index_inventory_sha256": "8b8a06165da15f3346e5c25da46149e7ff5dc9e5d0573b5b1b7d54b46d30c38b",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -7571,7 +7579,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "d1dfc558c4fa08e18c4a4d1bad4ea2589a90e0e25785f5f226edab49f3794591",
+        "schema_snapshot_inventory_sha256": "42aa4680c44d301dbe260e1b4ae34b885df6b6009b049ea367ff4d6f552aa146",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -7912,10 +7920,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "1ff70ff50eb3c0886fbfd9f98351a286ee94ae6285b5a86681362a6127d24761",
+        "campaign_sha256": "0b4526bad4abbc29255dc9511bcc584ff0d2d09be9f36370346cdd70fbe1d4ea",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "baff60b9c8d86ea602bfe71bac1c4214b6a72178f547ef0d0481f3c5f78df0c7",
-        "page_index_inventory_sha256": "ca3439de11f8b1f0c125f02aa67ff23531819e220350702c8509d78fde3a826b",
+        "page_index_inventory_sha256": "1cd037c129ab228f448de901a35cd1565ce2ef59ae7199a909bc5d3c9156ccb5",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -7999,7 +8007,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "7655affa2f72c7fe24f0f16c79f21c40cb44e7c37cea4ec3c943df5d5c5f6a72",
+        "schema_snapshot_inventory_sha256": "c652b2af1e74d9147a03a174281a4af85b8e8ec1de30e8bc9b8ab11c676b16aa",
         "unique_page_blob_count": 159
       },
       "charges": {
@@ -8343,10 +8351,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "8e83422607b7a4dc742a22cdc5bed65b824b22c6bdf07cb9f3f7873fe0d416ce",
+        "campaign_sha256": "f52807e361e4ff2dd6c9d3f04ca349248044f7a9144d368b5a2a29a48af063ba",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "78375f77c0d0846e2d2dfd2eeab06f4b06c6cd535dd11c954c84e35bdb9ae244",
-        "page_index_inventory_sha256": "c2d3e09f78c47eb5f3b225ed317562594e25f96eb1584eaf34e4a46b9ba6de2d",
+        "page_index_inventory_sha256": "506fd91731151d5d46c3fee7edd4868951ea0b5821a10f3768a1ace0f44356e0",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -8430,7 +8438,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "bc3d324f2c539b607a74c421ac9308f9a96bc813511378979997670d47808b60",
+        "schema_snapshot_inventory_sha256": "556477ec8c0807d63e936c78aff1b83923be75e904545204a386432265982270",
         "unique_page_blob_count": 159
       },
       "charges": {
@@ -8775,10 +8783,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "cabf85763d8e56a93308e9ad077dbc5a77f1d9b737295e2eeb6f3341ea6e29c3",
+        "campaign_sha256": "03b23544affe0e48a9874552569059fb2412b50707b236e10803c70ac67e9893",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "df00d109987aa9bca0285ee123041c361fe0d2b76aceb2da0a656c2d8c19db78",
-        "page_index_inventory_sha256": "4e2781e49d08a8339b90d977a4498ce03a47990a3228236f4ea6760665e73946",
+        "page_index_inventory_sha256": "80dd8fd5388454fea5fe6ae41d6c57ecc3ee12da700b8f55430f3750a96353c0",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -8862,7 +8870,7 @@
             "T4_REL_0904": 17389
           }
         },
-        "schema_snapshot_inventory_sha256": "bf05b73108eea6ef148ecea10c69310d25deb5cd86d85b2283127bd419ac842a",
+        "schema_snapshot_inventory_sha256": "12d9badcc5fa1d2a81aafec9146c9dc742ab8a079cd2fea969391f25b9fc44b4",
         "unique_page_blob_count": 134
       },
       "charges": {
@@ -9205,10 +9213,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "baaa0cffa2cd17fc94e96050939e1afa0e7a527a2acda5022ad9d6dd4f04af4d",
+        "campaign_sha256": "7ba9631f8e9e36d93f11d6b0cedef9e0bf5af02a823539b0dbb5f3cdaf60900b",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "7e9c42db43ceef69fb2dee2a3ee03967d19500ea8611571d0409da419c637fae",
-        "page_index_inventory_sha256": "cdf164229fec7dbb376e269e31049c033c9c25efb5620b22f55c33ff6a3cfa69",
+        "page_index_inventory_sha256": "f4a16cba4607f8c673dffb56119efba4f872509a86dee65b1ed5e04c3a7bacc5",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -9292,7 +9300,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "a5a548ba7a4b2f9c8068654fba0b52d8e680cea1e0a2de49e94c3ea59c3e0e3f",
+        "schema_snapshot_inventory_sha256": "f1b62d6b392b637e857442a0aa651769b3c86bc90a035c718e0c2fb727bf135c",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -9637,10 +9645,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "5829041d503d1922a66b376ef0393cce3aefcb8203e1641b20789c7e4e280e25",
+        "campaign_sha256": "f53e51b942fbb056c7960aa1f52ab6e03bf22906debd89eebfcc42a65f5102df",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "39afc4128e32b1439b37f6998873be42e86a0e3184150537a3c484a72a9f2320",
-        "page_index_inventory_sha256": "2d56b2d5f64059b625934b13d890a1ae5fd4de56de148454f0ae4800a7496d7a",
+        "page_index_inventory_sha256": "8a771a456df1ba0abb2a1b238eca59ffa65832965993f7dae4b7273efb816340",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -9724,7 +9732,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "fa626696fa34da1eddcb7ac7a8c5efd462ead2990f7fa5c5e522b70183ead573",
+        "schema_snapshot_inventory_sha256": "b691c3d447c0118faf66528456b6b6783d316bce3c12e8e04326a47424fa7821",
         "unique_page_blob_count": 156
       },
       "charges": {
@@ -10073,10 +10081,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "b9463b9e064fc64c8fade63b37d3057a0e93070311df7b165d433492057b7ca3",
+        "campaign_sha256": "35efbb0dc5bfde79e045b6cb13ec419fecd756f231db9923ae13a4b721025d4b",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "803c45e042429868be17cc2a754a810dac6d0925a29486c53df4990ed2ed507c",
-        "page_index_inventory_sha256": "82fa3adc8f5d61acc660e88b0d64c1bf035c8eb8b11093067bb52cd68301cd5d",
+        "page_index_inventory_sha256": "00c781a609a037e460671b4d0359e42c9dca01ff32e46f675f8cc1141dd8bf8a",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -10160,7 +10168,7 @@
             "T4_REL_0904": 17390
           }
         },
-        "schema_snapshot_inventory_sha256": "21262d3b02c10969c71ccaacfc896d06414d8ab8886c9395ff1cdae6acab6b46",
+        "schema_snapshot_inventory_sha256": "5a4bb48323c70ce09f7e42a20ff218a634efb801b486d72415a30325346b3958",
         "unique_page_blob_count": 137
       },
       "charges": {
@@ -10507,10 +10515,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "281d7c922e8cc0c7855d8d8b06b86488ae62b4b1dcdfcbd9bdfd4ca83779d821",
+        "campaign_sha256": "c4fe29f9bef22e2bc6945f4c0452ea8756937d6ea5bfa0a773877c6b218e6031",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "88215565e0abf16af7e627182ca7d325aeda694b765051cb0f2314ea530d5faa",
-        "page_index_inventory_sha256": "7efb48a2df2b4f96b1b4dfd2a9268c8840e9d66408420a2461f831ebc975071f",
+        "page_index_inventory_sha256": "b5eadbb4061f5094a627920fef4b472a06b6a3be008dc188a929db0a560c423d",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -10594,7 +10602,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "e2c3f7100650b7003882606ba7b4c9dd02439e8529255b0a40439ca4942861f2",
+        "schema_snapshot_inventory_sha256": "9b72a8e88f899a670ce53829750027f0e52ca0b1ca15e753e9770336e0ea52ee",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -10943,10 +10951,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "b3ce38a7ad3535df6d6b4d958dce3ebd7ca193d05525ee09b703dfc4670e6101",
+        "campaign_sha256": "c4e8587da6967a00c84751f4a2b4d7be8154e7d8edb5534d4ef8e715ab80d8ad",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "ce699aaa3ceee90dadf78322f01796c7080b713b919f7c83e711a663e7f5c87c",
-        "page_index_inventory_sha256": "7d01f4ae040496e125f0b9c5648b32630204f48cdf01f6980bc79c71ae439631",
+        "page_index_inventory_sha256": "d21f4bc3337f5813bc104634c46d38c031321ce771ff265b905048b2608437b9",
         "replica_page_counts": {
           "1": {
             "EMPTY": 16352,
@@ -11030,7 +11038,7 @@
             "T4_REL_0904": 18553
           }
         },
-        "schema_snapshot_inventory_sha256": "cf2be924f568dbc3f9448757acd997068213407412e7cd0f886b616cf636a9ed",
+        "schema_snapshot_inventory_sha256": "b3706542b514838e53e2af7c9c2a1701f8ba58d4015afbf907d041550087fd5e",
         "unique_page_blob_count": 136
       },
       "charges": {
@@ -11387,10 +11395,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "fba3dff88c42ee827213f227d7213581e5a8c28a0260378f8429e1644e667ff2",
+        "campaign_sha256": "81eef210a3cea48861fc8f920e13a84715351d34f800f86cd8b3aa690733f04c",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "5ce187594533617ed44f430abec8f2f4558d374c064eee0b41f14667925b6d95",
-        "page_index_inventory_sha256": "9dfbd2cb492c10de2ff92523d071ab25d42aebf3c5cd96b468cede91267ba6cd",
+        "page_index_inventory_sha256": "76c8173065dbd2c2e0eb86c19459a4de7c29a9777e53db4ec13085f010c5fa79",
         "replica_page_counts": {
           "1": {
             "EMPTY": 16351,
@@ -11474,7 +11482,7 @@
             "T4_REL_0904": 18554
           }
         },
-        "schema_snapshot_inventory_sha256": "93c4fad593f2e4ce02dafcaad091e05d4f5565ba8871d70ff9295694e63b7fea",
+        "schema_snapshot_inventory_sha256": "19d471d6edab46cf48471c132664a952b51ccef2505312e75724be941d171774",
         "unique_page_blob_count": 140
       },
       "charges": {
@@ -11829,10 +11837,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "cd5669e08f8f5acae44da3c171a3ab48fa7c66db94ca8ca67fd0c9cbd60463c8",
+        "campaign_sha256": "00deb3a9447d9b5c779978448a5ec5b85640ef0e048ea354849a15424cdbd832",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "3ee3a3a3f9f75629603bd684251fc7d9bca33f051c2a77480eb5c5fd6a6845bf",
-        "page_index_inventory_sha256": "91948523e60869c529971102ffd466706cb976fe9bfebea88bef7bb4dcff0fa6",
+        "page_index_inventory_sha256": "8a162aa0d63372faef3a0e661b0bfe7f6999bbf6d130dfe99fcd02e6c743fe45",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -11916,17 +11924,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "aee4c535f5f6b6c35ed6eeace32b936377079f84c890f7c01353b0e062f5fb36",
+        "schema_snapshot_inventory_sha256": "2cbda6367c0d07c794c9ca5085073ba42a2d931c82cee78c27fcdbd4371a270d",
         "unique_page_blob_count": 156
       },
       "charges": {
         "base_formula_evaluations": 563,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 452,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -11939,7 +11947,7 @@
       "count_contract": {
         "exact": 1
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "replica 3's slot-0 tag-05 page clears the bit of the T3 map page after conversion",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -12286,10 +12294,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "7aeb79c4793f898866c4be410e2349401415e8b70444a63f16e3742c50141a7e",
+        "campaign_sha256": "b080f0e8a5803154cabfb6355415c5170b2ab04dc23a425ac6c1a28481a8b8b5",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-        "page_index_inventory_sha256": "171e58d40b3434141420656c2c51fd565ccf16741549c5812e4af9add692347f",
+        "page_index_inventory_sha256": "57c57837b0778a007732900274f5107f39c4c456ad84a3aed0918e57218919d4",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -12373,7 +12381,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "91d4bdb974cbb8cc739854bf35ee9699f3b7c427542d656f494063ad63f45788",
+        "schema_snapshot_inventory_sha256": "5feb79c9151416faba332b882a2e5b3ea02a0a5a8544921040facb1bf6ee9cdc",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -12726,10 +12734,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "94f85ad26612558fbbd9655924001ca72eb11f8e2c6b4bc3c2a0f8c6d88daf16",
+        "campaign_sha256": "77664ed477dc63b12aa94b10491d49489d00aabea680dede9e0ba7e2c90ff500",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "76de9eae5f6acdaef4c93e99f7c2b897cb7f0cbe4c9954f42f27fec0aa39febb",
-        "page_index_inventory_sha256": "c86f667e9a53731dcc5a56b812c3171f59e40bdb7acabd3e02a31351ef5f998d",
+        "page_index_inventory_sha256": "c05e44af56b073dfe571fd5752bdeda360a7d3b571fae9e3dfb66b304055c9e2",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -12813,7 +12821,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "308211384a46e269bd3eca67ad36e77ba617a2f1573a9a1b4ad4b7e885fcb8ae",
+        "schema_snapshot_inventory_sha256": "508dfa3fe506d0a0f48cb63783c269b4d7de9ae27091e8a9829abd50fc3c19a1",
         "unique_page_blob_count": 164
       },
       "charges": {
@@ -13168,10 +13176,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "a792115a4596189d3c353974c7d68009695fdc04de89aedf3b51c4a025486322",
+        "campaign_sha256": "c9b5214d243974cd3f561fb3bd3290e91bdc44ccebdf35fe395c046514abbaf2",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "5dcd105a4c7f0a69f88856389d6e5e4053ac785fb64d132d8786e8ef78e0e344",
-        "page_index_inventory_sha256": "272f974f65108f2257c9575842a0957a31a886eee446df84f5436364be618307",
+        "page_index_inventory_sha256": "648685975d25dc6cf7678746b8e6afb104384cc7bd70d98a1f5eb535837fe0c1",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -13255,7 +13263,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "167e172e91b4d0c1ef703e0e9eafa8144282ef082307be66c796855698af6ada",
+        "schema_snapshot_inventory_sha256": "fc76e4fb0ba3e20e9747ef1a28742ccd32cd70e60ad16972cc97ec15e276b81d",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -13612,10 +13620,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "79b691080bfd75955d8df80dbe508023bb2be8a8d245d88eb2a6b45bef3a7bea",
+        "campaign_sha256": "2f895bb6e71f47da5e8982702b3b5c7914fcfa2033576f1c844b26d03a9418ae",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "d47f31bc4408355959a3eefe3e69c0d8f4fc38d79b5978ef2cd3fcb31a962d3b",
-        "page_index_inventory_sha256": "393a6a4a66924651001615c1b4f81a5be5afc606b367d5b6f9de6daf2a165b9e",
+        "page_index_inventory_sha256": "f763c83bb34684a01ce74e088b00ceaa715b5652de7f7d416d5dda765f81c4eb",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -13699,7 +13707,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "f10d2ba58e4a1b118e515253066beb3bf6f3ced433ce60c32230f0e531089714",
+        "schema_snapshot_inventory_sha256": "2cd7adc5624cab346ba497a217c3504bcb5f780f0bb92f9d5f799d0cd002c602",
         "unique_page_blob_count": 140
       },
       "charges": {
@@ -14058,10 +14066,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "62e3758d679b703f37ea051c9459330a74a963dca3cdda4c60f3592203c3bcca",
+        "campaign_sha256": "da4d5c9f93583bd6d058b0622097673970a7a7cebd6a5e442f8cc01722f68b58",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "3286e1dee9af8d07b4923b54f4eb743d7ada897db9444f37164c29a62c7f6403",
-        "page_index_inventory_sha256": "b60359765453756491096015ac226ead21faea32136cdd5cd7a1d0f34821856c",
+        "page_index_inventory_sha256": "4f424c75cc2a8faac5f81f7f72068ac8c881723a6b46053f6ae3cb9cf6170735",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -14145,7 +14153,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "9a2b9577aa3fad0756253859269c1f7c7d794c179a56ebb1d9ddb681874630a2",
+        "schema_snapshot_inventory_sha256": "0548b168d6a3e7e0d12ce659adc52d322c69a963a3c0679e7d1aeb632350ea7f",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -14506,10 +14514,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "5576dcff42c61ccd9eb5069f5b902c8049f4ec435fc07e03d3979af382df65a7",
+        "campaign_sha256": "92632dc6887e66df24815795244ffe0173bacf2cba41e37d07f873c6ec62e8b8",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "4f2962f2e27669d8e8777aecc1892b3f11a913c4c07ad0e313bac1e3cbafb797",
-        "page_index_inventory_sha256": "14451e7e6497de219c962657a08654d05aee8b8acae190ccb4f038a8745c2691",
+        "page_index_inventory_sha256": "5b900e40bd81bd9b12f6ac6bcb771fdb19e7d2a5fb0ca18537016c6c1ac959c9",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -14593,7 +14601,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "5063ff7bb291696248fa057e66dd6f1452f9f2087f21c9aaf5ac8ab3c0e45a73",
+        "schema_snapshot_inventory_sha256": "5100cacfaa0bf7e6805faf3a7bf5b3cc2ad913c5b66de71e13d1ede9392eda60",
         "unique_page_blob_count": 155
       },
       "charges": {
@@ -14602,7 +14610,7 @@
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 302,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -14615,7 +14623,7 @@
       "count_contract": {
         "exact": 0
       },
-      "derivation_candidate_set_sha256": "cef17f8452e510dd80e9ebe4bd98baa3d26d51a734d1cf5c6e24a8bb12a4f2d3",
+      "derivation_candidate_set_sha256": "26ac6268d778be699d1924fc7aa5a81f96c9cf9cf42adb244dddc230aa22b8b9",
       "description": "the T3_CREATE record stores kind 0x44 while other table records store 0x11",
       "evaluated_counts": {
         "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
@@ -14896,7 +14904,7 @@
           "status": "pass"
         },
         {
-          "detail": "replica 1: no compatible occurrence or disagreeing kind/id within one record x27632; kind mapping x16",
+          "detail": "replica 1: no compatible occurrence or disagreeing kind/id within one record x13816; kind mapping x8",
           "measured_count": 0,
           "predicate_id": "A4-H4-FIELD-MODEL-NONE",
           "status": "fail"
@@ -14956,10 +14964,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "d3a7d0605bf6d9c10cf26d233ff4aa34a1e1ecd71a85ab5005c4337f63281281",
+        "campaign_sha256": "82d9a9aaaea63420781350388230fe8e336a72816a676342870a108aca60e61f",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "2281507bc022d264fb4a838a643ddefd9874b0c360185b0bd4ce54603eddcb17",
-        "page_index_inventory_sha256": "4c5c0b64a5b84b340f7103333e1b01d178bb5ae65a04fbe35aa4b3f22834c354",
+        "page_index_inventory_sha256": "72011c1b7ea8e656992283e6f6e857582a23f224e3d8eaf9379b67cfdabed160",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -15043,17 +15051,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "30f61f9861767dff7c1d9b2c7e8e99cc6db31fbfff5817b7eae74ef0ad2a9a35",
+        "schema_snapshot_inventory_sha256": "7a5609d56420ae2c1a8fa91742b1ba833890731e62d9271212898f1173905474",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 504,
-        "candidate_serializations": 16,
+        "candidate_serializations": 8,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 236,
         "h1_target_validity_checks": 302,
-        "h4_name_length_structural_tuples": 56352,
+        "h4_name_length_structural_tuples": 28176,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -15407,10 +15415,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "d8e2b9f851f54a6e9fc24a9c4658a1f82157c77f0baf4738d98d8ae8e91121ce",
+        "campaign_sha256": "97cb7991e79f866b9c78e240bbd7e0fa9c63d66dd0a167a2ab61bd4a39cfb35c",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "0d131d1eef30c1e2c42dc7caa8cc557140a0b2abe4a63e69be5440f5d2e325f8",
-        "page_index_inventory_sha256": "5092de50653d107cc756596aa5dd5950b69b91b4985bb57041e078385ce6baed",
+        "page_index_inventory_sha256": "5631ea7889e0bd55b1fa84f21f3a3fa7ea4b595321a5762e16a8e539dd0de02d",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -15494,17 +15502,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "ea18d7bd3a9936d3192bd1d5134ded904cf8a2837c77b0ed734b3fb695c81a37",
+        "schema_snapshot_inventory_sha256": "29cd1aaef0559b4f6dd9c3eaf2d88a2bf3cbdd61e5c80cb60a15fcaf431edf8d",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 504,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 302,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -15866,10 +15874,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "0e2715aa0e264b01829499cb03e8865b215b8e4554711ba50cbcae55e2117aee",
+        "campaign_sha256": "0f985bcc1c9cb36171e792e104f7e86d3b45281d3b8331e99de01050c9c23566",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "1d05ffbcbabc97c634fbaf3305d91392b5a29ad3f9dabd1b1c303efc54aa2d5e",
-        "page_index_inventory_sha256": "ddd4e70a5f861f9dad9f8a30e9992f9b91b05735237f8921e3fa20f8fe4ea867",
+        "page_index_inventory_sha256": "27c46cc2bac355b2e62d9aa76c2e5f3795f59381e327ed3e0c979188d764ed78",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -15953,17 +15961,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "e970a5c4135a44787686d099283b7b7e5885108bff70a6bfe33687a4d137beaf",
+        "schema_snapshot_inventory_sha256": "876585054406b8047d9ec716979442e3fbb762108a5478f609c99648e9d7d4a1",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 504,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 302,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -15976,7 +15984,7 @@
       "count_contract": {
         "exact": 1
       },
-      "derivation_candidate_set_sha256": "a3cd3b60e4182b7981a743d4e451e6fe7e20dc785e624c376861ffa348a5e0c1",
+      "derivation_candidate_set_sha256": "1dfd595f9655476d78692ce04db42ec9a55b9096e6753de62fda8baf1ab17d6e",
       "description": "replica 2 reuses the T2-v1 identifier for T2-v2",
       "evaluated_counts": {
         "A4-H1-LOCATOR-LAYOUT-MULTIPLE": 1,
@@ -16278,7 +16286,7 @@
           "status": "pass"
         },
         {
-          "detail": "replica models differ: [{'root': {'root_tdef_page': 2, 'catalog_root_selection_signature': 'operation_delta_non_name_structure'}, 'fields': {'field_tuple_members': [{'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}], 'kind_mapping': {'table': 17, 'field': 34, 'index': 51}, 'identifier_lifecycle_relation': 'stable_for_same_operation_instance_and_distinct_for_t2_v1_v2', 'encoding_length_equivalence_class': 'cp1252_single_byte_per_scalar'}}, {'root': {'root_tdef_page': 2, 'catalog_root_selection_signature': 'operation_delta_non_name_structure'}, 'fields': {'field_tuple_members': [{'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'big'}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1, 'name_length_endianness': 'little'}], 'kind_mapping': {'table': 17, 'field': 34, 'index': 51}, 'identifier_lifecycle_relation': 'stable_for_same_physical_name_including_t2_v1_v2', 'encoding_length_equivalence_class': 'cp1252_single_byte_per_scalar'}}]",
+          "detail": "replica models differ: [{'root': {'root_tdef_page': 2, 'catalog_root_selection_signature': 'operation_delta_non_name_structure'}, 'fields': {'field_tuple_members': [{'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1}], 'kind_mapping': {'table': 17, 'field': 34, 'index': 51}, 'identifier_lifecycle_relation': 'stable_for_same_operation_instance_and_distinct_for_t2_v1_v2', 'encoding_length_equivalence_class': 'cp1252_single_byte_per_scalar'}}, {'root': {'root_tdef_page': 2, 'catalog_root_selection_signature': 'operation_delta_non_name_structure'}, 'fields': {'field_tuple_members': [{'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'big', 'name_length_start_delta': 1, 'name_length_width': 1}, {'kind_start_delta': 2, 'kind_width': 1, 'identifier_width': 1, 'endianness': 'little', 'name_length_start_delta': 1, 'name_length_width': 1}], 'kind_mapping': {'table': 17, 'field': 34, 'index': 51}, 'identifier_lifecycle_relation': 'stable_for_same_physical_name_including_t2_v1_v2', 'encoding_length_equivalence_class': 'cp1252_single_byte_per_scalar'}}]",
           "measured_count": 1,
           "predicate_id": "A4-H4-REPLICA-DISAGREEMENT",
           "status": "fail"
@@ -16320,10 +16328,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "b6fa441aa5c6e648543387a77f3b2c25fc334f0b9e60cfeb597547ba2aafe38c",
+        "campaign_sha256": "97533bd5b845507210c838e45e94a298c060a19e3cbe52c0e26845fbb1eb1746",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "5f21930575e7e2a22546922b5379e5926ac02c717f69fae8601d35c6c02a879c",
-        "page_index_inventory_sha256": "7861f579b6407610c92db784553b37219fdd74e01d99b1f3963d82e2b93dbd85",
+        "page_index_inventory_sha256": "9fde08294de0b87a49dca24bb4a86beb1e6665bd0906e8bf0c4f6908ab881a11",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -16407,17 +16415,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "7d2f415182659aa0d37a0b10c0906b5cd86db1903825afa3504611c290700ab0",
+        "schema_snapshot_inventory_sha256": "913963f70f25ee673717ee47e02b2a8b14ff4ff9214836ecb67c7046add0f3d7",
         "unique_page_blob_count": 157
       },
       "charges": {
         "base_formula_evaluations": 504,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 302,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -16430,7 +16438,7 @@
       "count_contract": {
         "exact": 1
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "replica 3 stores its locators at offsets 36/40",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -16778,10 +16786,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "c2515c415d0460416804852c4c9318e0fcefe257be4c17c4d1f0f101bdc04a7c",
+        "campaign_sha256": "3f860faa5ee0758c23f414e0ba68e0efa5a872b25cd88b427ffcfbc01ad2ff76",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "f95b239fb71bfe54efd1a1a8bba194daf62bf61cc83d988ebbc56eb7e799ebbf",
-        "page_index_inventory_sha256": "f729fdd25e3dc7869e5f843c6b56c59a873c27e07b6906952e215e9108d55aa5",
+        "page_index_inventory_sha256": "485a739c93ba8073be386e8cf2e868a314f91c35b6b76719042b46124e68fddd",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -16865,17 +16873,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "7626ce129035bb8578657f75b4370f866521dc62e424bc59800353d63e00d652",
+        "schema_snapshot_inventory_sha256": "7c615adf74e0fdbcb84d53dbd71b4a1681bab90252477c5f9821bed5334e34e2",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 504,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 452,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -16888,7 +16896,7 @@
       "count_contract": {
         "exact": 1
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "replica 3 stores the owned row at locator ordinal 1",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -17234,10 +17242,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "b84d8874b3c6a79aefaa8aee28d7eca81561129fbf46e0c6ac142faaafa7a8e9",
+        "campaign_sha256": "acc6f60d66be9bfe0ee3d92e239439238ba8fdeaa3c145cdcfff9cfa96ef8d01",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "7567883ae19424e3ff0c69acde0d50a5a5d15c52ae150b1e5ce33cd6afb13e54",
-        "page_index_inventory_sha256": "c5b2c572617efdf475d4476903a2e6f7cfffe42bf03f8fe898007c747dfea128",
+        "page_index_inventory_sha256": "66a974ab8618e12e5bef43f3ef9f6428de8b2d5943bdb3d35fdae444271a6151",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -17321,17 +17329,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "724a18eb648f23c28825fe31192751c785fc2b5e363b6f4c307a767be4fe532e",
+        "schema_snapshot_inventory_sha256": "0b5371f2f7cdfd747321760134aa6b401fde7ace15cf88a2c6e726c7b1f5bf32",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 579,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 188,
         "h1_target_validity_checks": 452,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -17344,7 +17352,7 @@
       "count_contract": {
         "exact": 1
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "replica 3 writes the T3_CREATE record to the unadmitted spare page",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -17694,10 +17702,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "55179949b65b7c0c0a9ca5d2fecc36ab6da88be0f55a8332aecfdb08c56aedbb",
+        "campaign_sha256": "f8ee1e83bdc409fa093bc22897c64c5fb79797e21d572a853c99e04c801ae176",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "2e0b2ed04d8a345439cc4652f4636c090a7008c85f884842692a25ad1e04b37f",
-        "page_index_inventory_sha256": "148d69eb47a19a8f2ea3155bd1ba351d7a7400a02a839a41485aa66299d98df1",
+        "page_index_inventory_sha256": "72e1740e13bb7a31f6ba5fb4dab10ab3ba2c7838b5a7bb4bbd7f6708faa17d71",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -17781,17 +17789,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "ded14d86e0bb6fee1ac6fa48e90c1b60a4f4d4489e7f1aedc401b8fcc7a10145",
+        "schema_snapshot_inventory_sha256": "3f28b15c75c491bcf701fe6c808e11f0debc54acdd55faf529ba969e2974d761",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 579,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 117,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 294,
         "h1_target_validity_checks": 452,
-        "h4_name_length_structural_tuples": 55488,
+        "h4_name_length_structural_tuples": 27744,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -17804,7 +17812,7 @@
       "count_contract": {
         "exact": 1
       },
-      "derivation_candidate_set_sha256": "58baf063cf81a9ffe614d7b3eec217184a38fed2326d601e5f14b47455a72977",
+      "derivation_candidate_set_sha256": "d2d70ecc7ce0f0c9e13e6c35766cefa2fb23fb5e70ba64ec02b7eb3fa754cfaa",
       "description": "replica 3's É record name ends in '5'",
       "evaluated_counts": {
         "A4-H1-HOLDOUT-PREDICTION": 1,
@@ -18151,10 +18159,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "83d5c7ba8ecc3bc97abefb717e2ee6b3d4ba8f52ee6e99d2e3aba30395e3bed0",
+        "campaign_sha256": "01c80e1b025b9fc4a3cb776b96f59c88fdca1429701d2ae97dce1169d9d96bd6",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "334a8e3b1c11bcb51bb3669fe7df2f36f48b5f50ec7ebed86e590559ccded486",
-        "page_index_inventory_sha256": "a3e9b6f175913eade32bda4c1b91f3899f0522633a2f3ae4784e641dc4db2658",
+        "page_index_inventory_sha256": "b4dca779ba19b0cc2bbe7656e1849fb4bdf926db96c8bd7c67f7530ebaeca775",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -18238,7 +18246,7 @@
             "T4_REL_0904": 17395
           }
         },
-        "schema_snapshot_inventory_sha256": "9353994fbc7c1c82dbfa4ab69921f36860ead25124de0d83852e862ccb4835e7",
+        "schema_snapshot_inventory_sha256": "534e52e8b6b6e2419a1f4fb8bfb863dee28db061d271c82130461d6dc94210c2",
         "unique_page_blob_count": 158
       },
       "charges": {
@@ -18564,10 +18572,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "49cf714b51f4d4c3fab5c25e2d57fb1491fcd506df2366fe4928c5bfec6f505a",
+        "campaign_sha256": "79499d06d70116029f7cdfc100daed55be6c9a94e6000d5e92e8e37b0ee29815",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "2b7ba1b10092eb458ec26f6e57ab1b51fa1b626d0cc60d07a269dfddf3bd8f0a",
-        "page_index_inventory_sha256": "992ae55d1386ff154aaff0b63235cfacc387bb044cb4d75d0b890956a1b2f799",
+        "page_index_inventory_sha256": "135a8c5afa514d16ce569391d7e2aca123d8834b8a6da7de6156c7b0ea471c4a",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -18651,7 +18659,7 @@
             "T4_REL_0904": 17390
           }
         },
-        "schema_snapshot_inventory_sha256": "b73201fdc9682cface03dc3566ef25c437cda8c28051a6a9f37546856b2c1794",
+        "schema_snapshot_inventory_sha256": "9e11d7a55e00623e7878a94efb9535c6f2c06d2e629b712086f31d4176239607",
         "unique_page_blob_count": 158
       },
       "charges": {
@@ -18977,10 +18985,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "fff8e2767b9c4ac95f7ce5e3d18d7adb7734381fc93052952d4286cec6ba6822",
+        "campaign_sha256": "f1c01184c12d6b9e66dbbbcd668c7b155c9cda2b61c3f1d414d4965d37eb81e1",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "7b8dc810f372cb1773bfb6e87db4128bf82a688f58d001a613b9c751807f1056",
-        "page_index_inventory_sha256": "2e22c05c620c7d624e66fecec789feb98112754ad95dc7f3e6858bcbc8d4d426",
+        "page_index_inventory_sha256": "c01a7b43d970340c52496e5c2c6341f9ae6596aa317bebffbc4b661f7c8a6842",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -19064,17 +19072,17 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "919570dbb454b20a0cfaaa92088cc6bfaaa3f5db2357118e7b80fd0ea4e7c895",
+        "schema_snapshot_inventory_sha256": "48816f1509352eec7b793bfba85f46021aeb69b4739a8777dc525e8e2fda9058",
         "unique_page_blob_count": 155
       },
       "charges": {
         "base_formula_evaluations": 504,
-        "candidate_serializations": 8,
+        "candidate_serializations": 4,
         "catalog_raw_rows": 78,
         "catalog_root_signatures": 28,
         "encoding_union_anchor_bytes": 240,
         "h1_target_validity_checks": 302,
-        "h4_name_length_structural_tuples": 55520,
+        "h4_name_length_structural_tuples": 27760,
         "qualified_tdef_pages": 6,
         "raw_locator_pairs": 40008968,
         "raw_locator_windows": 40900,
@@ -19436,10 +19444,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+        "campaign_sha256": "bf086b37261217ef210f0b4c5048aea89233227566ecb6a9709f63a6b19e2b4b",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "page_index_inventory_sha256": "b332814e850a9a2c8c1c940fb0db2305e29b68f99a9732202d3a9cf7656952f6",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -19523,7 +19531,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "schema_snapshot_inventory_sha256": "de72138f7df4ee6094dbc05c4bae15647930d653cf7829c62c1600dc23ef28fa",
         "unique_page_blob_count": 155
       },
       "description": "fixture names an unregistered base formula",
@@ -19590,10 +19598,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "63d1a59e21c935a701fef7dde0c3f1fd1d6397a64ded42d70558aecef1fd2df1",
+        "campaign_sha256": "bf086b37261217ef210f0b4c5048aea89233227566ecb6a9709f63a6b19e2b4b",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "6356075921059eaeabd8d509f8feea42b4890d55c9bda6a3b50646ac14460be1",
-        "page_index_inventory_sha256": "d5ce14c95d8ca583ec280be625091377e3ad226f729f7e3b4661e2dd6a8eeac8",
+        "page_index_inventory_sha256": "b332814e850a9a2c8c1c940fb0db2305e29b68f99a9732202d3a9cf7656952f6",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -19677,7 +19685,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "415b12ebcd04390af5832db5a0c28c90690050c83e7fa60c77c173deb187f25d",
+        "schema_snapshot_inventory_sha256": "de72138f7df4ee6094dbc05c4bae15647930d653cf7829c62c1600dc23ef28fa",
         "unique_page_blob_count": 155
       },
       "description": "one page blob is 2,047 bytes",
@@ -19742,10 +19750,10 @@
     {
       "accepted": true,
       "campaign": {
-        "campaign_sha256": "bb9dcecaae6d74065398c6f50fdc5483d80df96f5e024728e35691a2c572a033",
+        "campaign_sha256": "cb0beee7b5fcce343892562c9618d86f0fdfa208d424e976d35f38eaf4a80c41",
         "events_sha256": "6598bcb542eed6cb8cfdd0d52c61e67476c8b907dc3a540e6de4524f7303c2a4",
         "page_blob_inventory_sha256": "4e089a375cb2f19d26de2e528727a14362d233cdd45b839eb9ab4c1f27e9b79e",
-        "page_index_inventory_sha256": "7f503bf252adcd62ffb89a7ea99b69fae8933d3c3b53f7b8e08dc94fce723232",
+        "page_index_inventory_sha256": "e6ab5d3611bdfc290c887b750c993e012c8d3ccc2073e3c46a9656e12f0daf9d",
         "replica_page_counts": {
           "1": {
             "EMPTY": 8,
@@ -19829,7 +19837,7 @@
             "T4_REL_0904": 17393
           }
         },
-        "schema_snapshot_inventory_sha256": "10b69d7b30aea096cdb1f2e684fd32557fb3a8740534117182dc514553c3edbd",
+        "schema_snapshot_inventory_sha256": "9a9e6234c2e1d2807c16f4c5cbc0d5adb3b2b3c70ea3aacec2df0098c3bc1461",
         "unique_page_blob_count": 165
       },
       "charges": {
@@ -20164,8 +20172,9 @@
     }
   ],
   "generator_sha256": "da5fc5e6ef2afe4d5dbac0f23f842bf23439c3e1f7a9061388c1cf089579dee6",
-  "harness_commit": "4286129d3a7562f32afa2f243fd360f9f8ce05f6",
-  "harness_sources_sha256": "239f86e0c4bab68d913912ade8f7ff0ca119f3bc2bb87e4cacbd3f83004817aa",
+  "harness_commit": "aa06942a19622bef5035fc724fa4812b1914bd63",
+  "harness_sources_sha256": "7f7293f13cb629e9a67639e416abac65467bb078e632e5ecfd8d8036645db204",
+  "not_the_dispatch_gate_transcript": "reachability-transcript.schema.json requires analyzer and independent-validator results, a provenance entry, and a non-null first failure on all 40 entries; this reference transcript has none of those (AMB-16, AMB-17)",
   "plan_ambiguities": [
     {
       "id": "AMB-01",
@@ -20256,15 +20265,27 @@
       "plan": "h2 locator_role_assignments versus h1_frozen_model_rule",
       "reading": "The H2 assignment binds locator ordinal (first/second hole) to owned/available; swapping row order in one replica yields a different canonical H2 model while H1 stays replica-invariant.",
       "topic": "A4-H2-REPLICA-DISAGREEMENT and the H1 role-assignment"
+    },
+    {
+      "id": "AMB-16",
+      "plan": "reachability-transcript.schema.json fixtureEntry.first_failure_id (non-null) with minItems/maxItems 40",
+      "reading": "The schema admits no asserted-unreachable entry, yet A4-H1-LOCATOR-PAIR-MULTIPLE is unreachable under the exact-hole rule (AMB-02). Either the hole rule or the schema must change; the reference transcript records the unreachable assertion separately.",
+      "topic": "dispatch-gate transcript schema requires every predicate to be a first failure"
+    },
+    {
+      "id": "AMB-17",
+      "plan": "reachability_transcript_binding; adversarialOutcome.case_id resource_exact_ceiling / resource_one_over",
+      "reading": "The bound transcript requires analyzer and independent-validator commits and results, a provenance entry id, and resource-ceiling cases at exactly 600,000,000 work units. A synthetic campaign cannot reach that ceiling honestly (baseline charges are six orders of magnitude lower), so those two cases need a declared charging-injection mechanism in the plan. This harness writes a reference transcript under a distinct document type instead of claiming the gate artifact.",
+      "topic": "dispatch-gate transcript needs artifacts that do not exist yet"
     }
   ],
-  "plan_sha256": "12e62b89bda97290f441b78a08902acbfe7e5fd10b9b008b1393800f45345356",
+  "plan_sha256": "550c6e566b8cb14492508cbf6a9b4e3980fe2ecc9729e61b7b9830d4bdd337c3",
   "protocol_version": "1.0.0",
   "reachable_total": 39,
   "reached_count": 39,
-  "recorded_utc": "2026-08-23T17:36:22Z",
+  "recorded_utc": "2026-08-23T17:39:46Z",
   "result": "pass",
-  "revision_plan_sha256": "12e62b89bda97290f441b78a08902acbfe7e5fd10b9b008b1393800f45345356",
+  "revision_plan_sha256": "550c6e566b8cb14492508cbf6a9b4e3980fe2ecc9729e61b7b9830d4bdd337c3",
   "rows": [
     {
       "classification": "claimed_reachable",

--- a/oracle/windows-dao/experiments/a4/dry-run/checksums.json
+++ b/oracle/windows-dao/experiments/a4/dry-run/checksums.json
@@ -1,1 +1,1 @@
-{"a4-reachability-transcript.json":{"bytes":640987,"sha256":"8eba8f372e8901e0082f2b931bc2ee951eac1d3e3073dcb29980146a53e5630a"}}
+{"a4-reference-reachability-transcript.json":{"bytes":641972,"sha256":"06179c9fdada8cf7a8c3a6ce47919f4f19b4065ebf603b27720250fe9768af21"}}

--- a/oracle/windows-dao/experiments/a4/dry-run/checksums.json
+++ b/oracle/windows-dao/experiments/a4/dry-run/checksums.json
@@ -1,0 +1,1 @@
+{"a4-reachability-transcript.json":{"bytes":640987,"sha256":"8eba8f372e8901e0082f2b931bc2ee951eac1d3e3073dcb29980146a53e5630a"}}

--- a/oracle/windows-dao/scripts/a4_campaign.py
+++ b/oracle/windows-dao/scripts/a4_campaign.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Shared synthetic A4 campaign container: blobs, page indexes, DAO snapshots, lifecycle events.
+
+A campaign is exactly what the dry-run honesty clause permits a fixture to be:
+content-addressed 2,048-byte page blobs, one ordered page index per
+replica/checkpoint, one canonical DAO schema snapshot per replica/checkpoint,
+and the plan-derived checkpoint events. It carries no verdict booleans.
+Fixtures mutate a campaign through :meth:`Campaign.patch_page` and the snapshot
+/ page-index documents, after which :meth:`Campaign.refresh` re-derives every
+dependent field (changed indices, database SHA-256, snapshot before/after) so a
+mutation stays a consistent campaign unless the fixture deliberately breaks it.
+
+A4 rule | implementation
+--- | ---
+Content-addressed page store, duplicates stored once | :attr:`Campaign.blobs`
+Ordered page index with changed_page_indices per checkpoint | :meth:`Campaign.page_index`
+Canonical snapshot ordinals after exact scheduled-name filtering | :func:`snapshot_document`
+Rolling row hash from the row algorithm | :func:`a4_spec.rolling_sha256`
+Fixture identity hashes for the transcript | :meth:`Campaign.inventory`
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from a4_spec import (
+    CHECKPOINTS, EVENTS, EXPECTED_SCHEMA, EXPERIMENT_ID, FIELD_DEFS, INDEX_DEF, INSTANCE_BY_ID, ORDINAL, PAGE_SIZE,
+    PLAN_SHA256, REVISION_PLAN_SHA256, ROLE_BINDINGS, canonical_json_bytes, rolling_sha256, sha256_hex,
+)
+
+ZERO_COMMIT = "0" * 40
+PROVIDER_SHA256 = sha256_hex(b"A4 synthetic DAO provider; no binary exists")
+ENVIRONMENT_SHA256 = sha256_hex(b"A4 synthetic environment; Windows x86 PowerShell 5 code page 1252 declared, not observed")
+CAMPAIGN_ID = "a4-dryrun-synthetic"
+
+
+def _utf16(name: str) -> list[int]:
+    return [int.from_bytes(name.encode("utf-16-le")[i: i + 2], "little") for i in range(0, 2 * len(name), 2)]
+
+
+def _named(name: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "name_utf16_code_units": _utf16(name),
+        "name_windows_1252_hex": name.encode("cp1252").hex(),
+        "name_utf8_hex": name.encode("utf-8").hex(),
+    }
+
+
+def _field(ordinal: int, definition: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ordinal": ordinal,
+        "ordinal_source": "Fields zero-based position after Refresh and the all-fields filter",
+        **_named(definition["name"]),
+        "type": definition["dao_type_numeric"],
+        "size": definition["size"],
+        "attributes": definition["attributes_numeric"],
+        "required": definition["required"],
+        "allow_zero_length": definition["allow_zero_length"],
+    }
+
+
+def _index() -> dict[str, Any]:
+    return {
+        "ordinal": 0,
+        "ordinal_source": "Indexes zero-based position after Refresh and exact A4IX_ID scheduled-name filtering",
+        **_named(INDEX_DEF["name"]),
+        "attributes": 0,
+        "primary": INDEX_DEF["primary"],
+        "unique": INDEX_DEF["unique"],
+        "required": INDEX_DEF["required"],
+        "ignore_nulls": INDEX_DEF["ignore_nulls"],
+        "fields": [{
+            "ordinal": 0,
+            "ordinal_source": "Index.Fields zero-based position after Refresh and the all-fields filter",
+            **_named(INDEX_DEF["fields"][0]),
+            "descending": INDEX_DEF["descending"],
+        }],
+    }
+
+
+def snapshot_tables(replica: int, checkpoint: str, row_counts: dict[str, int]) -> list[dict[str, Any]]:
+    """Canonical tables array: extant scheduled tables, ordinals after exact-name filtering."""
+    rows = []
+    for token in EXPECTED_SCHEMA[checkpoint]:
+        parts = token.split(":")
+        role = parts[0]
+        version = parts[1] if parts[1].startswith("v") else "v1"
+        shape = parts[-1]
+        name = ROLE_BINDINGS[replica][role]
+        fields = [_field(0, FIELD_DEFS[0])]
+        if "payload" in shape:
+            fields.append(_field(1, FIELD_DEFS[1]))
+        count = row_counts.get(role, 0)
+        rows.append({
+            "logical_role": role,
+            "lifecycle_instance": f"{role}-{version}",
+            **_named(name),
+            "attributes": 0,
+            "row_count": count,
+            "rolling_row_sha256": rolling_sha256(role, count),
+            "fields": fields,
+            "indexes": [_index()] if "index" in shape else [],
+        })
+    rows.sort(key=lambda r: bytes.fromhex(r["name_windows_1252_hex"]))
+    for ordinal, row in enumerate(rows):
+        row["ordinal"] = ordinal
+        row["ordinal_source"] = "TableDefs zero-based position after Refresh and exact extant scheduled-name filtering"
+    return rows
+
+
+def _binding(replica: int, checkpoint: str) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "producer_commit": ZERO_COMMIT,
+        "campaign_id": CAMPAIGN_ID,
+        "environment_sha256": ENVIRONMENT_SHA256,
+        "provider_sha256": PROVIDER_SHA256,
+        "replica": replica,
+        "checkpoint_id": checkpoint,
+        "ordinal": ORDINAL[checkpoint],
+    }
+
+
+def snapshot_document(replica: int, checkpoint: str, database_sha256: str, row_counts: dict[str, int]) -> dict[str, Any]:
+    return {
+        "document_type": "dao_a4_schema_snapshot",
+        **_binding(replica, checkpoint),
+        "windows_ansi_code_page": 1252,
+        "database_sha256_before_read": database_sha256,
+        "database_sha256_after_read": database_sha256,
+        "database_unchanged_by_read": True,
+        "dao_identifier_observable": False,
+        "identity_oracle": "listed_operation_instance_equality_only",
+        "canonicalization": "synthetic dry-run snapshot canonicalized per dao-schema-snapshot.schema.json",
+        "tables": snapshot_tables(replica, checkpoint, row_counts),
+    }
+
+
+@dataclass
+class ReplicaData:
+    number: int
+    pages: dict[str, list[str]] = field(default_factory=dict)  # checkpoint -> ordered page hashes
+    page_indexes: dict[str, dict[str, Any]] = field(default_factory=dict)
+    snapshots: dict[str, dict[str, Any]] = field(default_factory=dict)
+    row_counts: dict[str, dict[str, int]] = field(default_factory=dict)  # checkpoint -> role -> rows
+    meta: dict[str, Any] = field(default_factory=dict)  # generator bookkeeping (instance pages); not evidence
+
+
+@dataclass
+class Campaign:
+    blobs: dict[str, bytes] = field(default_factory=dict)
+    replicas: dict[int, ReplicaData] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=lambda: [e.__dict__ for e in EVENTS])
+    _db_cache: dict[tuple[str, ...], str] = field(default_factory=dict, repr=False)
+
+    # ----------------------------------------------------------------- construction
+    def store(self, page: bytes) -> str:
+        digest = sha256_hex(page)
+        self.blobs.setdefault(digest, page)
+        return digest
+
+    def page(self, replica: int, checkpoint: str, number: int) -> bytes | None:
+        hashes = self.replicas[replica].pages[checkpoint]
+        if number < 0 or number >= len(hashes):
+            return None
+        return self.blobs.get(hashes[number])
+
+    def page_count(self, replica: int, checkpoint: str) -> int:
+        return len(self.replicas[replica].pages[checkpoint])
+
+    def database_sha256(self, hashes: list[str]) -> str:
+        key = tuple(hashes)
+        if key not in self._db_cache:
+            digest = hashlib.sha256()
+            for h in key:
+                digest.update(self.blobs.get(h, b""))
+            self._db_cache[key] = digest.hexdigest()
+        return self._db_cache[key]
+
+    def page_index(self, replica: int, checkpoint: str) -> dict[str, Any]:
+        data = self.replicas[replica]
+        hashes = data.pages[checkpoint]
+        ordinal = ORDINAL[checkpoint]
+        predecessor = CHECKPOINTS[ordinal - 1] if ordinal else None
+        previous = data.pages.get(predecessor, []) if predecessor else []
+        changed = [i for i, h in enumerate(hashes) if i >= len(previous) or previous[i] != h]
+        return {
+            "document_type": "dao_a4_page_index",
+            **_binding(replica, checkpoint),
+            "predecessor_checkpoint_id": predecessor,
+            "page_count": len(hashes),
+            "file_size_bytes": len(hashes) * PAGE_SIZE,
+            "database_sha256": self.database_sha256(hashes),
+            "ordered_page_sha256": list(hashes),
+            "changed_page_indices": changed,
+        }
+
+    def refresh(self, replica: int) -> None:
+        """Re-derive page indexes and snapshot hashes from the current page sequences."""
+        data = self.replicas[replica]
+        for checkpoint in CHECKPOINTS:
+            if checkpoint not in data.pages:
+                continue
+            index = self.page_index(replica, checkpoint)
+            data.page_indexes[checkpoint] = index
+            snapshot = snapshot_document(replica, checkpoint, index["database_sha256"], data.row_counts.get(checkpoint, {}))
+            data.snapshots[checkpoint] = snapshot
+
+    def patch_page(self, replica: int, checkpoint: str, number: int, page: bytes) -> None:
+        hashes = self.replicas[replica].pages[checkpoint]
+        if number >= len(hashes):
+            raise IndexError(f"page {number} beyond checkpoint {checkpoint} ({len(hashes)} pages)")
+        hashes[number] = self.store(page)
+
+    def patch_from(self, replica: int, first_checkpoint: str, number: int, transform) -> None:
+        """Apply ``transform(bytes) -> bytes`` to ``number`` at every checkpoint from ``first_checkpoint`` on."""
+        for checkpoint in CHECKPOINTS[ORDINAL[first_checkpoint]:]:
+            current = self.page(replica, checkpoint, number)
+            if current is not None:
+                self.patch_page(replica, checkpoint, number, transform(current))
+
+    # ----------------------------------------------------------------- identity
+    def inventory(self) -> dict[str, Any]:
+        """Hashes that identify this exact campaign for the transcript."""
+        index_digest = hashlib.sha256()
+        snapshot_digest = hashlib.sha256()
+        for replica in sorted(self.replicas):
+            data = self.replicas[replica]
+            for checkpoint in CHECKPOINTS:
+                if checkpoint in data.page_indexes:
+                    index_digest.update(canonical_json_bytes(data.page_indexes[checkpoint]))
+                    snapshot_digest.update(canonical_json_bytes(data.snapshots[checkpoint]))
+        blob_digest = hashlib.sha256()
+        for h in sorted(self.blobs):
+            blob_digest.update(bytes.fromhex(h))
+        events_sha = sha256_hex(canonical_json_bytes(self.events))
+        combined = sha256_hex((index_digest.hexdigest() + snapshot_digest.hexdigest() + blob_digest.hexdigest() + events_sha).encode())
+        return {
+            "campaign_sha256": combined,
+            "page_index_inventory_sha256": index_digest.hexdigest(),
+            "schema_snapshot_inventory_sha256": snapshot_digest.hexdigest(),
+            "page_blob_inventory_sha256": blob_digest.hexdigest(),
+            "events_sha256": events_sha,
+            "unique_page_blob_count": len(self.blobs),
+            "replica_page_counts": {
+                str(r): {cp: len(d.pages[cp]) for cp in CHECKPOINTS if cp in d.pages} for r, d in sorted(self.replicas.items())
+            },
+        }
+
+    def malformed_blobs(self) -> list[str]:
+        return sorted(h for h, b in self.blobs.items() if len(b) != PAGE_SIZE or sha256_hex(b) != h)
+
+    def instance_pages(self, replica: int, instance_id: str) -> dict[str, Any]:
+        """Generator bookkeeping for fixture authoring; never read by the evaluator."""
+        INSTANCE_BY_ID[instance_id]
+        return self.replicas[replica].meta["instances"][instance_id]

--- a/oracle/windows-dao/scripts/a4_campaign.py
+++ b/oracle/windows-dao/scripts/a4_campaign.py
@@ -27,7 +27,8 @@ from typing import Any
 
 from a4_spec import (
     CHECKPOINTS, EVENTS, EXPECTED_SCHEMA, EXPERIMENT_ID, FIELD_DEFS, INDEX_DEF, INSTANCE_BY_ID, ORDINAL, PAGE_SIZE,
-    PLAN_SHA256, REVISION_PLAN_SHA256, ROLE_BINDINGS, canonical_json_bytes, rolling_sha256, sha256_hex,
+    PLAN_SHA256, REVISION_PLAN_SHA256, ROLE_BINDINGS, SCHEMA_SNAPSHOT_CANONICALIZATION, canonical_json_bytes,
+    rolling_sha256, sha256_hex,
 )
 
 ZERO_COMMIT = "0" * 40
@@ -137,7 +138,7 @@ def snapshot_document(replica: int, checkpoint: str, database_sha256: str, row_c
         "database_unchanged_by_read": True,
         "dao_identifier_observable": False,
         "identity_oracle": "listed_operation_instance_equality_only",
-        "canonicalization": "synthetic dry-run snapshot canonicalized per dao-schema-snapshot.schema.json",
+        "canonicalization": SCHEMA_SNAPSHOT_CANONICALIZATION,
         "tables": snapshot_tables(replica, checkpoint, row_counts),
     }
 

--- a/oracle/windows-dao/scripts/a4_dryrun.py
+++ b/oracle/windows-dao/scripts/a4_dryrun.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""A4 byte-level reachability harness: executes every fixture and writes the hash-bound transcript.
+
+This harness executes the plan's ``dry_run_honesty_clause`` reachability
+contract against the plan-driven reference evaluator (not the production
+analyzer). For every registered predicate it builds the shared synthetic
+campaign plus the fixture's disclosed mutation, evaluates the 40 predicates in
+normative order from bytes, and accepts the fixture only when the target
+predicate is the measured first failure and the measured survivor count
+satisfies the predicate's ``exact``/``minimum``/``allowed_ranges`` contract.
+Unreachable terminals are asserted by enumeration across the whole sweep.
+
+A4 rule | implementation
+--- | ---
+Every claimed-reachable terminal demonstrated as measured first failure | :func:`run_fixture`, :func:`reachability_rows`
+Unreachable terminal asserted by enumeration | :func:`unreachable_rows`
+Adversarial cases rejected unless a legitimate measured outcome | :func:`run_fixture`
+Transcript bound to plan SHA-256, harness sources, campaign inventories | :func:`build_transcript`
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from a4_dryrun_core import AMBIGUITIES, FixtureRejected
+from a4_dryrun_eval import evaluate
+from a4_dryrun_fixtures import ADVERSARIAL, BASELINE, REGISTRY_FIXTURES, UNREACHABLE, Fixture, all_fixtures
+from a4_spec import (
+    EXPERIMENT_ID, PLAN_SHA256, PREDICATE_CONTRACTS, PREDICATE_ORDER, REVISION_PLAN_SHA256, canonical_json_bytes,
+    count_satisfies, sha256_hex,
+)
+
+SCRIPTS = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = SCRIPTS.parent / "experiments" / "a4" / "dry-run"
+HARNESS_FILES = (
+    "a4_spec.py", "a4_pages.py", "a4_campaign.py", "a4_generator.py", "a4_dryrun_core.py", "a4_dryrun_campaign.py",
+    "a4_dryrun_h1.py", "a4_dryrun_h2.py", "a4_dryrun_h3.py", "a4_dryrun_h4.py", "a4_dryrun_eval.py",
+    "a4_dryrun_fixtures.py", "a4_dryrun.py",
+)
+GENERATOR_FILES = ("a4_spec.py", "a4_pages.py", "a4_campaign.py", "a4_generator.py")
+
+
+def _sha256_files(names: tuple[str, ...]) -> str:
+    digest = hashlib.sha256()
+    for name in names:
+        digest.update((SCRIPTS / name).read_bytes())
+    return digest.hexdigest()
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=SCRIPTS, capture_output=True, text=True, check=True).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "0" * 40
+
+
+def run_fixture(fixture: Fixture) -> dict[str, Any]:
+    """Build, evaluate, and judge one fixture; the judgement is measured, never assumed."""
+    entry: dict[str, Any] = {
+        "fixture_id": fixture.fixture_id, "target_predicate_id": fixture.predicate_id, "description": fixture.description,
+        "mutation": fixture.mutation(), "mutation_sha256": fixture.mutation_sha256(),
+    }
+    try:
+        campaign = fixture.build()
+        entry["campaign"] = campaign.inventory()
+        evaluation = evaluate(campaign, fixture.grammar_selection)
+    except FixtureRejected as error:
+        entry.update({"rejected": True, "rejection": str(error), "accepted": fixture.expect_rejection is not None
+                      and fixture.expect_rejection in ("unregistered_candidate_id", "malformed_page")})
+        return entry
+    rows = [r.__dict__ for r in evaluation.rows]
+    first = evaluation.first_failure
+    entry.update({
+        "ordered_predicates": rows, "first_failure": first, "derivation_candidate_set_sha256": evaluation.derivation_sha256,
+        "models": evaluation.models, "stages": evaluation.stages, "charges": evaluation.charges, "notes": evaluation.notes,
+        "evaluated_counts": {r["predicate_id"]: r["measured_count"] for r in rows if r["status"] != "not_applicable"},
+    })
+    if fixture.expect_rejection == "first_failure_is_not_target":
+        entry["rejected"] = first != fixture.predicate_id
+        entry["rejection"] = f"first failure {first} is not the target {fixture.predicate_id}" if entry["rejected"] else ""
+        entry["accepted"] = entry["rejected"]
+        return entry
+    if fixture.predicate_id is None:
+        entry["accepted"] = first is None
+        entry["rejection"] = "" if first is None else f"unexpected first failure {first}"
+        return entry
+    target_row = evaluation.row(fixture.predicate_id)
+    contract = PREDICATE_CONTRACTS[fixture.predicate_id]["failure_survivor_count"]
+    entry["count_contract"] = contract
+    entry["measured_count"] = target_row.measured_count
+    problems = []
+    if first != fixture.predicate_id:
+        problems.append(f"first failure {first} is not the target")
+    if not count_satisfies(contract, target_row.measured_count):
+        problems.append(f"measured count {target_row.measured_count} violates {contract}")
+    if fixture.legitimate_count is not None and target_row.measured_count != fixture.legitimate_count:
+        problems.append(f"measured count {target_row.measured_count} differs from the fixture's stated {fixture.legitimate_count}")
+    entry["accepted"] = not problems
+    entry["rejection"] = "; ".join(problems)
+    return entry
+
+
+def _run_named(fixture_id: str) -> dict[str, Any]:
+    fixture = next(f for f in all_fixtures() if f.fixture_id == fixture_id)
+    return run_fixture(fixture)
+
+
+def reachability_rows(entries: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for predicate_id in PREDICATE_ORDER:
+        fixture = next(f for f in REGISTRY_FIXTURES if f.predicate_id == predicate_id)
+        entry = entries[fixture.fixture_id]
+        reaching = sorted(fid for fid, e in entries.items() if e.get("first_failure") == predicate_id)
+        if predicate_id in UNREACHABLE:
+            rows.append({"predicate_id": predicate_id, "classification": "unreachable", "attempt_fixture": fixture.fixture_id,
+                         "attempt_first_failure": entry.get("first_failure"), "fixtures_reaching": reaching,
+                         "status": "asserted_unreachable" if not reaching else "REACHED_CONTRARY_TO_ASSERTION"})
+            continue
+        rows.append({"predicate_id": predicate_id, "classification": "claimed_reachable", "designated_fixture": fixture.fixture_id,
+                     "measured_first_failure": entry.get("first_failure"), "measured_count": entry.get("measured_count"),
+                     "count_contract": entry.get("count_contract"), "fixtures_reaching": reaching,
+                     "status": "reached" if entry.get("accepted") else "NOT_REACHED"})
+    return rows
+
+
+def unreachable_rows(entries: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    out = []
+    for predicate_id in UNREACHABLE:
+        counts = {fid: e["evaluated_counts"].get(predicate_id) for fid, e in entries.items() if "evaluated_counts" in e}
+        evaluated = {fid: c for fid, c in counts.items() if c is not None}
+        out.append({
+            "predicate_id": predicate_id,
+            "enumeration_argument": "structural pairs must sit at the exact registered locator holes [35,39)/[39,43); one layout therefore admits at most one canonical pair (a<b, b-a>=4) and the pair count under the unique layout can never exceed one",
+            "max_measured_count_across_sweep": max(evaluated.values(), default=0),
+            "fixtures_evaluating_predicate": sorted(evaluated),
+            "terminal_in_any_fixture": any(e.get("first_failure") == predicate_id for e in entries.values()),
+        })
+    return out
+
+
+def build_transcript(entries: dict[str, dict[str, Any]], commit: str, recorded_utc: str) -> dict[str, Any]:
+    ordered = [entries[f.fixture_id] for f in all_fixtures()]
+    rows = reachability_rows(entries)
+    unreachable = unreachable_rows(entries)
+    adversarial = [{k: entries[f.fixture_id].get(k) for k in ("fixture_id", "target_predicate_id", "description", "accepted",
+                                                               "rejected", "rejection", "first_failure", "measured_count")}
+                   for f in ADVERSARIAL]
+    reached = sum(1 for r in rows if r["status"] == "reached")
+    asserted = sum(1 for r in rows if r["status"] == "asserted_unreachable")
+    baseline = entries[BASELINE.fixture_id]
+    # The attempt fixture of an asserted-unreachable terminal must NOT reach it; its rejection is the evidence.
+    accepted = all(e["accepted"] != (f.predicate_id in UNREACHABLE) for f, e in zip(all_fixtures(), ordered))
+    result = (reached + asserted == len(PREDICATE_ORDER) and baseline["accepted"] and accepted
+              and all(not u["terminal_in_any_fixture"] and u["max_measured_count_across_sweep"] <= 1 for u in unreachable))
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_reachability_transcript",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "harness_commit": commit,
+        "recorded_utc": recorded_utc,
+        "harness_sources_sha256": _sha256_files(HARNESS_FILES),
+        "generator_sha256": _sha256_files(GENERATOR_FILES),
+        "evaluator_role": "plan-driven reference evaluator decoding fixture bytes; not the production A4 analyzer",
+        "baseline": {"fixture_id": BASELINE.fixture_id, "campaign": baseline.get("campaign"), "first_failure": baseline.get("first_failure"),
+                     "derivation_candidate_set_sha256": baseline.get("derivation_candidate_set_sha256"), "models": baseline.get("models"),
+                     "charges": baseline.get("charges")},
+        "reachable_total": len(PREDICATE_ORDER) - len(UNREACHABLE),
+        "reached_count": reached,
+        "unreachable_asserted": unreachable,
+        "rows": rows,
+        "adversarial_cases": adversarial,
+        "fixtures": [{k: v for k, v in e.items() if k not in ("models", "stages")} for e in ordered],
+        "plan_ambiguities": list(AMBIGUITIES),
+        "result": "pass" if result else "fail",
+        "scientific_evidence": False,
+        "acquisition_authorized": False,
+        "capability_advancement_authorized": False,
+    }
+
+
+def run_all(jobs: int) -> dict[str, dict[str, Any]]:
+    fixtures = all_fixtures()
+    if jobs <= 1:
+        return {f.fixture_id: run_fixture(f) for f in fixtures}
+    with ProcessPoolExecutor(max_workers=jobs) as pool:
+        results = list(pool.map(_run_named, [f.fixture_id for f in fixtures]))
+    return {e["fixture_id"]: e for e in results}
+
+
+def write_outputs(output: Path, transcript: dict[str, Any]) -> dict[str, str]:
+    output.mkdir(parents=True, exist_ok=True)
+    documents = {"a4-reachability-transcript.json": transcript}
+    checksums = {}
+    for name, document in documents.items():
+        payload = json.dumps(document, indent=2, sort_keys=True, ensure_ascii=False).encode("utf-8") + b"\n"
+        (output / name).write_bytes(payload)
+        checksums[name] = {"sha256": sha256_hex(payload), "bytes": len(payload)}
+    (output / "checksums.json").write_bytes(canonical_json_bytes(checksums) + b"\n")
+    return {k: v["sha256"] for k, v in checksums.items()}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--jobs", type=int, default=4)
+    parser.add_argument("--fixture", action="append", help="run only the named fixture id(s) and print their entries")
+    args = parser.parse_args(argv)
+    if args.fixture:
+        for fixture_id in args.fixture:
+            entry = _run_named(fixture_id)
+            print(json.dumps({k: v for k, v in entry.items() if k not in ("models", "stages", "ordered_predicates", "mutation")}, indent=2, default=str))
+        return 0
+    entries = run_all(args.jobs)
+    transcript = build_transcript(entries, _git_commit(), datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    checksums = write_outputs(args.output, transcript)
+    for row in transcript["rows"]:
+        print(f"{row['status']:<22} {row['predicate_id']}")
+    for case in transcript["adversarial_cases"]:
+        print(f"{'adversarial-ok' if case['accepted'] else 'ADVERSARIAL-FAIL':<22} {case['fixture_id']}: {case['rejection'] or case['first_failure']}")
+    print(f"result={transcript['result']} reached={transcript['reached_count']}/{transcript['reachable_total']} plan={PLAN_SHA256[:12]} transcript={checksums['a4-reachability-transcript.json'][:12]}")
+    return 0 if transcript["result"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/oracle/windows-dao/scripts/a4_dryrun.py
+++ b/oracle/windows-dao/scripts/a4_dryrun.py
@@ -10,6 +10,12 @@ predicate is the measured first failure and the measured survivor count
 satisfies the predicate's ``exact``/``minimum``/``allowed_ranges`` contract.
 Unreachable terminals are asserted by enumeration across the whole sweep.
 
+The output is a *reference* transcript, deliberately distinct from the
+dispatch-gate ``dry-run/a4-reachability-transcript.json`` bound by
+``reachability-transcript.schema.json``: that document needs the production
+analyzer, an independent validator, and an additive provenance entry, none of
+which exist yet (see AMB-16/AMB-17).
+
 A4 rule | implementation
 --- | ---
 Every claimed-reachable terminal demonstrated as measured first failure | :func:`run_fixture`, :func:`reachability_rows`
@@ -46,6 +52,14 @@ HARNESS_FILES = (
     "a4_dryrun_fixtures.py", "a4_dryrun.py",
 )
 GENERATOR_FILES = ("a4_spec.py", "a4_pages.py", "a4_campaign.py", "a4_generator.py")
+TRANSCRIPT_NAME = "a4-reference-reachability-transcript.json"
+# reachability-transcript.schema.json adversarial case ids -> fixture demonstrating each outcome
+ADVERSARIAL_CASE_IDS = {
+    "multiple_count_2": "A4-R06-H1-TDEF-MULTIPLE", "multiple_count_3": "A4-ADV-TDEF-MULTIPLE-3",
+    "multiple_count_4": "A4-ADV-TDEF-MULTIPLE-4", "encoding_count_0": "A4-R37-H4-ENCODING",
+    "encoding_count_2": "A4-ADV-ENCODING-2", "unregistered_candidate_id": "A4-ADV-UNREGISTERED-ID",
+    "malformed_page": "A4-ADV-MALFORMED-PAGE", "earlier_predicate_invalidated": "A4-ADV-EARLIER-PREDICATE",
+}
 
 
 def _sha256_files(names: tuple[str, ...]) -> str:
@@ -150,9 +164,14 @@ def build_transcript(entries: dict[str, dict[str, Any]], commit: str, recorded_u
     ordered = [entries[f.fixture_id] for f in all_fixtures()]
     rows = reachability_rows(entries)
     unreachable = unreachable_rows(entries)
-    adversarial = [{k: entries[f.fixture_id].get(k) for k in ("fixture_id", "target_predicate_id", "description", "accepted",
-                                                               "rejected", "rejection", "first_failure", "measured_count")}
-                   for f in ADVERSARIAL]
+    adversarial = []
+    for case_id, fixture_id in ADVERSARIAL_CASE_IDS.items():
+        e = entries[fixture_id]
+        legitimate = e.get("first_failure") is not None and not e.get("rejected")
+        adversarial.append({"case_id": case_id, "fixture_id": fixture_id, "description": e["description"],
+                            "expected": "accept" if legitimate else "reject", "reference_evaluator_result": "accept" if legitimate else "reject",
+                            "accepted": e["accepted"], "rejection": e.get("rejection"), "first_failure": e.get("first_failure"),
+                            "measured_count": e.get("measured_count")})
     reached = sum(1 for r in rows if r["status"] == "reached")
     asserted = sum(1 for r in rows if r["status"] == "asserted_unreachable")
     baseline = entries[BASELINE.fixture_id]
@@ -162,7 +181,8 @@ def build_transcript(entries: dict[str, dict[str, Any]], commit: str, recorded_u
               and all(not u["terminal_in_any_fixture"] and u["max_measured_count_across_sweep"] <= 1 for u in unreachable))
     return {
         "protocol_version": "1.0.0",
-        "document_type": "dao_a4_reachability_transcript",
+        "document_type": "dao_a4_reference_reachability_transcript",
+        "not_the_dispatch_gate_transcript": "reachability-transcript.schema.json requires analyzer and independent-validator results, a provenance entry, and a non-null first failure on all 40 entries; this reference transcript has none of those (AMB-16, AMB-17)",
         "experiment_id": EXPERIMENT_ID,
         "plan_sha256": PLAN_SHA256,
         "revision_plan_sha256": REVISION_PLAN_SHA256,
@@ -199,7 +219,7 @@ def run_all(jobs: int) -> dict[str, dict[str, Any]]:
 
 def write_outputs(output: Path, transcript: dict[str, Any]) -> dict[str, str]:
     output.mkdir(parents=True, exist_ok=True)
-    documents = {"a4-reachability-transcript.json": transcript}
+    documents = {TRANSCRIPT_NAME: transcript}
     checksums = {}
     for name, document in documents.items():
         payload = json.dumps(document, indent=2, sort_keys=True, ensure_ascii=False).encode("utf-8") + b"\n"
@@ -226,8 +246,8 @@ def main(argv: list[str] | None = None) -> int:
     for row in transcript["rows"]:
         print(f"{row['status']:<22} {row['predicate_id']}")
     for case in transcript["adversarial_cases"]:
-        print(f"{'adversarial-ok' if case['accepted'] else 'ADVERSARIAL-FAIL':<22} {case['fixture_id']}: {case['rejection'] or case['first_failure']}")
-    print(f"result={transcript['result']} reached={transcript['reached_count']}/{transcript['reachable_total']} plan={PLAN_SHA256[:12]} transcript={checksums['a4-reachability-transcript.json'][:12]}")
+        print(f"{'adversarial-ok' if case['accepted'] else 'ADVERSARIAL-FAIL':<22} {case['case_id']} ({case['fixture_id']}): {case['rejection'] or case['first_failure']}")
+    print(f"result={transcript['result']} reached={transcript['reached_count']}/{transcript['reachable_total']} plan={PLAN_SHA256[:12]} transcript={checksums[TRANSCRIPT_NAME][:12]}")
     return 0 if transcript["result"] == "pass" else 1
 
 

--- a/oracle/windows-dao/scripts/a4_dryrun.py
+++ b/oracle/windows-dao/scripts/a4_dryrun.py
@@ -87,8 +87,8 @@ def run_fixture(fixture: Fixture) -> dict[str, Any]:
         entry["campaign"] = campaign.inventory()
         evaluation = evaluate(campaign, fixture.grammar_selection)
     except FixtureRejected as error:
-        entry.update({"rejected": True, "rejection": str(error), "accepted": fixture.expect_rejection is not None
-                      and fixture.expect_rejection in ("unregistered_candidate_id", "malformed_page")})
+        entry.update({"rejected": True, "rejection_code": error.code, "rejection": str(error),
+                      "accepted": fixture.expect_rejection == error.code})
         return entry
     rows = [r.__dict__ for r in evaluation.rows]
     first = evaluation.first_failure

--- a/oracle/windows-dao/scripts/a4_dryrun_campaign.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_campaign.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Campaign predicates (orders 1-4) of the A4 plan-driven reference evaluator.
+
+A4 rule | implementation
+--- | ---
+A4-IDLE-EQUALITY: idle pairs equal in bytes, page-index sequence, snapshot tables | :func:`idle_equality`
+A4-SCHEMA-SNAPSHOT: 75 snapshots bound, scheduled schema, constants, row hashes, code page, names, hashes | :func:`schema_snapshot`
+A4-SNAPSHOT-RECONSTRUCTION: page count, file size, ordered hashes, database SHA-256 | :func:`snapshot_reconstruction`
+A4-RESOURCE-BOUND: independently recomputed named resources <= bounds, equality passes | :func:`resource_bound`
+H1 qualified tag-02 pages from schema-lifecycle deltas | :func:`qualified_tag02_pages`
+"""
+
+from __future__ import annotations
+
+from a4_dryrun_core import Context, FixtureRejected
+from a4_pages import TAG_TDEF
+from a4_spec import (
+    BOUNDS, CHECKPOINTS, DERIVATION_REPLICAS, EVENT_BY_CHECKPOINT, EXPECTED_SCHEMA, EXPERIMENT_ID, FIELD_DEFS, IDLE_PAIRS,
+    INDEX_DEF, MAX_QUALIFIED_PAGES, MAX_ROWS, ORDINAL, PAGE_SIZE, PLAN_SHA256, REVISION_PLAN_SHA256, ROLE_BINDINGS,
+    ROW_BATCH, SCHEMA_LIFECYCLE, rolling_sha256, sha256_hex,
+)
+
+P_IDLE, P_SNAPSHOT, P_RECON, P_RESOURCE = (
+    "A4-IDLE-EQUALITY", "A4-SCHEMA-SNAPSHOT", "A4-SNAPSHOT-RECONSTRUCTION", "A4-RESOURCE-BOUND",
+)
+
+
+def reject_malformed(ctx: Context) -> None:
+    """Malformed blobs are rejected before any predicate; they are not a scientific outcome."""
+    bad = ctx.campaign.malformed_blobs()
+    if bad:
+        raise FixtureRejected(f"malformed page blob(s): {bad[:3]}")
+    for replica in ctx.replicas():
+        data = ctx.campaign.replicas[replica]
+        if tuple(data.pages) != CHECKPOINTS:
+            raise FixtureRejected(f"replica {replica} does not expose the 25 scheduled checkpoints")
+
+
+def idle_equality(ctx: Context) -> bool:
+    failures = []
+    for replica in ctx.replicas():
+        data = ctx.campaign.replicas[replica]
+        for left, right in IDLE_PAIRS:
+            if data.pages[left] != data.pages[right]:
+                failures.append(f"replica {replica} {left}/{right} page-index sequence differs")
+            elif ctx.campaign.database_sha256(data.pages[left]) != ctx.campaign.database_sha256(data.pages[right]):
+                failures.append(f"replica {replica} {left}/{right} reconstructed bytes differ")
+            if data.snapshots.get(left, {}).get("tables") != data.snapshots.get(right, {}).get("tables"):
+                failures.append(f"replica {replica} {left}/{right} canonical snapshot tables differ")
+    return ctx.record(P_IDLE, not failures, 0, "; ".join(failures[:3]))
+
+
+def _named_ok(entry: dict, name: str) -> bool:
+    units = [int.from_bytes(name.encode("utf-16-le")[i: i + 2], "little") for i in range(0, 2 * len(name), 2)]
+    return (entry.get("name") == name and entry.get("name_utf16_code_units") == units
+            and entry.get("name_windows_1252_hex") == name.encode("cp1252").hex()
+            and entry.get("name_utf8_hex") == name.encode("utf-8").hex())
+
+
+def _field_ok(entry: dict, definition: dict) -> bool:
+    return (_named_ok(entry, definition["name"]) and entry.get("type") == definition["dao_type_numeric"]
+            and entry.get("size") == definition["size"] and entry.get("attributes") == definition["attributes_numeric"]
+            and entry.get("required") == definition["required"] and entry.get("allow_zero_length") == definition["allow_zero_length"])
+
+
+def _table_problem(table: dict, token: str, replica: int, previous_counts: dict[str, int], checkpoint: str) -> str | None:
+    parts = token.split(":")
+    role, shape = parts[0], parts[-1]
+    version = parts[1] if parts[1].startswith("v") else "v1"
+    name = ROLE_BINDINGS[replica][role]
+    if table.get("logical_role") != role or table.get("lifecycle_instance") != f"{role}-{version}" or not _named_ok(table, name):
+        return f"{role} binding or name fields wrong"
+    if table.get("attributes") != 0:
+        return f"{role} attributes"
+    fields = table.get("fields", [])
+    expected_fields = [FIELD_DEFS[0]] + ([FIELD_DEFS[1]] if "payload" in shape else [])
+    if len(fields) != len(expected_fields) or any(
+            f.get("ordinal") != i or not _field_ok(f, d) for i, (f, d) in enumerate(zip(fields, expected_fields))):
+        return f"{role} fields differ from construction constants"
+    indexes = table.get("indexes", [])
+    if "index" in shape:
+        if len(indexes) != 1:
+            return f"{role} index missing"
+        index = indexes[0]
+        if not (_named_ok(index, INDEX_DEF["name"]) and index.get("primary") is False and index.get("unique") is False
+                and index.get("required") is False and index.get("ignore_nulls") is False and len(index.get("fields", [])) == 1
+                and _named_ok(index["fields"][0], INDEX_DEF["fields"][0]) and index["fields"][0].get("descending") is False):
+            return f"{role} index constants"
+    elif indexes:
+        return f"{role} unexpected index"
+    count = table.get("row_count")
+    if not isinstance(count, int) or count < 0 or count > MAX_ROWS or table.get("rolling_row_sha256") != rolling_sha256(role, count):
+        return f"{role} row count/hash"
+    event = EVENT_BY_CHECKPOINT[checkpoint]
+    before = previous_counts.get(role)
+    if event.kind == "grow" and event.role == role:
+        if before is None or count < before or (count - before) % ROW_BATCH:
+            return f"{role} growth is not whole fixed batches"
+    elif event.kind == "delete_all" and event.role == role:
+        if count != 0:
+            return f"{role} rows remain after delete"
+    elif event.kind == "reinsert" and event.role == role:
+        if count == 0:
+            return f"{role} reinsert produced no rows"
+    elif before is not None and count != before:
+        return f"{role} row count changed without a listed mutation"
+    elif before is None and count != 0:
+        return f"{role} created with rows"
+    return None
+
+
+def schema_snapshot(ctx: Context) -> bool:
+    problems = []
+    for replica in ctx.replicas():
+        data = ctx.campaign.replicas[replica]
+        previous_counts: dict[str, int] = {}
+        for checkpoint in CHECKPOINTS:
+            snapshot = data.snapshots.get(checkpoint)
+            index = data.page_indexes.get(checkpoint)
+            if snapshot is None or index is None:
+                problems.append(f"replica {replica} {checkpoint} snapshot missing")
+                continue
+            binding_ok = (snapshot.get("experiment_id") == EXPERIMENT_ID and snapshot.get("plan_sha256") == PLAN_SHA256
+                          and snapshot.get("revision_plan_sha256") == REVISION_PLAN_SHA256 and snapshot.get("replica") == replica
+                          and snapshot.get("checkpoint_id") == checkpoint and snapshot.get("ordinal") == ORDINAL[checkpoint])
+            if not binding_ok:
+                problems.append(f"replica {replica} {checkpoint} wrongly bound")
+            if snapshot.get("windows_ansi_code_page") != 1252:
+                problems.append(f"replica {replica} {checkpoint} code page")
+            if not (snapshot.get("database_sha256_before_read") == snapshot.get("database_sha256_after_read") == index["database_sha256"]):
+                problems.append(f"replica {replica} {checkpoint} before/after hash")
+            tables = snapshot.get("tables", [])
+            expected = EXPECTED_SCHEMA[checkpoint]
+            if len(tables) != len(expected):
+                problems.append(f"replica {replica} {checkpoint} table count {len(tables)} != {len(expected)}")
+                continue
+            by_role = {t.get("logical_role"): t for t in tables}
+            ordinals = [t.get("ordinal") for t in tables]
+            names = [bytes.fromhex(t.get("name_windows_1252_hex", "")) for t in tables]
+            if sorted(ordinals) != list(range(len(tables))) or names != sorted(names) or ordinals != sorted(ordinals):
+                problems.append(f"replica {replica} {checkpoint} ordinals are not unique and name-sorted")
+            for token in expected:
+                table = by_role.get(token.split(":")[0])
+                problem = None if table is None else _table_problem(table, token, replica, previous_counts, checkpoint)
+                if table is None or problem:
+                    problems.append(f"replica {replica} {checkpoint} {problem or token + ' missing'}")
+            previous_counts = {t.get("logical_role"): t.get("row_count", 0) for t in tables}
+            if EVENT_BY_CHECKPOINT[checkpoint].kind == "reinsert":
+                role = EVENT_BY_CHECKPOINT[checkpoint].role
+                grown = data.snapshots.get("T1_REL_1280", {}).get("tables", [])
+                expected_count = next((t.get("row_count") for t in grown if t.get("logical_role") == role), None)
+                if by_role.get(role, {}).get("row_count") != expected_count:
+                    problems.append(f"replica {replica} {checkpoint} reinsert count differs from T1_REL_1280")
+    return ctx.record(P_SNAPSHOT, not problems, 0, "; ".join(problems[:3]))
+
+
+def snapshot_reconstruction(ctx: Context) -> bool:
+    problems = []
+    for replica in ctx.replicas():
+        data = ctx.campaign.replicas[replica]
+        for checkpoint in CHECKPOINTS:
+            index = data.page_indexes[checkpoint]
+            hashes = index["ordered_page_sha256"]
+            if index["page_count"] != len(hashes) or index["file_size_bytes"] != len(hashes) * PAGE_SIZE:
+                problems.append(f"replica {replica} {checkpoint} page count/file size")
+            blobs = [ctx.campaign.blobs.get(h) for h in hashes]
+            if any(b is None for b in blobs):
+                problems.append(f"replica {replica} {checkpoint} missing page blob")
+                continue
+            if any(sha256_hex(b) != h for b, h in zip(blobs, hashes)):
+                problems.append(f"replica {replica} {checkpoint} ordered page hash differs from blob")
+            if ctx.campaign.database_sha256(list(hashes)) != index["database_sha256"]:
+                problems.append(f"replica {replica} {checkpoint} database SHA-256 differs")
+            if hashes != data.pages[checkpoint]:
+                problems.append(f"replica {replica} {checkpoint} page index differs from observation sequence")
+            predecessor = ctx.predecessor(checkpoint)
+            previous = data.pages[predecessor] if predecessor else []
+            changed = [i for i, h in enumerate(hashes) if i >= len(previous) or previous[i] != h]
+            if changed != index["changed_page_indices"]:
+                problems.append(f"replica {replica} {checkpoint} changed_page_indices differ")
+    return ctx.record(P_RECON, not problems, 0, "; ".join(problems[:3]))
+
+
+def qualified_tag02_pages(ctx: Context, replica: int) -> set[int]:
+    """Pages that change (or appear) across a schema-lifecycle transition and are tag 02 afterwards."""
+    out: set[int] = set()
+    for before, after in zip(SCHEMA_LIFECYCLE, SCHEMA_LIFECYCLE[1:]):
+        for number in ctx.changed_pages(replica, after):
+            if ctx.tag(replica, after, number) == TAG_TDEF:
+                out.add(number)
+    return out
+
+
+def resource_bound(ctx: Context) -> bool:
+    """Static named resources recomputed from the campaign; equality passes, one over fails."""
+    measured: dict[str, tuple[int, int]] = {}
+    union_qualified: set[int] = set()
+    for replica in DERIVATION_REPLICAS:
+        if replica in ctx.campaign.replicas:
+            union_qualified |= qualified_tag02_pages(ctx, replica)
+    measured["qualified_tdef_pages_union"] = (len(union_qualified), MAX_QUALIFIED_PAGES)
+    measured["unique_page_blobs"] = (len(ctx.campaign.blobs), int(BOUNDS["max_unique_page_blobs"]))
+    for replica in ctx.replicas():
+        data = ctx.campaign.replicas[replica]
+        measured[f"replica_{replica}_checkpoints"] = (len(data.pages), int(BOUNDS["max_checkpoints_per_replica"]))
+        measured[f"replica_{replica}_final_pages"] = (max(len(p) for p in data.pages.values()), int(BOUNDS["max_final_pages_per_replica"]))
+        changed = sum(len(i["changed_page_indices"]) for i in data.page_indexes.values())
+        measured[f"replica_{replica}_changed_hash_entries"] = (changed, int(BOUNDS["max_changed_hash_entries_per_replica"]))
+        inserted, previous = 0, {}
+        for checkpoint in CHECKPOINTS:
+            counts = {t["logical_role"]: t["row_count"] for t in data.snapshots[checkpoint]["tables"]}
+            inserted += sum(max(0, c - previous.get(r, 0)) for r, c in counts.items())
+            previous = counts
+        measured[f"replica_{replica}_inserted_rows"] = (inserted, MAX_ROWS)
+    ctx.charges.add("qualified_tdef_pages", len(union_qualified))
+    breaches = [f"{k}={v} > {bound}" for k, (v, bound) in measured.items() if v > bound]
+    ctx.models["resources"] = {k: {"measured": v, "bound": b} for k, (v, b) in measured.items()}
+    return ctx.record(P_RESOURCE, not breaches, 0, "; ".join(breaches[:3]))
+
+
+def evaluate_campaign(ctx: Context) -> bool:
+    reject_malformed(ctx)
+    return idle_equality(ctx) and schema_snapshot(ctx) and snapshot_reconstruction(ctx) and resource_bound(ctx)

--- a/oracle/windows-dao/scripts/a4_dryrun_campaign.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_campaign.py
@@ -17,8 +17,9 @@ from a4_pages import TAG_TDEF
 from a4_spec import (
     BOUNDS, CHECKPOINTS, DERIVATION_REPLICAS, EVENT_BY_CHECKPOINT, EXPECTED_SCHEMA, EXPERIMENT_ID, FIELD_DEFS, IDLE_PAIRS,
     INDEX_DEF, MAX_QUALIFIED_PAGES, MAX_ROWS, ORDINAL, PAGE_SIZE, PLAN_SHA256, REVISION_PLAN_SHA256, ROLE_BINDINGS,
-    ROW_BATCH, SCHEMA_LIFECYCLE, rolling_sha256, sha256_hex,
+    ROW_BATCH, SCHEMA_LIFECYCLE, SCHEMA_SNAPSHOT, rolling_sha256, sha256_hex,
 )
+from protocol_validation import ValidationError, validate_schema_value
 
 P_IDLE, P_SNAPSHOT, P_RECON, P_RESOURCE = (
     "A4-IDLE-EQUALITY", "A4-SCHEMA-SNAPSHOT", "A4-SNAPSHOT-RECONSTRUCTION", "A4-RESOURCE-BOUND",
@@ -29,11 +30,7 @@ def reject_malformed(ctx: Context) -> None:
     """Malformed blobs are rejected before any predicate; they are not a scientific outcome."""
     bad = ctx.campaign.malformed_blobs()
     if bad:
-        raise FixtureRejected(f"malformed page blob(s): {bad[:3]}")
-    for replica in ctx.replicas():
-        data = ctx.campaign.replicas[replica]
-        if tuple(data.pages) != CHECKPOINTS:
-            raise FixtureRejected(f"replica {replica} does not expose the 25 scheduled checkpoints")
+        raise FixtureRejected("malformed_page", f"malformed page blob(s): {bad[:3]}")
 
 
 def idle_equality(ctx: Context) -> bool:
@@ -41,9 +38,13 @@ def idle_equality(ctx: Context) -> bool:
     for replica in ctx.replicas():
         data = ctx.campaign.replicas[replica]
         for left, right in IDLE_PAIRS:
-            if data.pages[left] != data.pages[right]:
+            left_pages = data.pages.get(left)
+            right_pages = data.pages.get(right)
+            if left_pages is None or right_pages is None:
+                continue  # A4-SCHEMA-SNAPSHOT owns incomplete campaign cardinality.
+            if left_pages != right_pages:
                 failures.append(f"replica {replica} {left}/{right} page-index sequence differs")
-            elif ctx.campaign.database_sha256(data.pages[left]) != ctx.campaign.database_sha256(data.pages[right]):
+            elif ctx.campaign.database_sha256(left_pages) != ctx.campaign.database_sha256(right_pages):
                 failures.append(f"replica {replica} {left}/{right} reconstructed bytes differ")
             if data.snapshots.get(left, {}).get("tables") != data.snapshots.get(right, {}).get("tables"):
                 failures.append(f"replica {replica} {left}/{right} canonical snapshot tables differ")
@@ -111,14 +112,28 @@ def _table_problem(table: dict, token: str, replica: int, previous_counts: dict[
 
 def schema_snapshot(ctx: Context) -> bool:
     problems = []
-    for replica in ctx.replicas():
+    expected_replicas = {1, 2, 3}
+    actual_replicas = set(ctx.replicas())
+    if actual_replicas != expected_replicas:
+        problems.append(f"replicas {sorted(actual_replicas)} != [1, 2, 3]")
+    for replica in sorted(expected_replicas & actual_replicas):
         data = ctx.campaign.replicas[replica]
+        for label, documents in (("page indexes", data.page_indexes), ("page sequences", data.pages),
+                                 ("schema snapshots", data.snapshots)):
+            if len(documents) != len(CHECKPOINTS) or set(documents) != set(CHECKPOINTS):
+                problems.append(f"replica {replica} {label} do not expose exactly the 25 scheduled checkpoints")
         previous_counts: dict[str, int] = {}
         for checkpoint in CHECKPOINTS:
             snapshot = data.snapshots.get(checkpoint)
             index = data.page_indexes.get(checkpoint)
             if snapshot is None or index is None:
                 problems.append(f"replica {replica} {checkpoint} snapshot missing")
+                continue
+            try:
+                validate_schema_value(snapshot, SCHEMA_SNAPSHOT, SCHEMA_SNAPSHOT,
+                                      f"replica {replica} checkpoint {checkpoint}")
+            except ValidationError as error:
+                problems.append(str(error))
                 continue
             binding_ok = (snapshot.get("experiment_id") == EXPERIMENT_ID and snapshot.get("plan_sha256") == PLAN_SHA256
                           and snapshot.get("revision_plan_sha256") == REVISION_PLAN_SHA256 and snapshot.get("replica") == replica

--- a/oracle/windows-dao/scripts/a4_dryrun_core.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_core.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Shared state for the A4 plan-driven reference evaluator.
+
+This evaluator is NOT the production A4 analyzer. It is a plan-driven
+reference that decodes fixture bytes under the plan's normative predicate
+rules so that the later analyzer and independent-validator lanes must agree
+with it on real fixtures. Every place where the plan is ambiguous is recorded
+in :data:`AMBIGUITIES` and the reading chosen is stated next to the code.
+
+A4 rule | implementation
+--- | ---
+One propagated state per fixture, first failure reported | :class:`Context`, :class:`PredicateRow`
+Union-once resource charging | :class:`Charges`
+Unregistered candidate ids rejected before scientific filtering | :func:`require_registered`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from a4_campaign import Campaign
+from a4_pages import tag_of
+from a4_spec import (
+    BASE_FORMULAS, CHECKPOINTS, CONVERSIONS, ENDIANNESS, ID_WIDTHS, KIND_WIDTHS, LIFECYCLE_RELATIONS,
+    LOCATOR_LAYOUTS, ORDINAL, POLARITIES, ROLE_ASSIGNMENTS, ROOT_SIGNATURES, ROW_MASKS, TDEF_SIGNATURES,
+)
+
+PASS, FAIL, NOT_APPLICABLE = "pass", "fail", "not_applicable"
+
+
+class FixtureRejected(Exception):
+    """The fixture is not a legitimate campaign (malformed page, unregistered id, ...)."""
+
+
+@dataclass
+class PredicateRow:
+    predicate_id: str
+    status: str
+    measured_count: int
+    detail: str = ""
+
+
+@dataclass
+class Charges:
+    units: dict[str, int] = field(default_factory=dict)
+
+    def add(self, term: str, amount: int = 1) -> None:
+        self.units[term] = self.units.get(term, 0) + amount
+
+    def total(self) -> int:
+        return sum(self.units.values())
+
+
+REGISTERED: dict[str, tuple[Any, ...]] = {
+    "locator_layout": LOCATOR_LAYOUTS,
+    "tdef_lifecycle_signature": TDEF_SIGNATURES,
+    "row_mask": ROW_MASKS,
+    "type_0_polarity": POLARITIES,
+    "locator_role_assignment": ROLE_ASSIGNMENTS,
+    "conversion_candidate": CONVERSIONS,
+    "base_formula": BASE_FORMULAS,
+    "catalog_root_selection_signature": ROOT_SIGNATURES,
+    "kind_width": KIND_WIDTHS,
+    "identifier_width": ID_WIDTHS,
+    "endianness": ENDIANNESS,
+    "identifier_lifecycle_relation": LIFECYCLE_RELATIONS,
+}
+
+
+def require_registered(kind: str, value: Any) -> None:
+    if kind not in REGISTERED or value not in REGISTERED[kind]:
+        raise FixtureRejected(f"unregistered candidate id for {kind}: {value!r}")
+
+
+def require_all_registered(selection: dict[str, list[Any]] | None) -> None:
+    """A fixture may name the grammar members it expects to be enumerated; every one must be registered."""
+    for kind, values in (selection or {}).items():
+        for value in values:
+            require_registered(kind, value)
+
+
+@dataclass
+class Context:
+    campaign: Campaign
+    charges: Charges = field(default_factory=Charges)
+    rows: list[PredicateRow] = field(default_factory=list)
+    models: dict[str, Any] = field(default_factory=dict)  # layer key -> frozen derivation model
+    bindings: dict[str, Any] = field(default_factory=dict)  # layer key -> per-replica bindings
+    notes: list[str] = field(default_factory=list)
+
+    # ------------------------------------------------------------- byte access
+    def page(self, replica: int, checkpoint: str, number: int) -> bytes | None:
+        return self.campaign.page(replica, checkpoint, number)
+
+    def page_count(self, replica: int, checkpoint: str) -> int:
+        return self.campaign.page_count(replica, checkpoint)
+
+    def tag(self, replica: int, checkpoint: str, number: int) -> int | None:
+        page = self.page(replica, checkpoint, number)
+        return None if page is None else tag_of(page)
+
+    def page_hash(self, replica: int, checkpoint: str, number: int) -> str | None:
+        hashes = self.campaign.replicas[replica].pages[checkpoint]
+        return hashes[number] if 0 <= number < len(hashes) else None
+
+    def changed_pages(self, replica: int, checkpoint: str) -> set[int]:
+        return set(self.campaign.replicas[replica].page_indexes[checkpoint]["changed_page_indices"])
+
+    def predecessor(self, checkpoint: str) -> str | None:
+        ordinal = ORDINAL[checkpoint]
+        return CHECKPOINTS[ordinal - 1] if ordinal else None
+
+    def replicas(self) -> list[int]:
+        return sorted(self.campaign.replicas)
+
+    # ------------------------------------------------------------- rows
+    def record(self, predicate_id: str, passed: bool, measured: int, detail: str = "") -> bool:
+        self.rows.append(PredicateRow(predicate_id, PASS if passed else FAIL, measured, detail))
+        return passed
+
+    def skip(self, predicate_ids: tuple[str, ...]) -> None:
+        done = {row.predicate_id for row in self.rows}
+        for predicate_id in predicate_ids:
+            if predicate_id not in done:
+                self.rows.append(PredicateRow(predicate_id, NOT_APPLICABLE, 0))
+
+    def first_failure(self) -> str | None:
+        for row in self.rows:
+            if row.status == FAIL:
+                return row.predicate_id
+        return None
+
+
+def canonical_set_model(values: set[int]) -> list[int]:
+    return sorted(values)
+
+
+AMBIGUITIES: tuple[dict[str, str], ...] = (
+    {"id": "AMB-01", "topic": "syntactic decodability",
+     "plan": "candidate_grammars.h1.layout_candidate_rule / a3_page_23_recomputed_work",
+     "reading": "A four-byte window is syntactically decodable when its u24 page value is <= 65535 (high byte zero). Only this bound reproduces the plan's 1,872 preserved windows per layout on retained A3 page 23; the frozen-model bound 0..20479 yields 1,869."},
+    {"id": "AMB-02", "topic": "H1 structural pair requires the exact locator holes",
+     "plan": "filter_order.apply_table_record_signature_and_exact_locator_holes",
+     "reading": "A pair is structural only at offsets (35,39). Consequently at most one pair exists per layout and A4-H1-LOCATOR-PAIR-MULTIPLE is unreachable by enumeration, contradicting its claimed fixture."},
+    {"id": "AMB-03", "topic": "union-once qualified page identity",
+     "plan": "record_candidate_procedure.qualified_page_rule / union_once_charging",
+     "reading": "Qualified tag-02 pages are identified by page number in the union across derivation replicas; a page exposed by both replicas is charged once."},
+    {"id": "AMB-04", "topic": "NONE/MULTIPLE counts across replicas",
+     "plan": "predicate_contracts input_candidate_set (per replica versus union)",
+     "reading": "Each derivation replica is evaluated independently in order 1 then 2; a cardinality predicate fails on the first replica violating it and stores that replica's measured count. REPLICA-DISAGREEMENT compares the two replica-invariant models."},
+    {"id": "AMB-05", "topic": "H2 static role/polarity fit",
+     "plan": "A4-H2-ROLE-NONE 'fits their static structure' is undefined",
+     "reading": "Static fit at every applicable checkpoint: both type-0 admitted sets lie below page_count, the owned/in-use set is nonempty, and the available set is a subset of the owned set. Type-1 rows are skipped at H2 because their admitted set needs the H3 traversal."},
+    {"id": "AMB-06", "topic": "H2 idle transition versus A4-IDLE-EQUALITY",
+     "plan": "A4-R19-H2-TRANSITION fixture text 'owned set changes during an idle leg'",
+     "reading": "Every registered idle leg is an idle pair whose bytes must already be equal at A4-IDLE-EQUALITY, so the described fixture cannot first fail at H2. The harness reaches A4-H2-TRANSITION-UNEXPLAINED with a grow-leg violation instead."},
+    {"id": "AMB-07", "topic": "grow signature 'may remove but not add those same pages'",
+     "plan": "candidate_grammars.h2.transition_signature.grow",
+     "reading": "On a grow leg the owned set may only gain pages and the available set may not gain any page the owned set gained on that leg; unrelated instances are unconstrained on another role's leg."},
+    {"id": "AMB-08", "topic": "H3 base-formula fit and input regions",
+     "plan": "A4-H3-BASE-DISCRIMINATION / base_discrimination_rule",
+     "reading": "A formula fits when, at every conversion leg, the type-0 owned set is contained in the formula-decoded type-1 set and later legs obey the H2 transition signatures on formula-decoded sets. No extant-page rule is applied to admitted pages (claims.exact_allocation_set_equality is false). Regions: inactive slot, active slot, bit 0 set, nonzero bit set, bit 16351 set in slot s, bit 0 set in slot s+1 with both slots active."},
+    {"id": "AMB-09", "topic": "H4 root selection signature",
+     "plan": "catalog_root_selection_signature_rules.operation_delta_non_name_structure",
+     "reading": "A root candidate is an EMPTY tag-02 page whose frozen-model traversal is valid at every checkpoint and whose admitted stream (admitted set or admitted page hashes) changes at one or more of the seven listed operations. Requiring all seven would make A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED unreachable. The H1 record signature is not applied to system TDEFs."},
+    {"id": "AMB-10", "topic": "isolated physical schema delta",
+     "plan": "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+     "reading": "At an operation transition the isolated delta is changed_page_indices minus the TDEF and map pages of every user instance extant at that checkpoint. Page 0 is assumed unchanged; a real Jet header page that changes on every operation would fail this predicate on every campaign."},
+    {"id": "AMB-11", "topic": "H4 structural stage length field",
+     "plan": "raw_tuple_filter_order has no test of the name-length field before count_structural_field_layouts",
+     "reading": "A structural tuple's length field must decode to a count some registered encoding/length class could report for the expected name (union of both encodings' byte counts and the scalar count). Without this the length address is a free dimension and A4-H4-FIELD-MODEL-MULTIPLE is the only reachable H4 outcome."},
+    {"id": "AMB-12", "topic": "H4 observational equivalence of field tuples",
+     "plan": "deduplicate_identical_byte_address_tuple; endianness of one-byte fields",
+     "reading": "Tuples that decode identical kind, identifier and length values for every operation record at every checkpoint are one canonical model (as row masks with byte-identical bounds are). Endianness is otherwise unidentifiable by equality relations, making decisive H4 impossible."},
+    {"id": "AMB-13", "topic": "campaign predicates consume replica 3 before the freeze",
+     "plan": "A4-SCHEMA-SNAPSHOT input '75 canonical DAO snapshots' versus freeze_rule",
+     "reading": "Campaign predicates are evaluated over every replica present (75 snapshots); derivation layers read replicas 1 and 2 only; holdout predicates read replica 3 only."},
+    {"id": "AMB-14", "topic": "H3 holdout with no type-1 row",
+     "plan": "A4-H3-HOLDOUT-PREDICTION pass_iff 'predicts every replica-3 slot'",
+     "reading": "If replica 3 exposes no type-1 owned row the frozen H3 model is vacuously confirmed; the harness reports this as pass with a note."},
+    {"id": "AMB-15", "topic": "A4-H2-REPLICA-DISAGREEMENT and the H1 role-assignment",
+     "plan": "h2 locator_role_assignments versus h1_frozen_model_rule",
+     "reading": "The H2 assignment binds locator ordinal (first/second hole) to owned/available; swapping row order in one replica yields a different canonical H2 model while H1 stays replica-invariant."},
+)

--- a/oracle/windows-dao/scripts/a4_dryrun_core.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_core.py
@@ -32,6 +32,10 @@ PASS, FAIL, NOT_APPLICABLE = "pass", "fail", "not_applicable"
 class FixtureRejected(Exception):
     """The fixture is not a legitimate campaign (malformed page, unregistered id, ...)."""
 
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        super().__init__(detail)
+
 
 @dataclass
 class PredicateRow:
@@ -70,7 +74,7 @@ REGISTERED: dict[str, tuple[Any, ...]] = {
 
 def require_registered(kind: str, value: Any) -> None:
     if kind not in REGISTERED or value not in REGISTERED[kind]:
-        raise FixtureRejected(f"unregistered candidate id for {kind}: {value!r}")
+        raise FixtureRejected("unregistered_candidate_id", f"unregistered candidate id for {kind}: {value!r}")
 
 
 def require_all_registered(selection: dict[str, list[Any]] | None) -> None:

--- a/oracle/windows-dao/scripts/a4_dryrun_core.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_core.py
@@ -182,4 +182,10 @@ AMBIGUITIES: tuple[dict[str, str], ...] = (
     {"id": "AMB-15", "topic": "A4-H2-REPLICA-DISAGREEMENT and the H1 role-assignment",
      "plan": "h2 locator_role_assignments versus h1_frozen_model_rule",
      "reading": "The H2 assignment binds locator ordinal (first/second hole) to owned/available; swapping row order in one replica yields a different canonical H2 model while H1 stays replica-invariant."},
+    {"id": "AMB-16", "topic": "dispatch-gate transcript schema requires every predicate to be a first failure",
+     "plan": "reachability-transcript.schema.json fixtureEntry.first_failure_id (non-null) with minItems/maxItems 40",
+     "reading": "The schema admits no asserted-unreachable entry, yet A4-H1-LOCATOR-PAIR-MULTIPLE is unreachable under the exact-hole rule (AMB-02). Either the hole rule or the schema must change; the reference transcript records the unreachable assertion separately."},
+    {"id": "AMB-17", "topic": "dispatch-gate transcript needs artifacts that do not exist yet",
+     "plan": "reachability_transcript_binding; adversarialOutcome.case_id resource_exact_ceiling / resource_one_over",
+     "reading": "The bound transcript requires analyzer and independent-validator commits and results, a provenance entry id, and resource-ceiling cases at exactly 600,000,000 work units. A synthetic campaign cannot reach that ceiling honestly (baseline charges are six orders of magnitude lower), so those two cases need a declared charging-injection mechanism in the plan. This harness writes a reference transcript under a distinct document type instead of claiming the gate artifact."},
 )

--- a/oracle/windows-dao/scripts/a4_dryrun_eval.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_eval.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Plan-driven A4 reference evaluator: campaign, derivation layers, freeze, holdout.
+
+This module is a reference evaluator for the dry-run reachability harness, not
+the production A4 analyzer. It decodes campaign bytes under the plan's
+normative predicate rules so the analyzer and independent-validator lanes have
+a byte-level oracle to agree with on real fixtures.
+
+A4 rule | implementation
+--- | ---
+Campaign predicates first in registered order; failure makes all 36 scientific predicates not_applicable | :func:`evaluate`
+Derivation on replicas 1 and 2 only, layer order H1..H4, downstream layer depends on the unique upstream model | :func:`_layer`
+Replica-invariant canonical model comparison at REPLICA-DISAGREEMENT (AMB-04) | :func:`_layer`
+Freeze: canonical hash of the four derivation results before replica 3 is read | :func:`evaluate`
+Holdout H1, H2, H3, H4 root, H4 fields in order; upstream failure gates downstream | :func:`_holdout`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import a4_dryrun_h1 as h1
+import a4_dryrun_h2 as h2
+import a4_dryrun_h3 as h3
+import a4_dryrun_h4 as h4
+from a4_campaign import Campaign
+from a4_dryrun_campaign import evaluate_campaign
+from a4_dryrun_core import Context, PredicateRow, require_all_registered
+from a4_dryrun_h1 import ReplicaLayer
+from a4_spec import (
+    DERIVATION_REPLICAS, HOLDOUT_PREDICATES, HOLDOUT_REPLICA, LAYER_KEYS, LAYER_PREDICATES, PREDICATE_ORDER, canonical_id,
+)
+
+
+@dataclass
+class Evaluation:
+    rows: list[PredicateRow]
+    first_failure: str | None
+    models: dict[str, Any]
+    stages: dict[str, Any]
+    charges: dict[str, int]
+    derivation_sha256: str | None
+    notes: list[str] = field(default_factory=list)
+
+    def row(self, predicate_id: str) -> PredicateRow:
+        return next(r for r in self.rows if r.predicate_id == predicate_id)
+
+    def as_document(self) -> dict[str, Any]:
+        return {
+            "ordered_predicates": [r.__dict__ for r in self.rows],
+            "first_failure": self.first_failure,
+            "derivation_candidate_set_sha256": self.derivation_sha256,
+            "models": self.models,
+            "stages": self.stages,
+            "charges": self.charges,
+            "notes": self.notes,
+        }
+
+
+def _layer(ctx: Context, key: str, run: Callable[[int], ReplicaLayer], stages: dict[str, Any]) -> dict[int, ReplicaLayer] | None:
+    ids = LAYER_PREDICATES[key]
+    results = {replica: run(replica) for replica in DERIVATION_REPLICAS}
+    stages[key] = {str(r): res.stages for r, res in results.items()}
+    for predicate_id in ids[:-1]:
+        for replica in DERIVATION_REPLICAS:
+            outcome = next((o for o in results[replica].outcomes if o[0] == predicate_id), None)
+            if outcome is None:
+                raise AssertionError(f"replica {replica} did not evaluate {predicate_id} in order")
+            _, passed, count, detail = outcome
+            if not passed:
+                ctx.record(predicate_id, False, count, f"replica {replica}: {detail}")
+                return None
+        ctx.record(predicate_id, True, next(o[2] for o in results[DERIVATION_REPLICAS[0]].outcomes if o[0] == predicate_id))
+    models = [results[r].model for r in DERIVATION_REPLICAS]
+    if any(m is None for m in models):
+        raise AssertionError("layer passed every local predicate without a model")
+    ids_equal = len({m["canonical_model_id"] for m in models if m}) == 1
+    detail = "" if ids_equal else f"replica models differ: {[m['model'] for m in models if m]}"
+    ctx.record(ids[-1], ids_equal, 1, detail)
+    if not ids_equal:
+        return None
+    ctx.models[key] = models[0]
+    return results
+
+
+def _holdout(ctx: Context, layers: dict[str, dict[int, ReplicaLayer]]) -> None:
+    replica = HOLDOUT_REPLICA
+    models = {"h1": ctx.models["h1_tdef_to_map_row"], "h2": ctx.models["h2_row_identity_map_role"],
+              "h3": ctx.models["h3_indirect_traversal"], "h4": ctx.models["h4_catalog_bootstrap"]}
+    if replica not in ctx.campaign.replicas:
+        ctx.record(HOLDOUT_PREDICATES[0], False, 1, "replica 3 missing")
+        return
+    ok, detail, bindings = h1.holdout(ctx, replica, models["h1"])
+    if not ctx.record(HOLDOUT_PREDICATES[0], ok, 1, detail):
+        return
+    ok, detail, located = h2.holdout(ctx, replica, models["h2"], bindings)
+    if not ctx.record(HOLDOUT_PREDICATES[1], ok, 1, detail) or located is None:
+        return
+    owned = h2.owned_rows(located, models["h2"]["model"]["locator_role_assignment"])
+    ok, detail = h3.holdout(ctx, replica, models["h3"], owned, models["h2"]["model"]["polarity"])
+    if not ctx.record(HOLDOUT_PREDICATES[2], ok, 1, detail):
+        return
+    ok, detail, admitted = h4.holdout_root(ctx, replica, models, bindings)
+    if not ctx.record(HOLDOUT_PREDICATES[3], ok, 1, detail) or admitted is None:
+        return
+    ok, detail = h4.holdout_fields(ctx, replica, models, admitted)
+    ctx.record(HOLDOUT_PREDICATES[4], ok, 1, detail)
+
+
+def evaluate(campaign: Campaign, grammar_selection: dict[str, list[Any]] | None = None) -> Evaluation:
+    """Evaluate one shared campaign through the 40 registered predicates in order; first failure is terminal."""
+    require_all_registered(grammar_selection)
+    ctx = Context(campaign)
+    stages: dict[str, Any] = {}
+    derivation_sha256 = None
+    if evaluate_campaign(ctx):
+        layers: dict[str, dict[int, ReplicaLayer]] = {}
+        h1_results = _layer(ctx, LAYER_KEYS[0], lambda r: h1.evaluate_replica(ctx, r), stages)
+        if h1_results:
+            layers[LAYER_KEYS[0]] = h1_results
+            h2_results = _layer(ctx, LAYER_KEYS[1], lambda r: h2.evaluate_replica(ctx, r, h1_results[r].bindings), stages)
+            if h2_results:
+                layers[LAYER_KEYS[1]] = h2_results
+                assignment = ctx.models[LAYER_KEYS[1]]["model"]["locator_role_assignment"]
+                polarity = ctx.models[LAYER_KEYS[1]]["model"]["polarity"]
+                h3_results = _layer(ctx, LAYER_KEYS[2], lambda r: h3.evaluate_replica(
+                    ctx, r, h2.owned_rows(h2_results[r].bindings["located"], assignment), polarity), stages)
+                if h3_results:
+                    layers[LAYER_KEYS[2]] = h3_results
+                    models = {"h1": ctx.models[LAYER_KEYS[0]], "h2": ctx.models[LAYER_KEYS[1]], "h3": ctx.models[LAYER_KEYS[2]]}
+                    h4_results = _layer(ctx, LAYER_KEYS[3], lambda r: h4.evaluate_replica(ctx, r, models, h1_results[r].bindings), stages)
+                    if h4_results:
+                        layers[LAYER_KEYS[3]] = h4_results
+        # Freeze before any replica-3 read: the four derivation results are hashed whatever their outcome.
+        derivation_sha256 = canonical_id({
+            "rows": [r.__dict__ for r in ctx.rows],
+            "models": {k: ctx.models.get(k) for k in LAYER_KEYS},
+        })
+        if len(layers) == len(LAYER_KEYS):
+            _holdout(ctx, layers)
+    ctx.skip(PREDICATE_ORDER)
+    order = {p: i for i, p in enumerate(PREDICATE_ORDER)}
+    rows = sorted(ctx.rows, key=lambda r: order[r.predicate_id])
+    return Evaluation(rows, ctx.first_failure(), dict(ctx.models), stages, dict(ctx.charges.units), derivation_sha256, list(ctx.notes))

--- a/oracle/windows-dao/scripts/a4_dryrun_fixtures.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_fixtures.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Byte-level reachability fixtures for every registered A4 predicate.
+
+Each fixture is the all-pass baseline campaign plus one disclosed mutation
+(generator parameters and/or a post-generation page patch). No fixture carries
+an expected status beyond the predicate it is registered against; the harness
+measures the first failure from bytes and rejects a fixture whose first
+failure is not its target.
+
+A4 rule | implementation
+--- | ---
+One shared synthetic campaign per fixture, mutation from the baseline | :class:`Fixture`
+Plan reachability_fixture_id per predicate | :data:`REGISTRY_FIXTURES`
+Adversarial evaluator cases (MULTIPLE 2/3/4, encoding 0/2, unregistered id, malformed page, earlier-invalidating mutation) | :data:`ADVERSARIAL`
+Unreachable terminal asserted by enumeration with an attempt fixture | :data:`UNREACHABLE`
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable
+
+from a4_campaign import Campaign
+from a4_generator import Params, generate
+from a4_pages import DELETED_FLAG, data_page, decode_directory, tag05_bits, tag05_page
+from a4_spec import PAGE_SIZE, PREDICATE_CONTRACTS, TAG05_BITS, canonical_json_bytes, sha256_hex
+
+Patch = Callable[[Campaign], None]
+
+
+def _rows(page: bytes) -> tuple[list[bytes], dict[int, int]]:
+    slots = decode_directory(page, 0x1FFF)
+    return [page[s.start: s.end] for s in slots], {s.ordinal: s.raw & 0xC000 for s in slots}
+
+
+def rebuild(page: bytes, transform: Callable[[list[bytes]], list[bytes]], flags: dict[int, int] | None = None) -> bytes:
+    rows, existing = _rows(page)
+    return data_page(transform(rows), flags if flags is not None else existing)
+
+
+def _set_bit(row: bytes, page: int) -> bytes:
+    base = int.from_bytes(row[1:5], "little")
+    bit = page - base
+    body = bytearray(row[5:])
+    while len(body) * 8 <= bit:
+        body.append(0)
+    body[bit >> 3] |= 1 << (bit & 7)
+    return row[:5] + bytes(body)
+
+
+def _clear_bit(row: bytes, page: int) -> bytes:
+    base = int.from_bytes(row[1:5], "little")
+    bit = page - base
+    body = bytearray(row[5:])
+    body[bit >> 3] &= ~(1 << (bit & 7)) & 0xFF
+    return row[:5] + bytes(body)
+
+
+# ----------------------------------------------------------------------------- patches
+
+def flip_empty_r_byte(c: Campaign) -> None:
+    page = bytearray(c.page(1, "EMPTY_R", 1) or b"")
+    page[100] ^= 0x01
+    c.patch_page(1, "EMPTY_R", 1, bytes(page))
+    c.refresh(1)
+
+
+def snapshot_duplicate_ordinal(c: Campaign) -> None:
+    tables = c.replicas[1].snapshots["T2_CREATE"]["tables"]
+    tables[1]["ordinal"] = tables[0]["ordinal"]
+
+
+def page_index_hash_swap(c: Campaign) -> None:
+    index = c.replicas[1].page_indexes["T1_REL_0064"]
+    index["ordered_page_sha256"][5] = index["ordered_page_sha256"][4]
+
+
+def _map_patch(c: Campaign, replica: int, instance: str, first: str, transform: Callable[[bytes], bytes]) -> None:
+    meta = c.instance_pages(replica, instance)
+    c.patch_from(replica, first, meta["map"], transform)
+    c.refresh(replica)
+
+
+def t3_directory_overlap(c: Campaign) -> None:
+    def patch(page: bytes) -> bytes:
+        out = bytearray(page)
+        out[12:14] = (12).to_bytes(2, "little")  # slot 1 start below 10+2*row_count
+        return bytes(out)
+    _map_patch(c, 1, "T3-v1", "T3_CREATE", patch)
+
+
+def t3_owned_deleted_flag(c: Campaign) -> None:
+    _map_patch(c, 1, "T3-v1", "T3_CREATE", lambda p: rebuild(p, lambda rows: rows, {0: DELETED_FLAG}))
+
+
+def t3_owned_tag_02(c: Campaign) -> None:
+    _map_patch(c, 1, "T3-v1", "T3_CREATE", lambda p: rebuild(p, lambda rows: [b"\x02" + rows[0][1:]] + rows[1:]))
+
+
+def t1_available_outside_owned(c: Campaign) -> None:
+    foreign = c.instance_pages(1, "T1-v1")["map"] + 1  # next page: never owned by T1
+    _map_patch(c, 1, "T1-v1", "T1_CREATE_ID", lambda p: rebuild(p, lambda rows: [rows[0], _set_bit(rows[1], foreign)]))
+
+
+def t1_owned_drops_page_at_0512(c: Campaign) -> None:
+    dropped = c.instance_pages(1, "T1-v1")["data_pages"][0]
+
+    def transform(rows: list[bytes]) -> list[bytes]:
+        available = rows[1]
+        if len(available) * 8 > (dropped - int.from_bytes(available[1:5], "little")) + 40:
+            available = _clear_bit(available, dropped)
+        return [_clear_bit(rows[0], dropped), available]
+    _map_patch(c, 1, "T1-v1", "T1_REL_0512", lambda p: rebuild(p, transform))
+
+
+def t3_reference_to_tag01(c: Campaign) -> None:
+    data_page_number = c.instance_pages(1, "T3-v1")["data_pages"][0]
+
+    def patch(page: bytes) -> bytes:
+        def rows_transform(rows: list[bytes]) -> list[bytes]:
+            row = bytearray(rows[0])
+            if row[0] == 0x01:
+                row[5:9] = data_page_number.to_bytes(4, "little")  # slot 1 now references a tag-01 page
+            return [bytes(row)] + rows[1:]
+        return rebuild(page, rows_transform)
+    _map_patch(c, 1, "T3-v1", "T3_ABS_16480", patch)
+
+
+def holdout_t3_tag05_clears_map_bit(c: Campaign) -> None:
+    meta = c.instance_pages(3, "T3-v1")
+    reference, map_page = meta["tag05"][0], meta["map"]
+    c.patch_from(3, "T3_ABS_16480", reference, lambda p: tag05_page(set(tag05_bits(p)) - {map_page}))
+    c.refresh(3)
+
+
+def second_locator_pair_copy(c: Campaign) -> None:
+    """Copy the locator pair to [100,108) on every user TDEF: preserved and target-valid, but not at the holes."""
+    for replica in (1, 2, 3):
+        for instance, meta in c.replicas[replica].meta["instances"].items():
+            first = next(cp for cp in c.replicas[replica].pages if (c.page(replica, cp, meta["tdef"]) or b"\x00")[0] == 0x02)
+
+            def patch(page: bytes) -> bytes:
+                return page[:100] + page[35:43] + page[108:] if page[0] == 0x02 else page
+            c.patch_from(replica, first, meta["tdef"], patch)
+        c.refresh(replica)
+
+
+def malformed_page(c: Campaign) -> None:
+    digest = c.replicas[1].pages["EMPTY"][1]
+    c.blobs[digest] = c.blobs[digest][: PAGE_SIZE - 1]
+
+
+def flags_and_directory(c: Campaign) -> None:
+    """Targets ROW-FLAGS but also breaks the directory: the earlier predicate must win."""
+    t3_owned_deleted_flag(c)
+    t3_directory_overlap(c)
+
+
+PATCHES: dict[str, Patch] = {f.__name__: f for f in (
+    flip_empty_r_byte, snapshot_duplicate_ordinal, page_index_hash_swap, t3_directory_overlap, t3_owned_deleted_flag,
+    t3_owned_tag_02, t1_available_outside_owned, t1_owned_drops_page_at_0512, t3_reference_to_tag01,
+    holdout_t3_tag05_clears_map_bit, second_locator_pair_copy, malformed_page, flags_and_directory,
+)}
+
+
+# ----------------------------------------------------------------------------- fixtures
+
+@dataclass(frozen=True)
+class Fixture:
+    fixture_id: str
+    predicate_id: str | None  # expected first failure; None means all-pass
+    description: str
+    params: Params = field(default_factory=Params)
+    patches: tuple[str, ...] = ()
+    grammar_selection: dict[str, list[Any]] | None = None
+    expect_rejection: str | None = None  # harness must reject this fixture for the stated reason
+    legitimate_count: int | None = None  # asserted measured count where the plan names one
+
+    def mutation(self) -> dict[str, Any]:
+        raw = asdict(self.params)
+        return {"generator_params": _jsonable(raw), "patches": list(self.patches), "grammar_selection": self.grammar_selection}
+
+    def mutation_sha256(self) -> str:
+        return sha256_hex(canonical_json_bytes(self.mutation()))
+
+    def build(self) -> Campaign:
+        campaign = generate(self.params)
+        for name in self.patches:
+            PATCHES[name](campaign)
+        return campaign
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))}
+    if isinstance(value, (set, frozenset)):
+        return sorted(_jsonable(v) for v in value)
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return value
+
+
+BLOAT = 16352 - 9  # first user page at or above the 16,352-page boundary (nine system pages with two reserved tag-05 pages)
+
+
+def _fixture_for(predicate_id: str, description: str, **kwargs: Any) -> Fixture:
+    return Fixture(PREDICATE_CONTRACTS[predicate_id]["reachability_fixture_id"], predicate_id, description, **kwargs)
+
+
+BASELINE = Fixture("A4-R00-BASELINE", None, "all-pass synthetic campaign; every derivation layer decisive and every holdout predicted")
+
+REGISTRY_FIXTURES: tuple[Fixture, ...] = (
+    _fixture_for("A4-IDLE-EQUALITY", "one byte differs in replica 1 EMPTY_R page 1", patches=("flip_empty_r_byte",)),
+    _fixture_for("A4-SCHEMA-SNAPSHOT", "replica 1 T2_CREATE snapshot carries a duplicate table ordinal", patches=("snapshot_duplicate_ordinal",)),
+    _fixture_for("A4-SNAPSHOT-RECONSTRUCTION", "replica 1 T1_REL_0064 page index lists another blob's hash at page 5", patches=("page_index_hash_swap",)),
+    _fixture_for("A4-RESOURCE-BOUND", "twelve extra tag-02 pages appear at T4_CREATE: 17 qualified pages in the union, one over 16",
+                 params=Params(decoy_tdef_pages={"T4_CREATE": 12})),
+    _fixture_for("A4-H1-TDEF-NONE", "user TDEF pages carry tag 03, so no tag-02 page matches either lifecycle signature", params=Params(user_tdef_tag=0x03)),
+    _fixture_for("A4-H1-TDEF-MULTIPLE", "a second new tag-02 page appears at T3_CREATE: two lifecycle-matching TDEF candidates",
+                 params=Params(decoy_tdef_pages={"T3_CREATE": 1}), legitimate_count=2),
+    _fixture_for("A4-H1-LOCATOR-LAYOUT-NONE", "user TDEF bytes after the tag are all 0xA5: no window decodes under either layout", params=Params(tdef_style="opaque")),
+    _fixture_for("A4-H1-LOCATOR-PAIR-NONE", "signature byte 2 differs on every user TDEF: windows preserved, no masked pair", params=Params(tdef_style="broken_signature")),
+    _fixture_for("A4-H1-TARGET-ROW-INVALID", "locators point at the TDEF page itself (tag 02) under both layouts", params=Params(locator_target="tdef")),
+    _fixture_for("A4-H1-LOCATOR-LAYOUT-MULTIPLE", "user pages preallocated below 18 and EMPTY padded past 256*17 so page-then-row targets are extant tag 01 too",
+                 params=Params(preallocate_user_pages=True, extra_empty_filler=256 * 18 + 2), legitimate_count=2),
+    _fixture_for("A4-H1-LOCATOR-PAIR-MULTIPLE", "attempt: the locator pair is copied to [100,108); exact-hole filtering keeps one structural pair (asserted unreachable)",
+                 patches=("second_locator_pair_copy",)),
+    _fixture_for("A4-H1-REPLICA-DISAGREEMENT", "replica 2 encodes its locators page-then-row", params=Params(layout_by_replica={2: "u24le_page_then_u8_row"})),
+    _fixture_for("A4-H2-ROW-DIRECTORY-INVALID", "replica 1 T3 map page slot 1 starts at 12, inside the directory bytes", patches=("t3_directory_overlap",)),
+    _fixture_for("A4-H2-ROW-FLAGS-INVALID", "replica 1 T3 owned row has the deleted flag set", patches=("t3_owned_deleted_flag",)),
+    _fixture_for("A4-H2-MAP-TAG-UNSUPPORTED", "replica 1 T3 owned row begins 02", patches=("t3_owned_tag_02",)),
+    _fixture_for("A4-H2-ROLE-NONE", "replica 1 T1 available row admits a page the owned row never admits", patches=("t1_available_outside_owned",)),
+    _fixture_for("A4-H2-ROLE-MULTIPLE", "available rows equal owned rows everywhere: both role assignments fit", params=Params(available_equals_owned=True), legitimate_count=2),
+    _fixture_for("A4-H2-TRANSITION-UNEXPLAINED", "replica 1 T1 owned row drops its first data page on the T1_REL_0064->T1_REL_0512 grow leg (AMB-06)",
+                 patches=("t1_owned_drops_page_at_0512",)),
+    _fixture_for("A4-H2-REPLICA-DISAGREEMENT", "replica 2 stores the owned row at locator ordinal 1", params=Params(owned_ordinal_by_replica={2: 1})),
+    _fixture_for("A4-H3-CONVERSION-NONE", "owned rows never convert to type 1", params=Params(conversion="never")),
+    _fixture_for("A4-H3-INACTIVE-SLOT-NONE", "type-1 rows carry exactly their nonzero slots", params=Params(type1_exact_slots=True)),
+    _fixture_for("A4-H3-REFERENCE-INVALID", "replica 1 T3 slot 1 references a tag-01 data page from T3_ABS_16480", patches=("t3_reference_to_tag01",)),
+    _fixture_for("A4-H3-BASE-DISCRIMINATION", "owned sets stop below page 16352: no boundary input region", params=Params(omit_pages_at_or_above=16352)),
+    _fixture_for("A4-H3-BASE-NONE", "every owned tag-05 bit is shifted by two (synthetic boundary bits keep every input region exercised): no formula contains the pre-conversion set",
+                 params=Params(tag05_bit_shift=2, synthetic_boundary_bits=True)),
+    _fixture_for("A4-H3-BASE-MULTIPLE", "reference == slot for every active slot (user pages beyond 16352, forced T3 conversion): slot and referenced-page formulas both fit",
+                 params=Params(extra_empty_filler=BLOAT, tag05_mode_by_replica={1: "equals_slot", 2: "equals_slot", 3: "equals_slot"},
+                               force_conversion_at={"T3-v1": "T3_ABS_04096"}, synthetic_boundary_bits=True), legitimate_count=2),
+    _fixture_for("A4-H3-REPLICA-DISAGREEMENT", "replica 2 references page k+1 from slot k (referenced-page formula) while replica 1 keeps the slot formula",
+                 params=Params(extra_empty_filler=BLOAT, tag05_mode_by_replica={2: "referenced"}, force_conversion_at={"T3-v1": "T3_ABS_04096"},
+                               synthetic_boundary_bits=True)),
+    _fixture_for("A4-H3-HOLDOUT-PREDICTION", "replica 3's slot-0 tag-05 page clears the bit of the T3 map page after conversion", patches=("holdout_t3_tag05_clears_map_bit",)),
+    _fixture_for("A4-H4-CATALOG-ROOT-NONE", "catalog records are written to a page no system stream admits", params=Params(record_page_default="spare")),
+    _fixture_for("A4-H4-CATALOG-ROOT-MULTIPLE", "the decoy system table owns the spare page and changes it at every operation", params=Params(decoy_follows_ops=True), legitimate_count=2),
+    _fixture_for("A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED", "the T3_CREATE record is written to the unadmitted spare page", params=Params(record_page_override={"T3_CREATE": "spare"})),
+    _fixture_for("A4-H4-CATALOG-RECORD-NONE", "no record is written at T3_CREATE", params=Params(skip_record_at={"T3_CREATE"})),
+    _fixture_for("A4-H4-CATALOG-RECORD-MULTIPLE", "two records are written at T3_CREATE", params=Params(duplicate_record_at={"T3_CREATE"}), legitimate_count=2),
+    _fixture_for("A4-H4-FIELD-MODEL-NONE", "the T3_CREATE record stores kind 0x44 while other table records store 0x11", params=Params(kind_override={"T3_CREATE": 0x44})),
+    _fixture_for("A4-H4-FIELD-MODEL-MULTIPLE", "records carry two stamp/id/kind prefixes with distinct identifiers before one length byte", params=Params(record_layout="double"), legitimate_count=2),
+    _fixture_for("A4-H4-ENCODING-AMBIGUOUS", "the É record stores Windows-1252 bytes with stored length 9: zero fitting classes", params=Params(e_acute_length_override=9), legitimate_count=0),
+    _fixture_for("A4-H4-REPLICA-DISAGREEMENT", "replica 2 reuses the T2-v1 identifier for T2-v2", params=Params(t2_id_relation_by_replica={2: "same"})),
+    _fixture_for("A4-H1-HOLDOUT-PREDICTION", "replica 3 stores its locators at offsets 36/40", params=Params(locator_offsets_by_replica={3: (36, 40)})),
+    _fixture_for("A4-H2-HOLDOUT-PREDICTION", "replica 3 stores the owned row at locator ordinal 1", params=Params(owned_ordinal_by_replica={3: 1})),
+    _fixture_for("A4-H4-HOLDOUT-ROOT", "replica 3 writes the T3_CREATE record to the unadmitted spare page", params=Params(record_page_override_by_replica={3: {"T3_CREATE": "spare"}})),
+    _fixture_for("A4-H4-HOLDOUT-FIELDS", "replica 3's É record name ends in '5'", params=Params(holdout_name_corruption=True)),
+)
+
+UNREACHABLE: tuple[str, ...] = ("A4-H1-LOCATOR-PAIR-MULTIPLE",)
+
+ADVERSARIAL: tuple[Fixture, ...] = (
+    Fixture("A4-ADV-TDEF-MULTIPLE-3", "A4-H1-TDEF-MULTIPLE", "three lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+            params=Params(decoy_tdef_pages={"T3_CREATE": 2}), legitimate_count=3),
+    Fixture("A4-ADV-TDEF-MULTIPLE-4", "A4-H1-TDEF-MULTIPLE", "four lifecycle-matching TDEF candidates (legitimate minimum-2 outcome)",
+            params=Params(decoy_tdef_pages={"T3_CREATE": 3}), legitimate_count=4),
+    Fixture("A4-ADV-ENCODING-2", "A4-H4-ENCODING-AMBIGUOUS", "the É record carries both registered byte occurrences at compatible anchors: two fitting classes",
+            params=Params(e_acute_double_occurrence=True), legitimate_count=2),
+    Fixture("A4-ADV-UNREGISTERED-ID", None, "fixture names an unregistered base formula", grammar_selection={"base_formula": ["not-a-registered-formula"]},
+            expect_rejection="unregistered_candidate_id"),
+    Fixture("A4-ADV-MALFORMED-PAGE", None, "one page blob is 2,047 bytes", patches=("malformed_page",), expect_rejection="malformed_page"),
+    Fixture("A4-ADV-EARLIER-PREDICATE", "A4-H2-ROW-FLAGS-INVALID", "claims ROW-FLAGS but the same mutation breaks the directory first",
+            patches=("flags_and_directory",), expect_rejection="first_failure_is_not_target"),
+)
+
+
+def all_fixtures() -> tuple[Fixture, ...]:
+    return (BASELINE,) + REGISTRY_FIXTURES + ADVERSARIAL

--- a/oracle/windows-dao/scripts/a4_dryrun_h1.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h1.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""A4-H1 (TDEF-to-map-row location) reference evaluation per derivation replica.
+
+A4 rule | implementation
+--- | ---
+TDEF lifecycle signatures (new tag 02 at create / preexisting hash transition) | :func:`tdef_matches`
+4,090 raw window identities, syntactic decode, cross-checkpoint preservation | :func:`preserved_windows`
+Canonical nonoverlapping pairs charged arithmetically, structural pairs at the exact holes | :func:`evaluate_replica`
+Target existence, tag 01, row ordinal < row_count, distinct targets | :func:`targets_valid`
+Replica-invariant model {layout, signature id, offsets} plus per-instance bindings | :func:`evaluate_replica`
+H1 holdout: re-derive replica-3 bindings under the unchanged model | :func:`holdout`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from a4_dryrun_campaign import qualified_tag02_pages
+from a4_dryrun_core import Context
+from a4_pages import TAG_DATA, TAG_TDEF, decode_locator, row_count
+from a4_spec import (
+    EVENT_BY_CHECKPOINT, IDLE_PAIRS, INSTANCES, Instance, LAYER_PREDICATES, LOCATOR_HOLES, LOCATOR_LAYOUTS, PAGE_SIZE,
+    SCHEMA_LIFECYCLE, SIGNATURE_MASK, SIGNATURE_VALUE, TDEF_SIGNATURES, canonical_id, sha256_hex,
+)
+
+H1 = LAYER_PREDICATES["h1_tdef_to_map_row"]
+SIGNATURE_ID = sha256_hex(SIGNATURE_VALUE + SIGNATURE_MASK)
+WINDOW_OFFSETS = range(0, PAGE_SIZE - 3)  # 2045 offsets per layout, 4090 raw window identities
+MAX_SYNTACTIC_PAGE = 0xFFFF  # AMB-01
+
+
+@dataclass
+class ReplicaLayer:
+    outcomes: list[tuple[str, bool, int, str]] = field(default_factory=list)
+    model: dict[str, Any] | None = None
+    bindings: dict[str, Any] = field(default_factory=dict)
+    stages: dict[str, Any] = field(default_factory=dict)
+
+    def fail(self, predicate_id: str, count: int, detail: str = "") -> "ReplicaLayer":
+        self.outcomes.append((predicate_id, False, count, detail))
+        return self
+
+    def ok(self, predicate_id: str, count: int) -> None:
+        self.outcomes.append((predicate_id, True, count, ""))
+
+    @property
+    def terminal(self) -> str | None:
+        return next((p for p, passed, _, _ in self.outcomes if not passed), None)
+
+
+def signature_matches(page: bytes) -> bool:
+    return all((page[i] & SIGNATURE_MASK[i]) == (SIGNATURE_VALUE[i] & SIGNATURE_MASK[i]) for i in range(len(SIGNATURE_VALUE)))
+
+
+def tdef_matches(ctx: Context, replica: int, inst: Instance, page: int, signature: str) -> bool:
+    before = ctx.predecessor(inst.create_checkpoint)
+    tag_before = ctx.tag(replica, before, page) if before else None
+    for checkpoint in inst.checkpoints:
+        ctx.charges.add("tdef_lifecycle_signatures")
+        if ctx.tag(replica, checkpoint, page) != TAG_TDEF:
+            return False
+    if signature == "new_tag_02_at_role_create":
+        return tag_before != TAG_TDEF
+    if tag_before != TAG_TDEF or ctx.page_hash(replica, before or "", page) == ctx.page_hash(replica, inst.create_checkpoint, page):
+        return False
+    for left, right in list(zip(SCHEMA_LIFECYCLE, SCHEMA_LIFECYCLE[1:])) + list(IDLE_PAIRS):
+        if EVENT_BY_CHECKPOINT[right].role == inst.role:
+            continue
+        if ctx.page_hash(replica, left, page) != ctx.page_hash(replica, right, page):
+            return False
+    return True
+
+
+def preserved_windows(ctx: Context, replica: int, page: int, checkpoints: tuple[str, ...], layout: str) -> set[int]:
+    """Offsets whose decoded (page,row) is syntactically decodable and identical at every checkpoint."""
+    pages = [ctx.page(replica, cp, page) or b"" for cp in checkpoints]
+    out = set()
+    for offset in WINDOW_OFFSETS:
+        ctx.charges.add("raw_locator_windows")
+        decoded = {decode_locator(p[offset: offset + 4], layout) for p in pages}
+        if len(decoded) == 1 and next(iter(decoded))[0] <= MAX_SYNTACTIC_PAGE:
+            out.add(offset)
+    return out
+
+
+def canonical_pair_count(offsets: set[int]) -> int:
+    """Number of canonical pairs a<b with b-a>=4 among preserved offsets (counted, not materialised)."""
+    ordered = sorted(offsets)
+    total, j = 0, 0
+    for i, b in enumerate(ordered):
+        while ordered[j] <= b - 4:
+            j += 1
+        total += j
+    return total
+
+
+def target_of(page: bytes, offset: int, layout: str) -> tuple[int, int]:
+    return decode_locator(page[offset: offset + 4], layout)
+
+
+def targets_valid(ctx: Context, replica: int, page_bytes: bytes, checkpoint: str, offsets: tuple[int, int], layout: str) -> str | None:
+    targets = [target_of(page_bytes, o, layout) for o in offsets]
+    if targets[0] == targets[1]:
+        return "duplicate targets"
+    for target_page, row in targets:
+        ctx.charges.add("h1_target_validity_checks")
+        blob = ctx.page(replica, checkpoint, target_page)
+        if blob is None:
+            return f"target page {target_page} absent at {checkpoint}"
+        if blob[0] != TAG_DATA:
+            return f"target page {target_page} tag {blob[0]:02x} at {checkpoint}"
+        if row >= row_count(blob):
+            return f"row {row} out of range on page {target_page} at {checkpoint}"
+    return None
+
+
+def evaluate_replica(ctx: Context, replica: int) -> ReplicaLayer:
+    out = ReplicaLayer()
+    qualified = sorted(qualified_tag02_pages(ctx, replica))
+    candidates: list[tuple[str, dict[str, int]]] = []
+    for signature in TDEF_SIGNATURES:
+        per_instance = {inst.id: [p for p in qualified if tdef_matches(ctx, replica, inst, p, signature)] for inst in INSTANCES}
+        if all(per_instance.values()):
+            combos: list[dict[str, int]] = [{}]
+            for inst_id, pages in per_instance.items():
+                combos = [{**c, inst_id: p} for c in combos for p in pages]
+            candidates += [(signature, c) for c in combos]
+    out.stages["tdef_candidates"] = [{"signature": s, "pages": c} for s, c in candidates]
+    if not candidates:
+        return out.fail(H1[0], 0, "no lifecycle-matching TDEF candidate")
+    out.ok(H1[0], len(candidates))
+    if len(candidates) > 1:
+        return out.fail(H1[1], len(candidates), "multiple lifecycle-matching TDEF candidates")
+    out.ok(H1[1], 1)
+    signature, pages = candidates[0]
+
+    preserved = {layout: {inst.id: preserved_windows(ctx, replica, pages[inst.id], inst.checkpoints, layout)
+                          for inst in INSTANCES} for layout in LOCATOR_LAYOUTS}
+    layouts_with_windows = [l for l in LOCATOR_LAYOUTS if any(preserved[l].values())]
+    out.stages["preserved_windows"] = {l: {i: len(s) for i, s in m.items()} for l, m in preserved.items()}
+    if not layouts_with_windows:
+        return out.fail(H1[2], 0, "no syntactically preserved window under either layout")
+    out.ok(H1[2], len(layouts_with_windows))
+
+    holes = (LOCATOR_HOLES[0][0], LOCATOR_HOLES[1][0])
+    structural: list[tuple[str, tuple[int, int]]] = []
+    for layout in LOCATOR_LAYOUTS:
+        for inst in INSTANCES:
+            ctx.charges.add("raw_locator_pairs", canonical_pair_count(preserved[layout][inst.id]))
+        if all(holes[0] in preserved[layout][i.id] and holes[1] in preserved[layout][i.id] for i in INSTANCES) and all(
+                signature_matches(ctx.page(replica, cp, pages[i.id]) or b"") for i in INSTANCES for cp in i.checkpoints):
+            structural.append((layout, holes))
+    out.stages["structural_pairs"] = [{"layout": l, "offsets": list(o)} for l, o in structural]
+    if not structural:
+        return out.fail(H1[3], 0, "no masked, nonoverlapping, identity-preserved pair")
+    out.ok(H1[3], len(structural))
+
+    valid: list[tuple[str, tuple[int, int]]] = []
+    reasons = []
+    for layout, offsets in structural:
+        problem = None
+        for inst in INSTANCES:
+            for cp in inst.checkpoints:
+                problem = targets_valid(ctx, replica, ctx.page(replica, cp, pages[inst.id]) or b"", cp, offsets, layout)
+                if problem:
+                    break
+            if problem:
+                break
+        if problem:
+            reasons.append(f"{layout}: {problem}")
+        else:
+            valid.append((layout, offsets))
+    out.stages["target_valid_pairs"] = [{"layout": l, "offsets": list(o)} for l, o in valid]
+    if not valid:
+        return out.fail(H1[4], 0, "; ".join(reasons))
+    out.ok(H1[4], len(valid))
+    layouts = sorted({l for l, _ in valid}, key=LOCATOR_LAYOUTS.index)
+    if len(layouts) > 1:
+        return out.fail(H1[5], len(layouts), "target-valid pairs under more than one layout")
+    out.ok(H1[5], 1)
+    pairs = [o for l, o in valid if l == layouts[0]]
+    if len(pairs) > 1:
+        return out.fail(H1[6], len(pairs), "more than one target-valid pair under the unique layout")
+    out.ok(H1[6], 1)
+    layout, offsets = layouts[0], pairs[0]
+    model = {"layout": layout, "table_record_signature_id": SIGNATURE_ID, "locator_offsets": list(offsets),
+             "tdef_lifecycle_signature": signature}
+    out.model = {"model_type": "h1_locator_model", "model": model, "canonical_model_id": canonical_id({"model_type": "h1_locator_model", "model": model})}
+    for inst in INSTANCES:
+        page_bytes = ctx.page(replica, inst.create_checkpoint, pages[inst.id]) or b""
+        out.bindings[inst.id] = {"logical_role": inst.role, "lifecycle_instance": inst.id, "tdef_page": pages[inst.id],
+                                 "targets": [list(target_of(page_bytes, o, layout)) for o in offsets],
+                                 "applicable_checkpoint_range": [inst.create_checkpoint, inst.last_checkpoint]}
+    out.model["canonical_candidate_id"] = canonical_id({**out.model, "instance_bindings": out.bindings})
+    return out
+
+
+def holdout(ctx: Context, replica: int, frozen: dict[str, Any]) -> tuple[bool, str, dict[str, Any]]:
+    """Apply the unchanged H1 model to the holdout replica and re-derive its bindings."""
+    model = frozen["model"]
+    layout, offsets, signature = model["layout"], tuple(model["locator_offsets"]), model["tdef_lifecycle_signature"]
+    qualified = sorted(qualified_tag02_pages(ctx, replica))
+    bindings: dict[str, Any] = {}
+    for inst in INSTANCES:
+        pages = [p for p in qualified if tdef_matches(ctx, replica, inst, p, signature)]
+        if len(pages) != 1:
+            return False, f"{inst.id}: {len(pages)} lifecycle-matching TDEF pages", bindings
+        page = pages[0]
+        for cp in inst.checkpoints:
+            blob = ctx.page(replica, cp, page) or b""
+            if not signature_matches(blob):
+                return False, f"{inst.id}: signature mismatch at {cp}", bindings
+            problem = targets_valid(ctx, replica, blob, cp, offsets, layout)
+            if problem:
+                return False, f"{inst.id}: {problem}", bindings
+        first = ctx.page(replica, inst.create_checkpoint, page) or b""
+        preserved = all(target_of(ctx.page(replica, cp, page) or b"", o, layout) == target_of(first, o, layout)
+                        for cp in inst.checkpoints for o in offsets)
+        if not preserved:
+            return False, f"{inst.id}: locator identity not preserved", bindings
+        bindings[inst.id] = {"logical_role": inst.role, "lifecycle_instance": inst.id, "tdef_page": page,
+                             "targets": [list(target_of(first, o, layout)) for o in offsets],
+                             "applicable_checkpoint_range": [inst.create_checkpoint, inst.last_checkpoint]}
+    return True, "", bindings

--- a/oracle/windows-dao/scripts/a4_dryrun_h2.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h2.py
@@ -3,7 +3,7 @@
 
 A4 rule | implementation
 --- | ---
-Complete SRC-0020 directory validation under both offset masks, byte-identical masks merged | :func:`locate_rows`
+Complete checked row-directory validation under both offset masks, byte-identical masks merged | :func:`locate_rows`
 Deleted/overflow flags explicit | :func:`evaluate_replica`
 Tag 00/01 with type-1 payload divisible by four | :func:`evaluate_replica`
 Static role/polarity fit (AMB-05) then registered transition signatures (AMB-07) | :func:`static_fit`, :func:`transitions_hold`

--- a/oracle/windows-dao/scripts/a4_dryrun_h2.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h2.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""A4-H2 (row identity and map role) reference evaluation per derivation replica.
+
+A4 rule | implementation
+--- | ---
+Complete SRC-0020 directory validation under both offset masks, byte-identical masks merged | :func:`locate_rows`
+Deleted/overflow flags explicit | :func:`evaluate_replica`
+Tag 00/01 with type-1 payload divisible by four | :func:`evaluate_replica`
+Static role/polarity fit (AMB-05) then registered transition signatures (AMB-07) | :func:`static_fit`, :func:`transitions_hold`
+H2 holdout: unchanged model re-applied to replica 3 | :func:`holdout`
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a4_dryrun_core import Context
+from a4_dryrun_h1 import ReplicaLayer
+from a4_pages import MapRow, Slot, decode_directory, decode_map_row, validate_directory
+from a4_spec import (
+    EVENT_BY_CHECKPOINT, INSTANCES, Instance, LAYER_PREDICATES, POLARITIES, ROLE_ASSIGNMENTS, ROW_MASKS, canonical_id,
+)
+
+H2 = LAYER_PREDICATES["h2_row_identity_map_role"]
+Located = dict[tuple[str, str], list[tuple[Slot, bytes]]]  # (instance, checkpoint) -> [(slot, row bytes)] per locator ordinal
+
+
+def locate_rows(ctx: Context, replica: int, bindings: dict[str, Any], mask: int) -> tuple[Located | None, str]:
+    located: Located = {}
+    for inst in INSTANCES:
+        binding = bindings[inst.id]
+        for cp in inst.checkpoints:
+            rows = []
+            for target_page, row in binding["targets"]:
+                page = ctx.page(replica, cp, target_page) or b""
+                slots = decode_directory(page, mask)
+                ctx.charges.add("valid_path_row_directory_entries", len(slots))
+                problem = validate_directory(slots)
+                if problem:
+                    return None, f"{inst.id} page {target_page} at {cp}: {problem}"
+                slot = slots[row]
+                rows.append((slot, page[slot.start: slot.end]))
+            located[(inst.id, cp)] = rows
+    return located, ""
+
+
+def owned_available(rows: list[tuple[Slot, bytes]], assignment: str) -> tuple[bytes, bytes]:
+    owned_ordinal = 0 if assignment == ROLE_ASSIGNMENTS[0] else 1
+    return rows[owned_ordinal][1], rows[1 - owned_ordinal][1]
+
+
+def decode_sets(row: bytes, polarity: str, ctx: Context) -> set[int] | None:
+    decoded = decode_map_row(row)
+    if isinstance(decoded, str) or decoded.kind != 0:
+        return None
+    ctx.charges.add("type_0_and_tag_05_bitmap_bits", len(decoded.bitmap) * 8)
+    return decoded.type0_pages(polarity)
+
+
+def static_fit(ctx: Context, replica: int, located: Located, polarity: str, assignment: str) -> str | None:
+    for (inst_id, cp), rows in located.items():
+        owned_row, available_row = owned_available(rows, assignment)
+        owned = decode_sets(owned_row, polarity, ctx)
+        available = decode_sets(available_row, polarity, ctx)
+        limit = ctx.page_count(replica, cp)
+        if owned is not None:
+            if not owned:
+                return f"{inst_id} at {cp}: owned/in-use set is empty"
+            if max(owned) >= limit:
+                return f"{inst_id} at {cp}: owned/in-use admits page beyond page_count"
+        if available is not None:
+            if available and max(available) >= limit:
+                return f"{inst_id} at {cp}: available admits page beyond page_count"
+            if owned is not None and not available <= owned:
+                return f"{inst_id} at {cp}: available set is not within the owned set"
+    return None
+
+
+def transitions_hold(ctx: Context, located: Located, polarity: str, assignment: str, instances: tuple[Instance, ...] = INSTANCES) -> str | None:
+    for inst in instances:
+        cps = inst.checkpoints
+        for before, after in zip(cps, cps[1:]):
+            event = EVENT_BY_CHECKPOINT[after]
+            ctx.charges.add("role_transition_evaluations")
+            rows_before, rows_after = located[(inst.id, before)], located[(inst.id, after)]
+            if event.kind == "idle":
+                if [r[1] for r in rows_before] != [r[1] for r in rows_after]:
+                    return f"{inst.id} {before}->{after}: rows differ across an idle leg"
+                continue
+            if event.role != inst.role or event.kind not in ("grow", "delete_all", "reinsert"):
+                continue
+            o_row_b, a_row_b = owned_available(rows_before, assignment)
+            o_row_a, a_row_a = owned_available(rows_after, assignment)
+            o_b, o_a = decode_sets(o_row_b, polarity, ctx), decode_sets(o_row_a, polarity, ctx)
+            a_b, a_a = decode_sets(a_row_b, polarity, ctx), decode_sets(a_row_a, polarity, ctx)
+            if None in (o_b, o_a, a_b, a_a):
+                continue  # type-1 side: admitted set needs the H3 traversal (AMB-05)
+            assert o_b is not None and o_a is not None and a_b is not None and a_a is not None
+            leg = f"{inst.id} {before}->{after} ({event.kind})"
+            if event.kind == "grow":
+                if not o_b <= o_a:
+                    return f"{leg}: owned/in-use removed pages {sorted(o_b - o_a)[:4]}"
+                if (a_a - a_b) & (o_a - o_b):
+                    return f"{leg}: available added pages the owned set gained"
+            elif event.kind == "delete_all":
+                changes = (o_b ^ o_a) | (a_b ^ a_a)
+                if not o_a <= o_b or not a_b <= a_a or not changes <= o_b:
+                    return f"{leg}: delete_all signature violated"
+            else:
+                changes = (o_b ^ o_a) | (a_b ^ a_a)
+                if not o_b <= o_a or not a_a <= a_b or not changes <= (o_b | o_a):
+                    return f"{leg}: reinsert signature violated"
+    return None
+
+
+def _mask_models(ctx: Context, replica: int, bindings: dict[str, Any]) -> tuple[list[tuple[list[int], Located]], str]:
+    """Valid masks grouped into canonical models with byte-identical complete bounds (ambiguity_rule)."""
+    models: list[tuple[list[int], Located]] = []
+    last_problem = ""
+    for mask in ROW_MASKS:
+        located, problem = locate_rows(ctx, replica, bindings, mask)
+        if located is None:
+            last_problem = problem
+            continue
+        bounds = {k: [(s.start, s.end) for s, _ in v] for k, v in located.items()}
+        for members, existing in models:
+            if {k: [(s.start, s.end) for s, _ in v] for k, v in existing.items()} == bounds:
+                members.append(mask)
+                break
+        else:
+            models.append(([mask], located))
+    return models, last_problem
+
+
+def evaluate_replica(ctx: Context, replica: int, bindings: dict[str, Any]) -> ReplicaLayer:
+    out = ReplicaLayer()
+    mask_models, problem = _mask_models(ctx, replica, bindings)
+    if not mask_models:
+        return out.fail(H2[0], 1, problem)
+    out.ok(H2[0], len(mask_models))
+    flagged = [(k, s.ordinal) for _, located in mask_models for k, rows in located.items() for s, _ in rows if s.deleted or s.overflow]
+    if flagged:
+        return out.fail(H2[1], 1, f"located row has deleted/overflow set: {flagged[0]}")
+    out.ok(H2[1], 1)
+    for _, located in mask_models:
+        for key, rows in located.items():
+            for _, row in rows:
+                decoded = decode_map_row(row)
+                if isinstance(decoded, str):
+                    return out.fail(H2[2], 1, f"{key}: {decoded}")
+                if decoded.kind == 1:
+                    ctx.charges.add("type_1_slots", len(decoded.slots))
+    out.ok(H2[2], 1)
+
+    candidates = []
+    reasons = []
+    for members, located in mask_models:
+        for polarity in POLARITIES:
+            for assignment in ROLE_ASSIGNMENTS:
+                problem = static_fit(ctx, replica, located, polarity, assignment)
+                if problem:
+                    reasons.append(f"{polarity}/{assignment}: {problem}")
+                else:
+                    candidates.append((members, polarity, assignment, located))
+    out.stages["static_role_candidates"] = [{"row_masks": m, "polarity": p, "assignment": a} for m, p, a, _ in candidates]
+    if not candidates:
+        return out.fail(H2[3], 0, "; ".join(reasons[:2]))
+    out.ok(H2[3], len(candidates))
+    if len(candidates) > 1:
+        return out.fail(H2[4], len(candidates), "multiple static role/polarity/mask candidates")
+    out.ok(H2[4], 1)
+    members, polarity, assignment, located = candidates[0]
+    problem = transitions_hold(ctx, located, polarity, assignment)
+    if problem:
+        return out.fail(H2[5], 1, problem)
+    out.ok(H2[5], 1)
+    model = {"row_masks": members, "polarity": polarity, "locator_role_assignment": assignment}
+    out.model = {"model_type": "h2_role_model", "model": model, "canonical_model_id": canonical_id({"model_type": "h2_role_model", "model": model})}
+    out.bindings = {"located": located}
+    return out
+
+
+def holdout(ctx: Context, replica: int, frozen: dict[str, Any], bindings: dict[str, Any]) -> tuple[bool, str, Located | None]:
+    model = frozen["model"]
+    located, problem = locate_rows(ctx, replica, bindings, model["row_masks"][0])
+    if located is None:
+        return False, problem, None
+    flagged = [k for k, rows in located.items() for s, _ in rows if s.deleted or s.overflow]
+    if flagged:
+        return False, f"flagged row at {flagged[0]}", located
+    for key, rows in located.items():
+        for _, row in rows:
+            decoded = decode_map_row(row)
+            if isinstance(decoded, str):
+                return False, f"{key}: {decoded}", located
+    problem = static_fit(ctx, replica, located, model["polarity"], model["locator_role_assignment"]) or transitions_hold(
+        ctx, located, model["polarity"], model["locator_role_assignment"])
+    return (problem is None), problem or "", located
+
+
+def owned_rows(located: Located, assignment: str) -> dict[tuple[str, str], MapRow]:
+    """Decoded owned/in-use map row per (instance, checkpoint) for the H3 layer."""
+    out = {}
+    for key, rows in located.items():
+        decoded = decode_map_row(owned_available(rows, assignment)[0])
+        if not isinstance(decoded, str):
+            out[key] = decoded
+    return out

--- a/oracle/windows-dao/scripts/a4_dryrun_h3.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h3.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""A4-H3 (indirect traversal) reference evaluation per derivation replica.
+
+A4 rule | implementation
+--- | ---
+Structural type-0 -> type-1 conversion with a nonzero u32 slot, no tag test | :func:`conversions`
+Zero slot inactive, nonzero slot an exact tag-05 reference | :func:`evaluate_replica`
+Input-region coverage before formula fitting (AMB-08) | :func:`regions`
+Four registered base formulas fitted by containment/transition signatures on decoded sets | :func:`formula_fits`
+H3 holdout: unchanged formula re-applied to replica 3 | :func:`holdout`
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a4_dryrun_core import Context
+from a4_dryrun_h1 import ReplicaLayer
+from a4_pages import TAG_EXTENDED, MapRow, absolute_page, tag05_bits
+from a4_spec import (
+    BASE_FORMULAS, CONVERSIONS, EVENT_BY_CHECKPOINT, INSTANCES, LAYER_PREDICATES, TAG05_BITS, canonical_id,
+)
+
+H3 = LAYER_PREDICATES["h3_indirect_traversal"]
+Owned = dict[tuple[str, str], MapRow]
+REGION_NAMES = ("inactive_slot", "active_slot", "bit_index_zero", "bit_index_nonzero", "boundary_last_bit", "boundary_next_slot_first_bit")
+
+
+def conversions(owned: Owned) -> list[tuple[str, str, str]]:
+    out = []
+    for inst in INSTANCES:
+        cps = inst.checkpoints
+        for before, after in zip(cps, cps[1:]):
+            a, b = owned.get((inst.id, before)), owned.get((inst.id, after))
+            if a is not None and b is not None and a.kind == 0 and b.kind == 1 and any(b.slots):
+                out.append((inst.id, before, after))
+    return out
+
+
+def _bits(ctx: Context, replica: int, cp: str, page: int) -> list[int] | None:
+    blob = ctx.page(replica, cp, page)
+    if blob is None or blob[0] != TAG_EXTENDED:
+        return None
+    ctx.charges.add("type_0_and_tag_05_bitmap_bits", TAG05_BITS)
+    return tag05_bits(blob)
+
+
+def invalid_reference(ctx: Context, replica: int, owned: Owned) -> str | None:
+    for (inst_id, cp), row in owned.items():
+        if row.kind != 1:
+            continue
+        for ordinal, reference in enumerate(row.slots):
+            if reference == 0:
+                continue
+            ctx.charges.add("type_1_slots")
+            tag = ctx.tag(replica, cp, reference)
+            if tag is None:
+                return f"{inst_id} at {cp}: slot {ordinal} references page {reference} beyond page_count"
+            if tag != TAG_EXTENDED:
+                return f"{inst_id} at {cp}: slot {ordinal} references page {reference} with tag {tag:02x}"
+    return None
+
+
+def regions(ctx: Context, replica: int, owned: Owned) -> dict[str, bool]:
+    seen = {name: False for name in REGION_NAMES}
+    for (_, cp), row in owned.items():
+        if row.kind != 1:
+            continue
+        for ordinal, reference in enumerate(row.slots):
+            if reference == 0:
+                seen["inactive_slot"] = True
+                continue
+            seen["active_slot"] = True
+            bits = _bits(ctx, replica, cp, reference) or []
+            if 0 in bits:
+                seen["bit_index_zero"] = True
+            if any(b > 0 for b in bits):
+                seen["bit_index_nonzero"] = True
+            following = row.slots[ordinal + 1] if ordinal + 1 < len(row.slots) else 0
+            if following:
+                if TAG05_BITS - 1 in bits:
+                    seen["boundary_last_bit"] = True
+                if 0 in (_bits(ctx, replica, cp, following) or []):
+                    seen["boundary_next_slot_first_bit"] = True
+    return seen
+
+
+def admitted(ctx: Context, replica: int, cp: str, row: MapRow, polarity: str, formula: str) -> set[int]:
+    if row.kind == 0:
+        return row.type0_pages(polarity)
+    out: set[int] = set()
+    for ordinal, reference in enumerate(row.slots):
+        if reference:
+            for bit in _bits(ctx, replica, cp, reference) or []:
+                out.add(absolute_page(formula, ordinal, reference, bit))
+    return out
+
+
+def formula_fits(ctx: Context, replica: int, owned: Owned, polarity: str, formula: str) -> str | None:
+    for inst in INSTANCES:
+        cps = inst.checkpoints
+        sets = {}
+        for cp in cps:
+            row = owned.get((inst.id, cp))
+            if row is None:
+                return f"{inst.id} at {cp}: no located owned row"
+            ctx.charges.add("base_formula_evaluations")
+            sets[cp] = admitted(ctx, replica, cp, row, polarity, formula)
+        for before, after in zip(cps, cps[1:]):
+            a, b = owned[(inst.id, before)], owned[(inst.id, after)]
+            event = EVENT_BY_CHECKPOINT[after]
+            leg = f"{inst.id} {before}->{after}"
+            if a.kind == 0 and b.kind == 1:
+                if not sets[before] <= sets[after]:
+                    return f"{leg}: conversion drops pages {sorted(sets[before] - sets[after])[:4]}"
+            elif a.kind == 1 and b.kind == 1:
+                if event.kind == "idle" and sets[before] != sets[after]:
+                    return f"{leg}: idle leg changes the admitted set"
+                if event.role != inst.role:
+                    continue
+                if event.kind in ("grow", "reinsert") and not sets[before] <= sets[after]:
+                    return f"{leg}: {event.kind} removes admitted pages"
+                if event.kind == "delete_all" and not sets[after] <= sets[before]:
+                    return f"{leg}: delete_all adds admitted pages"
+    return None
+
+
+def evaluate_replica(ctx: Context, replica: int, owned: Owned, polarity: str) -> ReplicaLayer:
+    out = ReplicaLayer()
+    found = conversions(owned)
+    out.stages["conversions"] = [{"instance": i, "before": b, "after": a} for i, b, a in found]
+    if not found:
+        return out.fail(H3[0], 0, "no structural type-0 to type-1 transition with a nonzero slot")
+    out.ok(H3[0], 1)
+    type1 = [row for row in owned.values() if row.kind == 1]
+    if not any(0 in row.slots for row in type1):
+        return out.fail(H3[1], 1, "every observed slot is nonzero")
+    out.ok(H3[1], 1)
+    problem = invalid_reference(ctx, replica, owned)
+    if problem:
+        return out.fail(H3[2], 1, problem)
+    out.ok(H3[2], 1)
+    seen = regions(ctx, replica, owned)
+    out.stages["input_regions"] = seen
+    missing = [name for name, ok in seen.items() if not ok]
+    if missing:
+        return out.fail(H3[3], 1, f"unexercised input regions: {missing}")
+    out.ok(H3[3], 1)
+    fitting, reasons = [], []
+    for formula in BASE_FORMULAS:
+        problem = formula_fits(ctx, replica, owned, polarity, formula)
+        (reasons if problem else fitting).append(problem or formula)
+    out.stages["fitting_formulas"] = list(fitting)
+    if not fitting:
+        return out.fail(H3[4], 0, "; ".join(reasons[:2]))
+    out.ok(H3[4], len(fitting))
+    if len(fitting) > 1:
+        return out.fail(H3[5], len(fitting), "more than one base formula fits")
+    out.ok(H3[5], 1)
+    model = {"conversion_candidate": CONVERSIONS[0], "base_formula": fitting[0], "tag_05_bitmap_polarity": "set_bit_owned_in_use"}
+    out.model = {"model_type": "h3_traversal_model", "model": model, "canonical_model_id": canonical_id({"model_type": "h3_traversal_model", "model": model})}
+    return out
+
+
+def holdout(ctx: Context, replica: int, frozen: dict[str, Any], owned: Owned, polarity: str) -> tuple[bool, str]:
+    if not any(row.kind == 1 for row in owned.values()):
+        ctx.notes.append("H3 holdout: replica 3 exposes no type-1 owned row; frozen formula vacuously confirmed (AMB-14)")
+        return True, ""
+    problem = invalid_reference(ctx, replica, owned) or formula_fits(ctx, replica, owned, polarity, frozen["model"]["base_formula"])
+    return problem is None, problem or ""

--- a/oracle/windows-dao/scripts/a4_dryrun_h4.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h4.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""A4-H4 (catalog bootstrap) reference evaluation per derivation replica.
+
+A4 rule | implementation
+--- | ---
+System TDEFs are EMPTY tag-02 pages traversed with the frozen H1/H2/H3 models without refit | :func:`traverse`
+Root selection by operation deltas only (AMB-09) | :func:`root_candidates`
+SCHEMA-DELTA-OUTSIDE-OWNED before record restriction (AMB-10) | :func:`isolated_delta_outside`
+One operation-delta record per instance on admitted tag-01 pages | :func:`delta_records`
+Encoding-neutral union name anchor, bounded kind/id/length tuples, kind mapping, lifecycle relation | :func:`structural_candidates`
+Observational dedup (AMB-12) and structural length plausibility (AMB-11) | :func:`structural_candidates`
+Three encoding/length equivalence classes after one structural model | :func:`fitting_classes`
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Any
+
+from a4_dryrun_core import Context
+from a4_dryrun_h1 import ReplicaLayer, target_of
+from a4_dryrun_h2 import owned_available
+from a4_dryrun_h3 import admitted
+from a4_pages import TAG_DATA, TAG_TDEF, decode_directory, decode_map_row, row_count, validate_directory
+from a4_spec import (
+    CHECKPOINTS, ENDIANNESS, FIELD_DELTA_RANGE, ID_WIDTHS, INSTANCE_BY_ID, KIND_WIDTHS, LAYER_PREDICATES, LENGTH_CLASSES,
+    LIFECYCLE_RELATIONS, OPERATION_INSTANCES, ORDINAL, ROOT_SIGNATURES, canonical_id, expected_name, name_bytes,
+)
+
+H4 = LAYER_PREDICATES["h4_catalog_bootstrap"]
+OP_CHECKPOINTS = tuple(cp for cp, _, _ in OPERATION_INSTANCES)
+OP_KIND = {cp: kind for cp, _, kind in OPERATION_INSTANCES}
+OP_INSTANCE = {cp: inst for cp, inst, _ in OPERATION_INSTANCES}
+CLASS_ENCODING = {c["id"]: ("strict_windows_1252" if c["id"].startswith("cp1252") else "utf_8") for c in LENGTH_CLASSES}
+Models = dict[str, Any]
+
+
+def traverse(ctx: Context, replica: int, page: int, models: Models) -> dict[str, set[int]] | str:
+    """Admitted owned/in-use page set per checkpoint for a system TDEF under the frozen models."""
+    h1, h2, h3 = models["h1"]["model"], models["h2"]["model"], models["h3"]["model"]
+    out: dict[str, set[int]] = {}
+    for cp in CHECKPOINTS:
+        blob = ctx.page(replica, cp, page)
+        if blob is None or blob[0] != TAG_TDEF:
+            return f"page {page} is not tag 02 at {cp}"
+        targets = [target_of(blob, o, h1["layout"]) for o in h1["locator_offsets"]]
+        rows = []
+        for target_page, row in targets:
+            target = ctx.page(replica, cp, target_page)
+            if target is None or target[0] != TAG_DATA or row >= row_count(target):
+                return f"page {page} locator target ({target_page},{row}) invalid at {cp}"
+            slots = decode_directory(target, h2["row_masks"][0])
+            if validate_directory(slots):
+                return f"page {page} target directory invalid at {cp}"
+            slot = slots[row]
+            rows.append((slot, target[slot.start: slot.end]))
+        decoded = decode_map_row(owned_available(rows, h2["locator_role_assignment"])[0])
+        if isinstance(decoded, str):
+            return f"page {page}: {decoded} at {cp}"
+        out[cp] = admitted(ctx, replica, cp, decoded, h2["polarity"], h3["base_formula"])
+    return out
+
+
+def stream_changes(ctx: Context, replica: int, admitted_by_cp: dict[str, set[int]], cp: str) -> bool:
+    previous = ctx.predecessor(cp) or cp
+    if admitted_by_cp[previous] != admitted_by_cp[cp]:
+        return True
+    return bool((admitted_by_cp[cp] | admitted_by_cp[previous]) & ctx.changed_pages(replica, cp))
+
+
+def root_candidates(ctx: Context, replica: int, models: Models) -> tuple[list[tuple[int, dict[str, set[int]]]], list[str]]:
+    found, reasons = [], []
+    empty_count = ctx.page_count(replica, CHECKPOINTS[0])
+    for page in range(empty_count):
+        if ctx.tag(replica, CHECKPOINTS[0], page) != TAG_TDEF:
+            continue
+        ctx.charges.add("catalog_root_signatures", len(OP_CHECKPOINTS))
+        traversal = traverse(ctx, replica, page, models)
+        if isinstance(traversal, str):
+            reasons.append(traversal)
+            continue
+        if any(stream_changes(ctx, replica, traversal, cp) for cp in OP_CHECKPOINTS):
+            found.append((page, traversal))
+        else:
+            reasons.append(f"page {page}: admitted stream follows no listed operation")
+    return found, reasons
+
+
+def isolated_delta_outside(ctx: Context, replica: int, admitted_by_cp: dict[str, set[int]], h1_bindings: dict[str, Any]) -> str | None:
+    for cp in OP_CHECKPOINTS:
+        explained: set[int] = set()
+        for inst_id, binding in h1_bindings.items():
+            inst = INSTANCE_BY_ID[inst_id]
+            if cp in inst.checkpoints:
+                explained.add(binding["tdef_page"])
+                explained.update(p for p, _ in binding["targets"])
+        outside = (ctx.changed_pages(replica, cp) - explained) - admitted_by_cp[cp]
+        if outside:
+            return f"{cp}: schema delta on non-admitted page(s) {sorted(outside)[:4]}"
+    return None
+
+
+def _complete_rows(ctx: Context, replica: int, cp: str, page: int, mask: int) -> dict[int, bytes] | None:
+    blob = ctx.page(replica, cp, page)
+    if blob is None or blob[0] != TAG_DATA:
+        return None
+    slots = decode_directory(blob, mask)
+    if validate_directory(slots):
+        return None
+    return {s.ordinal: blob[s.start: s.end] for s in slots if not (s.deleted or s.overflow)}
+
+
+def delta_records(ctx: Context, replica: int, admitted_by_cp: dict[str, set[int]], mask: int) -> dict[str, list[tuple[int, int, bytes]]]:
+    """Per operation: complete rows on admitted tag-01 pages that are new or changed at that transition."""
+    out: dict[str, list[tuple[int, int, bytes]]] = {}
+    for cp in OP_CHECKPOINTS:
+        previous = ctx.predecessor(cp) or cp
+        found = []
+        for page in sorted(admitted_by_cp[cp]):
+            rows = _complete_rows(ctx, replica, cp, page, mask)
+            if rows is None:
+                continue
+            before = _complete_rows(ctx, replica, previous, page, mask) or {}
+            for ordinal, row in rows.items():
+                ctx.charges.add("catalog_raw_rows")
+                if before.get(ordinal) != row:
+                    found.append((page, ordinal, row))
+        out[cp] = found
+    return out
+
+
+def _decode(row: bytes, start: int, width: int, endianness: str) -> int:
+    return int.from_bytes(row[start: start + width], "little" if endianness == "little" else "big")
+
+
+def _occurrences(ctx: Context, replica: int, cp: str, row: bytes) -> list[tuple[int, str, bytes]]:
+    patterns: dict[bytes, str] = {}
+    for encoding_id, pattern in name_bytes(expected_name(replica, cp)).items():
+        patterns.setdefault(pattern, encoding_id)
+    ctx.charges.add("encoding_union_anchor_bytes", len(row) * len(patterns))
+    return [(o, encoding_id, pattern) for pattern, encoding_id in patterns.items()
+            for o in range(len(row) - len(pattern) + 1) if row[o: o + len(pattern)] == pattern]
+
+
+def plausible_lengths(name: str) -> set[int]:
+    """Counts some registered encoding/length class could report for this name (encoding-neutral union)."""
+    return {len(b) for b in name_bytes(name).values()} | {len(name)}
+
+
+def _row_at(ctx: Context, replica: int, cp: str, page: int, ordinal: int, mask: int) -> bytes | None:
+    rows = _complete_rows(ctx, replica, cp, page, mask)
+    return None if rows is None else rows.get(ordinal)
+
+
+def _tuples():
+    for dk, wk, wid, e, dl, wl, el in product(FIELD_DELTA_RANGE, KIND_WIDTHS, ID_WIDTHS, ENDIANNESS, FIELD_DELTA_RANGE, KIND_WIDTHS, ENDIANNESS):
+        yield {"kind_start_delta": dk, "kind_width": wk, "identifier_width": wid, "endianness": e,
+               "name_length_start_delta": dl, "name_length_width": wl, "name_length_endianness": el}
+
+
+def _fields(t: dict[str, int | str], o: int, name_len: int, row_len: int) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int]] | None:
+    kind = (o - int(t["kind_start_delta"]), o - int(t["kind_start_delta"]) + int(t["kind_width"]))
+    ident = (kind[0] - int(t["identifier_width"]), kind[0])
+    length = (o - int(t["name_length_start_delta"]), o - int(t["name_length_start_delta"]) + int(t["name_length_width"]))
+    spans = [kind, ident, length, (o, o + name_len)]
+    if any(a < 0 or b > row_len for a, b in spans):
+        return None
+    ordered = sorted(spans)
+    if any(ordered[i][1] > ordered[i + 1][0] for i in range(3)):
+        return None
+    return kind, ident, length
+
+
+def structural_candidates(ctx: Context, replica: int, records: dict[str, tuple[int, int, bytes]], mask: int) -> tuple[list[dict[str, Any]], list[str]]:
+    """Canonical structural field models after kind-mapping and identifier-lifecycle tests."""
+    occurrences = {cp: _occurrences(ctx, replica, cp, records[cp][2]) for cp in OP_CHECKPOINTS}
+    if any(not v for v in occurrences.values()):
+        return [], [f"{cp}: no registered expected-name occurrence" for cp, v in occurrences.items() if not v]
+    later: dict[str, list[str]] = {cp: [c for c in INSTANCE_BY_ID[OP_INSTANCE[cp]].checkpoints if ORDINAL[c] > ORDINAL[cp]] for cp in OP_CHECKPOINTS}
+    survivors: dict[str, dict[str, Any]] = {}
+    reasons: dict[str, int] = {}
+
+    def note(reason: str) -> None:
+        reasons[reason] = reasons.get(reason, 0) + 1
+
+    for t in _tuples():
+        per_op: dict[str, list[dict[str, Any]]] = {}
+        dead = False
+        for cp in OP_CHECKPOINTS:
+            page, ordinal, row = records[cp]
+            compatible = []
+            for o, encoding_id, pattern in occurrences[cp]:
+                ctx.charges.add("h4_name_length_structural_tuples")
+                fields = _fields(t, o, len(pattern), len(row))
+                if fields is None:
+                    continue
+                kind_span, id_span, len_span = fields
+                length = _decode(row, len_span[0], len_span[1] - len_span[0], str(t["name_length_endianness"]))
+                if length not in plausible_lengths(expected_name(replica, cp)):
+                    continue  # AMB-11 structural length plausibility
+                compatible.append({"name_start": o, "encoding_id": encoding_id, "bytes": pattern, "length": length,
+                                   "kind": _decode(row, kind_span[0], kind_span[1] - kind_span[0], str(t["endianness"])),
+                                   "identifier": _decode(row, id_span[0], id_span[1] - id_span[0], str(t["endianness"])),
+                                   "id_span": id_span})
+            if not compatible or len({(c["kind"], c["identifier"]) for c in compatible}) != 1:
+                dead = True
+                note("no compatible occurrence or disagreeing kind/id within one record")
+                break
+            per_op[cp] = compatible
+        if dead:
+            continue
+        kinds = {cp: per_op[cp][0]["kind"] for cp in OP_CHECKPOINTS}
+        table_values = {kinds[cp] for cp in OP_CHECKPOINTS if OP_KIND[cp] == "table"}
+        field_value = next(kinds[cp] for cp in OP_CHECKPOINTS if OP_KIND[cp] == "field")
+        index_value = next(kinds[cp] for cp in OP_CHECKPOINTS if OP_KIND[cp] == "index")
+        if len(table_values) != 1 or len({next(iter(table_values)), field_value, index_value}) != 3:
+            note("kind mapping")
+            continue
+        mapping = {"table": next(iter(table_values)), "field": field_value, "index": index_value}
+        ids = {cp: per_op[cp][0]["identifier"] for cp in OP_CHECKPOINTS}
+        stable = True
+        for cp in OP_CHECKPOINTS:
+            page, ordinal, _ = records[cp]
+            span = per_op[cp][0]["id_span"]
+            for c in later[cp]:
+                row = _row_at(ctx, replica, c, page, ordinal, mask)
+                if row is None or len(row) < span[1] or _decode(row, span[0], span[1] - span[0], str(t["endianness"])) != ids[cp]:
+                    stable = False
+                    break
+            if not stable:
+                break
+        if not stable:
+            note("identifier not stable across later checkpoints")
+            continue
+        distinct = True
+        for c in CHECKPOINTS:
+            extant = [ids[cp] for cp in OP_CHECKPOINTS if c in INSTANCE_BY_ID[OP_INSTANCE[cp]].checkpoints and ORDINAL[c] >= ORDINAL[cp]]
+            if len(extant) != len(set(extant)):
+                distinct = False
+                break
+        if not distinct:
+            note("simultaneously extant identifiers are not distinct")
+            continue
+        relation = LIFECYCLE_RELATIONS[1] if ids["T2_CREATE"] == ids["T2_RECREATE"] else LIFECYCLE_RELATIONS[0]
+        vector = canonical_id({cp: [(c["kind"], c["identifier"], c["length"], c["name_start"]) for c in per_op[cp]] for cp in OP_CHECKPOINTS})
+        entry = survivors.setdefault(vector, {"members": [], "kind_mapping": mapping, "identifier_lifecycle_relation": relation,
+                                              "operation_bindings": {cp: {"page": records[cp][0], "slot": records[cp][1],
+                                                                          "compatible_name_occurrences": per_op[cp]} for cp in OP_CHECKPOINTS}})
+        entry["members"].append(t)
+        ctx.charges.add("candidate_serializations")
+    return list(survivors.values()), [f"{k} x{v}" for k, v in reasons.items()]
+
+
+def fitting_classes(candidate: dict[str, Any], replica: int) -> list[str]:
+    fits = []
+    for cls in LENGTH_CLASSES:
+        encoding = CLASS_ENCODING[cls["id"]]
+        ok = True
+        for cp in OP_CHECKPOINTS:
+            name = expected_name(replica, cp)
+            expected = name_bytes(name)[encoding]
+            lengths = {len(expected) if m == "encoded_byte_count" else len(name) for m in cls["members"]}
+            occurrences = candidate["operation_bindings"][cp]["compatible_name_occurrences"]
+            if not any(c["bytes"] == expected and c["length"] in lengths for c in occurrences):
+                ok = False
+                break
+        if ok:
+            fits.append(cls["id"])
+    return fits
+
+
+def canonical_field_model(candidate: dict[str, Any], encoding_class: str | None) -> dict[str, Any]:
+    model = {"field_tuple_members": sorted(candidate["members"], key=lambda m: tuple(m.values())),
+             "kind_mapping": candidate["kind_mapping"], "identifier_lifecycle_relation": candidate["identifier_lifecycle_relation"]}
+    if encoding_class is not None:
+        model["encoding_length_equivalence_class"] = encoding_class
+    return model
+
+
+def evaluate_replica(ctx: Context, replica: int, models: Models, h1_bindings: dict[str, Any]) -> ReplicaLayer:
+    out = ReplicaLayer()
+    roots, reasons = root_candidates(ctx, replica, models)
+    out.stages["root_candidates"] = [p for p, _ in roots]
+    if not roots:
+        return out.fail(H4[0], 0, "; ".join(reasons[:2]))
+    out.ok(H4[0], len(roots))
+    if len(roots) > 1:
+        return out.fail(H4[1], len(roots), "multiple system streams follow the operation deltas")
+    out.ok(H4[1], 1)
+    root_page, admitted_by_cp = roots[0]
+    problem = isolated_delta_outside(ctx, replica, admitted_by_cp, h1_bindings)
+    if problem:
+        return out.fail(H4[2], 1, problem)
+    out.ok(H4[2], 1)
+    mask = models["h2"]["model"]["row_masks"][0]
+    records = delta_records(ctx, replica, admitted_by_cp, mask)
+    counts = {cp: len(v) for cp, v in records.items()}
+    out.stages["record_counts"] = counts
+    empty = [cp for cp, n in counts.items() if n == 0]
+    if empty:
+        return out.fail(H4[3], 0, f"no operation-delta record for {empty}")
+    out.ok(H4[3], 1)
+    many = [cp for cp, n in counts.items() if n > 1]
+    if many:
+        return out.fail(H4[4], max(counts[cp] for cp in many), f"multiple operation-delta records for {many}")
+    out.ok(H4[4], 1)
+    candidates, reasons = structural_candidates(ctx, replica, {cp: v[0] for cp, v in records.items()}, mask)
+    out.stages["structural_field_models"] = [canonical_field_model(c, None) for c in candidates]
+    if not candidates:
+        return out.fail(H4[5], 0, "; ".join(reasons[:3]))
+    out.ok(H4[5], len(candidates))
+    if len(candidates) > 1:
+        return out.fail(H4[6], len(candidates), "multiple structural field layouts")
+    out.ok(H4[6], 1)
+    classes = fitting_classes(candidates[0], replica)
+    out.stages["fitting_encoding_classes"] = classes
+    if len(classes) != 1:
+        return out.fail(H4[7], len(classes), f"fitting encoding/length classes: {classes}")
+    out.ok(H4[7], 1)
+    root_model = {"root_tdef_page": root_page, "catalog_root_selection_signature": ROOT_SIGNATURES[0]}
+    field_model = canonical_field_model(candidates[0], classes[0])
+    model = {"root": root_model, "fields": field_model}
+    out.model = {"model_type": "h4_catalog_model", "model": model, "canonical_model_id": canonical_id({"model_type": "h4_catalog_model", "model": model})}
+    out.bindings = {"admitted": {cp: sorted(s) for cp, s in admitted_by_cp.items()}, "records": {cp: list(v[0][:2]) for cp, v in records.items()}}
+    return out
+
+
+def holdout_root(ctx: Context, replica: int, models: Models, h1_bindings: dict[str, Any]) -> tuple[bool, str, dict[str, set[int]] | None]:
+    page = models["h4"]["model"]["root"]["root_tdef_page"]
+    traversal = traverse(ctx, replica, page, models)
+    if isinstance(traversal, str):
+        return False, traversal, None
+    if not any(stream_changes(ctx, replica, traversal, cp) for cp in OP_CHECKPOINTS):
+        return False, "frozen root follows no listed operation on replica 3", traversal
+    problem = isolated_delta_outside(ctx, replica, traversal, h1_bindings)
+    return problem is None, problem or "", traversal
+
+
+def holdout_fields(ctx: Context, replica: int, models: Models, admitted_by_cp: dict[str, set[int]]) -> tuple[bool, str]:
+    frozen = models["h4"]["model"]["fields"]
+    mask = models["h2"]["model"]["row_masks"][0]
+    records = delta_records(ctx, replica, admitted_by_cp, mask)
+    bad = [cp for cp, v in records.items() if len(v) != 1]
+    if bad:
+        return False, f"replica 3 record cardinality is not one for {bad}"
+    candidates, reasons = structural_candidates(ctx, replica, {cp: v[0] for cp, v in records.items()}, mask)
+    member = frozen["field_tuple_members"][0]
+    match = [c for c in candidates if member in c["members"]]
+    if not match:
+        return False, "frozen structural field tuple does not fit replica 3: " + "; ".join(reasons[:2])
+    candidate = match[0]
+    if candidate["kind_mapping"] != frozen["kind_mapping"]:
+        return False, f"kind mapping differs: {candidate['kind_mapping']} != {frozen['kind_mapping']}"
+    if candidate["identifier_lifecycle_relation"] != frozen["identifier_lifecycle_relation"]:
+        return False, "identifier lifecycle relation differs"
+    if frozen["encoding_length_equivalence_class"] not in fitting_classes(candidate, replica):
+        return False, "exact name bytes or stored length differ from the frozen equivalence class"
+    return True, ""

--- a/oracle/windows-dao/scripts/a4_dryrun_h4.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h4.py
@@ -318,21 +318,26 @@ def evaluate_replica(ctx: Context, replica: int, models: Models, h1_bindings: di
     if len(classes) != 1:
         return out.fail(H4[7], len(classes), f"fitting encoding/length classes: {classes}")
     out.ok(H4[7], 1)
-    root_model = {"root_tdef_page": root_page, "catalog_root_selection_signature": ROOT_SIGNATURES[0]}
+    root_model = {"catalog_root_selection_signature": ROOT_SIGNATURES[0]}
     field_model = canonical_field_model(candidates[0], classes[0])
     model = {"root": root_model, "fields": field_model}
     out.model = {"model_type": "h4_catalog_model", "model": model, "canonical_model_id": canonical_id({"model_type": "h4_catalog_model", "model": model})}
-    out.bindings = {"admitted": {cp: sorted(s) for cp, s in admitted_by_cp.items()}, "records": {cp: list(v[0][:2]) for cp, v in records.items()}}
+    out.bindings = {"replica": replica, "root_tdef_page": root_page,
+                    "admitted": {cp: sorted(s) for cp, s in admitted_by_cp.items()},
+                    "records": {cp: list(v[0][:2]) for cp, v in records.items()}}
+    out.model["canonical_candidate_id"] = canonical_id({**out.model, "instance_bindings": out.bindings})
+    out.stages.update({"root_tdef_page": root_page, "canonical_model_id": out.model["canonical_model_id"],
+                       "canonical_candidate_id": out.model["canonical_candidate_id"]})
     return out
 
 
 def holdout_root(ctx: Context, replica: int, models: Models, h1_bindings: dict[str, Any]) -> tuple[bool, str, dict[str, set[int]] | None]:
-    page = models["h4"]["model"]["root"]["root_tdef_page"]
-    traversal = traverse(ctx, replica, page, models)
-    if isinstance(traversal, str):
-        return False, traversal, None
-    if not any(stream_changes(ctx, replica, traversal, cp) for cp in OP_CHECKPOINTS):
-        return False, "frozen root follows no listed operation on replica 3", traversal
+    if models["h4"]["model"]["root"] != {"catalog_root_selection_signature": ROOT_SIGNATURES[0]}:
+        return False, "frozen root-selection signature is not registered", None
+    roots, reasons = root_candidates(ctx, replica, models)
+    if len(roots) != 1:
+        return False, f"frozen root signature selects {len(roots)} holdout roots: {reasons[:2]}", None
+    _, traversal = roots[0]
     problem = isolated_delta_outside(ctx, replica, traversal, h1_bindings)
     return problem is None, problem or "", traversal
 

--- a/oracle/windows-dao/scripts/a4_dryrun_h4.py
+++ b/oracle/windows-dao/scripts/a4_dryrun_h4.py
@@ -153,9 +153,10 @@ def _row_at(ctx: Context, replica: int, cp: str, page: int, ordinal: int, mask: 
 
 
 def _tuples():
-    for dk, wk, wid, e, dl, wl, el in product(FIELD_DELTA_RANGE, KIND_WIDTHS, ID_WIDTHS, ENDIANNESS, FIELD_DELTA_RANGE, KIND_WIDTHS, ENDIANNESS):
+    """13,824 relative field-address tuples: one shared endianness for kind, identifier and stored name length (plan P4-B2)."""
+    for dk, wk, wid, e, dl, wl in product(FIELD_DELTA_RANGE, KIND_WIDTHS, ID_WIDTHS, ENDIANNESS, FIELD_DELTA_RANGE, KIND_WIDTHS):
         yield {"kind_start_delta": dk, "kind_width": wk, "identifier_width": wid, "endianness": e,
-               "name_length_start_delta": dl, "name_length_width": wl, "name_length_endianness": el}
+               "name_length_start_delta": dl, "name_length_width": wl}
 
 
 def _fields(t: dict[str, int | str], o: int, name_len: int, row_len: int) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int]] | None:
@@ -195,7 +196,7 @@ def structural_candidates(ctx: Context, replica: int, records: dict[str, tuple[i
                 if fields is None:
                     continue
                 kind_span, id_span, len_span = fields
-                length = _decode(row, len_span[0], len_span[1] - len_span[0], str(t["name_length_endianness"]))
+                length = _decode(row, len_span[0], len_span[1] - len_span[0], str(t["endianness"]))
                 if length not in plausible_lengths(expected_name(replica, cp)):
                     continue  # AMB-11 structural length plausibility
                 compatible.append({"name_start": o, "encoding_id": encoding_id, "bytes": pattern, "length": length,

--- a/oracle/windows-dao/scripts/a4_generator.py
+++ b/oracle/windows-dao/scripts/a4_generator.py
@@ -61,6 +61,7 @@ class Params:
     """Every knob is a synthetic free choice; none encodes an expected predicate status."""
 
     profiles: dict[int, Profile] = field(default_factory=lambda: dict(DEFAULT_PROFILES))
+    system_prefix_pages_by_replica: dict[int, int] = field(default_factory=dict)
     layout_by_replica: dict[int, str] = field(default_factory=dict)
     locator_offsets_by_replica: dict[int, tuple[int, int]] = field(default_factory=dict)
     owned_ordinal_by_replica: dict[int, int] = field(default_factory=dict)
@@ -204,6 +205,8 @@ class ReplicaBuilder:
             self.reserved_tag05 = (self._append(tag05_page(set())), self._append(tag05_page(set())))
         else:
             self._append(empty_data_page())  # page 1: static global page, not used by A4
+        for _ in range(self.params.system_prefix_pages_by_replica.get(self.replica, 0)):
+            self._append(empty_data_page())
         root_tdef = self._append(b"")
         root_map = self._append(b"")
         record = self._append(b"")

--- a/oracle/windows-dao/scripts/a4_generator.py
+++ b/oracle/windows-dao/scripts/a4_generator.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Plan-driven synthetic A4 campaign generator (non-evidential; page bytes only).
+
+Every replica walks the 25 checkpoints of ``checkpoint_design`` with the
+listed operation, fixed 32-row batches, relative/absolute thresholds with
+per-replica overshoot, T2 drop/recreate without page reuse, and one DAO
+snapshot per checkpoint. Physical layout: user tables get one tag-02 TDEF page
+carrying the registered 92-byte record signature with two table-relative
+locators, one tag-01 map page with an owned/in-use type-0 row and an available
+type-0 row (rows move as bitmaps grow), and type-0 to type-1 conversion with
+tag-05 extended pages once the type-0 row no longer fits. A system catalog
+(root TDEF, map page, record page) records one operation-delta row per listed
+operation; a second system table is a static decoy.
+
+Generator and environment: deterministic pure Python (stdlib only); identity is
+the SHA-256 of this module recorded in the transcript. Nothing produced here is
+A4 evidence.
+
+A4 rule | implementation
+--- | ---
+Relative/absolute growth, baseline capture, overshoot disclosure | :meth:`ReplicaBuilder._grow`
+Independent replica 3 overshoot | :data:`DEFAULT_PROFILES`
+TDEF signature with exact locator holes [35,39)/[39,43) | :func:`tdef_page`
+Moving row starts as the owned bitmap grows | :meth:`ReplicaBuilder._render_map`
+Type-0 -> type-1 conversion with zero (inactive) slots | :meth:`ReplicaBuilder._render_map`
+One catalog record per operation instance, non-name fields first | :meth:`ReplicaBuilder._record`
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from a4_campaign import Campaign, ReplicaData
+from a4_pages import (
+    TAG_DATA, TAG_TDEF, data_page, encode_locator, tag05_page, type0_row, type1_row,
+)
+from a4_spec import (
+    CHECKPOINTS, EVENT_BY_CHECKPOINT, EVENTS, INSTANCE_BY_ID, LOCATOR_HOLES, MAX_ROWS, ORDINAL, PAGE_SIZE,
+    ROLE_BINDINGS, ROW_BATCH, SIGNATURE_VALUE, TAG05_BITS, expected_name, name_bytes, row_payload,
+)
+
+KIND_BYTES = {"table": 0x11, "field": 0x22, "index": 0x33}
+TYPE1_SLOTS = 33
+STAMP0 = 0x10
+FIRST_ID = 0x21
+DIRECTORY_RESERVE = 14  # header + two directory entries
+
+
+@dataclass(frozen=True)
+class Profile:
+    rows_per_page: int
+    empty_filler: int
+
+
+DEFAULT_PROFILES = {1: Profile(8, 0), 2: Profile(7, 2), 3: Profile(6, 1)}
+
+
+@dataclass
+class Params:
+    """Every knob is a synthetic free choice; none encodes an expected predicate status."""
+
+    profiles: dict[int, Profile] = field(default_factory=lambda: dict(DEFAULT_PROFILES))
+    layout_by_replica: dict[int, str] = field(default_factory=dict)
+    locator_offsets_by_replica: dict[int, tuple[int, int]] = field(default_factory=dict)
+    owned_ordinal_by_replica: dict[int, int] = field(default_factory=dict)
+    user_tdef_tag: int = TAG_TDEF
+    tdef_style: str = "signature"  # signature | opaque | broken_signature
+    locator_target: str = "map"  # map | tdef
+    decoy_tdef_pages: dict[str, int] = field(default_factory=dict)
+    extra_empty_filler: int = 0
+    conversion: str = "capacity"  # capacity | never
+    force_conversion_at: dict[str, str] = field(default_factory=dict)
+    type1_exact_slots: bool = False
+    omit_pages_at_or_above: int | None = None
+    tag05_mode_by_replica: dict[int, str] = field(default_factory=dict)  # slot | equals_slot | referenced
+    extra_tag05_bits: dict[int, set[int]] = field(default_factory=dict)
+    tag05_bit_shift: int = 0
+    record_page_default: str = "root"  # root | spare
+    record_page_override: dict[str, str] = field(default_factory=dict)
+    record_page_override_by_replica: dict[int, dict[str, str]] = field(default_factory=dict)
+    decoy_follows_ops: bool = False
+    skip_record_at: set[str] = field(default_factory=set)
+    duplicate_record_at: set[str] = field(default_factory=set)
+    kind_override: dict[str, int] = field(default_factory=dict)
+    record_layout: str = "single"  # single | double
+    e_acute_length_override: int | None = None
+    e_acute_double_occurrence: bool = False
+    t2_id_relation_by_replica: dict[int, str] = field(default_factory=dict)  # distinct | same
+    holdout_name_corruption: bool = False
+    preallocate_user_pages: bool = False  # reserve low page numbers at EMPTY for user TDEF/map pages
+    available_equals_owned: bool = False
+    synthetic_boundary_bits: bool = False  # activate the next slot and set bit 16351 / bit 0 around one boundary
+
+    def layout(self, replica: int) -> str:
+        return self.layout_by_replica.get(replica, "u8_row_then_u24le_page")
+
+    def offsets(self, replica: int) -> tuple[int, int]:
+        return self.locator_offsets_by_replica.get(replica, (LOCATOR_HOLES[0][0], LOCATOR_HOLES[1][0]))
+
+    def owned_ordinal(self, replica: int) -> int:
+        return self.owned_ordinal_by_replica.get(replica, 0)
+
+    def tag05_mode(self, replica: int) -> str:
+        return self.tag05_mode_by_replica.get(replica, "slot")
+
+
+def tdef_page(style: str, tag: int, locators: tuple[tuple[int, bytes], ...], version: int) -> bytes:
+    if style == "opaque":
+        page = bytearray([0xA5] * PAGE_SIZE)
+        page[0] = tag
+        return bytes(page)
+    page = bytearray(PAGE_SIZE)
+    page[: len(SIGNATURE_VALUE)] = SIGNATURE_VALUE
+    page[0] = tag
+    page[12:14] = version.to_bytes(2, "little")
+    if style == "broken_signature":
+        page[2] ^= 0x01
+    for offset, window in locators:
+        page[offset: offset + 4] = window
+    return bytes(page)
+
+
+def system_tdef_page(locators: tuple[tuple[int, bytes], ...]) -> bytes:
+    page = bytearray(PAGE_SIZE)
+    page[0:4] = bytes([TAG_TDEF, 0x01, ord("S"), ord("Y")])
+    for offset, window in locators:
+        page[offset: offset + 4] = window
+    return bytes(page)
+
+
+def header_page() -> bytes:
+    page = bytearray(PAGE_SIZE)
+    page[0:8] = b"\x00\x01Jet3A4\x00"[:8]
+    return bytes(page)
+
+
+def empty_data_page(rows: int = 0) -> bytes:
+    return data_page([b"\x01\x00\x00\x00filler" ] * rows)
+
+
+@dataclass
+class TableState:
+    instance: str
+    role: str
+    tdef: int
+    map: int
+    owned: set[int]
+    available: set[int] = field(default_factory=set)
+    data_pages: list[int] = field(default_factory=list)
+    rows: int = 0
+    version: int = 0
+    converted: bool = False
+    tag05: dict[int, int] = field(default_factory=dict)
+    dropped: bool = False
+
+
+@dataclass
+class Record:
+    checkpoint: str
+    instance: str
+    kind: str
+    object_id: int
+    stamp: int = STAMP0
+    deleted: bool = False
+    page_slot: str = "root"
+
+
+class ReplicaBuilder:
+    def __init__(self, campaign: Campaign, params: Params, replica: int) -> None:
+        self.campaign, self.params, self.replica = campaign, params, replica
+        self.profile = params.profiles[replica]
+        self.file: list[bytes] = []
+        self.tables: dict[str, TableState] = {}
+        self.records: list[Record] = []
+        self.next_id = FIRST_ID
+        self.baselines: dict[str, int] = {}
+        self.data = ReplicaData(replica)
+        self.mode = params.tag05_mode(replica)
+        self.reserved_tag05: tuple[int, ...] = ()
+        self.system: dict[str, int] = {}
+        self.op_counter = 0
+        self.reserved_user: list[int] = []
+        self.rows_per_batch_pages = math.ceil(ROW_BATCH / self.profile.rows_per_page)
+
+    # ------------------------------------------------------------------ helpers
+    def _append(self, page: bytes) -> int:
+        self.file.append(page)
+        return len(self.file) - 1
+
+    def _locators(self, page: int, ordinal_pages: tuple[int, int]) -> tuple[tuple[int, bytes], ...]:
+        layout = self.params.layout(self.replica)
+        a, b = self.params.offsets(self.replica)
+        return ((a, encode_locator(layout, ordinal_pages[0], 0)), (b, encode_locator(layout, ordinal_pages[1], 1)))
+
+    def _data_page(self, role: str) -> bytes:
+        row = (1).to_bytes(4, "little") + row_payload(role, 1)
+        return data_page([row] * self.profile.rows_per_page)
+
+    # ------------------------------------------------------------------ EMPTY layout
+    def _build_empty(self) -> None:
+        self._append(header_page())
+        if self.mode != "slot":
+            self.reserved_tag05 = (self._append(tag05_page(set())), self._append(tag05_page(set())))
+        else:
+            self._append(empty_data_page())  # page 1: static global page, not used by A4
+        root_tdef = self._append(b"")
+        root_map = self._append(b"")
+        record = self._append(b"")
+        decoy_tdef = self._append(b"")
+        decoy_map = self._append(b"")
+        spare = self._append(b"")
+        self.system = {"root_tdef": root_tdef, "root_map": root_map, "record": record,
+                       "decoy_tdef": decoy_tdef, "decoy_map": decoy_map, "spare": spare}
+        self.file[root_tdef] = system_tdef_page(self._locators(root_tdef, (root_map, root_map)))
+        self.file[decoy_tdef] = system_tdef_page(self._locators(decoy_tdef, (decoy_map, decoy_map)))
+        if self.params.preallocate_user_pages:
+            self.reserved_user = [self._append(empty_data_page()) for _ in range(2 * len(INSTANCE_BY_ID))]
+        for _ in range(self.profile.empty_filler + self.params.extra_empty_filler):
+            self._append(empty_data_page(1))
+        self._render_system()
+
+    def _render_system(self) -> None:
+        root_map, record, decoy_map, spare = (self.system[k] for k in ("root_map", "record", "decoy_map", "spare"))
+        self.file[root_map] = data_page([type0_row(root_map, {root_map, record}), type0_row(root_map, set())])
+        decoy_owned = {decoy_map, spare} if self.params.decoy_follows_ops else {decoy_map}
+        self.file[decoy_map] = data_page([type0_row(decoy_map, decoy_owned), type0_row(decoy_map, set())])
+        self._render_records()
+
+    def _render_records(self) -> None:
+        for slot_name, page in (("root", self.system["record"]), ("spare", self.system["spare"])):
+            rows, flags = [], {}
+            for record in [r for r in self.records if r.page_slot == slot_name]:
+                if record.deleted:
+                    flags[len(rows)] = 0x8000
+                rows.append(self._record_bytes(record))
+            if slot_name == "spare" and self.params.decoy_follows_ops:
+                rows.append(b"\x01" + self.op_counter.to_bytes(2, "little"))
+            self.file[page] = data_page(rows, flags)
+
+    def _record_bytes(self, record: Record) -> bytes:
+        name = expected_name(self.replica, record.checkpoint)
+        encodings = name_bytes(name)
+        kind = self.params.kind_override.get(record.checkpoint, KIND_BYTES[record.kind])
+        primary = encodings["strict_windows_1252"]
+        is_e_acute = primary != encodings["utf_8"]
+        if is_e_acute and self.params.holdout_name_corruption and self.replica == 3:
+            primary = primary[:-1] + b"5"
+        length = len(primary)
+        if is_e_acute and self.params.e_acute_length_override is not None:
+            length = self.params.e_acute_length_override
+        prefix = bytes([record.stamp, record.object_id & 0xFF, kind])
+        if self.params.record_layout == "double":
+            prefix += bytes([record.stamp, (record.object_id ^ 0x40) & 0xFF, kind])
+        row = prefix + bytes([length]) + primary
+        if is_e_acute and self.params.e_acute_double_occurrence:
+            utf8 = encodings["utf_8"]
+            row += bytes([record.stamp, record.object_id & 0xFF, kind, len(utf8)]) + utf8
+        return row
+
+    # ------------------------------------------------------------------ user tables
+    def _create(self, checkpoint: str, instance_id: str) -> None:
+        inst = INSTANCE_BY_ID[instance_id]
+        if self.reserved_user:
+            tdef, map_page = self.reserved_user.pop(0), self.reserved_user.pop(0)
+        else:
+            tdef, map_page = self._append(b""), self._append(b"")
+        target = tdef if self.params.locator_target == "tdef" else map_page
+        self.file[tdef] = tdef_page(self.params.tdef_style, self.params.user_tdef_tag, self._locators(tdef, (target, target)), 0)
+        for _ in range(self.params.decoy_tdef_pages.get(checkpoint, 0)):
+            self._append(tdef_page(self.params.tdef_style, self.params.user_tdef_tag, (), 0))
+        state = TableState(instance_id, inst.role, tdef, map_page, {map_page})
+        self.tables[instance_id] = state
+        self.file[map_page] = b""
+        self._record(checkpoint, instance_id, "table", self._allocate_id(instance_id))
+
+    def _allocate_id(self, instance_id: str) -> int:
+        relation = self.params.t2_id_relation_by_replica.get(self.replica, "distinct")
+        if instance_id == "T2-v2" and relation == "same":
+            return next(r.object_id for r in self.records if r.instance == "T2-v1" and r.kind == "table")
+        value, self.next_id = self.next_id, self.next_id + 1
+        return value
+
+    def _record(self, checkpoint: str, instance_id: str, kind: str, object_id: int) -> None:
+        if checkpoint in self.params.skip_record_at:
+            return
+        override = dict(self.params.record_page_override)
+        override.update(self.params.record_page_override_by_replica.get(self.replica, {}))
+        slot = override.get(checkpoint, self.params.record_page_default)
+        stamp = STAMP0 + len(self.records)
+        self.records.append(Record(checkpoint, instance_id, kind, object_id, stamp=stamp, page_slot=slot))
+        if checkpoint in self.params.duplicate_record_at:
+            self.records.append(Record(checkpoint, instance_id, kind, object_id, stamp=stamp, page_slot=slot))
+
+    def _table_record(self, instance_id: str) -> Record | None:
+        for record in self.records:
+            if record.instance == instance_id and record.kind == "table" and not record.deleted:
+                return record
+        return None
+
+    def _grow(self, checkpoint: str, instance_id: str) -> None:
+        state = self.tables[instance_id]
+        suffix = int(checkpoint.rsplit("_", 1)[1])
+        target = suffix if "_ABS_" in checkpoint else self.baselines[state.role] + suffix
+        while len(self.file) < target:
+            if state.rows + ROW_BATCH > MAX_ROWS:
+                raise RuntimeError("row cap reached in synthetic growth")
+            for _ in range(self.rows_per_batch_pages):
+                page = self._append(self._data_page(state.role))
+                state.data_pages.append(page)
+                state.owned.add(page)
+            state.rows += ROW_BATCH
+        self._stamp(instance_id)
+
+    def _stamp(self, instance_id: str) -> None:
+        record = self._table_record(instance_id)
+        if record is not None:
+            record.stamp += 1
+
+    # ------------------------------------------------------------------ map rendering
+    def _visible(self, pages: set[int]) -> set[int]:
+        limit = self.params.omit_pages_at_or_above
+        return {p for p in pages if limit is None or p < limit}
+
+    def _type0_fits(self, state: TableState) -> bool:
+        owned, available = self._visible(state.owned), self._visible(state.available)
+        if self.params.available_equals_owned:
+            available = set(owned)
+        len0 = 5 + math.ceil((max(owned) - state.map + 1) / 8) if owned else 5
+        len1 = 5 + math.ceil((max(available) - state.map + 1) / 8) if available else 5
+        return DIRECTORY_RESERVE + len0 + len1 <= PAGE_SIZE
+
+    def _slot_of(self, page: int) -> tuple[int, int]:
+        """(slot ordinal, referenced page) for an owned page under this replica's tag-05 mode."""
+        block = page // TAG05_BITS
+        if self.mode == "slot":
+            return block, -1
+        if self.mode == "equals_slot":
+            return block, block
+        return block - 1, block  # referenced: slot k references page k+1
+
+    def _reference(self, state: TableState, slot: int) -> int:
+        if slot not in state.tag05:
+            if self.mode == "slot":
+                state.tag05[slot] = self._append(tag05_page(set()))
+            elif self.mode == "equals_slot":
+                state.tag05[slot] = slot
+            else:
+                state.tag05[slot] = slot + 1
+        return state.tag05[slot]
+
+    def _activate(self, state: TableState, pages: set[int]) -> list[int]:
+        """Return the u32 slot values for a converted table, allocating references as needed."""
+        for page in sorted(pages):
+            self._reference(state, self._slot_of(page)[0])
+        if self.params.synthetic_boundary_bits and state.tag05:
+            self._reference(state, min(state.tag05) + 1)
+        return [state.tag05.get(i, 0) for i in range(max(state.tag05) + 1)] if state.tag05 else []
+
+    def _render_map(self, checkpoint: str, state: TableState) -> None:
+        owned, available = self._visible(state.owned), self._visible(state.available)
+        forced = self.params.force_conversion_at.get(state.instance)
+        convert = self.params.conversion != "never" and (
+            state.converted or not self._type0_fits(state) or (forced is not None and ORDINAL[checkpoint] >= ORDINAL[forced]))
+        if self.params.available_equals_owned:
+            available = set() if convert else set(owned)
+        if convert:
+            state.converted = True
+            references = self._activate(state, owned)
+            count = len(references) if self.params.type1_exact_slots else TYPE1_SLOTS
+            owned_row = type1_row(references, count)
+        else:
+            if self.params.conversion == "never":
+                capacity = (PAGE_SIZE - DIRECTORY_RESERVE - 10) * 8
+                owned = {p for p in owned if p - state.map < capacity}
+            owned_row = type0_row(state.map, owned)
+        available_row = owned_row if self.params.available_equals_owned else type0_row(state.map, available)
+        rows = [owned_row, available_row] if self.params.owned_ordinal(self.replica) == 0 else [available_row, owned_row]
+        self.file[state.map] = data_page(rows)
+
+    def _render_tag05(self) -> None:
+        bits: dict[int, set[int]] = {}
+        for state in self.tables.values():
+            if not state.converted or state.dropped:
+                continue
+            for page in self._visible(state.owned):
+                slot, _ = self._slot_of(page)
+                reference = state.tag05[slot]
+                base = reference if self.mode == "referenced" else slot
+                bits.setdefault(reference, set()).add(page - base * TAG05_BITS + self.params.tag05_bit_shift)
+            if self.params.synthetic_boundary_bits and state.tag05:
+                low = min(state.tag05)
+                bits.setdefault(state.tag05[low], set()).add(TAG05_BITS - 1)
+                bits.setdefault(state.tag05[low + 1], set()).add(0)
+        for page, extra in self.params.extra_tag05_bits.items():
+            bits.setdefault(page, set()).update(extra)
+        for page, values in bits.items():
+            self.file[page] = tag05_page({b for b in values if 0 <= b < TAG05_BITS})
+
+    # ------------------------------------------------------------------ checkpoint walk
+    def build(self) -> ReplicaData:
+        for event in EVENTS:
+            cp = event.checkpoint
+            if event.kind == "empty":
+                self._build_empty()
+            elif event.kind == "create":
+                self._create(cp, event.instance or "")
+            elif event.kind == "add_field":
+                self.tables[event.instance or ""].version += 1
+                self._record(cp, event.instance or "", "field", self._allocate_id("field"))
+            elif event.kind == "add_index":
+                self.tables[event.instance or ""].version += 1
+                self._record(cp, event.instance or "", "index", self._allocate_id("index"))
+            elif event.kind == "drop":
+                self._drop("T2-v1")
+            elif event.kind == "grow":
+                self._grow(cp, event.instance or "")
+            elif event.kind == "delete_all":
+                state = self.tables[event.instance or ""]
+                state.available = set(state.data_pages)
+                state.rows = 0
+                self._stamp(state.instance)
+            elif event.kind == "reinsert":
+                state = self.tables[event.instance or ""]
+                state.available = set()
+                state.rows = self._reinsert_rows(state)
+                self._stamp(state.instance)
+            if event.kind in ("create", "add_field", "add_index", "drop"):
+                self.op_counter += 1
+            self._render(cp)
+            self._capture(cp)
+            if cp == "T4_CREATE":
+                self.baselines["T1"] = len(self.file)
+            if cp == "T3_ABS_16480":
+                self.baselines["T4"] = len(self.file)
+        return self.data
+
+    def _reinsert_rows(self, state: TableState) -> int:
+        return self.data.row_counts["T1_REL_1280"][state.role]
+
+    def _drop(self, instance_id: str) -> None:
+        state = self.tables[instance_id]
+        state.dropped = True
+        self.file[state.tdef] = empty_data_page()
+        self.file[state.map] = empty_data_page()
+        for record in self.records:
+            if record.instance == instance_id:
+                record.deleted = True
+
+    def _render(self, checkpoint: str) -> None:
+        for state in self.tables.values():
+            if not state.dropped:
+                self.file[state.tdef] = self.file[state.tdef][:12] + state.version.to_bytes(2, "little") + self.file[state.tdef][14:] \
+                    if self.params.tdef_style != "opaque" else self.file[state.tdef]
+                self._render_map(checkpoint, state)
+        self._render_tag05()
+        self._render_system()
+
+    def _capture(self, checkpoint: str) -> None:
+        self.data.pages[checkpoint] = [self.campaign.store(page) for page in self.file]
+        self.data.row_counts[checkpoint] = {s.role: s.rows for s in self.tables.values() if not s.dropped}
+        self.data.meta = {
+            "system": dict(self.system),
+            "instances": {k: {"tdef": s.tdef, "map": s.map, "data_pages": list(s.data_pages), "tag05": dict(s.tag05),
+                              "converted": s.converted} for k, s in self.tables.items()},
+            "baselines": dict(self.baselines),
+            "role_binding": dict(ROLE_BINDINGS[self.replica]),
+        }
+
+
+def generate(params: Params | None = None, replicas: tuple[int, ...] = (1, 2, 3)) -> Campaign:
+    params = params or Params()
+    campaign = Campaign()
+    for replica in replicas:
+        campaign.replicas[replica] = ReplicaBuilder(campaign, params, replica).build()
+        campaign.refresh(replica)
+    return campaign
+
+
+def overshoots(campaign: Campaign, replica: int) -> dict[str, int]:
+    """Achieved minus threshold for every growth checkpoint (relative_growth_rule / absolute_growth_rule)."""
+    data = campaign.replicas[replica]
+    out = {}
+    for cp in CHECKPOINTS:
+        event = EVENT_BY_CHECKPOINT[cp]
+        if event.kind != "grow":
+            continue
+        suffix = int(cp.rsplit("_", 1)[1])
+        baseline = 0 if "_ABS_" in cp else data.meta["baselines"][event.role or ""]
+        out[cp] = len(data.pages[cp]) - (baseline + suffix)
+    return out

--- a/oracle/windows-dao/scripts/a4_pages.py
+++ b/oracle/windows-dao/scripts/a4_pages.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""SRC-0020 page byte codec for the A4 dry run: encoders for the generator, decoders for the evaluator.
+
+Encoders build exact 2,048-byte pages; decoders read bytes back under the
+plan's registered rules (row_directory_source, row_boundary_rule,
+map_row_layouts). Nothing here carries a verdict: decoders return structure or
+a typed failure reason and the evaluator decides.
+
+A4 rule | implementation
+--- | ---
+Row count at [8,10), offsets at [10+2i,12+2i), masks 0x1fff/0x0fff, flags 0x8000/0x4000 | :func:`decode_directory`
+start/end rule, 10+2*row_count <= start < end <= 2048, nonoverlap in directory order | :func:`validate_directory`
+Type-0 tag 00 + u32 base + LSB-first bitmap; type-1 tag 01 + u32 slots | :func:`decode_map_row`
+Tag-05 header [0,4) + 16,352 LSB-first bits | :func:`tag05_bits`
+Locator layouts u24le_page_then_u8_row / u8_row_then_u24le_page | :func:`decode_locator`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from a4_spec import DELETED_FLAG, OVERFLOW_FLAG, PAGE_SIZE, TAG05_BITS
+
+DIRECTORY_START = 10
+TYPE0_HEADER = 5
+TAG_DATA, TAG_TDEF, TAG_EXTENDED = 0x01, 0x02, 0x05
+
+
+def tag_of(page: bytes) -> int:
+    return page[0]
+
+
+# ----------------------------------------------------------------------------- encoders
+
+def bitmap_bytes(bits: set[int], capacity_bits: int | None = None) -> bytes:
+    if capacity_bits is None:
+        capacity_bits = (max(bits) + 1) if bits else 0
+    out = bytearray((capacity_bits + 7) // 8)
+    for bit in bits:
+        if bit < 0 or bit >= len(out) * 8:
+            raise ValueError(f"bit {bit} outside capacity {len(out) * 8}")
+        out[bit >> 3] |= 1 << (bit & 7)
+    return bytes(out)
+
+
+def type0_row(base: int, pages: set[int], polarity: str = "set_bit_owned_in_use") -> bytes:
+    bits = {p - base for p in pages}
+    if any(b < 0 for b in bits):
+        raise ValueError("page below base")
+    body = bitmap_bytes(bits)
+    if polarity != "set_bit_owned_in_use":
+        body = bytes(b ^ 0xFF for b in body)
+    return bytes([0x00]) + base.to_bytes(4, "little") + body
+
+
+def type1_row(references: list[int], slot_count: int) -> bytes:
+    if len(references) > slot_count:
+        raise ValueError("more references than slots")
+    slots = list(references) + [0] * (slot_count - len(references))
+    return bytes([0x01]) + b"".join(s.to_bytes(4, "little") for s in slots)
+
+
+def data_page(rows: list[bytes], flags: dict[int, int] | None = None, tag: int = TAG_DATA) -> bytes:
+    """Rows are packed from the page end in slot order: slot 0 ends at 2048."""
+    page = bytearray(PAGE_SIZE)
+    page[0], page[1] = tag, 0x01
+    page[8:10] = len(rows).to_bytes(2, "little")
+    end = PAGE_SIZE
+    for slot, row in enumerate(rows):
+        start = end - len(row)
+        if start < DIRECTORY_START + 2 * len(rows):
+            raise ValueError("rows overflow the page")
+        page[start:end] = row
+        raw = start | (flags or {}).get(slot, 0)
+        page[DIRECTORY_START + 2 * slot: DIRECTORY_START + 2 * slot + 2] = raw.to_bytes(2, "little")
+        end = start
+    return bytes(page)
+
+
+def tag05_page(bits: set[int]) -> bytes:
+    page = bytearray(PAGE_SIZE)
+    page[0:4] = bytes([TAG_EXTENDED, 0x01, 0x00, 0x00])
+    page[4:] = bitmap_bytes(bits, TAG05_BITS)
+    return bytes(page)
+
+
+def encode_locator(layout: str, page: int, row: int) -> bytes:
+    if layout == "u24le_page_then_u8_row":
+        return page.to_bytes(3, "little") + bytes([row])
+    if layout == "u8_row_then_u24le_page":
+        return bytes([row]) + page.to_bytes(3, "little")
+    raise ValueError(layout)
+
+
+# ----------------------------------------------------------------------------- decoders
+
+def decode_locator(window: bytes, layout: str) -> tuple[int, int]:
+    """Return (page, row) for a four-byte window under a registered layout."""
+    if layout == "u24le_page_then_u8_row":
+        return int.from_bytes(window[0:3], "little"), window[3]
+    if layout == "u8_row_then_u24le_page":
+        return int.from_bytes(window[1:4], "little"), window[0]
+    raise ValueError(layout)
+
+
+@dataclass(frozen=True)
+class Slot:
+    ordinal: int
+    raw: int
+    start: int
+    end: int
+    deleted: bool
+    overflow: bool
+
+
+def row_count(page: bytes) -> int:
+    return int.from_bytes(page[8:10], "little")
+
+
+def decode_directory(page: bytes, mask: int) -> list[Slot]:
+    """Decode every directory slot under one offset mask; no validity judgement."""
+    count = row_count(page)
+    slots: list[Slot] = []
+    end = PAGE_SIZE
+    for ordinal in range(count):
+        at = DIRECTORY_START + 2 * ordinal
+        raw = int.from_bytes(page[at: at + 2], "little") if at + 2 <= PAGE_SIZE else 0
+        start = raw & mask
+        slots.append(Slot(ordinal, raw, start, end, bool(raw & DELETED_FLAG), bool(raw & OVERFLOW_FLAG)))
+        end = start
+    return slots
+
+
+def validate_directory(slots: list[Slot]) -> str | None:
+    """Complete SRC-0020 directory validation; returns the first violation or None."""
+    floor = DIRECTORY_START + 2 * len(slots)
+    previous_start = PAGE_SIZE
+    for slot in slots:
+        if slot.start < floor:
+            return f"slot {slot.ordinal} start {slot.start} overlaps directory bytes below {floor}"
+        if not slot.start < slot.end <= PAGE_SIZE:
+            return f"slot {slot.ordinal} bounds [{slot.start},{slot.end}) are not increasing within the page"
+        if slot.start >= previous_start:
+            return f"slot {slot.ordinal} start {slot.start} does not precede slot {slot.ordinal - 1}"
+        previous_start = slot.start
+    return None
+
+
+@dataclass(frozen=True)
+class MapRow:
+    kind: int  # 0 or 1
+    base: int | None
+    bitmap: bytes
+    slots: tuple[int, ...]
+
+    def type0_pages(self, polarity: str) -> set[int]:
+        assert self.kind == 0 and self.base is not None
+        want = 1 if polarity == "set_bit_owned_in_use" else 0
+        out = set()
+        for index in range(len(self.bitmap) * 8):
+            if ((self.bitmap[index >> 3] >> (index & 7)) & 1) == want:
+                out.add(self.base + index)
+        return out
+
+
+def decode_map_row(row: bytes) -> MapRow | str:
+    """Decode a located row as a map row; a string is the plan-registered rejection reason."""
+    if not row:
+        return "empty row"
+    tag = row[0]
+    if tag == 0x00:
+        if len(row) < TYPE0_HEADER:
+            return "type-0 row shorter than tag plus u32 base"
+        return MapRow(0, int.from_bytes(row[1:5], "little"), bytes(row[5:]), ())
+    if tag == 0x01:
+        if (len(row) - 1) % 4 != 0:
+            return "type-1 payload length is not divisible by four"
+        slots = tuple(int.from_bytes(row[1 + 4 * i: 5 + 4 * i], "little") for i in range((len(row) - 1) // 4))
+        return MapRow(1, None, b"", slots)
+    return f"row tag {tag:02x} is neither 00 nor 01"
+
+
+def tag05_bits(page: bytes) -> list[int]:
+    """Indices of set bits in a tag-05 page bitmap [4,2048), LSB-first."""
+    out = []
+    body = page[4:]
+    for byte_index, value in enumerate(body):
+        if value:
+            for bit in range(8):
+                if value >> bit & 1:
+                    out.append(byte_index * 8 + bit)
+    return out
+
+
+def absolute_page(formula: str, slot_ordinal: int, reference: int, bit_index: int) -> int:
+    if formula == "slot_ordinal_times_16352_plus_bit_index":
+        return slot_ordinal * TAG05_BITS + bit_index
+    if formula == "referenced_page_times_16352_plus_bit_index":
+        return reference * TAG05_BITS + bit_index
+    if formula == "slot_ordinal_times_16352_plus_bit_index_minus_one":
+        return slot_ordinal * TAG05_BITS + bit_index - 1
+    if formula == "slot_ordinal_times_16352_plus_bit_index_plus_one":
+        return slot_ordinal * TAG05_BITS + bit_index + 1
+    raise ValueError(formula)

--- a/oracle/windows-dao/scripts/a4_pages.py
+++ b/oracle/windows-dao/scripts/a4_pages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""SRC-0020 page byte codec for the A4 dry run: encoders for the generator, decoders for the evaluator.
+"""A4 page codec using the checked provenance entry "Secondary documentation of Jet page, row-slot, and usage-map primitives".
 
 Encoders build exact 2,048-byte pages; decoders read bytes back under the
 plan's registered rules (row_directory_source, row_boundary_rule,
@@ -132,7 +132,7 @@ def decode_directory(page: bytes, mask: int) -> list[Slot]:
 
 
 def validate_directory(slots: list[Slot]) -> str | None:
-    """Complete SRC-0020 directory validation; returns the first violation or None."""
+    """Complete checked row-directory validation; returns the first violation or None."""
     floor = DIRECTORY_START + 2 * len(slots)
     previous_start = PAGE_SIZE
     for slot in slots:

--- a/oracle/windows-dao/scripts/a4_spec.py
+++ b/oracle/windows-dao/scripts/a4_spec.py
@@ -264,9 +264,19 @@ def rolling_sha256(role: str, row_count: int) -> str:
 
 
 def count_satisfies(contract: dict[str, Any], measured: int) -> bool:
-    """R4-S01 semantics: exact equality, minimum >=, or membership in one allowed range."""
+    """R4-S01 semantics for scalar and replica-qualified survivor counts."""
     if "allowed_ranges" in contract:
         return any(count_satisfies(r, measured) for r in contract["allowed_ranges"])
+    if "per_replica_exact" in contract:
+        required = {"per_replica_exact", "replica_count", "total_exact"}
+        if not required <= contract.keys():
+            raise SpecError(f"incomplete replica-qualified survivor count contract {contract}")
+        per_replica = int(contract["per_replica_exact"])
+        replica_count = int(contract["replica_count"])
+        total = int(contract["total_exact"])
+        if per_replica < 0 or replica_count < 1 or per_replica * replica_count != total:
+            raise SpecError(f"inconsistent replica-qualified survivor count contract {contract}")
+        return measured == total
     if "exact" in contract:
         return measured == int(contract["exact"])
     if "minimum" in contract:

--- a/oracle/windows-dao/scripts/a4_spec.py
+++ b/oracle/windows-dao/scripts/a4_spec.py
@@ -29,6 +29,7 @@ DAO_ROOT = Path(__file__).resolve().parents[1]
 A4_ROOT = DAO_ROOT / "experiments" / "a4"
 PLAN_PATH = A4_ROOT / "a4-row-anchored-maps.plan.json"
 README_PATH = A4_ROOT / "README.md"
+SCHEMA_SNAPSHOT_PATH = A4_ROOT / "dao-schema-snapshot.schema.json"
 EXPERIMENT_ID = "DAO-A4-ROW-ANCHORED-MAPS-001"
 PAGE_SIZE = 2048
 DERIVATION_REPLICAS = (1, 2)
@@ -74,6 +75,8 @@ def load_plan() -> tuple[dict[str, Any], str]:
 PLAN, PLAN_SHA256 = load_plan()
 # Until an additive revision exists both bindings equal the base hash (revision_binding_rule).
 REVISION_PLAN_SHA256 = PLAN_SHA256
+SCHEMA_SNAPSHOT = json.loads(SCHEMA_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+SCHEMA_SNAPSHOT_CANONICALIZATION = SCHEMA_SNAPSHOT["properties"]["canonicalization"]["const"]
 
 CHECKPOINTS: tuple[str, ...] = tuple(PLAN["checkpoint_design"]["checkpoint_ids"])
 ORDINAL: Mapping[str, int] = MappingProxyType({cp: i for i, cp in enumerate(CHECKPOINTS)})

--- a/oracle/windows-dao/scripts/a4_spec.py
+++ b/oracle/windows-dao/scripts/a4_spec.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Plan-bound constants for the DAO-A4-ROW-ANCHORED-MAPS-001 dry-run harness.
+
+Everything here is read from the checked base plan; nothing is a hand-authored
+expected status. The plan hash is verified against the README pin so every
+transcript is bound to the exact plan bytes it was evaluated under.
+
+A4 rule | implementation
+--- | ---
+Plan/README hash binding | :func:`load_plan`
+40 predicate contracts in registry order | :data:`PREDICATE_CONTRACTS`
+Closed candidate grammars | :data:`GRAMMAR`
+Lifecycle instances and inclusive checkpoint ranges (P4-B3 text) | :data:`INSTANCES`
+Checkpoint events derived from ``checkpoint_operations`` | :data:`EVENTS`
+Measured count versus ``exact``/``minimum``/``allowed_ranges`` | :func:`count_satisfies`
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+DAO_ROOT = Path(__file__).resolve().parents[1]
+A4_ROOT = DAO_ROOT / "experiments" / "a4"
+PLAN_PATH = A4_ROOT / "a4-row-anchored-maps.plan.json"
+README_PATH = A4_ROOT / "README.md"
+EXPERIMENT_ID = "DAO-A4-ROW-ANCHORED-MAPS-001"
+PAGE_SIZE = 2048
+DERIVATION_REPLICAS = (1, 2)
+HOLDOUT_REPLICA = 3
+
+
+class SpecError(Exception):
+    """The checked plan is absent, altered, or not pinned by the README."""
+
+
+def canonical_json_bytes(document: Any) -> bytes:
+    return json.dumps(document, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256_hex(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def canonical_id(document: Any) -> str:
+    return sha256_hex(canonical_json_bytes(document))
+
+
+def _readme_pin(text: str) -> str:
+    match = re.search(r"`a4-row-anchored-maps\.plan\.json`, SHA-256\s*\n?`([0-9a-f]{64})`", text)
+    if match is None:
+        raise SpecError("README does not pin the base plan SHA-256")
+    return match.group(1)
+
+
+def load_plan() -> tuple[dict[str, Any], str]:
+    """Return the plan document and its SHA-256, rejecting a README/plan mismatch."""
+    raw = PLAN_PATH.read_bytes()
+    digest = sha256_hex(raw)
+    pinned = _readme_pin(README_PATH.read_text(encoding="utf-8"))
+    if pinned != digest:
+        raise SpecError(f"plan SHA-256 {digest} differs from README pin {pinned}")
+    document = json.loads(raw)
+    if document.get("experiment_id") != EXPERIMENT_ID:
+        raise SpecError("plan experiment id mismatch")
+    return document, digest
+
+
+PLAN, PLAN_SHA256 = load_plan()
+# Until an additive revision exists both bindings equal the base hash (revision_binding_rule).
+REVISION_PLAN_SHA256 = PLAN_SHA256
+
+CHECKPOINTS: tuple[str, ...] = tuple(PLAN["checkpoint_design"]["checkpoint_ids"])
+ORDINAL: Mapping[str, int] = MappingProxyType({cp: i for i, cp in enumerate(CHECKPOINTS)})
+IDLE_PAIRS: tuple[tuple[str, str], ...] = tuple(tuple(p) for p in PLAN["checkpoint_design"]["idle_pairs"])
+TRANSITIONS = PLAN["checkpoint_design"]["transition_coverage"]
+SCHEMA_LIFECYCLE: tuple[str, ...] = tuple(TRANSITIONS["schema_lifecycle"])
+EXPECTED_SCHEMA: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {cp: tuple(v) for cp, v in PLAN["tables"]["expected_schema_by_checkpoint"].items()}
+)
+ROLES: tuple[str, ...] = tuple(PLAN["tables"]["logical_roles"])
+PHYSICAL_NAMES: tuple[str, ...] = tuple(PLAN["tables"]["physical_names"])
+ROLE_BINDINGS: Mapping[int, Mapping[str, str]] = MappingProxyType(
+    {b["replica"]: MappingProxyType({r: b[r] for r in ROLES}) for b in PLAN["tables"]["role_bindings"]}
+)
+FIELD_DEFS = PLAN["tables"]["definition"]["fields"]
+INDEX_DEF = PLAN["tables"]["definition"]["index"]
+ROW_BATCH = int(PLAN["tables"]["row_algorithm"]["growth_batch_rows"])
+MAX_ROWS = int(PLAN["bounds"]["max_inserted_rows_per_replica"])
+BOUNDS = PLAN["bounds"]
+MAX_QUALIFIED_PAGES = int(BOUNDS["max_qualified_pages_per_submodel"])
+GRAMMAR = PLAN["candidate_grammars"]
+H1_SIGNATURE = GRAMMAR["h1"]["table_record_signature"]
+SIGNATURE_VALUE = bytes.fromhex(H1_SIGNATURE["value_hex"])
+SIGNATURE_MASK = bytes.fromhex(H1_SIGNATURE["mask_hex"])
+LOCATOR_HOLES: tuple[tuple[int, int], ...] = tuple(tuple(h) for h in H1_SIGNATURE["locator_holes"])
+LOCATOR_LAYOUTS: tuple[str, ...] = tuple(GRAMMAR["h1"]["locator_layouts"])
+TDEF_SIGNATURES: tuple[str, ...] = tuple(GRAMMAR["h1"]["tdef_lifecycle_signatures"])
+ROW_MASKS: tuple[int, ...] = tuple(int(m) for m in GRAMMAR["h2"]["row_masks"])
+POLARITIES: tuple[str, ...] = tuple(GRAMMAR["h2"]["type_0_polarities"])
+ROLE_ASSIGNMENTS: tuple[str, ...] = tuple(GRAMMAR["h2"]["locator_role_assignments"])
+CONVERSIONS: tuple[str, ...] = tuple(GRAMMAR["h3"]["conversion_candidates"])
+BASE_FORMULAS: tuple[str, ...] = tuple(GRAMMAR["h3"]["base_formulas"])
+ROOT_SIGNATURES: tuple[str, ...] = tuple(GRAMMAR["h4"]["catalog_root_selection_signatures"])
+KIND_WIDTHS: tuple[int, ...] = tuple(GRAMMAR["h4"]["kind_widths"])
+ID_WIDTHS: tuple[int, ...] = tuple(GRAMMAR["h4"]["identifier_widths"])
+ENDIANNESS: tuple[str, ...] = tuple(GRAMMAR["h4"]["endianness"])
+LIFECYCLE_RELATIONS: tuple[str, ...] = tuple(GRAMMAR["h4"]["identifier_lifecycle_relations"])
+NAME_ENCODINGS: tuple[dict[str, str], ...] = tuple(GRAMMAR["h4"]["name_encodings"])
+LENGTH_CLASSES: tuple[dict[str, Any], ...] = tuple(GRAMMAR["h4"]["name_length_equivalence_classes"])
+FIELD_DELTA_RANGE = range(1, 17)
+MAX_CANDIDATES = int(BOUNDS["max_candidate_models"])
+TAG05_BITS = (PAGE_SIZE - 4) * 8
+DELETED_FLAG, OVERFLOW_FLAG = 0x8000, 0x4000
+
+PREDICATE_IDS: tuple[str, ...] = tuple(PLAN["predicate_registry"]["ids"])
+_CONTRACT_ROWS = sorted(PLAN["predicate_registry"]["predicate_contracts"], key=lambda c: c["order"])
+PREDICATE_CONTRACTS: Mapping[str, dict[str, Any]] = MappingProxyType({c["predicate_id"]: c for c in _CONTRACT_ROWS})
+PREDICATE_ORDER: tuple[str, ...] = tuple(c["predicate_id"] for c in _CONTRACT_ROWS)
+CAMPAIGN_PREDICATES: tuple[str, ...] = tuple(PLAN["predicate_registry"]["campaign_evaluated_before_any_layer"])
+LAYER_PREDICATES: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {k: tuple(v) for k, v in PLAN["predicate_registry"]["per_layer_ordered_predicates"].items()}
+)
+LAYER_KEYS: tuple[str, ...] = tuple(LAYER_PREDICATES)
+HOLDOUT_PREDICATES: tuple[str, ...] = tuple(PLAN["predicate_registry"]["holdout_phase_ordered_predicates"])
+if len(PREDICATE_ORDER) != 40 or set(PREDICATE_ORDER) != set(PREDICATE_IDS):
+    raise SpecError("predicate contracts do not cover the 40 registered ids exactly once")
+
+
+@dataclass(frozen=True)
+class Instance:
+    """A lifecycle instance with the inclusive checkpoint range derived from expected_schema_by_checkpoint."""
+
+    id: str
+    role: str
+    version: str
+    create_checkpoint: str
+    last_checkpoint: str
+
+    @property
+    def checkpoints(self) -> tuple[str, ...]:
+        return CHECKPOINTS[ORDINAL[self.create_checkpoint]: ORDINAL[self.last_checkpoint] + 1]
+
+
+def _instances() -> tuple[Instance, ...]:
+    spans: dict[str, list[str]] = {}
+    for cp in CHECKPOINTS:
+        for token in EXPECTED_SCHEMA[cp]:
+            parts = token.split(":")
+            role = parts[0]
+            version = parts[1] if parts[1].startswith("v") else "v1"
+            spans.setdefault(f"{role}-{version}", []).append(cp)
+    out = []
+    for key, cps in spans.items():
+        role, version = key.split("-")
+        out.append(Instance(key, role, version, cps[0], cps[-1]))
+    return tuple(sorted(out, key=lambda i: ORDINAL[i.create_checkpoint]))
+
+
+INSTANCES: tuple[Instance, ...] = _instances()
+INSTANCE_BY_ID: Mapping[str, Instance] = MappingProxyType({i.id: i for i in INSTANCES})
+if tuple(i.id for i in INSTANCES) != ("T1-v1", "T2-v1", "T2-v2", "T3-v1", "T4-v1"):
+    raise SpecError("lifecycle instances derived from the plan are not the five registered instances")
+
+
+@dataclass(frozen=True)
+class Event:
+    """What the listed operation between the previous checkpoint and this one does."""
+
+    checkpoint: str
+    kind: str  # create | add_field | add_index | drop | grow | delete_all | reinsert | idle | empty
+    role: str | None
+    instance: str | None
+
+
+def _events() -> tuple[Event, ...]:
+    ops = PLAN["tables"]["checkpoint_operations"]
+    out = []
+    for cp in CHECKPOINTS:
+        text = ops[cp]
+        role = cp[:2] if cp[:2] in ROLES else None
+        instance = None
+        if role is not None:
+            live = [i for i in INSTANCES if i.role == role and cp in i.checkpoints]
+            instance = live[0].id if live else None
+        if cp == "EMPTY":
+            kind = "empty"
+        elif "Close and reopen" in text:
+            kind = "idle"
+        elif "TableDefs.Delete" in text:
+            kind = "drop"
+        elif "TableDefs.Append" in text:
+            kind = "create"
+        elif "Fields.Append" in text:
+            kind = "add_field"
+        elif "Indexes.Append" in text:
+            kind = "add_index"
+        elif "Delete every" in text:
+            kind = "delete_all"
+        elif "Reinsert" in text:
+            kind = "reinsert"
+        else:
+            kind = "grow"
+        out.append(Event(cp, kind, role, instance))
+    return tuple(out)
+
+
+EVENTS: tuple[Event, ...] = _events()
+EVENT_BY_CHECKPOINT: Mapping[str, Event] = MappingProxyType({e.checkpoint: e for e in EVENTS})
+# The seven H4 operation instances in checkpoint order (expected_kind_relations).
+OPERATION_INSTANCES: tuple[tuple[str, str, str], ...] = tuple(
+    (e.checkpoint, e.instance or "", {"create": "table", "add_field": "field", "add_index": "index"}[e.kind])
+    for e in EVENTS if e.kind in ("create", "add_field", "add_index")
+)
+if len(OPERATION_INSTANCES) != 7:
+    raise SpecError("plan does not list exactly seven catalog operation instances")
+FIELD_NAME = FIELD_DEFS[1]["name"]
+INDEX_NAME = INDEX_DEF["name"]
+
+
+def expected_name(replica: int, checkpoint: str) -> str:
+    """Object name created by the listed operation at ``checkpoint`` under the replica's role rotation."""
+    event = EVENT_BY_CHECKPOINT[checkpoint]
+    if event.kind == "create":
+        return ROLE_BINDINGS[replica][event.role or ""]
+    return FIELD_NAME if event.kind == "add_field" else INDEX_NAME
+
+
+def name_bytes(name: str) -> dict[str, bytes]:
+    """Both registered expected byte sequences for a name; strict, no best-fit."""
+    return {
+        NAME_ENCODINGS[0]["id"]: name.encode("cp1252"),
+        NAME_ENCODINGS[1]["id"]: name.encode("utf-8"),
+    }
+
+
+def row_payload(role: str, row_id: int) -> bytes:
+    text = f"A4|{role}|{row_id:010d}|"
+    return (text * (240 // len(text) + 1))[:240].encode("ascii")
+
+
+_ROLLING_CACHE: dict[tuple[str, int], str] = {}
+
+
+def rolling_sha256(role: str, row_count: int) -> str:
+    key = (role, row_count)
+    if key not in _ROLLING_CACHE:
+        digest = hashlib.sha256()
+        for row_id in range(1, row_count + 1):
+            payload = row_payload(role, row_id)
+            digest.update(row_id.to_bytes(4, "little", signed=True))
+            digest.update(len(payload).to_bytes(2, "little"))
+            digest.update(payload)
+        _ROLLING_CACHE[key] = digest.hexdigest()
+    return _ROLLING_CACHE[key]
+
+
+def count_satisfies(contract: dict[str, Any], measured: int) -> bool:
+    """R4-S01 semantics: exact equality, minimum >=, or membership in one allowed range."""
+    if "allowed_ranges" in contract:
+        return any(count_satisfies(r, measured) for r in contract["allowed_ranges"])
+    if "exact" in contract:
+        return measured == int(contract["exact"])
+    if "minimum" in contract:
+        return measured >= int(contract["minimum"])
+    raise SpecError(f"unrecognised survivor count contract {contract}")
+
+
+def layer_of(predicate_id: str) -> str | None:
+    for key, ids in LAYER_PREDICATES.items():
+        if predicate_id in ids:
+            return key
+    return None

--- a/oracle/windows-dao/tests/test_a4_dryrun.py
+++ b/oracle/windows-dao/tests/test_a4_dryrun.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 import unittest
+from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
 
@@ -85,6 +86,30 @@ class A4GeneratorTests(unittest.TestCase):
         self.assertIsNone(evaluation.first_failure)
         self.assertIsNotNone(evaluation.derivation_sha256)
 
+    def test_schema_snapshot_requires_full_schema_and_exact_campaign(self) -> None:
+        for field in ("document_type", "database_unchanged_by_read", "producer_commit", "environment_sha256"):
+            campaign = generate()
+            del campaign.replicas[1].snapshots["T2_CREATE"][field]
+            self.assertEqual(evaluate(campaign).first_failure, "A4-SCHEMA-SNAPSHOT", field)
+
+        for replicas in ((1, 2), (1, 3)):
+            campaign = generate()
+            campaign.replicas = {replica: campaign.replicas[replica] for replica in replicas}
+            self.assertEqual(evaluate(campaign).first_failure, "A4-SCHEMA-SNAPSHOT", replicas)
+
+        campaign = generate()
+        campaign.replicas[4] = deepcopy(campaign.replicas[3])
+        campaign.replicas[4].number = 4
+        self.assertEqual(evaluate(campaign).first_failure, "A4-SCHEMA-SNAPSHOT")
+
+    def test_h4_model_identity_excludes_replica_physical_root_page(self) -> None:
+        evaluation = evaluate(generate(Params(system_prefix_pages_by_replica={2: 1, 3: 2})))
+        self.assertIsNone(evaluation.first_failure)
+        stages = evaluation.stages["h4_catalog_bootstrap"]
+        self.assertNotEqual(stages["1"]["root_tdef_page"], stages["2"]["root_tdef_page"])
+        self.assertEqual(stages["1"]["canonical_model_id"], stages["2"]["canonical_model_id"])
+        self.assertNotEqual(stages["1"]["canonical_candidate_id"], stages["2"]["canonical_candidate_id"])
+
 
 class A4HarnessTests(unittest.TestCase):
     def test_adversarial_cases_are_handled_as_registered(self) -> None:
@@ -107,6 +132,14 @@ class A4HarnessTests(unittest.TestCase):
         campaign.blobs[digest] = campaign.blobs[digest][:-1]
         with self.assertRaises(FixtureRejected):
             evaluate(campaign)
+
+    def test_adversarial_rejection_reason_must_match(self) -> None:
+        fixture = replace(_fixture("A4-ADV-MALFORMED-PAGE"),
+                          grammar_selection={"base_formula": ["not-a-registered-formula"]})
+        entry = run_fixture(fixture)
+        self.assertTrue(entry["rejected"])
+        self.assertEqual(entry["rejection_code"], "unregistered_candidate_id")
+        self.assertFalse(entry["accepted"])
 
     def test_earlier_predicate_wins_and_fixture_is_rejected(self) -> None:
         entry = run_fixture(_fixture("A4-ADV-EARLIER-PREDICATE"))

--- a/oracle/windows-dao/tests/test_a4_dryrun.py
+++ b/oracle/windows-dao/tests/test_a4_dryrun.py
@@ -46,8 +46,19 @@ class A4SpecTests(unittest.TestCase):
         self.assertFalse(count_satisfies({"exact": 0}, 1))
         self.assertTrue(count_satisfies({"minimum": 2}, 3))
         self.assertFalse(count_satisfies({"minimum": 2}, 1))
+        replica_contract = {"per_replica_exact": 1, "replica_count": 2, "total_exact": 2}
+        self.assertTrue(count_satisfies(replica_contract, 2))
+        self.assertFalse(count_satisfies(replica_contract, 1))
         for contract in (c["failure_survivor_count"] for c in PREDICATE_CONTRACTS.values()):
-            self.assertTrue({"exact", "minimum", "allowed_range", "allowed_ranges"} & set(contract), contract)
+            if "per_replica_exact" in contract:
+                self.assertTrue({"per_replica_exact", "replica_count", "total_exact"} <= set(contract), contract)
+                self.assertEqual(
+                    int(contract["per_replica_exact"]) * int(contract["replica_count"]),
+                    int(contract["total_exact"]),
+                    contract,
+                )
+            else:
+                self.assertTrue({"exact", "minimum", "allowed_range", "allowed_ranges"} & set(contract), contract)
 
 
 class A4PageCodecTests(unittest.TestCase):

--- a/oracle/windows-dao/tests/test_a4_dryrun.py
+++ b/oracle/windows-dao/tests/test_a4_dryrun.py
@@ -1,0 +1,152 @@
+"""Focused contracts for the A4 dry-run reachability harness (no full sweep here)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from a4_campaign import Campaign  # noqa: E402
+from a4_dryrun import run_fixture  # noqa: E402
+from a4_dryrun_core import FixtureRejected  # noqa: E402
+from a4_dryrun_eval import evaluate  # noqa: E402
+from a4_dryrun_fixtures import ADVERSARIAL, BASELINE, REGISTRY_FIXTURES, UNREACHABLE, all_fixtures  # noqa: E402
+from a4_dryrun_h1 import MAX_SYNTACTIC_PAGE, WINDOW_OFFSETS, canonical_pair_count  # noqa: E402
+from a4_generator import Params, generate  # noqa: E402
+from a4_pages import (  # noqa: E402
+    data_page, decode_directory, decode_locator, decode_map_row, encode_locator, type0_row, validate_directory,
+)
+from a4_spec import (  # noqa: E402
+    LOCATOR_LAYOUTS, PLAN, PLAN_SHA256, PREDICATE_CONTRACTS, PREDICATE_ORDER, count_satisfies,
+)
+
+A3_BUNDLE = Path(PLAN["candidate_grammars"]["h1"]["a3_page_23_recomputed_work"]["source_bundle"]) / "jet3-a3-bundle"
+
+
+def _fixture(fixture_id: str):
+    return next(f for f in all_fixtures() if f.fixture_id == fixture_id)
+
+
+class A4SpecTests(unittest.TestCase):
+    def test_plan_pin_and_registry_cover_forty_predicates(self) -> None:
+        self.assertEqual(len(PLAN_SHA256), 64)
+        self.assertEqual(len(PREDICATE_ORDER), 40)
+        self.assertEqual({f.predicate_id for f in REGISTRY_FIXTURES}, set(PREDICATE_ORDER))
+        self.assertTrue(set(UNREACHABLE) <= set(PREDICATE_ORDER))
+
+    def test_count_contract_semantics(self) -> None:
+        self.assertTrue(count_satisfies({"exact": 0}, 0))
+        self.assertFalse(count_satisfies({"exact": 0}, 1))
+        self.assertTrue(count_satisfies({"minimum": 2}, 3))
+        self.assertFalse(count_satisfies({"minimum": 2}, 1))
+        for contract in (c["failure_survivor_count"] for c in PREDICATE_CONTRACTS.values()):
+            self.assertTrue({"exact", "minimum", "allowed_range", "allowed_ranges"} & set(contract), contract)
+
+
+class A4PageCodecTests(unittest.TestCase):
+    def test_locator_roundtrip_both_layouts(self) -> None:
+        for layout in LOCATOR_LAYOUTS:
+            self.assertEqual(decode_locator(encode_locator(layout, 0x012345, 7), layout), (0x012345, 7))
+
+    def test_directory_validation_rejects_overlap_and_out_of_page(self) -> None:
+        page = data_page([type0_row(3, {3, 4}), type0_row(3, set())])
+        self.assertIsNone(validate_directory(decode_directory(page, 0x1FFF)))
+        broken = bytearray(page)
+        broken[12:14] = (12).to_bytes(2, "little")
+        self.assertIsNotNone(validate_directory(decode_directory(bytes(broken), 0x1FFF)))
+
+    def test_map_row_rejects_unknown_type(self) -> None:
+        self.assertIsInstance(decode_map_row(b"\x07\x00\x00\x00\x00"), str)
+        row = decode_map_row(type0_row(10, {10, 12}))
+        self.assertEqual(row.type0_pages("set_bit_owned_in_use"), {10, 12})
+
+    def test_canonical_pair_count_matches_brute_force(self) -> None:
+        offsets = {0, 1, 4, 5, 9, 40}
+        brute = sum(1 for a in offsets for b in offsets if b - a >= 4)
+        self.assertEqual(canonical_pair_count(offsets), brute)
+
+
+class A4GeneratorTests(unittest.TestCase):
+    def test_campaign_is_reproducible_and_exact_pages(self) -> None:
+        a, b = generate(), generate()
+        self.assertEqual(a.inventory()["campaign_sha256"], b.inventory()["campaign_sha256"])
+        self.assertTrue(all(len(blob) == 2048 for blob in a.blobs.values()))
+        self.assertEqual(sorted(a.replicas), [1, 2, 3])
+        self.assertEqual(len(a.replicas[1].snapshots), 25)
+
+    def test_baseline_passes_every_predicate(self) -> None:
+        evaluation = evaluate(generate())
+        self.assertIsNone(evaluation.first_failure)
+        self.assertIsNotNone(evaluation.derivation_sha256)
+
+
+class A4HarnessTests(unittest.TestCase):
+    def test_adversarial_cases_are_handled_as_registered(self) -> None:
+        for fixture in ADVERSARIAL:
+            entry = run_fixture(fixture)
+            self.assertTrue(entry["accepted"], (fixture.fixture_id, entry.get("rejection")))
+        counts = {f.fixture_id: run_fixture(f)["measured_count"] for f in ADVERSARIAL if f.fixture_id.startswith("A4-ADV-TDEF")}
+        self.assertEqual(counts, {"A4-ADV-TDEF-MULTIPLE-3": 3, "A4-ADV-TDEF-MULTIPLE-4": 4})
+
+    def test_multiple_two_and_encoding_zero_two(self) -> None:
+        self.assertEqual(run_fixture(_fixture("A4-R06-H1-TDEF-MULTIPLE"))["measured_count"], 2)
+        self.assertEqual(run_fixture(_fixture("A4-R37-H4-ENCODING"))["measured_count"], 0)
+        self.assertEqual(run_fixture(_fixture("A4-ADV-ENCODING-2"))["measured_count"], 2)
+
+    def test_unregistered_id_and_malformed_page_raise_before_evaluation(self) -> None:
+        with self.assertRaises(FixtureRejected):
+            evaluate(generate(), {"row_mask": ["0x0001"]})
+        campaign = generate()
+        digest = campaign.replicas[1].pages["EMPTY"][1]
+        campaign.blobs[digest] = campaign.blobs[digest][:-1]
+        with self.assertRaises(FixtureRejected):
+            evaluate(campaign)
+
+    def test_earlier_predicate_wins_and_fixture_is_rejected(self) -> None:
+        entry = run_fixture(_fixture("A4-ADV-EARLIER-PREDICATE"))
+        self.assertTrue(entry["rejected"])
+        self.assertEqual(entry["first_failure"], "A4-H2-ROW-DIRECTORY-INVALID")
+
+    def test_wrong_target_claim_is_rejected(self) -> None:
+        fixture = replace(_fixture("A4-R15-H2-FLAGS"), predicate_id="A4-H3-BASE-NONE")
+        entry = run_fixture(fixture)
+        self.assertFalse(entry["accepted"])
+
+    def test_unreachable_attempt_fixture_does_not_reach(self) -> None:
+        for predicate_id in UNREACHABLE:
+            entry = run_fixture(next(f for f in REGISTRY_FIXTURES if f.predicate_id == predicate_id))
+            self.assertFalse(entry["accepted"])
+            self.assertLessEqual(entry["measured_count"], 1)
+
+    def test_baseline_fixture_has_no_patches_or_knobs(self) -> None:
+        self.assertEqual(BASELINE.params, Params())
+        self.assertEqual(BASELINE.patches, ())
+
+
+class A4CalibrationTests(unittest.TestCase):
+    @unittest.skipUnless(A3_BUNDLE.is_dir(), "retained A3 bundle is absent")
+    def test_a3_page_23_preserved_windows_match_plan(self) -> None:
+        index_dir = A3_BUNDLE / "page-indexes" / "replica-01"
+        pages = []
+        for index in sorted(index_dir.glob("*.json")):
+            digest = json.loads(index.read_text())["ordered_page_sha256"][23]
+            pages.append((A3_BUNDLE / "page-store" / f"{digest}.page").read_bytes())
+        self.assertEqual(len(pages), 25)
+        expected = PLAN["candidate_grammars"]["h1"]["a3_page_23_recomputed_work"]
+        for layout, key in (("u24le_page_then_u8_row", "syntactically_preserved_page_row"),
+                            ("u8_row_then_u24le_page", "syntactically_preserved_row_page")):
+            preserved = 0
+            for offset in WINDOW_OFFSETS:
+                decoded = {decode_locator(p[offset: offset + 4], layout) for p in pages}
+                preserved += len(decoded) == 1 and next(iter(decoded))[0] <= MAX_SYNTACTIC_PAGE
+            self.assertEqual(preserved, expected[key], layout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Byte-level A4 dry-run harness modelled on the rebuilt A3 harness (#58): a plan-driven synthetic campaign generator and a **plan-driven reference evaluator** (explicitly *not* the production A4 analyzer) that decodes exact 2,048-byte page campaigns under the 40 registered predicate contracts in normative order. Based on `codex/a4-plan` at review pass 4 (plan SHA `550c6e56…`).

- `a4_spec.py`, `a4_pages.py`, `a4_campaign.py`, `a4_generator.py` — plan-pinned constants, SRC-0020 page codec, shared-campaign fixture model (page blobs + page indexes + lifecycle events + DAO snapshot values, no verdict booleans), reproducible generator with per-replica overshoot profiles.
- `a4_dryrun_core/campaign/h1/h2/h3/h4/eval.py` — one propagated state, first-failure reporting, union-once charging, freeze hash before any replica-3 read, holdout H1→H4.
- `a4_dryrun_fixtures.py`, `a4_dryrun.py` — one fixture per registry `reachability_fixture_id`, adversarial cases, sweep + hash-bound transcript.
- `tests/test_a4_dryrun.py` — 16 tests (codec, generator reproducibility, count-contract semantics, all adversarial cases, wrong-target rejection, A3 page-23 calibration when the retained bundle is present).

## Executed result

`python3 a4_dryrun.py --jobs 8` → `result=pass`: 39/39 claimed-reachable terminals measured as first failure with counts satisfying their contracts, `A4-H1-LOCATOR-PAIR-MULTIPLE` asserted unreachable by enumeration (max measured count 1 across the sweep), 8 adversarial cases OK. Transcript: `experiments/a4/dry-run/a4-reference-reachability-transcript.json` (+ `checksums.json`), bound to plan SHA, harness-source and generator hashes.

The artifact is deliberately **not** the dispatch-gate `a4-reachability-transcript.json`: that schema needs analyzer/independent-validator commits and results, a provenance entry, and resource-ceiling cases (see AMB-16/17 below).

## Plan ambiguities found (recorded in the transcript as `plan_ambiguities`)

1. AMB-01 syntactic decodability: the plan's 1,872 preserved windows on A3 page 23 reproduce only with u24 page ≤ 65535; the frozen 0..20479 bound gives 1,869.
2. AMB-02 exact locator holes ⇒ at most one structural pair per layout ⇒ `A4-H1-LOCATOR-PAIR-MULTIPLE` is unreachable, contradicting its registry claim.
3. AMB-03 union-once qualified pages identified by page number.
4. AMB-04 NONE/MULTIPLE counts are per replica (1 then 2); REPLICA-DISAGREEMENT compares canonical models.
5. AMB-05 H2 "fits their static structure" undefined; reading used: sets below page_count, owned nonempty, available ⊆ owned, type-1 rows deferred to H3.
6. AMB-06 R19's "owned set changes during an idle leg" is preempted by A4-IDLE-EQUALITY; a grow-leg violation is used instead.
7. AMB-07 grow signature "may remove but not add those same pages" reading.
8. AMB-08 H3 fit = containment at conversion + transition signatures; no extant-page rule; six input regions defined.
9. AMB-09 root signature: stream must change at ≥1 of the seven operations (all seven would make SCHEMA-DELTA-OUTSIDE-OWNED unreachable); no H1 signature on system TDEFs.
10. AMB-10 isolated delta excludes user TDEF/map pages; page 0 assumed static (a real Jet header that changes per operation fails the predicate on every campaign).
11. AMB-11 structural stage needs a length-plausibility test (stored length ∈ union of registered encodings' counts) or FIELD-MODEL-MULTIPLE is the only reachable H4 outcome.
12. AMB-12 tuples decoding identical values are one model; endianness of one-byte fields is unidentifiable otherwise.
13. AMB-13 campaign predicates read replica 3 before the freeze.
14. AMB-14 H3 holdout is vacuous if replica 3 has no type-1 row.
15. AMB-15 H2 role assignment binds locator ordinal; swapping rows in one replica changes the H2 model only.
16. AMB-16 `reachability-transcript.schema.json` requires a non-null first failure on all 40 entries — no room for an asserted-unreachable terminal.
17. AMB-17 the bound transcript needs analyzer/validator commits, a provenance entry, and `resource_exact_ceiling`/`resource_one_over` cases at exactly 600,000,000 units, which a synthetic campaign cannot reach honestly without a declared charge-injection mechanism.

Also noted: LAYOUT-MULTIPLE is only constructible with preallocated low user pages; the dry-run-report schema's parameter_coverage/timing cases belong to the analyzer lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7kEF5zhiqN6kNyX4fVi6L
