### PR TITLE
feat(a4): build the preregistered analyzer and generator

### DIFF
--- a/oracle/windows-dao/scripts/a4_analysis.py
+++ b/oracle/windows-dao/scripts/a4_analysis.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Top-level A4 analyze/freeze/open-holdout/report pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from a4_analysis_input import (
+    CheckedAnalysisInput,
+    HoldoutProvider,
+    ReplicaAnalysisInput,
+    check_analysis_input,
+    close_derivation,
+    open_holdout,
+    open_holdout_campaign,
+)
+from a4_analysis_state import FrozenDerivation, freeze_derivation, resume_derivation
+from a4_analysis_holdout import HoldoutResults, evaluate_holdout
+from a4_frozen_models import load_frozen_models
+from a4_layers import DerivationLayers, derive_layers
+from a4_model import WorkLedger
+from a4_measurements import PredicateMeasurement
+from a4_terminal import DerivationTerminal
+from a4_spec import (
+    EXPERIMENT_ID,
+    PLAN,
+    PLAN_SHA256,
+    PREDICATE_CONTRACTS,
+    PREDICATE_IDS,
+    REVISION_PLAN_SHA256,
+    validate_schema,
+)
+
+
+_HOLDOUT_IDS = {
+    "h1": "A4-H1-HOLDOUT-PREDICTION",
+    "h2": "A4-H2-HOLDOUT-PREDICTION",
+    "h3": "A4-H3-HOLDOUT-PREDICTION",
+    "h4_root": "A4-H4-HOLDOUT-ROOT",
+    "h4_fields": "A4-H4-HOLDOUT-FIELDS",
+}
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    frozen: FrozenDerivation
+    occurrence_evidence: Mapping[str, object]
+    report: Mapping[str, Any]
+
+
+def _holdout_document(
+    results: HoldoutResults | None,
+) -> dict[str, dict[str, str | None]]:
+    output: dict[str, dict[str, str | None]] = {}
+    for name, predicate_id in _HOLDOUT_IDS.items():
+        value = None if results is None else getattr(results, name)
+        output[name] = {
+            "status": "not_applicable" if value is None else "pass" if value else "fail",
+            "terminal_predicate_id": predicate_id if value is False else None,
+        }
+    return output
+
+
+def _predicate_rows(
+    layers: Mapping[str, Any],
+    holdout: HoldoutResults | None,
+    measurements: tuple[PredicateMeasurement, ...],
+) -> list[dict[str, Any]]:
+    holdout_values = {
+        predicate_id: None if holdout is None else getattr(holdout, name)
+        for name, predicate_id in _HOLDOUT_IDS.items()
+    }
+    rows: list[dict[str, Any]] = []
+    for predicate_id in PREDICATE_IDS:
+        contract = PREDICATE_CONTRACTS[predicate_id]
+        if contract["scope"] == "campaign":
+            status = "pass"
+        elif predicate_id in holdout_values:
+            value = holdout_values[predicate_id]
+            status = "not_applicable" if value is None else "pass" if value else "fail"
+        else:
+            events = tuple(
+                event for event in measurements if event.predicate_id == predicate_id
+            )
+            failed = next((event for event in events if not event.passed), None)
+            selected = failed if failed is not None else events[-1] if events else None
+            status = (
+                "not_applicable"
+                if selected is None
+                else "pass"
+                if selected.passed
+                else "fail"
+            )
+        if contract["scope"] == "campaign":
+            measured = 0
+        elif predicate_id in holdout_values:
+            measured = 0 if status == "not_applicable" else 1
+        else:
+            measured = 0 if selected is None else selected.measured_count
+        retains_derivation = (
+            contract["scope"] != "campaign"
+            and status != "not_applicable"
+            and (status == "pass" or predicate_id in holdout_values)
+        )
+        rows.append({
+            "predicate_id": predicate_id,
+            "order": contract["order"],
+            "scope": contract["scope"],
+            "status": status,
+            "terminal_predicate_id": predicate_id if status == "fail" else None,
+            "predicate_measured_survivor_count": measured,
+            "derivation_survivor_count": 1 if retains_derivation else 0,
+            "reachability_fixture_id": contract["reachability_fixture_id"],
+        })
+    return rows
+
+
+def _report(
+    campaign_id: str,
+    producer_commit: str,
+    frozen: FrozenDerivation,
+    holdout: HoldoutResults | None,
+    logical_read_bytes: list[int],
+    measurements: tuple[PredicateMeasurement, ...],
+) -> dict[str, Any]:
+    frozen_document = frozen.document
+    report: dict[str, Any] = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_analysis_report",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "campaign_id": campaign_id,
+        "producer_commit": producer_commit,
+        "derivation_replicas": [1, 2],
+        "qualified_pages": frozen_document["qualified_pages"],
+        "work_charges": frozen_document["work_charges"],
+        "derivation_candidate_set_sha256": frozen.sha256,
+        "holdout_replica": 3,
+        "holdout_opened_after_freeze": True,
+        "predicate_results": _predicate_rows(
+            frozen_document["layers"], holdout, measurements
+        ),
+        "h4_occurrence_evidence": frozen_document["h4_occurrence_evidence"],
+        "layers": frozen_document["layers"],
+        "holdout_results": _holdout_document(holdout),
+        "transcripts": frozen_document["transcripts"],
+        "scientific_outcome": (
+            "one_or_more_layers_predict_holdout"
+            if holdout is not None and any(value is True for value in (
+                holdout.h1,
+                holdout.h2,
+                holdout.h3,
+                holdout.h4_root,
+                holdout.h4_fields,
+            ))
+            else "no_layer_predicts_holdout"
+        ),
+        "claims": dict(PLAN["claims"]),
+        "analyzer_logical_read_bytes_by_replica": logical_read_bytes,
+    }
+    validate_schema(report, "dao_a4_analysis_report")
+    return report
+
+
+def analyze(
+    campaign_id: str,
+    producer_commit: str,
+    replicas: Mapping[int, ReplicaAnalysisInput],
+    holdout_provider: HoldoutProvider | None = None,
+) -> AnalysisResult:
+    """Derive on 1/2, freeze+verify exact bytes, then first open replica 3."""
+    provider = (
+        holdout_provider
+        if holdout_provider is not None
+        else getattr(replicas, "acquire_holdout", None)
+    )
+    if not callable(provider):
+        raise TypeError("A4 analysis requires a lazy holdout provider")
+    derivation_input = check_analysis_input(campaign_id, producer_commit, replicas)
+    ledger = WorkLedger()
+    layers = derive_layers(derivation_input, ledger)
+    frozen = freeze_derivation(derivation_input, layers, ledger)
+    resumed = resume_derivation(
+        frozen.canonical_bytes,
+        frozen.sha256,
+        frozen.occurrence_evidence_bytes,
+    )
+    if isinstance(layers, DerivationTerminal):
+        measurements = layers.measurements
+        occurrence_evidence = MappingProxyType(
+            {} if layers.h4_occurrence_evidence is None else dict(layers.h4_occurrence_evidence)
+        )
+        derivation_reads = [
+            derivation_input.views[replica].logical_read_bytes for replica in (1, 2)
+        ]
+        ticket = close_derivation(
+            derivation_input,
+            frozen.canonical_bytes,
+            frozen.sha256,
+            provider,
+            frozen.occurrence_evidence_bytes,
+        )
+        del layers, derivation_input, ledger, resumed
+        holdout_campaign = open_holdout_campaign(ticket, frozen.canonical_bytes)
+        del ticket
+        report = _report(
+            campaign_id,
+            producer_commit,
+            frozen,
+            None,
+            [*derivation_reads, holdout_campaign.view.logical_read_bytes],
+            measurements,
+        )
+        return AnalysisResult(frozen, occurrence_evidence, MappingProxyType(report))
+    frozen_models = load_frozen_models(resumed)
+    measurements = layers.measurements
+    occurrence_evidence = MappingProxyType(dict(layers.h4_occurrence_evidence))
+    derivation_reads = [
+        derivation_input.views[replica].logical_read_bytes for replica in (1, 2)
+    ]
+    ticket = close_derivation(
+        derivation_input,
+        frozen.canonical_bytes,
+        frozen.sha256,
+        provider,
+        frozen.occurrence_evidence_bytes,
+    )
+    prior_work_units = ledger.total_work_units
+    del layers, derivation_input, resumed, ledger
+    holdout_input = open_holdout(ticket, frozen.canonical_bytes)
+    del ticket
+    holdout_ledger = WorkLedger(prior_work_units)
+    holdout = evaluate_holdout(holdout_input, frozen_models, holdout_ledger)
+    report = _report(
+        campaign_id,
+        producer_commit,
+        frozen,
+        holdout,
+        [*derivation_reads, holdout_input.view.logical_read_bytes],
+        measurements,
+    )
+    return AnalysisResult(
+        frozen,
+        occurrence_evidence,
+        MappingProxyType(report),
+    )

--- a/oracle/windows-dao/scripts/a4_analysis_holdout.py
+++ b/oracle/windows-dao/scripts/a4_analysis_holdout.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Unchanged-model holdout evaluation for the A4 analyzer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from a4_analysis_input import HoldoutAnalysisInput
+from a4_derivation import isolated_operation_deltas
+from a4_frozen_models import FrozenModels
+from a4_layer_h1 import predict_h1
+from a4_layer_h2 import decode_frozen_owned_rows
+from a4_layer_h3 import predicts_h3
+from a4_layer_h4 import OPERATIONS
+from a4_layer_h4_holdout import predicts_fields, predicts_root
+from a4_model import A4AnalysisError, WorkLedger
+
+
+@dataclass(frozen=True)
+class HoldoutResults:
+    h1: bool
+    h2: bool | None
+    h3: bool | None
+    h4_root: bool | None
+    h4_fields: bool | None
+
+
+def evaluate_holdout(
+    inputs: HoldoutAnalysisInput,
+    frozen: FrozenModels,
+    ledger: WorkLedger | None = None,
+) -> HoldoutResults:
+    """Open replica 3 only after derivation freeze and apply unchanged models."""
+    from a4_layers import (
+        catalog_root_observations,
+        h3_observations,
+        operation_records,
+        predicts_h2,
+    )
+
+    work = ledger or WorkLedger()
+    view = inputs.view
+    holdout_h1 = predict_h1(
+        view, inputs.qualified_tdef_pages, frozen.h1, work
+    )
+    if holdout_h1 is None:
+        return HoldoutResults(False, None, None, None, None)
+    h2_ok = predicts_h2(
+        view,
+        holdout_h1,
+        frozen.h2,
+        inputs.replica.table_row_counts,
+    )
+    if not h2_ok:
+        return HoldoutResults(True, False, None, None, None)
+    try:
+        frozen_rows = decode_frozen_owned_rows(
+            view, holdout_h1, frozen.h2, work
+        )
+        rows = h3_observations(view, frozen_rows, work)
+    except A4AnalysisError:
+        raise
+    except ValueError:
+        return HoldoutResults(True, True, False, None, None)
+    h3_ok = predicts_h3(
+        frozen.h3, rows, inputs.replica.source.page_count
+    )
+    if not h3_ok:
+        return HoldoutResults(True, True, False, None, None)
+    roots = catalog_root_observations(
+        view,
+        inputs.qualified_tdef_pages,
+        holdout_h1,
+        frozen.h2,
+        frozen.h3,
+        work,
+    )
+    matching_roots = tuple(
+        root for root in roots if predicts_root(frozen.h4_root, root)
+    )
+    if len(matching_roots) != 1:
+        return HoldoutResults(True, True, True, False, None)
+    root = matching_roots[0]
+    try:
+        deltas = isolated_operation_deltas(view, holdout_h1, rows, frozen.h3)
+        for operation in OPERATIONS:
+            if deltas[operation] - root.admitted_pages_by_checkpoint[operation]:
+                return HoldoutResults(True, True, True, True, False)
+        candidates = operation_records(
+            view, root, deltas, frozen.h2, work
+        )
+        grouped = {operation: [] for operation in OPERATIONS}
+        for record in candidates:
+            grouped[record.operation_id].append(record)
+        if any(len(grouped[operation]) != 1 for operation in OPERATIONS):
+            return HoldoutResults(True, True, True, True, False)
+        records = tuple(grouped[operation][0] for operation in OPERATIONS)
+        fields_ok = predicts_fields(
+            frozen.h4.structural, frozen.h4.final, records
+        )
+    except A4AnalysisError:
+        raise
+    except (KeyError, TypeError, ValueError):
+        fields_ok = False
+    return HoldoutResults(True, True, True, True, fields_ok)

--- a/oracle/windows-dao/scripts/a4_analysis_input.py
+++ b/oracle/windows-dao/scripts/a4_analysis_input.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Fail-closed campaign inputs and the A4 freeze-before-holdout boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
+
+from a4_campaign import CampaignResourceTotals, check_campaign_replica
+from a4_model import A4AnalysisError, ReplicaData, View
+from a4_spec import BOUNDS, CHECKPOINT_IDS
+
+_MAX_QUALIFIED = int(BOUNDS["max_qualified_pages_per_submodel"])
+
+
+@dataclass(frozen=True)
+class ReplicaAnalysisInput:
+    """All independently checked surfaces for one physical replica."""
+
+    source: ReplicaData
+    table_row_counts: Mapping[str, Mapping[str, int]]
+    replica_observation: Mapping[str, Any] | None = None
+    page_indexes: Mapping[str, Mapping[str, Any]] | None = None
+    schema_snapshots: Mapping[str, Mapping[str, Any]] | None = None
+    artifact_manifest: Mapping[str, Any] | None = None
+    environment_payload: bytes | None = None
+
+
+HoldoutProvider = Callable[[bytes, str], ReplicaAnalysisInput]
+
+
+@dataclass(frozen=True)
+class _BoundedSource:
+    source: ReplicaData
+    checkpoint_ids: tuple[str, ...]
+    page_count: Mapping[str, int]
+    ordered_page_sha256: Mapping[str, tuple[str, ...]]
+
+    def page_bytes(self, sha256: str) -> bytes:
+        return self.source.page_bytes(sha256)
+
+
+def _bounded_sequence(value: Any, expected: int, label: str) -> tuple[Any, ...]:
+    try:
+        if len(value) != expected:
+            raise ValueError(f"{label} length differs")
+        result = tuple(value[index] for index in range(expected))
+        try:
+            value[expected]
+        except IndexError:
+            return result
+    except (IndexError, KeyError, OverflowError, TypeError, ValueError) as exc:
+        raise A4AnalysisError(
+            "A4-SNAPSHOT-RECONSTRUCTION", detail=f"invalid {label}: {exc}"
+        ) from exc
+    raise A4AnalysisError(
+        "A4-SNAPSHOT-RECONSTRUCTION", detail=f"{label} exceeds its declared length"
+    )
+
+
+def _bounded_replica(
+    replica: int, value: ReplicaAnalysisInput
+) -> tuple[ReplicaAnalysisInput, frozenset[str]]:
+    checkpoints = _bounded_sequence(
+        value.source.checkpoint_ids, len(CHECKPOINT_IDS), "checkpoint sequence"
+    )
+    if checkpoints != CHECKPOINT_IDS:
+        raise A4AnalysisError(
+            "A4-SNAPSHOT-RECONSTRUCTION",
+            detail=f"replica {replica}: checkpoint order differs",
+        )
+    counts: dict[str, int] = {}
+    hashes: dict[str, tuple[str, ...]] = {}
+    for checkpoint in CHECKPOINT_IDS:
+        try:
+            count = value.source.page_count[checkpoint]
+            sequence = value.source.ordered_page_sha256[checkpoint]
+        except (KeyError, TypeError) as exc:
+            raise A4AnalysisError(
+                "A4-SNAPSHOT-RECONSTRUCTION",
+                detail=f"replica {replica}: missing {checkpoint} page index",
+            ) from exc
+        if (
+            isinstance(count, bool)
+            or not isinstance(count, int)
+            or not 1 <= count <= int(BOUNDS["max_final_pages_per_replica"])
+        ):
+            raise A4AnalysisError(
+                "A4-SNAPSHOT-RECONSTRUCTION",
+                detail=f"replica {replica}: invalid {checkpoint} page count",
+            )
+        bounded = _bounded_sequence(sequence, count, f"{checkpoint} page hashes")
+        if any(
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+            for digest in bounded
+        ):
+            raise A4AnalysisError(
+                "A4-SNAPSHOT-RECONSTRUCTION",
+                detail=f"replica {replica}: invalid {checkpoint} page digest",
+            )
+        counts[checkpoint], hashes[checkpoint] = count, bounded
+    source = _BoundedSource(
+        value.source,
+        CHECKPOINT_IDS,
+        MappingProxyType(counts),
+        MappingProxyType(hashes),
+    )
+    bounded_input = ReplicaAnalysisInput(
+        source,
+        value.table_row_counts,
+        value.replica_observation,
+        value.page_indexes,
+        value.schema_snapshots,
+        value.artifact_manifest,
+        value.environment_payload,
+    )
+    return bounded_input, frozenset(
+        digest for sequence in hashes.values() for digest in sequence
+    )
+
+
+@dataclass(frozen=True)
+class CheckedAnalysisInput:
+    campaign_id: str
+    producer_commit: str
+    replicas: Mapping[int, ReplicaAnalysisInput]
+    views: Mapping[int, View]
+    qualified_tdef_pages: Mapping[int, tuple[int, ...]]
+    campaign_resources: Mapping[int, CampaignResourceTotals]
+    environment_exact_fields: tuple[object, ...]
+    derivation_matrix_job_ids: frozenset[str]
+
+
+@dataclass(frozen=True)
+class HoldoutAnalysisInput:
+    """Replica-3-only input surface created after exact frozen-state resume."""
+
+    campaign_id: str
+    producer_commit: str
+    replica: ReplicaAnalysisInput
+    view: View
+    qualified_tdef_pages: tuple[int, ...]
+    campaign_resources: CampaignResourceTotals
+
+
+@dataclass(frozen=True)
+class HoldoutCampaignInput:
+    """Structurally validated replica 3 before optional scientific evaluation."""
+
+    replica: ReplicaAnalysisInput
+    view: View
+    campaign_resources: CampaignResourceTotals
+
+
+@dataclass(frozen=True)
+class HoldoutTicket:
+    """The only capability retained after derivation state is closed."""
+
+    campaign_id: str
+    producer_commit: str
+    provider: HoldoutProvider
+    derivation_page_digests: frozenset[str]
+    frozen_derivation_sha256: str
+    occurrence_evidence_payload: bytes | None
+    environment_exact_fields: tuple[object, ...]
+    derivation_matrix_job_ids: frozenset[str]
+
+
+def _checked_identity(campaign_id: str, producer_commit: str) -> None:
+    allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+    if (
+        not 1 <= len(campaign_id) <= 128
+        or campaign_id[0] not in allowed
+        or set(campaign_id) - allowed
+    ):
+        raise ValueError("A4 campaign id is not canonical")
+    if len(producer_commit) != 40 or any(
+        value not in "0123456789abcdef" for value in producer_commit
+    ):
+        raise ValueError("A4 producer commit is not a full lowercase Git OID")
+
+
+def _qualified_tdefs(replica: int, view: View) -> tuple[int, ...]:
+    candidates: set[int] = set()
+    for checkpoint in CHECKPOINT_IDS:
+        for page in range(view.page_count(checkpoint)):
+            payload = view.page_optional(checkpoint, page)
+            if payload is not None and payload[0] == 0x02:
+                candidates.add(page)
+                if len(candidates) > _MAX_QUALIFIED:
+                    raise A4AnalysisError(
+                        "A4-RESOURCE-BOUND",
+                        detail=f"replica {replica}: qualified TDEF pages exceed the bound",
+                    )
+    return tuple(sorted(candidates))
+
+
+def check_analysis_input(
+    campaign_id: str,
+    producer_commit: str,
+    replicas: Mapping[int, ReplicaAnalysisInput],
+) -> CheckedAnalysisInput:
+    """Check replicas 1/2 completely without reading any replica-3 surface."""
+    _checked_identity(campaign_id, producer_commit)
+    expected_replicas = (1, 2)
+    if tuple(sorted(replicas)) != expected_replicas:
+        raise A4AnalysisError(
+            "A4-SNAPSHOT-RECONSTRUCTION",
+            detail="A4 derivation requires exact replicas 1 and 2",
+        )
+    bounded: dict[int, ReplicaAnalysisInput] = {}
+    derivation_digests: set[str] = set()
+    for replica in (1, 2):
+        bounded[replica], digests = _bounded_replica(replica, replicas[replica])
+        derivation_digests.update(digests)
+    _check_retained_store(derivation_digests)
+    checked = {
+        replica: check_campaign_replica(
+            replica, bounded[replica], campaign_id, producer_commit
+        )
+        for replica in (1, 2)
+    }
+    exact_fields = {
+        checked[replica].environment_exact_fields for replica in (1, 2)
+    }
+    job_ids = frozenset(
+        checked[replica].matrix_job_id for replica in (1, 2)
+    )
+    if len(exact_fields) != 1 or len(job_ids) != 2:
+        raise A4AnalysisError(
+            "A4-SCHEMA-SNAPSHOT",
+            detail="derivation environment or matrix-job identity differs",
+        )
+    views = {replica: checked[replica].view for replica in (1, 2)}
+    qualified = {
+        replica: _qualified_tdefs(replica, views[replica]) for replica in (1, 2)
+    }
+    derivation_digests = {
+        digest for view in views.values() for checkpoint in CHECKPOINT_IDS
+        for digest in view.hashes(checkpoint)
+    }
+    _check_retained_store(derivation_digests)
+    return CheckedAnalysisInput(
+        campaign_id,
+        producer_commit,
+        MappingProxyType(bounded),
+        MappingProxyType(views),
+        MappingProxyType(qualified),
+        MappingProxyType(
+            {replica: checked[replica].resources for replica in (1, 2)}
+        ),
+        next(iter(exact_fields)),
+        job_ids,
+    )
+
+
+def close_derivation(
+    inputs: CheckedAnalysisInput,
+    frozen_payload: bytes,
+    frozen_sha256: str,
+    holdout_provider: HoldoutProvider,
+    occurrence_evidence_payload: bytes | None = None,
+) -> HoldoutTicket:
+    """Mint a holdout capability only from verified frozen derivation bytes."""
+    if not callable(holdout_provider):
+        raise TypeError("A4 analysis requires a lazy holdout provider")
+    # Delayed to keep the input/freeze modules acyclic at import time.
+    from a4_analysis_state import resume_derivation
+
+    frozen = resume_derivation(
+        frozen_payload, frozen_sha256, occurrence_evidence_payload
+    )
+    if (
+        frozen["campaign_id"] != inputs.campaign_id
+        or frozen["derivation_replicas"] != [1, 2]
+    ):
+        raise ValueError("A4 frozen derivation does not bind this campaign")
+    digests = frozenset(
+        digest
+        for replica in (1, 2)
+        for checkpoint in CHECKPOINT_IDS
+        for digest in inputs.views[replica].hashes(checkpoint)
+    )
+    return HoldoutTicket(
+        inputs.campaign_id,
+        inputs.producer_commit,
+        holdout_provider,
+        digests,
+        frozen_sha256,
+        occurrence_evidence_payload,
+        inputs.environment_exact_fields,
+        inputs.derivation_matrix_job_ids,
+    )
+
+
+def _check_retained_store(digests: set[str] | frozenset[str]) -> None:
+    if (
+        len(digests) > int(BOUNDS["max_unique_page_blobs"])
+        or len(digests) * int(BOUNDS["page_size"])
+        > int(BOUNDS["max_retained_page_store_bytes"])
+    ):
+        raise A4AnalysisError(
+            "A4-RESOURCE-BOUND",
+            detail="aggregate retained page store exceeds the campaign bound",
+        )
+
+
+def open_holdout_campaign(
+    inputs: HoldoutTicket, frozen_payload: bytes
+) -> HoldoutCampaignInput:
+    """Acquire and campaign-check replica 3 only after exact freeze resume."""
+    from a4_analysis_state import resume_derivation
+
+    frozen = resume_derivation(
+        frozen_payload,
+        inputs.frozen_derivation_sha256,
+        inputs.occurrence_evidence_payload,
+    )
+    if frozen["campaign_id"] != inputs.campaign_id:
+        raise ValueError("A4 frozen derivation does not bind this holdout ticket")
+    replica = inputs.provider(frozen_payload, inputs.frozen_derivation_sha256)
+    if not isinstance(replica, ReplicaAnalysisInput):
+        raise TypeError("A4 holdout provider did not return a replica input")
+    replica, holdout_digests = _bounded_replica(3, replica)
+    _check_retained_store(inputs.derivation_page_digests | holdout_digests)
+    checked = check_campaign_replica(
+        3, replica, inputs.campaign_id, inputs.producer_commit
+    )
+    if (
+        checked.environment_exact_fields != inputs.environment_exact_fields
+        or checked.matrix_job_id in inputs.derivation_matrix_job_ids
+    ):
+        raise A4AnalysisError(
+            "A4-SCHEMA-SNAPSHOT",
+            detail="holdout environment or matrix-job identity differs",
+        )
+    holdout_digests = {
+        digest
+        for checkpoint in CHECKPOINT_IDS
+        for digest in checked.view.hashes(checkpoint)
+    }
+    _check_retained_store(inputs.derivation_page_digests | holdout_digests)
+    return HoldoutCampaignInput(replica, checked.view, checked.resources)
+
+
+def open_holdout(inputs: HoldoutTicket, frozen_payload: bytes) -> HoldoutAnalysisInput:
+    """Open replica 3 for scientific evaluation after its campaign checks pass."""
+    campaign = open_holdout_campaign(inputs, frozen_payload)
+    qualified = _qualified_tdefs(3, campaign.view)
+    return HoldoutAnalysisInput(
+        inputs.campaign_id,
+        inputs.producer_commit,
+        campaign.replica,
+        campaign.view,
+        qualified,
+        campaign.campaign_resources,
+    )

--- a/oracle/windows-dao/scripts/a4_analysis_state.py
+++ b/oracle/windows-dao/scripts/a4_analysis_state.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python3
+"""Freeze/resume primitives for the A4 derivation boundary."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from a4_analysis_input import CheckedAnalysisInput
+from a4_frozen_validation import _verify_physical_projection, validate_frozen_layers
+from a4_layers import DerivationLayers
+from a4_model import QualifiedPage, WORK_TERM_LIMITS, WorkLedger
+from a4_terminal import DerivationTerminal
+from a4_spec import (
+    BOUNDS,
+    CHECKPOINT_IDS,
+    CHECKPOINT_ORDINALS,
+    EXPERIMENT_ID,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    canonical_json_bytes,
+    sha256_hex,
+    validate_schema,
+)
+
+
+_LAYER_KEYS = (
+    "h1_tdef_to_map_row",
+    "h2_row_identity_map_role",
+    "h3_indirect_traversal",
+    "h4_catalog_bootstrap",
+)
+_QUALIFIED_PAGE_MARKER = hashlib.sha256(
+    b"dao-a4-qualified-page-transcript-v1"
+).digest()[:15]
+_TRANSCRIPT_CATEGORY_CODES = dict(zip(
+    ("locators", "row_directories", "map_transitions", "reference_bitmaps",
+     "catalog_roots", "catalog_fields"), range(1, 7), strict=True,
+))
+
+
+def _candidate_hash(candidates: Sequence[Mapping[str, Any]]) -> str:
+    return sha256_hex(canonical_json_bytes(list(candidates)))
+
+
+def _decisive(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    candidates = [dict(candidate)]
+    return {
+        "status": "model",
+        "predicate_measured_survivor_count": 1,
+        "derivation_survivor_count": 1,
+        "terminal_predicate_id": None,
+        "terminal_payload_kind": None,
+        "terminal_candidate_stage": None,
+        "candidates": candidates,
+        "terminal_evidence": None,
+        "canonical_candidates_sha256": _candidate_hash(candidates),
+    }
+
+
+def _charge_frozen_candidates(layers: Mapping[str, Any], ledger: WorkLedger) -> None:
+    results = (
+        layers["h1_tdef_to_map_row"],
+        layers["h2_row_identity_map_role"],
+        layers["h3_indirect_traversal"],
+        layers["h4_catalog_bootstrap"]["root_result"],
+        layers["h4_catalog_bootstrap"]["structural_result"],
+        layers["h4_catalog_bootstrap"]["encoding_result"],
+    )
+    for result in results:
+        ledger.charge_candidate_documents(result["candidates"])
+
+
+def _verify_candidate_hashes(layers: Mapping[str, Any]) -> None:
+    """Recompute every frozen candidate-array hash for every outcome shape."""
+    results = (
+        layers["h1_tdef_to_map_row"],
+        layers["h2_row_identity_map_role"],
+        layers["h3_indirect_traversal"],
+        layers["h4_catalog_bootstrap"]["root_result"],
+        layers["h4_catalog_bootstrap"]["structural_result"],
+        layers["h4_catalog_bootstrap"]["encoding_result"],
+    )
+    for result in results:
+        if result["canonical_candidates_sha256"] != _candidate_hash(
+            result["candidates"]
+        ):
+            raise ValueError("A4 frozen candidate-array hash mismatch")
+
+
+def _verify_envelope(document: Mapping[str, Any]) -> None:
+    """Recheck canonical inventory ordering and the registered work sum."""
+    pages = document["qualified_pages"]
+    page_keys = [
+        (row["replica"], CHECKPOINT_ORDINALS[row["checkpoint_id"]], row["page_number"])
+        for row in pages
+    ]
+    if page_keys != sorted(set(page_keys)):
+        raise ValueError("A4 frozen qualified-page inventory is not canonical and unique")
+    charges = document["work_charges"]
+    terms = [value for key, value in charges.items() if key != "total_work_units"]
+    if any(isinstance(value, bool) or not isinstance(value, int) or value < 0 for value in terms):
+        raise ValueError("A4 frozen work charges contain an invalid term")
+    if charges["total_work_units"] != sum(terms) or sum(terms) > int(BOUNDS["max_analysis_work_units"]):
+        raise ValueError("A4 frozen work total differs from its bounded term sum")
+    for term, maximum in WORK_TERM_LIMITS.items():
+        if charges[term] > maximum:
+            raise ValueError(f"A4 frozen work term {term} exceeds its registered maximum")
+    candidate_payloads = {
+        canonical_json_bytes(dict(candidate))
+        for candidate in _all_frozen_candidates(document["layers"])
+    }
+    if len(candidate_payloads) > int(BOUNDS["max_candidate_models"]):
+        raise ValueError("A4 frozen candidates exceed the registered global maximum")
+    if any(len(payload) > 4096 for payload in candidate_payloads):
+        raise ValueError("A4 frozen candidate exceeds 4,096 encoded bytes")
+    if charges["candidate_serializations"] < len(candidate_payloads):
+        raise ValueError("A4 frozen candidate serialization charge omits retained candidates")
+    if (charges["invalid_path_row_directory_entries"]
+            and any(charges[term] for term in (
+                "valid_path_row_directory_entries",
+                "type_0_and_tag_05_bitmap_bits",
+                "type_1_slots",
+                "role_transition_evaluations",
+                "base_formula_evaluations",
+                "catalog_root_signatures",
+                "catalog_raw_rows",
+                "encoding_union_anchor_bytes",
+                "h4_name_length_structural_tuples",
+                "encoding_length_equivalence_candidates",
+            ))):
+        raise ValueError("A4 frozen work document mixes invalid and valid directory paths")
+
+
+def _all_frozen_candidates(layers: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    candidates: list[Mapping[str, Any]] = []
+    for result in (
+        layers["h1_tdef_to_map_row"],
+        layers["h2_row_identity_map_role"],
+        layers["h3_indirect_traversal"],
+        layers["h4_catalog_bootstrap"]["root_result"],
+        layers["h4_catalog_bootstrap"]["structural_result"],
+        layers["h4_catalog_bootstrap"]["encoding_result"],
+    ):
+        candidates.extend(result["candidates"])
+        evidence = result.get("terminal_evidence")
+        if isinstance(evidence, Mapping) and evidence.get("kind") == "replica_pair":
+            candidates.extend(entry["complete_candidate"] for entry in evidence["entries"])
+    return tuple(candidates)
+
+
+def _coverage_category(
+    ledger: WorkLedger,
+    page: QualifiedPage,
+    payload: bytes,
+    *,
+    h2_reached: bool,
+    h3_reached: bool,
+    h4_reached: bool,
+) -> tuple[str, str]:
+    """Classify a reached page by its registered read source and reached stage."""
+    discriminators = ledger.reached_page_discriminators(page)
+    prefixes = {value[0] for value in discriminators
+                if isinstance(value, tuple) and value and isinstance(value[0], str)}
+    if "catalog_page" in discriminators:
+        return "catalog_fields", "catalog_field"
+    if "system_map_page" in prefixes:
+        return "row_directories", "row_directory"
+    if prefixes & {"h3_reference_tag", "system_reference_tag"}:
+        return "reference_bitmaps", "reference_bitmap"
+    terms = set(ledger.qualified_page_terms(page))
+    if "catalog_raw_rows" in terms:
+        return "catalog_fields", "catalog_field"
+    if "catalog_root_signatures" in terms:
+        return "catalog_roots", "catalog_root"
+    if not h2_reached:
+        return "locators", "locator"
+    if not h3_reached:
+        return "row_directories", "row_directory"
+    if payload[:1] == b"\x05":
+        return "reference_bitmaps", "reference_bitmap"
+    map_terms = {"type_1_slots", "type_0_and_tag_05_bitmap_bits",
+                 "role_transition_evaluations", "base_formula_evaluations"}
+    if terms & map_terms:
+        return "map_transitions", "map_transition"
+    if h4_reached and payload[:1] == b"\x01":
+        return "catalog_fields", "catalog_field"
+    return "map_transitions", "map_transition"
+
+
+def _qualified_pages(ledger: WorkLedger) -> list[dict[str, int | str]]:
+    ordered = (
+        (page.replica, page.checkpoint_id, page.page_number)
+        for page in ledger.qualified_pages()
+    )
+    return [
+        {"replica": replica, "checkpoint_id": checkpoint, "page_number": page}
+        for replica, checkpoint, page in ordered
+    ]
+
+
+def _transcripts(
+    inputs: CheckedAnalysisInput, layers: DerivationLayers
+) -> dict[str, list[dict[str, Any]]]:
+    output: dict[str, list[dict[str, Any]]] = {
+        "row_directories": [],
+        "locators": [],
+        "map_transitions": [],
+        "reference_bitmaps": [],
+        "catalog_roots": [],
+        "catalog_fields": [],
+    }
+    for replica in (1, 2):
+        view = inputs.views[replica]
+        for binding in layers.h1_by_replica[replica].bindings:
+            for checkpoint in binding.checkpoints:
+                page = view.page(checkpoint, binding.tdef_page)
+                locator_bytes = b"".join(
+                    page[offset : offset + 4]
+                    for offset in layers.h1_by_replica[replica].locator_offsets
+                )
+                output["locators"].append({
+                    "kind": "locator",
+                    "checkpoint_id": checkpoint,
+                    "page": binding.tdef_page,
+                    "detail_hex": locator_bytes.hex(),
+                })
+                if binding.locator_targets is not None:
+                    for target in binding.locator_targets:
+                        data = view.page(checkpoint, target.page)
+                        output["row_directories"].append({
+                            "kind": "row_directory",
+                            "checkpoint_id": checkpoint,
+                            "page": target.page,
+                            "detail_hex": data[8:14].hex(),
+                        })
+        for row in layers.h3_observations[replica]:
+            output["map_transitions"].append({
+                "kind": "map_transition",
+                "checkpoint_id": row.checkpoint_id,
+                "page": row.map_page,
+                "detail_hex": row.representation.encode("ascii").hex(),
+            })
+            for slot in row.slots:
+                if slot.reference:
+                    output["reference_bitmaps"].append({
+                        "kind": "reference_bitmap",
+                        "checkpoint_id": row.checkpoint_id,
+                        "page": slot.reference,
+                        "detail_hex": slot.reference.to_bytes(4, "little").hex(),
+                    })
+        root = layers.h4_root_observations[replica]
+        output["catalog_roots"].append({
+            "kind": "catalog_root",
+            "checkpoint_id": "EMPTY",
+            "page": root.tdef_page,
+            "detail_hex": bytes(root.locator_offsets).hex(),
+        })
+        output["catalog_fields"].extend(
+            {
+                "kind": "catalog_field",
+                "checkpoint_id": record.operation_id,
+                "page": record.locator.page,
+                "detail_hex": record.row_bytes[:64].hex(),
+            }
+            for record in layers.h4_records[replica]
+        )
+    return output
+
+
+def _empty_transcripts() -> dict[str, list[dict[str, Any]]]:
+    return {
+        "row_directories": [],
+        "locators": [],
+        "map_transitions": [],
+        "reference_bitmaps": [],
+        "catalog_roots": [],
+        "catalog_fields": [],
+    }
+
+
+def _complete_transcript_coverage(
+    inputs: CheckedAnalysisInput,
+    ledger: WorkLedger,
+    transcripts: dict[str, list[dict[str, Any]]],
+    *,
+    h2_reached: bool,
+    h3_reached: bool,
+    h4_reached: bool,
+    markerless_catalog_pages: set[tuple[int, str, int]],
+) -> None:
+    """Retain one byte-derived transcript for every reached qualified page."""
+    views = getattr(inputs, "views", {})
+    for page in ledger.qualified_pages():
+        identity = (page.replica, page.checkpoint_id, page.page_number)
+        if identity in markerless_catalog_pages:
+            continue
+        view = views[page.replica]
+        if page.page_number >= view.page_count(page.checkpoint_id):
+            payload = b""
+        else:
+            payload = view.page(page.checkpoint_id, page.page_number)
+        category, kind = _coverage_category(
+            ledger,
+            page,
+            payload,
+            h2_reached=h2_reached,
+            h3_reached=h3_reached,
+            h4_reached=h4_reached,
+        )
+        detail = (
+            _QUALIFIED_PAGE_MARKER
+            + bytes((page.replica,))
+            + bytes((_TRANSCRIPT_CATEGORY_CODES[category],))
+            + hashlib.sha256(payload).digest()[:15]
+        )
+        transcripts[category].append({
+            "kind": kind,
+            "checkpoint_id": page.checkpoint_id,
+            "page": page.page_number,
+            "detail_hex": detail.hex(),
+        })
+
+
+def _terminal_candidates(layers: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    results = (
+        layers["h1_tdef_to_map_row"],
+        layers["h2_row_identity_map_role"],
+        layers["h3_indirect_traversal"],
+        layers["h4_catalog_bootstrap"]["root_result"],
+        layers["h4_catalog_bootstrap"]["structural_result"],
+        layers["h4_catalog_bootstrap"]["encoding_result"],
+    )
+    candidates: list[Mapping[str, Any]] = []
+    for result in results:
+        candidates.extend(result["candidates"])
+        evidence = result["terminal_evidence"]
+        if evidence is not None and evidence.get("kind") == "replica_pair":
+            candidates.extend(
+                entry["complete_candidate"] for entry in evidence["entries"]
+            )
+    return tuple(candidates)
+
+
+def _raw_catalog_identities(
+    occurrence: Mapping[str, Any] | None,
+) -> set[tuple[int, str, int]]:
+    if occurrence is None:
+        return set()
+    return {
+        (
+            group["replica"],
+            operation["operation_id"],
+            operation["canonical_record_locator"]["page"],
+        )
+        for group in occurrence["replica_groups"]
+        for operation in group["operation_bindings"]
+    }
+
+
+def _binding_checkpoints(binding: Mapping[str, Any]) -> tuple[str, ...]:
+    interval = binding["applicable_checkpoint_range"]
+    first = CHECKPOINT_ORDINALS[interval["start"]]
+    last = CHECKPOINT_ORDINALS[interval["end"]]
+    return tuple(CHECKPOINT_IDS[first : last + 1])
+
+
+def _terminal_evidence(
+    inputs: CheckedAnalysisInput,
+    terminal: DerivationTerminal,
+    ledger: WorkLedger,
+) -> tuple[list[dict[str, int | str]], dict[str, list[dict[str, Any]]]]:
+    """Project only reached, replica-qualified terminal evidence."""
+    identities: set[tuple[int, str, int]] = {
+        (page.replica, page.checkpoint_id, page.page_number)
+        for page in ledger.qualified_pages()
+    }
+    transcripts = _empty_transcripts()
+    views = getattr(inputs, "views", None)
+    if not isinstance(views, Mapping):
+        return ([], transcripts)
+
+    seen: dict[str, set[tuple[int, str, int, str, object | None]]] = {
+        key: set() for key in transcripts
+    }
+    h2_reached = (
+        terminal.layers["h2_row_identity_map_role"]["status"]
+        != "not_applicable"
+    )
+    h3_reached = (
+        terminal.layers["h3_indirect_traversal"]["status"]
+        != "not_applicable"
+    )
+
+    def append(
+        category: str,
+        kind: str,
+        replica: int,
+        checkpoint: str,
+        page: int,
+        detail: bytes,
+        *,
+        discriminator: object | None = None,
+    ) -> None:
+        detail_hex = detail.hex()
+        key = (replica, checkpoint, page, detail_hex, discriminator)
+        if key in seen[category]:
+            return
+        seen[category].add(key)
+        transcripts[category].append(
+            {
+                "kind": kind,
+                "checkpoint_id": checkpoint,
+                "page": page,
+                "detail_hex": detail_hex,
+            }
+        )
+
+    for candidate in _terminal_candidates(terminal.layers):
+        model_type = candidate["model_type"]
+        model = candidate["model"]
+        if model_type.startswith("h1_"):
+            offsets = tuple(model.get("locator_offsets", ()))
+            for binding in candidate.get("instance_bindings", ()):
+                replica = binding["replica"]
+                checkpoints = _binding_checkpoints(binding)
+                tdef_page = binding["tdef_page"]
+                identities.update(
+                    (replica, checkpoint, tdef_page) for checkpoint in checkpoints
+                )
+                targets = binding.get("locator_targets", ())
+                identities.update(
+                    (replica, checkpoint, target["page"])
+                    for checkpoint in checkpoints
+                    for target in targets
+                )
+                for checkpoint in checkpoints:
+                    if len(offsets) == 2:
+                        payload = views[replica].page(checkpoint, tdef_page)
+                        append(
+                            "locators",
+                            "locator",
+                            replica,
+                            checkpoint,
+                            tdef_page,
+                            b"".join(
+                                payload[offset : offset + 4]
+                                for offset in offsets
+                            ),
+                        )
+                    if h2_reached:
+                        for page in sorted({target["page"] for target in targets}):
+                            payload = views[replica].page(checkpoint, page)
+                            append(
+                                "row_directories",
+                                "row_directory",
+                                replica,
+                                checkpoint,
+                                page,
+                                payload[8:14],
+                            )
+        elif model_type == "h4_catalog_root":
+            offsets = tuple(model["locator_offsets"])
+            for binding in candidate["instance_bindings"]:
+                replica = binding["replica"]
+                page = binding["tdef_page"]
+                identities.update(
+                    (replica, checkpoint, page) for checkpoint in CHECKPOINT_IDS
+                )
+                append(
+                    "catalog_roots",
+                    "catalog_root",
+                    replica,
+                    "EMPTY",
+                    page,
+                    bytes(offsets),
+                )
+        elif model_type == "h4_operation_record":
+            replica = model["replica"]
+            checkpoint = model["operation_id"]
+            page = model["canonical_record_locator"]["page"]
+            identities.add((replica, checkpoint, page))
+
+    if terminal.h4_occurrence_evidence is not None:
+        for group in terminal.h4_occurrence_evidence["replica_groups"]:
+            replica = group["replica"]
+            for operation in group["operation_bindings"]:
+                checkpoint = operation["operation_id"]
+                locator = operation["canonical_record_locator"]
+                page = locator["page"]
+                payload = views[replica].page(checkpoint, page)
+                append(
+                    "catalog_fields",
+                    "catalog_field",
+                    replica,
+                    checkpoint,
+                    page,
+                    payload[locator["row_start"] : locator["row_end"]][:64],
+                    discriminator=(
+                        "catalog_record",
+                        locator["row"],
+                        locator["row_start"],
+                        locator["row_end"],
+                    ),
+                )
+
+    if h3_reached:
+        for term in (
+            "type_1_slots",
+            "type_0_and_tag_05_bitmap_bits",
+            "base_formula_evaluations",
+        ):
+            for identity in ledger.identities(term):
+                page = (
+                    identity
+                    if isinstance(identity, QualifiedPage)
+                    else identity[0]
+                    if isinstance(identity, tuple)
+                    and identity
+                    and isinstance(identity[0], QualifiedPage)
+                    else None
+                )
+                if page is None:
+                    continue
+                key = (page.replica, page.checkpoint_id, page.page_number)
+                identities.add(key)
+                payload = views[page.replica].page(
+                    page.checkpoint_id, page.page_number
+                )
+                if payload[0] == 0x05:
+                    append(
+                        "reference_bitmaps",
+                        "reference_bitmap",
+                        *key,
+                        page.page_number.to_bytes(4, "little"),
+                    )
+                else:
+                    append(
+                        "map_transitions",
+                        "map_transition",
+                        *key,
+                        payload[:1],
+                    )
+
+    identities = {
+        (page.replica, page.checkpoint_id, page.page_number)
+        for page in ledger.qualified_pages()
+    }
+    ordered = sorted(
+        identities,
+        key=lambda row: (row[0], CHECKPOINT_ORDINALS[row[1]], row[2]),
+    )
+    return (
+        [
+            {"replica": replica, "checkpoint_id": checkpoint, "page_number": page}
+            for replica, checkpoint, page in ordered
+        ],
+        transcripts,
+    )
+
+
+@dataclass(frozen=True)
+class FrozenDerivation:
+    document: Mapping[str, Any]
+    canonical_bytes: bytes
+    sha256: str
+    occurrence_evidence_bytes: bytes | None
+
+
+def freeze_derivation(
+    inputs: CheckedAnalysisInput,
+    layers: DerivationLayers | DerivationTerminal,
+    ledger: WorkLedger,
+) -> FrozenDerivation:
+    """Serialize and schema-check the complete derivation state before holdout."""
+    if isinstance(layers, DerivationTerminal):
+        _charge_frozen_candidates(layers.layers, ledger)
+        qualified_pages, transcripts = _terminal_evidence(inputs, layers, ledger)
+        occurrence = layers.h4_occurrence_evidence
+        _complete_transcript_coverage(
+            inputs,
+            ledger,
+            transcripts,
+            h2_reached=(
+                layers.layers["h2_row_identity_map_role"]["status"]
+                != "not_applicable"
+            ),
+            h3_reached=(
+                layers.layers["h3_indirect_traversal"]["status"]
+                != "not_applicable"
+            ),
+            h4_reached=(
+                layers.layers["h4_catalog_bootstrap"]["root_result"]["status"]
+                != "not_applicable"
+            ),
+            markerless_catalog_pages=_raw_catalog_identities(occurrence),
+        )
+        occurrence_bytes = None
+        evidence_reference = None
+        if occurrence is not None:
+            occurrence_bytes = canonical_json_bytes(occurrence)
+            evidence_reference = {
+                "path": "analysis/h4-occurrence-evidence.json",
+                "sha256": sha256_hex(occurrence_bytes),
+                "size_bytes": len(occurrence_bytes),
+            }
+        document: dict[str, Any] = {
+            "protocol_version": "1.0.0",
+            "document_type": "dao_a4_frozen_derivation_candidates",
+            "experiment_id": EXPERIMENT_ID,
+            "plan_sha256": PLAN_SHA256,
+            "revision_plan_sha256": REVISION_PLAN_SHA256,
+            "campaign_id": inputs.campaign_id,
+            "derivation_replicas": [1, 2],
+            "qualified_pages": qualified_pages,
+            "work_charges": ledger.document(),
+            "h4_occurrence_evidence": evidence_reference,
+            "layers": dict(layers.layers),
+            "transcripts": transcripts,
+        }
+        validate_schema(document, "dao_a4_frozen_derivation_candidates")
+        _verify_envelope(document)
+        _verify_physical_projection(document, occurrence)
+        _verify_candidate_hashes(document["layers"])
+        validate_frozen_layers(
+            document["layers"], document["h4_occurrence_evidence"], occurrence,
+            document["transcripts"], document["qualified_pages"],
+        )
+        encoded = canonical_json_bytes(document)
+        return FrozenDerivation(
+            MappingProxyType(document), encoded, sha256_hex(encoded), occurrence_bytes
+        )
+    h4 = {
+        "root_result": _decisive(layers.h4_root.document()),
+        "structural_result": _decisive(layers.h4.structural.document()),
+        "encoding_result": _decisive(layers.h4.final.document()),
+    }
+    frozen_layers = {
+        "h1_tdef_to_map_row": _decisive(layers.h1.document()),
+        "h2_row_identity_map_role": _decisive(layers.h2.document()),
+        "h3_indirect_traversal": _decisive(layers.h3.document()),
+        "h4_catalog_bootstrap": h4,
+    }
+    _charge_frozen_candidates(frozen_layers, ledger)
+    evidence_bytes = canonical_json_bytes(layers.h4_occurrence_evidence)
+    transcripts = _transcripts(inputs, layers)
+    _complete_transcript_coverage(
+        inputs,
+        ledger,
+        transcripts,
+        h2_reached=True,
+        h3_reached=True,
+        h4_reached=True,
+        markerless_catalog_pages=_raw_catalog_identities(
+            layers.h4_occurrence_evidence
+        ),
+    )
+    document: dict[str, Any] = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_frozen_derivation_candidates",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "campaign_id": inputs.campaign_id,
+        "derivation_replicas": [1, 2],
+        "qualified_pages": _qualified_pages(ledger),
+        "work_charges": ledger.document(),
+        "h4_occurrence_evidence": {
+            "path": "analysis/h4-occurrence-evidence.json",
+            "sha256": sha256_hex(evidence_bytes),
+            "size_bytes": len(evidence_bytes),
+        },
+        "layers": frozen_layers,
+        "transcripts": transcripts,
+    }
+    validate_schema(document, "dao_a4_frozen_derivation_candidates")
+    _verify_envelope(document)
+    _verify_physical_projection(document, layers.h4_occurrence_evidence)
+    _verify_candidate_hashes(document["layers"])
+    validate_frozen_layers(
+        document["layers"], document["h4_occurrence_evidence"],
+        layers.h4_occurrence_evidence,
+        document["transcripts"], document["qualified_pages"],
+    )
+    encoded = canonical_json_bytes(document)
+    return FrozenDerivation(
+        MappingProxyType(document), encoded, sha256_hex(encoded), evidence_bytes
+    )
+
+
+def resume_derivation(
+    payload: bytes,
+    expected_sha256: str,
+    occurrence_evidence_payload: bytes | None = None,
+) -> Mapping[str, Any]:
+    """Verify frozen bytes against an externally trusted SHA, without holdout."""
+    import json
+
+    if not isinstance(payload, bytes):
+        raise ValueError("A4 frozen derivation payload must be bytes")
+    if len(payload) > int(BOUNDS["max_json_bytes"]):
+        raise ValueError("A4 frozen derivation exceeds the registered JSON byte bound")
+    if sha256_hex(payload) != expected_sha256:
+        raise ValueError("A4 frozen derivation hash mismatch")
+    try:
+        document = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, ValueError, TypeError, RecursionError) as exc:
+        raise ValueError("A4 frozen derivation is not canonical JSON") from exc
+    try:
+        if canonical_json_bytes(document) != payload:
+            raise ValueError("A4 frozen derivation bytes are not canonical")
+        validate_schema(document, "dao_a4_frozen_derivation_candidates")
+        _verify_envelope(document)
+        _verify_candidate_hashes(document["layers"])
+        reference = document["h4_occurrence_evidence"]
+        occurrence_evidence = None
+        if reference is None:
+            if occurrence_evidence_payload is not None:
+                raise ValueError("A4 frozen derivation has unexpected occurrence evidence bytes")
+        else:
+            if not isinstance(occurrence_evidence_payload, bytes):
+                raise ValueError("A4 frozen derivation requires occurrence evidence bytes")
+            if len(occurrence_evidence_payload) > int(BOUNDS["max_h4_occurrence_evidence_bytes"]):
+                raise ValueError("A4 H4 occurrence evidence exceeds its registered byte bound")
+            if (len(occurrence_evidence_payload) != reference["size_bytes"]
+                    or sha256_hex(occurrence_evidence_payload) != reference["sha256"]):
+                raise ValueError("A4 H4 occurrence evidence reference mismatch")
+            occurrence_evidence = json.loads(occurrence_evidence_payload.decode("utf-8"))
+            if canonical_json_bytes(occurrence_evidence) != occurrence_evidence_payload:
+                raise ValueError("A4 H4 occurrence evidence bytes are not canonical")
+            validate_schema(occurrence_evidence, "dao_a4_h4_occurrence_evidence")
+            if occurrence_evidence.get("campaign_id") != document["campaign_id"]:
+                raise ValueError("A4 H4 occurrence evidence campaign differs from the frozen derivation")
+        _verify_physical_projection(document, occurrence_evidence)
+        validate_frozen_layers(
+            document["layers"], reference, occurrence_evidence,
+            document["transcripts"], document["qualified_pages"],
+        )
+    except (RecursionError, TypeError) as exc:
+        raise ValueError("A4 frozen derivation is malformed") from exc
+    return MappingProxyType(document)

--- a/oracle/windows-dao/scripts/a4_campaign.py
+++ b/oracle/windows-dao/scripts/a4_campaign.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""Independent campaign-predicate checks for the DAO A4 analyzer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Mapping, Protocol, Sequence
+
+from protocol_validation import canonical_json_bytes as artifact_json_bytes
+
+from a4_model import A4AnalysisError, ReplicaData, View
+from a4_spec import (
+    BOUNDS,
+    CHECKPOINT_IDS,
+    PAGE_SIZE,
+    PLAN,
+    ROLE_BINDINGS,
+    sha256_hex,
+    validate_schema,
+)
+
+_ROLES = tuple(PLAN["tables"]["logical_roles"])
+_EXPECTED = PLAN["tables"]["expected_schema_by_checkpoint"]
+_DEFINITION = PLAN["tables"]["definition"]
+_IDLE_PAIRS = tuple(tuple(pair) for pair in PLAN["checkpoint_design"]["idle_pairs"])
+_ENVIRONMENT_PATHS = tuple(PLAN["artifacts"]["replica_environments"])
+_OBSERVATION_PATHS = tuple(PLAN["artifacts"]["replica_observations"])
+_EMPTY_SHA256 = hashlib.sha256().hexdigest()
+
+
+class CampaignReplicaInput(Protocol):
+    source: ReplicaData
+    table_row_counts: Mapping[str, Mapping[str, int]]
+    replica_observation: Mapping[str, Any] | None
+    page_indexes: Mapping[str, Mapping[str, Any]] | None
+    schema_snapshots: Mapping[str, Mapping[str, Any]] | None
+    artifact_manifest: Mapping[str, Any] | None
+    environment_payload: bytes | None
+
+
+@dataclass(frozen=True)
+class CampaignResourceTotals:
+    inserted_rows: int
+    changed_hash_entries: int
+    unique_page_blobs: int
+    retained_page_store_bytes: int
+    logical_checkpoint_read_bytes: int
+    maximum_companion_bytes: int
+
+
+@dataclass(frozen=True)
+class CheckedCampaignReplica:
+    view: View
+    table_row_counts: Mapping[str, Mapping[str, int]]
+    resources: CampaignResourceTotals
+    environment_exact_fields: tuple[object, ...]
+    matrix_job_id: str
+
+
+def _fail(predicate: str, detail: str) -> None:
+    raise A4AnalysisError(predicate, 0, detail=detail)
+
+
+def _mapping(
+    value: Mapping[str, Mapping[str, Any]] | None,
+    replica: int,
+    label: str,
+    predicate: str,
+) -> Mapping[str, Mapping[str, Any]]:
+    if value is None or tuple(value) != CHECKPOINT_IDS:
+        _fail(predicate, f"replica {replica}: {label} do not cover the exact schedule")
+    return value
+
+
+def _common_binding(
+    document: Mapping[str, Any],
+    *,
+    replica: int,
+    checkpoint: str | None,
+    campaign_id: str,
+    producer_commit: str,
+    environment_sha256: str,
+    provider_sha256: str,
+    predicate: str,
+) -> None:
+    expected = {
+        "producer_commit": producer_commit,
+        "campaign_id": campaign_id,
+        "environment_sha256": environment_sha256,
+        "provider_sha256": provider_sha256,
+        "replica": replica,
+    }
+    if checkpoint is not None:
+        expected["checkpoint_id"] = checkpoint
+        expected["ordinal"] = CHECKPOINT_IDS.index(checkpoint)
+    for key, value in expected.items():
+        if document.get(key) != value:
+            _fail(predicate, f"replica {replica} {checkpoint or 'observation'}: wrong {key}")
+
+
+def _artifact_matches(
+    reference: Mapping[str, Any],
+    document: Mapping[str, Any],
+    manifest_files: Mapping[str, Mapping[str, Any]],
+    expected_path: str,
+    role: str,
+) -> bool:
+    payload = artifact_json_bytes(dict(document))
+    entry = manifest_files.get(expected_path, {})
+    return (
+        reference.get("path") == expected_path
+        and reference.get("sha256") == sha256_hex(payload)
+        and reference.get("size_bytes") == len(payload)
+        and entry.get("path") == expected_path
+        and entry.get("role") == role
+        and entry.get("sha256") == reference.get("sha256")
+        and entry.get("size_bytes") == reference.get("size_bytes")
+        and entry.get("media_type") == "application/json"
+    )
+
+
+def _checked_manifest(
+    replica: int,
+    value: CampaignReplicaInput,
+    view: View,
+    observation: Mapping[str, Any],
+    campaign_id: str,
+    producer_commit: str,
+) -> tuple[Mapping[str, Mapping[str, Any]], tuple[object, ...], str | None]:
+    manifest = value.artifact_manifest
+    if manifest is None:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: artifact manifest is missing")
+    try:
+        validate_schema(dict(manifest), "dao_a4_replica_artifact_manifest")
+    except Exception as exc:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: artifact manifest invalid: {exc}")
+    _common_binding(
+        manifest,
+        replica=replica,
+        checkpoint=None,
+        campaign_id=campaign_id,
+        producer_commit=producer_commit,
+        environment_sha256=observation["environment_sha256"],
+        provider_sha256=observation["provider_sha256"],
+        predicate="A4-SCHEMA-SNAPSHOT",
+    )
+    if (
+        manifest["checkpoint_count"] != len(CHECKPOINT_IDS)
+        or not manifest["inventory_closed"]
+        or not manifest["hashes_verified"]
+        or not manifest["paths_closed"]
+    ):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: artifact inventory is not closed")
+    files = manifest["files"]
+    by_path = {entry["path"]: entry for entry in files}
+    if len(by_path) != len(files):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: artifact paths are duplicated")
+    environment_path = _ENVIRONMENT_PATHS[replica - 1]
+    observation_path = _OBSERVATION_PATHS[replica - 1]
+    indexed_blobs = {
+        digest
+        for checkpoint in CHECKPOINT_IDS
+        for digest in view.hashes(checkpoint)
+    }
+    expected_paths = {environment_path, observation_path}
+    expected_paths.update(
+        f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json"
+        for ordinal, checkpoint in enumerate(CHECKPOINT_IDS)
+    )
+    expected_paths.update(
+        f"schema-snapshots/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json"
+        for ordinal, checkpoint in enumerate(CHECKPOINT_IDS)
+    )
+    expected_paths.update(f"page-store/{digest}.page" for digest in indexed_blobs)
+    reconstruction_error = None
+    if set(by_path) != expected_paths:
+        differing = set(by_path) ^ expected_paths
+        reconstruction_paths = {
+            path
+            for path in differing
+            if path.startswith("page-indexes/") or path.startswith("page-store/")
+        }
+        reconstruction_paths.update(
+            path
+            for path in differing & set(by_path)
+            if by_path[path]["role"] in ("page_index", "page_blob")
+        )
+        if differing - reconstruction_paths:
+            _fail(
+                "A4-SCHEMA-SNAPSHOT",
+                f"replica {replica}: artifact inventory differs from the closed plan paths",
+            )
+        reconstruction_error = "artifact inventory differs from the closed plan paths"
+    environment_entry = by_path[environment_path]
+    payload = value.environment_payload
+    if not isinstance(payload, bytes) or not payload:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: environment bytes are missing")
+    if len(payload) > int(BOUNDS["max_json_bytes"]):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: environment bytes exceed the bound")
+    try:
+        environment = json.loads(payload.decode("utf-8"))
+        if not isinstance(environment, dict):
+            raise ValueError("environment is not an object")
+        if artifact_json_bytes(environment) != payload:
+            raise ValueError("environment JSON is not canonical")
+        validate_schema(environment, "dao_a4_environment")
+    except Exception as exc:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: environment invalid: {exc}")
+    environment_sha256 = sha256_hex(payload)
+    if (
+        environment_entry["role"] != "environment"
+        or environment_entry["sha256"] != environment_sha256
+        or environment_entry["size_bytes"] != len(payload)
+        or environment_entry["media_type"] != "application/json"
+        or observation["environment_sha256"] != environment_sha256
+    ):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: environment manifest binding differs")
+    if (
+        environment["producer_commit"] != producer_commit
+        or environment["campaign_id"] != campaign_id
+        or environment["replica"] != replica
+        or environment["matrix_job_id"] != observation["matrix_job"]["job_id"]
+        or environment["provider"]["server_sha256"]
+        != observation["provider_sha256"]
+    ):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: environment cross-binding differs")
+    exact_values = {
+        "dao_prog_id": environment["provider"]["prog_id"],
+        "provider_clsid": environment["provider"]["clsid"],
+        "provider_binary_sha256": environment["provider"]["server_sha256"],
+        "process_architecture": environment["host"]["process_architecture"],
+        "powershell_major": int(
+            environment["host"]["powershell_version"].split(".", 1)[0]
+        ),
+        "windows_ansi_code_page": environment["host"][
+            "windows_ansi_code_page"
+        ],
+    }
+    try:
+        exact_fields = tuple(
+            exact_values[field]
+            for field in PLAN["environment_binding"]["cross_replica_exact_fields"]
+        )
+    except KeyError as exc:
+        _fail("A4-SCHEMA-SNAPSHOT", f"unknown exact environment field: {exc}")
+    if manifest["matrix_job_id"] != observation["matrix_job"]["job_id"]:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: manifest matrix job differs")
+    blob_entries = [entry for entry in files if entry["role"] == "page_blob"]
+    manifested_blob_digests = [entry["sha256"] for entry in blob_entries]
+    canonical_blob_entries = all(
+        entry["path"] == f"page-store/{entry['sha256']}.page"
+        and entry["size_bytes"] == PAGE_SIZE
+        and entry["media_type"] == "application/octet-stream"
+        for entry in blob_entries
+    )
+    if (
+        not canonical_blob_entries
+        or len(manifested_blob_digests) != len(set(manifested_blob_digests))
+        or set(manifested_blob_digests) != indexed_blobs
+    ):
+        reconstruction_error = "page-blob inventory differs"
+    return by_path, exact_fields, reconstruction_error
+
+
+def _check_observation_artifact(
+    replica: int,
+    observation: Mapping[str, Any],
+    manifest_files: Mapping[str, Mapping[str, Any]],
+) -> None:
+    """Cross-bind actual observation bytes after earlier predicates run."""
+    observation_path = _OBSERVATION_PATHS[replica - 1]
+    if not _artifact_matches(
+        manifest_files[observation_path],
+        observation,
+        manifest_files,
+        observation_path,
+        "replica_observation",
+    ):
+        _fail(
+            "A4-SCHEMA-SNAPSHOT",
+            f"replica {replica}: observation manifest binding differs",
+        )
+
+
+def _idle_bytes_equal(view: View, left: str, right: str) -> bool:
+    left_hashes, right_hashes = view.hashes(left), view.hashes(right)
+    if left_hashes != right_hashes:
+        return False
+    for page_number in range(len(left_hashes)):
+        left_payload = view.page(left, page_number)
+        right_payload = view.page(right, page_number)
+        if left_payload != right_payload:
+            return False
+    return True
+
+
+def _check_idle(
+    replica: int,
+    view: View,
+    indexes: Mapping[str, Mapping[str, Any]],
+    snapshots: Mapping[str, Mapping[str, Any]],
+) -> None:
+    for left, right in _IDLE_PAIRS:
+        left_index, right_index = indexes.get(left, {}), indexes.get(right, {})
+        left_snapshot, right_snapshot = snapshots.get(left, {}), snapshots.get(right, {})
+        if (
+            not _idle_bytes_equal(view, left, right)
+            or left_index.get("ordered_page_sha256")
+            != right_index.get("ordered_page_sha256")
+            or left_snapshot.get("tables") != right_snapshot.get("tables")
+        ):
+            _fail("A4-IDLE-EQUALITY", f"replica {replica}: idle pair {left}/{right} differs")
+
+
+def _name_fields(name: str) -> dict[str, Any]:
+    try:
+        cp1252 = name.encode("cp1252")
+        utf8 = name.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"name {name!r} is outside strict Windows-1252") from exc
+    return {
+        "name": name,
+        "name_utf16_code_units": [ord(character) for character in name],
+        "name_windows_1252_hex": cp1252.hex(),
+        "name_utf8_hex": utf8.hex(),
+    }
+
+
+@lru_cache(maxsize=1024)
+def expected_row_sha256(role: str, row_count: int) -> str:
+    """Recompute the plan's deterministic DAO reread stream."""
+    if role not in _ROLES or isinstance(row_count, bool) or not 0 <= row_count <= 200_000:
+        raise ValueError("invalid A4 row-hash input")
+    digest = hashlib.sha256()
+    for identifier in range(1, row_count + 1):
+        seed = f"A4|{role}|{identifier:010d}|"
+        payload = (seed * ((240 + len(seed) - 1) // len(seed)))[:240].encode("ascii")
+        digest.update(identifier.to_bytes(4, "little", signed=True))
+        digest.update(len(payload).to_bytes(2, "little"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _token(token: str) -> tuple[str, str, bool, bool]:
+    parts = token.split(":")
+    role = parts[0]
+    version = parts[1] if len(parts) > 2 and parts[1].startswith("v") else "v1"
+    shape = parts[-1]
+    return role, f"{role}-{version}", "payload" in shape, "index" in shape
+
+
+def _expected_field(definition: Mapping[str, Any], ordinal: int) -> dict[str, Any]:
+    return {
+        "ordinal": ordinal,
+        "ordinal_source": "Fields zero-based position after Refresh and the all-fields filter",
+        **_name_fields(definition["name"]),
+        "type": definition["dao_type_numeric"],
+        "size": definition["size"],
+        "attributes": definition["attributes_numeric"],
+        "required": definition["required"],
+        "allow_zero_length": definition["allow_zero_length"],
+    }
+
+
+def _expected_index() -> dict[str, Any]:
+    index = _DEFINITION["index"]
+    return {
+        "ordinal": 0,
+        "ordinal_source": "Indexes zero-based position after Refresh and exact A4IX_ID scheduled-name filtering",
+        **_name_fields(index["name"]),
+        "attributes": 0,
+        "primary": index["primary"],
+        "unique": index["unique"],
+        "required": index["required"],
+        "ignore_nulls": index["ignore_nulls"],
+        "fields": [
+            {
+                "ordinal": 0,
+                "ordinal_source": "Index.Fields zero-based position after Refresh and the all-fields filter",
+                **_name_fields("Id"),
+                "descending": index["descending"],
+            }
+        ],
+    }
+
+
+def expected_snapshot_tables(
+    replica: int, checkpoint: str, row_counts: Mapping[str, int]
+) -> list[dict[str, Any]]:
+    """Build the exact plan-derived canonical table values for one snapshot."""
+    result = []
+    binding = ROLE_BINDINGS[replica]
+    for ordinal, token in enumerate(_EXPECTED[checkpoint]):
+        role, instance, has_payload, has_index = _token(token)
+        count = row_counts[role]
+        fields = [_expected_field(_DEFINITION["fields"][0], 0)]
+        if has_payload:
+            fields.append(_expected_field(_DEFINITION["fields"][1], 1))
+        result.append(
+            {
+                "ordinal": ordinal,
+                "ordinal_source": "TableDefs zero-based position after Refresh and exact extant scheduled-name filtering",
+                "logical_role": role,
+                "lifecycle_instance": instance,
+                **_name_fields(binding[role]),
+                "attributes": _DEFINITION["table_attributes_numeric"],
+                "row_count": count,
+                "rolling_row_sha256": expected_row_sha256(role, count),
+                "fields": fields,
+                "indexes": [_expected_index()] if has_index else [],
+            }
+        )
+    return result
+
+
+def _check_schema_snapshots(
+    replica: int,
+    value: CampaignReplicaInput,
+    observation: Mapping[str, Any],
+    snapshots: Mapping[str, Mapping[str, Any]],
+    indexes: Mapping[str, Mapping[str, Any]],
+    campaign_id: str,
+    producer_commit: str,
+    manifest_files: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, int]]:
+    environment = observation["environment_sha256"]
+    provider = observation["provider_sha256"]
+    rows: dict[str, dict[str, int]] = {}
+    checkpoints = observation["checkpoints"]
+    for ordinal, checkpoint in enumerate(CHECKPOINT_IDS):
+        snapshot = snapshots[checkpoint]
+        try:
+            validate_schema(dict(snapshot), "dao_a4_schema_snapshot")
+        except Exception as exc:
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: {exc}")
+        _common_binding(
+            snapshot, replica=replica, checkpoint=checkpoint,
+            campaign_id=campaign_id, producer_commit=producer_commit,
+            environment_sha256=environment, provider_sha256=provider,
+            predicate="A4-SCHEMA-SNAPSHOT",
+        )
+        reference = checkpoints[ordinal]["dao_schema_snapshot"]
+        expected_path = f"schema-snapshots/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json"
+        if not _artifact_matches(
+            reference, snapshot, manifest_files, expected_path, "dao_schema_snapshot"
+        ):
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: snapshot reference differs")
+        checkpoint_rows = checkpoints[ordinal]["table_row_counts"]
+        expected_roles = {_token(token)[0] for token in _EXPECTED[checkpoint]}
+        if any(
+            role not in expected_roles and checkpoint_rows[role] != 0
+            for role in _ROLES
+        ):
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: absent role has rows")
+        expected_tables = expected_snapshot_tables(replica, checkpoint, checkpoint_rows)
+        if snapshot["tables"] != expected_tables:
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: canonical tables differ")
+        reread = [
+            {
+                "role": table["logical_role"],
+                "row_count": table["row_count"],
+                "rolling_sha256": table["rolling_row_sha256"],
+            }
+            for table in snapshot["tables"]
+        ]
+        if checkpoints[ordinal]["dao_reread"] != reread:
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: DAO reread differs")
+        if dict(value.table_row_counts[checkpoint]) != dict(checkpoint_rows):
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: analyzer row counts differ")
+        rows[checkpoint] = dict(checkpoint_rows)
+        database_hash = indexes[checkpoint].get("database_sha256")
+        if not (
+            snapshot["database_sha256_before_read"]
+            == snapshot["database_sha256_after_read"]
+            == database_hash
+        ):
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint}: read changed database")
+    return rows
+
+
+def changed_page_indices(
+    predecessor: Sequence[str] | None, current: Sequence[str]
+) -> tuple[int, ...]:
+    """Return every changed, appended, or removed ordered-page position."""
+    if predecessor is None:
+        return ()
+    maximum = max(len(predecessor), len(current))
+    return tuple(
+        index
+        for index in range(maximum)
+        if (predecessor[index] if index < len(predecessor) else None)
+        != (current[index] if index < len(current) else None)
+    )
+
+
+def _check_reconstruction(
+    replica: int,
+    value: CampaignReplicaInput,
+    view: View,
+    observation: Mapping[str, Any],
+    indexes: Mapping[str, Mapping[str, Any]],
+    campaign_id: str,
+    producer_commit: str,
+    manifest_files: Mapping[str, Mapping[str, Any]],
+) -> tuple[View, tuple[tuple[str, ...], ...], int]:
+    environment = observation["environment_sha256"]
+    provider = observation["provider_sha256"]
+    sequences: list[tuple[str, ...]] = []
+    checkpoints = observation["checkpoints"]
+    predecessor: tuple[str, ...] | None = None
+    changed_total = 0
+    for ordinal, checkpoint in enumerate(CHECKPOINT_IDS):
+        index = indexes[checkpoint]
+        try:
+            validate_schema(dict(index), "dao_a4_page_index")
+        except Exception as exc:
+            _fail("A4-SNAPSHOT-RECONSTRUCTION", f"replica {replica} {checkpoint}: {exc}")
+        _common_binding(
+            index, replica=replica, checkpoint=checkpoint,
+            campaign_id=campaign_id, producer_commit=producer_commit,
+            environment_sha256=environment, provider_sha256=provider,
+            predicate="A4-SNAPSHOT-RECONSTRUCTION",
+        )
+        expected_predecessor = None if ordinal == 0 else CHECKPOINT_IDS[ordinal - 1]
+        sequence = tuple(index["ordered_page_sha256"])
+        changed = changed_page_indices(predecessor, sequence)
+        checkpoint_row = checkpoints[ordinal]
+        if (
+            index["predecessor_checkpoint_id"] != expected_predecessor
+            or index["page_count"] != len(sequence)
+            or index["file_size_bytes"] != len(sequence) * PAGE_SIZE
+            or index["changed_page_indices"] != list(changed)
+            or checkpoint_row["actual_file_pages"] != len(sequence)
+            or checkpoint_row["actual_size_bytes"] != len(sequence) * PAGE_SIZE
+            or view.hashes(checkpoint) != sequence
+            or value.source.page_count.get(checkpoint) != len(sequence)
+            or not _artifact_matches(
+                checkpoint_row["page_index"],
+                index,
+                manifest_files,
+                f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json",
+                "page_index",
+            )
+        ):
+            _fail("A4-SNAPSHOT-RECONSTRUCTION", f"replica {replica} {checkpoint}: index cross-binding differs")
+        database = hashlib.sha256()
+        for page_number, digest in enumerate(sequence):
+            try:
+                payload = view.page(checkpoint, page_number)
+            except (KeyError, OSError, TypeError, ValueError) as exc:
+                _fail("A4-SNAPSHOT-RECONSTRUCTION", f"replica {replica} {checkpoint}: missing page {digest}: {exc}")
+            if not isinstance(payload, bytes) or len(payload) != PAGE_SIZE or sha256_hex(payload) != digest:
+                _fail("A4-SNAPSHOT-RECONSTRUCTION", f"replica {replica} {checkpoint}: page blob differs")
+            database.update(payload)
+        if database.hexdigest() != index["database_sha256"]:
+            _fail("A4-SNAPSHOT-RECONSTRUCTION", f"replica {replica} {checkpoint}: database hash differs")
+        sequences.append(sequence)
+        predecessor = sequence
+        changed_total += len(changed)
+    return view, tuple(sequences), changed_total
+
+
+def _inserted_rows(rows: Mapping[str, Mapping[str, int]]) -> tuple[int, tuple[int, ...]]:
+    previous = {role: 0 for role in _ROLES}
+    total = 0
+    running = []
+    for checkpoint in CHECKPOINT_IDS:
+        current = rows[checkpoint]
+        total += sum(max(0, current[role] - previous[role]) for role in _ROLES)
+        running.append(total)
+        previous = dict(current)
+    return total, tuple(running)
+
+
+def _relative_baselines() -> Mapping[str, str]:
+    coverage = PLAN["checkpoint_design"]["transition_coverage"]
+    result: dict[str, str] = {}
+    for role in _ROLES:
+        relative = tuple(
+            checkpoint
+            for checkpoint in CHECKPOINT_IDS
+            if checkpoint.startswith(f"{role}_REL_")
+        )
+        if not relative:
+            continue
+        matches = [
+            tuple(sequence)
+            for sequence in coverage.values()
+            if isinstance(sequence, list)
+            and tuple(checkpoint for checkpoint in sequence if checkpoint in relative)
+            == relative
+            and sequence[0] not in relative
+            and all(value.startswith(f"{role}_") for value in sequence[1:])
+        ]
+        if len(matches) != 1:
+            raise ValueError(f"A4 {role} relative baseline is not unique")
+        result[role] = matches[0][0]
+    return result
+
+
+_RELATIVE_BASELINES = _relative_baselines()
+_GROWTH_CHECKPOINTS = tuple(
+    checkpoint
+    for checkpoint in CHECKPOINT_IDS
+    if "_REL_" in checkpoint or "_ABS_" in checkpoint
+)
+
+
+def _check_growth_schedule(
+    replica: int,
+    checkpoints: Sequence[Mapping[str, Any]],
+    growth_observations: Sequence[Mapping[str, Any]],
+) -> None:
+    """Recompute every scheduled growth disclosure from closed checkpoints."""
+    if [row.get("checkpoint_id") for row in growth_observations] != list(
+        _GROWTH_CHECKPOINTS
+    ):
+        _fail(
+            "A4-SCHEMA-SNAPSHOT",
+            f"replica {replica}: growth observations differ from the schedule",
+        )
+    by_checkpoint = {row["checkpoint_id"]: row for row in checkpoints}
+    batch_rows = int(PLAN["tables"]["row_algorithm"]["growth_batch_rows"])
+    for observation in growth_observations:
+        checkpoint = observation["checkpoint_id"]
+        row = by_checkpoint[checkpoint]
+        ordinal = CHECKPOINT_IDS.index(checkpoint)
+        previous = by_checkpoint[CHECKPOINT_IDS[ordinal - 1]]
+        role = checkpoint.split("_", 1)[0]
+        suffix = int(checkpoint.rsplit("_", 1)[1])
+        if "_REL_" in checkpoint:
+            baseline = by_checkpoint[_RELATIVE_BASELINES[role]]["actual_file_pages"]
+            target = baseline + suffix
+        else:
+            baseline = None
+            target = suffix
+        achieved = row["actual_file_pages"]
+        overshoot = achieved - target
+        inserted = row["table_row_counts"][role] - previous["table_row_counts"][role]
+        if (
+            previous["actual_file_pages"] >= target
+            or overshoot < 0
+            or inserted <= 0
+            or inserted % batch_rows
+            or row["target_baseline_pages"] != baseline
+            or row["target_threshold_pages"] != target
+            or row["target_overshoot_pages"] != overshoot
+            or dict(observation)
+            != {
+                "checkpoint_id": checkpoint,
+                "baseline_pages": baseline,
+                "target_pages": target,
+                "achieved_pages": achieved,
+                "overshoot_pages": overshoot,
+                "rows": inserted,
+            }
+        ):
+            _fail(
+                "A4-SCHEMA-SNAPSHOT",
+                f"replica {replica} {checkpoint}: growth arithmetic differs",
+            )
+    growth = set(_GROWTH_CHECKPOINTS)
+    if any(
+        checkpoint["checkpoint_id"] not in growth
+        and any(
+            checkpoint[field] is not None
+            for field in (
+                "target_baseline_pages",
+                "target_threshold_pages",
+                "target_overshoot_pages",
+            )
+        )
+        for checkpoint in checkpoints
+    ):
+        _fail(
+            "A4-SCHEMA-SNAPSHOT",
+            f"replica {replica}: non-growth checkpoint carries a target",
+        )
+    previous_counts = {role: 0 for role in _ROLES}
+    reinsert_counts = by_checkpoint["T1_REL_1280"]["table_row_counts"]
+    for checkpoint in checkpoints:
+        checkpoint_id = checkpoint["checkpoint_id"]
+        current_counts = dict(checkpoint["table_row_counts"])
+        if checkpoint_id in growth:
+            changed_role = checkpoint_id.split("_", 1)[0]
+            differs = any(
+                current_counts[role] != previous_counts[role]
+                for role in _ROLES
+                if role != changed_role
+            )
+        else:
+            expected = dict(previous_counts)
+            if checkpoint_id == "T1_DELETE_ALL":
+                expected["T1"] = 0
+            elif checkpoint_id == "T1_REINSERT_SAME":
+                expected["T1"] = reinsert_counts["T1"]
+            differs = current_counts != expected
+        if differs:
+            _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica} {checkpoint_id}: unrelated rows differ")
+        previous_counts = current_counts
+
+
+def require_resource_bounds(totals: CampaignResourceTotals) -> None:
+    """Apply the six independently recomputed campaign resource ceilings."""
+    checks = {
+        "inserted rows": (totals.inserted_rows, BOUNDS["max_inserted_rows_per_replica"]),
+        "changed hash entries": (totals.changed_hash_entries, BOUNDS["max_changed_hash_entries_per_replica"]),
+        "unique page blobs": (totals.unique_page_blobs, BOUNDS["max_unique_page_blobs"]),
+        "retained page store": (totals.retained_page_store_bytes, BOUNDS["max_retained_page_store_bytes"]),
+        "checkpoint reads": (totals.logical_checkpoint_read_bytes, BOUNDS["max_logical_checkpoint_read_bytes_per_replica"]),
+        "companion bytes": (totals.maximum_companion_bytes, BOUNDS["max_companion_bytes_per_checkpoint"]),
+    }
+    for name, (actual, maximum) in checks.items():
+        if actual > int(maximum):
+            _fail("A4-RESOURCE-BOUND", f"{name} {actual} exceeds {maximum}")
+
+
+def check_campaign_replica(
+    replica: int,
+    value: CampaignReplicaInput,
+    campaign_id: str,
+    producer_commit: str,
+) -> CheckedCampaignReplica:
+    """Evaluate the four campaign predicates, in registered order."""
+    observation = value.replica_observation
+    indexes = {} if value.page_indexes is None else value.page_indexes
+    snapshots = {} if value.schema_snapshots is None else value.schema_snapshots
+    view = View(replica, value.source)
+    _check_idle(replica, view, indexes, snapshots)
+    indexes = _mapping(indexes, replica, "page indexes", "A4-SCHEMA-SNAPSHOT")
+    snapshots = _mapping(snapshots, replica, "schema snapshots", "A4-SCHEMA-SNAPSHOT")
+    if observation is None:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: observation is missing")
+    try:
+        validate_schema(dict(observation), "dao_a4_replica_observation")
+    except Exception as exc:
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: observation invalid: {exc}")
+    _common_binding(
+        observation, replica=replica, checkpoint=None,
+        campaign_id=campaign_id, producer_commit=producer_commit,
+        environment_sha256=observation["environment_sha256"],
+        provider_sha256=observation["provider_sha256"],
+        predicate="A4-SCHEMA-SNAPSHOT",
+    )
+    if dict(observation["role_binding"]) != dict(ROLE_BINDINGS[replica]):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: role binding differs")
+    checkpoints = observation["checkpoints"]
+    if [row["checkpoint_id"] for row in checkpoints] != list(CHECKPOINT_IDS) or [row["ordinal"] for row in checkpoints] != list(range(len(CHECKPOINT_IDS))):
+        _fail("A4-SCHEMA-SNAPSHOT", f"replica {replica}: observation schedule differs")
+    _check_growth_schedule(replica, checkpoints, observation["growth_observations"])
+    manifest_files, environment_exact_fields, reconstruction_error = (
+        _checked_manifest(
+            replica, value, view, observation, campaign_id, producer_commit
+        )
+    )
+    _check_observation_artifact(replica, observation, manifest_files)
+    rows = _check_schema_snapshots(
+        replica, value, observation, snapshots, indexes, campaign_id, producer_commit,
+        manifest_files,
+    )
+    if reconstruction_error is not None:
+        _fail(
+            "A4-SNAPSHOT-RECONSTRUCTION",
+            f"replica {replica}: {reconstruction_error}",
+        )
+    view, sequences, changed_total = _check_reconstruction(
+        replica, value, view, observation, indexes, campaign_id, producer_commit,
+        manifest_files,
+    )
+    inserted, running = _inserted_rows(rows)
+    if any(checkpoints[index]["inserted_rows_total"] != running[index] for index in range(len(checkpoints))):
+        _fail("A4-RESOURCE-BOUND", f"replica {replica}: checkpoint inserted-row totals differ")
+    unique = {digest for sequence in sequences for digest in sequence}
+    companions = [row["post_close_companion"]["observed_size_bytes"] for row in checkpoints]
+    totals = CampaignResourceTotals(
+        inserted,
+        changed_total,
+        len(unique),
+        len(unique) * PAGE_SIZE,
+        sum(len(sequence) * PAGE_SIZE for sequence in sequences),
+        max(companions, default=0),
+    )
+    require_resource_bounds(totals)
+    if (
+        observation["inserted_rows_total"] != totals.inserted_rows
+        or observation["changed_hash_entries"] != totals.changed_hash_entries
+        or observation["logical_checkpoint_read_bytes"] != totals.logical_checkpoint_read_bytes
+    ):
+        _fail("A4-RESOURCE-BOUND", f"replica {replica}: recorded resource totals differ")
+    return CheckedCampaignReplica(
+        view,
+        rows,
+        totals,
+        environment_exact_fields,
+        observation["matrix_job"]["job_id"],
+    )

--- a/oracle/windows-dao/scripts/a4_catalog_inventory.py
+++ b/oracle/windows-dao/scripts/a4_catalog_inventory.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Bounded, union-accounted catalog-row inventory for A4 H4."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Mapping
+
+from a4_layer_h2 import H2ReplicaCandidate
+from a4_layer_h4 import (
+    OPERATIONS,
+    CatalogRecordLocator,
+    CatalogRootObservation,
+    OperationRecord,
+    applicable_operation_checkpoints,
+)
+from a4_model import A4AnalysisError, QualifiedPage, View, WorkLedger
+from a4_spec import BOUNDS, CHECKPOINT_IDS, CHECKPOINT_ORDINALS, PAGE_SIZE
+
+
+MAX_CANDIDATES = int(BOUNDS["max_candidate_models"])
+MAX_QUALIFIED_PAGES = int(BOUNDS["max_qualified_pages_per_submodel"])
+MAX_CACHE_PAGES = MAX_QUALIFIED_PAGES * (
+    2 * len(OPERATIONS)
+    + sum(len(applicable_operation_checkpoints(operation)) - 1 for operation in OPERATIONS)
+)
+
+
+def row_bounds(payload: bytes, mask: int) -> tuple[tuple[int, int], ...]:
+    """Decode one complete tag-01 row directory under a frozen H2 mask."""
+    if len(payload) != PAGE_SIZE or payload[0] != 0x01:
+        raise ValueError("A4 frozen row page is invalid")
+    count = int.from_bytes(payload[8:10], "little")
+    directory_end = 10 + 2 * count
+    if directory_end > PAGE_SIZE:
+        raise ValueError("A4 row directory exceeds the page")
+    result: list[tuple[int, int]] = []
+    end = PAGE_SIZE
+    for ordinal in range(count):
+        raw = int.from_bytes(
+            payload[10 + 2 * ordinal : 12 + 2 * ordinal], "little"
+        )
+        if raw & 0xC000:
+            raise ValueError("A4 frozen row carries deleted/overflow flags")
+        start = raw & mask
+        if not directory_end <= start < end <= PAGE_SIZE:
+            raise ValueError("A4 frozen row directory is inconsistent")
+        result.append((start, end))
+        end = start
+    return tuple(result)
+
+
+class CatalogInventory:
+    """Cache bounded page inventories and charge each inspected row once."""
+
+    def __init__(self, view: View, mask: int, ledger: WorkLedger) -> None:
+        self._view = view
+        self._mask = mask
+        self._ledger = ledger
+        self._pages: dict[
+            tuple[str, int], tuple[bytes, tuple[tuple[int, int], ...]]
+        ] = {}
+        self._inventories: dict[
+            tuple[str, int], tuple[tuple[CatalogRecordLocator | None, bytes], ...]
+        ] = {}
+
+    def _page(
+        self, checkpoint: str, page: int
+    ) -> tuple[bytes, tuple[tuple[int, int], ...]]:
+        key = (checkpoint, page)
+        cached = self._pages.get(key)
+        if cached is not None:
+            return cached
+        if len(self._pages) >= MAX_CACHE_PAGES:
+            raise A4AnalysisError(
+                "A4-RESOURCE-BOUND", detail="H4 catalog inventory page bound exceeded"
+            )
+        payload = self._view.page(checkpoint, page)
+        if self._view.replica in (1, 2):
+            self._ledger.record_qualified_page(
+                QualifiedPage(self._view.replica, checkpoint, page),
+                discriminator="catalog_page",
+            )
+        cached = payload, row_bounds(payload, self._mask)
+        self._pages[key] = cached
+        return cached
+
+    def _row(
+        self,
+        checkpoint: str,
+        page: int,
+        ordinal: int,
+        payload: bytes,
+        bounds: tuple[tuple[int, int], ...],
+    ) -> tuple[CatalogRecordLocator | None, bytes]:
+        start, end = bounds[ordinal]
+        identity = (
+            (QualifiedPage(self._view.replica, checkpoint, page), ordinal)
+            if self._view.replica in (1, 2)
+            else ("holdout", self._view.replica, checkpoint, page, ordinal)
+        )
+        self._ledger.charge_once(
+            "catalog_raw_rows",
+            identity,
+        )
+        locator = (
+            CatalogRecordLocator(page, ordinal, start, end)
+            if ordinal <= 255
+            else None
+        )
+        return locator, payload[start:end]
+
+    def all_rows(
+        self, checkpoint: str, page: int
+    ) -> tuple[tuple[CatalogRecordLocator | None, bytes], ...]:
+        key = (checkpoint, page)
+        cached = self._inventories.get(key)
+        if cached is not None:
+            return cached
+        payload, bounds = self._page(checkpoint, page)
+        cached = tuple(
+            self._row(checkpoint, page, ordinal, payload, bounds)
+            for ordinal in range(len(bounds))
+        )
+        self._inventories[key] = cached
+        return cached
+
+    def row_at(
+        self, checkpoint: str, page: int, ordinal: int
+    ) -> tuple[CatalogRecordLocator | None, bytes] | None:
+        payload, bounds = self._page(checkpoint, page)
+        if not 0 <= ordinal < len(bounds):
+            return None
+        return self._row(checkpoint, page, ordinal, payload, bounds)
+
+
+def operation_records(
+    view: View,
+    root: CatalogRootObservation,
+    deltas: Mapping[str, frozenset[int]],
+    h2: H2ReplicaCandidate,
+    ledger: WorkLedger,
+) -> tuple[OperationRecord, ...]:
+    """Build complete same-locator operation records with bounded row scans."""
+    for checkpoint in CHECKPOINT_IDS:
+        if len(root.admitted_pages_by_checkpoint[checkpoint]) > MAX_QUALIFIED_PAGES:
+            raise A4AnalysisError(
+                "A4-RESOURCE-BOUND",
+                detail="H4 catalog admitted-page bound exceeded",
+            )
+    inventory = CatalogInventory(view, h2.row_mask, ledger)
+    candidates: list[OperationRecord] = []
+    for operation in OPERATIONS:
+        ordinal = CHECKPOINT_ORDINALS[operation]
+        before_checkpoint = CHECKPOINT_IDS[ordinal - 1]
+        admitted = root.admitted_pages_by_checkpoint[operation]
+        for page in sorted(deltas[operation] & admitted):
+            before = (
+                inventory.all_rows(before_checkpoint, page)
+                if page < view.page_count(before_checkpoint)
+                else ()
+            )
+            after = inventory.all_rows(operation, page)
+            remaining = Counter(row for _locator, row in before)
+            for locator, row in after:
+                if remaining[row]:
+                    remaining[row] -= 1
+                    continue
+                if locator is None:
+                    continue
+                checkpoint_rows = {operation: (locator, row)}
+                for later in applicable_operation_checkpoints(operation)[1:]:
+                    if locator.page not in root.admitted_pages_by_checkpoint[later]:
+                        break
+                    match = inventory.row_at(later, locator.page, locator.row)
+                    if match is None or match[0] is None:
+                        break
+                    checkpoint_rows[later] = match
+                else:
+                    if len(candidates) >= MAX_CANDIDATES:
+                        raise A4AnalysisError(
+                            "A4-RESOURCE-BOUND",
+                            detail="constructed H4 operation-record candidate 4097",
+                        )
+                    candidates.append(
+                        OperationRecord.from_checkpoint_rows(
+                            view.replica, operation, checkpoint_rows
+                        )
+                    )
+    return tuple(candidates)

--- a/oracle/windows-dao/scripts/a4_catalog_root.py
+++ b/oracle/windows-dao/scripts/a4_catalog_root.py
@@ -1,0 +1,203 @@
+"""Frozen H1-H3 adapter for A4 catalog-root observations."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Sequence
+
+from a4_catalog_inventory import row_bounds
+from a4_layer_decoding import decode_locator, set_bits, type0_owned
+from a4_layer_h1 import H1ReplicaCandidate
+from a4_layer_h2 import H2ReplicaCandidate
+from a4_layer_h3 import (
+    BITMAP_BITS,
+    H3Candidate,
+    MAX_ADMITTED_PAGES,
+    SlotObservation,
+    TraversalObservation,
+    admitted_pages,
+)
+from a4_layer_h4 import CatalogRootObservation
+from a4_model import A4AnalysisError, QualifiedPage, View, WorkLedger
+from a4_spec import CHECKPOINT_IDS
+
+
+def _stream_fingerprint(
+    view: View, checkpoint: str, pages: frozenset[int]
+) -> str:
+    hasher = hashlib.sha256()
+    for page in sorted(pages):
+        digest = view.hash_at(checkpoint, page)
+        if digest is None:
+            raise ValueError("A4 admitted stream names an absent page")
+        hasher.update(page.to_bytes(4, "little"))
+        hasher.update(bytes.fromhex(digest))
+    return hasher.hexdigest()
+
+
+def catalog_root_observations(
+    view: View,
+    qualified_tdef_pages: Sequence[int],
+    h1: H1ReplicaCandidate,
+    h2: H2ReplicaCandidate,
+    h3: H3Candidate,
+    ledger: WorkLedger,
+) -> tuple[CatalogRootObservation, ...]:
+    """Traverse EMPTY-extant tag-02 pages with only the frozen H1-H3 model."""
+    output: list[CatalogRootObservation] = []
+    for tdef_page in qualified_tdef_pages:
+        empty = view.page_optional("EMPTY", tdef_page)
+        if empty is None or empty[0] != 0x02:
+            continue
+        locators = tuple(
+            decode_locator(empty[offset : offset + 4], h1.layout)
+            for offset in h1.locator_offsets
+        )
+        admitted_by_checkpoint: dict[str, frozenset[int]] = {}
+        fingerprints: dict[str, str] = {}
+        valid: set[str] = set()
+        invalid_prefix = False
+        for checkpoint in CHECKPOINT_IDS:
+            if invalid_prefix:
+                admitted_by_checkpoint[checkpoint] = frozenset()
+                fingerprints[checkpoint] = hashlib.sha256(b"").hexdigest()
+                continue
+            try:
+                payload = view.page(checkpoint, tdef_page)
+                current = tuple(
+                    decode_locator(payload[offset : offset + 4], h1.layout)
+                    for offset in h1.locator_offsets
+                )
+                if current != locators:
+                    raise ValueError("system locator identity changed")
+                rows: list[bytes] = []
+                for locator_ordinal, (page, row_ordinal) in enumerate(current):
+                    map_payload = view.page(checkpoint, page)
+                    if view.replica in (1, 2):
+                        ledger.record_qualified_page(
+                            QualifiedPage(view.replica, checkpoint, page),
+                            discriminator=(
+                                "system_map_page",
+                                tdef_page,
+                                locator_ordinal,
+                            ),
+                        )
+                    bounds = row_bounds(map_payload, h2.row_mask)
+                    start, end = bounds[row_ordinal]
+                    rows.append(map_payload[start:end])
+                owned_row = rows[h2.owned_in_use_locator_ordinal]
+                if owned_row[0] == 0:
+                    owned = type0_owned(
+                        owned_row,
+                        h2.polarity,
+                        maximum=MAX_ADMITTED_PAGES,
+                    )
+                elif owned_row[0] == 1 and (len(owned_row) - 1) % 4 == 0:
+                    references = tuple(
+                        int.from_bytes(owned_row[start : start + 4], "little")
+                        for start in range(1, len(owned_row), 4)
+                    )
+                    if view.replica in (1, 2):
+                        ledger.charge_qualified(
+                            "type_1_slots",
+                            QualifiedPage(
+                                view.replica,
+                                checkpoint,
+                                current[h2.owned_in_use_locator_ordinal][0],
+                            ),
+                            len(references),
+                            discriminator=(
+                                "system",
+                                h2.owned_in_use_locator_ordinal,
+                            ),
+                        )
+                    slots: list[SlotObservation] = []
+                    referenced_pages: set[int] = set()
+                    for slot_ordinal, reference in enumerate(references):
+                        if reference == 0:
+                            slots.append(SlotObservation(slot_ordinal, 0, None))
+                            continue
+                        if (
+                            reference not in referenced_pages
+                            and len(referenced_pages) == MAX_ADMITTED_PAGES
+                        ):
+                            raise A4AnalysisError(
+                                "A4-RESOURCE-BOUND",
+                                detail=(
+                                    "system traversal references more than "
+                                    "16 qualified pages"
+                                ),
+                            )
+                        referenced_pages.add(reference)
+                        bitmap = view.page_optional(checkpoint, reference)
+                        if view.replica in (1, 2) and bitmap is not None:
+                            ledger.record_qualified_page(
+                                QualifiedPage(view.replica, checkpoint, reference),
+                                discriminator=(
+                                    "system_reference_tag",
+                                    current[h2.owned_in_use_locator_ordinal][0],
+                                    slot_ordinal,
+                                ),
+                            )
+                        if bitmap is None or bitmap[0] != 0x05:
+                            raise ValueError(
+                                "system allocation reference is absent or not tag 05"
+                            )
+                        if view.replica in (1, 2):
+                            ledger.charge_qualified(
+                                "type_0_and_tag_05_bitmap_bits",
+                                QualifiedPage(view.replica, checkpoint, reference),
+                                BITMAP_BITS,
+                            )
+                        slots.append(
+                            SlotObservation(
+                                slot_ordinal,
+                                reference,
+                                bitmap[0],
+                                set_bits(bitmap[4:]),
+                            )
+                        )
+                    traversal = TraversalObservation(
+                        view.replica,
+                        checkpoint,
+                        current[h2.owned_in_use_locator_ordinal][0],
+                        "type_1",
+                        "system-catalog",
+                        allocation_role="owned_in_use",
+                        slots=tuple(slots),
+                        locator_ordinal=h2.owned_in_use_locator_ordinal,
+                    )
+                    owned = admitted_pages(
+                        traversal,
+                        str(h3.model["base_formula"]),
+                        maximum=MAX_ADMITTED_PAGES,
+                    )
+                else:
+                    raise ValueError(
+                        "system allocation row has an unsupported representation"
+                    )
+                if any(page >= view.page_count(checkpoint) for page in owned):
+                    raise ValueError("system traversal admits an absent page")
+                admitted_by_checkpoint[checkpoint] = owned
+                fingerprints[checkpoint] = _stream_fingerprint(
+                    view, checkpoint, owned
+                )
+                valid.add(checkpoint)
+            except A4AnalysisError:
+                raise
+            except (IndexError, KeyError, ValueError):
+                admitted_by_checkpoint[checkpoint] = frozenset()
+                fingerprints[checkpoint] = hashlib.sha256(b"").hexdigest()
+                invalid_prefix = True
+        output.append(
+            CatalogRootObservation(
+                view.replica,
+                tdef_page,
+                h1.locator_offsets,
+                empty[0],
+                frozenset(valid),
+                fingerprints,
+                admitted_by_checkpoint,
+            )
+        )
+    return tuple(output)

--- a/oracle/windows-dao/scripts/a4_derivation.py
+++ b/oracle/windows-dao/scripts/a4_derivation.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Terminal-payload reconstruction helpers for A4 derivation orchestration."""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import a4_layer_h4 as h4_primitive
+from a4_analysis_input import CheckedAnalysisInput
+from a4_layer_h3 import (
+    BASE_FORMULAS,
+    H3Candidate,
+    TraversalObservation,
+    admitted_pages,
+    conversion_legs,
+    formula_fits,
+    reference_invalid,
+)
+from a4_layer_h4 import (
+    OPERATIONS,
+    CatalogRootObservation,
+    H4Candidate,
+    OperationRecord,
+    StructuralDerivation,
+    derive_catalog_root,
+    operation_candidate,
+)
+from a4_layer_h4_fields import (
+    bitmap_hex,
+    bitmap_members,
+    encoding_class_matches,
+    identifier_assignment,
+    identifier_assignment_exists,
+    kind_mappings,
+    value_equivalence_key,
+)
+from a4_model import A4AnalysisError, WorkLedger
+from a4_layer_h1 import H1ReplicaCandidate
+from a4_model import View
+from a4_spec import (
+    CHECKPOINT_IDS,
+    CHECKPOINT_ORDINALS,
+    EXPERIMENT_ID,
+    PLAN,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    validate_schema,
+)
+from a4_terminal import not_applicable_result, terminal_result
+
+
+def empty_layer_results() -> dict[str, Any]:
+    return {
+        "h1_tdef_to_map_row": not_applicable_result(),
+        "h2_row_identity_map_role": not_applicable_result(),
+        "h3_indirect_traversal": not_applicable_result(),
+        "h4_catalog_bootstrap": {
+            "root_result": not_applicable_result(),
+            "structural_result": not_applicable_result(),
+            "encoding_result": not_applicable_result(),
+        },
+    }
+
+
+def caught_terminal(
+    error: A4AnalysisError,
+    ledger: WorkLedger,
+    *,
+    candidates: Sequence[Mapping[str, Any]] | None = None,
+    evidence: Mapping[str, Any] | None = None,
+    per_replica_counts: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    return terminal_result(
+        error,
+        ledger,
+        candidates=(getattr(error, "candidates", ()) if candidates is None else candidates),
+        terminal_evidence=(
+            getattr(error, "terminal_evidence", None) if evidence is None else evidence
+        ),
+        per_replica_counts=per_replica_counts,
+    )
+
+
+def h3_terminal_payload(
+    error: A4AnalysisError,
+    rows: Sequence[TraversalObservation],
+    page_counts: Mapping[str, int],
+) -> tuple[tuple[Mapping[str, Any], ...], Mapping[str, Any] | None]:
+    conversion_name = PLAN["candidate_grammars"]["h3"]["conversion_candidates"][0]
+    conversion = H3Candidate("h3_conversion", {"conversion": conversion_name})
+    if error.predicate_id == "A4-H3-CONVERSION-NONE":
+        return (), None
+    if error.predicate_id in (
+        "A4-H3-INACTIVE-SLOT-NONE",
+        "A4-H3-BASE-DISCRIMINATION",
+    ):
+        return (conversion.document(),), None
+    if error.predicate_id == "A4-H3-REFERENCE-INVALID":
+        for row in rows:
+            if row.representation != "type_1":
+                continue
+            invalid = reference_invalid(row, page_counts[row.checkpoint_id])
+            if invalid is None:
+                continue
+            reason = (
+                "out_of_range"
+                if invalid.reference >= page_counts[row.checkpoint_id]
+                else "missing_page"
+                if invalid.referenced_page_tag is None
+                else "not_tag_05"
+            )
+            return (conversion.document(),), {
+                "kind": "reference",
+                "input_model_id": conversion.canonical_candidate_id,
+                "observation": {
+                    "replica": row.replica,
+                    "checkpoint_id": row.checkpoint_id,
+                    "page": row.map_page,
+                    "slot_ordinal": invalid.slot_ordinal,
+                    "referenced_page": invalid.reference,
+                    "observed_tag_byte": invalid.referenced_page_tag,
+                    "reason": reason,
+                },
+            }
+        raise ValueError("H3 reference terminal has no invalid observation")
+    if error.predicate_id in ("A4-H3-BASE-NONE", "A4-H3-BASE-MULTIPLE"):
+        legs = conversion_legs(rows)
+        candidates = tuple(
+            H3Candidate(
+                "h3_final_base_formula",
+                {"conversion": conversion_name, "base_formula": formula},
+            ).document()
+            for formula in BASE_FORMULAS
+            if formula_fits(formula, rows, legs)
+        )
+        return candidates, None
+    raise error
+
+
+def replica_pair(candidates: Sequence[Any]) -> dict[str, Any]:
+    entries = []
+    for replica, candidate in zip((1, 2), candidates):
+        entries.append({
+            "replica": replica,
+            "canonical_model_id": candidate.canonical_model_id,
+            "canonical_candidate_id": candidate.canonical_candidate_id,
+            "complete_candidate": candidate.document(),
+        })
+    return {"kind": "replica_pair", "entries": entries}
+
+
+def root_candidates(
+    replica: int, observations: Sequence[CatalogRootObservation]
+) -> tuple[H4Candidate, ...]:
+    candidates = []
+    for observation in observations:
+        try:
+            candidates.append(derive_catalog_root(replica, (observation,)))
+        except A4AnalysisError as error:
+            if error.predicate_id != "A4-H4-CATALOG-ROOT-NONE":
+                raise
+    return tuple(sorted(candidates, key=lambda row: row.canonical_candidate_id))
+
+
+def operation_groups(
+    root: H4Candidate, records: Sequence[OperationRecord]
+) -> tuple[tuple[dict[str, Any], ...], dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {operation: [] for operation in OPERATIONS}
+    for record in records:
+        grouped[record.operation_id].append(operation_candidate(root, record).document())
+    for operation in OPERATIONS:
+        grouped[operation].sort(key=lambda row: row["canonical_candidate_id"])
+    candidates = tuple(
+        sorted(
+            (
+                candidate
+                for operation in OPERATIONS
+                for candidate in grouped[operation]
+            ),
+            key=lambda row: row["canonical_candidate_id"],
+        )
+    )
+    evidence = {
+        "kind": "operation_groups",
+        "groups": [
+            {
+                "operation_id": operation,
+                "cardinality": len(grouped[operation]),
+                "candidate_ids": [
+                    candidate["canonical_candidate_id"] for candidate in grouped[operation]
+                ],
+            }
+            for operation in OPERATIONS
+        ],
+    }
+    return candidates, evidence
+
+
+def outside_evidence(
+    inputs: CheckedAnalysisInput,
+    replica: int,
+    root_candidate: H4Candidate,
+    root: CatalogRootObservation,
+    deltas: Mapping[str, frozenset[int]],
+) -> dict[str, Any] | None:
+    view = inputs.views[replica]
+    for operation in OPERATIONS:
+        outside = sorted(deltas[operation] - root.admitted_pages_by_checkpoint[operation])
+        if not outside:
+            continue
+        page = outside[0]
+        ordinal = CHECKPOINT_ORDINALS[operation]
+        before = CHECKPOINT_IDS[ordinal - 1]
+        return {
+            "kind": "schema_delta_outside",
+            "input_model_id": root_candidate.canonical_candidate_id,
+            "observation": {
+                "replica": replica,
+                "operation_id": operation,
+                "checkpoint_before": before,
+                "checkpoint_after": operation,
+                "page": page,
+                "page_sha256_before": view.hash_at(before, page),
+                "page_sha256_after": view.hash_at(operation, page),
+            },
+        }
+    return None
+
+
+def isolated_operation_deltas(
+    view: View,
+    h1: H1ReplicaCandidate,
+    observations: Sequence[TraversalObservation],
+    h3: H3Candidate,
+) -> Mapping[str, frozenset[int]]:
+    def changed_pages(checkpoint: str) -> frozenset[int]:
+        ordinal = CHECKPOINT_ORDINALS[checkpoint]
+        before = view.hashes(CHECKPOINT_IDS[ordinal - 1])
+        after = view.hashes(checkpoint)
+        maximum = max(len(before), len(after))
+        return frozenset(
+            page
+            for page in range(maximum)
+            if (before[page] if page < len(before) else None)
+            != (after[page] if page < len(after) else None)
+        )
+
+    formula = str(h3.model["base_formula"])
+    result = {}
+    for operation in OPERATIONS:
+        ordinal = CHECKPOINT_ORDINALS[operation]
+        checkpoints = (CHECKPOINT_IDS[ordinal - 1], operation)
+        excluded = {0, 1}
+        for checkpoint in checkpoints:
+            for binding in h1.bindings:
+                if checkpoint in binding.checkpoints:
+                    excluded.add(binding.tdef_page)
+                    if binding.locator_targets is not None:
+                        excluded.update(target.page for target in binding.locator_targets)
+            for row in observations:
+                if row.checkpoint_id == checkpoint:
+                    excluded.update(
+                        row.type0_owned
+                        if row.representation == "type_0"
+                        else admitted_pages(row, formula)
+                    )
+        result[operation] = changed_pages(operation) - excluded
+    return result
+
+
+def occurrence_evidence_document(
+    campaign_id: str,
+    root: H4Candidate,
+    structural: Mapping[int, StructuralDerivation],
+) -> dict[str, object]:
+    groups = []
+    for replica in (1, 2):
+        groups.append({
+            "replica": replica,
+            "operation_bindings": [
+                {
+                    "operation_id": group.record.operation_id,
+                    "canonical_record_locator": group.record.locator.document(),
+                    "occurrences": [
+                        {
+                            "occurrence_index": occurrence.index,
+                            "name_start": occurrence.start,
+                            "matched_registered_pattern_id": (
+                                f"{group.record.operation_id}_CP1252"
+                                if "strict_windows_1252" in occurrence.encoding_ids
+                                else f"{group.record.operation_id}_UTF8"
+                            ),
+                            "matched_bytes_hex": occurrence.encoded_hex,
+                        }
+                        for occurrence in group.occurrences
+                    ],
+                }
+                for group in structural[replica].evidence
+            ],
+        })
+    document: dict[str, object] = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_h4_occurrence_evidence",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "campaign_id": campaign_id,
+        "root_candidate_id": root.canonical_candidate_id,
+        "replica_groups": groups,
+    }
+    validate_schema(document, "dao_a4_h4_occurrence_evidence")
+    return document
+
+
+def rebind_evidence(
+    structural: StructuralDerivation, digest: str
+) -> StructuralDerivation:
+    candidate = structural.candidates[0]
+    binding = {
+        **dict(candidate.instance_bindings[0]),
+        "occurrence_evidence_sha256": digest,
+    }
+    rebound = H4Candidate(candidate.model_type, candidate.model, (binding,))
+    return StructuralDerivation(
+        structural.replica, digest, structural.evidence, (rebound,)
+    )
+
+
+def structural_candidates(
+    replica: int, records: Sequence[OperationRecord]
+) -> StructuralDerivation:
+    evidence = tuple(h4_primitive.scan_name_occurrences(record) for record in records)
+    digest = h4_primitive._evidence_hash(evidence)
+    equivalent: dict[
+        tuple[Any, ...], tuple[dict[str, Any], dict[str, tuple[int, ...]], int]
+    ] = {}
+    shapes = itertools.product(
+        h4_primitive.KIND_START_DELTAS,
+        h4_primitive.KIND_WIDTHS,
+        h4_primitive.IDENTIFIER_WIDTHS,
+        h4_primitive.ENDIANNESS,
+        h4_primitive.NAME_LENGTH_START_DELTAS,
+        h4_primitive.NAME_LENGTH_WIDTHS,
+    )
+    for shape in shapes:
+        decoded: dict[str, tuple[Any, ...]] = {}
+        for group in evidence:
+            rows = tuple(
+                result
+                for occurrence in group.occurrences
+                if (result := h4_primitive._decode_shape(group, occurrence, shape))
+                is not None
+            )
+            if not rows:
+                break
+            decoded[group.record.operation_id] = rows
+        if len(decoded) != len(OPERATIONS):
+            continue
+        for mapping in kind_mappings(
+            frozenset(row.kind for rows in decoded.values() for row in rows)
+        ):
+            filtered = {
+                operation: tuple(
+                    row
+                    for row in decoded[operation]
+                    if row.kind == mapping[h4_primitive._OBJECT_KIND[operation]]
+                )
+                for operation in OPERATIONS
+            }
+            if not all(filtered.values()):
+                continue
+            options = {
+                operation: frozenset(row.identifier for row in filtered[operation])
+                for operation in OPERATIONS
+            }
+            for lifecycle in h4_primitive.IDENTIFIER_LIFECYCLES:
+                if not identifier_assignment_exists(OPERATIONS, options, lifecycle):
+                    continue
+                compatible: dict[str, tuple[int, ...]] = {}
+                for operation in OPERATIONS:
+                    indexes = tuple(
+                        row.occurrence.index
+                        for row in filtered[operation]
+                        if identifier_assignment_exists(
+                            OPERATIONS, options, lifecycle, (operation, row.identifier)
+                        )
+                    )
+                    if not indexes:
+                        break
+                    compatible[operation] = tuple(sorted(set(indexes)))
+                if len(compatible) != len(OPERATIONS):
+                    continue
+                model = {
+                    "kind_start_delta": shape[0],
+                    "kind_width": shape[1],
+                    "identifier_width": shape[2],
+                    "endianness": shape[3],
+                    "name_length_start_delta": shape[4],
+                    "name_length_width": shape[5],
+                    "kind_mapping": mapping,
+                    "identifier_lifecycle": lifecycle,
+                }
+                key = value_equivalence_key(
+                    OPERATIONS, filtered, compatible, mapping, lifecycle
+                )
+                if key in equivalent:
+                    first_model, first_compatible, count = equivalent[key]
+                    equivalent[key] = (first_model, first_compatible, count + 1)
+                else:
+                    equivalent[key] = (model, compatible, 1)
+    candidates = []
+    for model, compatible, count in equivalent.values():
+        binding = {
+            "replica": replica,
+            "occurrence_evidence_sha256": digest,
+            "value_equivalent_tuple_count": count,
+            "compatible_occurrences_by_operation": [
+                {
+                    "operation_id": operation,
+                    "compatible_occurrence_count": len(compatible[operation]),
+                    "compatible_occurrence_bitmap_hex": bitmap_hex(
+                        compatible[operation],
+                        290 if operation in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254,
+                    ),
+                }
+                for operation in OPERATIONS
+            ],
+        }
+        candidates.append(H4Candidate("h4_structural_field", model, (binding,)))
+    return StructuralDerivation(
+        replica,
+        digest,
+        evidence,
+        tuple(sorted(candidates, key=lambda row: row.canonical_candidate_id)),
+    )
+
+
+def encoding_candidates(structural: StructuralDerivation) -> tuple[H4Candidate, ...]:
+    candidate = structural.candidates[0]
+    binding = candidate.instance_bindings[0]
+    bitmap_rows = {
+        row["operation_id"]: bitmap_members(row["compatible_occurrence_bitmap_hex"])
+        for row in binding["compatible_occurrences_by_operation"]
+    }
+    finals = []
+    for class_id in h4_primitive.ENCODING_CLASSES:
+        matching_by_operation = {}
+        for evidence in structural.evidence:
+            matching = []
+            for occurrence in evidence.occurrences:
+                if occurrence.index not in bitmap_rows[evidence.record.operation_id]:
+                    continue
+                decoded = h4_primitive._decode_for_model(
+                    evidence, occurrence, candidate.model
+                )
+                if decoded is not None and encoding_class_matches(
+                    class_id,
+                    evidence.expected_name,
+                    bytes.fromhex(occurrence.encoded_hex),
+                    decoded.stored_length,
+                ):
+                    matching.append(decoded)
+            if not matching:
+                break
+            matching_by_operation[evidence.record.operation_id] = tuple(matching)
+        if len(matching_by_operation) != len(OPERATIONS):
+            continue
+        assignment = identifier_assignment(
+            OPERATIONS,
+            {
+                operation: frozenset(
+                    row.identifier for row in matching_by_operation[operation]
+                )
+                for operation in OPERATIONS
+            },
+            str(candidate.model["identifier_lifecycle"]),
+        )
+        if assignment is None:
+            continue
+        selected = [
+            {
+                "operation_id": operation,
+                "occurrence_index": min(
+                    row.occurrence.index
+                    for row in matching_by_operation[operation]
+                    if row.identifier == assignment[operation]
+                ),
+            }
+            for operation in OPERATIONS
+        ]
+        finals.append(H4Candidate(
+            "h4_final_encoded_field",
+            {
+                "structural_model_id": candidate.canonical_model_id,
+                "encoding_length_equivalence_class": class_id,
+            },
+            ({
+                "replica": structural.replica,
+                "structural_candidate_id": candidate.canonical_candidate_id,
+                "selected_operation_occurrences": selected,
+            },),
+        ))
+    return tuple(finals)

--- a/oracle/windows-dao/scripts/a4_frozen_models.py
+++ b/oracle/windows-dao/scripts/a4_frozen_models.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Reconstruct holdout-only A4 models from validated frozen JSON."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from a4_layer_h1 import H1Binding, H1ReplicaCandidate, LocatorTarget
+from a4_layer_h2 import H2ReplicaCandidate
+from a4_layer_h3 import H3Candidate
+from a4_layer_h4 import EncodedDerivation, H4Candidate
+from a4_spec import canonical_json_bytes, sha256_hex
+
+
+@dataclass(frozen=True)
+class FrozenModels:
+    """The replica-invariant models permitted to cross the holdout boundary."""
+
+    h1: H1ReplicaCandidate
+    h2: H2ReplicaCandidate
+    h3: H3Candidate
+    h4_root: H4Candidate
+    h4: EncodedDerivation
+
+
+def _only_model(result: Mapping[str, Any], stage: str) -> Mapping[str, Any]:
+    if (
+        result.get("status") != "model"
+        or result.get("terminal_predicate_id") is not None
+        or result.get("derivation_survivor_count") != 1
+    ):
+        raise ValueError(f"A4 frozen {stage} is not a decisive model")
+    candidates = result.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) != 1:
+        raise ValueError(f"A4 frozen {stage} does not contain exactly one candidate")
+    candidate = candidates[0]
+    if not isinstance(candidate, dict):
+        raise ValueError(f"A4 frozen {stage} candidate is not an object")
+    if result.get("canonical_candidates_sha256") != sha256_hex(
+        canonical_json_bytes(candidates)
+    ):
+        raise ValueError(f"A4 frozen {stage} candidate-array hash does not recompute")
+    return candidate
+
+
+def _same_document(actual: Mapping[str, Any], expected: Mapping[str, Any], stage: str) -> None:
+    if canonical_json_bytes(actual) != canonical_json_bytes(expected):
+        raise ValueError(f"A4 frozen {stage} candidate identity does not recompute")
+
+
+def _h1(candidate: Mapping[str, Any]) -> H1ReplicaCandidate:
+    model = candidate["model"]
+    bindings = tuple(
+        H1Binding(
+            int(row["replica"]),
+            str(row["logical_role"]),
+            str(row["lifecycle_instance"]),
+            int(row["tdef_page"]),
+            tuple(
+                LocatorTarget(int(target["page"]), int(target["row"]))
+                for target in row["locator_targets"]
+            ),
+        )
+        for row in candidate["instance_bindings"]
+    )
+    result = H1ReplicaCandidate(
+        0,
+        str(model["layout"]),
+        str(model["table_signature_id"]),
+        tuple(int(value) for value in model["locator_offsets"]),
+        bindings,
+    )
+    _same_document(candidate, result.document(), "H1")
+    return result
+
+
+def _h2(candidate: Mapping[str, Any]) -> H2ReplicaCandidate:
+    model = candidate["model"]
+    result = H2ReplicaCandidate(
+        0,
+        int(model["row_mask"]),
+        str(model["polarity"]),
+        int(model["owned_in_use_locator_ordinal"]),
+        int(model["available_locator_ordinal"]),
+    )
+    _same_document(candidate, result.document(), "H2")
+    return result
+
+
+def _plain(candidate: Mapping[str, Any], stage: str) -> H3Candidate:
+    result = H3Candidate(str(candidate["model_type"]), dict(candidate["model"]))
+    _same_document(candidate, result.document(), stage)
+    return result
+
+
+def _h4(candidate: Mapping[str, Any], stage: str) -> H4Candidate:
+    bindings = tuple(dict(row) for row in candidate.get("instance_bindings", ()))
+    result = H4Candidate(str(candidate["model_type"]), dict(candidate["model"]), bindings)
+    _same_document(candidate, result.document(), stage)
+    return result
+
+
+def load_frozen_models(document: Mapping[str, Any]) -> FrozenModels:
+    """Recompute every canonical identity from one validated frozen document."""
+    layers = document["layers"]
+    h4 = layers["h4_catalog_bootstrap"]
+    h1 = _h1(_only_model(layers["h1_tdef_to_map_row"], "H1"))
+    h2 = _h2(_only_model(layers["h2_row_identity_map_role"], "H2"))
+    h3 = _plain(_only_model(layers["h3_indirect_traversal"], "H3"), "H3")
+    root = _h4(_only_model(h4["root_result"], "H4 root"), "H4 root")
+    structural = _h4(
+        _only_model(h4["structural_result"], "H4 structural"),
+        "H4 structural",
+    )
+    final = _h4(_only_model(h4["encoding_result"], "H4 encoding"), "H4 encoding")
+    return FrozenModels(h1, h2, h3, root, EncodedDerivation(structural, final))

--- a/oracle/windows-dao/scripts/a4_frozen_validation.py
+++ b/oracle/windows-dao/scripts/a4_frozen_validation.py
@@ -1,0 +1,789 @@
+#!/usr/bin/env python3
+"""Semantic validation for every frozen A4 derivation outcome."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from typing import Any, Mapping
+
+from a4_spec import (
+    BOUNDS, CHECKPOINT_IDS, CHECKPOINT_ORDINALS, EXPERIMENT_ID,
+    LIFECYCLE_RANGES, PLAN, PLAN_SHA256,
+    PREDICATE_CONTRACTS, REVISION_PLAN_SHA256,
+    canonical_candidate_id, canonical_model_id, validate_failure_count,
+)
+
+_SLOTS = ("h1_tdef_to_map_row", "h2_row_identity_map_role", "h3_indirect_traversal",
+          "root_result", "structural_result", "encoding_result")
+_DECISIVE_TYPES = {
+    "h1_tdef_to_map_row": "h1_locator_pair", "h2_row_identity_map_role": "h2_final_role",
+    "h3_indirect_traversal": "h3_final_base_formula", "root_result": "h4_catalog_root",
+    "structural_result": "h4_structural_field", "encoding_result": "h4_final_encoded_field",
+}
+_BOUND_TYPES = {"h1_tdef", "h1_target_valid_layout", "h1_locator_pair", "h4_catalog_root",
+                "h4_structural_field", "h4_final_encoded_field"}
+_OPERATIONS = tuple(PLAN["candidate_grammars"]["h4"]["operation_binding_order"])
+_H1_INSTANCES = tuple(LIFECYCLE_RANGES)
+_H1, _H2, _H3, _H4 = (PLAN["candidate_grammars"][key] for key in ("h1", "h2", "h3", "h4"))
+_OCCURRENCE_LIMIT = {op: 290 if op in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254 for op in _OPERATIONS}
+_ROLE_BINDINGS = {
+    row["replica"]: {key: value for key, value in row.items() if key != "replica"}
+    for row in PLAN["tables"]["role_bindings"]
+}
+_TABLE_ROLE = {
+    operation: operation.split("_", 1)[0]
+    for operation in _OPERATIONS
+    if operation not in ("T1_ADD_TEXT", "T1_ADD_INDEX")
+}
+_QUALIFIED_PAGE_MARKER = hashlib.sha256(
+    b"dao-a4-qualified-page-transcript-v1"
+).digest()[:15]
+_TRANSCRIPT_CATEGORY_CODES = dict(zip(
+    ("locators", "row_directories", "map_transitions", "reference_bitmaps",
+     "catalog_roots", "catalog_fields"), range(1, 7), strict=True,
+))
+
+
+def _expected_name(replica: int, operation: str) -> str:
+    if operation == "T1_ADD_TEXT":
+        return "Payload"
+    if operation == "T1_ADD_INDEX":
+        return "A4IX_ID"
+    return _ROLE_BINDINGS[replica][_TABLE_ROLE[operation]]
+
+
+def _registered_patterns(replica: int, operation: str) -> Mapping[str, bytes]:
+    name = _expected_name(replica, operation)
+    cp1252 = name.encode("cp1252", errors="strict")
+    utf8 = name.encode("utf-8", errors="strict")
+    patterns = {f"{operation}_CP1252": cp1252}
+    if utf8 != cp1252:
+        patterns[f"{operation}_UTF8"] = utf8
+    return patterns
+
+
+def _results(layers: Mapping[str, Any]) -> tuple[tuple[str, Mapping[str, Any]], ...]:
+    h4 = layers["h4_catalog_bootstrap"]
+    return (("h1_tdef_to_map_row", layers["h1_tdef_to_map_row"]),
+            ("h2_row_identity_map_role", layers["h2_row_identity_map_role"]),
+            ("h3_indirect_traversal", layers["h3_indirect_traversal"]),
+            ("root_result", h4["root_result"]), ("structural_result", h4["structural_result"]),
+            ("encoding_result", h4["encoding_result"]))
+
+
+def _binding_checkpoints(binding: Mapping[str, Any]) -> tuple[str, ...]:
+    interval = binding["applicable_checkpoint_range"]
+    first = CHECKPOINT_ORDINALS[interval["start"]]
+    last = CHECKPOINT_ORDINALS[interval["end"]]
+    return tuple(CHECKPOINT_IDS[first:last + 1])
+
+
+def _decode_frozen_locator(raw: bytes, layout: str) -> dict[str, int]:
+    if len(raw) != 4:
+        raise ValueError("A4 frozen locator transcript is incomplete")
+    if layout == "u24le_page_then_u8_row":
+        return {"page": int.from_bytes(raw[:3], "little"), "row": raw[3]}
+    if layout == "u8_row_then_u24le_page":
+        return {"page": int.from_bytes(raw[1:], "little"), "row": raw[0]}
+    raise ValueError("A4 frozen locator transcript has an unknown layout")
+
+
+def _all_frozen_candidates(layers: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    candidates: list[Mapping[str, Any]] = []
+    for _, result in _results(layers):
+        candidates.extend(result["candidates"])
+        evidence = result.get("terminal_evidence")
+        if isinstance(evidence, Mapping) and evidence.get("kind") == "replica_pair":
+            candidates.extend(entry["complete_candidate"] for entry in evidence["entries"])
+    return tuple(candidates)
+
+
+def _verify_physical_projection(
+    document: Mapping[str, Any],
+    occurrence_evidence: Mapping[str, Any] | None,
+) -> None:
+    """Cross-bind every candidate-derived physical identity to frozen evidence."""
+    qualified = {
+        (row["replica"], row["checkpoint_id"], row["page_number"])
+        for row in document["qualified_pages"]
+    }
+    locators: dict[tuple[str, int], list[bytes]] = {}
+    retained: dict[str, dict[tuple[str, int], list[bytes]]] = {
+        category: {} for category in _TRANSCRIPT_CATEGORY_CODES
+    }
+    coverage: dict[tuple[int, str, int], str] = {}
+    h4 = document["layers"]["h4_catalog_bootstrap"]
+    allowed_marker_categories = {"locators"}
+    if document["layers"]["h2_row_identity_map_role"]["status"] != "not_applicable":
+        allowed_marker_categories.add("row_directories")
+    if document["layers"]["h3_indirect_traversal"]["status"] != "not_applicable":
+        allowed_marker_categories.update(("map_transitions", "reference_bitmaps"))
+    if h4["root_result"]["status"] != "not_applicable":
+        allowed_marker_categories.update(("catalog_roots", "catalog_fields"))
+    for category, rows in document["transcripts"].items():
+        for row in rows:
+            raw = bytes.fromhex(row["detail_hex"])
+            if raw.startswith(_QUALIFIED_PAGE_MARKER):
+                replica_index = len(_QUALIFIED_PAGE_MARKER)
+                if (
+                    len(raw) != replica_index + 17
+                    or raw[replica_index] not in (1, 2)
+                    or raw[replica_index + 1] != _TRANSCRIPT_CATEGORY_CODES[category]
+                    or category not in allowed_marker_categories
+                ):
+                    raise ValueError("A4 frozen qualified-page transcript marker is malformed")
+                identity = (raw[replica_index], row["checkpoint_id"], row["page"])
+                if identity in coverage:
+                    raise ValueError(
+                        "A4 frozen qualified-page inventory has a duplicated transcript marker"
+                    )
+                coverage[identity] = category
+            else:
+                pair = (row["checkpoint_id"], row["page"])
+                retained[category].setdefault(pair, []).append(raw)
+                if category == "locators":
+                    locators.setdefault(pair, []).append(raw)
+    if not set(coverage) <= qualified:
+        raise ValueError("A4 frozen qualified-page inventory differs from transcript evidence")
+
+    required: set[tuple[int, str, int]] = set()
+    required_categories: dict[tuple[int, str, int], str] = {}
+    raw_evidenced: set[tuple[int, str, int]] = set()
+    operation_locators: dict[tuple[int, str], set[tuple[int, int, int, int]]] = {}
+    occurrence_locators: dict[tuple[int, str], set[tuple[int, int, int, int]]] = {}
+
+    def require(identity: tuple[int, str, int], category: str) -> None:
+        previous = required_categories.setdefault(identity, category)
+        if previous != category:
+            raise ValueError("A4 frozen physical evidence has conflicting stage roles")
+        required.add(identity)
+
+    for candidate in _all_frozen_candidates(document["layers"]):
+        model_type = candidate["model_type"]
+        if model_type.startswith("h1_"):
+            offsets = candidate["model"].get("locator_offsets")
+            for binding in candidate["instance_bindings"]:
+                for checkpoint in _binding_checkpoints(binding):
+                    required.add((binding["replica"], checkpoint, binding["tdef_page"]))
+                    targets = binding.get("locator_targets", ())
+                    required.update(
+                        (binding["replica"], checkpoint, target["page"])
+                        for target in targets
+                    )
+                    if offsets is not None and not any(
+                        len(raw) == 8
+                        and [_decode_frozen_locator(
+                            raw[index:index + 4], candidate["model"]["layout"]
+                        ) for index in (0, 4)] == list(targets)
+                        for raw in locators.get((checkpoint, binding["tdef_page"]), ())
+                    ):
+                        raise ValueError(
+                            "A4 frozen H1 target binding differs from its locator transcript"
+                        )
+        elif model_type == "h4_catalog_root":
+            expected = bytes(candidate["model"]["locator_offsets"])
+            for binding in candidate["instance_bindings"]:
+                for checkpoint in CHECKPOINT_IDS:
+                    require(
+                        (binding["replica"], checkpoint, binding["tdef_page"]),
+                        "catalog_roots",
+                    )
+                if expected not in retained["catalog_roots"].get(
+                    ("EMPTY", binding["tdef_page"]), ()
+                ):
+                    raise ValueError("A4 frozen H4 root lacks its retained transcript")
+        elif model_type == "h4_operation_record":
+            model = candidate["model"]
+            locator = model["canonical_record_locator"]
+            pair = (model["operation_id"], locator["page"])
+            identity = (model["replica"], *pair)
+            require(identity, "catalog_fields")
+            operation_locators.setdefault(
+                (model["replica"], model["operation_id"]), set()
+            ).add((locator["page"], locator["row"], locator["row_start"], locator["row_end"]))
+
+    if occurrence_evidence is not None:
+        for group in occurrence_evidence["replica_groups"]:
+            for operation in group["operation_bindings"]:
+                locator = operation["canonical_record_locator"]
+                pair = (operation["operation_id"], locator["page"])
+                identity = (group["replica"], *pair)
+                require(identity, "catalog_fields")
+                raw_evidenced.add(identity)
+                occurrence_locators.setdefault(
+                    (group["replica"], operation["operation_id"]), set()
+                ).add((locator["page"], locator["row"], locator["row_start"], locator["row_end"]))
+
+    for scope in operation_locators.keys() & occurrence_locators.keys():
+        if operation_locators[scope] != occurrence_locators[scope]:
+            raise ValueError("A4 H4 occurrence locator differs from its retained record")
+    required_lengths: dict[tuple[str, int], Counter[int]] = {}
+    for replica, operation in occurrence_locators:
+        rows = occurrence_locators[(replica, operation)]
+        for page in {row[0] for row in rows}:
+            lengths = required_lengths.setdefault((operation, page), Counter())
+            lengths.update(
+                min(row[3] - row[2], 64) for row in rows if row[0] == page
+            )
+    if any(
+        any(Counter(map(len, retained["catalog_fields"].get(pair, ())))[length] < count
+            for length, count in lengths.items())
+        for pair, lengths in required_lengths.items()
+    ):
+        raise ValueError("A4 frozen H4 retained record transcript cardinality differs")
+
+    if not qualified - set(coverage) <= raw_evidenced:
+        raise ValueError("A4 frozen qualified-page inventory differs from transcript evidence")
+    if not required <= qualified:
+        raise ValueError("A4 frozen qualified-page inventory omits retained physical evidence")
+    if any(identity in coverage and coverage[identity] != category
+           for identity, category in required_categories.items()):
+        raise ValueError("A4 frozen qualified-page marker differs from candidate stage")
+    transcript_pairs = {
+        (row["checkpoint_id"], row["page"])
+        for rows in document["transcripts"].values()
+        for row in rows
+    }
+    if transcript_pairs != {(identity[1], identity[2]) for identity in qualified}:
+        raise ValueError("A4 frozen qualified-page inventory differs from transcript evidence")
+
+
+def _binding_replicas(candidate: Mapping[str, Any]) -> tuple[int, ...]:
+    return tuple(binding["replica"] for binding in candidate.get("instance_bindings", ()))
+
+
+def _validate_h1(candidate: Mapping[str, Any]) -> None:
+    model_type, model = candidate["model_type"], candidate["model"]
+    bindings = candidate["instance_bindings"]
+    replicas = _binding_replicas(candidate)
+    if not replicas or replicas not in ((1,) * 5, (2,) * 5, (1,) * 5 + (2,) * 5):
+        raise ValueError("A4 frozen H1 bindings have an invalid replica order")
+    for start in range(0, len(bindings), 5):
+        group = bindings[start:start + 5]
+        if tuple(row["lifecycle_instance"] for row in group) != _H1_INSTANCES:
+            raise ValueError("A4 frozen H1 lifecycle bindings are incomplete or reordered")
+        for row in group:
+            lifecycle = LIFECYCLE_RANGES[row["lifecycle_instance"]]
+            expected_range = {"start": lifecycle.first_checkpoint, "end": lifecycle.last_checkpoint}
+            if row["logical_role"] != lifecycle.logical_role or row["applicable_checkpoint_range"] != expected_range:
+                raise ValueError("A4 frozen H1 lifecycle role/range differs from the plan")
+            if isinstance(row["tdef_page"], bool) or not 0 <= row["tdef_page"] < int(BOUNDS["max_final_pages_per_replica"]):
+                raise ValueError("A4 frozen H1 TDEF page is outside the plan bound")
+            targets = row.get("locator_targets")
+            if model_type == "h1_tdef":
+                if targets is not None:
+                    raise ValueError("A4 frozen H1 TDEF candidate has downstream targets")
+            elif not isinstance(targets, list) or len(targets) != 2 or targets[0] == targets[1]:
+                raise ValueError("A4 frozen H1 locator binding lacks two distinct targets")
+            elif any(isinstance(t.get("page"), bool) or not 0 <= t.get("page", -1) < int(BOUNDS["max_final_pages_per_replica"])
+                     or isinstance(t.get("row"), bool) or not 0 <= t.get("row", -1) <= 255 for t in targets):
+                raise ValueError("A4 frozen H1 locator target is outside its registered range")
+    if model_type == "h1_tdef":
+        if set(model) != {"tdef_lifecycle_signature"} or model["tdef_lifecycle_signature"] not in _H1["tdef_lifecycle_signatures"]:
+            raise ValueError("A4 frozen H1 TDEF model is outside the grammar")
+        return
+    signatures = {_H1["table_record_signature"]["signature_id"],
+                  _H1["pair_multiple_reachability_signature"]["signature_id"]}
+    if model.get("layout") not in _H1["locator_layouts"] or model.get("table_signature_id") not in signatures:
+        raise ValueError("A4 frozen H1 locator model is outside the grammar")
+    if model_type == "h1_target_valid_layout":
+        if set(model) != {"layout", "table_signature_id"}:
+            raise ValueError("A4 frozen H1 layout model has downstream fields")
+        return
+    signature = (_H1["table_record_signature"] if model["table_signature_id"] == _H1["table_record_signature"]["signature_id"]
+                 else _H1["pair_multiple_reachability_signature"])
+    holes = signature["locator_holes"]
+    allowed = {tuple(sorted((left[0], right[0]))) for i, left in enumerate(holes) for right in holes[i + 1:]}
+    offsets = model.get("locator_offsets")
+    if set(model) != {"layout", "table_signature_id", "locator_offsets"} or not isinstance(offsets, list) or tuple(offsets) not in allowed:
+        raise ValueError("A4 frozen H1 locator offsets are not derived from the signature holes")
+    multiple = _H1["pair_multiple_reachability_signature"]
+    if model["table_signature_id"] == multiple["signature_id"]:
+        equality = multiple["equal_byte_intervals"][0]
+        if tuple(offsets) == (equality["left"][0], equality["right"][0]):
+            raise ValueError("A4 frozen H1 target-valid candidate uses duplicate locator holes")
+
+
+def _validate_h2(model: Mapping[str, Any]) -> None:
+    ordinals = (model.get("owned_in_use_locator_ordinal"), model.get("available_locator_ordinal"))
+    if (set(model) != {"row_mask", "polarity", "owned_in_use_locator_ordinal", "available_locator_ordinal"}
+            or model.get("row_mask") not in _H2["row_masks"] or model.get("polarity") not in _H2["type_0_polarities"]
+            or set(ordinals) != {0, 1}):
+        raise ValueError("A4 frozen H2 model is outside the registered grammar")
+
+
+def _validate_h3(model_type: str, model: Mapping[str, Any]) -> None:
+    expected = {"conversion": _H3["conversion_candidates"][0]}
+    if model_type == "h3_final_base_formula":
+        if model.get("base_formula") not in _H3["base_formulas"]:
+            raise ValueError("A4 frozen H3 base formula is outside the grammar")
+        expected["base_formula"] = model["base_formula"]
+    if dict(model) != expected:
+        raise ValueError("A4 frozen H3 model is outside the registered grammar")
+
+
+def _bitmap_members(raw_hex: Any, maximum: int) -> frozenset[int]:
+    if not isinstance(raw_hex, str):
+        raise ValueError("A4 frozen H4 occurrence bitmap is not hexadecimal")
+    try:
+        raw = bytes.fromhex(raw_hex)
+    except ValueError as exc:
+        raise ValueError("A4 frozen H4 occurrence bitmap is not hexadecimal") from exc
+    if len(raw) != (maximum + 7) // 8:
+        raise ValueError("A4 frozen H4 occurrence bitmap has the wrong width")
+    members = frozenset(i for i in range(len(raw) * 8) if raw[i // 8] & (1 << (i % 8)))
+    if any(i >= maximum for i in members):
+        raise ValueError("A4 frozen H4 occurrence bitmap sets an out-of-range bit")
+    return members
+
+
+def _validate_h4(candidate: Mapping[str, Any], occurrence_sha256: str | None) -> None:
+    model_type, model = candidate["model_type"], candidate["model"]
+    bindings, replicas = candidate.get("instance_bindings", ()), _binding_replicas(candidate)
+    if model_type == "h4_operation_record":
+        locator = model.get("canonical_record_locator")
+        if (set(model) != {"replica", "root_candidate_id", "operation_id", "canonical_record_locator"}
+                or model.get("replica") not in (1, 2) or model.get("operation_id") not in _OPERATIONS
+                or not isinstance(locator, Mapping) or set(locator) != {"page", "row", "row_start", "row_end"}
+                or not 0 <= locator["row_start"] < locator["row_end"] <= int(BOUNDS["page_size"])):
+            raise ValueError("A4 frozen H4 operation record is malformed")
+        return
+    if replicas not in ((1,), (2,), (1, 2)):
+        raise ValueError("A4 frozen H4 bindings are missing, duplicated, or reordered")
+    if model_type == "h4_catalog_root":
+        if set(model) != {"root_selection_signature", "locator_offsets"} or model.get("root_selection_signature") not in _H4["catalog_root_selection_signatures"]:
+            raise ValueError("A4 frozen H4 root model is outside the grammar")
+        offsets = model.get("locator_offsets")
+        if not isinstance(offsets, list) or len(offsets) != 2 or offsets != sorted(offsets) or len(set(offsets)) != 2:
+            raise ValueError("A4 frozen H4 root locator offsets are malformed")
+        return
+    if model_type == "h4_structural_field":
+        fields = {"kind_start_delta", "kind_width", "identifier_width", "endianness", "name_length_start_delta", "name_length_width", "kind_mapping", "identifier_lifecycle"}
+        if (set(model) != fields or model["kind_start_delta"] not in _H4["kind_start_deltas"]
+                or model["kind_width"] not in _H4["kind_widths"] or model["identifier_width"] not in _H4["identifier_widths"]
+                or model["endianness"] not in _H4["endianness"] or model["name_length_start_delta"] not in _H4["name_length_start_deltas"]
+                or model["name_length_width"] not in _H4["name_length_widths"] or model["identifier_lifecycle"] not in _H4["identifier_lifecycle_relations"]):
+            raise ValueError("A4 frozen H4 structural model is outside the grammar")
+        mapping = model["kind_mapping"]
+        if (set(mapping) != {"table", "field", "index"} or len(set(mapping.values())) != 3
+                or any(isinstance(value, bool) or not isinstance(value, int)
+                       or not 0 <= value < 1 << (8 * model["kind_width"])
+                       for value in mapping.values())):
+            raise ValueError("A4 frozen H4 kind mapping is not a three-value bijection")
+        if occurrence_sha256 is None:
+            raise ValueError("A4 frozen H4 structural candidate lacks occurrence evidence")
+        for binding in bindings:
+            if binding.get("occurrence_evidence_sha256") != occurrence_sha256:
+                raise ValueError("A4 frozen H4 structural candidate is bound to different occurrence evidence")
+            count = binding.get("value_equivalent_tuple_count")
+            if isinstance(count, bool) or not 1 <= count <= int(BOUNDS["max_h4_value_equivalent_tuples"]):
+                raise ValueError("A4 frozen H4 value-equivalent count is outside its bound")
+            rows = binding.get("compatible_occurrences_by_operation")
+            if not isinstance(rows, list) or [row.get("operation_id") for row in rows] != list(_OPERATIONS):
+                raise ValueError("A4 frozen H4 compatible occurrences are incomplete or reordered")
+            for row in rows:
+                members = _bitmap_members(row.get("compatible_occurrence_bitmap_hex"), _OCCURRENCE_LIMIT[row["operation_id"]])
+                if row.get("compatible_occurrence_count") != len(members) or not members:
+                    raise ValueError("A4 frozen H4 bitmap popcount differs from its reported count")
+        return
+    if model_type == "h4_final_encoded_field":
+        classes = {row["id"] for row in _H4["name_length_equivalence_classes"]}
+        if set(model) != {"structural_model_id", "encoding_length_equivalence_class"} or model["encoding_length_equivalence_class"] not in classes:
+            raise ValueError("A4 frozen H4 final model is outside the grammar")
+        for binding in bindings:
+            selected = binding.get("selected_operation_occurrences")
+            if not isinstance(selected, list) or [row.get("operation_id") for row in selected] != list(_OPERATIONS):
+                raise ValueError("A4 frozen H4 final selections are incomplete or reordered")
+            if any(isinstance(row.get("occurrence_index"), bool) or not 0 <= row.get("occurrence_index", -1) < _OCCURRENCE_LIMIT[row["operation_id"]] for row in selected):
+                raise ValueError("A4 frozen H4 final selection is outside the occurrence range")
+        return
+    raise ValueError("A4 frozen candidate has an unregistered model type")
+
+
+def _candidate_identity(candidate: Mapping[str, Any], occurrence_sha256: str | None = None) -> tuple[str, str]:
+    model_type, model = candidate["model_type"], candidate["model"]
+    model_id = canonical_model_id(model_type, model)
+    bindings = candidate.get("instance_bindings") if model_type in _BOUND_TYPES else None
+    candidate_id = canonical_candidate_id(model_type, model, bindings)
+    if candidate["canonical_candidate_id"] != candidate_id:
+        raise ValueError("A4 frozen candidate identity does not recompute")
+    if model_type in _BOUND_TYPES:
+        if candidate.get("canonical_model_id") != model_id:
+            raise ValueError("A4 frozen model identity does not recompute")
+    elif "canonical_model_id" in candidate:
+        raise ValueError("A4 frozen candidate has an unregistered model identity")
+    if model_type.startswith("h1_"): _validate_h1(candidate)
+    elif model_type == "h2_final_role": _validate_h2(model)
+    elif model_type.startswith("h3_"): _validate_h3(model_type, model)
+    elif model_type.startswith("h4_"): _validate_h4(candidate, occurrence_sha256)
+    else: raise ValueError("A4 frozen candidate has an unregistered model type")
+    return model_id, candidate_id
+
+
+def _validate_replica_pair(predicate_id: str, slot: str, result: Mapping[str, Any], evidence: Mapping[str, Any], occurrence_sha256: str | None) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    entries = evidence.get("entries")
+    if evidence.get("kind") != "replica_pair" or not isinstance(entries, list) or len(entries) != 2 or [e.get("replica") for e in entries] != [1, 2]:
+        raise ValueError(f"{predicate_id}: invalid or reordered frozen replica pair")
+    models, candidates = [], []
+    for entry in entries:
+        candidate = entry.get("complete_candidate")
+        if not isinstance(candidate, Mapping):
+            raise ValueError(f"{predicate_id}: replica pair lacks a complete candidate")
+        model_id, candidate_id = _candidate_identity(candidate, occurrence_sha256)
+        expected_type = "h4_structural_field" if slot == "structural_result" else result["terminal_candidate_stage"]
+        if candidate["model_type"] != expected_type:
+            raise ValueError(f"{predicate_id}: replica-pair candidate has the wrong stage")
+        replicas = _binding_replicas(candidate)
+        if replicas and replicas != (entry["replica"],):
+            raise ValueError(f"{predicate_id}: replica-pair candidate is bound to another replica")
+        if candidate["model_type"] == "h4_operation_record" and candidate["model"]["replica"] != entry["replica"]:
+            raise ValueError(f"{predicate_id}: replica-pair operation record is cross-replica")
+        if entry.get("canonical_model_id") != model_id or entry.get("canonical_candidate_id") != candidate_id:
+            raise ValueError(f"{predicate_id}: replica-pair identity does not recompute")
+        models.append(model_id); candidates.append(candidate)
+    if result["predicate_measured_survivor_count"] != 2:
+        raise ValueError(f"{predicate_id}: replica pair has the wrong measured count")
+    if predicate_id != "A4-H4-REPLICA-DISAGREEMENT" and len(set(models)) != 2:
+        raise ValueError(f"{predicate_id}: replica pair is not a measured disagreement")
+    return candidates[0], candidates[1]
+
+
+def _validate_groups(predicate_id: str, result: Mapping[str, Any], evidence: Mapping[str, Any], occurrence_sha256: str | None) -> None:
+    groups = evidence.get("groups")
+    if evidence.get("kind") != "operation_groups" or not isinstance(groups, list) or [g.get("operation_id") for g in groups] != list(_OPERATIONS):
+        raise ValueError(f"{predicate_id}: invalid or reordered operation groups")
+    candidates = result["candidates"]
+    by_id: dict[str, Mapping[str, Any]] = {}
+    for candidate in candidates:
+        _candidate_identity(candidate, occurrence_sha256)
+        by_id[candidate["canonical_candidate_id"]] = candidate
+    if len(by_id) != len(candidates):
+        raise ValueError(f"{predicate_id}: duplicate retained operation candidate")
+    grouped, counts = set(), []
+    for group in groups:
+        ids, count = group.get("candidate_ids"), group.get("cardinality")
+        if not isinstance(ids, list) or len(ids) != len(set(ids)) or count != len(ids):
+            raise ValueError(f"{predicate_id}: operation-group cardinality differs")
+        expected_ids = sorted(i for i, candidate in by_id.items() if candidate["model"]["operation_id"] == group["operation_id"])
+        if ids != expected_ids:
+            raise ValueError(f"{predicate_id}: operation-group membership differs by operation")
+        grouped.update(ids); counts.append(count)
+    measured = result["predicate_measured_survivor_count"]
+    expected = min(counts) if predicate_id.endswith("RECORD-NONE") else max(counts)
+    if set(by_id) != grouped or measured != expected:
+        raise ValueError(f"{predicate_id}: grouped terminal union differs")
+    replicas = {candidate["model"]["replica"] for candidate in candidates}
+    if len(replicas) > 1:
+        raise ValueError(f"{predicate_id}: grouped candidate set mixes first-violating replicas")
+
+
+def _validate_terminal_payload(slot: str, result: Mapping[str, Any], immediate_input_id: str | None, occurrence_sha256: str | None) -> None:
+    predicate_id = result["terminal_predicate_id"]
+    contract = PREDICATE_CONTRACTS.get(predicate_id)
+    if contract is None or slot not in contract["result_slots"]:
+        raise ValueError(f"{predicate_id}: terminal occupies an unregistered result slot")
+    if result["terminal_payload_kind"] != contract["terminal_payload_schema"] or result["terminal_candidate_stage"] != contract["candidate_stage"] or result["derivation_survivor_count"] != 0:
+        raise ValueError(f"{predicate_id}: terminal projection differs from its contract")
+    payload, measured = contract["terminal_payload_schema"], result["predicate_measured_survivor_count"]
+    validate_failure_count(predicate_id, measured, per_replica_counts=(1, 1) if payload == "replica_pair" else None)
+    candidates, evidence = result["candidates"], result["terminal_evidence"]
+    if payload == "candidate_set":
+        if len(candidates) != measured or evidence is not None: raise ValueError(f"{predicate_id}: candidate-set payload differs from its count")
+        scopes: set[int] = set()
+        for candidate in candidates:
+            replicas = set(_binding_replicas(candidate))
+            if candidate["model_type"] == "h4_operation_record":
+                replicas = {candidate["model"]["replica"]}
+            if replicas:
+                if len(replicas) != 1:
+                    raise ValueError(f"{predicate_id}: candidate-set entry is not replica-local")
+                scopes.update(replicas)
+        if len(scopes) > 1:
+            raise ValueError(f"{predicate_id}: candidate set mixes first-violating replicas")
+    elif payload == "replica_pair":
+        if candidates or not isinstance(evidence, Mapping): raise ValueError(f"{predicate_id}: replica-pair payload is incomplete")
+        _validate_replica_pair(predicate_id, slot, result, evidence, occurrence_sha256)
+    elif payload == "grouped_candidate_set":
+        if not isinstance(evidence, Mapping): raise ValueError(f"{predicate_id}: grouped payload is incomplete")
+        _validate_groups(predicate_id, result, evidence, occurrence_sha256)
+    elif payload == "invalid_observation":
+        if not isinstance(evidence, Mapping) or len(candidates) > 1: raise ValueError(f"{predicate_id}: invalid-observation payload is incomplete")
+        expected = candidates[0]["canonical_candidate_id"] if candidates else immediate_input_id
+        if expected is None or evidence.get("input_model_id") != expected: raise ValueError(f"{predicate_id}: invalid observation is not bound to its immediate input")
+        if evidence.get("kind") in ("replica_pair", "operation_groups"):
+            raise ValueError(f"{predicate_id}: invalid observation has a foreign evidence kind")
+        expected_kinds = {
+            "A4-H2-ROW-DIRECTORY-INVALID": "row_directory",
+            "A4-H2-ROW-FLAGS-INVALID": "row_flags",
+            "A4-H2-MAP-TAG-UNSUPPORTED": "map_tag",
+            "A4-H3-REFERENCE-INVALID": "reference",
+            "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED": "schema_delta_outside",
+        }
+        if evidence.get("kind") != expected_kinds.get(predicate_id):
+            raise ValueError(f"{predicate_id}: invalid observation kind differs from the predicate")
+        if not isinstance(evidence.get("observation"), Mapping): raise ValueError(f"{predicate_id}: invalid observation is absent")
+    else: raise ValueError(f"{predicate_id}: unknown frozen terminal payload")
+
+
+def _validate_occurrence_evidence(
+    evidence: Mapping[str, Any],
+    transcripts: Mapping[str, Any] | None,
+    qualified_pages: list[Mapping[str, Any]] | None,
+) -> tuple[
+    dict[tuple[int, str], frozenset[int]],
+    dict[tuple[int, str, int], Mapping[str, Any]],
+]:
+    """Validate the complete plan-derived meaning of each retained occurrence."""
+    if (
+        evidence.get("experiment_id") != EXPERIMENT_ID
+        or evidence.get("plan_sha256") != PLAN_SHA256
+        or evidence.get("revision_plan_sha256") != REVISION_PLAN_SHA256
+    ):
+        raise ValueError("A4 H4 occurrence evidence metadata differs from the plan")
+    groups = evidence.get("replica_groups")
+    if not isinstance(groups, list) or [group.get("replica") for group in groups] != [1, 2]:
+        raise ValueError("A4 H4 occurrence evidence replica groups are reordered")
+    qualified = None if qualified_pages is None else {
+        (row["replica"], row["checkpoint_id"], row["page_number"])
+        for row in qualified_pages
+    }
+    retained_rows: dict[tuple[str, int], list[bytes]] = {}
+    if isinstance(transcripts, Mapping):
+        for row in transcripts.get("catalog_fields", ()):
+            raw = bytes.fromhex(row["detail_hex"])
+            if not raw.startswith(_QUALIFIED_PAGE_MARKER):
+                retained_rows.setdefault(
+                    (row["checkpoint_id"], row["page"]), []
+                ).append(raw)
+    indexes_by_group: dict[tuple[int, str], frozenset[int]] = {}
+    occurrences_by_key: dict[tuple[int, str, int], Mapping[str, Any]] = {}
+    total = 0
+    for group in groups:
+        replica = group["replica"]
+        operations = group.get("operation_bindings")
+        if (
+            not isinstance(operations, list)
+            or [row.get("operation_id") for row in operations] != list(_OPERATIONS)
+        ):
+            raise ValueError("A4 H4 occurrence operations are incomplete or reordered")
+        for operation in operations:
+            operation_id = operation["operation_id"]
+            locator = operation.get("canonical_record_locator")
+            if (
+                not isinstance(locator, Mapping)
+                or set(locator) != {"page", "row", "row_start", "row_end"}
+                or isinstance(locator["page"], bool)
+                or not 0 <= locator["page"] < int(BOUNDS["max_final_pages_per_replica"])
+                or isinstance(locator["row"], bool)
+                or not 0 <= locator["row"] <= 255
+                or not 10 <= locator["row_start"] < locator["row_end"] <= int(BOUNDS["page_size"])
+            ):
+                raise ValueError("A4 H4 occurrence record locator is malformed")
+            if qualified is not None and (
+                replica, operation_id, locator["page"]
+            ) not in qualified:
+                raise ValueError("A4 H4 occurrence record page is absent from qualified evidence")
+            patterns = _registered_patterns(replica, operation_id)
+            rows = operation.get("occurrences")
+            if not isinstance(rows, list):
+                raise ValueError("A4 H4 occurrence rows are malformed")
+            indexes = tuple(row.get("occurrence_index") for row in rows)
+            if indexes != tuple(range(len(rows))):
+                raise ValueError("A4 H4 occurrence evidence indexes are not canonical and contiguous")
+            if len(rows) > _OCCURRENCE_LIMIT[operation_id]:
+                raise ValueError("A4 H4 operation occurrence count exceeds its bound")
+            identities: list[tuple[int, str, str]] = []
+            row_length = locator["row_end"] - locator["row_start"]
+            for row in rows:
+                pattern_id = row.get("matched_registered_pattern_id")
+                try:
+                    matched = bytes.fromhex(row.get("matched_bytes_hex", ""))
+                except (TypeError, ValueError) as exc:
+                    raise ValueError("A4 H4 occurrence bytes are malformed") from exc
+                if pattern_id not in patterns or matched != patterns[pattern_id]:
+                    raise ValueError("A4 H4 occurrence bytes differ from the registered operation name")
+                name_start = row.get("name_start")
+                if (
+                    isinstance(name_start, bool)
+                    or not isinstance(name_start, int)
+                    or not 0 <= name_start
+                    or name_start + len(matched) > row_length
+                ):
+                    raise ValueError("A4 H4 occurrence name range is outside its record")
+                identity = (name_start, pattern_id, matched.hex())
+                identities.append(identity)
+                retained = [
+                    payload
+                    for payload in retained_rows.get((operation_id, locator["page"]), ())
+                    if len(payload) >= name_start + len(matched)
+                ]
+                if isinstance(transcripts, Mapping) and (
+                    not retained or not any(
+                        payload[name_start:name_start + len(matched)] == matched
+                        for payload in retained
+                    )
+                ):
+                    raise ValueError("A4 H4 occurrence bytes differ from retained record evidence")
+                occurrences_by_key[(replica, operation_id, row["occurrence_index"])] = row
+            if identities != sorted(set(identities)):
+                raise ValueError("A4 H4 occurrence identities are duplicated or reordered")
+            indexes_by_group[(replica, operation_id)] = frozenset(indexes)
+            total += len(rows)
+    if total > int(BOUNDS["max_h4_occurrence_identities"]):
+        raise ValueError("A4 H4 occurrence identity total exceeds its bound")
+    return indexes_by_group, occurrences_by_key
+
+
+def _h4_cross_stage(
+    rows: Mapping[str, Mapping[str, Any]],
+    occurrence_sha256: str | None,
+    occurrence_evidence: Mapping[str, Any] | None,
+    transcripts: Mapping[str, Any] | None,
+    qualified_pages: list[Mapping[str, Any]] | None,
+) -> None:
+    sr, fr = rows["structural_result"], rows["encoding_result"]
+    root = rows["root_result"]
+    root_ids = {candidate["canonical_candidate_id"] for candidate in root["candidates"]}
+    for candidate in root["candidates"]:
+        for binding in candidate.get("instance_bindings", ()):
+            root_ids.add(canonical_candidate_id(candidate["model_type"], candidate["model"], [binding]))
+    root_evidence = root.get("terminal_evidence")
+    if isinstance(root_evidence, Mapping) and root_evidence.get("kind") == "replica_pair":
+        root_ids.update(entry["canonical_candidate_id"] for entry in root_evidence["entries"])
+    for candidate in sr["candidates"]:
+        if candidate["model_type"] == "h4_operation_record" and candidate["model"]["root_candidate_id"] not in root_ids:
+            raise ValueError("A4 frozen H4 operation record is orphaned from its root candidate")
+    structural, final = list(sr["candidates"]), list(fr["candidates"])
+    if isinstance(sr.get("terminal_evidence"), Mapping) and sr["terminal_evidence"].get("kind") == "replica_pair":
+        structural = [e["complete_candidate"] for e in sr["terminal_evidence"]["entries"]]
+    if isinstance(fr.get("terminal_evidence"), Mapping) and fr["terminal_evidence"].get("kind") == "replica_pair":
+        final = [e["complete_candidate"] for e in fr["terminal_evidence"]["entries"]]
+    began = (any(c["model_type"] == "h4_structural_field" for c in structural)
+             or sr.get("terminal_candidate_stage") == "h4_structural_field"
+             or sr.get("terminal_payload_kind") == "replica_pair")
+    if began != (occurrence_sha256 is not None):
+        raise ValueError("A4 frozen H4 occurrence evidence presence differs from reached stages")
+    if began and occurrence_evidence is None:
+        raise ValueError("A4 frozen H4 candidates lack canonical occurrence evidence bytes")
+    evidence_indexes: dict[tuple[int, str], frozenset[int]] = {}
+    evidence_occurrences: dict[tuple[int, str, int], Mapping[str, Any]] = {}
+    if occurrence_evidence is not None:
+        root_candidates = root["candidates"]
+        if len(root_candidates) == 1 and occurrence_evidence.get("root_candidate_id") != root_candidates[0]["canonical_candidate_id"]:
+            raise ValueError("A4 H4 occurrence evidence is bound to another root candidate")
+        evidence_indexes, evidence_occurrences = _validate_occurrence_evidence(
+            occurrence_evidence, transcripts, qualified_pages
+        )
+        for candidate in structural:
+            if candidate["model_type"] != "h4_structural_field":
+                continue
+            for binding in candidate["instance_bindings"]:
+                for row in binding["compatible_occurrences_by_operation"]:
+                    members = _bitmap_members(
+                        row["compatible_occurrence_bitmap_hex"],
+                        _OCCURRENCE_LIMIT[row["operation_id"]],
+                    )
+                    if not members <= evidence_indexes[(binding["replica"], row["operation_id"])]:
+                        raise ValueError("A4 frozen H4 bitmap selects an absent evidence occurrence")
+    if not final: return
+    classes: set[tuple[tuple[int, ...], str]] = set()
+    for candidate in final:
+        scope = _binding_replicas(candidate)
+        linked_candidates = [
+            structural_candidate
+            for structural_candidate in structural
+            if structural_candidate["model_type"] == "h4_structural_field"
+            and set(scope) <= set(_binding_replicas(structural_candidate))
+            and candidate["model"].get("structural_model_id")
+            == structural_candidate["canonical_model_id"]
+        ]
+        if len(linked_candidates) != 1:
+            raise ValueError("A4 frozen H4 final model is orphaned from its structural model")
+        linked = linked_candidates[0]
+        by_replica = {b["replica"]: b for b in linked["instance_bindings"]}
+        for binding in candidate["instance_bindings"]:
+            structural_binding = by_replica[binding["replica"]]
+            if binding.get("structural_candidate_id") != linked["canonical_candidate_id"]:
+                raise ValueError("A4 frozen H4 final binding is orphaned from its structural candidate")
+            bitmaps = {r["operation_id"]: _bitmap_members(r["compatible_occurrence_bitmap_hex"], _OCCURRENCE_LIMIT[r["operation_id"]]) for r in structural_binding["compatible_occurrences_by_operation"]}
+            if any(r["occurrence_index"] not in bitmaps[r["operation_id"]] for r in binding["selected_operation_occurrences"]):
+                raise ValueError("A4 frozen H4 final occurrence is absent from the structural bitmap")
+            class_id = candidate["model"]["encoding_length_equivalence_class"]
+            for selected in binding["selected_operation_occurrences"]:
+                occurrence = evidence_occurrences[
+                    (binding["replica"], selected["operation_id"], selected["occurrence_index"])
+                ]
+                payload = bytes.fromhex(occurrence["matched_bytes_hex"])
+                name = _expected_name(binding["replica"], selected["operation_id"])
+                expected = (
+                    name.encode("cp1252", errors="strict")
+                    if class_id == "cp1252_single_byte_per_scalar"
+                    else name.encode("utf-8", errors="strict")
+                )
+                if payload != expected:
+                    raise ValueError("A4 frozen H4 final occurrence differs from its encoding class")
+        class_key = (scope, candidate["model"]["encoding_length_equivalence_class"])
+        if class_key in classes:
+            raise ValueError("A4 frozen H4 final candidates duplicate an equivalence class")
+        classes.add(class_key)
+    if fr.get("terminal_predicate_id") == "A4-H4-REPLICA-DISAGREEMENT" and len({c["canonical_model_id"] for c in final}) != 2:
+        raise ValueError("A4-H4-REPLICA-DISAGREEMENT: final replica models are equal")
+
+
+def validate_frozen_layers(
+    layers: Mapping[str, Any],
+    occurrence_reference: Mapping[str, Any] | None = None,
+    occurrence_evidence: Mapping[str, Any] | None = None,
+    transcripts: Mapping[str, Any] | None = None,
+    qualified_pages: list[Mapping[str, Any]] | None = None,
+) -> None:
+    """Recompute candidate semantics and project the unique terminal path."""
+    occurrence_sha256 = None if occurrence_reference is None else occurrence_reference["sha256"]
+    rows = _results(layers); by_slot = dict(rows)
+    h1_result = by_slot["h1_tdef_to_map_row"]
+    root_result = by_slot["root_result"]
+    if h1_result["status"] == "model" and root_result["status"] != "not_applicable":
+        roots = list(root_result["candidates"])
+        root_evidence = root_result.get("terminal_evidence")
+        if isinstance(root_evidence, Mapping) and root_evidence.get("kind") == "replica_pair":
+            roots.extend(entry["complete_candidate"] for entry in root_evidence["entries"])
+        expected_offsets = h1_result["candidates"][0]["model"]["locator_offsets"]
+        if any(candidate["model"]["locator_offsets"] != expected_offsets for candidate in roots):
+            raise ValueError("A4 frozen H4 root locator offsets differ from the frozen H1 model")
+    terminal_ids = {r["terminal_predicate_id"] for _, r in rows if r["status"] == "no_outcome"}
+    if len(terminal_ids) > 1: raise ValueError("A4 frozen derivation contains multiple terminals")
+    terminal_id = next(iter(terminal_ids), None)
+    expected_slots = set(PREDICATE_CONTRACTS[terminal_id]["result_slots"]) if terminal_id else set()
+    actual_slots = {slot for slot, result in rows if result["status"] == "no_outcome"}
+    if actual_slots != expected_slots: raise ValueError("A4 frozen terminal result slots differ from the contract")
+    first = min((_SLOTS.index(s) for s in expected_slots), default=len(_SLOTS)); last = max((_SLOTS.index(s) for s in expected_slots), default=-1)
+    immediate_input_id: str | None = None
+    for index, (slot, result) in enumerate(rows):
+        expected = "model" if terminal_id is None or index < first else "no_outcome" if first <= index <= last and slot in expected_slots else "not_applicable"
+        if result["status"] != expected: raise ValueError("A4 frozen layer status does not follow terminal order")
+        for candidate in result["candidates"]:
+            _candidate_identity(candidate, occurrence_sha256)
+            if result["terminal_candidate_stage"] is not None and candidate["model_type"] != result["terminal_candidate_stage"]:
+                raise ValueError("A4 frozen terminal candidate has the wrong stage")
+        candidate_ids = [candidate["canonical_candidate_id"] for candidate in result["candidates"]]
+        if candidate_ids != sorted(set(candidate_ids)):
+            raise ValueError("A4 frozen candidate array is not canonical and unique")
+        if expected == "model":
+            if (len(result["candidates"]) != 1 or result["candidates"][0]["model_type"] != _DECISIVE_TYPES[slot]
+                    or result["predicate_measured_survivor_count"] != 1 or result["derivation_survivor_count"] != 1
+                    or result["terminal_predicate_id"] is not None or result["terminal_evidence"] is not None):
+                raise ValueError("A4 frozen decisive result is inconsistent")
+            candidate = result["candidates"][0]
+            if candidate["model_type"] in _BOUND_TYPES:
+                exact = (1,) * 5 + (2,) * 5 if candidate["model_type"].startswith("h1_") else (1, 2)
+                if _binding_replicas(candidate) != exact: raise ValueError("A4 frozen decisive candidate does not bind exact replicas 1 and 2")
+            immediate_input_id = candidate["canonical_candidate_id"]
+        elif expected == "not_applicable":
+            if result["candidates"] or result["predicate_measured_survivor_count"] != 0 or result["derivation_survivor_count"] != 0 or result["terminal_predicate_id"] is not None or result["terminal_evidence"] is not None:
+                raise ValueError("A4 frozen not-applicable result is inconsistent")
+        else:
+            _validate_terminal_payload(slot, result, immediate_input_id, occurrence_sha256)
+    _h4_cross_stage(
+        by_slot, occurrence_sha256, occurrence_evidence, transcripts, qualified_pages
+    )

--- a/oracle/windows-dao/scripts/a4_generator.py
+++ b/oracle/windows-dao/scripts/a4_generator.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Deterministic, non-evidential byte generator for the A4 protocol.
+
+The generator compiles its checkpoint walk from :mod:`a4_generator_schedule`
+and encodes pages through :mod:`a4_generator_pages`.  It does not import an
+analyzer and it never stores predicate outcomes in a fixture.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping
+
+from protocol_validation import ValidationError
+from a4_generator_pages import (
+    TAG_DATA,
+    TAG_TDEF,
+    data_page,
+    empty_page,
+    encode_locator,
+    masked_tdef_page,
+    tag_05_page,
+    type_0_row,
+    type_1_row,
+)
+from a4_generator_schedule import EVENTS, PROFILES, EventKind, Profile, SCHEDULE
+from a4_spec import BOUNDS, CHECKPOINT_IDS, PAGE_SIZE, PLAN
+
+
+GRAMMAR = PLAN["candidate_grammars"]
+H1 = GRAMMAR["h1"]
+H4 = GRAMMAR["h4"]
+STANDARD_SIGNATURE = H1["table_record_signature"]["signature_id"]
+DUPLICATE_SIGNATURE = H1["pair_multiple_reachability_signature"]["signature_id"]
+DEFAULT_LAYOUT = H1["locator_layouts"][1]
+DEFAULT_OFFSETS = tuple(interval[0] for interval in H1["table_record_signature"]["locator_holes"])
+TAG05_BITS = (PAGE_SIZE - 4) * 8
+SYSTEM_PAGE_NAMES = (
+    "root_tdef",
+    "root_map",
+    "catalog",
+    "decoy_tdef",
+    "decoy_map",
+)
+CATALOG_KINDS = MappingProxyType({"table": 0x11, "field": 0x22, "index": 0x33})
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _header_page(replica: int) -> bytes:
+    page = bytearray(PAGE_SIZE)
+    marker = b"Jet3-A4-SYN"
+    page[: len(marker)] = marker
+    page[12] = replica
+    return bytes(page)
+
+
+def _system_tdef(layout: str, map_page: int) -> bytes:
+    page = bytearray(PAGE_SIZE)
+    page[:8] = bytes([TAG_TDEF, 1]) + b"A4SYS0"
+    page[35:39] = encode_locator(layout, map_page, 0)
+    page[39:43] = encode_locator(layout, map_page, 1)
+    return bytes(page)
+
+
+def _payload(role: str, row_id: int) -> bytes:
+    seed = f"A4|{role}|{row_id:010d}|".encode("ascii")
+    return (seed * (240 // len(seed) + 1))[:240]
+
+
+def _strict_name_bytes(name: str) -> bytes:
+    try:
+        return name.encode("cp1252", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise ValidationError("A4 synthetic name is not strict Windows-1252") from exc
+
+
+@dataclass(frozen=True)
+class SyntheticParameters:
+    """Bounded byte-level choices; none is a scientific result label."""
+
+    layout_by_replica: Mapping[int, str] = field(default_factory=dict)
+    owned_ordinal_by_replica: Mapping[int, int] = field(default_factory=dict)
+    signature_id: str = STANDARD_SIGNATURE
+    locator_offsets: tuple[int, ...] = DEFAULT_OFFSETS
+    type_0_polarity: str = "set_bit_owned_in_use"
+    row_flag: int = 0x1000
+    force_t3_conversion_checkpoint: str = "T3_ABS_08192"
+    initial_filler_delta: int = 0
+    omit_blob_digest: str | None = None
+
+    def layout(self, replica: int) -> str:
+        return self.layout_by_replica.get(replica, DEFAULT_LAYOUT)
+
+    def owned_ordinal(self, replica: int) -> int:
+        return self.owned_ordinal_by_replica.get(replica, 0)
+
+    def validate(self) -> None:
+        layouts = tuple(H1["locator_layouts"])
+        if any(replica not in PROFILES for replica in self.layout_by_replica):
+            raise ValidationError("A4 synthetic layout names an unknown replica")
+        if any(layout not in layouts for layout in self.layout_by_replica.values()):
+            raise ValidationError("A4 synthetic locator layout is not registered")
+        if any(value not in (0, 1) for value in self.owned_ordinal_by_replica.values()):
+            raise ValidationError("A4 synthetic owned ordinal must be zero or one")
+        signatures = {STANDARD_SIGNATURE, DUPLICATE_SIGNATURE}
+        if self.signature_id not in signatures:
+            raise ValidationError("A4 synthetic TDEF signature is not registered")
+        signature = (
+            H1["table_record_signature"]
+            if self.signature_id == STANDARD_SIGNATURE
+            else H1["pair_multiple_reachability_signature"]
+        )
+        required = tuple(interval[0] for interval in signature["locator_holes"])
+        if self.locator_offsets != required:
+            raise ValidationError("A4 synthetic locator offsets differ from the signature")
+        if self.type_0_polarity not in H1.get("type_0_polarities", ()) and self.type_0_polarity not in GRAMMAR["h2"]["type_0_polarities"]:
+            raise ValidationError("A4 synthetic type-0 polarity is not registered")
+        if self.row_flag < 0 or self.row_flag > 0xF000 or self.row_flag & 0x0FFF:
+            raise ValidationError("A4 synthetic row flag overlaps the offset bits")
+        if self.force_t3_conversion_checkpoint not in CHECKPOINT_IDS:
+            raise ValidationError("A4 synthetic conversion checkpoint is unknown")
+        if self.initial_filler_delta < 0 or self.initial_filler_delta > 32:
+            raise ValidationError("A4 synthetic filler delta is outside its local bound")
+        if self.omit_blob_digest is not None and (
+            len(self.omit_blob_digest) != 64
+            or any(value not in "0123456789abcdef" for value in self.omit_blob_digest)
+        ):
+            raise ValidationError("A4 omitted blob identity is not canonical SHA-256")
+
+
+@dataclass
+class TableState:
+    instance_id: str
+    role: str
+    tdef_page: int
+    map_page: int
+    owned_pages: set[int]
+    available_pages: set[int] = field(default_factory=set)
+    data_pages: list[int] = field(default_factory=list)
+    tag05_pages: dict[int, int] = field(default_factory=dict)
+    row_count: int = 0
+    retained_row_count: int = 0
+    version: int = 0
+    converted: bool = False
+    dropped: bool = False
+
+
+@dataclass(frozen=True)
+class CatalogRecord:
+    checkpoint_id: str
+    instance_id: str
+    object_kind: str
+    object_id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class SyntheticReplica:
+    """The exact in-memory page-store surface consumed by ``a4_model.View``."""
+
+    replica: int
+    ordered_page_sha256: Mapping[str, tuple[str, ...]]
+    payloads: Mapping[str, bytes]
+    row_counts: Mapping[str, Mapping[str, int]]
+    metadata: Mapping[str, object]
+    omitted_digests: frozenset[str] = frozenset()
+
+    @property
+    def checkpoint_ids(self) -> tuple[str, ...]:
+        return CHECKPOINT_IDS
+
+    @property
+    def page_count(self) -> Mapping[str, int]:
+        return {checkpoint: len(hashes) for checkpoint, hashes in self.ordered_page_sha256.items()}
+
+    def page_bytes(self, digest: str) -> bytes:
+        if digest in self.omitted_digests:
+            raise KeyError(digest)
+        return self.payloads[digest]
+
+
+@dataclass(frozen=True)
+class SyntheticCampaign:
+    replicas: Mapping[int, SyntheticReplica]
+    payloads: Mapping[str, bytes]
+
+
+class ReplicaBuilder:
+    def __init__(self, parameters: SyntheticParameters, replica: int) -> None:
+        parameters.validate()
+        if replica not in PROFILES:
+            raise ValidationError("A4 synthetic replica ordinal is outside the plan")
+        self.parameters = parameters
+        self.replica = replica
+        self.profile: Profile = PROFILES[replica]
+        self.pages: list[bytes] = []
+        self.payloads: dict[str, bytes] = {}
+        self.ordered: dict[str, tuple[str, ...]] = {}
+        self.row_counts: dict[str, Mapping[str, int]] = {}
+        self.tables: dict[str, TableState] = {}
+        self.catalog_records: list[CatalogRecord] = []
+        self.system: dict[str, int] = {}
+        self.reserved: dict[str, tuple[int, int]] = {}
+        self.baselines: dict[str, int] = {}
+        self.inserted_rows = 0
+
+    def _append(self, payload: bytes) -> int:
+        if len(payload) != PAGE_SIZE:
+            raise ValidationError("A4 synthetic page is not exactly 2,048 bytes")
+        self.pages.append(payload)
+        return len(self.pages) - 1
+
+    def _store(self, payload: bytes) -> str:
+        digest = _digest(payload)
+        self.payloads.setdefault(digest, payload)
+        if len(self.payloads) > int(BOUNDS["max_unique_page_blobs"]):
+            raise ValidationError("A4 synthetic unique-page bound exceeded")
+        return digest
+
+    def _build_empty(self) -> None:
+        self._append(_header_page(self.replica))
+        self._append(empty_page())
+        for name in SYSTEM_PAGE_NAMES:
+            self.system[name] = self._append(empty_page())
+        for _ in range(self.profile.initial_filler_pages + self.parameters.initial_filler_delta):
+            self._append(empty_page())
+        for instance in SCHEDULE.instances:
+            self.reserved[instance.instance_id] = (
+                self._append(empty_page()),
+                self._append(empty_page()),
+            )
+        layout = self.parameters.layout(self.replica)
+        self.pages[self.system["root_tdef"]] = _system_tdef(layout, self.system["root_map"])
+        self.pages[self.system["decoy_tdef"]] = _system_tdef(layout, self.system["decoy_map"])
+        self._render_system()
+
+    def _render_system(self) -> None:
+        root_map = self.system["root_map"]
+        catalog = self.system["catalog"]
+        decoy_map = self.system["decoy_map"]
+        owned = type_0_row(root_map, {root_map, catalog}, polarity=self.parameters.type_0_polarity)
+        available = type_0_row(root_map, (), polarity=self.parameters.type_0_polarity)
+        flags = {0: self.parameters.row_flag, 1: self.parameters.row_flag}
+        self.pages[root_map] = data_page((owned, available), raw_flags=flags)
+        decoy_available = type_0_row(decoy_map, (), polarity=self.parameters.type_0_polarity)
+        self.pages[decoy_map] = data_page((type_0_row(decoy_map, {decoy_map}), decoy_available), raw_flags=flags)
+        rows = tuple(self._catalog_row(record) for record in self.catalog_records)
+        self.pages[catalog] = data_page(rows)
+
+    def _catalog_row(self, record: CatalogRecord) -> bytes:
+        kind = CATALOG_KINDS[record.object_kind]
+        name = _strict_name_bytes(record.name)
+        if len(name) > 0xFFFF:
+            raise ValidationError("A4 synthetic catalog name is too long")
+        return bytes([record.object_id, kind, len(name)]) + name
+
+    def _name_for(self, checkpoint_id: str, role: str) -> str:
+        binding = next(item for item in PLAN["tables"]["role_bindings"] if item["replica"] == self.replica)
+        if checkpoint_id == "T1_ADD_TEXT":
+            return "Payload"
+        if checkpoint_id == "T1_ADD_INDEX":
+            return "A4IX_ID"
+        return str(binding[role])
+
+    def _record(self, checkpoint_id: str, instance_id: str, kind: str) -> None:
+        role = SCHEDULE.instance(instance_id).role
+        ordinal = len(self.catalog_records)
+        object_id = 0x21 + ordinal
+        self.catalog_records.append(CatalogRecord(
+            checkpoint_id,
+            instance_id,
+            kind,
+            object_id,
+            self._name_for(checkpoint_id, role),
+        ))
+
+    def _locators(self, map_page: int) -> Mapping[int, bytes]:
+        layout = self.parameters.layout(self.replica)
+        offsets = self.parameters.locator_offsets
+        locators = {
+            offsets[0]: encode_locator(layout, map_page, 0),
+            offsets[1]: encode_locator(layout, map_page, 1),
+        }
+        if len(offsets) == 3:
+            locators[offsets[2]] = locators[offsets[1]]
+        return locators
+
+    def _create(self, checkpoint_id: str, instance_id: str) -> None:
+        role = SCHEDULE.instance(instance_id).role
+        tdef_page, map_page = self.reserved[instance_id]
+        state = TableState(instance_id, role, tdef_page, map_page, {map_page})
+        self.tables[instance_id] = state
+        self.pages[tdef_page] = masked_tdef_page(
+            self.parameters.signature_id,
+            self._locators(map_page),
+            version=state.version,
+        )
+        self._record(checkpoint_id, instance_id, "table")
+
+    def _drop(self, instance_id: str) -> None:
+        state = self.tables[instance_id]
+        state.dropped = True
+        state.owned_pages.clear()
+        state.available_pages.clear()
+        self.catalog_records = [
+            record for record in self.catalog_records if record.instance_id != instance_id
+        ]
+        self.pages[state.tdef_page] = empty_page()
+        self.pages[state.map_page] = empty_page()
+
+    def _grow(self, checkpoint_id: str, instance_id: str) -> None:
+        state = self.tables[instance_id]
+        event = SCHEDULE.event(checkpoint_id)
+        baseline = None
+        if event.baseline_checkpoint_id is not None:
+            baseline = self.baselines.get(event.baseline_checkpoint_id)
+            if baseline is None:
+                raise ValidationError(f"missing A4 relative baseline {event.baseline_checkpoint_id}")
+        target = event.target_pages(baseline)
+        if target is None:
+            raise ValidationError("A4 growth event lacks a target")
+        projected_bits = max(1, target - state.map_page)
+        projected_row_bytes = 15 + math.ceil(projected_bits / 8)
+        force_t3 = state.role == "T3" and CHECKPOINT_IDS.index(checkpoint_id) >= CHECKPOINT_IDS.index(self.parameters.force_t3_conversion_checkpoint)
+        if state.converted or force_t3 or projected_row_bytes > PAGE_SIZE:
+            state.converted = True
+        while len(self.pages) < target:
+            if self.inserted_rows + self.profile.batch_rows > SCHEDULE.max_inserted_rows_per_replica:
+                raise ValidationError("A4 synthetic inserted-row bound exceeded")
+            first_id = state.row_count + 1
+            batch = tuple(range(first_id, first_id + self.profile.batch_rows))
+            for start in range(0, len(batch), self.profile.rows_per_page):
+                row_ids = batch[start : start + self.profile.rows_per_page]
+                rows = tuple(
+                    row_id.to_bytes(4, "little", signed=True)
+                    + _payload(state.role, row_id)
+                    for row_id in row_ids
+                )
+                page_number = self._append(data_page(rows))
+                state.data_pages.append(page_number)
+                state.owned_pages.add(page_number)
+            if state.converted:
+                self._prepare_tag05_slots(state, len(self.pages))
+            state.row_count += self.profile.batch_rows
+            self.inserted_rows += self.profile.batch_rows
+        state.retained_row_count = state.row_count
+
+    def _prepare_tag05_slots(self, state: TableState, achieved_pages: int) -> None:
+        """Allocate required map pages as part of the current complete batch."""
+        while True:
+            highest = max((*state.owned_pages, achieved_pages - 1), default=0)
+            required = set(range(highest // TAG05_BITS + 1))
+            missing = sorted(required - set(state.tag05_pages))
+            if not missing:
+                return
+            for slot in missing:
+                state.tag05_pages[slot] = self._append(tag_05_page(()))
+
+    def _should_convert(self, checkpoint_id: str, state: TableState) -> bool:
+        if state.role == "T3" and CHECKPOINT_IDS.index(checkpoint_id) >= CHECKPOINT_IDS.index(self.parameters.force_t3_conversion_checkpoint):
+            return True
+        owned_bits = max(state.owned_pages, default=state.map_page) - state.map_page + 1
+        available_bits = max(state.available_pages, default=state.map_page) - state.map_page + 1
+        serialized = 10 + math.ceil(owned_bits / 8) + math.ceil(available_bits / 8)
+        return 14 + serialized > PAGE_SIZE
+
+    def _render_tag05(self, state: TableState) -> tuple[int, ...]:
+        slots = sorted({page // TAG05_BITS for page in state.owned_pages})
+        if not slots:
+            return ()
+        for slot in slots:
+            if slot not in state.tag05_pages:
+                raise ValidationError("A4 synthetic tag-05 page was not allocated during growth")
+        references = [0] * (max(slots) + 1)
+        for slot in slots:
+            reference = state.tag05_pages[slot]
+            references[slot] = reference
+            bits = {page - slot * TAG05_BITS for page in state.owned_pages if page // TAG05_BITS == slot}
+            self.pages[reference] = tag_05_page(bits)
+        return tuple(references)
+
+    def _render_table(self, checkpoint_id: str, state: TableState) -> None:
+        if state.dropped:
+            return
+        state.converted = state.converted or self._should_convert(checkpoint_id, state)
+        if state.converted:
+            owned_row = type_1_row(self._render_tag05(state), slot_count=3)
+        else:
+            capacity = max(state.owned_pages | state.available_pages, default=state.map_page) - state.map_page + 1
+            owned_row = type_0_row(
+                state.map_page,
+                state.owned_pages,
+                polarity=self.parameters.type_0_polarity,
+                capacity_bits=capacity,
+            )
+        available_row = type_0_row(
+            state.map_page,
+            state.available_pages,
+            polarity=self.parameters.type_0_polarity,
+            capacity_bits=max(state.available_pages, default=state.map_page) - state.map_page + 1,
+        )
+        rows = (owned_row, available_row)
+        if self.parameters.owned_ordinal(self.replica) == 1:
+            rows = tuple(reversed(rows))
+        flags = {0: self.parameters.row_flag, 1: self.parameters.row_flag}
+        self.pages[state.map_page] = data_page(rows, raw_flags=flags)
+        self.pages[state.tdef_page] = masked_tdef_page(
+            self.parameters.signature_id,
+            self._locators(state.map_page),
+            version=state.version,
+        )
+
+    def _capture(self, checkpoint_id: str) -> None:
+        if len(self.pages) > int(BOUNDS["max_final_pages_per_replica"]):
+            raise ValidationError("A4 synthetic final-page bound exceeded")
+        hashes = tuple(self._store(page) for page in self.pages)
+        self.ordered[checkpoint_id] = hashes
+        counts = {role: 0 for role in PLAN["tables"]["logical_roles"]}
+        counts.update({
+            state.role: state.row_count
+            for state in self.tables.values()
+            if not state.dropped
+        })
+        self.row_counts[checkpoint_id] = MappingProxyType(counts)
+
+    def build(self) -> SyntheticReplica:
+        for event in EVENTS:
+            checkpoint_id = event.checkpoint_id
+            if event.kind is EventKind.EMPTY:
+                self._build_empty()
+            elif event.kind is EventKind.CREATE:
+                self._create(checkpoint_id, event.lifecycle_instance or "")
+            elif event.kind is EventKind.ADD_FIELD:
+                state = self.tables[event.lifecycle_instance or ""]
+                state.version += 1
+                self._record(checkpoint_id, state.instance_id, "field")
+            elif event.kind is EventKind.ADD_INDEX:
+                state = self.tables[event.lifecycle_instance or ""]
+                state.version += 1
+                self._record(checkpoint_id, state.instance_id, "index")
+            elif event.kind is EventKind.DROP:
+                self._drop(event.lifecycle_instance or "")
+            elif event.kind is EventKind.GROW:
+                self._grow(checkpoint_id, event.lifecycle_instance or "")
+            elif event.kind is EventKind.DELETE_ALL:
+                state = self.tables[event.lifecycle_instance or ""]
+                state.available_pages = set(state.data_pages)
+                state.row_count = 0
+            elif event.kind is EventKind.REINSERT:
+                state = self.tables[event.lifecycle_instance or ""]
+                state.available_pages.clear()
+                state.row_count = state.retained_row_count
+                self.inserted_rows += state.row_count
+            self._render_system()
+            for state in self.tables.values():
+                self._render_table(checkpoint_id, state)
+            self._render_system()
+            self._capture(checkpoint_id)
+            if checkpoint_id in {event.baseline_checkpoint_id for event in EVENTS if event.baseline_checkpoint_id}:
+                self.baselines[checkpoint_id] = len(self.pages)
+        if tuple(self.ordered) != CHECKPOINT_IDS:
+            raise ValidationError("A4 synthetic checkpoint walk departed from the plan")
+        omitted = frozenset(
+            {self.parameters.omit_blob_digest}
+            if self.parameters.omit_blob_digest in self.payloads
+            else set()
+        )
+        metadata = MappingProxyType({
+            "system_pages": MappingProxyType(dict(self.system)),
+            "lifecycle_pages": MappingProxyType({
+                instance_id: MappingProxyType({
+                    "tdef_page": state.tdef_page,
+                    "map_page": state.map_page,
+                    "tag05_pages": MappingProxyType(dict(state.tag05_pages)),
+                    "data_pages": tuple(state.data_pages),
+                })
+                for instance_id, state in self.tables.items()
+            }),
+            "baselines": MappingProxyType(dict(self.baselines)),
+            "profile": self.profile,
+        })
+        return SyntheticReplica(
+            self.replica,
+            MappingProxyType(dict(self.ordered)),
+            MappingProxyType(dict(self.payloads)),
+            MappingProxyType(dict(self.row_counts)),
+            metadata,
+            omitted,
+        )
+
+
+def generate_replica(parameters: SyntheticParameters | None = None, replica: int = 1) -> SyntheticReplica:
+    return ReplicaBuilder(parameters or SyntheticParameters(), replica).build()
+
+
+def generate_campaign(parameters: SyntheticParameters | None = None) -> SyntheticCampaign:
+    selected = parameters or SyntheticParameters()
+    replicas = {replica: generate_replica(selected, replica) for replica in sorted(PROFILES)}
+    payloads: dict[str, bytes] = {}
+    for replica in replicas.values():
+        for digest, payload in replica.payloads.items():
+            previous = payloads.setdefault(digest, payload)
+            if previous != payload:
+                raise ValidationError("A4 synthetic digest collision")
+    return SyntheticCampaign(MappingProxyType(replicas), MappingProxyType(payloads))
+
+
+def overshoots(replica: SyntheticReplica) -> Mapping[str, int]:
+    output: dict[str, int] = {}
+    for event in EVENTS:
+        if event.kind is not EventKind.GROW:
+            continue
+        baseline = None
+        if event.baseline_checkpoint_id is not None:
+            baseline = int(replica.metadata["baselines"][event.baseline_checkpoint_id])  # type: ignore[index]
+        target = event.target_pages(baseline)
+        if target is None:
+            raise ValidationError("A4 growth target unexpectedly absent")
+        output[event.checkpoint_id] = replica.page_count[event.checkpoint_id] - target
+    return MappingProxyType(output)

--- a/oracle/windows-dao/scripts/a4_generator_pages.py
+++ b/oracle/windows-dao/scripts/a4_generator_pages.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Independent exact-page encoders for synthetic A4 campaigns.
+
+This module only constructs bytes. It deliberately contains no decoder,
+candidate enumeration, predicate result, or analyzer import.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+from a4_spec import PAGE_SIZE, PLAN
+
+TAG_DATA = 0x01
+TAG_TDEF = 0x02
+TAG_EXTENDED_USAGE = 0x05
+DIRECTORY_START = 10
+TYPE_0_HEADER_BYTES = 5
+TAG_05_HEADER_BYTES = 4
+TAG_05_BITS = (PAGE_SIZE - TAG_05_HEADER_BYTES) * 8
+
+
+def _u16(value: int, label: str) -> bytes:
+    if not 0 <= value <= 0xFFFF:
+        raise ValueError(f"{label} is outside u16")
+    return value.to_bytes(2, "little")
+
+
+def _u32(value: int, label: str) -> bytes:
+    if not 0 <= value <= 0xFFFF_FFFF:
+        raise ValueError(f"{label} is outside u32")
+    return value.to_bytes(4, "little")
+
+
+def bitmap_bytes(bits: Iterable[int], capacity_bits: int | None = None) -> bytes:
+    selected = frozenset(bits)
+    if any(bit < 0 for bit in selected):
+        raise ValueError("bitmap indices must be nonnegative")
+    required = max(selected, default=-1) + 1
+    if capacity_bits is None:
+        capacity_bits = required
+    if capacity_bits < 0 or required > capacity_bits:
+        raise ValueError("bitmap index exceeds the declared capacity")
+    payload = bytearray((capacity_bits + 7) // 8)
+    for bit in selected:
+        payload[bit // 8] |= 1 << (bit % 8)
+    return bytes(payload)
+
+
+def encode_locator(layout: str, page_number: int, row_number: int) -> bytes:
+    layouts = tuple(PLAN["candidate_grammars"]["h1"]["locator_layouts"])
+    if layout not in layouts:
+        raise ValueError("locator layout is not registered")
+    if not 0 <= page_number <= 0xFF_FFFF or not 0 <= row_number <= 0xFF:
+        raise ValueError("locator target is outside its serialized domain")
+    page = page_number.to_bytes(3, "little")
+    return page + bytes([row_number]) if layout == layouts[0] else bytes([row_number]) + page
+
+
+def data_page(
+    rows: Sequence[bytes],
+    *,
+    raw_flags: Mapping[int, int] | None = None,
+    tag: int = TAG_DATA,
+) -> bytes:
+    """Pack rows from the end of an exact 2,048-byte page in slot order."""
+    if not 0 <= tag <= 0xFF:
+        raise ValueError("page tag is outside one byte")
+    if len(rows) > (PAGE_SIZE - DIRECTORY_START) // 2:
+        raise ValueError("row count cannot fit the directory")
+    flags = raw_flags or {}
+    if set(flags) - set(range(len(rows))):
+        raise ValueError("row flags name a nonexistent slot")
+    page = bytearray(PAGE_SIZE)
+    page[0] = tag
+    page[1] = 0x01
+    page[8:10] = _u16(len(rows), "row count")
+    end = PAGE_SIZE
+    floor = DIRECTORY_START + 2 * len(rows)
+    for ordinal, row in enumerate(rows):
+        start = end - len(row)
+        if start < floor:
+            raise ValueError("rows overlap the row directory")
+        flag = flags.get(ordinal, 0)
+        if flag & 0x0FFF:
+            raise ValueError("row flags overlap the 0x0fff offset domain")
+        raw = start | flag
+        if raw > 0xFFFF:
+            raise ValueError("row directory entry is outside u16")
+        page[start:end] = row
+        offset = DIRECTORY_START + 2 * ordinal
+        page[offset : offset + 2] = raw.to_bytes(2, "little")
+        end = start
+    return bytes(page)
+
+
+def type_0_row(
+    base_page: int,
+    pages: Iterable[int],
+    *,
+    polarity: str = "set_bit_owned_in_use",
+    capacity_bits: int | None = None,
+) -> bytes:
+    polarities = tuple(PLAN["candidate_grammars"]["h2"]["type_0_polarities"])
+    if polarity not in polarities:
+        raise ValueError("type-0 polarity is not registered")
+    selected = frozenset(pages)
+    relative = frozenset(page - base_page for page in selected)
+    if any(bit < 0 for bit in relative):
+        raise ValueError("type-0 page precedes its base")
+    body = bytearray(bitmap_bytes(relative, capacity_bits))
+    if polarity != "set_bit_owned_in_use":
+        for index in range(len(body)):
+            body[index] ^= 0xFF
+    return b"\x00" + _u32(base_page, "type-0 base") + bytes(body)
+
+
+def type_1_row(references: Sequence[int], *, slot_count: int | None = None) -> bytes:
+    count = len(references) if slot_count is None else slot_count
+    if count < len(references):
+        raise ValueError("type-1 slot count is below the reference count")
+    slots = tuple(references) + (0,) * (count - len(references))
+    return b"\x01" + b"".join(_u32(value, "type-1 reference") for value in slots)
+
+
+def tag_05_page(bits: Iterable[int]) -> bytes:
+    page = bytearray(PAGE_SIZE)
+    page[:TAG_05_HEADER_BYTES] = bytes([TAG_EXTENDED_USAGE, 0x01, 0x00, 0x00])
+    page[TAG_05_HEADER_BYTES:] = bitmap_bytes(bits, TAG_05_BITS)
+    return bytes(page)
+
+
+def masked_tdef_page(
+    signature_id: str,
+    locators: Mapping[int, bytes],
+    *,
+    version: int = 0,
+) -> bytes:
+    """Encode one of the two closed H1 signatures from the plan grammar."""
+    grammar = PLAN["candidate_grammars"]["h1"]
+    base = grammar["table_record_signature"]
+    duplicate = grammar["pair_multiple_reachability_signature"]
+    allowed = {base["signature_id"]: base, duplicate["signature_id"]: duplicate}
+    if signature_id not in allowed:
+        raise ValueError("TDEF signature is not registered")
+    record = bytearray.fromhex(base["value_hex"])
+    start, end = allowed[signature_id]["record_bounds"]
+    if start != 0 or end != len(record):
+        raise ValueError("registered signature record bounds are inconsistent")
+    record[12:14] = _u16(version, "TDEF version")
+    expected_offsets = {interval[0] for interval in allowed[signature_id]["locator_holes"]}
+    if set(locators) != expected_offsets:
+        raise ValueError("locator offsets do not match the selected signature")
+    for offset, locator in locators.items():
+        if len(locator) != 4:
+            raise ValueError("locator must occupy four bytes")
+        record[offset : offset + 4] = locator
+    if signature_id == duplicate["signature_id"]:
+        equality = duplicate["equal_byte_intervals"][0]
+        left, right = equality["left"], equality["right"]
+        if record[slice(*left)] != record[slice(*right)]:
+            raise ValueError("duplicate signature locators violate registered equality")
+        inequality = duplicate["mutual_exclusion_inequality"]
+        fixed = bytes.fromhex(inequality["right"]["fixed_value_hex"])
+        if record[slice(*inequality["left"])] == fixed:
+            raise ValueError("duplicate signature does not exclude the base signature")
+    page = bytearray(PAGE_SIZE)
+    page[: len(record)] = record
+    page[0] = TAG_TDEF
+    return bytes(page)
+
+
+def catalog_row(
+    *,
+    stamp: int,
+    object_id: int,
+    kind: int,
+    name: bytes,
+    stored_length: int | None = None,
+) -> bytes:
+    """Construct a bounded synthetic catalog row without interpreting it."""
+    if not all(0 <= value <= 0xFF for value in (stamp, object_id, kind)):
+        raise ValueError("catalog scalar is outside one byte")
+    length = len(name) if stored_length is None else stored_length
+    if not 0 <= length <= 0xFF:
+        raise ValueError("catalog stored length is outside one byte")
+    return bytes([stamp, object_id, kind, length]) + name
+
+
+def empty_page(tag: int = TAG_DATA) -> bytes:
+    return data_page((), tag=tag)

--- a/oracle/windows-dao/scripts/a4_generator_schedule.py
+++ b/oracle/windows-dao/scripts/a4_generator_schedule.py
@@ -1,0 +1,442 @@
+"""Immutable, plan-derived checkpoint schedule for the synthetic A4 generator.
+
+The module deliberately contains no checkpoint table of its own.  Checkpoint
+order, operations, lifecycle instances, schemas, growth thresholds, and
+replica profiles are compiled from the checked document exported by
+``a4_spec``.  The synthetic profiles are deterministic free choices; they do
+not encode an analyzer outcome and their products are not A4 evidence.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from protocol_validation import ValidationError
+from a4_spec import PLAN
+
+
+class EventKind(str, Enum):
+    """Closed set of mutations represented by the preregistered schedule."""
+
+    EMPTY = "empty"
+    IDLE = "idle"
+    CREATE = "create"
+    ADD_FIELD = "add_field"
+    ADD_INDEX = "add_index"
+    DROP = "drop"
+    GROW = "grow"
+    DELETE_ALL = "delete_all"
+    REINSERT = "reinsert"
+
+
+class ThresholdKind(str, Enum):
+    """How a growth checkpoint's decimal suffix is interpreted."""
+
+    NONE = "none"
+    RELATIVE = "relative"
+    ABSOLUTE = "absolute"
+
+
+@dataclass(frozen=True)
+class LifecycleInstance:
+    """One role incarnation derived from the expected-schema tokens."""
+
+    instance_id: str
+    role: str
+    version: str
+    create_checkpoint: str
+    last_extant_checkpoint: str
+    extant_checkpoints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Event:
+    """One checkpoint and the single logical operation that precedes it."""
+
+    checkpoint_id: str
+    ordinal: int
+    kind: EventKind
+    role: str | None
+    lifecycle_instance: str | None
+    expected_schema: tuple[str, ...]
+    operation: str
+    threshold_kind: ThresholdKind = ThresholdKind.NONE
+    threshold_pages: int | None = None
+    baseline_checkpoint_id: str | None = None
+
+    @property
+    def checkpoint(self) -> str:
+        """Short generator-facing alias for ``checkpoint_id``."""
+        return self.checkpoint_id
+
+    @property
+    def instance(self) -> str | None:
+        """Short generator-facing alias for ``lifecycle_instance``."""
+        return self.lifecycle_instance
+
+    @property
+    def uses_batches(self) -> bool:
+        return self.kind is EventKind.GROW
+
+    def target_pages(self, baseline_pages: int | None = None) -> int | None:
+        """Resolve this checkpoint's target, rejecting the wrong baseline mode."""
+        if self.threshold_kind is ThresholdKind.NONE:
+            if baseline_pages is not None:
+                raise ValidationError(f"{self.checkpoint_id}: non-growth event has a baseline")
+            return None
+        if self.threshold_pages is None or self.threshold_pages < 1:
+            raise ValidationError(f"{self.checkpoint_id}: invalid growth threshold")
+        if self.threshold_kind is ThresholdKind.ABSOLUTE:
+            if baseline_pages is not None or self.baseline_checkpoint_id is not None:
+                raise ValidationError(f"{self.checkpoint_id}: absolute target has a baseline")
+            return self.threshold_pages
+        if (
+            isinstance(baseline_pages, bool)
+            or not isinstance(baseline_pages, int)
+            or baseline_pages < 0
+            or self.baseline_checkpoint_id is None
+        ):
+            raise ValidationError(f"{self.checkpoint_id}: relative target lacks its baseline")
+        return baseline_pages + self.threshold_pages
+
+
+@dataclass(frozen=True)
+class Profile:
+    """A deterministic synthetic storage profile for exactly one replica.
+
+    ``rows_per_page`` and ``initial_filler_pages`` are derived from the
+    replica's position in the plan's role rotation.  A real DAO run does not
+    use these values; it measures first-reaching file sizes directly.
+    """
+
+    replica: int
+    rows_per_page: int
+    initial_filler_pages: int
+    batch_rows: int
+
+    @property
+    def pages_per_batch(self) -> int:
+        if self.rows_per_page < 1 or self.batch_rows < 1:
+            raise ValidationError(f"replica {self.replica}: invalid synthetic batch profile")
+        return math.ceil(self.batch_rows / self.rows_per_page)
+
+
+@dataclass(frozen=True)
+class Schedule:
+    """The fully checked plan projection consumed by ``a4_generator``."""
+
+    events: tuple[Event, ...]
+    instances: tuple[LifecycleInstance, ...]
+    profiles: Mapping[int, Profile]
+    batch_rows: int
+    max_inserted_rows_per_replica: int
+    _event_by_checkpoint: Mapping[str, Event]
+    _instance_by_id: Mapping[str, LifecycleInstance]
+
+    def event(self, checkpoint_id: str) -> Event:
+        try:
+            return self._event_by_checkpoint[checkpoint_id]
+        except KeyError as exc:
+            raise ValidationError(f"unknown A4 checkpoint {checkpoint_id!r}") from exc
+
+    def instance(self, instance_id: str) -> LifecycleInstance:
+        try:
+            return self._instance_by_id[instance_id]
+        except KeyError as exc:
+            raise ValidationError(f"unknown A4 lifecycle instance {instance_id!r}") from exc
+
+    def profile(self, replica: int) -> Profile:
+        try:
+            return self.profiles[replica]
+        except KeyError as exc:
+            raise ValidationError(f"unknown A4 replica {replica!r}") from exc
+
+    @property
+    def checkpoints(self) -> tuple[str, ...]:
+        return tuple(event.checkpoint_id for event in self.events)
+
+
+def _document() -> Mapping[str, Any]:
+    document = getattr(PLAN, "document", PLAN)
+    if not isinstance(document, Mapping):
+        raise ValidationError("a4_spec.PLAN is not a checked mapping")
+    return document
+
+
+def _schema_identity(token: str, roles: tuple[str, ...]) -> tuple[str, str, str]:
+    parts = token.split(":")
+    if len(parts) < 2 or parts[0] not in roles:
+        raise ValidationError(f"invalid expected-schema token {token!r}")
+    role = parts[0]
+    version = parts[1] if len(parts) > 2 and parts[1].startswith("v") else "v1"
+    return role, version, f"{role}-{version}"
+
+
+def _compile_instances(
+    checkpoints: tuple[str, ...],
+    expected: Mapping[str, Any],
+    roles: tuple[str, ...],
+) -> tuple[LifecycleInstance, ...]:
+    spans: dict[str, tuple[str, str, list[str]]] = {}
+    for checkpoint in checkpoints:
+        schema = expected.get(checkpoint)
+        if not isinstance(schema, list) or not all(isinstance(token, str) for token in schema):
+            raise ValidationError(f"{checkpoint}: expected schema must be a string array")
+        seen_roles: set[str] = set()
+        for token in schema:
+            role, version, instance_id = _schema_identity(token, roles)
+            if role in seen_roles:
+                raise ValidationError(f"{checkpoint}: duplicate expected-schema role {role}")
+            seen_roles.add(role)
+            if instance_id not in spans:
+                spans[instance_id] = (role, version, [])
+            spans[instance_id][2].append(checkpoint)
+    ordinals = {checkpoint: ordinal for ordinal, checkpoint in enumerate(checkpoints)}
+    instances = tuple(
+        LifecycleInstance(instance_id, role, version, extant[0], extant[-1], tuple(extant))
+        for instance_id, (role, version, extant) in sorted(
+            spans.items(), key=lambda row: ordinals[row[1][2][0]]
+        )
+    )
+    if not instances:
+        raise ValidationError("A4 plan has no lifecycle instances")
+    for instance in instances:
+        actual = tuple(ordinals[checkpoint] for checkpoint in instance.extant_checkpoints)
+        expected_ordinals = tuple(range(actual[0], actual[-1] + 1))
+        if actual != expected_ordinals:
+            raise ValidationError(f"{instance.instance_id}: lifecycle reappears after absence")
+    return instances
+
+
+def _classify(checkpoint: str, operation: str, ordinal: int, schema: tuple[str, ...]) -> EventKind:
+    matches: list[EventKind] = []
+    if ordinal == 0 and not schema and "fresh Jet 3 database" in operation:
+        matches.append(EventKind.EMPTY)
+    markers = (
+        ("Close and reopen without mutation", EventKind.IDLE),
+        ("TableDefs.Delete", EventKind.DROP),
+        ("TableDefs.Append", EventKind.CREATE),
+        ("Fields.Append", EventKind.ADD_FIELD),
+        ("Indexes.Append", EventKind.ADD_INDEX),
+        ("Delete every", EventKind.DELETE_ALL),
+        ("Reinsert", EventKind.REINSERT),
+    )
+    matches.extend(kind for marker, kind in markers if marker in operation)
+    if ("_REL_" in checkpoint or "_ABS_" in checkpoint) and "batch" in operation:
+        matches.append(EventKind.GROW)
+    matches = list(dict.fromkeys(matches))
+    if len(matches) != 1:
+        raise ValidationError(
+            f"{checkpoint}: operation maps to {len(matches)} event kinds, expected exactly one"
+        )
+    return matches[0]
+
+
+def _relative_baseline(
+    checkpoint: str,
+    role: str,
+    transition_coverage: Mapping[str, Any],
+) -> str:
+    candidates: set[str] = set()
+    for sequence in transition_coverage.values():
+        if not isinstance(sequence, list) or checkpoint not in sequence:
+            continue
+        # The schema-snapshot coverage also contains every checkpoint.  A
+        # baseline sequence is distinguished structurally: after its first
+        # (baseline) member, every member belongs to the growing role.
+        if not sequence[1:] or not all(value.startswith(f"{role}_") for value in sequence[1:]):
+            continue
+        position = sequence.index(checkpoint)
+        if position < 1:
+            continue
+        role_growth = [value for value in sequence[1:] if value.startswith(f"{role}_REL_")]
+        if checkpoint in role_growth:
+            candidates.add(sequence[0])
+    if len(candidates) != 1:
+        raise ValidationError(
+            f"{checkpoint}: expected one plan-declared relative baseline, found {sorted(candidates)}"
+        )
+    return next(iter(candidates))
+
+
+def _role_for(checkpoint: str, roles: tuple[str, ...]) -> str | None:
+    matches = [role for role in roles if checkpoint.startswith(f"{role}_")]
+    if len(matches) > 1:
+        raise ValidationError(f"{checkpoint}: ambiguous logical role")
+    return matches[0] if matches else None
+
+
+def _event_instance(
+    kind: EventKind,
+    role: str | None,
+    schema: tuple[str, ...],
+    previous_schema: tuple[str, ...],
+    roles: tuple[str, ...],
+) -> str | None:
+    if role is None:
+        return None
+    source = previous_schema if kind is EventKind.DROP else schema
+    matches = [_schema_identity(token, roles)[2] for token in source if token.split(":", 1)[0] == role]
+    if len(matches) != 1:
+        raise ValidationError(f"{role}: event does not select exactly one lifecycle instance")
+    return matches[0]
+
+
+def _compile_profiles(
+    document: Mapping[str, Any],
+    batch_rows: int,
+    events: tuple[Event, ...],
+) -> Mapping[int, Profile]:
+    tables = document["tables"]
+    roles = tuple(tables["logical_roles"])
+    physical_names = tuple(tables["physical_names"])
+    bindings = tables["role_bindings"]
+    replica_count = int(document["replicas"]["count"])
+    if len(bindings) != replica_count or len(roles) < replica_count:
+        raise ValidationError("A4 role rotations do not cover the declared replicas")
+    base_rows_per_page = batch_rows // len(roles)
+    if base_rows_per_page <= replica_count - 1:
+        raise ValidationError("A4 batch size cannot derive distinct positive replica profiles")
+    growth_events = tuple(event for event in events if event.kind is EventKind.GROW)
+    if not growth_events:
+        raise ValidationError("A4 plan has no growth events")
+    profiles: dict[int, Profile] = {}
+    for binding in bindings:
+        replica = binding.get("replica")
+        if isinstance(replica, bool) or not isinstance(replica, int) or replica in profiles:
+            raise ValidationError("A4 role bindings have an invalid replica id")
+        try:
+            rotation = physical_names.index(binding[roles[0]])
+        except (KeyError, ValueError) as exc:
+            raise ValidationError(f"replica {replica}: invalid role rotation") from exc
+        profiles[replica] = Profile(
+            replica=replica,
+            rows_per_page=base_rows_per_page - rotation,
+            initial_filler_pages=rotation,
+            batch_rows=batch_rows,
+        )
+    expected_replicas = set(range(1, replica_count + 1))
+    signatures = {(p.rows_per_page, p.initial_filler_pages, p.pages_per_batch) for p in profiles.values()}
+    if set(profiles) != expected_replicas or len(signatures) != replica_count:
+        raise ValidationError("A4 synthetic replica profiles are not complete and distinct")
+    return MappingProxyType(profiles)
+
+
+def build_schedule() -> Schedule:
+    document = _document()
+    design = document["checkpoint_design"]
+    tables = document["tables"]
+    bounds = document["bounds"]
+    checkpoints = tuple(design["checkpoint_ids"])
+    if (
+        len(checkpoints) != design["count"]
+        or len(checkpoints) != bounds["planned_checkpoints_per_replica"]
+        or len(checkpoints) != len(set(checkpoints))
+    ):
+        raise ValidationError("A4 checkpoint count/order contract is inconsistent")
+    roles = tuple(tables["logical_roles"])
+    expected = tables["expected_schema_by_checkpoint"]
+    operations = tables["checkpoint_operations"]
+    if tuple(expected) != checkpoints or tuple(operations) != checkpoints:
+        raise ValidationError("A4 schema/operation coverage differs from checkpoint order")
+    batch_rows = int(tables["row_algorithm"]["growth_batch_rows"])
+    if batch_rows < 1 or batch_rows > int(bounds["max_inserted_rows_per_replica"]):
+        raise ValidationError("A4 growth batch size is outside the row bound")
+    instances = _compile_instances(checkpoints, expected, roles)
+    events: list[Event] = []
+    previous_schema: tuple[str, ...] = ()
+    for ordinal, checkpoint in enumerate(checkpoints):
+        schema = tuple(expected[checkpoint])
+        operation = operations[checkpoint]
+        if not isinstance(operation, str):
+            raise ValidationError(f"{checkpoint}: checkpoint operation is not text")
+        kind = _classify(checkpoint, operation, ordinal, schema)
+        role = _role_for(checkpoint, roles)
+        instance_id = _event_instance(kind, role, schema, previous_schema, roles)
+        threshold_kind = ThresholdKind.NONE
+        threshold_pages = None
+        baseline = None
+        if kind is EventKind.GROW:
+            try:
+                threshold_pages = int(checkpoint.rsplit("_", 1)[1])
+            except (IndexError, ValueError) as exc:
+                raise ValidationError(f"{checkpoint}: growth suffix is not decimal") from exc
+            if "_ABS_" in checkpoint:
+                threshold_kind = ThresholdKind.ABSOLUTE
+            elif "_REL_" in checkpoint and role is not None:
+                threshold_kind = ThresholdKind.RELATIVE
+                baseline = _relative_baseline(checkpoint, role, design["transition_coverage"])
+            else:
+                raise ValidationError(f"{checkpoint}: growth target mode is ambiguous")
+        events.append(Event(
+            checkpoint, ordinal, kind, role, instance_id, schema, operation,
+            threshold_kind, threshold_pages, baseline,
+        ))
+        previous_schema = schema
+    if tuple(event.ordinal for event in events) != tuple(range(len(checkpoints))):
+        raise ValidationError("A4 event ordinals are not contiguous")
+    if any(event.kind is EventKind.GROW and event.lifecycle_instance is None for event in events):
+        raise ValidationError("A4 growth event lacks a lifecycle instance")
+    created = [event for event in events if event.kind is EventKind.CREATE]
+    if (
+        len(created) != len(instances)
+        or {event.lifecycle_instance for event in created}
+        != {instance.instance_id for instance in instances}
+        or any(
+            event.checkpoint_id != next(
+                instance.create_checkpoint
+                for instance in instances
+                if instance.instance_id == event.lifecycle_instance
+            )
+            for event in created
+        )
+    ):
+        raise ValidationError("A4 create events do not cover lifecycle instances exactly")
+    prior_roles: set[str] = set()
+    for event in events:
+        current_roles = {_schema_identity(token, roles)[0] for token in event.expected_schema}
+        if event.kind is EventKind.CREATE:
+            expected_roles = prior_roles | {event.role or ""}
+        elif event.kind is EventKind.DROP:
+            expected_roles = prior_roles - {event.role or ""}
+        else:
+            expected_roles = prior_roles
+        if current_roles != expected_roles:
+            raise ValidationError(
+                f"{event.checkpoint_id}: schema roles disagree with the logical operation"
+            )
+        prior_roles = current_roles
+    for left, right in design["idle_pairs"]:
+        right_event = next((event for event in events if event.checkpoint_id == right), None)
+        if (
+            right_event is None
+            or right_event.kind is not EventKind.IDLE
+            or right_event.ordinal < 1
+            or events[right_event.ordinal - 1].checkpoint_id != left
+        ):
+            raise ValidationError(f"A4 idle pair {left!r}, {right!r} is not adjacent")
+    max_pages = int(bounds["max_final_pages_per_replica"])
+    for event in events:
+        if event.threshold_pages is not None and event.threshold_pages > max_pages:
+            raise ValidationError(f"{event.checkpoint_id}: threshold exceeds the page bound")
+    event_map = MappingProxyType({event.checkpoint_id: event for event in events})
+    instance_map = MappingProxyType({instance.instance_id: instance for instance in instances})
+    if len(event_map) != len(events) or len(instance_map) != len(instances):
+        raise ValidationError("A4 compiled schedule contains duplicate identities")
+    compiled_events = tuple(events)
+    return Schedule(
+        compiled_events, instances, _compile_profiles(document, batch_rows, compiled_events), batch_rows,
+        int(bounds["max_inserted_rows_per_replica"]), event_map, instance_map,
+    )
+
+
+SCHEDULE = build_schedule()
+EVENTS = SCHEDULE.events
+EVENT_BY_CHECKPOINT = SCHEDULE._event_by_checkpoint
+PROFILES = SCHEDULE.profiles
+ROW_BATCH = SCHEDULE.batch_rows
+DEFAULT_PROFILES = PROFILES

--- a/oracle/windows-dao/scripts/a4_layer_decoding.py
+++ b/oracle/windows-dao/scripts/a4_layer_decoding.py
@@ -1,0 +1,49 @@
+"""Shared bounded binary decoders for the A4 layer adapters."""
+
+from __future__ import annotations
+
+from a4_model import A4AnalysisError
+
+
+def set_bits(payload: bytes) -> frozenset[int]:
+    result: set[int] = set()
+    for byte_index, value in enumerate(payload):
+        for bit in range(8):
+            if value & (1 << bit):
+                result.add(byte_index * 8 + bit)
+    return frozenset(result)
+
+
+def decode_locator(raw: bytes, layout: str) -> tuple[int, int]:
+    if len(raw) != 4:
+        raise ValueError("A4 locator must be four bytes")
+    if layout == "u24le_page_then_u8_row":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    if layout == "u8_row_then_u24le_page":
+        return int.from_bytes(raw[1:], "little"), raw[0]
+    raise ValueError("A4 frozen locator layout is unknown")
+
+
+def type0_owned(
+    row: bytes, polarity: str, *, maximum: int | None = None
+) -> frozenset[int]:
+    if len(row) < 5 or row[0] != 0:
+        raise ValueError("A4 frozen system usage row is not type 0")
+    if maximum is not None and (
+        isinstance(maximum, bool) or not isinstance(maximum, int) or maximum < 1
+    ):
+        raise ValueError("A4 type-0 admitted-page maximum must be positive")
+    base = int.from_bytes(row[1:5], "little")
+    selected: set[int] = set()
+    for byte_index, value in enumerate(row[5:]):
+        for bit in range(8):
+            is_set = bool(value & (1 << bit))
+            if is_set == (polarity == "set_bit_owned_in_use"):
+                page = base + byte_index * 8 + bit
+                if page not in selected and maximum is not None and len(selected) == maximum:
+                    raise A4AnalysisError(
+                        "A4-RESOURCE-BOUND",
+                        detail=f"type-0 traversal admits more than {maximum} pages",
+                    )
+                selected.add(page)
+    return frozenset(selected)

--- a/oracle/windows-dao/scripts/a4_layer_h1.py
+++ b/oracle/windows-dao/scripts/a4_layer_h1.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+"""Bounded A4 H1 derivation: TDEF lifecycle to allocation-row locators.
+
+H1 intentionally stops at tag-01 existence and row-ordinal validity.  Row
+directories, row flags, map tags, bitmap polarity, and role semantics belong to
+H2 and are not interpreted here.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from protocol_validation import ValidationError
+
+from a4_measurements import MeasurementRecorder, measure
+from a4_model import (
+    A4AnalysisError,
+    QualifiedPage,
+    View,
+    WorkLedger,
+    canonical_candidate_id,
+    canonical_model_id,
+)
+from a4_spec import (
+    BOUNDS,
+    CANDIDATE_GRAMMARS,
+    CHECKPOINT_IDS,
+    CHECKPOINT_ORDINALS,
+    LIFECYCLE_RANGES,
+    PAGE_SIZE,
+    PLAN,
+    canonical_json_bytes,
+    validate_failure_count,
+)
+
+_H1 = CANDIDATE_GRAMMARS["h1"]
+_LAYOUTS = tuple(_H1["locator_layouts"])
+_LIFECYCLE_SIGNATURES = tuple(_H1["tdef_lifecycle_signatures"])
+_INSTANCE_ORDER = tuple(LIFECYCLE_RANGES)
+_MAX_PAGE = int(BOUNDS["max_final_pages_per_replica"]) - 1
+_MAX_CANDIDATES = int(BOUNDS["max_candidate_models"])
+_MAX_CANDIDATE_BYTES = int(BOUNDS["max_canonical_candidate_bytes"])
+_MAX_QUALIFIED = int(BOUNDS["max_qualified_pages_per_submodel"])
+
+_SCHEMA_TRANSITIONS = tuple(
+    PLAN["checkpoint_design"]["transition_coverage"]["schema_lifecycle"]
+)
+_IDLE_PAIRS = tuple(
+    tuple(pair) for pair in PLAN["checkpoint_design"]["idle_pairs"]
+)
+_CREATE_CHECKPOINT = {
+    "T1-v1": "T1_CREATE_ID",
+    "T2-v1": "T2_CREATE",
+    "T2-v2": "T2_RECREATE",
+    "T3-v1": "T3_CREATE",
+    "T4-v1": "T4_CREATE",
+}
+_OWN_SCHEMA_TRANSITIONS = {
+    "T1-v1": frozenset(("T1_CREATE_ID", "T1_ADD_TEXT", "T1_ADD_INDEX")),
+    "T2-v1": frozenset(("T2_CREATE", "T2_DROP")),
+    "T2-v2": frozenset(("T2_RECREATE",)),
+    "T3-v1": frozenset(("T3_CREATE",)),
+    "T4-v1": frozenset(("T4_CREATE",)),
+}
+
+
+@dataclass(frozen=True, order=True)
+class LocatorTarget:
+    page: int
+    row: int
+
+    def document(self) -> dict[str, int]:
+        return {"page": self.page, "row": self.row}
+
+
+@dataclass(frozen=True)
+class H1Binding:
+    replica: int
+    logical_role: str
+    lifecycle_instance: str
+    tdef_page: int
+    locator_targets: tuple[LocatorTarget, LocatorTarget] | None = None
+
+    @property
+    def checkpoints(self) -> tuple[str, ...]:
+        lifecycle = LIFECYCLE_RANGES[self.lifecycle_instance]
+        return tuple(
+            CHECKPOINT_IDS[lifecycle.first_ordinal : lifecycle.last_ordinal + 1]
+        )
+
+    def document(self, *, include_targets: bool) -> dict[str, Any]:
+        lifecycle = LIFECYCLE_RANGES[self.lifecycle_instance]
+        result: dict[str, Any] = {
+            "replica": self.replica,
+            "logical_role": self.logical_role,
+            "lifecycle_instance": self.lifecycle_instance,
+            "tdef_page": self.tdef_page,
+        }
+        if include_targets:
+            if self.locator_targets is None:
+                raise ValueError("H1 locator binding is missing its targets")
+            result["locator_targets"] = [
+                target.document() for target in self.locator_targets
+            ]
+        result["applicable_checkpoint_range"] = {
+            "start": lifecycle.first_checkpoint,
+            "end": lifecycle.last_checkpoint,
+        }
+        return result
+
+
+@dataclass(frozen=True)
+class H1ReplicaCandidate:
+    replica: int
+    layout: str
+    table_signature_id: str
+    locator_offsets: tuple[int, int]
+    bindings: tuple[H1Binding, ...]
+
+    @property
+    def model(self) -> dict[str, Any]:
+        return {
+            "layout": self.layout,
+            "table_signature_id": self.table_signature_id,
+            "locator_offsets": list(self.locator_offsets),
+        }
+
+    @property
+    def canonical_model_id(self) -> str:
+        return canonical_model_id("h1_locator_pair", self.model)
+
+    @property
+    def canonical_candidate_id(self) -> str:
+        return canonical_candidate_id(
+            "h1_locator_pair",
+            self.model,
+            [binding.document(include_targets=True) for binding in self.bindings],
+        )
+
+    def document(self) -> dict[str, Any]:
+        return _checked_candidate(
+            "h1_locator_pair",
+            self.model,
+            self.bindings,
+            include_targets=True,
+        )
+
+
+class H1Terminal(A4AnalysisError):
+    """Registered H1 terminal with its schema-directed frozen payload."""
+
+    def __init__(
+        self,
+        predicate_id: str,
+        survivor_count: int,
+        *,
+        candidate_stage: str | None,
+        candidates: Sequence[Mapping[str, Any]] = (),
+        terminal_evidence: Mapping[str, Any] | None = None,
+        per_replica_counts: Sequence[int] | None = None,
+        detail: str | None = None,
+    ) -> None:
+        validate_failure_count(
+            predicate_id,
+            survivor_count,
+            per_replica_counts=per_replica_counts,
+        )
+        self.candidate_stage = candidate_stage
+        self.candidates = tuple(dict(candidate) for candidate in candidates)
+        self.terminal_evidence = (
+            None if terminal_evidence is None else dict(terminal_evidence)
+        )
+        if terminal_evidence is not None:
+            self.payload_kind = "replica_pair"
+        else:
+            self.payload_kind = "candidate_set"
+        super().__init__(predicate_id, survivor_count, detail=detail)
+
+
+def _checked_candidate(
+    model_type: str,
+    model: Mapping[str, Any],
+    bindings: Sequence[H1Binding],
+    *,
+    include_targets: bool,
+) -> dict[str, Any]:
+    binding_documents = [
+        binding.document(include_targets=include_targets) for binding in bindings
+    ]
+    document = {
+        "model_type": model_type,
+        "canonical_model_id": canonical_model_id(model_type, model),
+        "canonical_candidate_id": canonical_candidate_id(
+            model_type, model, binding_documents
+        ),
+        "model": dict(model),
+        "instance_bindings": binding_documents,
+    }
+    if len(canonical_json_bytes(document)) > _MAX_CANDIDATE_BYTES:
+        raise A4AnalysisError(
+            "A4-RESOURCE-BOUND", detail="H1 canonical candidate exceeds its bound"
+        )
+    return document
+
+
+def _bounded_candidates(values: Iterable[Any]) -> tuple[Any, ...]:
+    retained: list[Any] = []
+    for value in values:
+        retained.append(value)
+        if len(retained) > _MAX_CANDIDATES:
+            raise A4AnalysisError(
+                "A4-RESOURCE-BOUND", detail="H1 candidate count exceeds its bound"
+            )
+    return tuple(retained)
+
+
+def _tag(view: View, checkpoint: str, page: int) -> int | None:
+    payload = view.page_optional(checkpoint, page)
+    return None if payload is None else payload[0]
+
+
+def _hash_changed(view: View, left: str, right: str, page: int) -> bool:
+    left_hash = view.hash_at(left, page)
+    right_hash = view.hash_at(right, page)
+    return left_hash is not None and right_hash is not None and left_hash != right_hash
+
+
+def _lifecycle_holds(
+    view: View, instance: str, page: int, signature: str
+) -> bool:
+    lifecycle = LIFECYCLE_RANGES[instance]
+    create = _CREATE_CHECKPOINT[instance]
+    create_ordinal = CHECKPOINT_ORDINALS[create]
+    before = CHECKPOINT_IDS[create_ordinal - 1]
+    checkpoints = CHECKPOINT_IDS[
+        lifecycle.first_ordinal : lifecycle.last_ordinal + 1
+    ]
+    if signature == "new_tag_02_at_role_create":
+        if _tag(view, before, page) == 0x02:
+            return False
+        if any(_tag(view, checkpoint, page) != 0x02 for checkpoint in checkpoints):
+            return False
+        if instance == "T2-v1" and _tag(view, "T2_DROP", page) == 0x02:
+            return False
+        return True
+    if signature != "preexisting_tag_02_hash_transition":
+        raise ValidationError(f"unknown H1 lifecycle signature {signature!r}")
+    if _tag(view, before, page) != 0x02 or _tag(view, create, page) != 0x02:
+        return False
+    if not _hash_changed(view, before, create, page):
+        return False
+    if any(_tag(view, checkpoint, page) != 0x02 for checkpoint in checkpoints):
+        return False
+
+    for right in _SCHEMA_TRANSITIONS:
+        right_ordinal = CHECKPOINT_ORDINALS[right]
+        if right_ordinal == 0 or right in _OWN_SCHEMA_TRANSITIONS[instance]:
+            continue
+        left = CHECKPOINT_IDS[right_ordinal - 1]
+        if left not in checkpoints or right not in checkpoints:
+            continue
+        if view.hash_at(left, page) != view.hash_at(right, page):
+            return False
+    for left, right in _IDLE_PAIRS:
+        if left in checkpoints and right in checkpoints:
+            if view.hash_at(left, page) != view.hash_at(right, page):
+                return False
+    if instance == "T2-v1" and not _hash_changed(
+        view, "T2_CREATE", "T2_DROP", page
+    ):
+        return False
+    if instance == "T2-v2" and not _hash_changed(
+        view, "T2_DROP", "T2_RECREATE", page
+    ):
+        return False
+    return True
+
+
+def _qualify_pages(pages: Sequence[int]) -> tuple[int, ...]:
+    if any(
+        isinstance(page, bool)
+        or not isinstance(page, int)
+        or not 0 <= page <= _MAX_PAGE
+        for page in pages
+    ):
+        raise ValueError("H1 qualified TDEF pages must be bounded integers")
+    result = tuple(sorted(set(pages)))
+    if len(result) != len(pages):
+        raise ValueError("H1 qualified TDEF pages must be duplicate-free")
+    if len(result) > _MAX_QUALIFIED:
+        raise A4AnalysisError(
+            "A4-RESOURCE-BOUND", detail="too many H1 qualified TDEF pages"
+        )
+    return result
+
+
+def _tdef_candidates(
+    view: View, pages: Sequence[int], ledger: WorkLedger
+) -> tuple[dict[str, Any], ...]:
+    for page in pages:
+        for checkpoint in CHECKPOINT_IDS:
+            qualified = QualifiedPage(view.replica, checkpoint, page)
+            for signature in _LIFECYCLE_SIGNATURES:
+                ledger.charge_qualified(
+                    "tdef_lifecycle_signatures", qualified, discriminator=signature
+                )
+
+    def candidates() -> Iterable[dict[str, Any]]:
+        for signature in _LIFECYCLE_SIGNATURES:
+            choices = []
+            for instance in _INSTANCE_ORDER:
+                choices.append(
+                    tuple(
+                        page
+                        for page in pages
+                        if _lifecycle_holds(view, instance, page, signature)
+                    )
+                )
+            if any(not choice for choice in choices):
+                continue
+            for selected in itertools.product(*choices):
+                bindings = tuple(
+                    H1Binding(
+                        view.replica,
+                        LIFECYCLE_RANGES[instance].logical_role,
+                        instance,
+                        page,
+                    )
+                    for instance, page in zip(_INSTANCE_ORDER, selected)
+                )
+                yield _checked_candidate(
+                    "h1_tdef",
+                    {"tdef_lifecycle_signature": signature},
+                    bindings,
+                    include_targets=False,
+                )
+
+    return _bounded_candidates(candidates())
+
+
+def _decode_locator(raw: bytes, layout: str) -> LocatorTarget:
+    if len(raw) != 4:
+        raise ValueError("H1 locator must be exactly four bytes")
+    if layout == "u24le_page_then_u8_row":
+        return LocatorTarget(int.from_bytes(raw[:3], "little"), raw[3])
+    if layout == "u8_row_then_u24le_page":
+        return LocatorTarget(int.from_bytes(raw[1:], "little"), raw[0])
+    raise ValidationError(f"unknown H1 locator layout {layout!r}")
+
+
+def _preserved_window(view: View, page: int, layout: str, offset: int) -> bool:
+    """Apply AMB-01's fixed page bound at every derivation checkpoint."""
+    for checkpoint in CHECKPOINT_IDS:
+        payload = view.page_optional(checkpoint, page)
+        if payload is None:
+            return False
+        target = _decode_locator(payload[offset : offset + 4], layout)
+        if target.page > _MAX_PAGE:
+            return False
+    return True
+
+
+def _signature_spec(signature_id: str) -> tuple[bytes, bytes, tuple[tuple[int, int], ...]]:
+    base = _H1["table_record_signature"]
+    value = bytes.fromhex(base["value_hex"])
+    mask = bytearray.fromhex(base["mask_hex"])
+    if signature_id == base["signature_id"]:
+        holes = tuple(tuple(interval) for interval in base["locator_holes"])
+        return value, bytes(mask), holes
+    duplicate = _H1["pair_multiple_reachability_signature"]
+    if signature_id != duplicate["signature_id"]:
+        raise ValidationError(f"unknown H1 table signature {signature_id!r}")
+    for override in duplicate["mask_derivation"]["overrides"]:
+        start, end = override["interval"]
+        replacement = bytes.fromhex(override["mask_hex"])
+        if len(replacement) != end - start:
+            raise ValidationError("H1 signature mask override has the wrong width")
+        mask[start:end] = replacement
+    holes = tuple(tuple(interval) for interval in duplicate["locator_holes"])
+    return value, bytes(mask), holes
+
+
+def _signature_matches(payload: bytes, signature_id: str) -> bool:
+    value, mask, _ = _signature_spec(signature_id)
+    if len(value) != len(mask) or len(payload) < len(value):
+        return False
+    if any((actual & masked) != (expected & masked) for actual, expected, masked in zip(payload, value, mask)):
+        return False
+    if signature_id == _H1["table_record_signature"]["signature_id"]:
+        return True
+    duplicate = _H1["pair_multiple_reachability_signature"]
+    for equality in duplicate["equal_byte_intervals"]:
+        left_start, left_end = equality["left"]
+        right_start, right_end = equality["right"]
+        if payload[left_start:left_end] != payload[right_start:right_end]:
+            return False
+    inequality = duplicate["mutual_exclusion_inequality"]
+    left_start, left_end = inequality["left"]
+    right = inequality["right"]
+    fixed = bytes.fromhex(right["fixed_value_hex"])
+    fixed_mask = bytes.fromhex(right["fixed_mask_hex"])
+    actual = payload[left_start:left_end]
+    if all((byte & masked) == (expected & masked) for byte, expected, masked in zip(actual, fixed, fixed_mask)):
+        return False
+    return True
+
+
+def _structural_bindings(
+    view: View,
+    tdef_bindings: Sequence[H1Binding],
+    layout: str,
+    signature_id: str,
+    offsets: tuple[int, int],
+) -> tuple[H1Binding, ...] | None:
+    result: list[H1Binding] = []
+    for binding in tdef_bindings:
+        targets: list[LocatorTarget] = []
+        for checkpoint in binding.checkpoints:
+            payload = view.page_optional(checkpoint, binding.tdef_page)
+            if payload is None or not _signature_matches(payload, signature_id):
+                return None
+            decoded = tuple(
+                _decode_locator(payload[offset : offset + 4], layout)
+                for offset in offsets
+            )
+            if any(target.page > _MAX_PAGE for target in decoded):
+                return None
+            if not targets:
+                targets.extend(decoded)
+            elif tuple(targets) != decoded:
+                return None
+        if len(targets) != 2:
+            return None
+        result.append(
+            H1Binding(
+                binding.replica,
+                binding.logical_role,
+                binding.lifecycle_instance,
+                binding.tdef_page,
+                (targets[0], targets[1]),
+            )
+        )
+    return tuple(result)
+
+
+def _target_valid(
+    view: View,
+    bindings: Sequence[H1Binding],
+    layout: str,
+    ledger: WorkLedger,
+) -> bool:
+    for binding in bindings:
+        if binding.locator_targets is None:
+            return False
+        first, second = binding.locator_targets
+        distinct_targets = tuple(sorted(set((first, second))))
+        if len(distinct_targets) != 2:
+            return False
+        for checkpoint in binding.checkpoints:
+            for target in distinct_targets:
+                if view.replica in (1, 2):
+                    ledger.charge_qualified(
+                        "h1_target_validity_checks",
+                        QualifiedPage(view.replica, checkpoint, target.page),
+                        discriminator=(layout, target.page, target.row),
+                    )
+                payload = view.page_optional(checkpoint, target.page)
+                if payload is None or payload[0] != 0x01:
+                    return False
+                row_count = int.from_bytes(payload[8:10], "little")
+                if target.row >= row_count:
+                    return False
+    return True
+
+
+def derive_h1_replica(
+    view: View,
+    qualified_tdef_pages: Sequence[int],
+    ledger: WorkLedger,
+    measurements: MeasurementRecorder | None = None,
+) -> H1ReplicaCandidate:
+    """Run H1's eight non-holdout predicates for one derivation replica."""
+    if view.replica not in (1, 2):
+        raise ValueError("H1 derivation accepts only replicas 1 and 2")
+    pages = _qualify_pages(qualified_tdef_pages)
+    tdef = _tdef_candidates(view, pages, ledger)
+    measure(measurements, "A4-H1-TDEF-NONE", len(tdef), bool(tdef), replica=view.replica)
+    if not tdef:
+        raise H1Terminal("A4-H1-TDEF-NONE", 0, candidate_stage="h1_tdef")
+    measure(measurements, "A4-H1-TDEF-MULTIPLE", len(tdef), len(tdef) == 1, replica=view.replica)
+    if len(tdef) > 1:
+        raise H1Terminal(
+            "A4-H1-TDEF-MULTIPLE",
+            len(tdef),
+            candidate_stage="h1_tdef",
+            candidates=tdef,
+        )
+
+    bindings = tuple(
+        H1Binding(
+            binding["replica"],
+            binding["logical_role"],
+            binding["lifecycle_instance"],
+            binding["tdef_page"],
+        )
+        for binding in tdef[0]["instance_bindings"]
+    )
+    for page in pages:
+        ledger.charge_once("raw_locator_windows", (view.replica, page), 4090)
+        ledger.charge_once("raw_locator_pairs", (view.replica, page), 4_167_722)
+
+    syntactic_layouts = tuple(
+        layout
+        for layout in _LAYOUTS
+        if any(
+            any(
+                _preserved_window(view, binding.tdef_page, layout, offset)
+                for offset in range(PAGE_SIZE - 3)
+            )
+            for binding in bindings
+        )
+    )
+    measure(measurements, "A4-H1-LOCATOR-LAYOUT-NONE", len(syntactic_layouts), bool(syntactic_layouts), replica=view.replica)
+    if not syntactic_layouts:
+        raise H1Terminal(
+            "A4-H1-LOCATOR-LAYOUT-NONE",
+            0,
+            candidate_stage="h1_target_valid_layout",
+        )
+
+    structural: list[tuple[str, str, tuple[int, int], tuple[H1Binding, ...]]] = []
+    signature_specs = (
+        _H1["table_record_signature"],
+        _H1["pair_multiple_reachability_signature"],
+    )
+    for layout in syntactic_layouts:
+        for signature in signature_specs:
+            signature_id = signature["signature_id"]
+            holes = tuple(tuple(interval) for interval in signature["locator_holes"])
+            offsets = tuple(interval[0] for interval in holes)
+            for first, second in itertools.combinations(offsets, 2):
+                if second - first < 4:
+                    continue
+                pair = (first, second)
+                candidate_bindings = _structural_bindings(
+                    view, bindings, layout, signature_id, pair
+                )
+                if candidate_bindings is not None:
+                    structural.append(
+                        (layout, signature_id, pair, candidate_bindings)
+                    )
+    measure(measurements, "A4-H1-LOCATOR-PAIR-NONE", len(structural), bool(structural), replica=view.replica)
+    if not structural:
+        raise H1Terminal(
+            "A4-H1-LOCATOR-PAIR-NONE", 0, candidate_stage="h1_locator_pair"
+        )
+
+    target_valid = tuple(
+        candidate
+        for candidate in structural
+        if _target_valid(view, candidate[3], candidate[0], ledger)
+    )
+    measure(measurements, "A4-H1-TARGET-ROW-INVALID", len(target_valid), bool(target_valid), replica=view.replica)
+    if not target_valid:
+        raise H1Terminal(
+            "A4-H1-TARGET-ROW-INVALID", 0, candidate_stage="h1_locator_pair"
+        )
+
+    layouts = tuple(dict.fromkeys(candidate[0] for candidate in target_valid))
+    measure(measurements, "A4-H1-LOCATOR-LAYOUT-MULTIPLE", len(layouts), len(layouts) == 1, replica=view.replica)
+    if len(layouts) > 1:
+        layout_by_id: dict[str, dict[str, Any]] = {}
+        for layout, signature_id, _pair, candidate_bindings in target_valid:
+            document = _checked_candidate(
+                "h1_target_valid_layout",
+                {"layout": layout, "table_signature_id": signature_id},
+                candidate_bindings,
+                include_targets=True,
+            )
+            layout_by_id.setdefault(document["canonical_candidate_id"], document)
+        layout_candidates = tuple(layout_by_id.values())
+        raise H1Terminal(
+            "A4-H1-LOCATOR-LAYOUT-MULTIPLE",
+            len(layouts),
+            candidate_stage="h1_target_valid_layout",
+            candidates=layout_candidates,
+        )
+
+    surviving = tuple(candidate for candidate in target_valid if candidate[0] == layouts[0])
+    pair_documents = tuple(
+        _checked_candidate(
+            "h1_locator_pair",
+            {
+                "layout": layout,
+                "table_signature_id": signature_id,
+                "locator_offsets": list(pair),
+            },
+            candidate_bindings,
+            include_targets=True,
+        )
+        for layout, signature_id, pair, candidate_bindings in surviving
+    )
+    measure(measurements, "A4-H1-LOCATOR-PAIR-MULTIPLE", len(surviving), len(surviving) == 1, replica=view.replica)
+    if len(surviving) > 1:
+        raise H1Terminal(
+            "A4-H1-LOCATOR-PAIR-MULTIPLE",
+            len(surviving),
+            candidate_stage="h1_locator_pair",
+            candidates=pair_documents,
+        )
+    layout, signature_id, pair, final_bindings = surviving[0]
+    return H1ReplicaCandidate(
+        view.replica, layout, signature_id, pair, final_bindings
+    )
+
+
+def agree_h1_replicas(
+    replica_1: H1ReplicaCandidate,
+    replica_2: H1ReplicaCandidate,
+    measurements: MeasurementRecorder | None = None,
+) -> H1ReplicaCandidate:
+    """Apply H1 replica agreement and merge only agreeing physical bindings."""
+    if (replica_1.replica, replica_2.replica) != (1, 2):
+        raise ValueError("H1 replica agreement requires replicas 1 then 2")
+    model_count = len({replica_1.canonical_model_id, replica_2.canonical_model_id})
+    agrees = model_count == 1
+    measure(measurements, "A4-H1-REPLICA-DISAGREEMENT", model_count, agrees)
+    if not agrees:
+        entries = []
+        for candidate in (replica_1, replica_2):
+            entries.append(
+                {
+                    "replica": candidate.replica,
+                    "canonical_model_id": candidate.canonical_model_id,
+                    "canonical_candidate_id": candidate.canonical_candidate_id,
+                    "complete_candidate": candidate.document(),
+                }
+            )
+        raise H1Terminal(
+            "A4-H1-REPLICA-DISAGREEMENT",
+            2,
+            candidate_stage="h1_locator_pair",
+            terminal_evidence={"kind": "replica_pair", "entries": entries},
+            per_replica_counts=(1, 1),
+        )
+    return H1ReplicaCandidate(
+        0,
+        replica_1.layout,
+        replica_1.table_signature_id,
+        replica_1.locator_offsets,
+        replica_1.bindings + replica_2.bindings,
+    )
+
+
+def predict_h1(
+    view: View,
+    qualified_tdef_pages: Sequence[int],
+    frozen: H1ReplicaCandidate,
+    ledger: WorkLedger,
+) -> H1ReplicaCandidate | None:
+    """Apply only the frozen H1 model to holdout lifecycle bindings."""
+    if view.replica != 3 or frozen.replica not in (0, 3):
+        raise ValueError("H1 holdout prediction requires replica 3 and a frozen model")
+    pages = _qualify_pages(qualified_tdef_pages)
+    located: list[tuple[H1Binding, ...]] = []
+    for lifecycle_signature in _LIFECYCLE_SIGNATURES:
+        choices = [
+            tuple(
+                page
+                for page in pages
+                if _lifecycle_holds(view, instance, page, lifecycle_signature)
+            )
+            for instance in _INSTANCE_ORDER
+        ]
+        if any(not choice for choice in choices):
+            continue
+        for selected in itertools.product(*choices):
+            bindings = tuple(
+                H1Binding(
+                    3,
+                    LIFECYCLE_RANGES[instance].logical_role,
+                    instance,
+                    page,
+                )
+                for instance, page in zip(_INSTANCE_ORDER, selected)
+            )
+            complete = _structural_bindings(
+                view,
+                bindings,
+                frozen.layout,
+                frozen.table_signature_id,
+                frozen.locator_offsets,
+            )
+            if complete is not None and _target_valid(
+                view, complete, frozen.layout, ledger
+            ):
+                located.append(complete)
+                if len(located) > 1:
+                    return None
+    if len(located) != 1:
+        return None
+    result = H1ReplicaCandidate(
+        3,
+        frozen.layout,
+        frozen.table_signature_id,
+        frozen.locator_offsets,
+        located[0],
+    )
+    return result if result.canonical_model_id == frozen.canonical_model_id else None

--- a/oracle/windows-dao/scripts/a4_layer_h2.py
+++ b/oracle/windows-dao/scripts/a4_layer_h2.py
@@ -1,0 +1,800 @@
+#!/usr/bin/env python3
+"""Bounded A4 H2 allocation-row, polarity, and role derivation."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+from protocol_validation import ValidationError
+from a4_layer_h1 import H1Binding, H1ReplicaCandidate
+from a4_layer_h2_types import FrozenOwnedRow, MapRow
+from a4_measurements import MeasurementRecorder, measure
+from a4_model import A4AnalysisError, QualifiedPage, View, WorkLedger, canonical_model_id
+from a4_spec import (
+    BOUNDS,
+    CANDIDATE_GRAMMARS,
+    CHECKPOINT_IDS,
+    PLAN,
+    canonical_json_bytes,
+    validate_failure_count,
+)
+_H2 = CANDIDATE_GRAMMARS["h2"]
+_ROW_MASKS = tuple(int(value) for value in _H2["row_masks"])
+_POLARITIES = tuple(_H2["type_0_polarities"])
+_ASSIGNMENTS = tuple(_H2["locator_role_assignments"])
+_ROLES = tuple(PLAN["tables"]["logical_roles"])
+_MAX_CANDIDATES = int(BOUNDS["max_candidate_models"])
+_MAX_CANDIDATE_BYTES = int(BOUNDS["max_canonical_candidate_bytes"])
+_MAX_ROWS = int(BOUNDS["max_inserted_rows_per_replica"])
+_PAGE_SIZE = int(BOUNDS["page_size"])
+_ROW_DIRECTORY_CAPACITY = (_PAGE_SIZE - 10) // 2
+_MAX_COMPLETE_ROWS = (_PAGE_SIZE - 10) // 3
+_COVERAGE = PLAN["checkpoint_design"]["transition_coverage"]
+_IDLE_PAIRS = tuple(tuple(pair) for pair in PLAN["checkpoint_design"]["idle_pairs"])
+_GROW_SEQUENCES = tuple(
+    tuple(_COVERAGE[name])
+    for name in ("t1_growth", "t3_absolute", "t4_relative")
+)
+_GROW_ROLES = ("T1", "T3", "T4")
+_TRANSITION_KINDS = tuple(_H2["transition_signature"])
+
+@dataclass(frozen=True)
+class RowBounds:
+    raw_entry: int
+    start: int
+    end: int
+
+@dataclass(frozen=True)
+class Directory:
+    row_count: int
+    rows: tuple[RowBounds, ...]
+
+
+@dataclass(frozen=True)
+class H2ReplicaCandidate:
+    replica: int
+    row_mask: int
+    polarity: str
+    owned_in_use_locator_ordinal: int
+    available_locator_ordinal: int
+
+    @property
+    def model(self) -> dict[str, Any]:
+        return {
+            "row_mask": self.row_mask,
+            "polarity": self.polarity,
+            "owned_in_use_locator_ordinal": self.owned_in_use_locator_ordinal,
+            "available_locator_ordinal": self.available_locator_ordinal,
+        }
+
+    @property
+    def canonical_model_id(self) -> str:
+        return canonical_model_id("h2_final_role", self.model)
+
+    @property
+    def canonical_candidate_id(self) -> str:
+        # H2 has no replica-specific binding in its registered candidate shape.
+        return self.canonical_model_id
+
+    def document(self) -> dict[str, Any]:
+        document = {
+            "model_type": "h2_final_role",
+            "canonical_candidate_id": self.canonical_candidate_id,
+            "model": self.model,
+        }
+        if len(canonical_json_bytes(document)) > _MAX_CANDIDATE_BYTES:
+            raise A4AnalysisError(
+                "A4-RESOURCE-BOUND", detail="H2 canonical candidate exceeds its bound"
+            )
+        return document
+
+
+class H2Terminal(A4AnalysisError):
+    """Registered H2 terminal with its schema-directed frozen payload."""
+
+    def __init__(
+        self,
+        predicate_id: str,
+        survivor_count: int,
+        *,
+        candidates: Sequence[Mapping[str, Any]] = (),
+        terminal_evidence: Mapping[str, Any] | None = None,
+        per_replica_counts: Sequence[int] | None = None,
+        detail: str | None = None,
+    ) -> None:
+        validate_failure_count(
+            predicate_id,
+            survivor_count,
+            per_replica_counts=per_replica_counts,
+        )
+        self.candidates = tuple(dict(candidate) for candidate in candidates)
+        self.terminal_evidence = (
+            None if terminal_evidence is None else dict(terminal_evidence)
+        )
+        self.payload_kind = (
+            "invalid_observation"
+            if predicate_id
+            in {
+                "A4-H2-ROW-DIRECTORY-INVALID",
+                "A4-H2-ROW-FLAGS-INVALID",
+                "A4-H2-MAP-TAG-UNSUPPORTED",
+            }
+            else "replica_pair"
+            if terminal_evidence is not None
+            else "candidate_set"
+        )
+        self.candidate_stage = (
+            "h2_final_role" if self.payload_kind != "invalid_observation" else None
+        )
+        super().__init__(predicate_id, survivor_count, detail=detail)
+
+
+@dataclass(frozen=True)
+class _DirectoryFailure:
+    checkpoint: str
+    page: int
+    slot: int
+    row_count: int
+    raw_entry: int
+    reason: str
+
+    def evidence(self, replica: int, input_model_id: str) -> dict[str, Any]:
+        return {
+            "kind": "row_directory",
+            "input_model_id": input_model_id,
+            "observation": {
+                "replica": replica,
+                "checkpoint_id": self.checkpoint,
+                "page": self.page,
+                "row_count": self.row_count,
+                "slot": self.slot,
+                "raw_entry_u16le": self.raw_entry,
+                "masked_start_8191": self.raw_entry & 8191,
+                "masked_start_4095": self.raw_entry & 4095,
+                "reason": self.reason,
+            },
+        }
+
+
+def _directory(payload: bytes, mask: int) -> tuple[Directory | None, tuple[int, int, str] | None]:
+    row_count = int.from_bytes(payload[8:10], "little")
+    if row_count > _ROW_DIRECTORY_CAPACITY:
+        raise A4AnalysisError(
+            "A4-RESOURCE-BOUND", detail="row directory exceeds its bounded entry domain"
+        )
+    if row_count > _MAX_COMPLETE_ROWS:
+        return None, (0, 0, "row_count_exceeds_capacity")
+    directory_end = 10 + 2 * row_count
+    rows: list[RowBounds] = []
+    prior_start = _PAGE_SIZE
+    for slot in range(row_count):
+        offset = 10 + 2 * slot
+        raw = int.from_bytes(payload[offset : offset + 2], "little")
+        start = raw & mask
+        end = prior_start
+        if start < directory_end:
+            return None, (slot, raw, "start_below_directory_end")
+        if end > _PAGE_SIZE:
+            return None, (slot, raw, "end_above_page")
+        if start >= end:
+            return None, (slot, raw, "start_not_below_end")
+        rows.append(RowBounds(raw, start, end))
+        prior_start = start
+    return Directory(row_count, tuple(rows)), None
+
+
+def _target_pages(binding: H1Binding) -> tuple[int, ...]:
+    if binding.locator_targets is None:
+        raise ValueError("H2 requires a complete H1 locator binding")
+    return tuple(sorted({target.page for target in binding.locator_targets}))
+
+
+def _checked_row_counts(
+    row_counts: Mapping[str, Mapping[str, int]],
+) -> dict[str, dict[str, int]]:
+    if tuple(row_counts) != tuple(CHECKPOINT_IDS):
+        raise ValueError("H2 row counts must follow the exact checkpoint order")
+    result: dict[str, dict[str, int]] = {}
+    for checkpoint in CHECKPOINT_IDS:
+        counts = row_counts[checkpoint]
+        if set(counts) != set(_ROLES):
+            raise ValueError(f"H2 row counts at {checkpoint} have the wrong roles")
+        checked: dict[str, int] = {}
+        for role in _ROLES:
+            value = counts[role]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or not 0 <= value <= _MAX_ROWS
+            ):
+                raise ValueError(f"H2 row count for {role} at {checkpoint} is invalid")
+            checked[role] = value
+        result[checkpoint] = checked
+    return result
+
+
+def _directory_inventory(
+    view: View,
+    h1: H1ReplicaCandidate,
+) -> tuple[
+    dict[int, dict[tuple[str, str, int], Directory]],
+    dict[int, _DirectoryFailure],
+    int,
+]:
+    directories = {mask: {} for mask in _ROW_MASKS}
+    first_failure: dict[int, _DirectoryFailure] = {}
+    visited_entries: set[tuple[int, str, int, int]] = set()
+    for binding in h1.bindings:
+        for checkpoint in binding.checkpoints:
+            for page in _target_pages(binding):
+                payload = view.page_optional(checkpoint, page)
+                if payload is None or payload[0] != 0x01:
+                    raise A4AnalysisError(
+                        "A4-SNAPSHOT-RECONSTRUCTION",
+                        detail="H2 input no longer satisfies its decisive H1 model",
+                    )
+                row_count = int.from_bytes(payload[8:10], "little")
+                for slot in range(min(row_count, _ROW_DIRECTORY_CAPACITY)):
+                    visited_entries.add((view.replica, checkpoint, page, slot))
+                key = (binding.lifecycle_instance, checkpoint, page)
+                for mask in _ROW_MASKS:
+                    directory, failure = _directory(payload, mask)
+                    if directory is not None:
+                        directories[mask][key] = directory
+                    elif mask not in first_failure and failure is not None:
+                        slot, raw, reason = failure
+                        first_failure[mask] = _DirectoryFailure(
+                            checkpoint, page, slot, row_count, raw, reason
+                        )
+    return directories, first_failure, len(visited_entries)
+
+
+def _complete_masks(
+    h1: H1ReplicaCandidate,
+    directories: Mapping[int, Mapping[tuple[str, str, int], Directory]],
+) -> tuple[int, ...]:
+    required = {
+        (binding.lifecycle_instance, checkpoint, page)
+        for binding in h1.bindings
+        for checkpoint in binding.checkpoints
+        for page in _target_pages(binding)
+    }
+    representatives: list[int] = []
+    seen_bounds: set[tuple[Any, ...]] = set()
+    for mask in _ROW_MASKS:
+        if set(directories[mask]) != required:
+            continue
+        signature = tuple(
+            (
+                key,
+                tuple((row.start, row.end) for row in directories[mask][key].rows),
+            )
+            for key in sorted(required)
+        )
+        if signature not in seen_bounds:
+            seen_bounds.add(signature)
+            representatives.append(mask)
+    return tuple(representatives)
+
+
+def _first_flag_failure(
+    view: View,
+    h1: H1ReplicaCandidate,
+    directories: Mapping[tuple[str, str, int], Directory],
+) -> dict[str, Any] | None:
+    for binding in h1.bindings:
+        if binding.locator_targets is None:
+            raise ValueError("H2 requires H1 locator targets")
+        for checkpoint in binding.checkpoints:
+            for target in binding.locator_targets:
+                directory = directories[(binding.lifecycle_instance, checkpoint, target.page)]
+                raw = directory.rows[target.row].raw_entry
+                deleted = bool(raw & 0x8000)
+                overflow = bool(raw & 0x4000)
+                if deleted or overflow:
+                    return {
+                        "kind": "row_flags",
+                        "input_model_id": h1.canonical_candidate_id,
+                        "observation": {
+                            "replica": view.replica,
+                            "checkpoint_id": checkpoint,
+                            "page": target.page,
+                            "slot": target.row,
+                            "raw_entry_u16le": raw,
+                            "deleted_flag_0x8000": deleted,
+                            "overflow_flag_0x4000": overflow,
+                        },
+                    }
+    return None
+
+
+def _map_row(payload: bytes, bounds: RowBounds) -> MapRow:
+    row = payload[bounds.start : bounds.end]
+    if not row:
+        raise ValueError("H2 complete row unexpectedly has zero length")
+    if row[0] == 0:
+        if len(row) < 5:
+            return MapRow(0, row, None, None)
+        return MapRow(0, row, int.from_bytes(row[1:5], "little"), row[5:])
+    return MapRow(row[0], row, None, None)
+
+
+def _rows_for_mask(
+    view: View,
+    h1: H1ReplicaCandidate,
+    mask: int,
+    directories: Mapping[tuple[str, str, int], Directory],
+    ledger: WorkLedger,
+) -> tuple[dict[tuple[str, str, int], MapRow], dict[str, Any] | None]:
+    rows: dict[tuple[str, str, int], MapRow] = {}
+    first_invalid: dict[str, Any] | None = None
+    for binding in h1.bindings:
+        if binding.locator_targets is None:
+            raise ValueError("H2 requires H1 locator targets")
+        for checkpoint in binding.checkpoints:
+            for ordinal, target in enumerate(binding.locator_targets):
+                payload = view.page(checkpoint, target.page)
+                bounds = directories[
+                    (binding.lifecycle_instance, checkpoint, target.page)
+                ].rows[target.row]
+                row = _map_row(payload, bounds)
+                rows[(binding.lifecycle_instance, checkpoint, ordinal)] = row
+                if view.replica in (1, 2):
+                    qualified = QualifiedPage(view.replica, checkpoint, target.page)
+                    identity = (target.row, bounds.start, bounds.end)
+                    if row.tag == 0 and row.bitmap is not None:
+                        ledger.charge_qualified(
+                            "type_0_and_tag_05_bitmap_bits", qualified,
+                            len(row.bitmap) * 8, discriminator=identity,
+                        )
+                    elif row.tag == 1 and (len(row.payload) - 1) % 4 == 0:
+                        ledger.charge_qualified(
+                            "type_1_slots", qualified,
+                            (len(row.payload) - 1) // 4, discriminator=identity,
+                        )
+                reason: str | None = None
+                if row.tag not in (0, 1):
+                    reason = "unsupported_tag"
+                elif row.tag == 0 and (row.base is None or row.bitmap is None):
+                    reason = "unsupported_tag"
+                elif row.tag == 1 and (len(row.payload) - 1) % 4:
+                    reason = "type_1_payload_not_u32_multiple"
+                if first_invalid is None and reason is not None:
+                    first_invalid = {
+                        "kind": "map_tag",
+                        "input_model_id": h1.canonical_candidate_id,
+                        "observation": {
+                            "replica": view.replica,
+                            "checkpoint_id": checkpoint,
+                            "page": target.page,
+                            "slot": target.row,
+                            "row_start": bounds.start,
+                            "row_end": bounds.end,
+                            "tag_byte": row.tag,
+                            "reason": reason,
+                        },
+                    }
+    return rows, first_invalid
+
+
+def _admitted(row: MapRow, polarity: str) -> frozenset[int] | None:
+    if row.tag != 0 or row.base is None or row.bitmap is None:
+        return None
+    selected: set[int] = set()
+    for byte_ordinal, byte in enumerate(row.bitmap):
+        for bit in range(8):
+            is_set = bool(byte & (1 << bit))
+            owned = is_set if polarity == "set_bit_owned_in_use" else not is_set
+            if owned:
+                selected.add(row.base + byte_ordinal * 8 + bit)
+    return frozenset(selected)
+
+
+def decode_frozen_owned_rows(
+    view: View,
+    h1: H1ReplicaCandidate,
+    frozen: H2ReplicaCandidate,
+    ledger: WorkLedger,
+) -> tuple[FrozenOwnedRow, ...]:
+    """Decode H3 input with the frozen H1/H2 choices, without refitting."""
+    if view.replica not in (1, 2, 3) or h1.replica != view.replica:
+        raise ValueError("frozen H2 decoding requires matching replica input")
+    if frozen.replica not in (0, view.replica):
+        raise ValueError("frozen H2 model is bound to another replica")
+    if (
+        frozen.row_mask not in _ROW_MASKS
+        or frozen.polarity not in _POLARITIES
+        or {frozen.owned_in_use_locator_ordinal, frozen.available_locator_ordinal}
+        != {0, 1}
+    ):
+        raise ValueError("frozen H2 model is outside the closed grammar")
+    directories, _failures, _entries = _directory_inventory(view, h1)
+    required = {
+        (binding.lifecycle_instance, checkpoint, page)
+        for binding in h1.bindings
+        for checkpoint in binding.checkpoints
+        for page in _target_pages(binding)
+    }
+    selected = directories[frozen.row_mask]
+    if set(selected) != required or _first_flag_failure(view, h1, selected) is not None:
+        raise A4AnalysisError(
+            "A4-SNAPSHOT-RECONSTRUCTION",
+            detail="input contradicts the frozen H2 directory/flag model",
+        )
+    rows, tag_failure = _rows_for_mask(view, h1, frozen.row_mask, selected, ledger)
+    if tag_failure is not None:
+        raise A4AnalysisError(
+            "A4-SNAPSHOT-RECONSTRUCTION",
+            detail="input contradicts the frozen H2 map-row model",
+        )
+    observations: list[FrozenOwnedRow] = []
+    allocation_rows = (
+        ("owned_in_use", frozen.owned_in_use_locator_ordinal),
+        ("available", frozen.available_locator_ordinal),
+    )
+    for binding in h1.bindings:
+        if binding.locator_targets is None:
+            raise ValueError("frozen H2 decoding requires H1 locator targets")
+        for allocation_role, ordinal in allocation_rows:
+            target = binding.locator_targets[ordinal]
+            for checkpoint in binding.checkpoints:
+                row = rows[(binding.lifecycle_instance, checkpoint, ordinal)]
+                admitted = _admitted(row, frozen.polarity)
+                references = (
+                    tuple(
+                        int.from_bytes(row.payload[offset : offset + 4], "little")
+                        for offset in range(1, len(row.payload), 4)
+                    )
+                    if row.tag == 1
+                    else None
+                )
+                span = (
+                    (row.base, row.base + len(row.bitmap) * 8)
+                    if row.tag == 0
+                    and row.base is not None
+                    and row.bitmap is not None
+                    and row.bitmap
+                    else None
+                )
+                observations.append(
+                    FrozenOwnedRow(
+                        view.replica,
+                        binding.logical_role,
+                        binding.lifecycle_instance,
+                        allocation_role,
+                        checkpoint,
+                        target.page,
+                        target.row,
+                        "type_0" if row.tag == 0 else "type_1",
+                        None if admitted is None else tuple(sorted(admitted)),
+                        references,
+                        span,
+                    )
+                )
+    return tuple(observations)
+
+
+def _assignment_ordinals(assignment: str) -> tuple[int, int]:
+    if assignment == "ordinal_0_owned_ordinal_1_available":
+        return 0, 1
+    if assignment == "ordinal_1_owned_ordinal_0_available":
+        return 1, 0
+    raise ValidationError(f"unknown H2 locator-role assignment {assignment!r}")
+
+
+def _binding_for_role(
+    bindings: Sequence[H1Binding], role: str, left: str, right: str
+) -> H1Binding | None:
+    matches = [
+        binding
+        for binding in bindings
+        if binding.logical_role == role
+        and left in binding.checkpoints
+        and right in binding.checkpoints
+    ]
+    if len(matches) > 1:
+        raise ValueError("H2 found overlapping lifecycle bindings for one role")
+    return matches[0] if matches else None
+
+
+def _static_fits(
+    view: View,
+    h1: H1ReplicaCandidate,
+    rows: Mapping[tuple[str, str, int], MapRow],
+    row_counts: Mapping[str, Mapping[str, int]],
+    polarity: str,
+    owned_ordinal: int,
+    available_ordinal: int,
+) -> bool:
+    for binding in h1.bindings:
+        for checkpoint in binding.checkpoints:
+            owned = _admitted(
+                rows[(binding.lifecycle_instance, checkpoint, owned_ordinal)], polarity
+            )
+            available = _admitted(
+                rows[(binding.lifecycle_instance, checkpoint, available_ordinal)], polarity
+            )
+            for admitted in (owned, available):
+                if admitted is not None and any(
+                    page >= view.page_count(checkpoint) for page in admitted
+                ):
+                    return False
+            if owned is not None and available is not None:
+                if not available <= owned:
+                    return False
+            if (
+                row_counts[checkpoint][binding.logical_role] > 0
+                and owned is not None
+                and not owned
+            ):
+                return False
+    return True
+
+
+def _transition_charge(
+    ledger: WorkLedger,
+    replica: int,
+    mask: int,
+    polarity: str,
+    assignment: str,
+) -> None:
+    for kind in _TRANSITION_KINDS:
+        for role in _ROLES:
+            for checkpoint in CHECKPOINT_IDS:
+                ledger.charge_once(
+                    "role_transition_evaluations",
+                    (replica, mask, polarity, assignment, kind, role, checkpoint),
+                )
+
+
+def _state(
+    rows: Mapping[tuple[str, str, int], MapRow],
+    binding: H1Binding,
+    checkpoint: str,
+    polarity: str,
+    owned_ordinal: int,
+    available_ordinal: int,
+) -> tuple[frozenset[int] | None, frozenset[int] | None]:
+    return (
+        _admitted(rows[(binding.lifecycle_instance, checkpoint, owned_ordinal)], polarity),
+        _admitted(rows[(binding.lifecycle_instance, checkpoint, available_ordinal)], polarity),
+    )
+
+
+def _row_span(row: MapRow) -> range:
+    if row.tag != 0 or row.base is None or row.bitmap is None:
+        return range(0, 0)
+    return range(row.base, row.base + len(row.bitmap) * 8)
+
+
+def _transitions_fit(
+    h1: H1ReplicaCandidate,
+    rows: Mapping[tuple[str, str, int], MapRow],
+    polarity: str,
+    owned_ordinal: int,
+    available_ordinal: int,
+) -> bool:
+    for left, right in _IDLE_PAIRS:
+        for binding in h1.bindings:
+            if left not in binding.checkpoints or right not in binding.checkpoints:
+                continue
+            for ordinal in (0, 1):
+                if rows[(binding.lifecycle_instance, left, ordinal)].payload != rows[
+                    (binding.lifecycle_instance, right, ordinal)
+                ].payload:
+                    return False
+
+    for role, sequence in zip(_GROW_ROLES, _GROW_SEQUENCES):
+        for left, right in zip(sequence, sequence[1:]):
+            if not (right.startswith(f"{role}_REL_") or right.startswith(f"{role}_ABS_")):
+                continue
+            binding = _binding_for_role(h1.bindings, role, left, right)
+            if binding is None:
+                return False
+            left_owned, left_available = _state(
+                rows, binding, left, polarity, owned_ordinal, available_ordinal
+            )
+            right_owned, right_available = _state(
+                rows, binding, right, polarity, owned_ordinal, available_ordinal
+            )
+            if None in (left_owned, left_available, right_owned, right_available):
+                continue
+            if not left_owned <= right_owned:
+                return False
+            gained = right_owned - left_owned
+            if (right_available - left_available) & gained:
+                return False
+
+    t1 = _binding_for_role(
+        h1.bindings, "T1", "T1_REL_1280", "T1_DELETE_ALL"
+    )
+    if t1 is None:
+        return False
+    delete_before = _state(
+        rows, t1, "T1_REL_1280", polarity, owned_ordinal, available_ordinal
+    )
+    delete_after = _state(
+        rows, t1, "T1_DELETE_ALL", polarity, owned_ordinal, available_ordinal
+    )
+    reinsert_after = _state(
+        rows, t1, "T1_REINSERT_SAME", polarity, owned_ordinal, available_ordinal
+    )
+    if None not in delete_before + delete_after:
+        before_owned, before_available = delete_before
+        after_owned, after_available = delete_after
+        if not after_owned <= before_owned or not before_available <= after_available:
+            return False
+        before_row = rows[(t1.lifecycle_instance, "T1_REL_1280", owned_ordinal)]
+        after_row = rows[(t1.lifecycle_instance, "T1_DELETE_ALL", owned_ordinal)]
+        span = set(_row_span(before_row)) | set(_row_span(after_row))
+        if ((before_owned ^ after_owned) | (before_available ^ after_available)) - span:
+            return False
+    if None not in delete_after + reinsert_after:
+        before_owned, before_available = delete_after
+        after_owned, after_available = reinsert_after
+        if not before_owned <= after_owned or not after_available <= before_available:
+            return False
+        before_row = rows[(t1.lifecycle_instance, "T1_DELETE_ALL", owned_ordinal)]
+        after_row = rows[(t1.lifecycle_instance, "T1_REINSERT_SAME", owned_ordinal)]
+        span = set(_row_span(before_row)) | set(_row_span(after_row))
+        if ((before_owned ^ after_owned) | (before_available ^ after_available)) - span:
+            return False
+    return True
+
+
+def derive_h2_replica(
+    view: View,
+    h1: H1ReplicaCandidate,
+    table_row_counts: Mapping[str, Mapping[str, int]],
+    ledger: WorkLedger,
+    measurements: MeasurementRecorder | None = None,
+) -> H2ReplicaCandidate:
+    """Run H2's seven non-holdout predicates for one derivation replica."""
+    if view.replica not in (1, 2) or h1.replica != view.replica:
+        raise ValueError("H2 derivation requires matching replica-1/2 H1 input")
+    input_count = len((h1,))
+    row_counts = _checked_row_counts(table_row_counts)
+    directories, directory_failures, entries = _directory_inventory(view, h1)
+    masks = _complete_masks(h1, directories)
+    ledger.charge(
+        "valid_path_row_directory_entries"
+        if masks
+        else "invalid_path_row_directory_entries",
+        entries,
+    )
+    measure(measurements, "A4-H2-ROW-DIRECTORY-INVALID", input_count, bool(masks), replica=view.replica)
+    if not masks:
+        failure = next(
+            (directory_failures[mask] for mask in _ROW_MASKS if mask in directory_failures),
+            None,
+        )
+        if failure is None:
+            raise A4AnalysisError(
+                "A4-SNAPSHOT-RECONSTRUCTION",
+                detail="H2 directory-mask intersection is empty without an observation",
+            )
+        raise H2Terminal(
+            "A4-H2-ROW-DIRECTORY-INVALID",
+            1,
+            terminal_evidence=failure.evidence(
+                view.replica, h1.canonical_candidate_id
+            ),
+        )
+    flag_failure = _first_flag_failure(view, h1, directories[masks[0]])
+    measure(measurements, "A4-H2-ROW-FLAGS-INVALID", input_count, flag_failure is None, replica=view.replica)
+    if flag_failure is not None:
+        raise H2Terminal(
+            "A4-H2-ROW-FLAGS-INVALID", 1, terminal_evidence=flag_failure
+        )
+
+    row_models: dict[int, dict[tuple[str, str, int], MapRow]] = {}
+    tag_failures: dict[int, dict[str, Any]] = {}
+    for mask in masks:
+        rows, failure = _rows_for_mask(view, h1, mask, directories[mask], ledger)
+        if failure is None:
+            row_models[mask] = rows
+        else:
+            tag_failures[mask] = failure
+    masks = tuple(mask for mask in masks if mask in row_models)
+    measure(measurements, "A4-H2-MAP-TAG-UNSUPPORTED", input_count, bool(masks), replica=view.replica)
+    if not masks:
+        failure = next(tag_failures[mask] for mask in _ROW_MASKS if mask in tag_failures)
+        raise H2Terminal(
+            "A4-H2-MAP-TAG-UNSUPPORTED", 1, terminal_evidence=failure
+        )
+
+    static: list[tuple[H2ReplicaCandidate, str]] = []
+    for mask in masks:
+        for polarity in _POLARITIES:
+            for assignment in _ASSIGNMENTS:
+                owned, available = _assignment_ordinals(assignment)
+                if _static_fits(
+                    view,
+                    h1,
+                    row_models[mask],
+                    row_counts,
+                    polarity,
+                    owned,
+                    available,
+                ):
+                    static.append(
+                        (
+                            H2ReplicaCandidate(
+                                view.replica, mask, polarity, owned, available
+                            ),
+                            assignment,
+                        )
+                    )
+                    if len(static) > _MAX_CANDIDATES:
+                        raise A4AnalysisError(
+                            "A4-RESOURCE-BOUND",
+                            detail="H2 candidate count exceeds its bound",
+                        )
+    measure(measurements, "A4-H2-ROLE-NONE", len(static), bool(static), replica=view.replica)
+    if not static:
+        raise H2Terminal("A4-H2-ROLE-NONE", 0)
+    measure(measurements, "A4-H2-ROLE-MULTIPLE", len(static), len(static) == 1, replica=view.replica)
+    if len(static) > 1:
+        raise H2Terminal(
+            "A4-H2-ROLE-MULTIPLE",
+            len(static),
+            candidates=tuple(candidate.document() for candidate, _ in static),
+        )
+
+    candidate, assignment = static[0]
+    _transition_charge(
+        ledger,
+        view.replica,
+        candidate.row_mask,
+        candidate.polarity,
+        assignment,
+    )
+    transitions_fit = _transitions_fit(
+        h1,
+        row_models[candidate.row_mask],
+        candidate.polarity,
+        candidate.owned_in_use_locator_ordinal,
+        candidate.available_locator_ordinal,
+    )
+    measure(measurements, "A4-H2-TRANSITION-UNEXPLAINED", len((candidate,)), transitions_fit, replica=view.replica)
+    if not transitions_fit:
+        raise H2Terminal(
+            "A4-H2-TRANSITION-UNEXPLAINED",
+            1,
+            candidates=(candidate.document(),),
+        )
+    return candidate
+
+
+def agree_h2_replicas(
+    replica_1: H2ReplicaCandidate, replica_2: H2ReplicaCandidate,
+    measurements: MeasurementRecorder | None = None,
+) -> H2ReplicaCandidate:
+    """Apply H2 replica agreement to the replica-invariant role model."""
+    if (replica_1.replica, replica_2.replica) != (1, 2):
+        raise ValueError("H2 replica agreement requires replicas 1 then 2")
+    model_count = len({replica_1.canonical_model_id, replica_2.canonical_model_id})
+    agrees = model_count == 1
+    measure(measurements, "A4-H2-REPLICA-DISAGREEMENT", model_count, agrees)
+    if not agrees:
+        entries = []
+        for candidate in (replica_1, replica_2):
+            entries.append(
+                {
+                    "replica": candidate.replica,
+                    "canonical_model_id": candidate.canonical_model_id,
+                    "canonical_candidate_id": candidate.canonical_candidate_id,
+                    "complete_candidate": candidate.document(),
+                }
+            )
+        raise H2Terminal(
+            "A4-H2-REPLICA-DISAGREEMENT",
+            2,
+            terminal_evidence={"kind": "replica_pair", "entries": entries},
+            per_replica_counts=(1, 1),
+        )
+    return H2ReplicaCandidate(
+        0,
+        replica_1.row_mask,
+        replica_1.polarity,
+        replica_1.owned_in_use_locator_ordinal,
+        replica_1.available_locator_ordinal,
+    )

--- a/oracle/windows-dao/scripts/a4_layer_h2_types.py
+++ b/oracle/windows-dao/scripts/a4_layer_h2_types.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Neutral checked observations shared by the A4 H2 and H3 layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MapRow:
+    tag: int
+    payload: bytes
+    base: int | None
+    bitmap: bytes | None
+
+
+@dataclass(frozen=True)
+class FrozenOwnedRow:
+    """One frozen-H2 allocation-row observation handed to H3."""
+
+    replica: int
+    logical_role: str
+    lifecycle_instance: str
+    allocation_role: str
+    checkpoint_id: str
+    map_page: int
+    map_row: int
+    representation: str
+    owned_pages: tuple[int, ...] | None
+    type_1_references: tuple[int, ...] | None
+    type_0_span: tuple[int, int] | None

--- a/oracle/windows-dao/scripts/a4_layer_h3.py
+++ b/oracle/windows-dao/scripts/a4_layer_h3.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Bounded A4 H3 indirect-traversal derivation.
+
+H2 supplies already decoded type-0 owned sets and type-1 slot observations.
+This module deliberately does not decode H1/H2 rows again.  It applies the
+closed H3 grammar in predicate order, keeps physical observations replica
+qualified, and separates reference validity from conversion structure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from a4_measurements import MeasurementRecorder, measure
+from a4_model import (
+    A4AnalysisError,
+    QualifiedPage,
+    WorkLedger,
+    canonical_object_id,
+    canonical_model_id,
+)
+from a4_spec import BOUNDS, CANDIDATE_GRAMMARS, CHECKPOINT_IDS, PLAN
+
+
+_GRAMMAR = CANDIDATE_GRAMMARS["h3"]
+CONVERSIONS = tuple(_GRAMMAR["conversion_candidates"])
+BASE_FORMULAS = tuple(_GRAMMAR["base_formulas"])
+BITMAP_BITS = (int(BOUNDS["page_size"]) - 4) * 8
+MAX_ADMITTED_PAGES = int(BOUNDS["max_qualified_pages_per_submodel"])
+_CONVERSION = "structural_type_0_to_type_1_with_nonzero_u32_slots"
+_COVERAGE = PLAN["checkpoint_design"]["transition_coverage"]
+_IDLE_PAIRS = tuple(
+    tuple(pair) for pair in PLAN["checkpoint_design"]["idle_pairs"]
+)
+
+
+def _growth_sequences() -> tuple[tuple[str, ...], ...]:
+    sequences: list[tuple[str, ...]] = []
+    for value in _COVERAGE.values():
+        sequence = tuple(value)
+        if len(sequence) < 2:
+            continue
+        roles = {checkpoint.split("_", 1)[0] for checkpoint in sequence[1:]}
+        if (
+            len(roles) == 1
+            and roles <= set(PLAN["tables"]["logical_roles"])
+            and any("_REL_" in checkpoint or "_ABS_" in checkpoint for checkpoint in sequence)
+        ):
+            sequences.append(sequence)
+    return tuple(sequences)
+
+
+def _operation_checkpoint(marker: str) -> str:
+    matches = tuple(
+        checkpoint
+        for checkpoint, operation in PLAN["tables"]["checkpoint_operations"].items()
+        if marker in operation
+    )
+    if len(matches) != 1:
+        raise ValueError(f"A4 plan must declare exactly one {marker!r} checkpoint")
+    return matches[0]
+
+
+_GROW_SEQUENCES = _growth_sequences()
+_DELETE_CHECKPOINT = _operation_checkpoint("Delete every")
+_REINSERT_CHECKPOINT = _operation_checkpoint("Reinsert")
+_DELETE_BEFORE = CHECKPOINT_IDS[CHECKPOINT_IDS.index(_DELETE_CHECKPOINT) - 1]
+
+
+def _pages(values: Sequence[int], label: str) -> frozenset[int]:
+    result: set[int] = set()
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{label} must contain nonnegative integers")
+        result.add(value)
+    return frozenset(result)
+
+
+@dataclass(frozen=True, order=True)
+class SlotObservation:
+    """One type-1 u32 slot and its referenced tag-05 bitmap, if readable."""
+
+    slot_ordinal: int
+    reference: int
+    referenced_page_tag: int | None
+    set_bits: frozenset[int] = frozenset()
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.slot_ordinal, bool)
+            or not isinstance(self.slot_ordinal, int)
+            or self.slot_ordinal < 0
+            or isinstance(self.reference, bool)
+            or not isinstance(self.reference, int)
+            or self.reference < 0
+        ):
+            raise ValueError("H3 slot ordinal/reference must be nonnegative integers")
+        bits = _pages(tuple(self.set_bits), "H3 bitmap bits")
+        if any(bit >= BITMAP_BITS for bit in bits):
+            raise ValueError("H3 bitmap bit exceeds the tag-05 capacity")
+        object.__setattr__(self, "set_bits", bits)
+        if self.reference == 0 and (self.referenced_page_tag is not None or bits):
+            raise ValueError("an inactive H3 slot cannot carry referenced-page data")
+
+
+@dataclass(frozen=True)
+class TraversalObservation:
+    """One H2-located row at one checkpoint.
+
+    ``required_owned`` and ``forbidden_owned`` are the page constraints from
+    the frozen H2 transition signature.  They let H3 test formula-decoded sets
+    without importing or refitting H2 semantics.
+    """
+
+    replica: int
+    checkpoint_id: str
+    map_page: int
+    representation: str
+    logical_instance: str
+    allocation_role: str = "owned_in_use"
+    type0_owned: frozenset[int] = frozenset()
+    slots: tuple[SlotObservation, ...] = ()
+    required_owned: frozenset[int] = frozenset()
+    forbidden_owned: frozenset[int] = frozenset()
+    locator_ordinal: int = 0
+    allocation_span: tuple[int, int] | None = None
+
+    def __post_init__(self) -> None:
+        if self.replica not in (1, 2, 3) or isinstance(self.replica, bool):
+            raise ValueError("H3 replica must be 1, 2, or 3")
+        if self.checkpoint_id not in CHECKPOINT_IDS:
+            raise ValueError(f"unknown H3 checkpoint {self.checkpoint_id!r}")
+        if (
+            isinstance(self.map_page, bool)
+            or not isinstance(self.map_page, int)
+            or not 0 <= self.map_page < int(BOUNDS["max_final_pages_per_replica"])
+        ):
+            raise ValueError("H3 map page is outside the registered bound")
+        if self.representation not in ("type_0", "type_1"):
+            raise ValueError("H3 representation must be type_0 or type_1")
+        if not isinstance(self.logical_instance, str) or not self.logical_instance:
+            raise ValueError("H3 logical instance must be a nonempty string")
+        if self.allocation_role not in ("owned_in_use", "available"):
+            raise ValueError("H3 allocation role must be owned_in_use or available")
+        if isinstance(self.locator_ordinal, bool) or self.locator_ordinal not in (0, 1):
+            raise ValueError("H3 locator ordinal must be 0 or 1")
+        for name in ("type0_owned", "required_owned", "forbidden_owned"):
+            object.__setattr__(self, name, _pages(tuple(getattr(self, name)), name))
+        if self.required_owned & self.forbidden_owned:
+            raise ValueError("H3 owned constraints overlap")
+        if self.representation == "type_0" and self.slots:
+            raise ValueError("a type-0 observation cannot carry H3 slots")
+        if self.representation == "type_1" and self.type0_owned:
+            raise ValueError("a type-1 observation cannot carry a type-0 set")
+        if self.allocation_span is not None:
+            start, end = self.allocation_span
+            if (
+                isinstance(start, bool)
+                or isinstance(end, bool)
+                or not isinstance(start, int)
+                or not isinstance(end, int)
+                or not 0 <= start < end
+            ):
+                raise ValueError("H3 allocation span must be a nonempty page interval")
+        ordinals = tuple(slot.slot_ordinal for slot in self.slots)
+        if ordinals != tuple(range(len(ordinals))):
+            raise ValueError("H3 slots must be complete and in ordinal order")
+
+
+@dataclass(frozen=True)
+class ConversionLeg:
+    """A structural adjacent type-0 to type-1 transition."""
+
+    before: TraversalObservation
+    after: TraversalObservation
+
+    def __post_init__(self) -> None:
+        if self.before.replica != self.after.replica:
+            raise ValueError("H3 conversion legs cannot cross replicas")
+        if (
+            self.before.logical_instance != self.after.logical_instance
+            or self.before.allocation_role != self.after.allocation_role
+            or self.before.locator_ordinal != self.after.locator_ordinal
+        ):
+            raise ValueError("H3 conversion legs cannot cross located rows")
+        if self.before.representation != "type_0" or self.after.representation != "type_1":
+            raise ValueError("H3 conversion leg must be type_0 then type_1")
+        if not any(slot.reference for slot in self.after.slots):
+            raise ValueError("H3 conversion leg must contain a nonzero u32 slot")
+
+
+@dataclass(frozen=True)
+class H3Candidate:
+    model_type: str
+    model: Mapping[str, Any]
+
+    @property
+    def canonical_model_id(self) -> str:
+        return canonical_model_id(self.model_type, self.model)
+
+    @property
+    def canonical_candidate_id(self) -> str:
+        return canonical_object_id({"model_type": self.model_type, "model": dict(self.model)})
+
+    def document(self) -> dict[str, Any]:
+        # The preregistered H3 candidate shape has no physical bindings and no
+        # canonical_model_id field, even though agreement recomputes that id.
+        return {
+            "model_type": self.model_type,
+            "canonical_candidate_id": self.canonical_candidate_id,
+            "model": dict(self.model),
+        }
+
+
+@dataclass(frozen=True)
+class H3Derivation:
+    replica: int
+    conversion: H3Candidate
+    final: H3Candidate
+
+
+def conversion_legs(
+    observations: Sequence[TraversalObservation],
+) -> tuple[ConversionLeg, ...]:
+    """Return all adjacent structural conversions in checkpoint order."""
+    legs: list[ConversionLeg] = []
+    identities = sorted(
+        {
+            (row.logical_instance, row.allocation_role, row.locator_ordinal)
+            for row in observations
+        }
+    )
+    for identity in identities:
+        ordered = sorted(
+            (
+                row
+                for row in observations
+                if (
+                    row.logical_instance,
+                    row.allocation_role,
+                    row.locator_ordinal,
+                )
+                == identity
+            ),
+            key=lambda row: CHECKPOINT_IDS.index(row.checkpoint_id),
+        )
+        for before, after in zip(ordered, ordered[1:]):
+            if (
+                before.representation == "type_0"
+                and after.representation == "type_1"
+                and any(slot.reference for slot in after.slots)
+            ):
+                legs.append(ConversionLeg(before, after))
+    return tuple(legs)
+
+
+def reference_invalid(
+    observation: TraversalObservation, page_count: int
+) -> SlotObservation | None:
+    """Return the first invalid active reference; zero slots are inactive."""
+    if isinstance(page_count, bool) or not isinstance(page_count, int) or page_count < 1:
+        raise ValueError("H3 page count must be a positive integer")
+    for slot in observation.slots:
+        if slot.reference and (
+            slot.reference >= page_count or slot.referenced_page_tag != 0x05
+        ):
+            return slot
+    return None
+
+
+def admitted_pages(
+    observation: TraversalObservation,
+    formula: str,
+    *,
+    maximum: int | None = None,
+) -> frozenset[int]:
+    """Decode set tag-05 bits with one registered base formula."""
+    if formula not in BASE_FORMULAS:
+        raise ValueError(f"unregistered H3 base formula {formula!r}")
+    if maximum is not None and (
+        isinstance(maximum, bool) or not isinstance(maximum, int) or maximum < 1
+    ):
+        raise ValueError("H3 admitted-page maximum must be a positive integer")
+    result: set[int] = set()
+    for slot in observation.slots:
+        if slot.reference == 0:
+            continue
+        for bit in slot.set_bits:
+            if formula == "slot_ordinal_times_16352_plus_bit_index":
+                page = slot.slot_ordinal * BITMAP_BITS + bit
+            elif formula == "referenced_page_times_16352_plus_bit_index":
+                page = slot.reference * BITMAP_BITS + bit
+            elif formula == "slot_ordinal_times_16352_plus_bit_index_minus_one":
+                page = slot.slot_ordinal * BITMAP_BITS + bit - 1
+            else:
+                page = slot.slot_ordinal * BITMAP_BITS + bit + 1
+            if page >= 0:
+                if page not in result and maximum is not None and len(result) == maximum:
+                    raise A4AnalysisError(
+                        "A4-RESOURCE-BOUND",
+                        detail=f"H3 traversal admits more than {maximum} pages",
+                    )
+                result.add(page)
+    return frozenset(result)
+
+
+def input_regions_exercised(observations: Sequence[TraversalObservation]) -> bool:
+    """Apply AMB-08's six-region coverage test literally."""
+    inactive = any(slot.reference == 0 for row in observations for slot in row.slots)
+    active = any(slot.reference != 0 for row in observations for slot in row.slots)
+    bit_zero = any(0 in slot.set_bits for row in observations for slot in row.slots)
+    nonzero_bit = any(
+        any(bit != 0 for bit in slot.set_bits) for row in observations for slot in row.slots
+    )
+    last_bit = any(
+        BITMAP_BITS - 1 in slot.set_bits
+        for row in observations
+        for slot in row.slots
+    )
+    boundary = False
+    for row in observations:
+        by_ordinal = {slot.slot_ordinal: slot for slot in row.slots if slot.reference}
+        boundary = boundary or any(
+            BITMAP_BITS - 1 in slot.set_bits
+            and ordinal + 1 in by_ordinal
+            and 0 in by_ordinal[ordinal + 1].set_bits
+            for ordinal, slot in by_ordinal.items()
+        )
+    return inactive and active and bit_zero and nonzero_bit and last_bit and boundary
+
+
+def _decoded_set(
+    observation: TraversalObservation, formula: str
+) -> frozenset[int]:
+    if observation.representation == "type_0":
+        return observation.type0_owned
+    return admitted_pages(observation, formula)
+
+
+def _transition_rows(
+    observations: Sequence[TraversalObservation],
+) -> dict[tuple[str, str, str], TraversalObservation]:
+    rows: dict[tuple[str, str, str], TraversalObservation] = {}
+    for row in observations:
+        key = (row.logical_instance, row.allocation_role, row.checkpoint_id)
+        if key in rows:
+            raise ValueError("duplicate H3 transition observation")
+        rows[key] = row
+    return rows
+
+
+def _state(
+    rows: Mapping[tuple[str, str, str], TraversalObservation],
+    instance: str,
+    checkpoint: str,
+    formula: str,
+) -> tuple[frozenset[int], frozenset[int]] | None:
+    owned = rows.get((instance, "owned_in_use", checkpoint))
+    available = rows.get((instance, "available", checkpoint))
+    if owned is None and available is None:
+        return None
+    if owned is None or available is None:
+        raise ValueError("H3 transition state lacks one frozen allocation role")
+    return _decoded_set(owned, formula), _decoded_set(available, formula)
+
+
+def _changes_within_span(
+    changes: frozenset[int],
+    rows: Sequence[TraversalObservation],
+) -> bool:
+    spans = tuple(row.allocation_span for row in rows if row.allocation_span is not None)
+    if not changes:
+        return True
+    return bool(spans) and all(
+        any(start <= page < end for start, end in spans) for page in changes
+    )
+
+
+def transition_signature_fits(
+    formula: str, observations: Sequence[TraversalObservation]
+) -> bool:
+    """Apply every frozen H2 transition rule to formula-decoded type-1 sets."""
+    rows = _transition_rows(observations)
+    instances = tuple(sorted({row.logical_instance for row in observations}))
+
+    for left, right in _IDLE_PAIRS:
+        for instance in instances:
+            left_state = _state(rows, instance, left, formula)
+            right_state = _state(rows, instance, right, formula)
+            if left_state is None and right_state is None:
+                continue
+            if left_state is None or right_state is None or left_state != right_state:
+                return False
+
+    visited_growth: set[tuple[str, str]] = set()
+    for sequence in _GROW_SEQUENCES:
+        role = sequence[1].split("_", 1)[0]
+        for left, right in zip(sequence, sequence[1:]):
+            if not ("_REL_" in right or "_ABS_" in right):
+                continue
+            if (left, right) in visited_growth:
+                continue
+            visited_growth.add((left, right))
+            matching = tuple(
+                instance for instance in instances if instance.split("-", 1)[0] == role
+            )
+            for instance in matching:
+                before = _state(rows, instance, left, formula)
+                after = _state(rows, instance, right, formula)
+                if before is None and after is None:
+                    continue
+                if before is None or after is None:
+                    return False
+                before_owned, before_available = before
+                after_owned, after_available = after
+                gained = after_owned - before_owned
+                if not before_owned <= after_owned:
+                    return False
+                if gained & (after_available - before_available):
+                    return False
+
+    role = _DELETE_CHECKPOINT.split("_", 1)[0]
+    matching = tuple(
+        instance for instance in instances if instance.split("-", 1)[0] == role
+    )
+    for instance in matching:
+        before = _state(rows, instance, _DELETE_BEFORE, formula)
+        deleted = _state(rows, instance, _DELETE_CHECKPOINT, formula)
+        reinserted = _state(rows, instance, _REINSERT_CHECKPOINT, formula)
+        if before is None and deleted is None and reinserted is None:
+            continue
+        if before is None or deleted is None or reinserted is None:
+            return False
+        before_owned, before_available = before
+        deleted_owned, deleted_available = deleted
+        reinserted_owned, reinserted_available = reinserted
+        if not deleted_owned <= before_owned or not before_available <= deleted_available:
+            return False
+        if not deleted_owned <= reinserted_owned or not reinserted_available <= deleted_available:
+            return False
+        delete_observations = tuple(
+            row
+            for row in observations
+            if row.logical_instance == instance
+            and row.checkpoint_id in (_DELETE_BEFORE, _DELETE_CHECKPOINT)
+        )
+        delete_changes = frozenset(
+            (before_owned ^ deleted_owned)
+            | (before_available ^ deleted_available)
+        )
+        if not _changes_within_span(delete_changes, delete_observations):
+            return False
+        reinsert_observations = tuple(
+            row
+            for row in observations
+            if row.logical_instance == instance
+            and row.checkpoint_id in (_DELETE_CHECKPOINT, _REINSERT_CHECKPOINT)
+        )
+        reinsert_changes = frozenset(
+            (deleted_owned ^ reinserted_owned)
+            | (deleted_available ^ reinserted_available)
+        )
+        if not _changes_within_span(reinsert_changes, reinsert_observations):
+            return False
+    return True
+
+
+def formula_fits(
+    formula: str,
+    observations: Sequence[TraversalObservation],
+    legs: Sequence[ConversionLeg],
+    ledger: WorkLedger | None = None,
+) -> bool:
+    """Test conversion containment followed by frozen H2 set constraints."""
+    decoded = {id(row): admitted_pages(row, formula) for row in observations if row.representation == "type_1"}
+    if ledger is not None:
+        for row in observations:
+            if row.representation == "type_1":
+                ledger.charge_qualified(
+                    "base_formula_evaluations",
+                    QualifiedPage(row.replica, row.checkpoint_id, row.map_page),
+                    discriminator=formula,
+                )
+    for leg in legs:
+        if not leg.before.type0_owned <= decoded[id(leg.after)]:
+            return False
+    for row in observations:
+        if row.representation != "type_1":
+            continue
+        owned = decoded[id(row)]
+        if not row.required_owned <= owned or row.forbidden_owned & owned:
+            return False
+    return transition_signature_fits(formula, observations)
+
+
+def derive_h3(
+    replica: int,
+    observations: Sequence[TraversalObservation],
+    page_counts: Mapping[str, int],
+    ledger: WorkLedger | None = None,
+    measurements: MeasurementRecorder | None = None,
+) -> H3Derivation:
+    """Evaluate H3 derivation predicates through BASE-MULTIPLE in order."""
+    if replica not in (1, 2) or isinstance(replica, bool):
+        raise ValueError("H3 derivation replica must be 1 or 2")
+    rows = tuple(observations)
+    if not rows or any(row.replica != replica for row in rows):
+        raise ValueError("H3 observations must be nonempty and replica-local")
+
+    legs = conversion_legs(rows)
+    conversion_candidates = tuple(
+        candidate for candidate in CONVERSIONS if legs and candidate == _CONVERSION
+    )
+    conversion_count = len(conversion_candidates)
+    measure(measurements, "A4-H3-CONVERSION-NONE", conversion_count, conversion_count == 1, replica=replica)
+    if conversion_count == 0:
+        raise A4AnalysisError("A4-H3-CONVERSION-NONE")
+    conversion = H3Candidate("h3_conversion", {"conversion": _CONVERSION})
+    conversion_model_count = len((conversion,))
+
+    inactive_slot = any(slot.reference == 0 for row in rows for slot in row.slots)
+    measure(measurements, "A4-H3-INACTIVE-SLOT-NONE", conversion_model_count, inactive_slot, replica=replica)
+    if not inactive_slot:
+        raise A4AnalysisError("A4-H3-INACTIVE-SLOT-NONE", 1)
+
+    invalid_reference: tuple[TraversalObservation, SlotObservation] | None = None
+    for row in rows:
+        if row.representation != "type_1":
+            continue
+        try:
+            count = page_counts[row.checkpoint_id]
+        except KeyError as exc:
+            raise ValueError(f"missing H3 page count for {row.checkpoint_id}") from exc
+        invalid = reference_invalid(row, count)
+        if invalid is not None:
+            invalid_reference = (row, invalid)
+            break
+    measure(measurements, "A4-H3-REFERENCE-INVALID", conversion_model_count, invalid_reference is None, replica=replica)
+    if invalid_reference is not None:
+        row, invalid = invalid_reference
+        raise A4AnalysisError(
+            "A4-H3-REFERENCE-INVALID", 1,
+            detail=(f"replica {replica} {row.checkpoint_id} slot "
+                    f"{invalid.slot_ordinal} references {invalid.reference}"),
+        )
+
+    discriminates = input_regions_exercised(rows)
+    measure(measurements, "A4-H3-BASE-DISCRIMINATION", conversion_model_count, discriminates, replica=replica)
+    if not discriminates:
+        raise A4AnalysisError("A4-H3-BASE-DISCRIMINATION", 1)
+
+    survivors = tuple(
+        formula
+        for formula in BASE_FORMULAS
+        if formula_fits(formula, rows, legs, ledger)
+    )
+    measure(measurements, "A4-H3-BASE-NONE", len(survivors), bool(survivors), replica=replica)
+    if not survivors:
+        raise A4AnalysisError("A4-H3-BASE-NONE")
+    measure(measurements, "A4-H3-BASE-MULTIPLE", len(survivors), len(survivors) == 1, replica=replica)
+    if len(survivors) > 1:
+        raise A4AnalysisError("A4-H3-BASE-MULTIPLE", len(survivors))
+    final = H3Candidate(
+        "h3_final_base_formula",
+        {"conversion": _CONVERSION, "base_formula": survivors[0]},
+    )
+    return H3Derivation(replica, conversion, final)
+
+
+def agree_h3(
+    left: H3Derivation, right: H3Derivation,
+    measurements: MeasurementRecorder | None = None,
+) -> H3Candidate:
+    """Apply the replica-agreement predicate to two unique derivations."""
+    if (left.replica, right.replica) != (1, 2):
+        raise ValueError("H3 agreement requires replicas 1 then 2")
+    model_count = len({left.final.canonical_model_id, right.final.canonical_model_id})
+    agrees = model_count == 1
+    measure(measurements, "A4-H3-REPLICA-DISAGREEMENT", model_count, agrees)
+    if not agrees:
+        raise A4AnalysisError("A4-H3-REPLICA-DISAGREEMENT", 2)
+    return left.final
+
+
+def predicts_h3(
+    frozen: H3Candidate,
+    observations: Sequence[TraversalObservation],
+    page_counts: Mapping[str, int],
+) -> bool:
+    """Evaluate the unchanged H3 model on holdout without refitting."""
+    if frozen.model_type != "h3_final_base_formula":
+        raise ValueError("H3 holdout requires a final frozen model")
+    rows = tuple(observations)
+    if not rows or any(row.replica != 3 for row in rows):
+        return False
+    legs = conversion_legs(rows)
+    if not legs or not input_regions_exercised(rows):
+        return False
+    for row in rows:
+        if row.representation == "type_1":
+            count = page_counts.get(row.checkpoint_id)
+            if count is None or reference_invalid(row, count) is not None:
+                return False
+    formula = frozen.model.get("base_formula")
+    return isinstance(formula, str) and formula_fits(formula, rows, legs)

--- a/oracle/windows-dao/scripts/a4_layer_h4.py
+++ b/oracle/windows-dao/scripts/a4_layer_h4.py
@@ -1,0 +1,751 @@
+#!/usr/bin/env python3
+"""Bounded, name-deferred A4 H4 catalog-root and field-model analysis."""
+from __future__ import annotations
+import itertools
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+from a4_model import (A4AnalysisError, QualifiedPage, WorkLedger,
+                      canonical_candidate_id, canonical_model_id, canonical_object_id)
+from a4_layer_h4_fields import (
+    bitmap_hex,
+    bitmap_members,
+    encoded_patterns,
+    encoding_class_matches,
+    expected_operation_name,
+    identifier_assignment,
+    identifier_assignment_exists,
+    kind_mappings,
+    ranges_are_disjoint,
+    value_equivalence_key,
+)
+from a4_measurements import MeasurementRecorder, measure
+from a4_spec import (
+    BOUNDS,
+    CANDIDATE_GRAMMARS,
+    CHECKPOINT_IDS,
+    LIFECYCLE_RANGES,
+    PAGE_SIZE,
+    PLAN,
+    ROLE_BINDINGS,
+    canonical_json_bytes,
+    sha256_hex,
+)
+_GRAMMAR = CANDIDATE_GRAMMARS["h4"]
+OPERATIONS = tuple(_GRAMMAR["operation_binding_order"])
+ROOT_OPERATIONS = ("T1_CREATE_ID", "T2_CREATE", "T2_RECREATE", "T3_CREATE", "T4_CREATE")
+ROOT_SIGNATURE = tuple(_GRAMMAR["catalog_root_selection_signatures"])[0]
+KIND_START_DELTAS = tuple(int(value) for value in _GRAMMAR["kind_start_deltas"])
+KIND_WIDTHS = tuple(int(value) for value in _GRAMMAR["kind_widths"])
+IDENTIFIER_WIDTHS = tuple(int(value) for value in _GRAMMAR["identifier_widths"])
+ENDIANNESS = tuple(_GRAMMAR["endianness"])
+NAME_LENGTH_START_DELTAS = tuple(
+    int(value) for value in _GRAMMAR["name_length_start_deltas"]
+)
+NAME_LENGTH_WIDTHS = tuple(int(value) for value in _GRAMMAR["name_length_widths"])
+IDENTIFIER_LIFECYCLES = tuple(_GRAMMAR["identifier_lifecycle_relations"])
+ENCODING_CLASSES = tuple(
+    entry["id"] for entry in _GRAMMAR["name_length_equivalence_classes"]
+)
+MAX_CANDIDATES = int(BOUNDS["max_candidate_models"])
+RAW_TUPLES_PER_OCCURRENCE = math.prod(map(len, (KIND_START_DELTAS, KIND_WIDTHS, IDENTIFIER_WIDTHS, ENDIANNESS, NAME_LENGTH_START_DELTAS, NAME_LENGTH_WIDTHS))) * 6 * len(IDENTIFIER_LIFECYCLES)
+_OBJECT_KIND = dict.fromkeys(("T1_CREATE_ID", "T2_CREATE", "T2_RECREATE", "T3_CREATE", "T4_CREATE"), "table")
+_OBJECT_KIND.update({"T1_ADD_TEXT": "field", "T1_ADD_INDEX": "index"})
+_TABLE_ROLE = {operation: operation.split("_", 1)[0] for operation in ROOT_OPERATIONS}
+_TABLE_INSTANCE_BY_CREATE = {value.first_checkpoint: key for key, value in LIFECYCLE_RANGES.items()}
+_EXPECTED_SCHEMA = PLAN["tables"]["expected_schema_by_checkpoint"]
+_FEATURE_BY_OPERATION = {"T1_ADD_TEXT": "payload", "T1_ADD_INDEX": "index"}
+def applicable_operation_checkpoints(operation_id: str) -> tuple[str, ...]:
+    """Return the exact plan-derived checkpoints where one record must persist."""
+    if operation_id not in OPERATIONS:
+        raise ValueError(f"unregistered H4 operation {operation_id!r}")
+    instance_id = _TABLE_INSTANCE_BY_CREATE.get(operation_id)
+    if instance_id is not None:
+        lifecycle = LIFECYCLE_RANGES[instance_id]
+        return CHECKPOINT_IDS[lifecycle.first_ordinal : lifecycle.last_ordinal + 1]
+    feature = _FEATURE_BY_OPERATION.get(operation_id)
+    if feature is None:
+        raise ValueError(f"H4 operation {operation_id!r} has no applicability rule")
+    checkpoints = tuple(checkpoint for checkpoint in CHECKPOINT_IDS if any(
+            token.split(":", 1)[0] == "T1"
+            and feature in token.rsplit(":", 1)[-1].split("+")
+            for token in _EXPECTED_SCHEMA[checkpoint]
+        ))
+    if not checkpoints or checkpoints[0] != operation_id:
+        raise ValueError(f"H4 operation {operation_id!r} has inconsistent plan coverage")
+    return checkpoints
+_APPLICABLE_CHECKPOINTS = {operation: applicable_operation_checkpoints(operation) for operation in OPERATIONS}
+def _check_replica(replica: int, *, holdout: bool = False) -> None:
+    allowed = (1, 2, 3) if holdout else (1, 2)
+    if isinstance(replica, bool) or replica not in allowed:
+        raise ValueError(f"H4 replica must be one of {allowed}")
+def _page(value: int, label: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value < int(BOUNDS["max_final_pages_per_replica"])
+    ):
+        raise ValueError(f"{label} is outside the registered page bound")
+    return value
+def _ordered_bindings(bindings: Sequence[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
+    result = tuple(dict(binding) for binding in sorted(bindings, key=lambda item: item["replica"]))
+    replicas = tuple(binding["replica"] for binding in result)
+    if replicas not in ((), (1,), (2,), (1, 2), (3,)):
+        raise ValueError("H4 bindings must be unique and replica ordered")
+    return result
+@dataclass(frozen=True)
+class CatalogRootObservation:
+    """Name-blind system-TDEF traversal for one physical root candidate."""
+    replica: int
+    tdef_page: int
+    locator_offsets: tuple[int, int]
+    tag_at_empty: int
+    traversal_valid_checkpoints: frozenset[str]
+    stream_fingerprint_by_checkpoint: Mapping[str, str]
+    admitted_pages_by_checkpoint: Mapping[str, frozenset[int]]
+    def __post_init__(self) -> None:
+        _check_replica(self.replica, holdout=True)
+        _page(self.tdef_page, "H4 root TDEF page")
+        offsets = tuple(sorted(self.locator_offsets))
+        if (
+            len(offsets) != 2
+            or len(set(offsets)) != 2
+            or any(not 0 <= offset <= PAGE_SIZE - 4 for offset in offsets)
+        ):
+            raise ValueError("H4 root requires two distinct ascending locator offsets")
+        object.__setattr__(self, "locator_offsets", offsets)
+        checkpoints = frozenset(self.traversal_valid_checkpoints)
+        if not checkpoints <= frozenset(CHECKPOINT_IDS):
+            raise ValueError("H4 root contains an unknown traversal checkpoint")
+        object.__setattr__(self, "traversal_valid_checkpoints", checkpoints)
+        if set(self.stream_fingerprint_by_checkpoint) != set(CHECKPOINT_IDS):
+            raise ValueError("H4 root stream fingerprints must cover every checkpoint")
+        if set(self.admitted_pages_by_checkpoint) != set(CHECKPOINT_IDS):
+            raise ValueError("H4 root admitted sets must cover every checkpoint")
+        admitted: dict[str, frozenset[int]] = {}
+        for checkpoint_id in CHECKPOINT_IDS:
+            pages = frozenset(self.admitted_pages_by_checkpoint[checkpoint_id])
+            for page in pages:
+                _page(page, "H4 admitted page")
+            admitted[checkpoint_id] = pages
+        object.__setattr__(self, "admitted_pages_by_checkpoint", admitted)
+@dataclass(frozen=True)
+class H4Candidate:
+    model_type: str
+    model: Mapping[str, Any]
+    instance_bindings: tuple[Mapping[str, Any], ...] = ()
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "instance_bindings", _ordered_bindings(self.instance_bindings))
+    @property
+    def canonical_model_id(self) -> str:
+        return canonical_model_id(self.model_type, self.model)
+    @property
+    def canonical_candidate_id(self) -> str:
+        if self.model_type == "h4_operation_record":
+            return canonical_object_id(
+                {"model_type": self.model_type, "model": dict(self.model)}
+            )
+        return canonical_candidate_id(self.model_type, self.model, self.instance_bindings)
+    def document(self) -> dict[str, Any]:
+        document: dict[str, Any] = {
+            "model_type": self.model_type,
+            "canonical_candidate_id": self.canonical_candidate_id,
+            "model": dict(self.model),
+        }
+        if self.model_type != "h4_operation_record":
+            document["canonical_model_id"] = self.canonical_model_id
+            document["instance_bindings"] = [dict(binding) for binding in self.instance_bindings]
+        return document
+def _changed_at(
+    fingerprints: Mapping[str, str], checkpoint_id: str
+) -> bool:
+    ordinal = CHECKPOINT_IDS.index(checkpoint_id)
+    if ordinal == 0:
+        return False
+    return fingerprints[CHECKPOINT_IDS[ordinal - 1]] != fingerprints[checkpoint_id]
+def derive_catalog_root(
+    replica: int,
+    observations: Sequence[CatalogRootObservation],
+    ledger: WorkLedger | None = None,
+    measurements: MeasurementRecorder | None = None,
+) -> H4Candidate:
+    """Evaluate CATALOG-ROOT-NONE/MULTIPLE without inspecting name bytes."""
+    _check_replica(replica)
+    candidates: list[H4Candidate] = []
+    for observation in observations:
+        if observation.replica != replica:
+            raise ValueError("H4 root observations must be replica-local")
+        if ledger is not None:
+            for checkpoint_id in CHECKPOINT_IDS:
+                ledger.charge_qualified(
+                    "catalog_root_signatures",
+                    QualifiedPage(replica, checkpoint_id, observation.tdef_page),
+                    discriminator=observation.locator_offsets,
+                )
+                if checkpoint_id not in observation.traversal_valid_checkpoints:
+                    break
+        if (
+            observation.tag_at_empty != 0x02
+            or observation.traversal_valid_checkpoints != frozenset(CHECKPOINT_IDS)
+            or not all(
+                _changed_at(observation.stream_fingerprint_by_checkpoint, operation)
+                for operation in ROOT_OPERATIONS
+            )
+        ):
+            continue
+        model = {
+            "root_selection_signature": ROOT_SIGNATURE,
+            "locator_offsets": list(observation.locator_offsets),
+        }
+        candidates.append(
+            H4Candidate(
+                "h4_catalog_root",
+                model,
+                ({"replica": replica, "tdef_page": observation.tdef_page},),
+            )
+        )
+    candidates.sort(key=lambda candidate: candidate.canonical_candidate_id)
+    measure(measurements, "A4-H4-CATALOG-ROOT-NONE", len(candidates), bool(candidates), replica=replica)
+    if not candidates:
+        raise A4AnalysisError("A4-H4-CATALOG-ROOT-NONE")
+    measure(measurements, "A4-H4-CATALOG-ROOT-MULTIPLE", len(candidates), len(candidates) == 1, replica=replica)
+    if len(candidates) > 1:
+        raise A4AnalysisError("A4-H4-CATALOG-ROOT-MULTIPLE", len(candidates))
+    return candidates[0]
+def merge_catalog_roots(left: H4Candidate, right: H4Candidate,
+                        measurements: MeasurementRecorder | None = None) -> H4Candidate:
+    """Bind the same invariant root model to both derivation replicas."""
+    if left.model_type != "h4_catalog_root" or right.model_type != "h4_catalog_root":
+        raise ValueError("H4 root merge requires root candidates")
+    model_count = len({left.canonical_model_id, right.canonical_model_id})
+    if model_count != 1:
+        measure(measurements, "A4-H4-CATALOG-ROOT-MULTIPLE", model_count, False)
+        raise A4AnalysisError("A4-H4-CATALOG-ROOT-MULTIPLE", 2)
+    return H4Candidate(
+        "h4_catalog_root", left.model, left.instance_bindings + right.instance_bindings
+    )
+def validate_isolated_deltas(
+    replica: int,
+    root: CatalogRootObservation,
+    isolated_delta_pages: Mapping[str, frozenset[int]],
+    measurements: MeasurementRecorder | None = None,
+) -> None:
+    """Apply SCHEMA-DELTA-OUTSIDE-OWNED before record restriction."""
+    _check_replica(replica)
+    if root.replica != replica:
+        raise ValueError("H4 delta validation cannot cross replicas")
+    if set(isolated_delta_pages) != set(OPERATIONS):
+        raise ValueError("H4 isolated deltas must cover all seven operations")
+    root_count = len((root,))
+    for operation in OPERATIONS:
+        delta = frozenset(isolated_delta_pages[operation])
+        outside = sorted(delta - root.admitted_pages_by_checkpoint[operation])
+        if outside:
+            measure(measurements, "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED", root_count, False, replica=replica)
+            raise A4AnalysisError(
+                "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED",
+                1,
+                detail=f"replica {replica} {operation} page {outside[0]}",
+            )
+    measure(measurements, "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED", root_count, True, replica=replica)
+@dataclass(frozen=True, order=True)
+class CatalogRecordLocator:
+    page: int
+    row: int
+    row_start: int
+    row_end: int
+    def __post_init__(self) -> None:
+        _page(self.page, "H4 catalog-record page")
+        if isinstance(self.row, bool) or not isinstance(self.row, int) or not 0 <= self.row <= 255:
+            raise ValueError("H4 catalog row ordinal is outside the schema bound")
+        if not 10 <= self.row_start < self.row_end <= PAGE_SIZE:
+            raise ValueError("H4 catalog record is not a complete in-page row")
+    def document(self) -> dict[str, int]:
+        return {
+            "page": self.page,
+            "row": self.row,
+            "row_start": self.row_start,
+            "row_end": self.row_end,
+        }
+@dataclass(frozen=True)
+class CheckpointRecordEvidence:
+    """One complete row and locator at one applicable checkpoint."""
+    checkpoint_id: str
+    locator: CatalogRecordLocator
+    row_bytes: bytes
+    def __post_init__(self) -> None:
+        if self.checkpoint_id not in CHECKPOINT_IDS:
+            raise ValueError(f"unknown H4 checkpoint {self.checkpoint_id!r}")
+        if not isinstance(self.row_bytes, bytes) or not self.row_bytes:
+            raise ValueError("H4 checkpoint evidence must carry nonempty row bytes")
+        if len(self.row_bytes) != self.locator.row_end - self.locator.row_start:
+            raise ValueError("H4 checkpoint row length does not match its locator")
+        if len(self.row_bytes) > PAGE_SIZE - 12:
+            raise ValueError("H4 checkpoint row exceeds the complete-row bound")
+@dataclass(frozen=True)
+class OperationRecord:
+    """One name-blind record tracked across every applicable checkpoint."""
+    replica: int
+    operation_id: str
+    checkpoint_evidence: tuple[CheckpointRecordEvidence, ...]
+    def __post_init__(self) -> None:
+        _check_replica(self.replica, holdout=True)
+        if self.operation_id not in OPERATIONS:
+            raise ValueError(f"unregistered H4 operation {self.operation_id!r}")
+        if any(not isinstance(row, CheckpointRecordEvidence) for row in self.checkpoint_evidence):
+            raise ValueError("H4 checkpoint evidence has an invalid entry")
+        expected = _APPLICABLE_CHECKPOINTS[self.operation_id]
+        actual = tuple(row.checkpoint_id for row in self.checkpoint_evidence)
+        if actual != expected:
+            raise ValueError("H4 checkpoint evidence must cover every applicable checkpoint exactly once in plan order")
+    @classmethod
+    def from_checkpoint_rows(cls, replica: int, operation_id: str,
+                             rows: Mapping[str, tuple[CatalogRecordLocator, bytes]]) -> OperationRecord:
+        """Build checked evidence from a checkpoint-keyed orchestration mapping."""
+        expected = applicable_operation_checkpoints(operation_id)
+        if set(rows) != set(expected):
+            raise ValueError("H4 checkpoint rows must contain the exact applicable checkpoint set")
+        evidence = tuple(CheckpointRecordEvidence(checkpoint, *rows[checkpoint]) for checkpoint in expected)
+        return cls(replica, operation_id, evidence)
+    @property
+    def locator(self) -> CatalogRecordLocator:
+        return self.checkpoint_evidence[0].locator
+    @property
+    def row_bytes(self) -> bytes:
+        return self.checkpoint_evidence[0].row_bytes
+def select_operation_records(
+    replica: int,
+    root_candidate: H4Candidate,
+    candidates: Sequence[OperationRecord],
+    ledger: WorkLedger | None = None,
+    measurements: MeasurementRecorder | None = None,
+) -> tuple[OperationRecord, ...]:
+    """Apply grouped NONE then MULTIPLE, still without a name anchor."""
+    _check_replica(replica)
+    if root_candidate.model_type != "h4_catalog_root":
+        raise ValueError("H4 operation records require a root candidate")
+    if len(candidates) > MAX_CANDIDATES:
+        raise A4AnalysisError("A4-RESOURCE-BOUND", detail="constructed H4 operation-record candidate 4097")
+    grouped = {operation: [] for operation in OPERATIONS}
+    for candidate in candidates:
+        if candidate.replica != replica:
+            raise ValueError("H4 operation-record candidates must be replica-local")
+        grouped[candidate.operation_id].append(candidate)
+    counts = tuple(len(grouped[operation]) for operation in OPERATIONS)
+    measure(measurements, "A4-H4-CATALOG-RECORD-NONE", min(counts), min(counts) >= 1, replica=replica)
+    missing = [operation for operation in OPERATIONS if not grouped[operation]]
+    if missing:
+        raise A4AnalysisError(
+            "A4-H4-CATALOG-RECORD-NONE",
+            0,
+            detail=f"missing {missing[0]}",
+        )
+    measure(measurements, "A4-H4-CATALOG-RECORD-MULTIPLE", max(counts), max(counts) <= 1, replica=replica)
+    multiple = [operation for operation in OPERATIONS if len(grouped[operation]) > 1]
+    if multiple:
+        raise A4AnalysisError(
+            "A4-H4-CATALOG-RECORD-MULTIPLE",
+            max(len(grouped[operation]) for operation in multiple),
+            detail=f"multiple {multiple[0]}",
+        )
+    return tuple(grouped[operation][0] for operation in OPERATIONS)
+def operation_candidate(root: H4Candidate, record: OperationRecord) -> H4Candidate:
+    """Serialize one physical, replica-qualified operation record."""
+    model = {
+        "replica": record.replica,
+        "root_candidate_id": root.canonical_candidate_id,
+        "operation_id": record.operation_id,
+        "canonical_record_locator": record.locator.document(),
+    }
+    return H4Candidate("h4_operation_record", model)
+@dataclass(frozen=True, order=True)
+class NameOccurrence:
+    index: int
+    start: int
+    encoded_hex: str
+    encoding_ids: tuple[str, ...]
+@dataclass(frozen=True)
+class OperationEvidence:
+    record: OperationRecord
+    expected_name: str
+    occurrences: tuple[NameOccurrence, ...]
+def scan_name_occurrences(
+    record: OperationRecord, ledger: WorkLedger | None = None
+) -> OperationEvidence:
+    """Perform the deferred encoding-neutral union scan for one record."""
+    name = expected_operation_name(
+        record.replica, record.operation_id, ROLE_BINDINGS, _TABLE_ROLE
+    )
+    occurrences: list[NameOccurrence] = []
+    for pattern, encoding_ids in encoded_patterns(name):
+        if ledger is not None:
+            ledger.charge("encoding_union_anchor_bytes", len(record.row_bytes))
+        start = 0
+        while True:
+            at = record.row_bytes.find(pattern, start)
+            if at < 0:
+                break
+            occurrences.append(NameOccurrence(0, at, pattern.hex(), encoding_ids))
+            start = at + len(pattern)
+    unique = sorted(
+        {(row.start, row.encoded_hex, row.encoding_ids) for row in occurrences},
+        key=lambda row: (row[0], row[1], row[2]),
+    )
+    maximum = 290 if record.operation_id in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254
+    if len(unique) > maximum:
+        raise A4AnalysisError("A4-RESOURCE-BOUND", detail="H4 occurrence identity bound exceeded")
+    indexed = tuple(
+        NameOccurrence(index, at, encoded_hex, encoding_ids)
+        for index, (at, encoded_hex, encoding_ids) in enumerate(unique)
+    )
+    return OperationEvidence(record, name, indexed)
+@dataclass(frozen=True)
+class _DecodedOccurrence:
+    occurrence: NameOccurrence
+    kind: int
+    identifier: int
+    stored_length: int
+def _decode_row_shape(
+    row: bytes,
+    expected_name: str,
+    occurrence: NameOccurrence,
+    shape: tuple[int, int, int, str, int, int],
+) -> tuple[int, int, int] | None:
+    kind_delta, kind_width, identifier_width, endian, length_delta, length_width = shape
+    name_start = occurrence.start
+    name_end = name_start + len(bytes.fromhex(occurrence.encoded_hex))
+    kind_start = name_start - kind_delta
+    identifier_start = kind_start - identifier_width
+    length_start = name_start - length_delta
+    ranges = ((identifier_start, kind_start), (kind_start, kind_start + kind_width),
+              (length_start, length_start + length_width), (name_start, name_end))
+    if any(start < 0 or end > len(row) for start, end in ranges):
+        return None
+    if not ranges_are_disjoint(ranges):
+        return None
+    kind = int.from_bytes(row[kind_start : kind_start + kind_width], endian)
+    identifier = int.from_bytes(row[identifier_start:kind_start], endian)
+    stored_length = int.from_bytes(row[length_start : length_start + length_width], endian)
+    plausible = {len(expected_name.encode(encoding, errors="strict")) for encoding in ("cp1252", "utf-8")}
+    plausible.add(len(expected_name))
+    if stored_length not in plausible:
+        return None
+    return kind, identifier, stored_length
+def _matching_checkpoint_values(
+    row: bytes,
+    expected_name: str,
+    shape: tuple[int, int, int, str, int, int],
+) -> frozenset[tuple[int, int, int]]:
+    values: set[tuple[int, int, int]] = set()
+    for pattern, encoding_ids in encoded_patterns(expected_name):
+        start = 0
+        while True:
+            at = row.find(pattern, start)
+            if at < 0:
+                break
+            decoded = _decode_row_shape(row, expected_name, NameOccurrence(0, at, pattern.hex(), encoding_ids), shape)
+            if decoded is not None:
+                values.add(decoded)
+            start = at + len(pattern)
+    return frozenset(values)
+def _decode_shape(
+    evidence: OperationEvidence,
+    occurrence: NameOccurrence,
+    shape: tuple[int, int, int, str, int, int],
+) -> _DecodedOccurrence | None:
+    decoded = _decode_row_shape(evidence.record.row_bytes, evidence.expected_name, occurrence, shape)
+    if decoded is None:
+        return None
+    for checkpoint in evidence.record.checkpoint_evidence[1:]:
+        if decoded not in _matching_checkpoint_values(checkpoint.row_bytes, evidence.expected_name, shape):
+            return None
+    kind, identifier, stored_length = decoded
+    return _DecodedOccurrence(occurrence, kind, identifier, stored_length)
+@dataclass(frozen=True)
+class StructuralDerivation:
+    replica: int
+    evidence_sha256: str
+    evidence: tuple[OperationEvidence, ...]
+    candidates: tuple[H4Candidate, ...]
+def _evidence_hash(evidence: Sequence[OperationEvidence]) -> str:
+    document = {
+        "replica": evidence[0].record.replica,
+        "operations": [
+            {
+                "operation_id": group.record.operation_id,
+                "locator": group.record.locator.document(),
+                "occurrences": [
+                    {
+                        "occurrence_index": occurrence.index,
+                        "start": occurrence.start,
+                        "encoded_hex": occurrence.encoded_hex,
+                        "encoding_ids": list(occurrence.encoding_ids),
+                    }
+                    for occurrence in group.occurrences
+                ],
+            }
+            for group in evidence
+        ],
+    }
+    return sha256_hex(canonical_json_bytes(document))
+def derive_structural_fields(
+    replica: int,
+    records: Sequence[OperationRecord],
+    ledger: WorkLedger | None = None,
+    measurements: MeasurementRecorder | None = None,
+    scanned_evidence: Sequence[OperationEvidence] | None = None,
+) -> StructuralDerivation:
+    _check_replica(replica)
+    if tuple(record.operation_id for record in records) != OPERATIONS:
+        raise ValueError("H4 records must be in registered operation order")
+    evidence = (tuple(scanned_evidence) if scanned_evidence is not None else
+                tuple(scan_name_occurrences(record, ledger) for record in records))
+    occurrence_count = sum(len(group.occurrences) for group in evidence)
+    if occurrence_count > int(BOUNDS["max_h4_occurrence_identities"]) // 2:
+        raise A4AnalysisError("A4-RESOURCE-BOUND", detail="H4 replica occurrence bound exceeded")
+    if ledger is not None:
+        ledger.charge(
+            "h4_name_length_structural_tuples",
+            occurrence_count * RAW_TUPLES_PER_OCCURRENCE,
+        )
+    digest = _evidence_hash(evidence)
+    equivalent: dict[
+        tuple[Any, ...], tuple[dict[str, Any], dict[str, tuple[int, ...]], int]
+    ] = {}
+    shapes = itertools.product(
+        KIND_START_DELTAS,
+        KIND_WIDTHS,
+        IDENTIFIER_WIDTHS,
+        ENDIANNESS,
+        NAME_LENGTH_START_DELTAS,
+        NAME_LENGTH_WIDTHS,
+    )
+    for shape in shapes:
+        decoded: dict[str, tuple[_DecodedOccurrence, ...]] = {}
+        for group in evidence:
+            rows = tuple(
+                result
+                for occurrence in group.occurrences
+                if (result := _decode_shape(group, occurrence, shape)) is not None
+            )
+            if not rows:
+                break
+            decoded[group.record.operation_id] = rows
+        if len(decoded) != len(OPERATIONS):
+            continue
+        mappings = kind_mappings(
+            frozenset(row.kind for rows in decoded.values() for row in rows)
+        )
+        for mapping in mappings:
+            kind_filtered = {
+                operation: tuple(
+                    row for row in decoded[operation] if row.kind == mapping[_OBJECT_KIND[operation]]
+                )
+                for operation in OPERATIONS
+            }
+            if not all(kind_filtered.values()):
+                continue
+            options = {
+                operation: frozenset(row.identifier for row in kind_filtered[operation])
+                for operation in OPERATIONS
+            }
+            for lifecycle in IDENTIFIER_LIFECYCLES:
+                if not identifier_assignment_exists(OPERATIONS, options, lifecycle):
+                    continue
+                compatible: dict[str, tuple[int, ...]] = {}
+                for operation in OPERATIONS:
+                    indexes = tuple(
+                        row.occurrence.index
+                        for row in kind_filtered[operation]
+                        if identifier_assignment_exists(
+                            OPERATIONS, options, lifecycle, (operation, row.identifier)
+                        )
+                    )
+                    if not indexes:
+                        break
+                    compatible[operation] = tuple(sorted(set(indexes)))
+                if len(compatible) != len(OPERATIONS):
+                    continue
+                model = {
+                    "kind_start_delta": shape[0],
+                    "kind_width": shape[1],
+                    "identifier_width": shape[2],
+                    "endianness": shape[3],
+                    "name_length_start_delta": shape[4],
+                    "name_length_width": shape[5],
+                    "kind_mapping": mapping,
+                    "identifier_lifecycle": lifecycle,
+                }
+                key = value_equivalence_key(
+                    OPERATIONS, kind_filtered, compatible, mapping, lifecycle
+                )
+                if key in equivalent:
+                    first_model, first_compatible, count = equivalent[key]
+                    equivalent[key] = (first_model, first_compatible, count + 1)
+                else:
+                    equivalent[key] = (model, compatible, 1)
+                if len(equivalent) > MAX_CANDIDATES:
+                    raise A4AnalysisError(
+                        "A4-RESOURCE-BOUND", detail="constructed H4 candidate 4097"
+                    )
+    candidates: list[H4Candidate] = []
+    for model, compatible, count in equivalent.values():
+        binding = {
+            "replica": replica,
+            "occurrence_evidence_sha256": digest,
+            "value_equivalent_tuple_count": count,
+            "compatible_occurrences_by_operation": [
+                {
+                    "operation_id": operation,
+                    "compatible_occurrence_count": len(compatible[operation]),
+                    "compatible_occurrence_bitmap_hex": bitmap_hex(
+                        compatible[operation],
+                        290 if operation in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254,
+                    ),
+                }
+                for operation in OPERATIONS
+            ],
+        }
+        candidates.append(H4Candidate("h4_structural_field", model, (binding,)))
+    ordered = tuple(sorted(candidates, key=lambda row: row.canonical_candidate_id))
+    measure(measurements, "A4-H4-FIELD-MODEL-NONE", len(ordered), bool(ordered), replica=replica)
+    if not ordered:
+        error = A4AnalysisError("A4-H4-FIELD-MODEL-NONE")
+        error.candidates = ()
+        raise error
+    measure(measurements, "A4-H4-FIELD-MODEL-MULTIPLE", len(ordered), len(ordered) == 1, replica=replica)
+    if len(ordered) > 1:
+        error = A4AnalysisError("A4-H4-FIELD-MODEL-MULTIPLE", len(ordered))
+        error.candidates = tuple(candidate.document() for candidate in ordered)
+        raise error
+    return StructuralDerivation(replica, digest, evidence, ordered)
+def _decode_for_model(
+    evidence: OperationEvidence, occurrence: NameOccurrence, model: Mapping[str, Any]
+) -> _DecodedOccurrence | None:
+    shape = (
+        model["kind_start_delta"],
+        model["kind_width"],
+        model["identifier_width"],
+        model["endianness"],
+        model["name_length_start_delta"],
+        model["name_length_width"],
+    )
+    return _decode_shape(evidence, occurrence, shape)
+@dataclass(frozen=True)
+class EncodedDerivation:
+    structural: H4Candidate
+    final: H4Candidate
+def derive_encoding(
+    structural: StructuralDerivation, ledger: WorkLedger | None = None,
+    measurements: MeasurementRecorder | None = None,
+) -> EncodedDerivation:
+    """Evaluate the three equivalence classes after structural uniqueness."""
+    candidate = structural.candidates[0]
+    binding = candidate.instance_bindings[0]
+    bitmap_rows = {
+        row["operation_id"]: bitmap_members(row["compatible_occurrence_bitmap_hex"])
+        for row in binding["compatible_occurrences_by_operation"]
+    }
+    finals: list[H4Candidate] = []
+    for class_id in ENCODING_CLASSES:
+        matching_by_operation: dict[str, tuple[_DecodedOccurrence, ...]] = {}
+        fits = True
+        for evidence in structural.evidence:
+            if ledger is not None:
+                ledger.charge_once(
+                    "encoding_length_equivalence_candidates",
+                    (structural.replica, evidence.record.operation_id, class_id),
+                )
+            matching: list[_DecodedOccurrence] = []
+            for occurrence in evidence.occurrences:
+                if occurrence.index not in bitmap_rows[evidence.record.operation_id]:
+                    continue
+                decoded = _decode_for_model(evidence, occurrence, candidate.model)
+                if decoded is not None and encoding_class_matches(
+                    class_id,
+                    evidence.expected_name,
+                    bytes.fromhex(occurrence.encoded_hex),
+                    decoded.stored_length,
+                ):
+                    matching.append(decoded)
+            if not matching:
+                fits = False
+                break
+            matching_by_operation[evidence.record.operation_id] = tuple(matching)
+        if not fits:
+            continue
+        assignment = identifier_assignment(
+            OPERATIONS,
+            {
+                operation: frozenset(
+                    row.identifier for row in matching_by_operation[operation]
+                )
+                for operation in OPERATIONS
+            },
+            str(candidate.model["identifier_lifecycle"]),
+        )
+        if assignment is None:
+            continue
+        selected: list[dict[str, int | str]] = [
+            {
+                "operation_id": operation,
+                "occurrence_index": min(
+                    row.occurrence.index
+                    for row in matching_by_operation[operation]
+                    if row.identifier == assignment[operation]
+                ),
+            }
+            for operation in OPERATIONS
+        ]
+        model = {
+            "structural_model_id": candidate.canonical_model_id,
+            "encoding_length_equivalence_class": class_id,
+        }
+        final_binding = {
+            "replica": structural.replica,
+            "structural_candidate_id": candidate.canonical_candidate_id,
+            "selected_operation_occurrences": selected,
+        }
+        finals.append(H4Candidate("h4_final_encoded_field", model, (final_binding,)))
+    measure(measurements, "A4-H4-ENCODING-AMBIGUOUS", len(finals), len(finals) == 1, replica=structural.replica)
+    if len(finals) != 1:
+        raise A4AnalysisError("A4-H4-ENCODING-AMBIGUOUS", len(finals))
+    return EncodedDerivation(candidate, finals[0])
+def merge_encoded_derivations(
+    left: EncodedDerivation, right: EncodedDerivation,
+    measurements: MeasurementRecorder | None = None,
+) -> EncodedDerivation:
+    """Apply H4 replica agreement and bind both physical instances."""
+    left_replica = left.structural.instance_bindings[0]["replica"]
+    right_replica = right.structural.instance_bindings[0]["replica"]
+    if (left_replica, right_replica) != (1, 2):
+        raise ValueError("H4 agreement requires replicas 1 then 2")
+    model_count = len({
+        (left.structural.canonical_model_id, left.final.canonical_model_id),
+        (right.structural.canonical_model_id, right.final.canonical_model_id),
+    })
+    disagrees = model_count != 1
+    measure(measurements, "A4-H4-REPLICA-DISAGREEMENT", model_count, not disagrees)
+    if disagrees:
+        raise A4AnalysisError("A4-H4-REPLICA-DISAGREEMENT", 2)
+    structural = H4Candidate(
+        "h4_structural_field",
+        left.structural.model,
+        left.structural.instance_bindings + right.structural.instance_bindings,
+    )
+    # Final bindings must link to the merged structural candidate, not either
+    # per-replica candidate id.
+    final_bindings = tuple(
+        {
+            **dict(binding),
+            "structural_candidate_id": structural.canonical_candidate_id,
+        }
+        for binding in left.final.instance_bindings + right.final.instance_bindings
+    )
+    final = H4Candidate("h4_final_encoded_field", left.final.model, final_bindings)
+    return EncodedDerivation(structural, final)
+def evidence_document_sha256(evidence: Sequence[OperationEvidence]) -> str:
+    """Expose the canonical occurrence-table hash for orchestration/tests."""
+    if not evidence:
+        raise ValueError("H4 occurrence evidence cannot be empty")
+    return _evidence_hash(evidence)

--- a/oracle/windows-dao/scripts/a4_layer_h4_fields.py
+++ b/oracle/windows-dao/scripts/a4_layer_h4_fields.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Small bounded combinatorics helpers for the A4 H4 field layer."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Mapping, Sequence
+
+from a4_spec import CHECKPOINT_ORDINALS, LIFECYCLE_RANGES
+
+
+_OPERATION_LIFECYCLE = {
+    "T1_CREATE_ID": "T1-v1",
+    "T1_ADD_TEXT": "T1-v1",
+    "T1_ADD_INDEX": "T1-v1",
+    "T2_CREATE": "T2-v1",
+    "T2_RECREATE": "T2-v2",
+    "T3_CREATE": "T3-v1",
+    "T4_CREATE": "T4-v1",
+}
+
+
+def _simultaneously_extant(left: str, right: str) -> bool:
+    left_range = LIFECYCLE_RANGES[_OPERATION_LIFECYCLE[left]]
+    right_range = LIFECYCLE_RANGES[_OPERATION_LIFECYCLE[right]]
+    left_start = CHECKPOINT_ORDINALS[left]
+    right_start = CHECKPOINT_ORDINALS[right]
+    return max(left_start, right_start) <= min(
+        left_range.last_ordinal, right_range.last_ordinal
+    )
+
+
+def encoded_patterns(name: str) -> tuple[tuple[bytes, tuple[str, ...]], ...]:
+    """Return byte-unique CP1252/UTF-8 patterns without preference."""
+    by_bytes: dict[bytes, list[str]] = {}
+    for encoding_id, encoding in (
+        ("strict_windows_1252", "cp1252"),
+        ("utf_8", "utf-8"),
+    ):
+        by_bytes.setdefault(name.encode(encoding, errors="strict"), []).append(encoding_id)
+    return tuple(
+        (payload, tuple(encodings))
+        for payload, encodings in sorted(by_bytes.items(), key=lambda item: item[0])
+    )
+
+
+def expected_operation_name(
+    replica: int,
+    operation_id: str,
+    role_bindings: Mapping[int, Mapping[str, str]],
+    table_roles: Mapping[str, str],
+) -> str:
+    if operation_id == "T1_ADD_TEXT":
+        return "Payload"
+    if operation_id == "T1_ADD_INDEX":
+        return "A4IX_ID"
+    return str(role_bindings[replica][table_roles[operation_id]])
+
+
+def ranges_are_disjoint(ranges: Sequence[tuple[int, int]]) -> bool:
+    return all(
+        max(left[0], right[0]) >= min(left[1], right[1])
+        for left, right in itertools.combinations(ranges, 2)
+    )
+
+
+def kind_mappings(values: frozenset[int]) -> tuple[dict[str, int], ...]:
+    """Enumerate the six explicit mappings only for exactly three raw kinds."""
+    if len(values) != 3:
+        return ()
+    return tuple(
+        {"table": table, "field": field, "index": index}
+        for table, field, index in itertools.permutations(sorted(values))
+    )
+
+
+def encoding_class_matches(
+    class_id: str, name: str, payload: bytes, stored_length: int
+) -> bool:
+    """Match one registered encoding/length equivalence class exactly."""
+    cp = name.encode("cp1252", errors="strict")
+    utf8 = name.encode("utf-8", errors="strict")
+    if class_id == "cp1252_single_byte_per_scalar":
+        return payload == cp and stored_length == len(cp) == len(name)
+    if class_id == "utf8_encoded_byte_count":
+        return payload == utf8 and stored_length == len(utf8)
+    if class_id == "utf8_unicode_scalar_or_code_unit_count":
+        return payload == utf8 and stored_length == len(name)
+    raise ValueError(f"unregistered H4 encoding class {class_id!r}")
+
+
+def identifier_assignment(
+    operations: Sequence[str],
+    options: Mapping[str, frozenset[int]],
+    lifecycle: str,
+    forced: tuple[str, int] | None = None,
+) -> dict[str, int] | None:
+    """Return one canonical assignment satisfying the lifecycle relation."""
+    choices = {operation: set(options[operation]) for operation in operations}
+    if forced is not None:
+        operation, value = forced
+        choices[operation] &= {value}
+    equal_t2 = lifecycle == "stable_for_same_physical_name_including_t2_v1_v2"
+    if equal_t2:
+        common = choices["T2_CREATE"] & choices["T2_RECREATE"]
+        choices["T2_CREATE"] = set(common)
+        choices["T2_RECREATE"] = set(common)
+    order = sorted(operations, key=lambda operation: len(choices[operation]))
+
+    def visit(index: int, assigned: dict[str, int]) -> bool:
+        if index == len(order):
+            return True
+        operation = order[index]
+        for value in sorted(choices[operation]):
+            if operation in ("T2_CREATE", "T2_RECREATE"):
+                other = "T2_RECREATE" if operation == "T2_CREATE" else "T2_CREATE"
+                if other in assigned:
+                    same = assigned[other] == value
+                    if same != equal_t2:
+                        continue
+            if any(
+                existing == value
+                and not (
+                    equal_t2
+                    and {operation, other_operation}
+                    == {"T2_CREATE", "T2_RECREATE"}
+                )
+                and _simultaneously_extant(operation, other_operation)
+                for other_operation, existing in assigned.items()
+            ):
+                continue
+            assigned[operation] = value
+            if visit(index + 1, assigned):
+                return True
+            del assigned[operation]
+        return False
+
+    if not all(choices.values()):
+        return None
+    assigned: dict[str, int] = {}
+    return assigned if visit(0, assigned) else None
+
+
+def identifier_assignment_exists(
+    operations: Sequence[str],
+    options: Mapping[str, frozenset[int]],
+    lifecycle: str,
+    forced: tuple[str, int] | None = None,
+) -> bool:
+    """Return whether the seven object groups admit the lifecycle relation."""
+    return identifier_assignment(operations, options, lifecycle, forced) is not None
+
+
+def bitmap_hex(indexes: Sequence[int], maximum: int) -> str:
+    """Encode an LSB-first fixed-width occurrence-membership bitmap."""
+    raw = bytearray((maximum + 7) // 8)
+    for index in indexes:
+        if not 0 <= index < maximum:
+            raise ValueError("H4 occurrence index is outside its operation bitmap")
+        raw[index // 8] |= 1 << (index % 8)
+    return bytes(raw).hex()
+
+
+def bitmap_members(bitmap_hex_value: str) -> frozenset[int]:
+    """Decode a fixed-width LSB-first occurrence-membership bitmap."""
+    raw = bytes.fromhex(bitmap_hex_value)
+    return frozenset(
+        index
+        for index in range(len(raw) * 8)
+        if raw[index // 8] & (1 << (index % 8))
+    )
+
+
+def value_equivalence_key(
+    operations: Sequence[str],
+    rows: Mapping[str, Sequence[Any]],
+    compatible: Mapping[str, Sequence[int]],
+    mapping: Mapping[str, int],
+    lifecycle: str,
+) -> tuple[Any, ...]:
+    """Canonical byte-derived values used by tuple-equivalence deduplication."""
+    values = tuple(
+        (
+            operation,
+            tuple(
+                (row.occurrence.index, row.kind, row.identifier, row.stored_length)
+                for row in rows[operation]
+                if row.occurrence.index in compatible[operation]
+            ),
+        )
+        for operation in operations
+    )
+    return values, tuple(sorted(mapping.items())), lifecycle

--- a/oracle/windows-dao/scripts/a4_layer_h4_holdout.py
+++ b/oracle/windows-dao/scripts/a4_layer_h4_holdout.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unchanged-model H4 root and field prediction for replica 3."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from a4_layer_h4 import (
+    OPERATIONS,
+    ROOT_OPERATIONS,
+    ROOT_SIGNATURE,
+    CatalogRootObservation,
+    H4Candidate,
+    OperationRecord,
+    _changed_at,
+    _decode_for_model,
+    _OBJECT_KIND,
+    scan_name_occurrences,
+)
+from a4_layer_h4_fields import encoding_class_matches, identifier_assignment_exists
+from a4_model import canonical_model_id
+from a4_spec import CHECKPOINT_IDS
+
+
+def predicts_root(frozen: H4Candidate, observation: CatalogRootObservation) -> bool:
+    """Check one unchanged H4 root model on holdout."""
+    if frozen.model_type != "h4_catalog_root" or observation.replica != 3:
+        return False
+    model = {
+        "root_selection_signature": ROOT_SIGNATURE,
+        "locator_offsets": list(observation.locator_offsets),
+    }
+    return (
+        observation.tag_at_empty == 0x02
+        and observation.traversal_valid_checkpoints == frozenset(CHECKPOINT_IDS)
+        and all(
+            _changed_at(observation.stream_fingerprint_by_checkpoint, operation)
+            for operation in ROOT_OPERATIONS
+        )
+        and canonical_model_id("h4_catalog_root", model)
+        == frozen.canonical_model_id
+    )
+
+
+def predicts_fields(
+    frozen_structural: H4Candidate,
+    frozen_final: H4Candidate,
+    records: Sequence[OperationRecord],
+) -> bool:
+    """Select one holdout occurrence set satisfying both frozen field stages."""
+    if (
+        frozen_structural.model_type != "h4_structural_field"
+        or frozen_final.model_type != "h4_final_encoded_field"
+        or tuple(record.operation_id for record in records) != OPERATIONS
+        or any(record.replica != 3 for record in records)
+        or frozen_final.model.get("structural_model_id")
+        != frozen_structural.canonical_model_id
+    ):
+        return False
+    try:
+        evidence = tuple(scan_name_occurrences(record) for record in records)
+        mapping = frozen_structural.model["kind_mapping"]
+        class_id = frozen_final.model["encoding_length_equivalence_class"]
+        compatible = {}
+        for group in evidence:
+            rows = tuple(
+                decoded
+                for occurrence in group.occurrences
+                if (
+                    decoded := _decode_for_model(
+                        group, occurrence, frozen_structural.model
+                    )
+                )
+                is not None
+                and decoded.kind == mapping[_OBJECT_KIND[group.record.operation_id]]
+                and encoding_class_matches(
+                    class_id,
+                    group.expected_name,
+                    bytes.fromhex(decoded.occurrence.encoded_hex),
+                    decoded.stored_length,
+                )
+            )
+            if not rows:
+                return False
+            compatible[group.record.operation_id] = rows
+        options = {
+            operation: frozenset(row.identifier for row in compatible[operation])
+            for operation in OPERATIONS
+        }
+        return identifier_assignment_exists(
+            OPERATIONS,
+            options,
+            frozen_structural.model["identifier_lifecycle"],
+        )
+    except (KeyError, TypeError, ValueError, UnicodeError):
+        return False

--- a/oracle/windows-dao/scripts/a4_layers.py
+++ b/oracle/windows-dao/scripts/a4_layers.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""Dependency-ordered orchestration for the four A4 analyzer layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Mapping, Sequence
+
+from a4_analysis_input import CheckedAnalysisInput
+from a4_catalog_inventory import operation_records, row_bounds
+from a4_catalog_root import catalog_root_observations
+import a4_layer_h4 as h4_primitive
+from a4_derivation import (
+    caught_terminal,
+    empty_layer_results,
+    encoding_candidates,
+    h3_terminal_payload,
+    isolated_operation_deltas,
+    occurrence_evidence_document,
+    operation_groups,
+    outside_evidence,
+    rebind_evidence,
+    replica_pair,
+    root_candidates as reconstruct_root_candidates,
+)
+from a4_layer_decoding import decode_locator, set_bits, type0_owned
+from a4_layer_h1 import H1ReplicaCandidate, agree_h1_replicas, derive_h1_replica
+from a4_layer_h2 import (
+    H2ReplicaCandidate,
+    _transitions_fit as h2_transitions_fit,
+    agree_h2_replicas,
+    decode_frozen_owned_rows,
+    derive_h2_replica,
+)
+from a4_layer_h2_types import FrozenOwnedRow, MapRow
+from a4_layer_h3 import (
+    BITMAP_BITS,
+    H3Candidate,
+    H3Derivation,
+    MAX_ADMITTED_PAGES,
+    SlotObservation,
+    TraversalObservation,
+    agree_h3,
+    derive_h3,
+)
+from a4_layer_h4 import (
+    OPERATIONS,
+    CatalogRootObservation,
+    EncodedDerivation,
+    H4Candidate,
+    OperationRecord,
+    StructuralDerivation,
+    derive_catalog_root,
+    derive_encoding,
+    derive_structural_fields,
+    merge_catalog_roots,
+    merge_encoded_derivations,
+    select_operation_records,
+    validate_isolated_deltas,
+)
+from a4_measurements import MeasurementRecorder, PredicateMeasurement
+from a4_model import A4AnalysisError, QualifiedPage, View, WorkLedger
+from a4_predicate_major import evaluate_replica_predicates
+from a4_terminal import DerivationTerminal, decisive_result
+from a4_spec import (
+    BOUNDS,
+    CHECKPOINT_IDS,
+    CHECKPOINT_ORDINALS,
+    LAYER_PREDICATE_IDS,
+    PAGE_SIZE,
+    ROLE_BINDINGS,
+    canonical_json_bytes,
+    sha256_hex,
+)
+
+
+@dataclass(frozen=True)
+class DerivationLayers:
+    h1_by_replica: Mapping[int, H1ReplicaCandidate]
+    h1: H1ReplicaCandidate
+    h2_by_replica: Mapping[int, H2ReplicaCandidate]
+    h2: H2ReplicaCandidate
+    h3_observations: Mapping[int, tuple[TraversalObservation, ...]]
+    h3_by_replica: Mapping[int, H3Derivation]
+    h3: H3Candidate
+    h4_root_observations: Mapping[int, CatalogRootObservation]
+    h4_root: H4Candidate
+    h4_records: Mapping[int, tuple[OperationRecord, ...]]
+    h4_by_replica: Mapping[int, EncodedDerivation]
+    h4: EncodedDerivation
+    h4_occurrence_evidence: Mapping[str, object]
+    measurements: tuple[PredicateMeasurement, ...]
+
+
+def h3_observations(
+    view: View,
+    rows: Sequence[FrozenOwnedRow],
+    ledger: WorkLedger,
+) -> tuple[TraversalObservation, ...]:
+    """Read only frozen-H2 references and create formula-neutral H3 inputs."""
+    most_recent_span: dict[tuple[str, str], tuple[int, int]] = {}
+    output: list[TraversalObservation] = []
+    reference_payloads: dict[tuple[str, int], bytes] = {}
+    referenced_pages: dict[str, set[int]] = {}
+    invalid_reference_seen = False
+    for row in rows:
+        if row.replica != view.replica:
+            raise ValueError("H3 adapter cannot cross replicas")
+        identity = (row.lifecycle_instance, row.allocation_role)
+        if row.representation == "type_0":
+            owned = frozenset(row.owned_pages or ())
+            if row.type_0_span is not None:
+                most_recent_span[identity] = row.type_0_span
+            output.append(TraversalObservation(
+                row.replica,
+                row.checkpoint_id,
+                row.map_page,
+                "type_0",
+                row.lifecycle_instance,
+                allocation_role=row.allocation_role,
+                type0_owned=owned,
+                locator_ordinal=row.map_row,
+                allocation_span=row.type_0_span,
+            ))
+            continue
+        references = row.type_1_references
+        if references is None:
+            raise A4AnalysisError(
+                "A4-SNAPSHOT-RECONSTRUCTION",
+                detail="frozen H2 type-1 row lacks complete references",
+            )
+        slots: list[SlotObservation] = []
+        for ordinal, reference in enumerate(references):
+            if reference == 0:
+                slots.append(SlotObservation(ordinal, 0, None))
+                continue
+            checkpoint_references = referenced_pages.setdefault(
+                row.checkpoint_id, set()
+            )
+            if (
+                not invalid_reference_seen
+                and reference not in checkpoint_references
+                and len(checkpoint_references) == MAX_ADMITTED_PAGES
+            ):
+                raise A4AnalysisError(
+                    "A4-RESOURCE-BOUND",
+                    detail="H3 references more than 16 qualified pages",
+                )
+            if not invalid_reference_seen:
+                checkpoint_references.add(reference)
+            payload = (
+                None
+                if invalid_reference_seen
+                else view.page_optional(row.checkpoint_id, reference)
+            )
+            if (
+                not invalid_reference_seen
+                and view.replica in (1, 2)
+                and 0 <= reference < int(BOUNDS["max_final_pages_per_replica"])
+            ):
+                ledger.record_qualified_page(
+                    QualifiedPage(view.replica, row.checkpoint_id, reference),
+                    discriminator=("h3_reference_tag", row.map_page, ordinal),
+                )
+            tag = None if payload is None else payload[0]
+            slots.append(SlotObservation(ordinal, reference, tag))
+            if payload is None or tag != 0x05:
+                invalid_reference_seen = True
+            else:
+                reference_payloads[(row.checkpoint_id, reference)] = payload
+        output.append(TraversalObservation(
+            row.replica,
+            row.checkpoint_id,
+            row.map_page,
+            "type_1",
+            row.lifecycle_instance,
+            allocation_role=row.allocation_role,
+            slots=tuple(slots),
+            locator_ordinal=row.map_row,
+            allocation_span=most_recent_span.get(identity),
+        ))
+    if invalid_reference_seen:
+        return tuple(output)
+    hydrated: list[TraversalObservation] = []
+    for row in output:
+        slots: list[SlotObservation] = []
+        for slot in row.slots:
+            if slot.reference == 0:
+                slots.append(slot)
+                continue
+            payload = reference_payloads[(row.checkpoint_id, slot.reference)]
+            if row.replica in (1, 2):
+                ledger.charge_qualified(
+                    "type_0_and_tag_05_bitmap_bits",
+                    QualifiedPage(row.replica, row.checkpoint_id, slot.reference),
+                    BITMAP_BITS,
+                )
+            slots.append(
+                SlotObservation(
+                    slot.slot_ordinal,
+                    slot.reference,
+                    slot.referenced_page_tag,
+                    set_bits(payload[4:]),
+                )
+            )
+        hydrated.append(replace(row, slots=tuple(slots)))
+    return tuple(hydrated)
+
+
+def _frozen_rows(
+    view: View,
+    binding: object,
+    checkpoint: str,
+    h2: H2ReplicaCandidate,
+) -> tuple[tuple[bytes, frozenset[int] | None], ...]:
+    targets = getattr(binding, "locator_targets")
+    if targets is None:
+        raise ValueError("A4 frozen H1 binding lacks locator targets")
+    result: list[tuple[bytes, frozenset[int] | None]] = []
+    for target in targets:
+        payload = view.page(checkpoint, target.page)
+        start, end = row_bounds(payload, h2.row_mask)[target.row]
+        row = payload[start:end]
+        if not row or row[0] not in (0, 1) or (row[0] == 1 and (len(row) - 1) % 4):
+            raise ValueError("A4 holdout map row contradicts the frozen H2 grammar")
+        admitted = type0_owned(row, h2.polarity) if row[0] == 0 else None
+        result.append((row, admitted))
+    return tuple(result)
+
+
+def predicts_h2(
+    view: View,
+    h1: H1ReplicaCandidate,
+    h2: H2ReplicaCandidate,
+    row_counts: Mapping[str, Mapping[str, int]],
+) -> bool:
+    """Apply the complete frozen H2 model without refitting."""
+    try:
+        transition_rows: dict[tuple[str, str, int], MapRow] = {}
+        for binding in h1.bindings:
+            for checkpoint in binding.checkpoints:
+                rows = _frozen_rows(view, binding, checkpoint, h2)
+                for ordinal, (payload, _admitted) in enumerate(rows):
+                    type_0 = payload[0] == 0
+                    transition_rows[(binding.lifecycle_instance, checkpoint, ordinal)] = MapRow(
+                        payload[0],
+                        payload,
+                        int.from_bytes(payload[1:5], "little") if type_0 else None,
+                        payload[5:] if type_0 else None,
+                    )
+                owned = rows[h2.owned_in_use_locator_ordinal][1]
+                available = rows[h2.available_locator_ordinal][1]
+                if owned is not None:
+                    if any(page >= view.page_count(checkpoint) for page in owned):
+                        return False
+                    if row_counts[checkpoint][binding.logical_role] > 0 and not owned:
+                        return False
+                if owned is not None and available is not None and not available <= owned:
+                    return False
+        return h2_transitions_fit(
+            h1, transition_rows, h2.polarity,
+            h2.owned_in_use_locator_ordinal, h2.available_locator_ordinal,
+        )
+    except A4AnalysisError:
+        raise
+    except (IndexError, KeyError, TypeError, ValueError):
+        return False
+
+
+def derive_layers(
+    inputs: CheckedAnalysisInput, ledger: WorkLedger | None = None
+) -> DerivationLayers | DerivationTerminal:
+    """Run H1→H4 on replicas 1/2, freezing each model before proceeding."""
+    work = ledger or WorkLedger()
+    measurements = MeasurementRecorder()
+    results = empty_layer_results()
+
+    def terminal(
+        error: A4AnalysisError,
+        occurrence: Mapping[str, object] | None = None,
+    ) -> DerivationTerminal:
+        return DerivationTerminal(
+            error.predicate_id, results, occurrence, measurements.events
+        )
+    h1_predicates = LAYER_PREDICATE_IDS["h1_tdef_to_map_row"]
+    h1_outcome = evaluate_replica_predicates(
+        h1_predicates[:-1],
+        lambda replica, stage_work, stage_measurements: derive_h1_replica(
+            inputs.views[replica],
+            inputs.qualified_tdef_pages[replica],
+            stage_work,
+            stage_measurements,
+        ),
+        work,
+        measurements,
+    )
+    if h1_outcome.failure is not None:
+        error = h1_outcome.failure.error
+        results["h1_tdef_to_map_row"] = caught_terminal(error, work)
+        return terminal(error)
+    h1_by = dict(h1_outcome.values)
+    try:
+        frozen_h1 = agree_h1_replicas(h1_by[1], h1_by[2], measurements)
+    except A4AnalysisError as error:
+        results["h1_tdef_to_map_row"] = caught_terminal(
+            error, work, per_replica_counts=(1, 1)
+        )
+        return terminal(error)
+    results["h1_tdef_to_map_row"] = decisive_result(frozen_h1.document(), work)
+
+    h2_predicates = LAYER_PREDICATE_IDS["h2_row_identity_map_role"]
+    h2_outcome = evaluate_replica_predicates(
+        h2_predicates[:-1],
+        lambda replica, stage_work, stage_measurements: derive_h2_replica(
+            inputs.views[replica],
+            h1_by[replica],
+            inputs.replicas[replica].table_row_counts,
+            stage_work,
+            stage_measurements,
+        ),
+        work,
+        measurements,
+    )
+    if h2_outcome.failure is not None:
+        error = h2_outcome.failure.error
+        results["h2_row_identity_map_role"] = caught_terminal(error, work)
+        return terminal(error)
+    h2_by = dict(h2_outcome.values)
+    try:
+        frozen_h2 = agree_h2_replicas(h2_by[1], h2_by[2], measurements)
+    except A4AnalysisError as error:
+        results["h2_row_identity_map_role"] = caught_terminal(
+            error, work, per_replica_counts=(1, 1)
+        )
+        return terminal(error)
+    results["h2_row_identity_map_role"] = decisive_result(frozen_h2.document(), work)
+    rows_by: dict[int, tuple[TraversalObservation, ...]] = {}
+
+    def run_h3(
+        replica: int, stage_work: WorkLedger, stage_measurements: object
+    ) -> H3Derivation:
+        frozen_rows = decode_frozen_owned_rows(
+            inputs.views[replica], h1_by[replica], frozen_h2, stage_work
+        )
+        rows = h3_observations(inputs.views[replica], frozen_rows, stage_work)
+        rows_by[replica] = rows
+        return derive_h3(
+            replica,
+            rows,
+            inputs.replicas[replica].source.page_count,
+            stage_work,
+            stage_measurements,
+        )
+
+    h3_predicates = LAYER_PREDICATE_IDS["h3_indirect_traversal"]
+    h3_outcome = evaluate_replica_predicates(
+        h3_predicates[:-1],
+        run_h3,
+        work,
+        measurements,
+    )
+    if h3_outcome.failure is not None:
+        error = h3_outcome.failure.error
+        replica = h3_outcome.failure.replica
+        candidates, evidence = h3_terminal_payload(
+            error,
+            rows_by[replica],
+            inputs.replicas[replica].source.page_count,
+        )
+        results["h3_indirect_traversal"] = caught_terminal(
+            error,
+            work,
+            candidates=candidates,
+            evidence=evidence,
+        )
+        return terminal(error)
+    h3_by = dict(h3_outcome.values)
+    try:
+        frozen_h3 = agree_h3(h3_by[1], h3_by[2], measurements)
+    except A4AnalysisError as error:
+        evidence = replica_pair((h3_by[1].final, h3_by[2].final))
+        results["h3_indirect_traversal"] = caught_terminal(
+            error,
+            work,
+            candidates=(),
+            evidence=evidence,
+            per_replica_counts=(1, 1),
+        )
+        return terminal(error)
+    results["h3_indirect_traversal"] = decisive_result(frozen_h3.document(), work)
+
+    root_observation: dict[int, CatalogRootObservation] = {}
+    records_by: dict[int, tuple[OperationRecord, ...]] = {}
+    observations_by: dict[int, tuple[CatalogRootObservation, ...]] = {}
+
+    def run_root(
+        replica: int, stage_work: WorkLedger, stage_measurements: object
+    ) -> H4Candidate:
+        observations = catalog_root_observations(
+            inputs.views[replica],
+            inputs.qualified_tdef_pages[replica],
+            h1_by[replica],
+            frozen_h2,
+            frozen_h3,
+            stage_work,
+        )
+        observations_by[replica] = observations
+        return derive_catalog_root(
+            replica, observations, stage_work, stage_measurements
+        )
+
+    h4_predicates = LAYER_PREDICATE_IDS["h4_catalog_bootstrap"]
+    root_outcome = evaluate_replica_predicates(
+        h4_predicates[:2],
+        run_root,
+        work,
+        measurements,
+    )
+    if root_outcome.failure is not None:
+        error = root_outcome.failure.error
+        replica = root_outcome.failure.replica
+        candidates = reconstruct_root_candidates(replica, observations_by[replica])
+        results["h4_catalog_bootstrap"]["root_result"] = caught_terminal(
+            error,
+            work,
+            candidates=tuple(candidate.document() for candidate in candidates),
+        )
+        return terminal(error)
+    root_candidates = dict(root_outcome.values)
+    for replica in (1, 2):
+        tdef_page = root_candidates[replica].instance_bindings[0]["tdef_page"]
+        root_observation[replica] = next(
+            row for row in observations_by[replica] if row.tdef_page == tdef_page
+        )
+    try:
+        frozen_root = merge_catalog_roots(
+            root_candidates[1], root_candidates[2], measurements
+        )
+    except A4AnalysisError as error:
+        root_documents = tuple(
+            root_candidates[replica].document() for replica in (1, 2)
+        )
+        results["h4_catalog_bootstrap"]["root_result"] = caught_terminal(
+            error, work, candidates=root_documents
+        )
+        return terminal(error)
+    results["h4_catalog_bootstrap"]["root_result"] = decisive_result(
+        frozen_root.document(), work
+    )
+    deltas_by: dict[int, Mapping[str, frozenset[int]]] = {}
+
+    def run_delta(
+        replica: int, _stage_work: WorkLedger, stage_measurements: object
+    ) -> None:
+        deltas = isolated_operation_deltas(
+            inputs.views[replica], h1_by[replica], rows_by[replica], frozen_h3
+        )
+        deltas_by[replica] = deltas
+        return validate_isolated_deltas(
+            replica,
+            root_observation[replica],
+            deltas,
+            stage_measurements,
+        )
+
+    delta_outcome = evaluate_replica_predicates(
+        h4_predicates[2:3],
+        run_delta,
+        work,
+        measurements,
+    )
+    if delta_outcome.failure is not None:
+        error = delta_outcome.failure.error
+        replica = delta_outcome.failure.replica
+        outside = outside_evidence(
+            inputs,
+            replica,
+            root_candidates[replica],
+            root_observation[replica],
+            deltas_by[replica],
+        )
+        results["h4_catalog_bootstrap"]["structural_result"] = caught_terminal(
+            error, work, evidence=outside
+        )
+        return terminal(error)
+    raw_records_by: dict[int, tuple[OperationRecord, ...]] = {}
+
+    def run_records(
+        replica: int, stage_work: WorkLedger, stage_measurements: object
+    ) -> tuple[OperationRecord, ...]:
+        raw_records = operation_records(
+            inputs.views[replica],
+            root_observation[replica],
+            deltas_by[replica],
+            frozen_h2,
+            stage_work,
+        )
+        raw_records_by[replica] = raw_records
+        return select_operation_records(
+            replica,
+            root_candidates[replica],
+            raw_records,
+            stage_work,
+            stage_measurements,
+        )
+
+    record_outcome = evaluate_replica_predicates(
+        h4_predicates[3:5],
+        run_records,
+        work,
+        measurements,
+    )
+    if record_outcome.failure is not None:
+        error = record_outcome.failure.error
+        replica = record_outcome.failure.replica
+        grouped_candidates, grouped_evidence = operation_groups(
+            root_candidates[replica], raw_records_by[replica]
+        )
+        results["h4_catalog_bootstrap"]["structural_result"] = caught_terminal(
+            error,
+            work,
+            candidates=grouped_candidates,
+            evidence=grouped_evidence,
+        )
+        return terminal(error)
+    records_by = dict(record_outcome.values)
+    evidence_by: dict[int, StructuralDerivation] = {}
+
+    def run_structural(
+        replica: int, stage_work: WorkLedger, stage_measurements: object
+    ) -> StructuralDerivation:
+        groups = tuple(
+            h4_primitive.scan_name_occurrences(record, stage_work)
+            for record in records_by[replica]
+        )
+        evidence_by[replica] = StructuralDerivation(
+            replica, h4_primitive._evidence_hash(groups), groups, ()
+        )
+        return derive_structural_fields(
+            replica,
+            records_by[replica],
+            stage_work,
+            stage_measurements,
+            groups,
+        )
+
+    structural_outcome = evaluate_replica_predicates(
+        h4_predicates[5:7],
+        run_structural,
+        work,
+        measurements,
+    )
+    # Unreached replicas retain locator bindings but no name-byte observations.
+    reached_evidence = {
+        replica: evidence_by.get(replica)
+        or StructuralDerivation(
+            replica,
+            h4_primitive._evidence_hash(groups),
+            groups,
+            (),
+        )
+        for replica in (1, 2)
+        for groups in (
+            tuple(
+                h4_primitive.OperationEvidence(record, "", ())
+                for record in records_by[replica]
+            ),
+        )
+    }
+    evidence = occurrence_evidence_document(
+        inputs.campaign_id, frozen_root, reached_evidence
+    )
+    evidence_digest = sha256_hex(canonical_json_bytes(evidence))
+    if structural_outcome.failure is not None:
+        error = structural_outcome.failure.error
+        rebound = tuple(
+            H4Candidate(
+                candidate["model_type"],
+                candidate["model"],
+                ({
+                    **dict(candidate["instance_bindings"][0]),
+                    "occurrence_evidence_sha256": evidence_digest,
+                },),
+            )
+            for candidate in getattr(error, "candidates", ())
+        )
+        results["h4_catalog_bootstrap"]["structural_result"] = caught_terminal(
+            error,
+            work,
+            candidates=tuple(candidate.document() for candidate in rebound),
+        )
+        return terminal(error, evidence)
+    structural_by = {
+        replica: rebind_evidence(structural_outcome.values[replica], evidence_digest)
+        for replica in (1, 2)
+    }
+    encoding_outcome = evaluate_replica_predicates(
+        h4_predicates[7:8],
+        lambda replica, stage_work, stage_measurements: derive_encoding(
+            structural_by[replica], stage_work, stage_measurements
+        ),
+        work,
+        measurements,
+    )
+    if encoding_outcome.failure is not None:
+        error = encoding_outcome.failure.error
+        replica = encoding_outcome.failure.replica
+        structural_candidates = tuple(
+            structural_by[current].candidates[0] for current in (1, 2)
+        )
+        if len(
+            {candidate.canonical_model_id for candidate in structural_candidates}
+        ) != 1:
+            raise ValueError(
+                "A4 encoding terminal reached with unequal structural models"
+            )
+        structural_candidate = H4Candidate(
+            "h4_structural_field",
+            structural_candidates[0].model,
+            tuple(
+                binding
+                for candidate in structural_candidates
+                for binding in candidate.instance_bindings
+            ),
+        )
+        results["h4_catalog_bootstrap"]["structural_result"] = decisive_result(
+            structural_candidate.document(), work
+        )
+        finals = tuple(
+            sorted(
+                (
+                    H4Candidate(
+                        candidate.model_type,
+                        {
+                            **dict(candidate.model),
+                            "structural_model_id": (
+                                structural_candidate.canonical_model_id
+                            ),
+                        },
+                        tuple(
+                            {
+                                **dict(binding),
+                                "structural_candidate_id": (
+                                    structural_candidate.canonical_candidate_id
+                                ),
+                            }
+                            for binding in candidate.instance_bindings
+                        ),
+                    )
+                    for candidate in encoding_candidates(structural_by[replica])
+                ),
+                key=lambda candidate: candidate.canonical_candidate_id,
+            )
+        )
+        results["h4_catalog_bootstrap"]["encoding_result"] = caught_terminal(
+            error,
+            work,
+            candidates=tuple(candidate.document() for candidate in finals),
+        )
+        return terminal(error, evidence)
+    encoded_by = dict(encoding_outcome.values)
+    try:
+        frozen_fields = merge_encoded_derivations(
+            encoded_by[1], encoded_by[2], measurements
+        )
+    except A4AnalysisError as error:
+        results["h4_catalog_bootstrap"]["structural_result"] = caught_terminal(
+            error,
+            work,
+            candidates=(),
+            evidence=replica_pair(
+                (encoded_by[1].structural, encoded_by[2].structural)
+            ),
+            per_replica_counts=(1, 1),
+        )
+        results["h4_catalog_bootstrap"]["encoding_result"] = caught_terminal(
+            error,
+            work,
+            candidates=(),
+            evidence=replica_pair((encoded_by[1].final, encoded_by[2].final)),
+            per_replica_counts=(1, 1),
+        )
+        return terminal(error, evidence)
+    results["h4_catalog_bootstrap"]["structural_result"] = decisive_result(
+        frozen_fields.structural.document(), work
+    )
+    results["h4_catalog_bootstrap"]["encoding_result"] = decisive_result(
+        frozen_fields.final.document(), work
+    )
+    return DerivationLayers(
+        h1_by,
+        frozen_h1,
+        h2_by,
+        frozen_h2,
+        rows_by,
+        h3_by,
+        frozen_h3,
+        root_observation,
+        frozen_root,
+        records_by,
+        encoded_by,
+        frozen_fields,
+        evidence,
+        measurements.events,
+    )

--- a/oracle/windows-dao/scripts/a4_measurements.py
+++ b/oracle/windows-dao/scripts/a4_measurements.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Contract-checked primitive predicate measurements for the A4 analyzer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from protocol_validation import ValidationError
+from a4_spec import PREDICATE_CONTRACTS, validate_failure_count
+
+
+@dataclass(frozen=True)
+class PredicateMeasurement:
+    predicate_id: str
+    order: int
+    scope: str
+    counted_set_kind: str
+    measured_count: int
+    passed: bool
+    replica: int | None
+
+    def document(self) -> dict[str, Any]:
+        return {
+            "predicate_id": self.predicate_id,
+            "order": self.order,
+            "scope": self.scope,
+            "counted_set_kind": self.counted_set_kind,
+            "predicate_measured_survivor_count": self.measured_count,
+            "status": "pass" if self.passed else "fail",
+            "replica": self.replica,
+        }
+
+
+class MeasurementRecorder:
+    """Retain actual counts while enforcing registry identity and local order."""
+
+    def __init__(self) -> None:
+        self._events: list[PredicateMeasurement] = []
+        self._keys: set[tuple[str, int | None]] = set()
+        self._last_order: dict[tuple[str, int | None], int] = {}
+
+    @property
+    def events(self) -> tuple[PredicateMeasurement, ...]:
+        return tuple(self._events)
+
+    def for_predicate(self, predicate_id: str) -> tuple[PredicateMeasurement, ...]:
+        self._contract(predicate_id)
+        return tuple(row for row in self._events if row.predicate_id == predicate_id)
+
+    def record(
+        self,
+        predicate_id: str,
+        measured_count: int,
+        passed: bool,
+        *,
+        replica: int | None = None,
+    ) -> PredicateMeasurement:
+        contract = self._contract(predicate_id)
+        if isinstance(measured_count, bool) or not isinstance(measured_count, int) or measured_count < 0:
+            raise ValidationError("A4 predicate measurement must be a nonnegative integer")
+        if not isinstance(passed, bool):
+            raise ValidationError("A4 predicate measurement status must be boolean")
+        if replica is not None and (isinstance(replica, bool) or replica not in (1, 2, 3)):
+            raise ValidationError("A4 predicate measurement replica is invalid")
+        if not passed:
+            validate_failure_count(predicate_id, measured_count)
+        key = (predicate_id, replica)
+        if key in self._keys:
+            raise ValidationError("A4 predicate measurement is duplicated")
+        lane = (str(contract["scope"]), replica)
+        order = int(contract["order"])
+        if order <= self._last_order.get(lane, 0):
+            raise ValidationError("A4 predicate measurements are out of contract order")
+        row = PredicateMeasurement(
+            predicate_id,
+            order,
+            str(contract["scope"]),
+            str(contract["counted_set_kind"]),
+            measured_count,
+            passed,
+            replica,
+        )
+        self._events.append(row)
+        self._keys.add(key)
+        self._last_order[lane] = order
+        return row
+
+    @staticmethod
+    def _contract(predicate_id: str) -> Any:
+        try:
+            return PREDICATE_CONTRACTS[predicate_id]
+        except KeyError as exc:
+            raise ValidationError(f"unregistered A4 predicate {predicate_id!r}") from exc
+
+
+def measure(
+    recorder: MeasurementRecorder | None,
+    predicate_id: str,
+    measured_count: int,
+    passed: bool,
+    *,
+    replica: int | None = None,
+) -> None:
+    """Record one primitive boundary when orchestration supplied a recorder."""
+    if recorder is not None:
+        recorder.record(predicate_id, measured_count, passed, replica=replica)

--- a/oracle/windows-dao/scripts/a4_model.py
+++ b/oracle/windows-dao/scripts/a4_model.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Typed, bounded primitives shared by the A4 analyzer layers.
+
+This module deliberately contains no A4 scientific derivation.  It provides
+replica-qualified physical identities, checked page access, canonical identity
+hashes, registered analysis terminals, and the exact named work ledger required
+by the preregistered plan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Hashable, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import islice
+from types import MappingProxyType
+from typing import Any, Protocol
+
+from a4_spec import (
+    BOUNDS,
+    CHECKPOINT_IDS,
+    PLAN,
+    PREDICATE_IDS,
+    canonical_json_bytes,
+    sha256_hex,
+)
+
+
+def _plan_document() -> Mapping[str, Any]:
+    """Accept either a checked-plan wrapper or the plan mapping itself."""
+    document = getattr(PLAN, "document", PLAN)
+    if not isinstance(document, Mapping):
+        raise TypeError("A4 checked plan must expose a mapping document")
+    return document
+
+
+_PLAN_DOCUMENT = _plan_document()
+_WORK_MODEL = _PLAN_DOCUMENT["work_model"]
+_PRIMARY_WORK_TERMS = tuple(_WORK_MODEL["terms"])
+_ALTERNATIVE_WORK_TERMS = tuple(
+    _WORK_MODEL["terminal_path_maxima"]["alternative_terms"]
+)
+WORK_TERMS = _PRIMARY_WORK_TERMS + _ALTERNATIVE_WORK_TERMS
+WORK_TERM_LIMITS: Mapping[str, int] = MappingProxyType(
+    {
+        **{
+            term: int(_WORK_MODEL["terms"][term]["units"])
+            for term in _PRIMARY_WORK_TERMS
+        },
+        **{
+            term: int(
+                _WORK_MODEL["terminal_path_maxima"]["alternative_terms"][term][
+                    "units"
+                ]
+            )
+            for term in _ALTERNATIVE_WORK_TERMS
+        },
+    }
+)
+
+_INVALID_DIRECTORY_TERM = "invalid_path_row_directory_entries"
+_VALID_DIRECTORY_TERM = "valid_path_row_directory_entries"
+_LATEST_PATH = tuple(
+    _WORK_MODEL["terminal_path_maxima"]["term_table"][
+        "h4_latest_derivation_terminal"
+    ]
+)
+_VALID_DIRECTORY_PATH_TERMS = frozenset(
+    _LATEST_PATH[_LATEST_PATH.index(_VALID_DIRECTORY_TERM) :]
+)
+
+
+def _checked_nonnegative(value: int, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{label} must be a nonnegative integer")
+    return value
+
+
+def analysis_work_within_limit(total_work_units: int) -> bool:
+    """Return the checked comparator result; equality is accepted."""
+    total = _checked_nonnegative(total_work_units, "A4 work total")
+    return total <= int(BOUNDS["max_analysis_work_units"])
+
+
+@dataclass(frozen=True, order=True)
+class QualifiedPage:
+    """One derivation-replica page inspection at one checkpoint.
+
+    Numeric page and checkpoint values in replicas 1 and 2 are intentionally
+    distinct identities.  Replica 3 is holdout input and is not part of the
+    frozen ``qualified_pages`` inventory.
+    """
+
+    replica: int
+    checkpoint_id: str
+    page_number: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.replica, bool) or self.replica not in (1, 2):
+            raise ValueError("A4 qualified page replica must be 1 or 2")
+        if self.checkpoint_id not in CHECKPOINT_IDS:
+            raise ValueError(f"unknown A4 checkpoint {self.checkpoint_id!r}")
+        page = _checked_nonnegative(self.page_number, "A4 qualified page number")
+        if page >= int(BOUNDS["max_final_pages_per_replica"]):
+            raise ValueError("A4 qualified page number exceeds the plan bound")
+
+    def document(self) -> dict[str, int | str]:
+        return {
+            "replica": self.replica,
+            "checkpoint_id": self.checkpoint_id,
+            "page_number": self.page_number,
+        }
+
+
+class ReplicaData(Protocol):
+    """Minimal page-store surface consumed by the A4 analyzer."""
+
+    @property
+    def checkpoint_ids(self) -> Sequence[str]: ...
+
+    @property
+    def page_count(self) -> Mapping[str, int]: ...
+
+    @property
+    def ordered_page_sha256(self) -> Mapping[str, Sequence[str]]: ...
+
+    def page_bytes(self, sha256: str) -> bytes: ...
+
+
+class A4AnalysisError(Exception):
+    """One registered A4 campaign, layer, or holdout terminal."""
+
+    def __init__(
+        self,
+        predicate_id: str,
+        survivor_count: int = 0,
+        *,
+        detail: str | None = None,
+    ) -> None:
+        if predicate_id not in PREDICATE_IDS:
+            raise ValueError(f"unregistered A4 predicate {predicate_id!r}")
+        self.predicate_id = predicate_id
+        self.survivor_count = _checked_nonnegative(
+            survivor_count, "A4 survivor count"
+        )
+        self.detail = detail
+        message = predicate_id if detail is None else f"{predicate_id}: {detail}"
+        super().__init__(message)
+
+
+def require_analysis_work_within_limit(total_work_units: int) -> None:
+    """Raise the registered resource terminal when the comparator rejects."""
+    if not analysis_work_within_limit(total_work_units):
+        raise A4AnalysisError(
+            "A4-RESOURCE-BOUND",
+            detail=(
+                f"analysis work {total_work_units} exceeds "
+                f"{BOUNDS['max_analysis_work_units']}"
+            ),
+        )
+
+
+def canonical_object_id(document: Mapping[str, Any]) -> str:
+    """Hash one complete registered canonical identity object."""
+    return sha256_hex(canonical_json_bytes(dict(document)))
+
+
+def canonical_model_id(model_type: str, model: Mapping[str, Any]) -> str:
+    """Hash only the replica-invariant A4 scientific model."""
+    if not isinstance(model_type, str) or not model_type:
+        raise ValueError("A4 model_type must be a nonempty string")
+    return canonical_object_id({"model_type": model_type, "model": dict(model)})
+
+
+def canonical_candidate_id(
+    model_type: str,
+    model: Mapping[str, Any],
+    instance_bindings: Sequence[Mapping[str, Any]],
+) -> str:
+    """Hash one model together with its complete physical bindings."""
+    if not isinstance(model_type, str) or not model_type:
+        raise ValueError("A4 model_type must be a nonempty string")
+    return canonical_object_id(
+        {
+            "model_type": model_type,
+            "model": dict(model),
+            "instance_bindings": [dict(binding) for binding in instance_bindings],
+        }
+    )
+
+
+class View:
+    """Validated, bounded access to one replica's checkpoint page store."""
+
+    def __init__(self, replica: int, source: ReplicaData) -> None:
+        if (
+            isinstance(replica, bool)
+            or not isinstance(replica, int)
+            or not 1 <= replica <= int(BOUNDS["replicas"])
+        ):
+            raise ValueError("A4 replica ordinal is outside the plan")
+        self.replica = replica
+        self.source = source
+        self._counts: dict[str, int] = {}
+        self._hashes: dict[str, tuple[str, ...]] = {}
+        self._page_cache: dict[str, bytes] = {}
+        self._logical_page_reads: set[tuple[str, int]] = set()
+        self._checkpoint_read_bytes = 0
+        self._logical_read_bytes = 0
+
+        checkpoint_ids = self._bounded_sequence(
+            source.checkpoint_ids,
+            len(CHECKPOINT_IDS),
+            "checkpoint sequence",
+        )
+        if checkpoint_ids != tuple(CHECKPOINT_IDS):
+            self._snapshot_error("checkpoint order does not match the plan")
+        for checkpoint_id in CHECKPOINT_IDS:
+            try:
+                count = source.page_count[checkpoint_id]
+                declared_hashes = source.ordered_page_sha256[checkpoint_id]
+            except (KeyError, TypeError) as exc:
+                self._snapshot_error(
+                    f"missing page index for {checkpoint_id}", cause=exc
+                )
+            if (
+                isinstance(count, bool)
+                or not isinstance(count, int)
+                or not 1 <= count <= int(BOUNDS["max_final_pages_per_replica"])
+            ):
+                self._snapshot_error(f"invalid page count at {checkpoint_id}")
+            hashes = self._bounded_sequence(
+                declared_hashes,
+                int(BOUNDS["max_final_pages_per_replica"]),
+                f"page index at {checkpoint_id}",
+            )
+            if len(hashes) != count:
+                self._snapshot_error(f"invalid page count at {checkpoint_id}")
+            if any(not _valid_sha256(digest) for digest in hashes):
+                self._snapshot_error(f"invalid page digest at {checkpoint_id}")
+            self._counts[checkpoint_id] = count
+            self._hashes[checkpoint_id] = hashes
+
+    @classmethod
+    def _bounded_sequence(
+        cls, values: Sequence[Any], maximum: int, label: str
+    ) -> tuple[Any, ...]:
+        """Materialize no more than one item beyond a registered maximum."""
+        try:
+            declared_length = len(values)
+        except Exception as exc:
+            cls._snapshot_error(f"invalid {label}", cause=exc)
+        if (
+            isinstance(declared_length, bool)
+            or declared_length < 0
+            or declared_length > maximum
+        ):
+            cls._snapshot_error(f"invalid {label} length")
+        try:
+            materialized = tuple(islice(iter(values), maximum + 1))
+        except Exception as exc:
+            cls._snapshot_error(f"invalid {label}", cause=exc)
+        if len(materialized) > maximum or len(materialized) != declared_length:
+            cls._snapshot_error(f"inconsistent {label} length")
+        return materialized
+
+    @staticmethod
+    def _snapshot_error(
+        detail: str, *, cause: BaseException | None = None
+    ) -> None:
+        error = A4AnalysisError("A4-SNAPSHOT-RECONSTRUCTION", detail=detail)
+        if cause is None:
+            raise error
+        raise error from cause
+
+    @property
+    def logical_read_bytes(self) -> int:
+        return self._logical_read_bytes
+
+    @property
+    def opened_page_digests(self) -> frozenset[str]:
+        return frozenset(self._page_cache)
+
+    @property
+    def checkpoint_read_bytes(self) -> int:
+        return self._checkpoint_read_bytes
+
+    def page_count(self, checkpoint_id: str) -> int:
+        return self._counts[checkpoint_id]
+
+    def hashes(self, checkpoint_id: str) -> tuple[str, ...]:
+        return self._hashes[checkpoint_id]
+
+    def hash_at(self, checkpoint_id: str, page_number: int) -> str | None:
+        hashes = self._hashes[checkpoint_id]
+        return hashes[page_number] if 0 <= page_number < len(hashes) else None
+
+    def qualified_page(
+        self, checkpoint_id: str, page_number: int
+    ) -> QualifiedPage:
+        return QualifiedPage(self.replica, checkpoint_id, page_number)
+
+    def page_optional(self, checkpoint_id: str, page_number: int) -> bytes | None:
+        digest = self.hash_at(checkpoint_id, page_number)
+        if digest is None:
+            return None
+        identity = (checkpoint_id, page_number)
+        if identity not in self._logical_page_reads:
+            next_logical = self._checkpoint_read_bytes + int(BOUNDS["page_size"])
+            if next_logical > int(BOUNDS["max_logical_checkpoint_read_bytes_per_replica"]):
+                raise A4AnalysisError(
+                    "A4-RESOURCE-BOUND",
+                    detail="analyzer logical checkpoint reads exceed the bound",
+                )
+            self._logical_page_reads.add(identity)
+            self._checkpoint_read_bytes = next_logical
+        cached = self._page_cache.get(digest)
+        if cached is not None:
+            return cached
+        try:
+            payload = self.source.page_bytes(digest)
+        except (KeyError, OSError, TypeError, ValueError) as exc:
+            self._snapshot_error(f"cannot read page blob {digest}", cause=exc)
+        if (
+            not isinstance(payload, bytes)
+            or len(payload) != int(BOUNDS["page_size"])
+            or hashlib.sha256(payload).hexdigest() != digest
+        ):
+            self._snapshot_error(f"page blob {digest} does not match its index")
+        next_retained = self._logical_read_bytes + len(payload)
+        if next_retained > int(BOUNDS["max_retained_page_store_bytes"]):
+            raise A4AnalysisError(
+                "A4-RESOURCE-BOUND",
+                detail="analyzer retained page bytes exceed the bound",
+            )
+        self._page_cache[digest] = payload
+        self._logical_read_bytes = next_retained
+        return payload
+
+    def page(self, checkpoint_id: str, page_number: int) -> bytes:
+        payload = self.page_optional(checkpoint_id, page_number)
+        if payload is None:
+            raise A4AnalysisError(
+                "A4-SNAPSHOT-RECONSTRUCTION",
+                detail=f"page {page_number} is absent at {checkpoint_id}",
+            )
+        return payload
+
+
+def _valid_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+class WorkLedger:
+    """Checked A4 work charges with union-once physical identities."""
+
+    def __init__(self, prior_work_units: int = 0) -> None:
+        self._prior_work_units = _checked_nonnegative(
+            prior_work_units, "A4 prior work total"
+        )
+        require_analysis_work_within_limit(self._prior_work_units)
+        self._charges = {term: 0 for term in WORK_TERMS}
+        self._invalid_directory_terminal = False
+        self._identities: dict[str, set[Hashable]] = {
+            term: set() for term in WORK_TERMS
+        }
+        self._reached_page_identities: set[Hashable] = set()
+
+    @property
+    def total_work_units(self) -> int:
+        return sum(self._charges.values())
+
+    def value(self, term: str) -> int:
+        self._require_term(term)
+        return self._charges[term]
+
+    def charge(self, term: str, units: int = 1) -> None:
+        """Charge a reached term, failing before mutating on any violation."""
+        self._require_term(term)
+        if self._invalid_directory_terminal and term == _VALID_DIRECTORY_TERM:
+            term = _INVALID_DIRECTORY_TERM
+        units = _checked_nonnegative(units, f"A4 {term} charge")
+        if units == 0:
+            return
+        self._require_compatible_path(term)
+        next_term = self._charges[term] + units
+        if next_term > WORK_TERM_LIMITS[term]:
+            raise A4AnalysisError(
+                "A4-RESOURCE-BOUND",
+                detail=f"{term} exceeds its registered maximum",
+            )
+        require_analysis_work_within_limit(
+            self._prior_work_units + self.total_work_units + units
+        )
+        self._charges[term] = next_term
+
+    def select_invalid_directory_terminal(self) -> None:
+        """Classify both replica inspections under the registered alternative path."""
+        if any(self._charges[term] for term in _VALID_DIRECTORY_PATH_TERMS):
+            raise ValueError("A4 invalid-directory terminal was selected after later work")
+        self._invalid_directory_terminal = True
+
+    def charge_once(
+        self,
+        term: str,
+        identity: Hashable,
+        units: int = 1,
+    ) -> bool:
+        """Charge one identity once for this term; return whether it was new."""
+        self._require_term(term)
+        try:
+            hash(identity)
+        except TypeError as exc:
+            raise ValueError("A4 work identity must be hashable") from exc
+        if identity in self._identities[term]:
+            return False
+        self.charge(term, units)
+        self._identities[term].add(identity)
+        return True
+
+    def charge_qualified(
+        self,
+        term: str,
+        page: QualifiedPage,
+        units: int = 1,
+        *,
+        discriminator: Hashable | None = None,
+    ) -> bool:
+        """Charge a replica/checkpoint/page/model identity exactly once."""
+        identity: Hashable = (
+            page if discriminator is None else (page, discriminator)
+        )
+        return self.charge_once(term, identity, units)
+
+    def record_qualified_page(
+        self,
+        page: QualifiedPage,
+        *,
+        discriminator: Hashable | None = None,
+    ) -> bool:
+        """Record one reached page identity without changing registered work."""
+        if not isinstance(page, QualifiedPage):
+            raise TypeError("A4 reached page must be replica-qualified")
+        identity: Hashable = (
+            page if discriminator is None else (page, discriminator)
+        )
+        try:
+            hash(identity)
+        except TypeError as exc:
+            raise ValueError("A4 reached-page discriminator must be hashable") from exc
+        if identity in self._reached_page_identities:
+            return False
+        self._reached_page_identities.add(identity)
+        return True
+
+    def qualified_pages(self) -> tuple[QualifiedPage, ...]:
+        """Return the immutable canonical union of charged page identities."""
+        pages: set[QualifiedPage] = set()
+        for identities in (*self._identities.values(), self._reached_page_identities):
+            for identity in identities:
+                if isinstance(identity, QualifiedPage):
+                    pages.add(identity)
+                elif (
+                    isinstance(identity, tuple)
+                    and identity
+                    and isinstance(identity[0], QualifiedPage)
+                ):
+                    pages.add(identity[0])
+        ordinal = {checkpoint: index for index, checkpoint in enumerate(CHECKPOINT_IDS)}
+        return tuple(
+            sorted(
+                pages,
+                key=lambda page: (
+                    page.replica,
+                    ordinal[page.checkpoint_id],
+                    page.page_number,
+                ),
+            )
+        )
+
+    @staticmethod
+    def _identity_page(identity: Hashable) -> QualifiedPage | None:
+        if isinstance(identity, QualifiedPage):
+            return identity
+        if (
+            isinstance(identity, tuple)
+            and identity
+            and isinstance(identity[0], QualifiedPage)
+        ):
+            return identity[0]
+        return None
+
+    def qualified_page_terms(self, page: QualifiedPage) -> tuple[str, ...]:
+        """Return the registered charged terms that reached one physical page."""
+        return tuple(
+            term
+            for term in WORK_TERMS
+            if any(self._identity_page(identity) == page for identity in self._identities[term])
+        )
+
+    def reached_page_discriminators(self, page: QualifiedPage) -> frozenset[Hashable | None]:
+        """Return zero-cost read discriminators recorded for one physical page."""
+        output: set[Hashable | None] = set()
+        for identity in self._reached_page_identities:
+            if self._identity_page(identity) != page:
+                continue
+            output.add(identity[1] if isinstance(identity, tuple) else None)
+        return frozenset(output)
+
+    def document(self) -> dict[str, int]:
+        self._validate_path()
+        require_analysis_work_within_limit(self.total_work_units)
+        return {
+            **{term: self._charges[term] for term in WORK_TERMS},
+            "total_work_units": self.total_work_units,
+        }
+
+    def identities(self, term: str) -> frozenset[Hashable]:
+        """Return the immutable, charged identities for one registered term."""
+        self._require_term(term)
+        return frozenset(self._identities[term])
+
+    def charge_candidate_documents(
+        self, candidates: Sequence[Mapping[str, Any]]
+    ) -> None:
+        """Bound and charge each retained canonical candidate exactly once."""
+        for candidate in candidates:
+            payload = canonical_json_bytes(dict(candidate))
+            if len(payload) > 4096:
+                raise A4AnalysisError(
+                    "A4-RESOURCE-BOUND",
+                    detail="canonical candidate exceeds 4,096 encoded bytes",
+                )
+            self.charge_once(
+                "candidate_serializations", sha256_hex(payload)
+            )
+
+    def _require_term(self, term: str) -> None:
+        if term not in self._charges:
+            raise ValueError(f"unknown A4 work term {term!r}")
+
+    def _require_compatible_path(self, term: str) -> None:
+        if term == _INVALID_DIRECTORY_TERM and any(
+            self._charges[path_term] for path_term in _VALID_DIRECTORY_PATH_TERMS
+        ):
+            raise ValueError(
+                "invalid-directory work is mutually exclusive with the valid path"
+            )
+        if (
+            term in _VALID_DIRECTORY_PATH_TERMS
+            and self._charges[_INVALID_DIRECTORY_TERM]
+        ):
+            raise ValueError(
+                "valid-path work is mutually exclusive with invalid-directory work"
+            )
+
+    def _validate_path(self) -> None:
+        if self._charges[_INVALID_DIRECTORY_TERM] and any(
+            self._charges[term] for term in _VALID_DIRECTORY_PATH_TERMS
+        ):
+            raise ValueError(
+                "A4 work document mixes mutually exclusive directory paths"
+            )

--- a/oracle/windows-dao/scripts/a4_predicate_major.py
+++ b/oracle/windows-dao/scripts/a4_predicate_major.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Predicate-major evaluation of replica-local A4 derivation primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Generic, Mapping, Sequence, TypeVar
+
+from a4_measurements import MeasurementRecorder, PredicateMeasurement
+from a4_model import A4AnalysisError, WorkLedger
+
+
+T = TypeVar("T")
+
+
+class _TargetPassed(Exception):
+    """Stop a probe immediately after its target predicate passes."""
+
+
+class _TargetRecorder:
+    """Validate a primitive's prefix while retaining only its target event."""
+
+    def __init__(self, target: str, stop_after_pass: bool) -> None:
+        self._target = target
+        self._stop_after_pass = stop_after_pass
+        self._validation = MeasurementRecorder()
+        self.target_event: PredicateMeasurement | None = None
+
+    def record(
+        self,
+        predicate_id: str,
+        measured_count: int,
+        passed: bool,
+        *,
+        replica: int | None = None,
+    ) -> PredicateMeasurement:
+        row = self._validation.record(
+            predicate_id, measured_count, passed, replica=replica
+        )
+        if predicate_id == self._target:
+            self.target_event = row
+            if passed and self._stop_after_pass:
+                raise _TargetPassed
+        return row
+
+
+@dataclass(frozen=True)
+class LocalPredicateFailure:
+    """The first replica-local failure in predicate-major order."""
+
+    replica: int
+    error: A4AnalysisError
+
+
+@dataclass(frozen=True)
+class PredicateMajorResult(Generic[T]):
+    values: Mapping[int, T]
+    failure: LocalPredicateFailure | None = None
+
+
+ReplicaRunner = Callable[[int, WorkLedger, object], T]
+
+
+def evaluate_replica_predicates(
+    predicate_ids: Sequence[str],
+    runner: ReplicaRunner[T],
+    work: WorkLedger,
+    measurements: MeasurementRecorder,
+) -> PredicateMajorResult[T]:
+    """Evaluate each predicate on replica 1 then 2 before advancing.
+
+    Earlier successful predicates use bounded scratch ledgers and stop at the
+    measurement boundary.  The final local predicate runs the complete
+    primitive with the retained ledger, producing the value needed downstream
+    while accounting the primitive's work exactly once.
+    """
+    ordered = tuple(predicate_ids)
+    if not ordered:
+        raise ValueError("predicate-major evaluation requires a nonempty sequence")
+    values: dict[int, T] = {}
+    for predicate_index, predicate_id in enumerate(ordered):
+        final = predicate_index == len(ordered) - 1
+        for replica in (1, 2):
+            recorder = _TargetRecorder(predicate_id, stop_after_pass=not final)
+            try:
+                value = runner(replica, work if final else WorkLedger(), recorder)
+            except _TargetPassed:
+                value = None
+            except A4AnalysisError as error:
+                if error.predicate_id != predicate_id:
+                    raise
+                event = recorder.target_event
+                if event is None or event.passed:
+                    raise RuntimeError(
+                        "A4 primitive failed without its target measurement"
+                    ) from error
+                if not final:
+                    _account_reached_prefix(
+                        predicate_id, replica, runner, work
+                    )
+                if replica == 1 and predicate_index:
+                    _account_completed_replica(
+                        ordered[predicate_index - 1], 2, runner, work
+                    )
+                measurements.record(
+                    event.predicate_id,
+                    event.measured_count,
+                    event.passed,
+                    replica=event.replica,
+                )
+                return PredicateMajorResult(
+                    {}, LocalPredicateFailure(replica, error)
+                )
+            event = recorder.target_event
+            if event is None or not event.passed:
+                raise RuntimeError("A4 primitive did not reach its target predicate")
+            measurements.record(
+                event.predicate_id,
+                event.measured_count,
+                event.passed,
+                replica=event.replica,
+            )
+            if final:
+                values[replica] = value
+    return PredicateMajorResult(values)
+
+
+def _account_reached_prefix(
+    predicate_id: str,
+    failing_replica: int,
+    runner: ReplicaRunner[object],
+    work: WorkLedger,
+) -> None:
+    """Replay only the reached prefix into the retained work ledger."""
+    if predicate_id == "A4-H2-ROW-DIRECTORY-INVALID":
+        work.select_invalid_directory_terminal()
+    for replica in range(1, failing_replica + 1):
+        recorder = _TargetRecorder(predicate_id, stop_after_pass=True)
+        try:
+            runner(replica, work, recorder)
+        except _TargetPassed:
+            if replica == failing_replica:
+                raise RuntimeError("A4 failing predicate passed during replay")
+        except A4AnalysisError as error:
+            if replica != failing_replica or error.predicate_id != predicate_id:
+                raise
+            return
+    raise RuntimeError("A4 failing predicate did not fail during replay")
+
+
+def _account_completed_replica(
+    predicate_id: str,
+    replica: int,
+    runner: ReplicaRunner[object],
+    work: WorkLedger,
+) -> None:
+    """Transfer the latest completed prefix for a not-yet-current replica."""
+    recorder = _TargetRecorder(predicate_id, stop_after_pass=True)
+    try:
+        runner(replica, work, recorder)
+    except _TargetPassed:
+        return
+    except A4AnalysisError as error:
+        raise RuntimeError(
+            "A4 completed predicate failed during accounting replay"
+        ) from error
+    raise RuntimeError("A4 completed predicate did not pass during accounting replay")

--- a/oracle/windows-dao/scripts/a4_spec.py
+++ b/oracle/windows-dao/scripts/a4_spec.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Fail-closed checked contract primitives for the DAO A4 experiment.
+
+This module binds consumers to the immutable A4 plan and schema family.  It
+contains no analyzer or generator behavior; those modules consume the checked,
+ordered views compiled here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from protocol_validation import ProtocolSchemaSet, ValidationError
+
+DAO_ROOT = Path(__file__).resolve().parents[1]
+A4_ROOT = DAO_ROOT / "experiments" / "a4"
+CHECKED_PLAN_PATH = A4_ROOT / "a4-row-anchored-maps.plan.json"
+PLAN_SHA256 = "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+REVISION_PLAN_SHA256 = PLAN_SHA256
+EXPERIMENT_ID = "DAO-A4-ROW-ANCHORED-MAPS-001"
+
+_SCHEMA_FILES = {
+    "dao_a4_analysis_report": "analysis-report.schema.json",
+    "dao_a4_bundle_manifest": "bundle-manifest.schema.json",
+    "dao_a4_schema_snapshot": "dao-schema-snapshot.schema.json",
+    "dao_a4_frozen_derivation_candidates": "derivation-candidates.schema.json",
+    "dao_a4_analyzer_dry_run_report": "dry-run-report.schema.json",
+    "dao_a4_environment": "environment.schema.json",
+    "dao_a4_h4_occurrence_evidence": "h4-occurrence-evidence.schema.json",
+    "dao_a4_holdout_structure_receipt": "holdout-structure-receipt.schema.json",
+    "dao_a4_independent_validation_report": "independent-validation-report.schema.json",
+    "dao_a4_page_index": "page-index.schema.json",
+    "dao_a4_row_anchored_maps_plan": "plan.schema.json",
+    "dao_a4_reachability_transcript": "reachability-transcript.schema.json",
+    "dao_a4_replica_artifact_manifest": "replica-artifact-manifest.schema.json",
+    "dao_a4_replica_observation": "replica-observation.schema.json",
+}
+
+SCHEMA_SHA256: Mapping[str, str] = MappingProxyType(
+    {
+        "analysis-report.schema.json": "bd1cdd62fdf6dae1ed756c092a90936be1318dc3a66e9d1d6309ecfa0d3d2010",
+        "bundle-manifest.schema.json": "1b051fe4eeaf7dcdb7304cd885cc88d85630ccd76a7ea6d79b408c0d42272791",
+        "dao-schema-snapshot.schema.json": "f890d9c7f710c033b357609ebab73ac51c68153cb067af7e40162930cf5d76c8",
+        "derivation-candidates.schema.json": "1cf5829b14663a68c934ff4d16b1b95668291b21b645ad3ae0e93abe3c839a28",
+        "dry-run-report.schema.json": "c9a47933675749d3c0a631eb902cd0402502687b1cfbe0dbf5ba22ed6c76b3d9",
+        "environment.schema.json": "77f1a95a65d2d202205a8a15ed1a59934bb5d5cca6df2226ae118c90771d131f",
+        "h4-occurrence-evidence.schema.json": "272f591f857fa93e059bd66175eef4c13309fbbc276a7755dcd8859a4c2e1ae8",
+        "holdout-structure-receipt.schema.json": "92c255fa62a94c3855ea23441d3d1b5077dccf3148b3e255fd171c6508c8a769",
+        "independent-validation-report.schema.json": "2771f1cda975ba22b100bb607df2525181fc62721e854a84c7934fd7ea73b233",
+        "page-index.schema.json": "f612f77fb8e3180c15bf45681df3e51e4e8088803b297764d85a655de8ab099f",
+        "plan.schema.json": "9da16374db62251c55c3df26e7a0d066b8ca2ad3e514c51ce2c0c20b00afec49",
+        "reachability-transcript.schema.json": "beaa8179a9c0e5a3d26c1098494f6d0bf32c20ea87d162de65e0637aa3f95bb5",
+        "replica-artifact-manifest.schema.json": "61640502ae032877b43895098dcbf3a466bd207600676390b652ebea1bfa8d2b",
+        "replica-observation.schema.json": "d1ef77f91471935d99c3b9a1c0e7a4329a1d9d77cab8da51153cfb44de3d22cb",
+    }
+)
+
+SCHEMAS = ProtocolSchemaSet(A4_ROOT, _SCHEMA_FILES)
+
+
+def require_equal(actual: Any, expected: Any, location: str) -> None:
+    """Reject a value that differs from the checked A4 contract."""
+    if actual != expected:
+        raise ValidationError(f"{location}: does not match the checked A4 contract")
+
+
+def sha256_hex(payload: bytes) -> str:
+    """Return a lowercase SHA-256 digest for retained bytes."""
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    try:
+        return sha256_hex(path.read_bytes())
+    except OSError as exc:
+        raise ValidationError(f"{path}: cannot hash file: {exc}") from exc
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Encode a JSON value for A4 model and candidate identity hashing."""
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ValidationError(f"value is not canonical JSON: {exc}") from exc
+
+
+def canonical_model_id(model_type: str, model: Mapping[str, Any]) -> str:
+    """Hash the replica-invariant identity shared by H1 and H4 models."""
+    return sha256_hex(canonical_json_bytes({"model_type": model_type, "model": model}))
+
+
+def canonical_candidate_id(
+    model_type: str,
+    model: Mapping[str, Any],
+    instance_bindings: Sequence[Mapping[str, Any]] | None = None,
+) -> str:
+    """Hash a complete registered candidate identity."""
+    identity: dict[str, Any] = {"model_type": model_type, "model": model}
+    if instance_bindings is not None:
+        identity["instance_bindings"] = instance_bindings
+    return sha256_hex(canonical_json_bytes(identity))
+
+
+def load_bounded_json_with_payload(
+    path: Path, maximum: int = 64 * 1024 * 1024
+) -> tuple[dict[str, Any], bytes]:
+    """Load one regular, bounded, duplicate-key-free UTF-8 JSON object."""
+    if not isinstance(maximum, int) or isinstance(maximum, bool) or maximum < 0:
+        raise ValidationError("JSON byte ceiling must be a non-negative integer")
+    try:
+        metadata = path.lstat()
+        reparse = bool(getattr(metadata, "st_file_attributes", 0) & 0x400)
+        if path.is_symlink() or reparse or not stat.S_ISREG(metadata.st_mode):
+            raise ValidationError(f"{path}: JSON input must be a regular file")
+        if metadata.st_size > maximum:
+            raise ValidationError(f"{path}: exceeds {maximum}-byte JSON ceiling")
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise ValidationError(f"{path}: cannot inspect JSON: {exc}") from exc
+    if len(payload) > maximum:
+        raise ValidationError(f"{path}: exceeds {maximum}-byte JSON ceiling")
+    if len(payload) != metadata.st_size:
+        raise ValidationError(f"{path}: JSON input changed while it was read")
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise ValidationError(f"{path}: UTF-8 byte-order marks are forbidden")
+
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_nonfinite(value: str) -> None:
+        raise ValueError(f"non-finite JSON number {value}")
+
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=unique_object,
+            parse_constant=reject_nonfinite,
+        )
+    except (UnicodeError, json.JSONDecodeError, ValueError, RecursionError) as exc:
+        raise ValidationError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path}: JSON root must be an object")
+    return value, payload
+
+
+def load_bounded_json(path: Path, maximum: int = 64 * 1024 * 1024) -> dict[str, Any]:
+    """Load a bounded protocol JSON object without retaining its bytes."""
+    return load_bounded_json_with_payload(path, maximum)[0]
+
+
+@dataclass(frozen=True)
+class LifecycleRange:
+    logical_role: str
+    first_checkpoint: str
+    last_checkpoint: str
+    first_ordinal: int
+    last_ordinal: int
+
+
+@dataclass(frozen=True)
+class CheckedPlan:
+    document: dict[str, Any]
+    checkpoint_ids: tuple[str, ...]
+    checkpoint_ordinals: Mapping[str, int]
+    predicate_ids: tuple[str, ...]
+    ordered_predicate_contracts: tuple[Mapping[str, Any], ...]
+    predicate_contracts: Mapping[str, Mapping[str, Any]]
+    campaign_predicate_ids: tuple[str, ...]
+    layer_predicate_ids: Mapping[str, tuple[str, ...]]
+    holdout_predicate_ids: tuple[str, ...]
+    grammars: Mapping[str, Any]
+    bounds: Mapping[str, int]
+    logical_roles: tuple[str, ...]
+    role_bindings: Mapping[int, Mapping[str, str]]
+    lifecycle_ranges: Mapping[str, LifecycleRange]
+
+
+def _as_unique_strings(value: Any, location: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValidationError(f"{location}: expected an array of strings")
+    result = tuple(value)
+    if len(result) != len(set(result)):
+        raise ValidationError(f"{location}: values must be unique")
+    return result
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _compile_lifecycle_ranges(
+    checkpoint_ids: tuple[str, ...],
+    expected_schema: Mapping[str, Any],
+    logical_roles: tuple[str, ...],
+) -> Mapping[str, LifecycleRange]:
+    checkpoint_ordinals = {name: ordinal for ordinal, name in enumerate(checkpoint_ids)}
+    extant: dict[str, tuple[str, list[str]]] = {}
+    for checkpoint in checkpoint_ids:
+        tokens = _as_unique_strings(
+            expected_schema.get(checkpoint),
+            f"$.tables.expected_schema_by_checkpoint.{checkpoint}",
+        )
+        seen_roles: set[str] = set()
+        for token in tokens:
+            fields = token.split(":")
+            role = fields[0]
+            if role not in logical_roles or role in seen_roles or len(fields) < 2:
+                raise ValidationError(f"{checkpoint}: invalid lifecycle schema token {token!r}")
+            seen_roles.add(role)
+            version = fields[1] if len(fields) > 2 and fields[1].startswith("v") else "v1"
+            instance = f"{role}-{version}"
+            extant.setdefault(instance, (role, []))[1].append(checkpoint)
+    ranges: dict[str, LifecycleRange] = {}
+    for instance, (role, checkpoints) in extant.items():
+        first, last = checkpoints[0], checkpoints[-1]
+        first_ordinal = checkpoint_ordinals[first]
+        last_ordinal = checkpoint_ordinals[last]
+        if tuple(checkpoints) != checkpoint_ids[first_ordinal : last_ordinal + 1]:
+            raise ValidationError(f"lifecycle range {instance}: reappears after absence")
+        ranges[instance] = LifecycleRange(
+            role, first, last, first_ordinal, last_ordinal
+        )
+    return MappingProxyType(ranges)
+
+
+def _compile_plan(document: dict[str, Any]) -> CheckedPlan:
+    require_equal(
+        SCHEMAS.validate(document),
+        "dao_a4_row_anchored_maps_plan",
+        "$.document_type",
+    )
+    require_equal(document["experiment_id"], EXPERIMENT_ID, "$.experiment_id")
+
+    checkpoint_design = document["checkpoint_design"]
+    checkpoint_ids = _as_unique_strings(
+        checkpoint_design["checkpoint_ids"], "$.checkpoint_design.checkpoint_ids"
+    )
+    require_equal(len(checkpoint_ids), checkpoint_design["count"], "checkpoint count")
+    checkpoint_ordinals = MappingProxyType(
+        {name: ordinal for ordinal, name in enumerate(checkpoint_ids)}
+    )
+
+    registry = document["predicate_registry"]
+    predicate_ids = _as_unique_strings(registry["ids"], "$.predicate_registry.ids")
+    contracts = registry["predicate_contracts"]
+    if not isinstance(contracts, list):
+        raise ValidationError("$.predicate_registry.predicate_contracts: expected array")
+    require_equal(
+        [contract["predicate_id"] for contract in contracts],
+        list(predicate_ids),
+        "predicate contract order",
+    )
+    require_equal(
+        [contract["order"] for contract in contracts],
+        list(range(1, len(predicate_ids) + 1)),
+        "predicate numeric order",
+    )
+    require_equal(
+        [contract["terminal_id"] for contract in contracts],
+        list(predicate_ids),
+        "predicate terminal ids",
+    )
+    fixture_ids = [contract["reachability_fixture_id"] for contract in contracts]
+    require_equal(len(fixture_ids), len(set(fixture_ids)), "reachability fixture ids")
+
+    campaign = _as_unique_strings(
+        registry["campaign_evaluated_before_any_layer"],
+        "$.predicate_registry.campaign_evaluated_before_any_layer",
+    )
+    raw_layers = registry["per_layer_ordered_predicates"]
+    if not isinstance(raw_layers, dict):
+        raise ValidationError("$.predicate_registry.per_layer_ordered_predicates: expected object")
+    layer_sequences = {
+        layer: _as_unique_strings(sequence, f"predicate layer {layer}")
+        for layer, sequence in raw_layers.items()
+    }
+    holdout = _as_unique_strings(
+        registry["holdout_phase_ordered_predicates"],
+        "$.predicate_registry.holdout_phase_ordered_predicates",
+    )
+    flattened = campaign + tuple(
+        predicate
+        for sequence in layer_sequences.values()
+        for predicate in sequence
+    ) + holdout
+    require_equal(flattened, predicate_ids, "predicate phase order")
+
+    terminal_payloads = {
+        contract["predicate_id"]: {
+            "terminal_payload_schema": contract["terminal_payload_schema"],
+            "candidate_stage": contract["candidate_stage"],
+            "result_slots": contract["result_slots"],
+        }
+        for contract in contracts
+        if contract["terminal_payload_schema"] != "none"
+    }
+    require_equal(
+        registry["terminal_payload_by_predicate"],
+        terminal_payloads,
+        "terminal payload registry",
+    )
+
+    bounds = document["bounds"]
+    if any(
+        not isinstance(value, int) or isinstance(value, bool) or value <= 0
+        for value in bounds.values()
+    ):
+        raise ValidationError("$.bounds: every bound must be a positive integer")
+    require_equal(bounds["page_size"], document["page_capture"]["page_size"], "page size")
+    require_equal(
+        bounds["max_checkpoints_per_replica"] >= len(checkpoint_ids),
+        True,
+        "checkpoint bound",
+    )
+
+    tables = document["tables"]
+    logical_roles = _as_unique_strings(tables["logical_roles"], "$.tables.logical_roles")
+    require_equal(
+        tuple(document["candidate_grammars"]["h1"]["logical_roles"]),
+        logical_roles,
+        "H1 logical roles",
+    )
+    physical_names = _as_unique_strings(tables["physical_names"], "$.tables.physical_names")
+    role_bindings: dict[int, Mapping[str, str]] = {}
+    for expected_replica, row in enumerate(tables["role_bindings"], start=1):
+        require_equal(row["replica"], expected_replica, "role-binding replica order")
+        require_equal(set(row), {"replica", *logical_roles}, "role-binding keys")
+        binding = {role: row[role] for role in logical_roles}
+        require_equal(tuple(sorted(binding.values())), tuple(sorted(physical_names)), "role-binding permutation")
+        role_bindings[expected_replica] = MappingProxyType(binding)
+    require_equal(tuple(role_bindings), tuple(range(1, document["replicas"]["count"] + 1)), "replica role bindings")
+    require_equal(document["replicas"]["derivation"], [1, 2], "derivation replicas")
+    require_equal(document["replicas"]["holdout"], 3, "holdout replica")
+
+    frozen_contracts = tuple(_freeze_json(contract) for contract in contracts)
+    contract_map = MappingProxyType(
+        {
+            predicate_id: frozen_contracts[index]
+            for index, predicate_id in enumerate(predicate_ids)
+        }
+    )
+    return CheckedPlan(
+        document=document,
+        checkpoint_ids=checkpoint_ids,
+        checkpoint_ordinals=checkpoint_ordinals,
+        predicate_ids=predicate_ids,
+        ordered_predicate_contracts=frozen_contracts,
+        predicate_contracts=contract_map,
+        campaign_predicate_ids=campaign,
+        layer_predicate_ids=MappingProxyType(layer_sequences),
+        holdout_predicate_ids=holdout,
+        grammars=_freeze_json(document["candidate_grammars"]),
+        bounds=MappingProxyType(dict(bounds)),
+        logical_roles=logical_roles,
+        role_bindings=MappingProxyType(role_bindings),
+        lifecycle_ranges=_compile_lifecycle_ranges(
+            checkpoint_ids,
+            tables["expected_schema_by_checkpoint"],
+            logical_roles,
+        ),
+    )
+
+
+def load_checked_plan(path: Path = CHECKED_PLAN_PATH) -> CheckedPlan:
+    """Load the exact immutable A4 plan after checking every schema pin."""
+    require_equal(set(SCHEMA_SHA256), set(_SCHEMA_FILES.values()), "schema pin set")
+    for name, expected in SCHEMA_SHA256.items():
+        require_equal(_sha256_file(A4_ROOT / name), expected, name)
+    SCHEMAS.lint()
+    require_equal(_sha256_file(path), PLAN_SHA256, "preregistered plan sha256")
+    return _compile_plan(load_bounded_json(path))
+
+
+def validate_schema(document: dict[str, Any], expected: str | None = None) -> str:
+    """Validate an A4 document and its immutable plan/revision binding."""
+    document_type = SCHEMAS.validate(document)
+    if expected is not None:
+        require_equal(document_type, expected, "$.document_type")
+    if document_type == "dao_a4_row_anchored_maps_plan":
+        require_equal(document, PLAN, "checked plan")
+    else:
+        require_equal(document.get("experiment_id"), EXPERIMENT_ID, "$.experiment_id")
+        require_equal(document.get("plan_sha256"), PLAN_SHA256, "$.plan_sha256")
+        require_equal(
+            document.get("revision_plan_sha256"),
+            REVISION_PLAN_SHA256,
+            "$.revision_plan_sha256",
+        )
+    return document_type
+
+
+def _valid_nonnegative_count(value: Any, location: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValidationError(f"{location}: expected a non-negative integer")
+    return value
+
+
+def count_contract_accepts(
+    requirement: Mapping[str, Any],
+    measured_count: int,
+    *,
+    per_replica_counts: Sequence[int] | None = None,
+) -> bool:
+    """Evaluate one registered failure-survivor-count contract."""
+    measured = _valid_nonnegative_count(measured_count, "measured count")
+    if "exact" in requirement:
+        if set(requirement) != {"exact"}:
+            raise ValidationError("exact count contract has unknown keys")
+        expected = _valid_nonnegative_count(requirement["exact"], "exact count")
+        return measured == expected
+    if "minimum" in requirement:
+        if set(requirement) - {"minimum", "source"}:
+            raise ValidationError("minimum count contract has unknown keys")
+        minimum = _valid_nonnegative_count(requirement["minimum"], "minimum count")
+        return measured >= minimum
+    if "allowed_ranges" in requirement:
+        if set(requirement) - {"allowed_ranges", "source"}:
+            raise ValidationError("range count contract has unknown keys")
+        ranges = requirement["allowed_ranges"]
+        if not isinstance(ranges, (list, tuple)) or not ranges:
+            raise ValidationError("allowed_ranges must be a non-empty array")
+        return any(count_contract_accepts(item, measured) for item in ranges)
+    replica_keys = {"per_replica_exact", "replica_count", "total_exact"}
+    if replica_keys <= set(requirement):
+        if set(requirement) != replica_keys:
+            raise ValidationError("per-replica count contract has unknown keys")
+        per_replica = _valid_nonnegative_count(
+            requirement["per_replica_exact"], "per-replica exact count"
+        )
+        replica_count = _valid_nonnegative_count(
+            requirement["replica_count"], "replica count"
+        )
+        total = _valid_nonnegative_count(requirement["total_exact"], "total count")
+        if replica_count == 0:
+            raise ValidationError("replica count must be positive")
+        if total != per_replica * replica_count:
+            raise ValidationError("per-replica count contract has an inconsistent total")
+        if measured != total:
+            return False
+        if per_replica_counts is None:
+            return True
+        counts = tuple(
+            _valid_nonnegative_count(value, "per-replica count")
+            for value in per_replica_counts
+        )
+        return (
+            len(counts) == replica_count
+            and all(value == per_replica for value in counts)
+            and sum(counts) == measured
+        )
+    raise ValidationError("failure survivor-count contract has an unknown shape")
+
+
+def validate_failure_count(
+    predicate_id: str,
+    measured_count: int,
+    *,
+    per_replica_counts: Sequence[int] | None = None,
+) -> None:
+    """Require a measured terminal count to satisfy its predicate contract."""
+    contract = PREDICATE_CONTRACTS.get(predicate_id)
+    if contract is None:
+        raise ValidationError(f"unregistered A4 predicate {predicate_id!r}")
+    requirement = contract["failure_survivor_count"]
+    if not count_contract_accepts(
+        requirement, measured_count, per_replica_counts=per_replica_counts
+    ):
+        raise ValidationError(
+            f"{predicate_id}: measured failure count violates its contract"
+        )
+
+
+CHECKED_PLAN = load_checked_plan()
+PLAN = CHECKED_PLAN.document
+BOUNDS = CHECKED_PLAN.bounds
+CHECKPOINT_IDS = CHECKED_PLAN.checkpoint_ids
+CHECKPOINT_ORDINALS = CHECKED_PLAN.checkpoint_ordinals
+PREDICATE_IDS = CHECKED_PLAN.predicate_ids
+PREDICATE_CONTRACTS = CHECKED_PLAN.predicate_contracts
+CAMPAIGN_PREDICATE_IDS = CHECKED_PLAN.campaign_predicate_ids
+LAYER_PREDICATE_IDS = CHECKED_PLAN.layer_predicate_ids
+HOLDOUT_PREDICATE_IDS = CHECKED_PLAN.holdout_predicate_ids
+CANDIDATE_GRAMMARS = CHECKED_PLAN.grammars
+LOGICAL_ROLES = CHECKED_PLAN.logical_roles
+ROLE_BINDINGS = CHECKED_PLAN.role_bindings
+LIFECYCLE_RANGES = CHECKED_PLAN.lifecycle_ranges
+PAGE_SIZE = BOUNDS["page_size"]

--- a/oracle/windows-dao/scripts/a4_terminal.py
+++ b/oracle/windows-dao/scripts/a4_terminal.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Contract-directed frozen results for A4 derivation terminals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from protocol_validation import ValidationError
+
+from a4_model import A4AnalysisError, WorkLedger
+from a4_measurements import PredicateMeasurement
+from a4_spec import (
+    PREDICATE_CONTRACTS,
+    canonical_json_bytes,
+    sha256_hex,
+    validate_failure_count,
+)
+
+
+def _candidate_hash(candidates: Sequence[Mapping[str, Any]]) -> str:
+    return sha256_hex(canonical_json_bytes(list(candidates)))
+
+
+def not_applicable_result() -> dict[str, Any]:
+    """Return the one schema shape for a downstream inapplicable slot."""
+    candidates: list[dict[str, Any]] = []
+    return {
+        "status": "not_applicable",
+        "predicate_measured_survivor_count": 0,
+        "derivation_survivor_count": 0,
+        "terminal_predicate_id": None,
+        "terminal_payload_kind": None,
+        "terminal_candidate_stage": None,
+        "candidates": candidates,
+        "terminal_evidence": None,
+        "canonical_candidates_sha256": _candidate_hash(candidates),
+    }
+
+
+def decisive_result(
+    candidate: Mapping[str, Any], ledger: WorkLedger
+) -> dict[str, Any]:
+    """Retain and charge one final-stage decisive candidate."""
+    candidates = [dict(candidate)]
+    ledger.charge_candidate_documents(candidates)
+    return {
+        "status": "model",
+        "predicate_measured_survivor_count": 1,
+        "derivation_survivor_count": 1,
+        "terminal_predicate_id": None,
+        "terminal_payload_kind": None,
+        "terminal_candidate_stage": None,
+        "candidates": candidates,
+        "terminal_evidence": None,
+        "canonical_candidates_sha256": _candidate_hash(candidates),
+    }
+
+
+@dataclass(frozen=True)
+class DerivationTerminal:
+    """A registered scientific terminal plus all already-completed slots."""
+
+    predicate_id: str
+    layers: Mapping[str, Any]
+    h4_occurrence_evidence: Mapping[str, object] | None = None
+    measurements: tuple[PredicateMeasurement, ...] = ()
+
+    def __post_init__(self) -> None:
+        contract = PREDICATE_CONTRACTS.get(self.predicate_id)
+        if contract is None or contract["terminal_payload_schema"] == "none":
+            raise ValidationError(
+                f"{self.predicate_id}: is not a registered derivation terminal"
+            )
+        object.__setattr__(self, "layers", MappingProxyType(dict(self.layers)))
+
+
+def terminal_result(
+    error: A4AnalysisError,
+    ledger: WorkLedger,
+    *,
+    candidates: Sequence[Mapping[str, Any]] | None = None,
+    terminal_evidence: Mapping[str, Any] | None = None,
+    per_replica_counts: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    """Project one registered terminal solely through its predicate contract."""
+    contract = PREDICATE_CONTRACTS.get(error.predicate_id)
+    if contract is None:
+        raise error
+    payload_kind = contract["terminal_payload_schema"]
+    if payload_kind == "none" or contract["scope"] == "campaign":
+        raise error
+    measured = error.survivor_count
+    validate_failure_count(
+        error.predicate_id, measured, per_replica_counts=per_replica_counts
+    )
+    retained = [dict(candidate) for candidate in candidates or ()]
+    evidence = None if terminal_evidence is None else dict(terminal_evidence)
+
+    if payload_kind == "candidate_set":
+        if len(retained) != measured or evidence is not None:
+            raise ValidationError(
+                f"{error.predicate_id}: candidate-set terminal payload differs from its count"
+            )
+    elif payload_kind == "replica_pair":
+        if retained or evidence is None:
+            raise ValidationError(
+                f"{error.predicate_id}: replica-pair terminal payload is incomplete"
+            )
+        entries = evidence.get("entries")
+        if not isinstance(entries, list) or len(entries) != 2 or any(
+            not isinstance(entry, Mapping)
+            or not isinstance(entry.get("complete_candidate"), Mapping)
+            for entry in entries
+        ):
+            raise ValidationError(
+                f"{error.predicate_id}: replica-pair candidates are incomplete"
+            )
+        ledger.charge_candidate_documents(
+            [entry["complete_candidate"] for entry in entries]
+        )
+    elif payload_kind == "invalid_observation":
+        if evidence is None or len(retained) > 1:
+            raise ValidationError(
+                f"{error.predicate_id}: invalid-observation terminal payload is incomplete"
+            )
+    elif payload_kind == "grouped_candidate_set":
+        if evidence is None or evidence.get("kind") != "operation_groups":
+            raise ValidationError(
+                f"{error.predicate_id}: grouped terminal payload is incomplete"
+            )
+        groups = evidence.get("groups")
+        if not isinstance(groups, list) or len(groups) != 7:
+            raise ValidationError(
+                f"{error.predicate_id}: grouped terminal must retain seven groups"
+            )
+        counts = [group.get("cardinality") for group in groups]
+        expected = min(counts) if error.predicate_id.endswith("RECORD-NONE") else max(counts)
+        if measured != expected:
+            raise ValidationError(
+                f"{error.predicate_id}: measured count differs from grouped cardinality"
+            )
+        retained_ids = {candidate["canonical_candidate_id"] for candidate in retained}
+        grouped_ids = {
+            candidate_id for group in groups for candidate_id in group.get("candidate_ids", [])
+        }
+        if retained_ids != grouped_ids or any(
+            group.get("cardinality") != len(group.get("candidate_ids", []))
+            for group in groups
+        ):
+            raise ValidationError(
+                f"{error.predicate_id}: grouped candidate union is inconsistent"
+            )
+    else:
+        raise ValidationError(
+            f"{error.predicate_id}: unknown registered terminal payload {payload_kind!r}"
+        )
+
+    ledger.charge_candidate_documents(retained)
+    return {
+        "status": "no_outcome",
+        "predicate_measured_survivor_count": measured,
+        "derivation_survivor_count": 0,
+        "terminal_predicate_id": error.predicate_id,
+        "terminal_payload_kind": payload_kind,
+        "terminal_candidate_stage": contract["candidate_stage"],
+        "candidates": retained,
+        "terminal_evidence": evidence,
+        "canonical_candidates_sha256": _candidate_hash(retained),
+    }

--- a/oracle/windows-dao/tests/test_a4_analyzer.py
+++ b/oracle/windows-dao/tests/test_a4_analyzer.py
@@ -1,0 +1,1092 @@
+"""A4 derivation, freeze boundary, holdout, and schema contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import copy
+import sys
+import unittest
+from collections.abc import Iterator, Mapping
+from dataclasses import replace
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+from a4_analysis import analyze  # noqa: E402
+import a4_derivation  # noqa: E402
+import a4_analysis_input as input_module  # noqa: E402
+import a4_layer_h4  # noqa: E402
+from a4_analysis_input import (  # noqa: E402
+    HoldoutTicket,
+    ReplicaAnalysisInput,
+    check_analysis_input,
+    close_derivation,
+    open_holdout,
+)
+from a4_analysis_state import freeze_derivation, resume_derivation  # noqa: E402
+from a4_campaign import (  # noqa: E402
+    CampaignResourceTotals,
+    changed_page_indices,
+    expected_snapshot_tables,
+    require_resource_bounds,
+)
+from a4_generator import SyntheticParameters, generate_replica  # noqa: E402
+from a4_generator_pages import data_page  # noqa: E402
+from a4_layers import derive_layers  # noqa: E402
+from a4_model import A4AnalysisError, WorkLedger  # noqa: E402
+from a4_terminal import DerivationTerminal  # noqa: E402
+from a4_spec import (  # noqa: E402
+    CHECKPOINT_IDS,
+    EXPERIMENT_ID,
+    PAGE_SIZE,
+    PLAN,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    ROLE_BINDINGS,
+    canonical_json_bytes as canonical_model_bytes,
+    validate_schema,
+)
+from protocol_validation import canonical_json_bytes  # noqa: E402
+
+_COMMIT = "0" * 40
+_PROVIDER = "2" * 64
+_PROVIDER_CLSID = "{00000100-0000-0010-8000-00AA006D2EA4}"
+_CANONICALIZATION = json.loads(
+    (ROOT / "oracle/windows-dao/experiments/a4/dao-schema-snapshot.schema.json").read_text()
+)["properties"]["canonicalization"]["const"]
+
+
+def _ref(document: dict[str, object], path: str) -> dict[str, object]:
+    payload = canonical_json_bytes(document)
+    return {
+        "path": path,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size_bytes": len(payload),
+    }
+
+
+def _common(
+    replica: int, campaign_id: str, environment_sha256: str
+) -> dict[str, object]:
+    return {
+        "protocol_version": "1.0.0",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "producer_commit": _COMMIT,
+        "campaign_id": campaign_id,
+        "environment_sha256": environment_sha256,
+        "provider_sha256": _PROVIDER,
+        "replica": replica,
+    }
+
+
+def _environment(replica: int, campaign_id: str) -> bytes:
+    document = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_environment",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "producer_commit": _COMMIT,
+        "repository_url": "https://github.com/oglassdev/jet3-rs.git",
+        "campaign_id": campaign_id,
+        "replica": replica,
+        "matrix_job_id": f"synthetic-replica-{replica}",
+        "status": "ready",
+        "host": {
+            "windows_version": f"10.0.20348.{replica}",
+            "process_architecture": "x86",
+            "powershell_version": "5.1.20348.1",
+            "python_version": f"3.13.{replica}",
+            "runner_image": "windows-2022",
+            "windows_ansi_code_page": 1252,
+            "windows_oem_code_page": 437,
+            "locale_name": "en-US",
+        },
+        "provider": {
+            "prog_id": "DAO.DBEngine.36",
+            "clsid": _PROVIDER_CLSID,
+            "provider_version": "3.60",
+            "server_path": "C:/Program Files (x86)/Common Files/System/dao/dao360.dll",
+            "server_file_version": "3.60.8618.0",
+            "server_sha256": _PROVIDER,
+        },
+    }
+    return canonical_json_bytes(document)
+
+
+def _manifest(
+    source: object,
+    environment_payload: bytes,
+    observation: dict[str, object],
+    indexes: dict[str, dict[str, object]],
+    snapshots: dict[str, dict[str, object]],
+    campaign_id: str,
+) -> dict[str, object]:
+    replica = source.replica
+    files = [
+        {
+            "path": PLAN["artifacts"]["replica_environments"][replica - 1],
+            "role": "environment",
+            "sha256": hashlib.sha256(environment_payload).hexdigest(),
+            "size_bytes": len(environment_payload),
+            "media_type": "application/json",
+        },
+        {
+            **_ref(observation, f"observations/replica-{replica:02d}.json"),
+            "role": "replica_observation",
+            "media_type": "application/json",
+        },
+    ]
+    for checkpoint in CHECKPOINT_IDS:
+        files.extend(
+            (
+                {
+                    **observation["checkpoints"][CHECKPOINT_IDS.index(checkpoint)]["page_index"],
+                    "role": "page_index",
+                    "media_type": "application/json",
+                },
+                {
+                    **observation["checkpoints"][CHECKPOINT_IDS.index(checkpoint)]["dao_schema_snapshot"],
+                    "role": "dao_schema_snapshot",
+                    "media_type": "application/json",
+                },
+            )
+        )
+    for digest in sorted(
+        {
+            value
+            for checkpoint in CHECKPOINT_IDS
+            for value in source.ordered_page_sha256[checkpoint]
+        }
+    ):
+        files.append(
+            {
+                "path": f"page-store/{digest}.page",
+                "role": "page_blob",
+                "sha256": digest,
+                "size_bytes": PAGE_SIZE,
+                "media_type": "application/octet-stream",
+            }
+        )
+    return {
+        **_common(
+            replica,
+            campaign_id,
+            hashlib.sha256(environment_payload).hexdigest(),
+        ),
+        "document_type": "dao_a4_replica_artifact_manifest",
+        "matrix_job_id": f"synthetic-replica-{replica}",
+        "checkpoint_count": len(CHECKPOINT_IDS),
+        "inventory_closed": True,
+        "hashes_verified": True,
+        "paths_closed": True,
+        "files": files,
+    }
+
+
+def _surface(source: object, campaign_id: str) -> ReplicaAnalysisInput:
+    replica = source.replica
+    environment_payload = _environment(replica, campaign_id)
+    common = _common(
+        replica,
+        campaign_id,
+        hashlib.sha256(environment_payload).hexdigest(),
+    )
+    indexes: dict[str, dict[str, object]] = {}
+    snapshots: dict[str, dict[str, object]] = {}
+    predecessor: tuple[str, ...] | None = None
+    running_inserted = 0
+    previous_rows = {role: 0 for role in PLAN["tables"]["logical_roles"]}
+    checkpoint_rows = []
+    growth_observations = []
+    changed_total = 0
+    logical_reads = 0
+    for ordinal, checkpoint in enumerate(CHECKPOINT_IDS):
+        sequence = tuple(source.ordered_page_sha256[checkpoint])
+        database = hashlib.sha256()
+        for digest in sequence:
+            database.update(source.page_bytes(digest))
+        database_sha256 = database.hexdigest()
+        changed = changed_page_indices(predecessor, sequence)
+        changed_total += len(changed)
+        logical_reads += len(sequence) * PAGE_SIZE
+        index = {
+            **common,
+            "document_type": "dao_a4_page_index",
+            "checkpoint_id": checkpoint,
+            "ordinal": ordinal,
+            "predecessor_checkpoint_id": None if ordinal == 0 else CHECKPOINT_IDS[ordinal - 1],
+            "page_count": len(sequence),
+            "file_size_bytes": len(sequence) * PAGE_SIZE,
+            "database_sha256": database_sha256,
+            "ordered_page_sha256": list(sequence),
+            "changed_page_indices": list(changed),
+        }
+        indexes[checkpoint] = index
+        rows = dict(source.row_counts[checkpoint])
+        running_inserted += sum(
+            max(0, rows[role] - previous_rows[role]) for role in previous_rows
+        )
+        tables = expected_snapshot_tables(replica, checkpoint, rows)
+        snapshot = {
+            **common,
+            "document_type": "dao_a4_schema_snapshot",
+            "checkpoint_id": checkpoint,
+            "ordinal": ordinal,
+            "windows_ansi_code_page": 1252,
+            "database_sha256_before_read": database_sha256,
+            "database_sha256_after_read": database_sha256,
+            "database_unchanged_by_read": True,
+            "dao_identifier_observable": False,
+            "identity_oracle": "listed_operation_instance_equality_only",
+            "canonicalization": _CANONICALIZATION,
+            "tables": tables,
+        }
+        snapshots[checkpoint] = snapshot
+        checkpoint_row = {
+                "checkpoint_id": checkpoint,
+                "ordinal": ordinal,
+                "actual_file_pages": len(sequence),
+                "actual_size_bytes": len(sequence) * PAGE_SIZE,
+                "target_baseline_pages": None,
+                "target_threshold_pages": None,
+                "target_overshoot_pages": None,
+                "inserted_rows_total": running_inserted,
+                "table_row_counts": rows,
+                "dao_reread": [
+                    {
+                        "role": table["logical_role"],
+                        "row_count": table["row_count"],
+                        "rolling_sha256": table["rolling_row_sha256"],
+                    }
+                    for table in tables
+                ],
+                "quiescent": True,
+                "post_close_companion": {
+                    "present_after_close": False,
+                    "observed_size_bytes": 0,
+                    "retained_for_physical_analysis": False,
+                },
+                "page_index": _ref(index, f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json"),
+                "dao_schema_snapshot": _ref(snapshot, f"schema-snapshots/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json"),
+        }
+        if "_REL_" in checkpoint or "_ABS_" in checkpoint:
+            role = checkpoint.split("_", 1)[0]
+            suffix = int(checkpoint.rsplit("_", 1)[1])
+            if role == "T1":
+                baseline = len(source.ordered_page_sha256["T4_CREATE"])
+            elif role == "T4":
+                baseline = len(source.ordered_page_sha256["T3_ABS_16480"])
+            else:
+                baseline = None
+            target = suffix if baseline is None else baseline + suffix
+            overshoot = len(sequence) - target
+            inserted = rows[role] - previous_rows[role]
+            checkpoint_row.update(
+                target_baseline_pages=baseline,
+                target_threshold_pages=target,
+                target_overshoot_pages=overshoot,
+            )
+            growth_observations.append(
+                {
+                    "checkpoint_id": checkpoint,
+                    "baseline_pages": baseline,
+                    "target_pages": target,
+                    "achieved_pages": len(sequence),
+                    "overshoot_pages": overshoot,
+                    "rows": inserted,
+                }
+            )
+        checkpoint_rows.append(checkpoint_row)
+        previous_rows = rows
+        predecessor = sequence
+    observation = {
+        **common,
+        "document_type": "dao_a4_replica_observation",
+        "repository_url": "https://github.com/oglassdev/jet3-rs.git",
+        "matrix_job": {
+            "job_id": f"synthetic-replica-{replica}",
+            "replica_only": True,
+            "shared_mutable_state": False,
+        },
+        "role_binding": dict(ROLE_BINDINGS[replica]),
+        "growth_observations": growth_observations,
+        "logical_checkpoint_read_bytes": logical_reads,
+        "inserted_rows_total": running_inserted,
+        "changed_hash_entries": changed_total,
+        "checkpoints": checkpoint_rows,
+    }
+    manifest = _manifest(
+        source,
+        environment_payload,
+        observation,
+        indexes,
+        snapshots,
+        campaign_id,
+    )
+    return ReplicaAnalysisInput(
+        source,
+        source.row_counts,
+        observation,
+        indexes,
+        snapshots,
+        manifest,
+        environment_payload,
+    )
+
+
+class _LazyInputs(Mapping[int, ReplicaAnalysisInput]):
+    def __init__(self, parameters: SyntheticParameters | None = None) -> None:
+        self.parameters = parameters or SyntheticParameters()
+        self.derivation = {
+            replica: _surface(
+                generate_replica(self.parameters, replica), "a4-synthetic"
+            )
+            for replica in (1, 2)
+        }
+        self.holdout_calls = 0
+        self.last_holdout_sha256: str | None = None
+
+    def __getitem__(self, key: int) -> ReplicaAnalysisInput:
+        return self.derivation[key]
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.derivation)
+
+    def __len__(self) -> int:
+        return len(self.derivation)
+
+    def acquire_holdout(
+        self, frozen_payload: bytes, frozen_sha256: str
+    ) -> ReplicaAnalysisInput:
+        self.assert_frozen(frozen_payload, frozen_sha256)
+        self.holdout_calls += 1
+        self.last_holdout_sha256 = frozen_sha256
+        return _surface(
+            generate_replica(self.parameters, 3), "a4-synthetic"
+        )
+
+    @staticmethod
+    def assert_frozen(frozen_payload: bytes, frozen_sha256: str) -> None:
+        if hashlib.sha256(frozen_payload).hexdigest() != frozen_sha256:
+            raise AssertionError("holdout provider received unfrozen bytes")
+
+
+def _inputs(parameters: SyntheticParameters | None = None) -> _LazyInputs:
+    return _LazyInputs(parameters)
+
+
+def _close_after_freeze(checked, provider):
+    ledger = WorkLedger()
+    layers = derive_layers(checked, ledger)
+    frozen = freeze_derivation(checked, layers, ledger)
+    return (
+        close_derivation(
+            checked,
+            frozen.canonical_bytes,
+            frozen.sha256,
+            provider,
+            frozen.occurrence_evidence_bytes,
+        ),
+        frozen,
+    )
+
+
+class A4CampaignInputTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.inputs = _inputs()
+
+    def _changed(
+        self,
+        replica: int,
+        *,
+        observation: dict[str, object] | None = None,
+        indexes: dict[str, dict[str, object]] | None = None,
+        snapshots: dict[str, dict[str, object]] | None = None,
+        manifest: dict[str, object] | None = None,
+        environment_payload: bytes | None = None,
+    ) -> dict[int, ReplicaAnalysisInput]:
+        inputs = dict(self.inputs)
+        original = inputs[replica]
+        inputs[replica] = ReplicaAnalysisInput(
+            original.source,
+            original.table_row_counts,
+            original.replica_observation if observation is None else observation,
+            original.page_indexes if indexes is None else indexes,
+            original.schema_snapshots if snapshots is None else snapshots,
+            original.artifact_manifest if manifest is None else manifest,
+            (
+                original.environment_payload
+                if environment_payload is None
+                else environment_payload
+            ),
+        )
+        return inputs
+
+    def _changed_entry_adversary(self) -> ReplicaAnalysisInput:
+        original = self.inputs[1]
+        observation = copy.deepcopy(original.replica_observation)
+        indexes = copy.deepcopy(original.page_indexes)
+        snapshots = copy.deepcopy(original.schema_snapshots)
+        payloads = (bytes(PAGE_SIZE), bytes([1]) * PAGE_SIZE)
+        digests = tuple(hashlib.sha256(payload).hexdigest() for payload in payloads)
+        blobs = dict(zip(digests, payloads))
+        ordered: dict[str, tuple[str, ...]] = {}
+        selected = 0
+        idle_right = {right for _left, right in PLAN["checkpoint_design"]["idle_pairs"]}
+        predecessor: tuple[str, ...] | None = None
+        changed_total = 0
+        for ordinal, checkpoint in enumerate(CHECKPOINT_IDS):
+            if ordinal and checkpoint not in idle_right:
+                selected ^= 1
+            page_count = original.source.page_count[checkpoint]
+            sequence = (digests[selected],) * page_count
+            ordered[checkpoint] = sequence
+            changed = changed_page_indices(predecessor, sequence)
+            changed_total += len(changed)
+            database_sha256 = hashlib.sha256(
+                payloads[selected] * page_count
+            ).hexdigest()
+            index = indexes[checkpoint]
+            index.update(
+                page_count=page_count,
+                file_size_bytes=page_count * PAGE_SIZE,
+                database_sha256=database_sha256,
+                ordered_page_sha256=list(sequence),
+                changed_page_indices=list(changed),
+            )
+            snapshot = snapshots[checkpoint]
+            snapshot["database_sha256_before_read"] = database_sha256
+            snapshot["database_sha256_after_read"] = database_sha256
+            checkpoint_row = observation["checkpoints"][ordinal]
+            checkpoint_row["actual_file_pages"] = page_count
+            checkpoint_row["actual_size_bytes"] = page_count * PAGE_SIZE
+            checkpoint_row["page_index"] = _ref(
+                index,
+                f"page-indexes/replica-01/{ordinal:02d}-{checkpoint}.json",
+            )
+            checkpoint_row["dao_schema_snapshot"] = _ref(
+                snapshot,
+                f"schema-snapshots/replica-01/{ordinal:02d}-{checkpoint}.json",
+            )
+            predecessor = sequence
+        self.assertGreater(
+            changed_total,
+            PLAN["bounds"]["max_changed_hash_entries_per_replica"],
+        )
+        observation["changed_hash_entries"] = int(
+            PLAN["bounds"]["max_changed_hash_entries_per_replica"]
+        )
+        observation["logical_checkpoint_read_bytes"] = (
+            sum(len(sequence) for sequence in ordered.values()) * PAGE_SIZE
+        )
+
+        class Source:
+            checkpoint_ids = CHECKPOINT_IDS
+            page_count = {
+                checkpoint: len(sequence)
+                for checkpoint, sequence in ordered.items()
+            }
+            ordered_page_sha256 = ordered
+
+            @staticmethod
+            def page_bytes(digest: str) -> bytes:
+                return blobs[digest]
+
+        source = Source()
+        source.replica = 1
+        manifest = _manifest(
+            source,
+            original.environment_payload,
+            observation,
+            indexes,
+            snapshots,
+            "a4-synthetic",
+        )
+        return ReplicaAnalysisInput(
+            source,
+            original.table_row_counts,
+            observation,
+            indexes,
+            snapshots,
+            manifest,
+            original.environment_payload,
+        )
+
+    def test_all_75_surfaces_cross_bind_around_holdout_boundary(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, self.inputs)
+        self.assertEqual(tuple(checked.views), (1, 2))
+        self.assertEqual(tuple(checked.campaign_resources), (1, 2))
+        with self.assertRaises(TypeError):
+            close_derivation(checked)
+        ticket, frozen = _close_after_freeze(
+            checked, self.inputs.acquire_holdout
+        )
+        opened = open_holdout(ticket, frozen.canonical_bytes)
+        self.assertEqual(opened.view.replica, 3)
+        self.assertFalse(hasattr(opened, "views"))
+        self.assertGreater(opened.campaign_resources.logical_checkpoint_read_bytes, 0)
+        tampered = frozen.canonical_bytes[:-1] + bytes(
+            [frozen.canonical_bytes[-1] ^ 1]
+        )
+        with self.assertRaisesRegex(ValueError, "hash mismatch"):
+            open_holdout(ticket, tampered)
+
+    def test_replica_3_surfaces_are_not_opened_during_derivation_checks(self) -> None:
+        inputs = _inputs()
+        checked = check_analysis_input("a4-synthetic", _COMMIT, inputs)
+        self.assertEqual(tuple(checked.views), (1, 2))
+        self.assertEqual(inputs.holdout_calls, 0)
+        ticket, frozen = _close_after_freeze(checked, inputs.acquire_holdout)
+        self.assertEqual(inputs.holdout_calls, 0)
+        open_holdout(ticket, frozen.canonical_bytes)
+        self.assertEqual(inputs.holdout_calls, 1)
+
+    def test_idle_index_difference_is_the_first_terminal(self) -> None:
+        indexes = copy.deepcopy(self.inputs[1].page_indexes)
+        indexes["EMPTY_R"]["ordered_page_sha256"][0] = "f" * 64
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", _COMMIT, self._changed(1, indexes=indexes)
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-IDLE-EQUALITY")
+
+    def test_schema_ordinal_and_row_hash_are_recomputed(self) -> None:
+        snapshots = copy.deepcopy(self.inputs[1].schema_snapshots)
+        snapshots["T1_CREATE_ID"]["ordinal"] = 4
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", _COMMIT, self._changed(1, snapshots=snapshots)
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+        snapshots = copy.deepcopy(self.inputs[1].schema_snapshots)
+        snapshots["T1_CREATE_ID"]["tables"][0]["rolling_row_sha256"] = "f" * 64
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", _COMMIT, self._changed(1, snapshots=snapshots)
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+    def test_page_sequence_is_independently_reconstructed(self) -> None:
+        indexes = copy.deepcopy(self.inputs[1].page_indexes)
+        indexes["T1_CREATE_ID"]["ordered_page_sha256"][0] = "f" * 64
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", _COMMIT, self._changed(1, indexes=indexes)
+            )
+        self.assertEqual(
+            raised.exception.predicate_id, "A4-SNAPSHOT-RECONSTRUCTION"
+        )
+
+    def test_artifact_reference_path_must_match_manifest_and_checkpoint(self) -> None:
+        observation = copy.deepcopy(self.inputs[1].replica_observation)
+        observation["checkpoints"][0]["page_index"]["path"] = observation[
+            "checkpoints"
+        ][1]["page_index"]["path"]
+        manifest = copy.deepcopy(self.inputs[1].artifact_manifest)
+        observation_entry = next(
+            entry for entry in manifest["files"]
+            if entry["role"] == "replica_observation"
+        )
+        observation_payload = canonical_json_bytes(observation)
+        observation_entry.update(
+            sha256=hashlib.sha256(observation_payload).hexdigest(),
+            size_bytes=len(observation_payload),
+        )
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", _COMMIT,
+                self._changed(1, observation=observation, manifest=manifest),
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SNAPSHOT-RECONSTRUCTION")
+
+    def test_page_blob_inventory_rejects_noncanonical_extra_entry(self) -> None:
+        manifest = copy.deepcopy(self.inputs[1].artifact_manifest)
+        blob = next(entry for entry in manifest["files"] if entry["role"] == "page_blob")
+        manifest["files"].append({**blob, "path": "page-store/extra.page"})
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", _COMMIT, self._changed(1, manifest=manifest)
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SNAPSHOT-RECONSTRUCTION")
+
+    def test_changed_entry_equality_passes_and_67200_fixture_fails(self) -> None:
+        maximum = int(PLAN["bounds"]["max_changed_hash_entries_per_replica"])
+        require_resource_bounds(CampaignResourceTotals(0, maximum, 1, PAGE_SIZE, 0, 0))
+        with self.assertRaises(A4AnalysisError) as raised:
+            require_resource_bounds(
+                CampaignResourceTotals(0, 21 * 3_200, 2, 2 * PAGE_SIZE, 0, 0)
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+
+    def test_schema_valid_67200_changed_entry_campaign_reaches_resource(self) -> None:
+        inputs = dict(self.inputs)
+        inputs[1] = self._changed_entry_adversary()
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input("a4-synthetic", _COMMIT, inputs)
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+        self.assertIn("changed", str(raised.exception))
+
+    def test_prefreeze_campaign_resource_abort_never_opens_holdout(self) -> None:
+        inputs = _inputs()
+        inputs.derivation[1] = self._changed_entry_adversary()
+        with self.assertRaises(A4AnalysisError) as raised:
+            analyze("a4-synthetic", _COMMIT, inputs)
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+        self.assertEqual(inputs.holdout_calls, 0)
+
+    def test_aggregate_derivation_store_rejects_before_view_or_page_access(
+        self,
+    ) -> None:
+        maximum = int(PLAN["bounds"]["max_unique_page_blobs"])
+        per_checkpoint_maximum = int(
+            PLAN["bounds"]["max_final_pages_per_replica"]
+        )
+        all_digests = tuple(
+            hashlib.sha256(f"aggregate-{index}".encode()).hexdigest()
+            for index in range(maximum + 1)
+        )
+        page_calls: list[str] = []
+
+        def replica_input(
+            replica: int, digests: tuple[str, ...]
+        ) -> ReplicaAnalysisInput:
+            ordered = {
+                checkpoint: (digests[0],) for checkpoint in CHECKPOINT_IDS
+            }
+            ordered["EMPTY"] = digests[:per_checkpoint_maximum]
+            ordered["EMPTY_R"] = digests[per_checkpoint_maximum:]
+
+            class Source:
+                checkpoint_ids = CHECKPOINT_IDS
+                page_count = {
+                    checkpoint: len(sequence)
+                    for checkpoint, sequence in ordered.items()
+                }
+                ordered_page_sha256 = ordered
+
+                @staticmethod
+                def page_bytes(digest: str) -> bytes:
+                    page_calls.append(digest)
+                    raise AssertionError("page bytes accessed before aggregate preflight")
+
+            source = Source()
+            source.replica = replica
+            return ReplicaAnalysisInput(source, {}, None, None, None, None, None)
+
+        replicas = {
+            1: replica_input(1, all_digests[: maximum // 2 + 1]),
+            2: replica_input(2, all_digests[maximum // 2 + 1 :]),
+        }
+        with (
+            mock.patch.object(input_module, "check_campaign_replica") as campaign,
+            self.assertRaises(A4AnalysisError) as raised,
+        ):
+            check_analysis_input("a4-synthetic", _COMMIT, replicas)
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+        campaign.assert_not_called()
+        self.assertEqual(page_calls, [])
+
+    def test_aggregate_holdout_store_rejects_before_view_or_page_access(
+        self,
+    ) -> None:
+        maximum = int(PLAN["bounds"]["max_unique_page_blobs"])
+        derivation_digests = frozenset(
+            hashlib.sha256(f"retained-{index}".encode()).hexdigest()
+            for index in range(maximum)
+        )
+        extra_digest = hashlib.sha256(b"holdout-extra").hexdigest()
+        page_calls: list[str] = []
+
+        class Source:
+            replica = 3
+            checkpoint_ids = CHECKPOINT_IDS
+            page_count = {checkpoint: 1 for checkpoint in CHECKPOINT_IDS}
+            ordered_page_sha256 = {
+                checkpoint: (extra_digest,) for checkpoint in CHECKPOINT_IDS
+            }
+
+            @staticmethod
+            def page_bytes(digest: str) -> bytes:
+                page_calls.append(digest)
+                raise AssertionError("page bytes accessed before aggregate preflight")
+
+        holdout = ReplicaAnalysisInput(Source(), {}, None, None, None, None, None)
+
+        def provider(_payload: bytes, _sha256: str) -> ReplicaAnalysisInput:
+            return holdout
+
+        ticket = HoldoutTicket(
+            "a4-synthetic",
+            _COMMIT,
+            provider,
+            derivation_digests,
+            "a" * 64,
+            None,
+            (),
+            frozenset(),
+        )
+        with (
+            mock.patch(
+                "a4_analysis_state.resume_derivation",
+                return_value={"campaign_id": "a4-synthetic"},
+            ),
+            mock.patch.object(input_module, "check_campaign_replica") as campaign,
+            self.assertRaises(A4AnalysisError) as raised,
+        ):
+            open_holdout(ticket, b"frozen")
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+        campaign.assert_not_called()
+        self.assertEqual(page_calls, [])
+
+
+class A4AnalyzerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.result = analyze("a4-synthetic", _COMMIT, _inputs())
+
+    def test_decisive_report_is_schema_valid_and_keeps_claims_narrow(self) -> None:
+        report = dict(self.result.report)
+        validate_schema(report, "dao_a4_analysis_report")
+        self.assertEqual(len(report["predicate_results"]), 40)
+        self.assertTrue(all(row["status"] == "pass" for row in report["predicate_results"]))
+        self.assertEqual(
+            [
+                row["predicate_measured_survivor_count"]
+                for row in report["predicate_results"][:4]
+            ],
+            [0, 0, 0, 0],
+        )
+        self.assertEqual(report["claims"], PLAN["claims"])
+        self.assertFalse(report["claims"]["dao_compatibility_or_support"])
+        self.assertFalse(report["claims"]["synthetic_dry_run_is_a4_evidence"])
+
+    def test_frozen_document_round_trips_exact_bytes(self) -> None:
+        frozen = self.result.frozen
+        resumed = resume_derivation(
+            frozen.canonical_bytes,
+            frozen.sha256,
+            frozen.occurrence_evidence_bytes,
+        )
+        self.assertEqual(resumed["document_type"], "dao_a4_frozen_derivation_candidates")
+        tampered = frozen.canonical_bytes[:-1] + bytes([frozen.canonical_bytes[-1] ^ 1])
+        with self.assertRaisesRegex(ValueError, "hash mismatch"):
+            resume_derivation(tampered, frozen.sha256)
+        document = copy.deepcopy(dict(resumed))
+        document["layers"]["h1_tdef_to_map_row"][
+            "canonical_candidates_sha256"
+        ] = "f" * 64
+        with self.assertRaisesRegex(ValueError, "candidate-array hash"):
+            payload = canonical_model_bytes(document)
+            resume_derivation(
+                payload,
+                hashlib.sha256(payload).hexdigest(),
+                frozen.occurrence_evidence_bytes,
+            )
+
+    def test_holdout_is_not_opened_until_after_frozen_bytes_exist(self) -> None:
+        inputs = _inputs()
+        checked = check_analysis_input("a4-synthetic", _COMMIT, inputs)
+        self.assertEqual(tuple(checked.views), (1, 2))
+        self.assertEqual(inputs.holdout_calls, 0)
+        ledger = WorkLedger()
+        layers = derive_layers(checked, ledger)
+        frozen = freeze_derivation(checked, layers, ledger)
+        self.assertGreater(len(frozen.canonical_bytes), 0)
+        ticket = close_derivation(
+            checked,
+            frozen.canonical_bytes,
+            frozen.sha256,
+            inputs.acquire_holdout,
+            frozen.occurrence_evidence_bytes,
+        )
+        self.assertEqual(inputs.holdout_calls, 0)
+        tampered = frozen.canonical_bytes[:-1] + bytes(
+            [frozen.canonical_bytes[-1] ^ 1]
+        )
+        with self.assertRaisesRegex(ValueError, "hash mismatch"):
+            open_holdout(ticket, tampered)
+        self.assertEqual(inputs.holdout_calls, 0)
+        open_holdout(ticket, frozen.canonical_bytes)
+        self.assertEqual(inputs.holdout_calls, 1)
+
+    def _freeze_encoding_terminal(self, *, coherent_identifiers: bool):
+        inputs = _inputs()
+        if coherent_identifiers:
+            for replica in (1, 2):
+                source = generate_replica(replica=replica)
+                catalog_page = int(source.metadata["system_pages"]["catalog"])
+                payloads = dict(source.payloads)
+                transformed = {}
+                sequences = {}
+                for checkpoint, sequence in source.ordered_page_sha256.items():
+                    digest = sequence[catalog_page]
+                    replacement = transformed.get(digest)
+                    if replacement is None:
+                        page = source.page_bytes(digest)
+                        count = int.from_bytes(page[8:10], "little")
+                        starts = [
+                            int.from_bytes(
+                                page[10 + 2 * row : 12 + 2 * row], "little"
+                            )
+                            & 0x0FFF
+                            for row in range(count)
+                        ]
+                        ends = [2048, *starts[:-1]] if starts else []
+                        rows = []
+                        for start, end in zip(starts, ends, strict=True):
+                            row = page[start:end]
+                            name = row[3 : 3 + row[2]]
+                            utf8 = name.decode("cp1252").encode("utf-8")
+                            if utf8 != name:
+                                row += row[:2] + bytes([len(utf8)]) + utf8
+                            rows.append(row)
+                        rebuilt = data_page(rows)
+                        replacement = hashlib.sha256(rebuilt).hexdigest()
+                        transformed[digest] = replacement
+                        payloads[replacement] = rebuilt
+                    updated = list(sequence)
+                    updated[catalog_page] = replacement
+                    sequences[checkpoint] = tuple(updated)
+                source = replace(
+                    source,
+                    ordered_page_sha256=sequences,
+                    payloads=payloads,
+                )
+                inputs.derivation[replica] = _surface(source, "a4-synthetic")
+        checked = check_analysis_input("a4-synthetic", _COMMIT, inputs)
+        ledger = WorkLedger()
+        original_decode = a4_layer_h4._decode_for_model
+        first_class = a4_layer_h4.ENCODING_CLASSES[0]
+        original_class_match = a4_layer_h4.encoding_class_matches
+
+        def selected_identifier(group, occurrence, model):
+            decoded = original_decode(group, occurrence, model)
+            if decoded is None:
+                return None
+            operation = group.record.operation_id
+            operation_index = a4_layer_h4.OPERATIONS.index(operation)
+            if (
+                operation == "T2_RECREATE"
+                and model["identifier_lifecycle"]
+                == "stable_for_same_physical_name_including_t2_v1_v2"
+            ):
+                operation_index = a4_layer_h4.OPERATIONS.index("T2_CREATE")
+            identifier = (
+                10 + operation_index
+                if coherent_identifiers
+                else 1
+            )
+            stored_length = decoded.stored_length
+            if coherent_identifiers:
+                payload = bytes.fromhex(occurrence.encoded_hex)
+                cp1252 = group.expected_name.encode("cp1252", errors="strict")
+                utf8 = group.expected_name.encode("utf-8", errors="strict")
+                stored_length = len(cp1252) if payload == cp1252 else len(utf8)
+            return replace(
+                decoded,
+                identifier=identifier,
+                stored_length=stored_length,
+            )
+
+        def selected_classes(class_id, _name, _payload, _stored_length):
+            if coherent_identifiers:
+                return original_class_match(
+                    class_id, _name, _payload, _stored_length
+                )
+            return class_id == first_class
+
+        with mock.patch.object(
+            a4_layer_h4, "_decode_for_model", side_effect=selected_identifier
+        ), mock.patch.object(
+            a4_layer_h4,
+            "encoding_class_matches",
+            side_effect=selected_classes,
+        ), mock.patch.object(
+            a4_derivation,
+            "encoding_class_matches",
+            side_effect=selected_classes,
+        ):
+            layers = derive_layers(checked, ledger)
+
+        self.assertIsInstance(layers, DerivationTerminal)
+        self.assertEqual(layers.predicate_id, "A4-H4-ENCODING-AMBIGUOUS")
+        frozen = freeze_derivation(checked, layers, ledger)
+        resumed = resume_derivation(
+            frozen.canonical_bytes,
+            frozen.sha256,
+            frozen.occurrence_evidence_bytes,
+        )
+        self.assertEqual(
+            resumed["layers"]["h4_catalog_bootstrap"]["encoding_result"][
+                "terminal_predicate_id"
+            ],
+            "A4-H4-ENCODING-AMBIGUOUS",
+        )
+        return layers, resumed
+
+    def test_zero_survivor_encoding_terminal_freezes(self) -> None:
+        layers, _resumed = self._freeze_encoding_terminal(
+            coherent_identifiers=False
+        )
+        encoding = layers.layers["h4_catalog_bootstrap"]["encoding_result"]
+        self.assertEqual(encoding["predicate_measured_survivor_count"], 0)
+        self.assertEqual(encoding["candidates"], [])
+
+    def test_multiple_survivor_encoding_terminal_freezes(self) -> None:
+        layers, resumed = self._freeze_encoding_terminal(
+            coherent_identifiers=True
+        )
+        structural = resumed["layers"]["h4_catalog_bootstrap"][
+            "structural_result"
+        ]["candidates"][0]
+        self.assertEqual(
+            [binding["replica"] for binding in structural["instance_bindings"]],
+            [1, 2],
+        )
+        encoding = layers.layers["h4_catalog_bootstrap"]["encoding_result"]
+        self.assertEqual(encoding["predicate_measured_survivor_count"], 2)
+        self.assertEqual(len(encoding["candidates"]), 2)
+        for candidate in encoding["candidates"]:
+            self.assertEqual(
+                [
+                    binding["replica"]
+                    for binding in candidate["instance_bindings"]
+                ],
+                [1],
+            )
+            self.assertEqual(
+                candidate["instance_bindings"][0]["structural_candidate_id"],
+                structural["canonical_candidate_id"],
+            )
+
+    def test_h1_accepts_lifecycle_pages_reserved_before_create(self) -> None:
+        h1 = self.result.report["layers"]["h1_tdef_to_map_row"]
+        self.assertEqual(h1["status"], "model")
+        self.assertEqual(h1["candidates"][0]["model"]["layout"], "u8_row_then_u24le_page")
+        self.assertEqual(len(h1["candidates"][0]["instance_bindings"]), 10)
+
+    def test_value_equivalent_raw_tuples_are_one_structural_model(self) -> None:
+        structural = self.result.report["layers"]["h4_catalog_bootstrap"]["structural_result"]
+        self.assertEqual(structural["status"], "model")
+        candidate = structural["candidates"][0]
+        self.assertEqual(candidate["model"]["kind_width"], 1)
+        self.assertEqual(candidate["model"]["name_length_width"], 1)
+        self.assertEqual(
+            [binding["value_equivalent_tuple_count"] for binding in candidate["instance_bindings"]],
+            [2, 2],
+        )
+
+    def test_occurrence_evidence_hash_binds_both_replicas(self) -> None:
+        reference = self.result.report["h4_occurrence_evidence"]
+        bindings = self.result.report["layers"]["h4_catalog_bootstrap"]["structural_result"]["candidates"][0]["instance_bindings"]
+        self.assertEqual({binding["occurrence_evidence_sha256"] for binding in bindings}, {reference["sha256"]})
+        validate_schema(dict(self.result.occurrence_evidence), "dao_a4_h4_occurrence_evidence")
+
+    def test_holdout_layout_change_fails_h1_and_stops_downstream(self) -> None:
+        layouts = PLAN["candidate_grammars"]["h1"]["locator_layouts"]
+        result = analyze(
+            "a4-synthetic",
+            _COMMIT,
+            _inputs(SyntheticParameters(layout_by_replica={3: layouts[0]})),
+        )
+        holdout = result.report["holdout_results"]
+        self.assertEqual(holdout["h1"]["status"], "fail")
+        failed = next(
+            row
+            for row in result.report["predicate_results"]
+            if row["predicate_id"] == "A4-H1-HOLDOUT-PREDICTION"
+        )
+        self.assertEqual(failed["derivation_survivor_count"], 1)
+        self.assertTrue(all(holdout[name]["status"] == "not_applicable" for name in ("h2", "h3", "h4_root", "h4_fields")))
+        for layer in ("h1_tdef_to_map_row", "h2_row_identity_map_role", "h3_indirect_traversal"):
+            self.assertEqual(
+                result.report["layers"][layer]["candidates"][0]["model"],
+                self.result.report["layers"][layer]["candidates"][0]["model"],
+            )
+        for result_key in ("root_result", "structural_result", "encoding_result"):
+            self.assertEqual(
+                result.report["layers"]["h4_catalog_bootstrap"][result_key]["candidates"][0]["model"],
+                self.result.report["layers"]["h4_catalog_bootstrap"][result_key]["candidates"][0]["model"],
+            )
+
+    def test_derivation_terminal_campaign_check_opens_after_freeze(self) -> None:
+        signature = PLAN["candidate_grammars"]["h1"][
+            "pair_multiple_reachability_signature"
+        ]
+        inputs = _inputs(
+            SyntheticParameters(
+                signature_id=signature["signature_id"],
+                locator_offsets=tuple(
+                    interval[0] for interval in signature["locator_holes"]
+                ),
+            )
+        )
+        result = analyze("a4-synthetic", _COMMIT, inputs)
+        self.assertEqual(inputs.holdout_calls, 1)
+        self.assertEqual(inputs.last_holdout_sha256, result.frozen.sha256)
+        self.assertTrue(result.report["holdout_opened_after_freeze"])
+        self.assertGreater(result.report["analyzer_logical_read_bytes_by_replica"][2], 0)
+        self.assertTrue(
+            all(
+                row["status"] == "pass"
+                for row in result.report["predicate_results"][:4]
+            )
+        )
+        self.assertTrue(
+            all(
+                row["status"] == "not_applicable"
+                for row in result.report["holdout_results"].values()
+            )
+        )
+        self.assertEqual(
+            result.report["layers"]["h1_tdef_to_map_row"][
+                "terminal_predicate_id"
+            ],
+            "A4-H1-LOCATOR-PAIR-MULTIPLE",
+        )
+
+    def test_derivation_terminal_replica3_campaign_failure_emits_no_report(self) -> None:
+        signature = PLAN["candidate_grammars"]["h1"][
+            "pair_multiple_reachability_signature"
+        ]
+        inputs = _inputs(
+            SyntheticParameters(
+                signature_id=signature["signature_id"],
+                locator_offsets=tuple(
+                    interval[0] for interval in signature["locator_holes"]
+                ),
+            )
+        )
+
+        def invalid_holdout(
+            frozen_payload: bytes, frozen_sha256: str
+        ) -> ReplicaAnalysisInput:
+            original = inputs.acquire_holdout(frozen_payload, frozen_sha256)
+            return ReplicaAnalysisInput(
+                original.source,
+                original.table_row_counts,
+                original.replica_observation,
+                original.page_indexes,
+                original.schema_snapshots,
+                original.artifact_manifest,
+                b"{}",
+            )
+
+        with self.assertRaises(A4AnalysisError) as raised:
+            analyze(
+                "a4-synthetic", _COMMIT, inputs, holdout_provider=invalid_holdout
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+        self.assertEqual(inputs.holdout_calls, 1)
+        self.assertIsNotNone(inputs.last_holdout_sha256)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_campaign_semantics.py
+++ b/oracle/windows-dao/tests/test_a4_campaign_semantics.py
@@ -1,0 +1,322 @@
+"""Adversarial A4 campaign schedule and environment contracts."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import a4_campaign as campaign_module  # noqa: E402
+from a4_analysis_input import ReplicaAnalysisInput, check_analysis_input  # noqa: E402
+from a4_campaign import check_campaign_replica  # noqa: E402
+from a4_generator import generate_replica  # noqa: E402
+from a4_model import A4AnalysisError, View  # noqa: E402
+from a4_spec import BOUNDS  # noqa: E402
+from protocol_validation import canonical_json_bytes  # noqa: E402
+import test_a4_analyzer as fixtures  # noqa: E402
+
+
+def _with_observation(
+    original: ReplicaAnalysisInput, observation: dict[str, object]
+) -> ReplicaAnalysisInput:
+    manifest = copy.deepcopy(original.artifact_manifest)
+    payload = canonical_json_bytes(observation)
+    entry = next(
+        row
+        for row in manifest["files"]
+        if row["role"] == "replica_observation"
+    )
+    entry["sha256"] = hashlib.sha256(payload).hexdigest()
+    entry["size_bytes"] = len(payload)
+    return ReplicaAnalysisInput(
+        original.source,
+        original.table_row_counts,
+        observation,
+        original.page_indexes,
+        original.schema_snapshots,
+        manifest,
+        original.environment_payload,
+    )
+
+
+def _with_snapshot(
+    original: ReplicaAnalysisInput,
+    checkpoint: str,
+    snapshots: dict[str, dict[str, object]],
+) -> ReplicaAnalysisInput:
+    observation = copy.deepcopy(original.replica_observation)
+    manifest = copy.deepcopy(original.artifact_manifest)
+    ordinal = fixtures.CHECKPOINT_IDS.index(checkpoint)
+    payload = canonical_json_bytes(snapshots[checkpoint])
+    reference = observation["checkpoints"][ordinal]["dao_schema_snapshot"]
+    reference["sha256"] = hashlib.sha256(payload).hexdigest()
+    reference["size_bytes"] = len(payload)
+    entry = next(row for row in manifest["files"] if row["path"] == reference["path"])
+    entry.update(reference)
+    observation_payload = canonical_json_bytes(observation)
+    observation_entry = next(
+        row
+        for row in manifest["files"]
+        if row["role"] == "replica_observation"
+    )
+    observation_entry["sha256"] = hashlib.sha256(observation_payload).hexdigest()
+    observation_entry["size_bytes"] = len(observation_payload)
+    return ReplicaAnalysisInput(
+        original.source,
+        original.table_row_counts,
+        observation,
+        original.page_indexes,
+        snapshots,
+        manifest,
+        original.environment_payload,
+    )
+
+
+class A4CampaignSemanticTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.inputs = fixtures._inputs()
+
+    def test_growth_inventory_and_arithmetic_are_required(self) -> None:
+        original = self.inputs[1]
+        observation = copy.deepcopy(original.replica_observation)
+        observation["growth_observations"] = []
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_campaign_replica(
+                1,
+                _with_observation(original, observation),
+                "a4-synthetic",
+                fixtures._COMMIT,
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+        observation = copy.deepcopy(original.replica_observation)
+        growth = observation["growth_observations"][0]
+        growth["overshoot_pages"] += 1
+        with self.assertRaises(A4AnalysisError):
+            check_campaign_replica(
+                1,
+                _with_observation(original, observation),
+                "a4-synthetic",
+                fixtures._COMMIT,
+            )
+
+    def test_environment_bytes_and_cross_replica_identity_are_checked(self) -> None:
+        original = self.inputs[1]
+        broken = ReplicaAnalysisInput(
+            original.source,
+            original.table_row_counts,
+            original.replica_observation,
+            original.page_indexes,
+            original.schema_snapshots,
+            original.artifact_manifest,
+            original.environment_payload[:-1] + b" ",
+        )
+        with self.assertRaises(A4AnalysisError):
+            check_campaign_replica(
+                1, broken, "a4-synthetic", fixtures._COMMIT
+            )
+
+        original_environment = fixtures._environment
+
+        def changed_environment(replica: int, campaign_id: str) -> bytes:
+            payload = original_environment(replica, campaign_id)
+            document = json.loads(payload)
+            document["provider"]["clsid"] = (
+                "{00000101-0000-0010-8000-00AA006D2EA4}"
+            )
+            return canonical_json_bytes(document)
+
+        with mock.patch.object(fixtures, "_environment", changed_environment):
+            mismatched = fixtures._surface(
+                generate_replica(replica=2), "a4-synthetic"
+            )
+        derivation = {1: self.inputs[1], 2: mismatched}
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic", fixtures._COMMIT, derivation
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+        def duplicate_job_environment(replica: int, campaign_id: str) -> bytes:
+            payload = original_environment(replica, campaign_id)
+            document = json.loads(payload)
+            document["matrix_job_id"] = "synthetic-job-1"
+            return canonical_json_bytes(document)
+
+        with mock.patch.object(
+            fixtures, "_environment", duplicate_job_environment
+        ):
+            duplicate_job = fixtures._surface(
+                generate_replica(replica=2), "a4-synthetic"
+            )
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_analysis_input(
+                "a4-synthetic",
+                fixtures._COMMIT,
+                {1: self.inputs[1], 2: duplicate_job},
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+    def test_environment_size_is_rejected_before_json_parsing(self) -> None:
+        original = self.inputs[1]
+        reduced = {**BOUNDS, "max_json_bytes": len(original.environment_payload) - 1}
+        json_mock = mock.Mock(wraps=json)
+        with (
+            mock.patch.object(campaign_module, "BOUNDS", reduced),
+            mock.patch.object(campaign_module, "json", json_mock),
+            self.assertRaises(A4AnalysisError) as raised,
+        ):
+            check_campaign_replica(
+                1, original, "a4-synthetic", fixtures._COMMIT
+            )
+        json_mock.loads.assert_not_called()
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+    def test_idle_preflight_does_not_materialize_an_invalid_hash_sequence(self) -> None:
+        original = self.inputs[1]
+        page_calls: list[str] = []
+
+        class TrapSequence:
+            iterated = False
+
+            def __len__(self) -> int:
+                return int(BOUNDS["max_final_pages_per_replica"]) + 1
+
+            def __iter__(self):
+                self.iterated = True
+                raise AssertionError("invalid page hashes were materialized")
+
+        class Source:
+            checkpoint_ids = original.source.checkpoint_ids
+            page_count = {**original.source.page_count, "EMPTY": 1}
+            trap = TrapSequence()
+            ordered_page_sha256 = {
+                **original.source.ordered_page_sha256,
+                "EMPTY": trap,
+            }
+            def page_bytes(self, sha256: str) -> bytes:
+                page_calls.append(sha256)
+                return original.source.page_bytes(sha256)
+
+        broken = ReplicaAnalysisInput(
+            Source(),
+            original.table_row_counts,
+            original.replica_observation,
+            original.page_indexes,
+            original.schema_snapshots,
+            original.artifact_manifest,
+            original.environment_payload,
+        )
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_campaign_replica(
+                1, broken, "a4-synthetic", fixtures._COMMIT
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SNAPSHOT-RECONSTRUCTION")
+        self.assertFalse(Source.trap.iterated)
+        self.assertEqual(page_calls, [])
+
+    def test_view_boundedly_rejects_dishonest_and_infinite_hash_sequences(self) -> None:
+        original = self.inputs[1]
+        digest = original.source.ordered_page_sha256["EMPTY"][0]
+
+        class DishonestSequence:
+            def __len__(self) -> int:
+                return 1
+
+            def __iter__(self):
+                yield digest
+                yield digest
+
+        class InfiniteSequence:
+            yielded = 0
+
+            def __len__(self) -> int:
+                return 1
+
+            def __iter__(self):
+                while True:
+                    self.yielded += 1
+                    yield digest
+
+        infinite = InfiniteSequence()
+        for sequence in (DishonestSequence(), infinite):
+            source = mock.Mock(wraps=original.source)
+            source.checkpoint_ids = original.source.checkpoint_ids
+            source.page_count = {**original.source.page_count, "EMPTY": 1}
+            source.ordered_page_sha256 = {
+                **original.source.ordered_page_sha256,
+                "EMPTY": sequence,
+            }
+            with self.assertRaises(A4AnalysisError) as raised:
+                View(1, source)
+            self.assertEqual(
+                raised.exception.predicate_id, "A4-SNAPSHOT-RECONSTRUCTION"
+            )
+        self.assertEqual(
+            infinite.yielded,
+            int(BOUNDS["max_final_pages_per_replica"]) + 1,
+        )
+
+    def test_idle_resource_and_programming_errors_are_not_reclassified(self) -> None:
+        original = self.inputs[1]
+        resource = A4AnalysisError("A4-RESOURCE-BOUND", detail="test bound")
+        with (
+            mock.patch.object(campaign_module.View, "page", side_effect=resource),
+            self.assertRaises(A4AnalysisError) as raised,
+        ):
+            check_campaign_replica(
+                1, original, "a4-synthetic", fixtures._COMMIT
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+        with (
+            mock.patch.object(
+                campaign_module.View, "page", side_effect=RuntimeError("test bug")
+            ),
+            self.assertRaisesRegex(RuntimeError, "test bug"),
+        ):
+            check_campaign_replica(
+                1, original, "a4-synthetic", fixtures._COMMIT
+            )
+
+    def test_index_attributes_cannot_self_authorize(self) -> None:
+        original = self.inputs[1]
+        snapshots = copy.deepcopy(original.schema_snapshots)
+        snapshots["T1_ADD_INDEX"]["tables"][0]["indexes"][0][
+            "attributes"
+        ] = 123456
+        changed = _with_snapshot(original, "T1_ADD_INDEX", snapshots)
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_campaign_replica(
+                1, changed, "a4-synthetic", fixtures._COMMIT
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+    def test_growth_cannot_mutate_an_unrelated_role(self) -> None:
+        original = self.inputs[1]
+        observation = copy.deepcopy(original.replica_observation)
+        growth = next(
+            row
+            for row in observation["checkpoints"]
+            if row["checkpoint_id"] == "T1_REL_0064"
+        )
+        growth["table_row_counts"]["T4"] = 32
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_campaign_replica(
+                1,
+                _with_observation(original, observation),
+                "a4-synthetic",
+                fixtures._COMMIT,
+            )
+        self.assertIn("unrelated rows differ", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_catalog_accounting.py
+++ b/oracle/windows-dao/tests/test_a4_catalog_accounting.py
@@ -1,0 +1,213 @@
+"""Focused cutoff and union-accounting tests for A4 catalog preparation."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import a4_layers as layer_module  # noqa: E402
+from a4_analysis_input import check_analysis_input  # noqa: E402
+from a4_catalog_inventory import CatalogInventory, operation_records  # noqa: E402
+from a4_layer_h2 import H2ReplicaCandidate  # noqa: E402
+from a4_layer_h4 import OPERATIONS, CatalogRootObservation  # noqa: E402
+from a4_layers import DerivationLayers, derive_layers  # noqa: E402
+from a4_model import A4AnalysisError, QualifiedPage, WorkLedger  # noqa: E402
+from a4_spec import CHECKPOINT_IDS  # noqa: E402
+from a4_terminal import DerivationTerminal  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+
+class _OnePageView:
+    replica = 1
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def page(self, checkpoint: str, page: int) -> bytes:
+        if checkpoint != "EMPTY" or page != 4:
+            raise AssertionError("unexpected test page")
+        return self._payload
+
+
+class _GrowingCatalogView:
+    replica = 1
+
+    @staticmethod
+    def page(checkpoint: str, page: int) -> bytes:
+        if page != 4:
+            raise AssertionError("unexpected test page")
+        return _row_page(256 if checkpoint == "EMPTY" else 257)
+
+    @staticmethod
+    def page_count(_checkpoint: str) -> int:
+        return 5
+
+
+def _three_row_page() -> bytes:
+    payload = bytearray(2048)
+    payload[0] = 0x01
+    payload[8:10] = (3).to_bytes(2, "little")
+    for ordinal, start in enumerate((2045, 2044, 2043)):
+        offset = 10 + 2 * ordinal
+        payload[offset : offset + 2] = start.to_bytes(2, "little")
+    payload[2043:] = b"abcde"
+    return bytes(payload)
+
+
+def _row_page(count: int) -> bytes:
+    payload = bytearray(2048)
+    payload[0] = 0x01
+    payload[8:10] = count.to_bytes(2, "little")
+    for ordinal in range(count):
+        start = 2048 - ordinal - 1
+        offset = 10 + 2 * ordinal
+        payload[offset : offset + 2] = start.to_bytes(2, "little")
+    return bytes(payload)
+
+
+class A4CatalogAccountingTests(unittest.TestCase):
+    def test_page_is_recorded_for_empty_or_failed_inventory(self) -> None:
+        for payload, fails in ((_row_page(0), False), (_row_page(680), True)):
+            work = WorkLedger()
+            inventory = CatalogInventory(_OnePageView(payload), 0x1FFF, work)
+            if fails:
+                with self.assertRaises(ValueError):
+                    inventory.all_rows("EMPTY", 4)
+            else:
+                self.assertEqual(inventory.all_rows("EMPTY", 4), ())
+            self.assertIn(QualifiedPage(1, "EMPTY", 4), work.qualified_pages())
+
+    def test_rows_above_locator_ordinal_255_are_charged_but_not_candidates(self) -> None:
+        work = WorkLedger()
+        rows = CatalogInventory(
+            _OnePageView(_row_page(257)), 0x1FFF, work
+        ).all_rows("EMPTY", 4)
+        self.assertEqual(len(rows), 257)
+        self.assertIsNone(rows[-1][0])
+        self.assertEqual(work.value("catalog_raw_rows"), 257)
+
+        root = CatalogRootObservation(
+            1,
+            2,
+            (35, 39),
+            0x02,
+            frozenset(CHECKPOINT_IDS),
+            {checkpoint: "0" * 64 for checkpoint in CHECKPOINT_IDS},
+            {checkpoint: frozenset({4}) for checkpoint in CHECKPOINT_IDS},
+        )
+        deltas = {
+            operation: frozenset({4}) if operation == OPERATIONS[0] else frozenset()
+            for operation in OPERATIONS
+        }
+        records = operation_records(
+            _GrowingCatalogView(),
+            root,
+            deltas,
+            H2ReplicaCandidate(1, 0x1FFF, "set_bit_owned_in_use", 0, 1),
+            WorkLedger(),
+        )
+        self.assertEqual(records, ())
+
+    def test_inventory_charges_every_row_once_with_qualified_identity(self) -> None:
+        work = WorkLedger()
+        inventory = CatalogInventory(_OnePageView(_three_row_page()), 0x1FFF, work)
+
+        self.assertEqual(len(inventory.all_rows("EMPTY", 4)), 3)
+        self.assertEqual(len(inventory.all_rows("EMPTY", 4)), 3)
+        self.assertIsNotNone(inventory.row_at("EMPTY", 4, 1))
+        self.assertIsNone(inventory.row_at("EMPTY", 4, 3))
+
+        identities = work._identities["catalog_raw_rows"]
+        self.assertEqual(work.value("catalog_raw_rows"), 3)
+        self.assertEqual(
+            identities,
+            {
+                (QualifiedPage(1, "EMPTY", 4), ordinal)
+                for ordinal in range(3)
+            },
+        )
+
+    def test_success_charges_initial_and_continuation_rows_union_once(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        work = WorkLedger()
+        result = derive_layers(checked, work)
+        self.assertIsInstance(result, DerivationLayers)
+        assert isinstance(result, DerivationLayers)
+
+        evidence_rows = {
+            (
+                QualifiedPage(
+                    record.replica,
+                    evidence.checkpoint_id,
+                    evidence.locator.page,
+                ),
+                evidence.locator.row,
+            )
+            for records in result.h4_records.values()
+            for record in records
+            for evidence in record.checkpoint_evidence
+        }
+        identities = work._identities["catalog_raw_rows"]
+        self.assertEqual(len(evidence_rows), 236)
+        self.assertTrue(evidence_rows <= identities)
+        self.assertEqual(work.value("catalog_raw_rows"), len(identities))
+
+    def test_h3_replica_one_terminal_prevents_replica_two_adapter_work(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        original = layer_module.h3_observations
+        reached: list[int] = []
+
+        def guarded(view: object, rows: object, work: WorkLedger) -> object:
+            replica = view.replica
+            reached.append(replica)
+            if replica == 2:
+                raise A4AnalysisError(
+                    "A4-RESOURCE-BOUND", detail="replica 2 must remain unreachable"
+                )
+            return original(view, rows, work)[:1]
+
+        with patch.object(layer_module, "h3_observations", side_effect=guarded):
+            result = derive_layers(checked)
+        self.assertIsInstance(result, DerivationTerminal)
+        assert isinstance(result, DerivationTerminal)
+        self.assertEqual(result.predicate_id, "A4-H3-CONVERSION-NONE")
+        self.assertTrue(reached)
+        self.assertEqual(set(reached), {1})
+
+    def test_h4_replica_one_record_none_prevents_replica_two_resource(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        reached: list[int] = []
+
+        def guarded(
+            view: object,
+            root: object,
+            deltas: object,
+            h2: object,
+            work: WorkLedger,
+        ) -> tuple[()]:
+            del root, deltas, h2, work
+            reached.append(view.replica)
+            if view.replica == 2:
+                raise A4AnalysisError(
+                    "A4-RESOURCE-BOUND", detail="replica 2 must remain unreachable"
+                )
+            return ()
+
+        with patch.object(layer_module, "operation_records", side_effect=guarded):
+            result = derive_layers(checked)
+        self.assertIsInstance(result, DerivationTerminal)
+        assert isinstance(result, DerivationTerminal)
+        self.assertEqual(result.predicate_id, "A4-H4-CATALOG-RECORD-NONE")
+        self.assertTrue(reached)
+        self.assertEqual(set(reached), {1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_frozen_projection.py
+++ b/oracle/windows-dao/tests/test_a4_frozen_projection.py
@@ -1,0 +1,270 @@
+"""Adversarial closure checks for A4 frozen physical evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import unittest
+from functools import lru_cache
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import a4_layers  # noqa: E402
+from a4_analysis_input import check_analysis_input  # noqa: E402
+from a4_analysis_state import (  # noqa: E402
+    _QUALIFIED_PAGE_MARKER,
+    _TRANSCRIPT_CATEGORY_CODES,
+    freeze_derivation,
+    resume_derivation,
+)
+from a4_layer_h4 import (  # noqa: E402
+    CatalogRecordLocator,
+    CheckpointRecordEvidence,
+    OperationRecord,
+)
+from a4_layers import derive_layers  # noqa: E402
+from a4_model import WorkLedger  # noqa: E402
+from a4_spec import PLAN, canonical_json_bytes  # noqa: E402
+from a4_terminal import DerivationTerminal  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+from test_a4_frozen_terminal import _default_analysis  # noqa: E402
+
+
+def _rehash(document: dict[str, object]) -> tuple[bytes, str]:
+    payload = canonical_json_bytes(document)
+    return payload, hashlib.sha256(payload).hexdigest()
+
+
+def _remove_marker(
+    document: dict[str, object], identity: tuple[int, str, int]
+) -> None:
+    replica, checkpoint, page = identity
+    for rows in document["transcripts"].values():
+        rows[:] = [
+            row
+            for row in rows
+            if not (
+                row["checkpoint_id"] == checkpoint
+                and row["page"] == page
+                and (raw := bytes.fromhex(row["detail_hex"])).startswith(
+                    _QUALIFIED_PAGE_MARKER
+                )
+                and raw[len(_QUALIFIED_PAGE_MARKER)] == replica
+            )
+        ]
+
+
+@lru_cache(maxsize=2)
+def _record_multiple_frozen(*, identical_rows: bool):
+    checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+    ledger = WorkLedger()
+    original = a4_layers.operation_records
+
+    def duplicate_first(view, root, deltas, h2, work):
+        candidates = original(view, root, deltas, h2, work)
+        base = candidates[0]
+        evidence = []
+        for row in base.checkpoint_evidence:
+            locator = row.locator
+            if identical_rows:
+                alternate = CatalogRecordLocator(
+                    locator.page,
+                    locator.row + 1,
+                    locator.row_start,
+                    locator.row_end,
+                )
+                row_bytes = row.row_bytes
+            else:
+                alternate = CatalogRecordLocator(
+                    locator.page,
+                    locator.row,
+                    locator.row_start + 1,
+                    locator.row_end,
+                )
+                row_bytes = row.row_bytes[1:]
+            evidence.append(
+                CheckpointRecordEvidence(row.checkpoint_id, alternate, row_bytes)
+            )
+        extra = OperationRecord(base.replica, base.operation_id, tuple(evidence))
+        return tuple(candidates) + (extra,)
+
+    with patch.object(
+        a4_layers, "operation_records", side_effect=duplicate_first
+    ):
+        terminal = derive_layers(checked, ledger)
+    if not isinstance(terminal, DerivationTerminal):
+        raise AssertionError("record-multiple fixture did not reach its terminal")
+    return freeze_derivation(checked, terminal, ledger)
+
+
+class A4FrozenProjectionTests(unittest.TestCase):
+    def test_resume_rejects_removed_h4_root_qualified_page(self) -> None:
+        frozen = _default_analysis().frozen
+        document = json.loads(frozen.canonical_bytes)
+        root = document["layers"]["h4_catalog_bootstrap"]["root_result"][
+            "candidates"
+        ][0]
+        binding = root["instance_bindings"][0]
+        identity = (binding["replica"], "T1_ADD_TEXT", binding["tdef_page"])
+        document["qualified_pages"] = [
+            row
+            for row in document["qualified_pages"]
+            if (row["replica"], row["checkpoint_id"], row["page_number"])
+            != identity
+        ]
+        _remove_marker(document, identity)
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "omits retained physical evidence"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_resume_rejects_removed_h4_terminal_record_evidence(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        ledger = WorkLedger()
+        original = a4_layers.operation_records
+        first = PLAN["candidate_grammars"]["h4"]["operation_binding_order"][0]
+
+        def omit_first_operation(view, root, deltas, h2, work):
+            return tuple(
+                candidate
+                for candidate in original(view, root, deltas, h2, work)
+                if candidate.operation_id != first
+            )
+
+        with patch.object(
+            a4_layers, "operation_records", side_effect=omit_first_operation
+        ):
+            terminal = derive_layers(checked, ledger)
+        frozen = freeze_derivation(checked, terminal, ledger)
+        document = json.loads(frozen.canonical_bytes)
+        candidate = document["layers"]["h4_catalog_bootstrap"][
+            "structural_result"
+        ]["candidates"][0]
+        model = candidate["model"]
+        locator = model["canonical_record_locator"]
+        identity = (model["replica"], model["operation_id"], locator["page"])
+        document["qualified_pages"] = [
+            row
+            for row in document["qualified_pages"]
+            if (row["replica"], row["checkpoint_id"], row["page_number"])
+            != identity
+        ]
+        for rows in document["transcripts"].values():
+            rows[:] = [
+                row
+                for row in rows
+                if (row["checkpoint_id"], row["page"]) != identity[1:]
+            ]
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "omits retained physical evidence"):
+            resume_derivation(payload, digest)
+
+    def test_resume_rejects_h4_root_marker_moved_to_locator_stage(self) -> None:
+        frozen = _default_analysis().frozen
+        document = json.loads(frozen.canonical_bytes)
+        root = document["layers"]["h4_catalog_bootstrap"]["root_result"][
+            "candidates"
+        ][0]
+        binding = root["instance_bindings"][0]
+        identity = (binding["replica"], "T1_ADD_TEXT", binding["tdef_page"])
+        rows = document["transcripts"]["catalog_roots"]
+        marker = next(
+            row
+            for row in rows
+            if row["checkpoint_id"] == identity[1]
+            and row["page"] == identity[2]
+            and bytes.fromhex(row["detail_hex"]).startswith(_QUALIFIED_PAGE_MARKER)
+            and bytes.fromhex(row["detail_hex"])[len(_QUALIFIED_PAGE_MARKER)]
+            == identity[0]
+        )
+        rows.remove(marker)
+        raw = bytearray.fromhex(marker["detail_hex"])
+        raw[len(_QUALIFIED_PAGE_MARKER) + 1] = _TRANSCRIPT_CATEGORY_CODES["locators"]
+        marker["detail_hex"] = raw.hex()
+        marker["kind"] = "locator"
+        document["transcripts"]["locators"].append(marker)
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "marker differs from candidate stage"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_resume_rejects_removed_occurrence_record_transcript(self) -> None:
+        frozen = _default_analysis().frozen
+        document = json.loads(frozen.canonical_bytes)
+        occurrence = json.loads(frozen.occurrence_evidence_bytes)
+        operation = occurrence["replica_groups"][0]["operation_bindings"][0]
+        pair = (
+            operation["operation_id"],
+            operation["canonical_record_locator"]["page"],
+        )
+        rows = document["transcripts"]["catalog_fields"]
+        rows[:] = [
+            row
+            for row in rows
+            if not (
+                (row["checkpoint_id"], row["page"]) == pair
+                and not bytes.fromhex(row["detail_hex"]).startswith(
+                    _QUALIFIED_PAGE_MARKER
+                )
+            )
+        ]
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "transcript cardinality differs"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_resume_rejects_wrong_record_locator_length_multiset(self) -> None:
+        frozen = _default_analysis().frozen
+        document = json.loads(frozen.canonical_bytes)
+        occurrence = json.loads(frozen.occurrence_evidence_bytes)
+        operation = occurrence["replica_groups"][0]["operation_bindings"][0]
+        pair = (
+            operation["operation_id"],
+            operation["canonical_record_locator"]["page"],
+        )
+        rows = document["transcripts"]["catalog_fields"]
+        matching = next(
+            row
+            for row in rows
+            if (row["checkpoint_id"], row["page"]) == pair
+            and not bytes.fromhex(row["detail_hex"]).startswith(_QUALIFIED_PAGE_MARKER)
+        )
+        matching["detail_hex"] = matching["detail_hex"][:-2]
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "transcript cardinality differs"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_record_multiple_uses_bounded_page_markers_not_raw_rows(self) -> None:
+        frozen = _record_multiple_frozen(identical_rows=True)
+        resumed = resume_derivation(frozen.canonical_bytes, frozen.sha256)
+        result = resumed["layers"]["h4_catalog_bootstrap"]["structural_result"]
+        pairs: dict[tuple[str, int], int] = {}
+        for candidate in result["candidates"]:
+            model = candidate["model"]
+            locator = model["canonical_record_locator"]
+            pair = (model["operation_id"], locator["page"])
+            pairs[pair] = pairs.get(pair, 0) + 1
+        pair = next(pair for pair, count in pairs.items() if count == 2)
+        replica = next(
+            candidate["model"]["replica"]
+            for candidate in result["candidates"]
+            if (
+                candidate["model"]["operation_id"],
+                candidate["model"]["canonical_record_locator"]["page"],
+            ) == pair
+        )
+        matching = [
+            bytes.fromhex(row["detail_hex"])
+            for row in resumed["transcripts"]["catalog_fields"]
+            if (row["checkpoint_id"], row["page"]) == pair
+        ]
+        self.assertTrue(all(raw.startswith(_QUALIFIED_PAGE_MARKER) for raw in matching))
+        self.assertTrue(any(
+            raw[len(_QUALIFIED_PAGE_MARKER)] == replica for raw in matching
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_frozen_terminal.py
+++ b/oracle/windows-dao/tests/test_a4_frozen_terminal.py
@@ -1,0 +1,775 @@
+"""Adversarial frozen-terminal validation and evidence projection tests."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import unittest
+from functools import lru_cache
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_analysis import analyze  # noqa: E402
+from a4_analysis_input import check_analysis_input  # noqa: E402
+from a4_analysis_state import (  # noqa: E402
+    _QUALIFIED_PAGE_MARKER,
+    _TRANSCRIPT_CATEGORY_CODES,
+    freeze_derivation,
+    resume_derivation,
+)
+from a4_generator import SyntheticParameters  # noqa: E402
+from a4_frozen_validation import (  # noqa: E402
+    _candidate_identity,
+    _validate_groups,
+    validate_frozen_layers,
+)
+from a4_layer_h1 import (  # noqa: E402
+    H1Binding,
+    H1ReplicaCandidate,
+    LocatorTarget,
+    agree_h1_replicas,
+    derive_h1_replica,
+)
+from a4_layer_h2 import H2ReplicaCandidate  # noqa: E402
+from a4_layer_h3 import H3Candidate  # noqa: E402
+from a4_layer_h4 import H4Candidate  # noqa: E402
+import a4_layers  # noqa: E402
+from a4_layers import derive_layers  # noqa: E402
+from a4_model import A4AnalysisError, QualifiedPage, WorkLedger  # noqa: E402
+from a4_spec import (  # noqa: E402
+    BOUNDS,
+    CHECKPOINT_IDS,
+    CHECKPOINT_ORDINALS,
+    EXPERIMENT_ID,
+    PLAN,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    canonical_candidate_id,
+    canonical_json_bytes,
+    canonical_model_id,
+    sha256_hex,
+)
+from a4_terminal import (  # noqa: E402
+    DerivationTerminal,
+    decisive_result,
+    not_applicable_result,
+    terminal_result,
+)
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+
+@lru_cache(maxsize=1)
+def _pair_multiple_analysis():
+    signature = PLAN["candidate_grammars"]["h1"][
+        "pair_multiple_reachability_signature"
+    ]
+    parameters = SyntheticParameters(
+        signature_id=signature["signature_id"],
+        locator_offsets=tuple(interval[0] for interval in signature["locator_holes"]),
+    )
+    return analyze("a4-synthetic", _COMMIT, _inputs(parameters))
+
+
+@lru_cache(maxsize=1)
+def _default_analysis():
+    return analyze("a4-synthetic", _COMMIT, _inputs())
+
+
+def _rehash(document: dict[str, object]) -> tuple[bytes, str]:
+    payload = canonical_json_bytes(document)
+    return payload, hashlib.sha256(payload).hexdigest()
+
+
+def _h2_terminal_layers():
+    bindings = tuple(
+        H1Binding(
+            replica,
+            role,
+            instance,
+            20 + replica * 10 + index,
+            (LocatorTarget(50 + replica * 10 + index, 0), LocatorTarget(50 + replica * 10 + index, 1)),
+        )
+        for replica in (1, 2)
+        for index, (role, instance) in enumerate((
+            ("T1", "T1-v1"), ("T2", "T2-v1"), ("T2", "T2-v2"),
+            ("T3", "T3-v1"), ("T4", "T4-v1"),
+        ))
+    )
+    ledger = WorkLedger()
+    h1 = H1ReplicaCandidate(
+        0, "u8_row_then_u24le_page", "a4_pair_multiple_duplicate_locator_0_92",
+        (35, 39), bindings,
+    ).document()
+    layers = {
+        "h1_tdef_to_map_row": decisive_result(h1, ledger),
+        "h2_row_identity_map_role": terminal_result(A4AnalysisError("A4-H2-ROLE-NONE", 0), ledger),
+        "h3_indirect_traversal": not_applicable_result(),
+        "h4_catalog_bootstrap": {
+            "root_result": not_applicable_result(),
+            "structural_result": not_applicable_result(),
+            "encoding_result": not_applicable_result(),
+        },
+    }
+    return layers
+
+
+class A4FrozenTerminalTests(unittest.TestCase):
+    def test_reached_page_recording_is_zero_cost_and_page_exact(self) -> None:
+        ledger = WorkLedger()
+        page = QualifiedPage(1, "EMPTY", 7)
+        self.assertTrue(ledger.record_qualified_page(page))
+        self.assertFalse(ledger.record_qualified_page(page))
+        self.assertTrue(ledger.record_qualified_page(page, discriminator="second-read"))
+        self.assertEqual(ledger.total_work_units, 0)
+        self.assertEqual(ledger.qualified_pages(), (page,))
+
+    def test_resume_rejects_oversized_json_before_decode(self) -> None:
+        payload = b"[" * (int(BOUNDS["max_json_bytes"]) + 1)
+        with self.assertRaisesRegex(ValueError, "registered JSON byte bound"):
+            resume_derivation(payload, hashlib.sha256(payload).hexdigest())
+
+    def test_resume_rejects_recursion_bomb_as_malformed_json(self) -> None:
+        payload = b"[" * 10_000 + b"]" * 10_000
+        with self.assertRaisesRegex(ValueError, "canonical JSON"):
+            resume_derivation(payload, hashlib.sha256(payload).hexdigest())
+
+    def test_resume_rejects_rehashed_h1_lifecycle_role_tamper(self) -> None:
+        document = copy.deepcopy(dict(_pair_multiple_analysis().frozen.document))
+        result = document["layers"]["h1_tdef_to_map_row"]
+        candidate = result["candidates"][0]
+        candidate["instance_bindings"][0]["logical_role"] = "T2"
+        candidate["canonical_model_id"] = canonical_model_id(candidate["model_type"], candidate["model"])
+        candidate["canonical_candidate_id"] = canonical_candidate_id(
+            candidate["model_type"], candidate["model"], candidate["instance_bindings"]
+        )
+        result["canonical_candidates_sha256"] = sha256_hex(canonical_json_bytes(result["candidates"]))
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "lifecycle role/range"):
+            resume_derivation(payload, digest)
+
+    def test_resume_rejects_rehashed_h1_target_replacement(self) -> None:
+        document = copy.deepcopy(dict(_pair_multiple_analysis().frozen.document))
+        result = document["layers"]["h1_tdef_to_map_row"]
+        candidate = result["candidates"][0]
+        targets = candidate["instance_bindings"][0]["locator_targets"]
+        target = targets[0]
+        target["row"] = next(
+            row for row in range(256)
+            if row != target["row"]
+            and {"page": target["page"], "row": row} != targets[1]
+        )
+        candidate["canonical_candidate_id"] = canonical_candidate_id(
+            candidate["model_type"], candidate["model"], candidate["instance_bindings"]
+        )
+        result["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(result["candidates"])
+        )
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "target binding differs"):
+            resume_derivation(payload, digest)
+
+    def test_resume_rejects_rehashed_h1_tdef_replacement(self) -> None:
+        document = copy.deepcopy(dict(_pair_multiple_analysis().frozen.document))
+        result = document["layers"]["h1_tdef_to_map_row"]
+        candidate = result["candidates"][0]
+        candidate["instance_bindings"][0]["tdef_page"] += 100
+        candidate["canonical_candidate_id"] = canonical_candidate_id(
+            candidate["model_type"], candidate["model"], candidate["instance_bindings"]
+        )
+        result["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(result["candidates"])
+        )
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "physical evidence|target binding"):
+            resume_derivation(payload, digest)
+
+    def test_resume_rejects_added_or_removed_qualified_page(self) -> None:
+        original = _pair_multiple_analysis().frozen.document
+        added = copy.deepcopy(dict(original))
+        added["qualified_pages"].append({
+            "replica": 2,
+            "checkpoint_id": "T4_IDLE_R",
+            "page_number": int(BOUNDS["max_final_pages_per_replica"]) - 1,
+        })
+        added["qualified_pages"].sort(
+            key=lambda row: (
+                row["replica"],
+                CHECKPOINT_ORDINALS[row["checkpoint_id"]],
+                row["page_number"],
+            )
+        )
+        payload, digest = _rehash(added)
+        with self.assertRaisesRegex(ValueError, "qualified-page inventory"):
+            resume_derivation(payload, digest)
+
+        removed = copy.deepcopy(dict(original))
+        binding = removed["layers"]["h1_tdef_to_map_row"]["candidates"][0][
+            "instance_bindings"
+        ][0]
+        identity = (
+            binding["replica"],
+            binding["applicable_checkpoint_range"]["start"],
+            binding["tdef_page"],
+        )
+        removed["qualified_pages"] = [
+            row for row in removed["qualified_pages"]
+            if (row["replica"], row["checkpoint_id"], row["page_number"]) != identity
+        ]
+        payload, digest = _rehash(removed)
+        with self.assertRaisesRegex(ValueError, "qualified-page inventory"):
+            resume_derivation(payload, digest)
+
+        decisive = _default_analysis().frozen
+        one_replica_removed = copy.deepcopy(dict(decisive.document))
+        identities = {
+            (row["replica"], row["checkpoint_id"], row["page_number"])
+            for row in one_replica_removed["qualified_pages"]
+        }
+        identity = next(
+            row for row in sorted(identities)
+            if (3 - row[0], row[1], row[2]) in identities
+        )
+        one_replica_removed["qualified_pages"] = [
+            row for row in one_replica_removed["qualified_pages"]
+            if (row["replica"], row["checkpoint_id"], row["page_number"])
+            != identity
+        ]
+        payload, digest = _rehash(one_replica_removed)
+        with self.assertRaisesRegex(ValueError, "qualified-page inventory"):
+            resume_derivation(payload, digest, decisive.occurrence_evidence_bytes)
+
+    def test_resume_rejects_a_marker_with_a_foreign_stage_discriminator(self) -> None:
+        frozen = _default_analysis().frozen
+        document = copy.deepcopy(dict(frozen.document))
+        for category, rows in document["transcripts"].items():
+            marker = next(
+                (row for row in rows if bytes.fromhex(row["detail_hex"]).startswith(
+                    _QUALIFIED_PAGE_MARKER
+                )),
+                None,
+            )
+            if marker is not None:
+                raw = bytearray.fromhex(marker["detail_hex"])
+                raw[len(_QUALIFIED_PAGE_MARKER) + 1] = next(
+                    code for name, code in _TRANSCRIPT_CATEGORY_CODES.items()
+                    if name != category
+                )
+                marker["detail_hex"] = raw.hex()
+                break
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "transcript marker is malformed"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_resume_expected_sha_is_the_external_empirical_trust_anchor(self) -> None:
+        frozen = _default_analysis().frozen
+        document = copy.deepcopy(dict(frozen.document))
+        marker = next(
+            row
+            for rows in document["transcripts"].values()
+            for row in rows
+            if bytes.fromhex(row["detail_hex"]).startswith(_QUALIFIED_PAGE_MARKER)
+        )
+        raw = bytearray.fromhex(marker["detail_hex"])
+        raw[-1] ^= 1
+        marker["detail_hex"] = raw.hex()
+        payload, replacement_sha = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "hash mismatch"):
+            resume_derivation(payload, frozen.sha256, frozen.occurrence_evidence_bytes)
+        resume_derivation(payload, replacement_sha, frozen.occurrence_evidence_bytes)
+
+    def test_resume_rejects_mixed_terminal_candidate_replicas(self) -> None:
+        document = copy.deepcopy(dict(_pair_multiple_analysis().frozen.document))
+        result = document["layers"]["h1_tdef_to_map_row"]
+        candidate = result["candidates"][1]
+        added_identities: set[tuple[int, str, int]] = set()
+        for binding in candidate["instance_bindings"]:
+            binding["replica"] = 2
+            first = CHECKPOINT_ORDINALS[
+                binding["applicable_checkpoint_range"]["start"]
+            ]
+            last = CHECKPOINT_ORDINALS[
+                binding["applicable_checkpoint_range"]["end"]
+            ]
+            for checkpoint in CHECKPOINT_IDS[first:last + 1]:
+                for page in (
+                    binding["tdef_page"],
+                    *(target["page"] for target in binding["locator_targets"]),
+                ):
+                    document["qualified_pages"].append({
+                        "replica": 2,
+                        "checkpoint_id": checkpoint,
+                        "page_number": page,
+                    })
+                    added_identities.add((2, checkpoint, page))
+        candidate["canonical_candidate_id"] = canonical_candidate_id(
+            candidate["model_type"], candidate["model"], candidate["instance_bindings"]
+        )
+        result["candidates"].sort(key=lambda row: row["canonical_candidate_id"])
+        result["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(result["candidates"])
+        )
+        unique = {
+            (row["replica"], row["checkpoint_id"], row["page_number"]): row
+            for row in document["qualified_pages"]
+        }
+        document["qualified_pages"] = sorted(
+            unique.values(),
+            key=lambda row: (
+                row["replica"], CHECKPOINT_ORDINALS[row["checkpoint_id"]], row["page_number"]
+            ),
+        )
+        for _, checkpoint, page in sorted(added_identities):
+            for rows in document["transcripts"].values():
+                source = next(
+                    (
+                        row for row in rows
+                        if row["checkpoint_id"] == checkpoint
+                        and row["page"] == page
+                        and bytes.fromhex(row["detail_hex"]).startswith(
+                            _QUALIFIED_PAGE_MARKER
+                        )
+                    ),
+                    None,
+                )
+                if source is None:
+                    continue
+                duplicate = copy.deepcopy(source)
+                raw = bytearray.fromhex(duplicate["detail_hex"])
+                raw[len(_QUALIFIED_PAGE_MARKER)] = 2
+                duplicate["detail_hex"] = raw.hex()
+                rows.append(duplicate)
+                break
+        with self.assertRaisesRegex(ValueError, "mixes first-violating replicas"):
+            validate_frozen_layers(document["layers"])
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(
+            ValueError,
+            "qualified-page inventory|mixes first-violating replicas",
+        ):
+            resume_derivation(payload, digest)
+
+    def test_resume_requires_exact_occurrence_evidence_bytes(self) -> None:
+        frozen = _default_analysis().frozen
+        self.assertIsNotNone(frozen.occurrence_evidence_bytes)
+        with self.assertRaisesRegex(ValueError, "requires occurrence evidence bytes"):
+            resume_derivation(frozen.canonical_bytes, frozen.sha256)
+        malformed = b"{}"
+        with self.assertRaisesRegex(ValueError, "reference mismatch"):
+            resume_derivation(frozen.canonical_bytes, frozen.sha256, malformed)
+
+    def test_resume_rejects_coherently_rehashed_occurrence_name_bytes(self) -> None:
+        frozen = _default_analysis().frozen
+        document = copy.deepcopy(dict(frozen.document))
+        evidence = json.loads(frozen.occurrence_evidence_bytes)
+        occurrence = evidence["replica_groups"][0]["operation_bindings"][0][
+            "occurrences"
+        ][0]
+        occurrence["matched_bytes_hex"] = "00" * (
+            len(occurrence["matched_bytes_hex"]) // 2
+        )
+        evidence_bytes = canonical_json_bytes(evidence)
+        evidence_digest = sha256_hex(evidence_bytes)
+        document["h4_occurrence_evidence"].update({
+            "sha256": evidence_digest,
+            "size_bytes": len(evidence_bytes),
+        })
+        h4 = document["layers"]["h4_catalog_bootstrap"]
+        structural = h4["structural_result"]["candidates"][0]
+        for binding in structural["instance_bindings"]:
+            binding["occurrence_evidence_sha256"] = evidence_digest
+        structural["canonical_candidate_id"] = canonical_candidate_id(
+            structural["model_type"], structural["model"], structural["instance_bindings"]
+        )
+        h4["structural_result"]["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(h4["structural_result"]["candidates"])
+        )
+        final = h4["encoding_result"]["candidates"][0]
+        for binding in final["instance_bindings"]:
+            binding["structural_candidate_id"] = structural["canonical_candidate_id"]
+        final["canonical_candidate_id"] = canonical_candidate_id(
+            final["model_type"], final["model"], final["instance_bindings"]
+        )
+        h4["encoding_result"]["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(h4["encoding_result"]["candidates"])
+        )
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "registered operation name"):
+            resume_derivation(payload, digest, evidence_bytes)
+
+    def test_resume_rejects_rehashed_bitmap_index_absent_from_occurrences(self) -> None:
+        frozen = _default_analysis().frozen
+        document = copy.deepcopy(dict(frozen.document))
+        h4 = document["layers"]["h4_catalog_bootstrap"]
+        structural = h4["structural_result"]["candidates"][0]
+        final = h4["encoding_result"]["candidates"][0]
+        for binding in structural["instance_bindings"]:
+            row = binding["compatible_occurrences_by_operation"][0]
+            raw = bytearray.fromhex(row["compatible_occurrence_bitmap_hex"])
+            raw[0] = 0b10
+            row["compatible_occurrence_bitmap_hex"] = raw.hex()
+        structural["canonical_candidate_id"] = canonical_candidate_id(
+            structural["model_type"], structural["model"], structural["instance_bindings"]
+        )
+        h4["structural_result"]["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(h4["structural_result"]["candidates"])
+        )
+        for binding in final["instance_bindings"]:
+            binding["structural_candidate_id"] = structural["canonical_candidate_id"]
+            binding["selected_operation_occurrences"][0]["occurrence_index"] = 1
+        final["canonical_candidate_id"] = canonical_candidate_id(
+            final["model_type"], final["model"], final["instance_bindings"]
+        )
+        h4["encoding_result"]["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(h4["encoding_result"]["candidates"])
+        )
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "absent evidence occurrence"):
+            resume_derivation(
+                payload,
+                digest,
+                frozen.occurrence_evidence_bytes,
+            )
+
+    def test_resume_rejects_mixed_work_paths_after_rehash(self) -> None:
+        frozen = _default_analysis().frozen
+        document = copy.deepcopy(dict(frozen.document))
+        charges = document["work_charges"]
+        charges["invalid_path_row_directory_entries"] = 1
+        charges["total_work_units"] += 1
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "mixes invalid and valid"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_resume_rejects_an_underreported_candidate_serialization_charge(self) -> None:
+        frozen = _default_analysis().frozen
+        document = copy.deepcopy(dict(frozen.document))
+        charges = document["work_charges"]
+        charges["total_work_units"] -= charges["candidate_serializations"]
+        charges["candidate_serializations"] = 0
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "serialization charge omits"):
+            resume_derivation(payload, digest, frozen.occurrence_evidence_bytes)
+
+    def test_rehashed_h4_bitmap_count_tamper_is_rejected(self) -> None:
+        digest = "a" * 64
+        model = {
+            "kind_start_delta": 1,
+            "kind_width": 1,
+            "identifier_width": 1,
+            "endianness": "little",
+            "name_length_start_delta": 1,
+            "name_length_width": 1,
+            "kind_mapping": {"table": 1, "field": 2, "index": 3},
+            "identifier_lifecycle": PLAN["candidate_grammars"]["h4"]["identifier_lifecycle_relations"][0],
+        }
+        rows = []
+        for operation in PLAN["candidate_grammars"]["h4"]["operation_binding_order"]:
+            maximum = 290 if operation in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254
+            rows.append({
+                "operation_id": operation,
+                "compatible_occurrence_count": 1,
+                "compatible_occurrence_bitmap_hex": (b"\x01" + bytes((maximum + 7) // 8 - 1)).hex(),
+            })
+        candidate = H4Candidate("h4_structural_field", model, ({
+            "replica": 1,
+            "occurrence_evidence_sha256": digest,
+            "value_equivalent_tuple_count": 1,
+            "compatible_occurrences_by_operation": rows,
+        },)).document()
+        candidate["instance_bindings"][0]["compatible_occurrences_by_operation"][0]["compatible_occurrence_count"] = 2
+        candidate["canonical_candidate_id"] = canonical_candidate_id(
+            candidate["model_type"], candidate["model"], candidate["instance_bindings"]
+        )
+        with self.assertRaisesRegex(ValueError, "bitmap popcount"):
+            _candidate_identity(candidate, digest)
+
+    def test_grouped_candidate_set_rejects_mixed_first_violating_replicas(self) -> None:
+        operations = PLAN["candidate_grammars"]["h4"]["operation_binding_order"]
+        candidates = []
+        groups = []
+        for index, operation in enumerate(operations):
+            operation_candidates = [] if index == 0 else [
+                H4Candidate("h4_operation_record", {
+                    "replica": 1 if index % 2 else 2,
+                    "root_candidate_id": "a" * 64,
+                    "operation_id": operation,
+                    "canonical_record_locator": {
+                        "page": 10 + index, "row": 0,
+                        "row_start": 10, "row_end": 20,
+                    },
+                }).document()
+            ]
+            candidates.extend(operation_candidates)
+            groups.append({
+                "operation_id": operation,
+                "cardinality": len(operation_candidates),
+                "candidate_ids": [
+                    candidate["canonical_candidate_id"]
+                    for candidate in operation_candidates
+                ],
+            })
+        candidates.sort(key=lambda row: row["canonical_candidate_id"])
+        result = {"candidates": candidates, "predicate_measured_survivor_count": 0}
+        with self.assertRaisesRegex(ValueError, "mixes first-violating replicas"):
+            _validate_groups(
+                "A4-H4-CATALOG-RECORD-NONE",
+                result,
+                {"kind": "operation_groups", "groups": groups},
+                None,
+            )
+
+    def test_h4_disagreement_allows_equal_structural_models_only(self) -> None:
+        digest = "b" * 64
+        h1 = _h2_terminal_layers()["h1_tdef_to_map_row"]
+        h2_candidate = H2ReplicaCandidate(1, 0x1FFF, "set_bit_owned_in_use", 0, 1).document()
+        h3_candidate = H3Candidate("h3_final_base_formula", {
+            "conversion": PLAN["candidate_grammars"]["h3"]["conversion_candidates"][0],
+            "base_formula": PLAN["candidate_grammars"]["h3"]["base_formulas"][0],
+        }).document()
+        root = H4Candidate("h4_catalog_root", {
+            "root_selection_signature": PLAN["candidate_grammars"]["h4"]["catalog_root_selection_signatures"][0],
+            "locator_offsets": [35, 39],
+        }, ({"replica": 1, "tdef_page": 2}, {"replica": 2, "tdef_page": 2})).document()
+        structural_model = {
+            "kind_start_delta": 1, "kind_width": 1, "identifier_width": 1,
+            "endianness": "little", "name_length_start_delta": 1, "name_length_width": 1,
+            "kind_mapping": {"table": 1, "field": 2, "index": 3},
+            "identifier_lifecycle": PLAN["candidate_grammars"]["h4"]["identifier_lifecycle_relations"][0],
+        }
+        structures = []
+        finals = []
+        classes = ("cp1252_single_byte_per_scalar", "utf8_encoded_byte_count")
+        for replica in (1, 2):
+            compatible = []
+            for operation in PLAN["candidate_grammars"]["h4"]["operation_binding_order"]:
+                maximum = 290 if operation in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254
+                compatible.append({"operation_id": operation, "compatible_occurrence_count": 1,
+                                   "compatible_occurrence_bitmap_hex": (b"\x01" + bytes((maximum + 7) // 8 - 1)).hex()})
+            structural = H4Candidate("h4_structural_field", structural_model, ({
+                "replica": replica, "occurrence_evidence_sha256": digest,
+                "value_equivalent_tuple_count": 1,
+                "compatible_occurrences_by_operation": compatible,
+            },))
+            final = H4Candidate("h4_final_encoded_field", {
+                "structural_model_id": structural.canonical_model_id,
+                "encoding_length_equivalence_class": classes[replica - 1],
+            }, ({"replica": replica, "structural_candidate_id": structural.canonical_candidate_id,
+                 "selected_operation_occurrences": [{"operation_id": operation, "occurrence_index": 0}
+                                                     for operation in PLAN["candidate_grammars"]["h4"]["operation_binding_order"]]},))
+            structures.append(structural.document()); finals.append(final.document())
+        def pair(candidates):
+            return {"kind": "replica_pair", "entries": [
+                {"replica": index + 1, "canonical_model_id": candidate["canonical_model_id"],
+                 "canonical_candidate_id": candidate["canonical_candidate_id"], "complete_candidate": candidate}
+                for index, candidate in enumerate(candidates)
+            ]}
+        ledger = WorkLedger()
+        error = A4AnalysisError("A4-H4-REPLICA-DISAGREEMENT", 2)
+        layers = {
+            "h1_tdef_to_map_row": h1,
+            "h2_row_identity_map_role": decisive_result(h2_candidate, ledger),
+            "h3_indirect_traversal": decisive_result(h3_candidate, ledger),
+            "h4_catalog_bootstrap": {
+                "root_result": decisive_result(root, ledger),
+                "structural_result": terminal_result(error, ledger, terminal_evidence=pair(structures), per_replica_counts=(1, 1)),
+                "encoding_result": terminal_result(error, ledger, terminal_evidence=pair(finals), per_replica_counts=(1, 1)),
+            },
+        }
+        role_bindings = {
+            row["replica"]: row for row in PLAN["tables"]["role_bindings"]
+        }
+        table_role = {
+            operation: operation.split("_", 1)[0]
+            for operation in PLAN["candidate_grammars"]["h4"]["operation_binding_order"]
+        }
+        occurrence_evidence = {
+            "protocol_version": "1.0.0",
+            "document_type": "dao_a4_h4_occurrence_evidence",
+            "experiment_id": EXPERIMENT_ID,
+            "plan_sha256": PLAN_SHA256,
+            "revision_plan_sha256": REVISION_PLAN_SHA256,
+            "campaign_id": "semantic-unit",
+            "root_candidate_id": root["canonical_candidate_id"],
+            "replica_groups": [
+                {
+                    "replica": replica,
+                    "operation_bindings": [
+                        {
+                            "operation_id": operation,
+                            "canonical_record_locator": {
+                                "page": 10,
+                                "row": 0,
+                                "row_start": 10,
+                                "row_end": 100,
+                            },
+                            "occurrences": [{
+                                "occurrence_index": 0,
+                                "name_start": 20,
+                                "matched_registered_pattern_id": (
+                                    f"{operation}_UTF8"
+                                    if replica == 2 and "É" in (
+                                        role_bindings[replica][table_role[operation]]
+                                        if operation not in ("T1_ADD_TEXT", "T1_ADD_INDEX")
+                                        else "Payload" if operation == "T1_ADD_TEXT" else "A4IX_ID"
+                                    )
+                                    else f"{operation}_CP1252"
+                                ),
+                                "matched_bytes_hex": (
+                                    role_bindings[replica][table_role[operation]]
+                                    if operation not in ("T1_ADD_TEXT", "T1_ADD_INDEX")
+                                    else "Payload" if operation == "T1_ADD_TEXT" else "A4IX_ID"
+                                ).encode("utf-8" if replica == 2 else "cp1252").hex(),
+                            }],
+                        }
+                        for operation in PLAN["candidate_grammars"]["h4"]["operation_binding_order"]
+                    ],
+                }
+                for replica in (1, 2)
+            ],
+        }
+        validate_frozen_layers(layers, {"sha256": digest}, occurrence_evidence)
+
+    def test_h4_record_terminal_projects_every_reached_catalog_row_page(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        ledger = WorkLedger()
+        original = a4_layers.operation_records
+
+        def omit_first_operation(view, root, deltas, h2, work):
+            candidates = original(view, root, deltas, h2, work)
+            filtered = tuple(
+                candidate
+                for candidate in candidates
+                if candidate.operation_id
+                != PLAN["candidate_grammars"]["h4"]["operation_binding_order"][0]
+            )
+            return filtered
+
+        with patch.object(
+            a4_layers,
+            "operation_records",
+            side_effect=omit_first_operation,
+        ):
+            terminal = derive_layers(checked, ledger)
+        self.assertIsInstance(terminal, DerivationTerminal)
+        frozen = freeze_derivation(checked, terminal, ledger)
+        raw_pages = {
+            (identity[0].replica, identity[0].checkpoint_id, identity[0].page_number)
+            for identity in ledger.identities("catalog_raw_rows")
+        }
+        self.assertTrue(raw_pages)
+        qualified = {
+            (row["replica"], row["checkpoint_id"], row["page_number"])
+            for row in frozen.document["qualified_pages"]
+        }
+        self.assertTrue(raw_pages <= qualified)
+        transcript_pages = {
+            (row["checkpoint_id"], row["page"])
+            for row in frozen.document["transcripts"]["catalog_fields"]
+        }
+        self.assertTrue({(checkpoint, page) for _, checkpoint, page in raw_pages} <= transcript_pages)
+
+    def test_h1_terminal_inventory_is_exact_and_does_not_emit_h2_transcript(self) -> None:
+        frozen = _pair_multiple_analysis().frozen.document
+        h1 = frozen["layers"]["h1_tdef_to_map_row"]
+        expected: set[tuple[int, str, int]] = set()
+        for candidate in h1["candidates"]:
+            for binding in candidate["instance_bindings"]:
+                interval = binding["applicable_checkpoint_range"]
+                checkpoints = CHECKPOINT_IDS[
+                    CHECKPOINT_ORDINALS[interval["start"]] :
+                    CHECKPOINT_ORDINALS[interval["end"]] + 1
+                ]
+                for checkpoint in checkpoints:
+                    expected.add(
+                        (binding["replica"], checkpoint, binding["tdef_page"])
+                    )
+                    expected.update(
+                        (binding["replica"], checkpoint, target["page"])
+                        for target in binding["locator_targets"]
+                    )
+        actual = {
+            (row["replica"], row["checkpoint_id"], row["page_number"])
+            for row in frozen["qualified_pages"]
+        }
+        self.assertTrue(expected <= actual)
+        self.assertTrue(frozen["transcripts"]["locators"])
+        self.assertEqual(frozen["transcripts"]["row_directories"], [])
+
+    def test_resume_rejects_stale_terminal_candidate_identity(self) -> None:
+        frozen = _pair_multiple_analysis().frozen.document
+        document = copy.deepcopy(dict(frozen))
+        result = document["layers"]["h1_tdef_to_map_row"]
+        result["candidates"][0]["model"]["locator_offsets"] = [39, 43]
+        result["canonical_candidates_sha256"] = sha256_hex(
+            canonical_json_bytes(result["candidates"])
+        )
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "identity does not recompute"):
+            resume_derivation(payload, digest)
+
+    def test_resume_rejects_stale_embedded_replica_pair_identity(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        ledger = WorkLedger()
+        h1_by = {
+            replica: derive_h1_replica(
+                checked.views[replica], checked.qualified_tdef_pages[replica], ledger
+            )
+            for replica in (1, 2)
+        }
+        h1 = agree_h1_replicas(h1_by[1], h1_by[2])
+        pair = (
+            H2ReplicaCandidate(1, 0x1FFF, "set_bit_owned_in_use", 0, 1),
+            H2ReplicaCandidate(2, 0x1FFF, "clear_bit_owned_in_use", 0, 1),
+        )
+        evidence = {
+            "kind": "replica_pair",
+            "entries": [
+                {
+                    "replica": candidate.replica,
+                    "canonical_model_id": candidate.canonical_model_id,
+                    "canonical_candidate_id": candidate.canonical_candidate_id,
+                    "complete_candidate": candidate.document(),
+                }
+                for candidate in pair
+            ],
+        }
+        h2 = terminal_result(
+            A4AnalysisError("A4-H2-REPLICA-DISAGREEMENT", 2),
+            ledger,
+            terminal_evidence=evidence,
+            per_replica_counts=(1, 1),
+        )
+        layers = {
+            "h1_tdef_to_map_row": decisive_result(h1.document(), ledger),
+            "h2_row_identity_map_role": h2,
+            "h3_indirect_traversal": not_applicable_result(),
+            "h4_catalog_bootstrap": {
+                "root_result": not_applicable_result(),
+                "structural_result": not_applicable_result(),
+                "encoding_result": not_applicable_result(),
+            },
+        }
+        frozen = freeze_derivation(
+            checked,
+            DerivationTerminal("A4-H2-REPLICA-DISAGREEMENT", layers),
+            ledger,
+        )
+        resume_derivation(frozen.canonical_bytes, frozen.sha256)
+        document = copy.deepcopy(dict(frozen.document))
+        embedded = document["layers"]["h2_row_identity_map_role"][
+            "terminal_evidence"
+        ]["entries"][0]["complete_candidate"]
+        embedded["model"]["row_mask"] = 0x0FFF
+        payload, digest = _rehash(document)
+        with self.assertRaisesRegex(ValueError, "identity does not recompute"):
+            resume_derivation(payload, digest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_generator.py
+++ b/oracle/windows-dao/tests/test_a4_generator.py
@@ -1,0 +1,217 @@
+"""A4 plan compiler and synthetic byte-generator contracts."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+import a4_generator_schedule as schedule_module  # noqa: E402
+from a4_generator import (  # noqa: E402
+    SyntheticParameters,
+    generate_campaign,
+    generate_replica,
+    overshoots,
+)
+from a4_generator_pages import (  # noqa: E402
+    TAG_TDEF,
+    data_page,
+    encode_locator,
+    masked_tdef_page,
+    type_0_row,
+)
+from a4_generator_schedule import EVENTS, PROFILES, SCHEDULE, EventKind  # noqa: E402
+from a4_model import A4AnalysisError, View, WorkLedger, WORK_TERM_LIMITS  # noqa: E402
+from a4_spec import (  # noqa: E402
+    CHECKPOINT_IDS,
+    PAGE_SIZE,
+    PLAN,
+    PREDICATE_IDS,
+    SCHEMA_SHA256,
+)
+
+
+class A4GeneratorTests(unittest.TestCase):
+    def test_checked_contract_is_exact_and_complete(self) -> None:
+        self.assertEqual(len(CHECKPOINT_IDS), PLAN["checkpoint_design"]["count"])
+        self.assertEqual(len(PREDICATE_IDS), len(PLAN["predicate_registry"]["ids"]))
+        self.assertEqual(len(SCHEMA_SHA256), 14)
+        self.assertEqual(tuple(event.checkpoint_id for event in EVENTS), CHECKPOINT_IDS)
+
+    def test_schedule_derives_batch_arithmetic_from_the_document(self) -> None:
+        changed = copy.deepcopy(PLAN)
+        changed["tables"]["row_algorithm"]["growth_batch_rows"] = 40
+        with mock.patch.object(schedule_module, "PLAN", changed):
+            compiled = schedule_module.build_schedule()
+        self.assertEqual(compiled.batch_rows, 40)
+        self.assertEqual([compiled.profile(replica).rows_per_page for replica in (1, 2, 3)], [10, 9, 8])
+
+    def test_lifecycles_and_growth_modes_are_compiled(self) -> None:
+        self.assertEqual([instance.instance_id for instance in SCHEDULE.instances], [
+            "T1-v1", "T2-v1", "T2-v2", "T3-v1", "T4-v1",
+        ])
+        growth = [event for event in EVENTS if event.kind is EventKind.GROW]
+        self.assertEqual(len(growth), 11)
+        self.assertEqual(SCHEDULE.event("T1_REL_0064").baseline_checkpoint_id, "T4_CREATE")
+        self.assertIsNone(SCHEDULE.event("T3_ABS_04096").baseline_checkpoint_id)
+
+    def test_page_encoders_are_exact_and_duplicate_signature_is_byte_derived(self) -> None:
+        layout = PLAN["candidate_grammars"]["h1"]["locator_layouts"][1]
+        duplicate = PLAN["candidate_grammars"]["h1"]["pair_multiple_reachability_signature"]
+        first = encode_locator(layout, 24, 0)
+        second = encode_locator(layout, 24, 1)
+        page = masked_tdef_page(
+            duplicate["signature_id"],
+            {35: first, 39: second, 43: second},
+        )
+        self.assertEqual(len(page), PAGE_SIZE)
+        self.assertEqual(page[0], TAG_TDEF)
+        self.assertEqual(page[39:43], page[43:47])
+        self.assertNotEqual(page[43:47], bytes.fromhex("04000000"))
+        row_page = data_page((type_0_row(3, {3, 5}),), raw_flags={0: 0x1000})
+        self.assertEqual(len(row_page), PAGE_SIZE)
+        self.assertEqual(int.from_bytes(row_page[8:10], "little"), 1)
+
+    def test_replicas_follow_exact_first_reaching_profiles(self) -> None:
+        replicas = [generate_replica(replica=replica) for replica in (1, 2, 3)]
+        for replica in replicas:
+            self.assertEqual(tuple(replica.ordered_page_sha256), CHECKPOINT_IDS)
+            measured = overshoots(replica)
+            self.assertTrue(all(value >= 0 for value in measured.values()))
+            self.assertLessEqual(max(replica.page_count.values()), PLAN["bounds"]["max_final_pages_per_replica"])
+            View(replica.replica, replica)
+        signatures = [tuple(overshoots(replica).values()) for replica in replicas]
+        self.assertEqual(len(set(signatures)), 3)
+
+    def test_lifecycle_locator_pages_exist_for_every_amb01_checkpoint(self) -> None:
+        for replica_ordinal in (1, 2, 3):
+            replica = generate_replica(replica=replica_ordinal)
+            for lifecycle in replica.metadata["lifecycle_pages"].values():
+                for page in (lifecycle["tdef_page"], lifecycle["map_page"]):
+                    self.assertTrue(all(
+                        page < replica.page_count[checkpoint]
+                        for checkpoint in CHECKPOINT_IDS
+                    ))
+
+    def test_growth_uses_complete_batches_with_unique_monotonic_ids(self) -> None:
+        for replica_ordinal in (1, 2, 3):
+            replica = generate_replica(replica=replica_ordinal)
+            profile = PROFILES[replica_ordinal]
+            measured = overshoots(replica)
+            for event in (event for event in EVENTS if event.kind is EventKind.GROW):
+                checkpoint = event.checkpoint_id
+                instance = event.lifecycle_instance
+                self.assertIsNotNone(instance)
+                lifecycle = replica.metadata["lifecycle_pages"][instance]
+                captured = [
+                    page
+                    for page in lifecycle["data_pages"]
+                    if page < replica.page_count[checkpoint]
+                ]
+                self.assertEqual(len(captured) % profile.pages_per_batch, 0)
+
+                row_ids: list[int] = []
+                page_row_counts: list[int] = []
+                for page_number in captured:
+                    digest = replica.ordered_page_sha256[checkpoint][page_number]
+                    payload = replica.page_bytes(digest)
+                    row_count = int.from_bytes(payload[8:10], "little")
+                    page_row_counts.append(row_count)
+                    starts = [
+                        int.from_bytes(
+                            payload[10 + 2 * ordinal : 12 + 2 * ordinal], "little"
+                        )
+                        & 0x0FFF
+                        for ordinal in range(row_count)
+                    ]
+                    ends = [PAGE_SIZE, *starts[:-1]]
+                    row_ids.extend(
+                        int.from_bytes(payload[start:end][:4], "little", signed=True)
+                        for start, end in zip(starts, ends)
+                    )
+                expected_page_rows = [profile.rows_per_page] * profile.pages_per_batch
+                expected_page_rows[-1] = (
+                    profile.batch_rows
+                    - profile.rows_per_page * (profile.pages_per_batch - 1)
+                )
+                for start in range(0, len(page_row_counts), profile.pages_per_batch):
+                    self.assertEqual(
+                        page_row_counts[start : start + profile.pages_per_batch],
+                        expected_page_rows,
+                    )
+                self.assertEqual(row_ids, list(range(1, len(row_ids) + 1)))
+                self.assertEqual(
+                    len(row_ids), replica.row_counts[checkpoint][event.role]
+                )
+                self.assertEqual(len(row_ids) % profile.batch_rows, 0)
+
+                baseline = (
+                    replica.metadata["baselines"][event.baseline_checkpoint_id]
+                    if event.baseline_checkpoint_id is not None
+                    else None
+                )
+                target = event.target_pages(baseline)
+                self.assertIsNotNone(target)
+                previous = EVENTS[event.ordinal - 1].checkpoint_id
+                self.assertLess(replica.page_count[previous], target)
+                self.assertEqual(
+                    measured[checkpoint], replica.page_count[checkpoint] - target
+                )
+
+    def test_view_separates_checkpoint_reads_from_retained_blob_bytes(self) -> None:
+        replica = generate_replica(replica=1)
+        view = View(1, replica)
+        view.page("EMPTY", 0)
+        self.assertEqual(view.checkpoint_read_bytes, PAGE_SIZE)
+        self.assertEqual(view.logical_read_bytes, PAGE_SIZE)
+        view.page("EMPTY", 0)
+        self.assertEqual(view.checkpoint_read_bytes, PAGE_SIZE)
+        view.page("EMPTY_R", 0)
+        self.assertEqual(view.checkpoint_read_bytes, PAGE_SIZE * 2)
+        self.assertEqual(view.logical_read_bytes, PAGE_SIZE)
+
+    def test_campaign_shares_only_content_addressed_bytes(self) -> None:
+        campaign = generate_campaign()
+        self.assertEqual(tuple(campaign.replicas), (1, 2, 3))
+        for replica in campaign.replicas.values():
+            for digest, payload in replica.payloads.items():
+                self.assertEqual(campaign.payloads[digest], payload)
+        fixture_text = json.dumps({
+            "replicas": {
+                str(replica): data.metadata["system_pages"]
+                for replica, data in campaign.replicas.items()
+            }
+        }, default=dict)
+        for forbidden in ("accepted", "valid", "reachable", "passed"):
+            self.assertNotIn(f'"{forbidden}"', fixture_text)
+
+    def test_generator_parameters_fail_closed(self) -> None:
+        with self.assertRaisesRegex(Exception, "layout"):
+            generate_replica(SyntheticParameters(layout_by_replica={1: "invented"}))
+        with self.assertRaisesRegex(Exception, "offsets"):
+            generate_replica(SyntheticParameters(locator_offsets=(35, 43)))
+
+    def test_work_ledger_accepts_exact_limits_and_rejects_one_over(self) -> None:
+        term = next(iter(WORK_TERM_LIMITS))
+        ledger = WorkLedger()
+        ledger.charge(term, WORK_TERM_LIMITS[term])
+        self.assertEqual(ledger.value(term), WORK_TERM_LIMITS[term])
+        with self.assertRaises(A4AnalysisError) as raised:
+            ledger.charge(term)
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+
+    def test_work_paths_are_mutually_exclusive(self) -> None:
+        ledger = WorkLedger()
+        ledger.charge("invalid_path_row_directory_entries")
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            ledger.charge("valid_path_row_directory_entries")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_h2_holdout.py
+++ b/oracle/windows-dao/tests/test_a4_h2_holdout.py
@@ -1,0 +1,82 @@
+"""Focused holdout checks for the frozen A4 H2 transition model."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+from a4_layer_h1 import H1Binding, H1ReplicaCandidate, LocatorTarget  # noqa: E402
+from a4_layer_h2 import H2ReplicaCandidate  # noqa: E402
+from a4_layers import predicts_h2  # noqa: E402
+from a4_spec import CHECKPOINT_IDS, CHECKPOINT_ORDINALS, PAGE_SIZE  # noqa: E402
+
+
+def _type_0(pages: set[int]) -> bytes:
+    bitmap = sum(1 << page for page in pages).to_bytes(1, "little")
+    return bytes((0,)) + (0).to_bytes(4, "little") + bitmap
+
+
+def _map_page(owned: set[int], available: set[int]) -> bytes:
+    payload = bytearray(PAGE_SIZE)
+    payload[0] = 0x01
+    payload[8:10] = (2).to_bytes(2, "little")
+    cursor = PAGE_SIZE
+    for ordinal, row in enumerate((_type_0(owned), _type_0(available))):
+        cursor -= len(row)
+        payload[cursor : cursor + len(row)] = row
+        offset = 10 + 2 * ordinal
+        payload[offset : offset + 2] = cursor.to_bytes(2, "little")
+    return bytes(payload)
+
+
+class _HoldoutView:
+    replica = 3
+
+    def __init__(self, *, gained_page_also_available: bool) -> None:
+        self._pages: dict[tuple[str, int], bytes] = {}
+        threshold = CHECKPOINT_ORDINALS["T1_REL_0512"]
+        for role, instance, page in (("T1", "T1-v1", 5), ("T3", "T3-v1", 6), ("T4", "T4-v1", 7)):
+            binding = H1Binding(3, role, instance, 20 + page)
+            for checkpoint in binding.checkpoints:
+                grown = role == "T1" and CHECKPOINT_ORDINALS[checkpoint] >= threshold
+                owned = {1, 2} if grown else {1}
+                available = {2} if grown and gained_page_also_available else set()
+                self._pages[(checkpoint, page)] = _map_page(owned, available)
+
+    def page(self, checkpoint: str, page: int) -> bytes:
+        return self._pages[(checkpoint, page)]
+
+    @staticmethod
+    def page_count(_checkpoint: str) -> int:
+        return 64
+
+
+def _h1() -> H1ReplicaCandidate:
+    bindings = tuple(
+        H1Binding(
+            3,
+            role,
+            instance,
+            20 + page,
+            (LocatorTarget(page, 0), LocatorTarget(page, 1)),
+        )
+        for role, instance, page in (("T1", "T1-v1", 5), ("T3", "T3-v1", 6), ("T4", "T4-v1", 7))
+    )
+    return H1ReplicaCandidate(3, "u24le_page_then_u8_row", "tag_02", (4, 8), bindings)
+
+
+class A4H2HoldoutTests(unittest.TestCase):
+    def test_holdout_rejects_page_newly_owned_and_available_on_growth_leg(self) -> None:
+        model = H2ReplicaCandidate(0, 0x1FFF, "set_bit_owned_in_use", 0, 1)
+        counts = {checkpoint: {role: 1 for role in ("T1", "T2", "T3", "T4")} for checkpoint in CHECKPOINT_IDS}
+
+        self.assertTrue(predicts_h2(_HoldoutView(gained_page_also_available=False), _h1(), model, counts))
+        self.assertFalse(predicts_h2(_HoldoutView(gained_page_also_available=True), _h1(), model, counts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_h3_transitions.py
+++ b/oracle/windows-dao/tests/test_a4_h3_transitions.py
@@ -1,0 +1,240 @@
+"""Focused A4 H3 tests for the frozen H2 transition signature."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+from a4_layer_h3 import (  # noqa: E402
+    SlotObservation,
+    TraversalObservation,
+    conversion_legs,
+    formula_fits,
+    transition_signature_fits,
+)
+
+
+FORMULA = "slot_ordinal_times_16352_plus_bit_index"
+SPAN = (0, 16)
+
+
+def _type_0(
+    checkpoint: str,
+    pages: set[int],
+    *,
+    instance: str,
+    allocation_role: str,
+    ordinal: int,
+    span: tuple[int, int] = SPAN,
+) -> TraversalObservation:
+    return TraversalObservation(
+        1,
+        checkpoint,
+        24,
+        "type_0",
+        instance,
+        allocation_role=allocation_role,
+        type0_owned=frozenset(pages),
+        locator_ordinal=ordinal,
+        allocation_span=span,
+    )
+
+
+def _type_1(
+    checkpoint: str,
+    pages: set[int],
+    *,
+    instance: str,
+    allocation_role: str,
+    ordinal: int,
+    span: tuple[int, int] = SPAN,
+) -> TraversalObservation:
+    return TraversalObservation(
+        1,
+        checkpoint,
+        24,
+        "type_1",
+        instance,
+        allocation_role=allocation_role,
+        slots=(
+            SlotObservation(0, 30, 0x05, frozenset(pages)),
+            SlotObservation(1, 0, None),
+        ),
+        locator_ordinal=ordinal,
+        allocation_span=span,
+    )
+
+
+def _t3_growth(
+    owned: dict[str, set[int]], available: dict[str, set[int]]
+) -> tuple[TraversalObservation, ...]:
+    checkpoints = (
+        "T3_CREATE",
+        "T3_ABS_04096",
+        "T3_ABS_08192",
+        "T3_ABS_12288",
+        "T3_ABS_16480",
+    )
+    rows: list[TraversalObservation] = []
+    for index, checkpoint in enumerate(checkpoints):
+        owned_builder = _type_0 if index == 0 else _type_1
+        rows.append(
+            owned_builder(
+                checkpoint,
+                owned[checkpoint],
+                instance="T3-v1",
+                allocation_role="owned_in_use",
+                ordinal=0,
+            )
+        )
+        rows.append(
+            _type_0(
+                checkpoint,
+                available[checkpoint],
+                instance="T3-v1",
+                allocation_role="available",
+                ordinal=1,
+            )
+        )
+    return tuple(rows)
+
+
+class A4H3TransitionTests(unittest.TestCase):
+    def test_later_type_1_growth_may_not_lose_owned_pages(self) -> None:
+        checkpoints = (
+            "T3_CREATE",
+            "T3_ABS_04096",
+            "T3_ABS_08192",
+            "T3_ABS_12288",
+            "T3_ABS_16480",
+        )
+        owned = {
+            checkpoints[0]: {0},
+            checkpoints[1]: {0, 1},
+            checkpoints[2]: {0, 1, 2},
+            checkpoints[3]: {0, 1},
+            checkpoints[4]: {0, 1, 3},
+        }
+        rows = _t3_growth(owned, {checkpoint: set() for checkpoint in checkpoints})
+        self.assertFalse(formula_fits(FORMULA, rows, conversion_legs(rows)))
+
+    def test_growth_rejects_page_newly_owned_and_newly_available(self) -> None:
+        checkpoints = (
+            "T3_CREATE",
+            "T3_ABS_04096",
+            "T3_ABS_08192",
+            "T3_ABS_12288",
+            "T3_ABS_16480",
+        )
+        owned = {
+            checkpoints[0]: {0},
+            checkpoints[1]: {0, 1},
+            checkpoints[2]: {0, 1, 2},
+            checkpoints[3]: {0, 1, 2, 3},
+            checkpoints[4]: {0, 1, 2, 3, 4},
+        }
+        available = {checkpoint: set() for checkpoint in checkpoints}
+        available[checkpoints[2]] = {2}
+        rows = _t3_growth(owned, available)
+        self.assertFalse(formula_fits(FORMULA, rows, conversion_legs(rows)))
+
+    def test_complete_monotone_growth_signature_passes(self) -> None:
+        checkpoints = (
+            "T3_CREATE",
+            "T3_ABS_04096",
+            "T3_ABS_08192",
+            "T3_ABS_12288",
+            "T3_ABS_16480",
+        )
+        owned = {
+            checkpoint: set(range(index + 1))
+            for index, checkpoint in enumerate(checkpoints)
+        }
+        rows = _t3_growth(owned, {checkpoint: set() for checkpoint in checkpoints})
+        self.assertTrue(formula_fits(FORMULA, rows, conversion_legs(rows)))
+
+    def test_churn_and_idle_use_both_allocation_roles_and_span(self) -> None:
+        checkpoints = (
+            "T4_CREATE",
+            "T1_REL_0064",
+            "T1_REL_0512",
+            "T1_REL_0768",
+            "T1_REL_1280",
+            "T1_DELETE_ALL",
+            "T1_REINSERT_SAME",
+            "T1_IDLE_R",
+        )
+        owned = (
+            {0},
+            {0, 1},
+            {0, 1, 2},
+            {0, 1, 2, 3},
+            {0, 1, 2, 3, 4},
+            {0},
+            {0, 1, 2, 3, 4},
+            {0, 1, 2, 3, 4},
+        )
+        available = (set(), set(), set(), set(), set(), {1, 2, 3, 4}, set(), set())
+        rows = tuple(
+            row
+            for checkpoint, owned_pages, available_pages in zip(
+                checkpoints, owned, available
+            )
+            for row in (
+                _type_0(
+                    checkpoint,
+                    owned_pages,
+                    instance="T1-v1",
+                    allocation_role="owned_in_use",
+                    ordinal=0,
+                ),
+                _type_0(
+                    checkpoint,
+                    available_pages,
+                    instance="T1-v1",
+                    allocation_role="available",
+                    ordinal=1,
+                ),
+            )
+        )
+        self.assertTrue(transition_signature_fits(FORMULA, rows))
+
+        outside = list(rows)
+        delete_index = next(
+            index
+            for index, row in enumerate(outside)
+            if row.checkpoint_id == "T1_REL_1280"
+            and row.allocation_role == "owned_in_use"
+        )
+        outside[delete_index] = _type_0(
+            "T1_REL_1280",
+            {0, 1, 2, 3, 4, 20},
+            instance="T1-v1",
+            allocation_role="owned_in_use",
+            ordinal=0,
+        )
+        self.assertFalse(transition_signature_fits(FORMULA, outside))
+
+        idle_mismatch = list(rows)
+        idle_index = next(
+            index
+            for index, row in enumerate(idle_mismatch)
+            if row.checkpoint_id == "T1_IDLE_R"
+            and row.allocation_role == "available"
+        )
+        idle_mismatch[idle_index] = _type_0(
+            "T1_IDLE_R",
+            {7},
+            instance="T1-v1",
+            allocation_role="available",
+            ordinal=1,
+        )
+        self.assertFalse(transition_signature_fits(FORMULA, idle_mismatch))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_h4_continuity.py
+++ b/oracle/windows-dao/tests/test_a4_h4_continuity.py
@@ -1,0 +1,288 @@
+"""Focused AMB-12 checkpoint-continuity contracts for A4 H4."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+import a4_layer_h4  # noqa: E402
+from a4_layer_h4 import (  # noqa: E402
+    OPERATIONS,
+    CatalogRecordLocator,
+    CheckpointRecordEvidence,
+    H4Candidate,
+    OperationRecord,
+    StructuralDerivation,
+    applicable_operation_checkpoints,
+    derive_encoding,
+    derive_structural_fields,
+    select_operation_records,
+)
+from a4_layers import operation_records  # noqa: E402
+from a4_layer_h4_fields import expected_operation_name  # noqa: E402
+import a4_layer_h4_holdout  # noqa: E402
+from a4_model import A4AnalysisError  # noqa: E402
+from a4_spec import CHECKPOINT_IDS, ROLE_BINDINGS  # noqa: E402
+
+
+_ROOT_OPERATIONS = {
+    "T1_CREATE_ID",
+    "T2_CREATE",
+    "T2_RECREATE",
+    "T3_CREATE",
+    "T4_CREATE",
+}
+_TABLE_ROLES = {
+    operation: operation.split("_", 1)[0]
+    for operation in _ROOT_OPERATIONS
+}
+_KINDS = {"table": 0x11, "field": 0x22, "index": 0x33}
+
+
+def _kind(operation: str) -> int:
+    if operation == "T1_ADD_TEXT":
+        return _KINDS["field"]
+    if operation == "T1_ADD_INDEX":
+        return _KINDS["index"]
+    return _KINDS["table"]
+
+
+def _record_row(replica: int, operation: str, identifier: int) -> bytes:
+    name = expected_operation_name(
+        replica, operation, ROLE_BINDINGS, _TABLE_ROLES
+    ).encode("cp1252", errors="strict")
+    return bytes((identifier, _kind(operation), len(name))) + name
+
+
+def _locator(page: int, row: bytes) -> CatalogRecordLocator:
+    return CatalogRecordLocator(page, 0, 2048 - len(row), 2048)
+
+
+def _records(
+    mutation: tuple[str, str, int, int] | None = None,
+) -> tuple[OperationRecord, ...]:
+    records: list[OperationRecord] = []
+    for ordinal, operation in enumerate(OPERATIONS):
+        base = _record_row(1, operation, 0x21 + ordinal)
+        rows: dict[str, tuple[CatalogRecordLocator, bytes]] = {}
+        for checkpoint in applicable_operation_checkpoints(operation):
+            row = bytearray(base)
+            if mutation is not None:
+                selected_operation, selected_checkpoint, offset, value = mutation
+                if (operation, checkpoint) == (
+                    selected_operation,
+                    selected_checkpoint,
+                ):
+                    row[offset] = value
+            payload = bytes(row)
+            rows[checkpoint] = (_locator(10 + ordinal, payload), payload)
+        records.append(OperationRecord.from_checkpoint_rows(1, operation, rows))
+    return tuple(records)
+
+
+class A4H4ContinuityTests(unittest.TestCase):
+    def test_encoding_requires_one_coherent_identifier_assignment(self) -> None:
+        evidence = tuple(
+            SimpleNamespace(
+                record=SimpleNamespace(operation_id=operation),
+                expected_name="x",
+                occurrences=(
+                    SimpleNamespace(index=0, encoded_hex="67"),
+                    SimpleNamespace(index=1, encoded_hex="62"),
+                ),
+            )
+            for operation in OPERATIONS
+        )
+        model = {
+            "identifier_lifecycle": (
+                "stable_for_same_operation_instance_and_distinct_for_t2_v1_v2"
+            ),
+        }
+        candidate = H4Candidate(
+            "h4_structural_field",
+            model,
+            (
+                {
+                    "replica": 1,
+                    "compatible_occurrences_by_operation": [
+                        {
+                            "operation_id": operation,
+                            "compatible_occurrence_bitmap_hex": "03",
+                        }
+                        for operation in OPERATIONS
+                    ],
+                },
+            ),
+        )
+        structural = StructuralDerivation(1, "digest", evidence, (candidate,))
+
+        def decode(group, occurrence, _model):
+            operation = group.record.operation_id
+            return SimpleNamespace(
+                occurrence=occurrence,
+                identifier=(
+                    1
+                    if occurrence.index == 0
+                    else 10 + OPERATIONS.index(operation)
+                ),
+                stored_length=1,
+            )
+
+        with patch.object(
+            a4_layer_h4, "ENCODING_CLASSES", ("test-class",)
+        ), patch.object(
+            a4_layer_h4, "_decode_for_model", side_effect=decode
+        ), patch.object(
+            a4_layer_h4,
+            "encoding_class_matches",
+            side_effect=lambda _class, _name, payload, _length: payload == b"g",
+        ):
+            with self.assertRaises(A4AnalysisError) as raised:
+                derive_encoding(structural)
+        self.assertEqual(
+            raised.exception.predicate_id, "A4-H4-ENCODING-AMBIGUOUS"
+        )
+        self.assertEqual(raised.exception.survivor_count, 0)
+
+    def test_holdout_requires_one_coherent_structural_and_encoding_selection(self) -> None:
+        records = tuple(
+            SimpleNamespace(replica=3, operation_id=operation)
+            for operation in OPERATIONS
+        )
+        groups = {}
+        for index, record in enumerate(records):
+            groups[record.operation_id] = SimpleNamespace(
+                record=record,
+                expected_name="x",
+                occurrences=(
+                    SimpleNamespace(index=0, encoded_hex="67"),
+                    SimpleNamespace(index=1, encoded_hex="62"),
+                ),
+            )
+        model = {
+            "kind_mapping": _KINDS,
+            "identifier_lifecycle": (
+                "stable_for_same_operation_instance_and_distinct_for_t2_v1_v2"
+            ),
+        }
+        structural = H4Candidate("h4_structural_field", model)
+        final = H4Candidate(
+            "h4_final_encoded_field",
+            {
+                "structural_model_id": structural.canonical_model_id,
+                "encoding_length_equivalence_class": "test-class",
+            },
+        )
+
+        def decode(group, occurrence, _model):
+            operation = group.record.operation_id
+            kind = _kind(operation)
+            identifier = 1 if occurrence.index == 0 else 10 + OPERATIONS.index(operation)
+            return SimpleNamespace(
+                occurrence=occurrence,
+                kind=kind,
+                identifier=identifier,
+                stored_length=1,
+            )
+
+        with patch.object(
+            a4_layer_h4_holdout,
+            "scan_name_occurrences",
+            side_effect=lambda record: groups[record.operation_id],
+        ), patch.object(
+            a4_layer_h4_holdout, "_decode_for_model", side_effect=decode
+        ), patch.object(
+            a4_layer_h4_holdout,
+            "encoding_class_matches",
+            side_effect=lambda _class, _name, payload, _length: payload == b"g",
+        ):
+            self.assertFalse(
+                a4_layer_h4_holdout.predicts_fields(structural, final, records)
+            )
+
+    def test_record_enumeration_is_name_blind_and_bounded(self) -> None:
+        self.assertNotIn("expected_operation_name", operation_records.__code__.co_names)
+        self.assertNotIn("encoded_patterns", operation_records.__code__.co_names)
+        records = _records()
+        overflowing = (records[0],) * 4_097 + records[1:]
+        with self.assertRaises(A4AnalysisError) as raised:
+            select_operation_records(
+                1, H4Candidate("h4_catalog_root", {}), overflowing
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-RESOURCE-BOUND")
+
+    def test_applicability_is_exact_and_plan_ordered(self) -> None:
+        for operation in OPERATIONS:
+            checkpoints = applicable_operation_checkpoints(operation)
+            self.assertEqual(checkpoints[0], operation)
+            self.assertEqual(len(checkpoints), len(set(checkpoints)))
+            self.assertEqual(
+                checkpoints,
+                tuple(
+                    checkpoint
+                    for checkpoint in CHECKPOINT_IDS
+                    if checkpoint in checkpoints
+                ),
+            )
+        self.assertEqual(
+            applicable_operation_checkpoints("T2_CREATE"), ("T2_CREATE",)
+        )
+
+    def test_constructor_rejects_missing_extra_duplicate_or_reordered_evidence(self) -> None:
+        operation = "T4_CREATE"
+        expected = applicable_operation_checkpoints(operation)
+        row = _record_row(1, operation, 0x27)
+        locator = _locator(16, row)
+        complete = {checkpoint: (locator, row) for checkpoint in expected}
+        for changed in (
+            {checkpoint: complete[checkpoint] for checkpoint in expected[:-1]},
+            {**complete, "EMPTY": (locator, row)},
+        ):
+            with self.assertRaisesRegex(ValueError, "exact applicable checkpoint"):
+                OperationRecord.from_checkpoint_rows(1, operation, changed)
+
+        evidence = tuple(
+            CheckpointRecordEvidence(checkpoint, locator, row)
+            for checkpoint in expected
+        )
+        with self.assertRaisesRegex(ValueError, "exactly once in plan order"):
+            OperationRecord(1, operation, tuple(reversed(evidence)))
+        with self.assertRaisesRegex(ValueError, "exactly once in plan order"):
+            OperationRecord(1, operation, evidence[:-1] + (evidence[-2],))
+
+    def test_structural_fit_accepts_value_equivalence_at_every_checkpoint(self) -> None:
+        result = derive_structural_fields(1, _records())
+        self.assertEqual(len(result.candidates), 1)
+        self.assertEqual(
+            result.candidates[0].instance_bindings[0][
+                "value_equivalent_tuple_count"
+            ],
+            2,
+        )
+
+    def test_structural_fit_rejects_changed_kind_identifier_or_length(self) -> None:
+        operation = "T4_CREATE"
+        checkpoint = applicable_operation_checkpoints(operation)[-1]
+        for label, offset, value in (
+            ("kind", 1, 0x12),
+            ("identifier", 0, 0x55),
+            ("stored length", 2, 9),
+        ):
+            with self.subTest(field=label):
+                with self.assertRaises(A4AnalysisError) as raised:
+                    derive_structural_fields(
+                        1, _records((operation, checkpoint, offset, value))
+                    )
+                self.assertEqual(
+                    raised.exception.predicate_id, "A4-H4-FIELD-MODEL-NONE"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_layer_boundaries.py
+++ b/oracle/windows-dao/tests/test_a4_layer_boundaries.py
@@ -1,0 +1,378 @@
+"""Focused A4 adapter and lifecycle-boundary regressions."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+import a4_analysis_holdout  # noqa: E402
+import a4_layers  # noqa: E402
+from a4_layer_h1 import _preserved_window  # noqa: E402
+from a4_layer_h1 import H1Binding, H1ReplicaCandidate, LocatorTarget, _target_valid  # noqa: E402
+from a4_layer_h2 import H2ReplicaCandidate  # noqa: E402
+from a4_layer_h2_types import FrozenOwnedRow  # noqa: E402
+from a4_layer_h3 import (  # noqa: E402
+    H3Candidate,
+    SlotObservation,
+    TraversalObservation,
+    admitted_pages,
+)
+from a4_layer_h4 import derive_catalog_root  # noqa: E402
+from a4_layer_h4_fields import identifier_assignment_exists  # noqa: E402
+from a4_layers import catalog_root_observations, h3_observations  # noqa: E402
+from a4_model import A4AnalysisError, QualifiedPage, WorkLedger  # noqa: E402
+from a4_spec import CHECKPOINT_IDS, PAGE_SIZE, PLAN  # noqa: E402
+
+
+class _WindowView:
+    def __init__(self, invalid_checkpoint: str) -> None:
+        self.invalid_checkpoint = invalid_checkpoint
+        self.visited: list[str] = []
+
+    def page_optional(self, checkpoint: str, page: int) -> bytes:
+        self.visited.append(checkpoint)
+        payload = bytearray(2048)
+        if checkpoint == self.invalid_checkpoint:
+            payload[:3] = (20480).to_bytes(3, "little")
+        return bytes(payload)
+
+
+class _ReferenceView:
+    replica = 1
+
+    def __init__(self) -> None:
+        self.opened: list[int] = []
+
+    def page_optional(self, checkpoint: str, page: int) -> bytes:
+        self.opened.append(page)
+        if page != 30:
+            raise AssertionError("reference traversal continued after invalid tag")
+        return bytes((0x01,)) + bytes(2047)
+
+
+class _ValidReferenceView:
+    replica = 1
+
+    def __init__(self) -> None:
+        self.opened: list[int] = []
+
+    def page_optional(self, _checkpoint: str, page: int) -> bytes:
+        self.opened.append(page)
+        return bytes((0x05,)) + bytes(PAGE_SIZE - 1)
+
+
+class _TargetView:
+    replica = 1
+
+    @staticmethod
+    def page_optional(_checkpoint: str, _page: int) -> bytes:
+        payload = bytearray(PAGE_SIZE)
+        payload[0] = 0x01
+        payload[8:10] = (1).to_bytes(2, "little")
+        return bytes(payload)
+
+
+def _data_page(row: bytes) -> bytes:
+    payload = bytearray(PAGE_SIZE)
+    payload[0] = 0x01
+    payload[8:10] = (1).to_bytes(2, "little")
+    start = PAGE_SIZE - len(row)
+    payload[10:12] = start.to_bytes(2, "little")
+    payload[start:] = row
+    return bytes(payload)
+
+
+class _SystemView:
+    def __init__(self, replica: int, reference_tag: int) -> None:
+        self.replica = replica
+        self.opened: list[tuple[str, int]] = []
+        tdef = bytearray(PAGE_SIZE)
+        tdef[0] = 0x02
+        tdef[35:39] = bytes((0, 3, 0, 0))
+        tdef[39:43] = bytes((0, 4, 0, 0))
+        self.pages = {
+            2: bytes(tdef),
+            3: _data_page(b"\x01" + (5).to_bytes(4, "little")),
+            4: _data_page(b"\x00" + bytes(5)),
+            5: bytes((reference_tag,)) + bytes(PAGE_SIZE - 1),
+        }
+
+    def page_optional(self, checkpoint: str, page: int) -> bytes | None:
+        self.opened.append((checkpoint, page))
+        return self.pages.get(page)
+
+    def page(self, checkpoint: str, page: int) -> bytes:
+        self.opened.append((checkpoint, page))
+        return self.pages[page]
+
+    @staticmethod
+    def page_count(_checkpoint: str) -> int:
+        return 6
+
+    def hash_at(self, _checkpoint: str, page: int) -> str | None:
+        return f"{page:064x}" if page in self.pages else None
+
+
+def _system_models(replica: int):
+    h1 = H1ReplicaCandidate(
+        replica,
+        "u8_row_then_u24le_page",
+        "test-signature",
+        (35, 39),
+        (),
+    )
+    h2 = H2ReplicaCandidate(0, 0x1FFF, "set_bit_owned_in_use", 0, 1)
+    h3 = H3Candidate(
+        "h3_final_base_formula",
+        {
+            "conversion": PLAN["candidate_grammars"]["h3"][
+                "conversion_candidates"
+            ][0],
+            "base_formula": PLAN["candidate_grammars"]["h3"][
+                "base_formulas"
+            ][0],
+        },
+    )
+    return h1, h2, h3
+
+
+def _type1(reference: int) -> FrozenOwnedRow:
+    return FrozenOwnedRow(
+        1,
+        "T1",
+        "T1-v1",
+        "owned_in_use",
+        "T1_CREATE_ID",
+        24,
+        0,
+        "type_1",
+        None,
+        (reference,),
+        None,
+    )
+
+
+class A4LayerBoundaryTests(unittest.TestCase):
+    def test_h1_window_must_decode_at_all_25_checkpoints(self) -> None:
+        view = _WindowView("T4_IDLE_R")
+        self.assertFalse(
+            _preserved_window(view, 23, "u24le_page_then_u8_row", 0)
+        )
+        self.assertEqual(view.visited, list(CHECKPOINT_IDS))
+
+    def test_h3_invalid_reference_stops_before_bitmap_or_later_reference(self) -> None:
+        view = _ReferenceView()
+        work = WorkLedger()
+        rows = h3_observations(view, (_type1(30), _type1(31)), work)
+        self.assertEqual(view.opened, [30])
+        self.assertEqual(
+            work.value("type_0_and_tag_05_bitmap_bits"), 0
+        )
+        self.assertEqual(rows[0].slots[0].referenced_page_tag, 0x01)
+        self.assertIsNone(rows[1].slots[0].referenced_page_tag)
+        self.assertIn(
+            QualifiedPage(1, "T1_CREATE_ID", 30), work.qualified_pages()
+        )
+
+    def test_h3_stops_before_reading_seventeenth_qualified_reference(self) -> None:
+        view = _ValidReferenceView()
+        row = FrozenOwnedRow(
+            1,
+            "T1",
+            "T1-v1",
+            "owned_in_use",
+            "T1_CREATE_ID",
+            24,
+            0,
+            "type_1",
+            None,
+            tuple(range(30, 47)),
+            None,
+        )
+        with self.assertRaisesRegex(A4AnalysisError, "A4-RESOURCE-BOUND"):
+            h3_observations(view, (row,), WorkLedger())
+        self.assertEqual(view.opened, list(range(30, 46)))
+
+    def test_h3_stops_before_materializing_seventeenth_admitted_page(self) -> None:
+        observation = TraversalObservation(
+            1,
+            "T1_CREATE_ID",
+            24,
+            "type_1",
+            "T1-v1",
+            slots=(SlotObservation(0, 30, 0x05, frozenset(range(17))),),
+        )
+        with self.assertRaisesRegex(A4AnalysisError, "A4-RESOURCE-BOUND"):
+            admitted_pages(
+                observation,
+                PLAN["candidate_grammars"]["h3"]["base_formulas"][0],
+                maximum=16,
+            )
+
+    def test_h1_target_validity_records_target_pages(self) -> None:
+        binding = H1Binding(
+            1,
+            "T2",
+            "T2-v1",
+            7,
+            (LocatorTarget(30, 0), LocatorTarget(31, 0)),
+        )
+        work = WorkLedger()
+        self.assertTrue(
+            _target_valid(
+                _TargetView(), (binding,), "u8_row_then_u24le_page", work
+            )
+        )
+        self.assertEqual(
+            set(work.qualified_pages()),
+            {
+                QualifiedPage(1, "T2_CREATE", 30),
+                QualifiedPage(1, "T2_CREATE", 31),
+            },
+        )
+
+    def test_system_indirect_reference_validates_tag_before_bitmap(self) -> None:
+        view = _SystemView(1, 0x01)
+        h1, h2, h3 = _system_models(1)
+        work = WorkLedger()
+        observation = catalog_root_observations(
+            view, (2,), h1, h2, h3, work
+        )[0]
+        self.assertEqual(observation.traversal_valid_checkpoints, frozenset())
+        self.assertEqual(work.value("type_0_and_tag_05_bitmap_bits"), 0)
+        self.assertEqual(work.value("type_1_slots"), 1)
+        self.assertIn(QualifiedPage(1, "EMPTY", 5), work.qualified_pages())
+        self.assertIn(QualifiedPage(1, "EMPTY", 3), work.qualified_pages())
+        self.assertIn(QualifiedPage(1, "EMPTY", 4), work.qualified_pages())
+        self.assertEqual(
+            view.opened,
+            [("EMPTY", 2), ("EMPTY", 2), ("EMPTY", 3), ("EMPTY", 4), ("EMPTY", 5)],
+        )
+        with self.assertRaisesRegex(A4AnalysisError, "A4-H4-CATALOG-ROOT-NONE"):
+            derive_catalog_root(1, (observation,), work)
+        self.assertEqual(work.value("catalog_root_signatures"), 1)
+
+    def test_system_malformed_available_map_is_recorded_before_prefix_stops(self) -> None:
+        view = _SystemView(1, 0x05)
+        view.pages[4] = b""
+        h1, h2, h3 = _system_models(1)
+        work = WorkLedger()
+        observation = catalog_root_observations(
+            view, (2,), h1, h2, h3, work
+        )[0]
+        self.assertEqual(observation.traversal_valid_checkpoints, frozenset())
+        self.assertIn(QualifiedPage(1, "EMPTY", 3), work.qualified_pages())
+        self.assertIn(QualifiedPage(1, "EMPTY", 4), work.qualified_pages())
+        self.assertNotIn(("EMPTY", 5), view.opened)
+
+    def test_system_malformed_owned_map_stops_before_available_map(self) -> None:
+        view = _SystemView(1, 0x05)
+        view.pages[3] = b""
+        h1, h2, h3 = _system_models(1)
+        work = WorkLedger()
+        observation = catalog_root_observations(
+            view, (2,), h1, h2, h3, work
+        )[0]
+        self.assertEqual(observation.traversal_valid_checkpoints, frozenset())
+        self.assertIn(QualifiedPage(1, "EMPTY", 3), work.qualified_pages())
+        self.assertNotIn(QualifiedPage(1, "EMPTY", 4), work.qualified_pages())
+        self.assertNotIn(("EMPTY", 4), view.opened)
+
+    def test_system_type0_stops_before_seventeenth_admitted_page(self) -> None:
+        view = _SystemView(1, 0x05)
+        view.pages[3] = _data_page(b"\x00" + bytes(4) + b"\xff\xff\x01")
+        h1, h2, h3 = _system_models(1)
+        with self.assertRaisesRegex(A4AnalysisError, "A4-RESOURCE-BOUND"):
+            catalog_root_observations(view, (2,), h1, h2, h3, WorkLedger())
+
+    def test_system_type1_stops_before_seventeenth_reference_page(self) -> None:
+        view = _SystemView(1, 0x05)
+        references = tuple(range(5, 22))
+        view.pages[3] = _data_page(
+            b"\x01" + b"".join(page.to_bytes(4, "little") for page in references)
+        )
+        view.pages.update(
+            {
+                page: bytes((0x05,)) + bytes(PAGE_SIZE - 1)
+                for page in references
+            }
+        )
+        h1, h2, h3 = _system_models(1)
+        work = WorkLedger()
+        with self.assertRaisesRegex(A4AnalysisError, "A4-RESOURCE-BOUND"):
+            catalog_root_observations(view, (2,), h1, h2, h3, work)
+        self.assertNotIn(("EMPTY", 21), view.opened)
+        self.assertEqual(
+            {
+                page.page_number
+                for page in work.qualified_pages()
+                if page.page_number in references
+            },
+            set(range(5, 21)),
+        )
+
+    def test_system_indirect_holdout_does_not_construct_qualified_page_3(self) -> None:
+        view = _SystemView(3, 0x05)
+        h1, h2, h3 = _system_models(3)
+        observation = catalog_root_observations(
+            view, (2,), h1, h2, h3, WorkLedger()
+        )[0]
+        self.assertEqual(
+            observation.traversal_valid_checkpoints, frozenset(CHECKPOINT_IDS)
+        )
+
+    def test_identifier_reuse_depends_on_extant_interval(self) -> None:
+        operations = (
+            "T1_CREATE_ID", "T1_ADD_TEXT", "T1_ADD_INDEX", "T2_CREATE",
+            "T2_RECREATE", "T3_CREATE", "T4_CREATE",
+        )
+        values = dict(zip(operations, (1, 2, 3, 4, 5, 4, 7)))
+        options = {key: frozenset((value,)) for key, value in values.items()}
+        self.assertTrue(identifier_assignment_exists(
+            operations, options,
+            "stable_for_same_operation_instance_and_distinct_for_t2_v1_v2",
+        ))
+        values["T3_CREATE"] = 6
+        values["T2_CREATE"] = 1
+        simultaneous = {
+            key: frozenset((value,)) for key, value in values.items()
+        }
+        self.assertFalse(identifier_assignment_exists(
+            operations, simultaneous,
+            "stable_for_same_operation_instance_and_distinct_for_t2_v1_v2",
+        ))
+        values.update(T2_CREATE=4, T2_RECREATE=4)
+        same_t2 = {key: frozenset((value,)) for key, value in values.items()}
+        self.assertTrue(identifier_assignment_exists(
+            operations, same_t2,
+            "stable_for_same_physical_name_including_t2_v1_v2",
+        ))
+
+    def test_holdout_resource_terminal_is_not_a_prediction_failure(self) -> None:
+        inputs = SimpleNamespace(
+            view=object(),
+            qualified_tdef_pages=(),
+            replica=SimpleNamespace(table_row_counts={}),
+        )
+        frozen = SimpleNamespace(h1=object(), h2=object())
+        with patch.object(
+            a4_analysis_holdout, "predict_h1", return_value=object()
+        ), patch.object(
+            a4_layers, "predicts_h2", return_value=True
+        ), patch.object(
+            a4_analysis_holdout,
+            "decode_frozen_owned_rows",
+            side_effect=A4AnalysisError("A4-RESOURCE-BOUND"),
+        ):
+            with self.assertRaisesRegex(A4AnalysisError, "A4-RESOURCE-BOUND"):
+                a4_analysis_holdout.evaluate_holdout(inputs, frozen, WorkLedger())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_manifest_closure.py
+++ b/oracle/windows-dao/tests/test_a4_manifest_closure.py
@@ -1,0 +1,167 @@
+"""Focused closed-inventory contracts for A4 replica manifests."""
+
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_analysis_input import ReplicaAnalysisInput  # noqa: E402
+from a4_campaign import check_campaign_replica  # noqa: E402
+from a4_model import A4AnalysisError  # noqa: E402
+from a4_spec import PLAN  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+
+_CAMPAIGN = "a4-synthetic"
+
+
+def _canonical_surface() -> ReplicaAnalysisInput:
+    original = _inputs()[1]
+    manifest = copy.deepcopy(original.artifact_manifest)
+    environment = next(
+        entry for entry in manifest["files"] if entry["role"] == "environment"
+    )
+    environment["path"] = PLAN["artifacts"]["replica_environments"][0]
+    return ReplicaAnalysisInput(
+        original.source,
+        original.table_row_counts,
+        original.replica_observation,
+        original.page_indexes,
+        original.schema_snapshots,
+        manifest,
+        original.environment_payload,
+    )
+
+
+def _with_manifest(
+    original: ReplicaAnalysisInput, manifest: dict[str, object]
+) -> ReplicaAnalysisInput:
+    return ReplicaAnalysisInput(
+        original.source,
+        original.table_row_counts,
+        original.replica_observation,
+        original.page_indexes,
+        original.schema_snapshots,
+        manifest,
+        original.environment_payload,
+    )
+
+
+class A4ManifestClosureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.surface = _canonical_surface()
+
+    def _reject(self, mutate: object) -> None:
+        manifest = copy.deepcopy(self.surface.artifact_manifest)
+        mutate(manifest)
+        with self.assertRaises(A4AnalysisError) as raised:
+            check_campaign_replica(
+                1,
+                _with_manifest(self.surface, manifest),
+                _CAMPAIGN,
+                _COMMIT,
+            )
+        self.assertEqual(raised.exception.predicate_id, "A4-SCHEMA-SNAPSHOT")
+
+    def test_exact_hosted_inventory_is_accepted(self) -> None:
+        checked = check_campaign_replica(
+            1, self.surface, _CAMPAIGN, _COMMIT
+        )
+        self.assertEqual(checked.view.replica, 1)
+
+    def test_missing_or_extra_inventory_is_rejected(self) -> None:
+        environment_path = PLAN["artifacts"]["replica_environments"][0]
+        observation_path = PLAN["artifacts"]["replica_observations"][0]
+
+        def remove(path: str):
+            return lambda manifest: manifest["files"].__setitem__(
+                slice(None),
+                [entry for entry in manifest["files"] if entry["path"] != path],
+            )
+
+        for name, mutate in (
+            ("environment", remove(environment_path)),
+            ("observation", remove(observation_path)),
+            (
+                "acquisition_log",
+                lambda manifest: manifest["files"].append(
+                    {
+                        "path": "logs/acquisition.txt",
+                        "role": "acquisition_log",
+                        "sha256": "f" * 64,
+                        "size_bytes": 1,
+                        "media_type": "text/plain",
+                    }
+                ),
+            ),
+        ):
+            with self.subTest(name=name):
+                self._reject(mutate)
+
+    def test_wrong_roles_hashes_sizes_and_paths_are_rejected(self) -> None:
+        environment_path = PLAN["artifacts"]["replica_environments"][0]
+        observation_path = PLAN["artifacts"]["replica_observations"][0]
+
+        def change(path: str, key: str, value: object):
+            def mutate(manifest: dict[str, object]) -> None:
+                entry = next(
+                    row for row in manifest["files"] if row["path"] == path
+                )
+                entry[key] = value
+
+            return mutate
+
+        for name, mutate in (
+            ("environment_role", change(environment_path, "role", "acquisition_log")),
+            ("environment_hash", change(environment_path, "sha256", "f" * 64)),
+            ("environment_size", change(environment_path, "size_bytes", 0)),
+            ("environment_path", change(environment_path, "path", "environment.json")),
+            ("observation_role", change(observation_path, "role", "acquisition_log")),
+            ("observation_hash", change(observation_path, "sha256", "f" * 64)),
+            ("observation_size", change(observation_path, "size_bytes", 1)),
+            ("observation_path", change(observation_path, "path", "observations/fake.json")),
+        ):
+            with self.subTest(name=name):
+                self._reject(mutate)
+
+    def test_manifest_matrix_job_must_match_observation(self) -> None:
+        self._reject(
+            lambda manifest: manifest.__setitem__("matrix_job_id", "another-job")
+        )
+
+    def test_reconstruction_inventory_waits_for_schema_predicate(self) -> None:
+        manifest = copy.deepcopy(self.surface.artifact_manifest)
+        manifest["files"].remove(
+            next(entry for entry in manifest["files"] if entry["role"] == "page_blob")
+        )
+        snapshots = copy.deepcopy(self.surface.schema_snapshots)
+        snapshots["T1_CREATE_ID"]["ordinal"] = 4
+        invalid_schema = ReplicaAnalysisInput(
+            self.surface.source,
+            self.surface.table_row_counts,
+            self.surface.replica_observation,
+            self.surface.page_indexes,
+            snapshots,
+            manifest,
+            self.surface.environment_payload,
+        )
+        for surface, expected in (
+            (invalid_schema, "A4-SCHEMA-SNAPSHOT"),
+            (_with_manifest(self.surface, manifest), "A4-SNAPSHOT-RECONSTRUCTION"),
+        ):
+            with self.subTest(expected=expected), self.assertRaises(
+                A4AnalysisError
+            ) as raised:
+                check_campaign_replica(1, surface, _CAMPAIGN, _COMMIT)
+            self.assertEqual(raised.exception.predicate_id, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_measurements.py
+++ b/oracle/windows-dao/tests/test_a4_measurements.py
@@ -1,0 +1,132 @@
+"""Focused tests for measured A4 primitive predicate boundaries."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+
+from a4_analysis_input import check_analysis_input  # noqa: E402
+from a4_generator import SyntheticParameters  # noqa: E402
+from a4_layer_h1 import H1Terminal, agree_h1_replicas, derive_h1_replica  # noqa: E402
+from a4_layer_h2 import (  # noqa: E402
+    agree_h2_replicas,
+    decode_frozen_owned_rows,
+    derive_h2_replica,
+)
+from a4_layer_h3 import agree_h3, derive_h3  # noqa: E402
+from a4_layer_h4 import derive_catalog_root  # noqa: E402
+from a4_layers import catalog_root_observations, h3_observations  # noqa: E402
+from a4_measurements import MeasurementRecorder  # noqa: E402
+from a4_model import WorkLedger  # noqa: E402
+from a4_spec import PLAN, PREDICATE_CONTRACTS  # noqa: E402
+from protocol_validation import ValidationError  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+
+class A4MeasurementTests(unittest.TestCase):
+    def test_recorder_derives_metadata_and_rejects_invalid_accounting(self) -> None:
+        recorder = MeasurementRecorder()
+        row = recorder.record(
+            "A4-H1-LOCATOR-LAYOUT-NONE", 2, True, replica=1
+        )
+        contract = PREDICATE_CONTRACTS[row.predicate_id]
+        self.assertEqual(row.order, contract["order"])
+        self.assertEqual(row.scope, contract["scope"])
+        self.assertEqual(row.counted_set_kind, contract["counted_set_kind"])
+        self.assertEqual(row.document()["predicate_measured_survivor_count"], 2)
+        with self.assertRaisesRegex(ValidationError, "duplicated"):
+            recorder.record(row.predicate_id, 2, True, replica=1)
+        with self.assertRaisesRegex(ValidationError, "unregistered"):
+            MeasurementRecorder().record("A4-H9-INVENTED", 1, True)
+        with self.assertRaises(ValidationError):
+            MeasurementRecorder().record("A4-H1-TDEF-NONE", 1, False, replica=1)
+
+    def test_successful_primitives_retain_intermediate_cardinalities(self) -> None:
+        inputs = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        recorder = MeasurementRecorder()
+        work = WorkLedger()
+        h1 = {
+            replica: derive_h1_replica(
+                inputs.views[replica],
+                inputs.qualified_tdef_pages[replica],
+                work,
+                recorder,
+            )
+            for replica in (1, 2)
+        }
+        frozen_h1 = agree_h1_replicas(h1[1], h1[2], recorder)
+        h2 = {
+            replica: derive_h2_replica(
+                inputs.views[replica],
+                h1[replica],
+                inputs.replicas[replica].table_row_counts,
+                work,
+                recorder,
+            )
+            for replica in (1, 2)
+        }
+        frozen_h2 = agree_h2_replicas(h2[1], h2[2], recorder)
+        h3 = {}
+        for replica in (1, 2):
+            frozen_rows = decode_frozen_owned_rows(
+                inputs.views[replica], h1[replica], frozen_h2, work
+            )
+            observations = h3_observations(inputs.views[replica], frozen_rows, work)
+            h3[replica] = derive_h3(
+                replica,
+                observations,
+                inputs.replicas[replica].source.page_count,
+                work,
+                recorder,
+            )
+        frozen_h3 = agree_h3(h3[1], h3[2], recorder)
+        for replica in (1, 2):
+            roots = catalog_root_observations(
+                inputs.views[replica],
+                inputs.qualified_tdef_pages[replica],
+                h1[replica],
+                frozen_h2,
+                frozen_h3,
+                work,
+            )
+            derive_catalog_root(replica, roots, work, recorder)
+
+        layouts = recorder.for_predicate("A4-H1-LOCATOR-LAYOUT-NONE")
+        self.assertEqual([(row.replica, row.measured_count) for row in layouts], [(1, 2), (2, 2)])
+        for prefix, expected in (
+            ("A4-H1-", 15),
+            ("A4-H2-", 13),
+            ("A4-H3-", 13),
+            ("A4-H4-", 4),
+        ):
+            rows = [row for row in recorder.events if row.predicate_id.startswith(prefix)]
+            self.assertEqual(len(rows), expected)
+            self.assertTrue(all(row.passed for row in rows))
+        self.assertEqual(frozen_h1.replica, 0)
+
+    def test_terminal_retains_real_pair_cardinality(self) -> None:
+        signature = PLAN["candidate_grammars"]["h1"][
+            "pair_multiple_reachability_signature"
+        ]
+        parameters = SyntheticParameters(
+            signature_id=signature["signature_id"],
+            locator_offsets=tuple(interval[0] for interval in signature["locator_holes"]),
+        )
+        inputs = check_analysis_input("a4-synthetic", _COMMIT, _inputs(parameters))
+        recorder = MeasurementRecorder()
+        with self.assertRaises(H1Terminal) as raised:
+            derive_h1_replica(
+                inputs.views[1], inputs.qualified_tdef_pages[1], WorkLedger(), recorder
+            )
+        row = recorder.events[-1]
+        self.assertEqual(raised.exception.predicate_id, row.predicate_id)
+        self.assertEqual(raised.exception.survivor_count, 2)
+        self.assertEqual((row.measured_count, row.passed), (2, False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_predicate_major.py
+++ b/oracle/windows-dao/tests/test_a4_predicate_major.py
@@ -1,0 +1,172 @@
+"""Focused tests for predicate-major A4 replica orchestration."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "oracle" / "windows-dao" / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_analysis_input import check_analysis_input  # noqa: E402
+from a4_analysis_state import freeze_derivation  # noqa: E402
+import a4_layers  # noqa: E402
+from a4_layers import DerivationLayers, derive_layers  # noqa: E402
+from a4_measurements import MeasurementRecorder  # noqa: E402
+from a4_model import A4AnalysisError, WorkLedger  # noqa: E402
+from a4_predicate_major import evaluate_replica_predicates  # noqa: E402
+from a4_spec import LAYER_PREDICATE_IDS  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+
+class A4PredicateMajorTests(unittest.TestCase):
+    def test_successful_derivation_records_every_layer_predicate_major(self) -> None:
+        inputs = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        result = derive_layers(inputs)
+        self.assertIsInstance(result, DerivationLayers)
+        assert isinstance(result, DerivationLayers)
+
+        expected: list[tuple[str, int | None]] = []
+        for predicates in LAYER_PREDICATE_IDS.values():
+            expected.extend(
+                (predicate_id, replica)
+                for predicate_id in predicates[:-1]
+                for replica in (1, 2)
+            )
+            expected.append((predicates[-1], None))
+        self.assertEqual(
+            [(row.predicate_id, row.replica) for row in result.measurements],
+            expected,
+        )
+
+    def test_earlier_replica_two_failure_wins_in_all_four_layers(self) -> None:
+        cases = (
+            ("h1_tdef_to_map_row", 1, 5, 2),
+            ("h2_row_identity_map_role", 1, 4, 1),
+            ("h3_indirect_traversal", 1, 4, 1),
+            ("h4_catalog_bootstrap", 1, 6, 2),
+        )
+        for layer, earlier_index, later_index, failure_count in cases:
+            with self.subTest(layer=layer):
+                predicates = tuple(LAYER_PREDICATE_IDS[layer][:-1])
+                earlier = predicates[earlier_index]
+                later = predicates[later_index]
+                reached: list[tuple[int, str]] = []
+
+                def run(replica: int, _work: WorkLedger, recorder: object) -> str:
+                    for predicate_id in predicates:
+                        reached.append((replica, predicate_id))
+                        fails = (
+                            (replica == 2 and predicate_id == earlier)
+                            or (replica == 1 and predicate_id == later)
+                        )
+                        count = failure_count if fails else 1
+                        recorder.record(
+                            predicate_id, count, not fails, replica=replica
+                        )
+                        if fails:
+                            raise A4AnalysisError(predicate_id, count)
+                    return f"replica-{replica}"
+
+                measurements = MeasurementRecorder()
+                outcome = evaluate_replica_predicates(
+                    predicates, run, WorkLedger(), measurements
+                )
+                self.assertIsNotNone(outcome.failure)
+                assert outcome.failure is not None
+                self.assertEqual(
+                    (outcome.failure.replica, outcome.failure.error.predicate_id),
+                    (2, earlier),
+                )
+                self.assertFalse(any(predicate == later for _, predicate in reached))
+                expected_events = [
+                    (predicate, replica)
+                    for predicate in predicates[:earlier_index]
+                    for replica in (1, 2)
+                ] + [(earlier, 1), (earlier, 2)]
+                self.assertEqual(
+                    [(row.predicate_id, row.replica) for row in measurements.events],
+                    expected_events,
+                )
+
+    def test_replica_two_directory_failure_uses_one_alternative_work_path(self) -> None:
+        predicates = tuple(LAYER_PREDICATE_IDS["h2_row_identity_map_role"][:2])
+
+        def run(replica: int, work: WorkLedger, recorder: object) -> str:
+            work.charge(
+                "valid_path_row_directory_entries"
+                if replica == 1
+                else "invalid_path_row_directory_entries"
+            )
+            passed = replica == 1
+            recorder.record(predicates[0], 1, passed, replica=replica)
+            if not passed:
+                raise A4AnalysisError(predicates[0], 1)
+            recorder.record(predicates[1], 1, True, replica=replica)
+            return f"replica-{replica}"
+
+        work = WorkLedger()
+        outcome = evaluate_replica_predicates(
+            predicates, run, work, MeasurementRecorder()
+        )
+        self.assertIsNotNone(outcome.failure)
+        self.assertEqual(work.value("valid_path_row_directory_entries"), 0)
+        self.assertEqual(work.value("invalid_path_row_directory_entries"), 2)
+
+    def test_later_replica_one_failure_accounts_replica_two_completed_prefix(self) -> None:
+        predicates = ("A4-H1-TDEF-NONE", "A4-H1-TDEF-MULTIPLE")
+        reached: list[tuple[int, str]] = []
+
+        def run(replica: int, work: WorkLedger, recorder: object) -> str:
+            work.charge("candidate_serializations")
+            reached.append((replica, predicates[0]))
+            recorder.record(predicates[0], 1, True, replica=replica)
+            work.charge("candidate_serializations")
+            reached.append((replica, predicates[1]))
+            passed = replica != 1
+            recorder.record(predicates[1], 2, passed, replica=replica)
+            if not passed:
+                raise A4AnalysisError(predicates[1], 2)
+            return f"replica-{replica}"
+
+        work = WorkLedger()
+        outcome = evaluate_replica_predicates(
+            predicates, run, work, MeasurementRecorder()
+        )
+        self.assertEqual(outcome.failure.replica, 1)
+        self.assertEqual(work.value("candidate_serializations"), 3)
+        self.assertNotIn((2, predicates[1]), reached)
+
+    def test_h4_replica_one_field_failure_never_scans_replica_two_names(self) -> None:
+        inputs = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        scanned: list[int] = []
+        original_scan = a4_layers.h4_primitive.scan_name_occurrences
+
+        def scan(record, ledger=None):
+            scanned.append(record.replica)
+            return original_scan(record, ledger)
+
+        def fail(replica, records, ledger, measurements, evidence):
+            measurements.record(
+                "A4-H4-FIELD-MODEL-NONE", 0, False, replica=replica
+            )
+            error = A4AnalysisError("A4-H4-FIELD-MODEL-NONE")
+            error.candidates = ()
+            raise error
+
+        with patch.object(
+            a4_layers.h4_primitive, "scan_name_occurrences", side_effect=scan
+        ), patch.object(a4_layers, "derive_structural_fields", side_effect=fail):
+            work = WorkLedger()
+            result = derive_layers(inputs, work)
+            freeze_derivation(inputs, result, work)
+        self.assertEqual(result.predicate_id, "A4-H4-FIELD-MODEL-NONE")
+        self.assertTrue(scanned)
+        self.assertEqual(set(scanned), {1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_terminals.py
+++ b/oracle/windows-dao/tests/test_a4_terminals.py
@@ -1,0 +1,299 @@
+"""Focused schema and contract tests for A4 derivation terminals."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_analysis import analyze  # noqa: E402
+from a4_analysis_input import check_analysis_input  # noqa: E402
+from a4_generator import SyntheticParameters  # noqa: E402
+from a4_layer_h1 import (  # noqa: E402
+    H1Binding,
+    H1ReplicaCandidate,
+    LocatorTarget,
+    agree_h1_replicas,
+    derive_h1_replica,
+)
+from a4_layer_h2 import H2ReplicaCandidate  # noqa: E402
+from a4_layer_h3 import H3Candidate  # noqa: E402
+from a4_layer_h4 import H4Candidate, OPERATIONS  # noqa: E402
+from a4_model import A4AnalysisError, WorkLedger  # noqa: E402
+from a4_spec import PLAN  # noqa: E402
+from a4_analysis_state import freeze_derivation  # noqa: E402
+from a4_frozen_validation import _validate_groups  # noqa: E402
+from a4_terminal import (  # noqa: E402
+    DerivationTerminal,
+    decisive_result,
+    not_applicable_result,
+    terminal_result,
+)
+from protocol_validation import validate_schema_value  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+
+SCHEMA = json.loads(
+    (ROOT / "oracle/windows-dao/experiments/a4/derivation-candidates.schema.json").read_text()
+)
+
+
+class A4TerminalTests(unittest.TestCase):
+    def _validate(self, definition: str, result: dict[str, object]) -> None:
+        validate_schema_value(result, SCHEMA["$defs"][definition], SCHEMA, "$")
+
+    def test_exact_h1_pair_multiple_retains_both_counted_pairs(self) -> None:
+        bindings = tuple(
+            H1Binding(
+                1,
+                role,
+                instance,
+                23 + index,
+                (LocatorTarget(40 + index, 0), LocatorTarget(40 + index, 1)),
+            )
+            for index, (role, instance) in enumerate((
+                ("T1", "T1-v1"),
+                ("T2", "T2-v1"),
+                ("T2", "T2-v2"),
+                ("T3", "T3-v1"),
+                ("T4", "T4-v1"),
+            ))
+        )
+        candidates = tuple(
+            H1ReplicaCandidate(
+                1,
+                "u8_row_then_u24le_page",
+                "a4_pair_multiple_duplicate_locator_0_92",
+                offsets,
+                bindings,
+            ).document()
+            for offsets in ((35, 39), (35, 43))
+        )
+        result = terminal_result(
+            A4AnalysisError("A4-H1-LOCATOR-PAIR-MULTIPLE", 2),
+            WorkLedger(),
+            candidates=candidates,
+        )
+        self._validate("h1Result", result)
+        self.assertEqual(result["predicate_measured_survivor_count"], 2)
+        self.assertEqual(result["terminal_candidate_stage"], "h1_locator_pair")
+        self.assertEqual(len(result["candidates"]), 2)
+
+    def test_exact_h1_pair_multiple_freezes_and_reports_without_holdout_refit(self) -> None:
+        signature = PLAN["candidate_grammars"]["h1"][
+            "pair_multiple_reachability_signature"
+        ]
+        parameters = SyntheticParameters(
+            signature_id=signature["signature_id"],
+            locator_offsets=tuple(
+                interval[0] for interval in signature["locator_holes"]
+            ),
+        )
+        analysis = analyze("a4-synthetic", _COMMIT, _inputs(parameters))
+        layers = analysis.frozen.document["layers"]
+        h1 = layers["h1_tdef_to_map_row"]
+        self.assertEqual(h1["status"], "no_outcome")
+        self.assertEqual(h1["terminal_predicate_id"], "A4-H1-LOCATOR-PAIR-MULTIPLE")
+        self.assertEqual(h1["predicate_measured_survivor_count"], 2)
+        self.assertEqual(layers["h2_row_identity_map_role"]["status"], "not_applicable")
+        rows = {row["predicate_id"]: row for row in analysis.report["predicate_results"]}
+        self.assertEqual(rows["A4-H1-LOCATOR-LAYOUT-NONE"]["predicate_measured_survivor_count"], 2)
+        self.assertEqual(rows["A4-H1-LOCATOR-PAIR-MULTIPLE"]["status"], "fail")
+        qualified = analysis.frozen.document["qualified_pages"]
+        transcripts = analysis.frozen.document["transcripts"]
+        first_binding = h1["candidates"][0]["instance_bindings"][0]
+        first_checkpoint = first_binding["applicable_checkpoint_range"]["start"]
+        self.assertIn(
+            {
+                "replica": 1,
+                "checkpoint_id": first_checkpoint,
+                "page_number": first_binding["tdef_page"],
+            },
+            qualified,
+        )
+        self.assertIn(
+            {
+                "replica": 1,
+                "checkpoint_id": first_checkpoint,
+                "page_number": first_binding["locator_targets"][0]["page"],
+            },
+            qualified,
+        )
+        self.assertTrue(transcripts["locators"])
+        self.assertFalse(transcripts["row_directories"])
+        self.assertEqual(analysis.report["qualified_pages"], qualified)
+        self.assertEqual(analysis.report["transcripts"], transcripts)
+        self.assertTrue(
+            all(row["status"] == "not_applicable" for row in analysis.report["holdout_results"].values())
+        )
+
+    def test_h2_transition_retains_its_one_static_model(self) -> None:
+        candidate = H2ReplicaCandidate(
+            1, 0x1FFF, "set_bit_owned_in_use", 0, 1
+        ).document()
+        result = terminal_result(
+            A4AnalysisError("A4-H2-TRANSITION-UNEXPLAINED", 1),
+            WorkLedger(),
+            candidates=(candidate,),
+        )
+        self._validate("h2Result", result)
+        self.assertEqual(result["derivation_survivor_count"], 0)
+
+    def test_replica_pair_candidates_are_size_bounded_and_charged(self) -> None:
+        candidates = (
+            H2ReplicaCandidate(1, 0x1FFF, "set_bit_owned_in_use", 0, 1),
+            H2ReplicaCandidate(2, 0x0FFF, "set_bit_owned_in_use", 0, 1),
+        )
+        evidence = {
+            "kind": "replica_pair",
+            "entries": [
+                {
+                    "replica": candidate.replica,
+                    "canonical_model_id": candidate.canonical_model_id,
+                    "canonical_candidate_id": candidate.canonical_candidate_id,
+                    "complete_candidate": candidate.document(),
+                }
+                for candidate in candidates
+            ],
+        }
+        ledger = WorkLedger()
+        result = terminal_result(
+            A4AnalysisError("A4-H2-REPLICA-DISAGREEMENT", 2),
+            ledger,
+            terminal_evidence=evidence,
+            per_replica_counts=(1, 1),
+        )
+        self._validate("h2Result", result)
+        self.assertEqual(ledger.value("candidate_serializations"), 2)
+
+    def test_h3_invalid_reference_retains_conversion_and_observation(self) -> None:
+        conversion = H3Candidate(
+            "h3_conversion",
+            {"conversion": "structural_type_0_to_type_1_with_nonzero_u32_slots"},
+        ).document()
+        evidence = {
+            "kind": "reference",
+            "input_model_id": conversion["canonical_candidate_id"],
+            "observation": {
+                "replica": 1,
+                "checkpoint_id": "T1_REL_0512",
+                "page": 24,
+                "slot_ordinal": 0,
+                "referenced_page": 25,
+                "observed_tag_byte": 1,
+                "reason": "not_tag_05",
+            },
+        }
+        result = terminal_result(
+            A4AnalysisError("A4-H3-REFERENCE-INVALID", 1),
+            WorkLedger(),
+            candidates=(conversion,),
+            terminal_evidence=evidence,
+        )
+        self._validate("h3Result", result)
+        self.assertEqual(result["terminal_payload_kind"], "invalid_observation")
+
+    def test_h4_record_none_uses_group_minimum_and_union(self) -> None:
+        root_id = "a" * 64
+        candidates = []
+        groups = []
+        for index, operation in enumerate(OPERATIONS):
+            operation_candidates = [] if index == 0 else [
+                H4Candidate(
+                    "h4_operation_record",
+                    {
+                        "replica": 1,
+                        "root_candidate_id": root_id,
+                        "operation_id": operation,
+                        "canonical_record_locator": {
+                            "page": 30 + index,
+                            "row": 0,
+                            "row_start": 100,
+                            "row_end": 120,
+                        },
+                    },
+                ).document()
+            ]
+            candidates.extend(operation_candidates)
+            groups.append({
+                "operation_id": operation,
+                "cardinality": len(operation_candidates),
+                "candidate_ids": [
+                    item["canonical_candidate_id"] for item in operation_candidates
+                ],
+            })
+        result = terminal_result(
+            A4AnalysisError("A4-H4-CATALOG-RECORD-NONE", 0),
+            WorkLedger(),
+            candidates=candidates,
+            terminal_evidence={"kind": "operation_groups", "groups": groups},
+        )
+        self._validate("h4StructuralResult", result)
+        self.assertEqual(result["predicate_measured_survivor_count"], 0)
+        self.assertEqual(len(result["candidates"]), 6)
+
+        tampered = json.loads(json.dumps(result))
+        first = tampered["terminal_evidence"]["groups"][1]["candidate_ids"]
+        second = tampered["terminal_evidence"]["groups"][2]["candidate_ids"]
+        first[0], second[0] = second[0], first[0]
+        with self.assertRaisesRegex(ValueError, "membership differs by operation"):
+            _validate_groups(
+                "A4-H4-CATALOG-RECORD-NONE",
+                tampered,
+                tampered["terminal_evidence"],
+                None,
+            )
+
+    def test_campaign_resource_terminal_is_not_converted(self) -> None:
+        error = A4AnalysisError("A4-RESOURCE-BOUND", 0)
+        with self.assertRaises(A4AnalysisError) as raised:
+            terminal_result(error, WorkLedger())
+        self.assertIs(raised.exception, error)
+
+    def test_freeze_preserves_upstream_model_and_gates_downstream_slots(self) -> None:
+        checked = check_analysis_input("a4-synthetic", _COMMIT, _inputs())
+        ledger = WorkLedger()
+        h1_by = {
+            replica: derive_h1_replica(
+                checked.views[replica],
+                checked.qualified_tdef_pages[replica],
+                ledger,
+            )
+            for replica in (1, 2)
+        }
+        h1 = agree_h1_replicas(h1_by[1], h1_by[2]).document()
+        h2 = terminal_result(
+            A4AnalysisError("A4-H2-ROLE-NONE", 0), ledger, candidates=()
+        )
+        layers = {
+            "h1_tdef_to_map_row": decisive_result(h1, ledger),
+            "h2_row_identity_map_role": h2,
+            "h3_indirect_traversal": not_applicable_result(),
+            "h4_catalog_bootstrap": {
+                "root_result": not_applicable_result(),
+                "structural_result": not_applicable_result(),
+                "encoding_result": not_applicable_result(),
+            },
+        }
+        frozen = freeze_derivation(
+            checked,
+            DerivationTerminal("A4-H2-ROLE-NONE", layers),
+            ledger,
+        )
+        self.assertEqual(
+            frozen.document["layers"]["h1_tdef_to_map_row"]["status"], "model"
+        )
+        self.assertEqual(
+            frozen.document["layers"]["h3_indirect_traversal"]["status"],
+            "not_applicable",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A4 cannot proceed to independent validation or a hosted DAO campaign until its plan-pinned byte analyzer and synthetic campaign generator are executable. This implements P1 Step 1 against the immutable PR #72 merge at b69201e09286ad9f953691dedc878298990b2e1d.

The analyzer now validates the closed campaign inventory, evaluates H1-H4 and all registered terminal semantics in dependency order, freezes derivation state before lazily acquiring the holdout, retains bounded replica-qualified evidence, and fails closed on malformed or over-budget inputs. The generator produces the preregistered 25-checkpoint/75-job synthetic schedules and page fixtures without reading analyzer expectations.

This PR intentionally does not implement the independent validator, hosted workflow, dry-run disclosure, provenance entry, DAO acquisition, or any compatibility/support claim. Those remain P1 Steps 2-4 and P2 in #75.

Validation:
- python -m unittest discover -s oracle/windows-dao/tests -p test_a4_*.py — 154 passed, 1 expected optional A3-calibration skip
- mise install && mise exec -- just ready — passed
- exact 4,096-candidate boundary — freeze/resume passed with 4,092 H4 candidates plus four upstream candidates
- exact staged tree 71233ff08435354f754d66ebf2737d88cb920aec — independent code, contract, and scientific reviews all reported zero blockers
- commit 2a840295da63837a399eeeef3abb84be5e7fca85 is the reviewed tree

Roadmap: #75 (P1 Step 1 of 4)