### PR TITLE
feat(a4): independent validator

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -842,7 +842,8 @@ Use `not applicable` explicitly rather than omitting a field.
   Additional tracked Usage:
   `file:oracle/windows-dao/experiments/a4/README.md`;
   `file:oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json`;
-  `file:oracle/windows-dao/experiments/a4/design-inputs/a4-scope-approved.md`.
+  `file:oracle/windows-dao/experiments/a4/design-inputs/a4-scope-approved.md`;
+  `file:oracle/windows-dao/scripts/a4_independent_h3.py`.
 - Rights: citation to public documentation distributed upstream under the MIT
   license; no upstream documentation content is redistributed
 - Review: pending independent review

--- a/oracle/windows-dao/scripts/a4_independent_bundle.py
+++ b/oracle/windows-dao/scripts/a4_independent_bundle.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""Bounded, analyzer-independent loading of a retained DAO A4 bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import stat
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+
+from a4_independent_contract import (
+    CONTRACT,
+    EXPERIMENT_ID,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    ContractError,
+    IndependentContract,
+    sha256_bytes,
+    validate_canonical_snapshot,
+    validate_snapshot_schedule,
+)
+
+
+class ValidationError(Exception):
+    """A stable independent-validation failure."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ValidationError("canonical_json_failure") from exc
+
+
+def canonical_document_bytes(value: Any) -> bytes:
+    """Canonical protocol document bytes include one final line feed."""
+    return canonical_json_bytes(value) + b"\n"
+
+
+def read_bytes(path: Path, maximum: int) -> bytes:
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise ValidationError("missing_file", str(path)) from exc
+    if not stat.S_ISREG(metadata.st_mode) or not 0 <= metadata.st_size <= maximum:
+        raise ValidationError("file_size_bound", str(path))
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise ValidationError("file_read_failure", str(path)) from exc
+
+
+def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValidationError("json_not_utf8", label) from exc
+    if text.startswith("\ufeff"):
+        raise ValidationError("json_bom", label)
+    try:
+        value = json.loads(text)
+    except (json.JSONDecodeError, RecursionError) as exc:
+        raise ValidationError("invalid_json", label) from exc
+    if not isinstance(value, dict):
+        raise ValidationError("json_not_object", label)
+    return value
+
+
+def _utc(value: Any) -> float:
+    if not isinstance(value, str):
+        raise ValidationError("campaign_timing_unparseable")
+    try:
+        moment = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError("campaign_timing_unparseable") from exc
+    if moment.tzinfo is None:
+        raise ValidationError("campaign_timing_unparseable")
+    return moment.timestamp()
+
+
+@dataclass
+class PageStore:
+    """One physical read per content digest, with replica-qualified accounting."""
+
+    paths: Mapping[str, Path]
+    maximum_blobs: int
+    maximum_bytes: int
+    _cache: dict[str, bytes] = field(default_factory=dict, init=False)
+    _charged: dict[int, set[str]] = field(
+        default_factory=lambda: {1: set(), 2: set(), 3: set()}, init=False
+    )
+
+    def read(self, digest: str, replica: int) -> bytes:
+        try:
+            path = self.paths[digest]
+        except KeyError as exc:
+            raise ValidationError("page_blob_missing", digest) from exc
+        if digest not in self._cache:
+            if len(self._cache) >= self.maximum_blobs:
+                raise ValidationError("resource_bound_breach", "page blob count")
+            payload = read_bytes(path, 2048)
+            if len(payload) != 2048 or sha256_bytes(payload) != digest:
+                raise ValidationError("page_blob_hash_mismatch", digest)
+            self._cache[digest] = payload
+        charged = self._charged[replica]
+        charged.add(digest)
+        if len(charged) * 2048 > self.maximum_bytes:
+            raise ValidationError("resource_bound_breach", f"replica {replica} page reads")
+        return self._cache[digest]
+
+    def logical_read_bytes(self, replica: int) -> int:
+        return len(self._charged[replica]) * 2048
+
+    @property
+    def physical_read_count(self) -> int:
+        return len(self._cache)
+
+
+@dataclass(frozen=True)
+class Replica:
+    number: int
+    environment: Mapping[str, Any]
+    artifact_manifest: Mapping[str, Any]
+    observation: Mapping[str, Any]
+    indexes: Mapping[str, Mapping[str, Any]]
+    snapshots: Mapping[str, Mapping[str, Any]]
+    store: PageStore
+
+    @property
+    def checkpoint_ids(self) -> tuple[str, ...]:
+        return tuple(row["checkpoint_id"] for row in self.observation["checkpoints"])
+
+    @property
+    def logical_read_bytes(self) -> int:
+        return self.store.logical_read_bytes(self.number)
+
+    def index(self, checkpoint_id: str) -> Mapping[str, Any]:
+        try:
+            return self.indexes[checkpoint_id]
+        except KeyError as exc:
+            raise ValidationError("checkpoint_missing", f"r{self.number}:{checkpoint_id}") from exc
+
+    def checkpoint_observation(self, checkpoint_id: str) -> Mapping[str, Any]:
+        for row in self.observation["checkpoints"]:
+            if row["checkpoint_id"] == checkpoint_id:
+                return row
+        raise ValidationError("checkpoint_observation_missing", checkpoint_id)
+
+    def state(self, checkpoint_id: str, page_number: int) -> str | None:
+        hashes = self.index(checkpoint_id)["ordered_page_sha256"]
+        if 0 <= page_number < len(hashes):
+            return hashes[page_number]
+        return None
+
+    def page(self, checkpoint_id: str, page_number: int) -> bytes | None:
+        digest = self.state(checkpoint_id, page_number)
+        return None if digest is None else self.store.read(digest, self.number)
+
+    def page_bytes(self, digest: str) -> bytes:
+        return self.store.read(digest, self.number)
+
+    def candidate_page_space(self) -> range:
+        return range(max(index["page_count"] for index in self.indexes.values()))
+
+
+@dataclass(frozen=True)
+class LoadedBundle:
+    root: Path
+    manifest: Mapping[str, Any]
+    manifest_raw: bytes
+    manifest_sha256: str
+    plan: Mapping[str, Any]
+    plan_sha256: str
+    entries: Mapping[str, Mapping[str, Any]]
+    replicas: Mapping[int, Replica]
+    frozen: Mapping[str, Any]
+    frozen_raw: bytes
+    report: Mapping[str, Any]
+    receipt: Mapping[str, Any]
+    occurrence_evidence: Mapping[str, Any] | None
+    occurrence_evidence_raw: bytes | None
+    page_store: PageStore
+
+
+class BundleLoader:
+    """Load and cross-bind one complete successful A4 evidence bundle."""
+
+    def __init__(self, root: Path, contract: IndependentContract = CONTRACT) -> None:
+        if root.is_symlink():
+            raise ValidationError("bundle_symlink", str(root))
+        try:
+            self.root = root.resolve(strict=True)
+        except OSError as exc:
+            raise ValidationError("bundle_root_missing", str(root)) from exc
+        if not self.root.is_dir():
+            raise ValidationError("bundle_root_not_directory", str(root))
+        self.contract = contract
+        self.bounds = contract.bounds
+        self._raw: dict[str, bytes] = {}
+        self._documents: dict[str, dict[str, Any]] = {}
+
+    def _safe(self, relative: str) -> Path:
+        if not isinstance(relative, str) or not relative or "\\" in relative:
+            raise ValidationError("unsafe_path", str(relative))
+        pure = PurePosixPath(relative)
+        if pure.is_absolute() or pure.as_posix() != relative or any(
+            part in ("", ".", "..") for part in pure.parts
+        ):
+            raise ValidationError("unsafe_path", relative)
+        candidate = self.root
+        for part in pure.parts:
+            candidate = candidate / part
+            if candidate.is_symlink():
+                raise ValidationError("bundle_symlink", relative)
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError as exc:
+            raise ValidationError("missing_file", relative) from exc
+        if self.root not in resolved.parents:
+            raise ValidationError("unsafe_path", relative)
+        return resolved
+
+    def _read_entry(self, relative: str, entry: Mapping[str, Any]) -> bytes:
+        if relative in self._raw:
+            return self._raw[relative]
+        maximum = 2048 if entry["role"] == "page_blob" else int(self.bounds["max_json_bytes"])
+        if entry["role"] == "acquisition_log":
+            maximum = int(self.bounds["max_child_log_bytes"])
+        payload = read_bytes(self._safe(relative), maximum)
+        if len(payload) != entry["size_bytes"] or sha256_bytes(payload) != entry["sha256"]:
+            raise ValidationError("manifest_file_mismatch", relative)
+        self._raw[relative] = payload
+        return payload
+
+    def _document(self, relative: str, entry: Mapping[str, Any]) -> dict[str, Any]:
+        if relative not in self._documents:
+            self._documents[relative] = load_json_bytes(
+                self._read_entry(relative, entry), relative
+            )
+        return self._documents[relative]
+
+    def _validate(self, value: Any, document_type: str, relative: str) -> None:
+        try:
+            self.contract.validate_document(value, document_type)
+        except ContractError as exc:
+            raise ValidationError("schema_validation_failed", f"{relative}: {exc.detail}") from exc
+
+    def _manifest(self) -> tuple[dict[str, Any], bytes]:
+        path = self._safe("bundle-manifest.json")
+        raw = read_bytes(path, int(self.bounds["max_json_bytes"]))
+        manifest = load_json_bytes(raw, "bundle-manifest.json")
+        if manifest.get("plan_sha256") != PLAN_SHA256 or manifest.get(
+            "revision_plan_sha256"
+        ) != REVISION_PLAN_SHA256:
+            raise ValidationError("plan_binding_mismatch")
+        elapsed = manifest.get("campaign_elapsed_seconds")
+        if isinstance(elapsed, int) and not isinstance(elapsed, bool):
+            if elapsed > int(self.bounds["campaign_timeout_seconds"]):
+                raise ValidationError("campaign_timeout_exceeded")
+        started = _utc(manifest.get("campaign_started_utc"))
+        created = _utc(manifest.get("created_utc"))
+        if not isinstance(elapsed, int) or isinstance(elapsed, bool) or elapsed < 0:
+            raise ValidationError("campaign_timing_mismatch")
+        if created < started or math.floor(created - started) != elapsed:
+            raise ValidationError("campaign_timing_mismatch")
+        self._validate(manifest, "dao_a4_bundle_manifest", "bundle-manifest.json")
+        return manifest, raw
+
+    def _inventory(
+        self, manifest: Mapping[str, Any]
+    ) -> tuple[dict[str, Mapping[str, Any]], dict[str, Path]]:
+        entries: dict[str, Mapping[str, Any]] = {}
+        page_paths: dict[str, Path] = {}
+        declared_total = 0
+        for entry in manifest["files"]:
+            relative = entry["path"]
+            if relative in entries:
+                raise ValidationError("manifest_duplicate_path", relative)
+            path = self._safe(relative)
+            try:
+                size = path.stat().st_size
+            except OSError as exc:
+                raise ValidationError("missing_file", relative) from exc
+            if size != entry["size_bytes"]:
+                raise ValidationError("manifest_file_mismatch", relative)
+            declared_total += size
+            entries[relative] = entry
+            role = entry["role"]
+            if role == "page_blob":
+                digest = entry["sha256"]
+                if (
+                    entry["media_type"] != "application/octet-stream"
+                    or entry["size_bytes"] != 2048
+                    or relative != f"page-store/{digest}.page"
+                    or digest in page_paths
+                ):
+                    raise ValidationError("page_blob_contract", relative)
+                page_paths[digest] = path
+            elif role == "acquisition_log":
+                if entry["media_type"] != "text/plain" or size > int(
+                    self.bounds["max_child_log_bytes"]
+                ):
+                    raise ValidationError("acquisition_log_contract", relative)
+            elif entry["media_type"] != "application/json":
+                raise ValidationError("manifest_media_type", relative)
+        if (
+            declared_total != manifest["bundle_size_bytes_excluding_manifest"]
+            or declared_total > int(self.bounds["max_bundle_bytes"])
+        ):
+            raise ValidationError("manifest_size_total_mismatch")
+        if (
+            len(page_paths) != manifest["page_blob_count"]
+            or len(page_paths) > int(self.bounds["max_unique_page_blobs"])
+            or len(page_paths) * 2048 > int(self.bounds["max_retained_page_store_bytes"])
+        ):
+            raise ValidationError("resource_bound_breach", "aggregate page store")
+        declared_files = set(entries) | {"bundle-manifest.json"}
+        declared_directories: set[str] = set()
+        for relative in declared_files:
+            declared_directories.update(
+                parent.as_posix() for parent in Path(relative).parents if parent != Path(".")
+            )
+        actual: set[str] = set()
+        pending = [self.root]
+        while pending:
+            base = pending.pop()
+            try:
+                children = os.scandir(base)
+            except OSError as exc:
+                raise ValidationError("manifest_inventory_not_closed") from exc
+            with children:
+                for child in children:
+                    relative = Path(child.path).relative_to(self.root).as_posix()
+                    if child.is_symlink():
+                        raise ValidationError("bundle_symlink", relative)
+                    if child.is_dir(follow_symlinks=False):
+                        if relative not in declared_directories:
+                            raise ValidationError("manifest_inventory_not_closed")
+                        pending.append(Path(child.path))
+                    elif child.is_file(follow_symlinks=False) and relative in declared_files:
+                        if relative != "bundle-manifest.json":
+                            actual.add(relative)
+                    else:
+                        raise ValidationError("manifest_inventory_not_closed")
+        if actual != set(entries):
+            raise ValidationError("manifest_inventory_not_closed")
+        # Page bytes remain untouched until every declared aggregate bound passes.
+        for relative, entry in entries.items():
+            if entry["role"] != "page_blob":
+                self._read_entry(relative, entry)
+        return entries, page_paths
+
+    @staticmethod
+    def _roles(entries: Mapping[str, Mapping[str, Any]]) -> dict[str, list[str]]:
+        roles: dict[str, list[str]] = {}
+        for relative, entry in entries.items():
+            roles.setdefault(entry["role"], []).append(relative)
+        for paths in roles.values():
+            paths.sort()
+        required = {
+            "plan": 1,
+            "revision_plan": 0,
+            "environment": 3,
+            "replica_artifact_manifest": 3,
+            "replica_observation": 3,
+            "dao_schema_snapshot": 75,
+            "page_index": 75,
+            "frozen_candidate_set": 1,
+            "analysis_report": 1,
+            "holdout_structure_receipt": 1,
+        }
+        for role, count in required.items():
+            if len(roles.get(role, [])) != count:
+                raise ValidationError("manifest_role_count", role)
+        if not roles.get("page_blob"):
+            raise ValidationError("manifest_role_count", "page_blob")
+        if len(roles.get("h4_occurrence_evidence", [])) > 1:
+            raise ValidationError("manifest_role_count", "h4_occurrence_evidence")
+        return roles
+
+    def _common_binding(
+        self, value: Mapping[str, Any], manifest: Mapping[str, Any], relative: str
+    ) -> None:
+        for key in (
+            "experiment_id",
+            "plan_sha256",
+            "revision_plan_sha256",
+            "producer_commit",
+            "campaign_id",
+        ):
+            if key in value and value.get(key) != manifest.get(key):
+                raise ValidationError("document_binding_mismatch", f"{relative}:{key}")
+
+    def _growth(self, observation: Mapping[str, Any], checkpoints: Mapping[str, Any]) -> None:
+        ids = [
+            checkpoint
+            for checkpoint in self.contract.checkpoint_ids
+            if "_REL_" in checkpoint or "_ABS_" in checkpoint
+        ]
+        growth = observation["growth_observations"]
+        if [row["checkpoint_id"] for row in growth] != ids or len(growth) != 11:
+            raise ValidationError("growth_observation_mismatch")
+        baseline_by_role = {
+            "T1": checkpoints["T4_CREATE"]["actual_file_pages"],
+            "T4": checkpoints["T3_ABS_16480"]["actual_file_pages"],
+        }
+        for row in growth:
+            checkpoint = checkpoints[row["checkpoint_id"]]
+            role = row["checkpoint_id"].split("_", 1)[0]
+            suffix = int(row["checkpoint_id"].rsplit("_", 1)[1])
+            baseline = baseline_by_role.get(role)
+            target = suffix if baseline is None else baseline + suffix
+            achieved = checkpoint["actual_file_pages"]
+            if row != {
+                "checkpoint_id": row["checkpoint_id"],
+                "baseline_pages": baseline,
+                "target_pages": target,
+                "achieved_pages": achieved,
+                "overshoot_pages": achieved - target,
+                "rows": row["rows"],
+            } or achieved < target or row["rows"] % 32:
+                raise ValidationError("growth_observation_mismatch", row["checkpoint_id"])
+            if (
+                checkpoint["target_baseline_pages"] != baseline
+                or checkpoint["target_threshold_pages"] != target
+                or checkpoint["target_overshoot_pages"] != achieved - target
+            ):
+                raise ValidationError("growth_observation_mismatch", row["checkpoint_id"])
+
+    def _replica(
+        self,
+        number: int,
+        manifest: Mapping[str, Any],
+        entries: Mapping[str, Mapping[str, Any]],
+        store: PageStore,
+    ) -> Replica:
+        environment_path = f"environment/replica-{number:02d}.json"
+        artifact_path = f"replica-artifacts/replica-{number:02d}-manifest.json"
+        observation_path = f"observations/replica-{number:02d}.json"
+        for path, role in (
+            (environment_path, "environment"),
+            (artifact_path, "replica_artifact_manifest"),
+            (observation_path, "replica_observation"),
+        ):
+            if path not in entries or entries[path]["role"] != role:
+                raise ValidationError("manifest_path_missing", path)
+        environment = self._document(environment_path, entries[environment_path])
+        artifact = self._document(artifact_path, entries[artifact_path])
+        observation = self._document(observation_path, entries[observation_path])
+        self._validate(environment, "dao_a4_environment", environment_path)
+        self._validate(artifact, "dao_a4_replica_artifact_manifest", artifact_path)
+        self._validate(observation, "dao_a4_replica_observation", observation_path)
+        for path, value in (
+            (environment_path, environment),
+            (artifact_path, artifact),
+            (observation_path, observation),
+        ):
+            self._common_binding(value, manifest, path)
+            if value.get("replica") != number:
+                raise ValidationError("replica_binding_mismatch", path)
+        environment_sha = entries[environment_path]["sha256"]
+        job = environment["matrix_job_id"]
+        if (
+            artifact["matrix_job_id"] != job
+            or observation["matrix_job"]["job_id"] != job
+            or artifact["environment_sha256"] != environment_sha
+            or observation["environment_sha256"] != environment_sha
+            or artifact["provider_sha256"] != manifest["provider_sha256"]
+            or observation["provider_sha256"] != manifest["provider_sha256"]
+        ):
+            raise ValidationError("replica_cross_binding_mismatch", str(number))
+        expected_binding = next(
+            row for row in self.contract.plan["tables"]["role_bindings"] if row["replica"] == number
+        )
+        if observation["role_binding"] != {
+            role: expected_binding[role] for role in self.contract.plan["tables"]["logical_roles"]
+        }:
+            raise ValidationError("role_binding_mismatch", str(number))
+        indexes: dict[str, Mapping[str, Any]] = {}
+        snapshots: dict[str, Mapping[str, Any]] = {}
+        previous: list[str] = []
+        checkpoint_rows = observation["checkpoints"]
+        if len(checkpoint_rows) != 25:
+            raise ValidationError("checkpoint_count_mismatch", str(number))
+        for ordinal, checkpoint_id in enumerate(self.contract.checkpoint_ids):
+            row = checkpoint_rows[ordinal]
+            if row["checkpoint_id"] != checkpoint_id or row["ordinal"] != ordinal:
+                raise ValidationError("checkpoint_order_mismatch", str(number))
+            expected_index = f"page-indexes/replica-{number:02d}/{ordinal:02d}-{checkpoint_id}.json"
+            expected_snapshot = f"schema-snapshots/replica-{number:02d}/{ordinal:02d}-{checkpoint_id}.json"
+            for key, expected, role in (
+                ("page_index", expected_index, "page_index"),
+                ("dao_schema_snapshot", expected_snapshot, "dao_schema_snapshot"),
+            ):
+                reference = row[key]
+                entry = entries.get(expected)
+                if (
+                    reference.get("path") != expected
+                    or entry is None
+                    or entry["role"] != role
+                    or reference.get("sha256") != entry["sha256"]
+                    or reference.get("size_bytes") != entry["size_bytes"]
+                ):
+                    raise ValidationError("checkpoint_reference_mismatch", expected)
+            index = self._document(expected_index, entries[expected_index])
+            snapshot = self._document(expected_snapshot, entries[expected_snapshot])
+            self._validate(index, "dao_a4_page_index", expected_index)
+            self._validate(snapshot, "dao_a4_schema_snapshot", expected_snapshot)
+            for path, value in ((expected_index, index), (expected_snapshot, snapshot)):
+                self._common_binding(value, manifest, path)
+                if (
+                    value["replica"] != number
+                    or value["checkpoint_id"] != checkpoint_id
+                    or value["ordinal"] != ordinal
+                    or value["environment_sha256"] != environment_sha
+                    or value["provider_sha256"] != manifest["provider_sha256"]
+                ):
+                    raise ValidationError("checkpoint_cross_binding_mismatch", path)
+            hashes = index["ordered_page_sha256"]
+            changed = [] if ordinal == 0 else [
+                page
+                for page in range(max(len(previous), len(hashes)))
+                if (previous[page] if page < len(previous) else None)
+                != (hashes[page] if page < len(hashes) else None)
+            ]
+            if (
+                index["predecessor_checkpoint_id"]
+                != (None if ordinal == 0 else self.contract.checkpoint_ids[ordinal - 1])
+                or index["page_count"] != len(hashes)
+                or index["file_size_bytes"] != len(hashes) * 2048
+                or index["changed_page_indices"] != changed
+                or row["actual_file_pages"] != len(hashes)
+                or row["actual_size_bytes"] != len(hashes) * 2048
+                or any(digest not in store.paths for digest in hashes)
+                or snapshot["database_sha256_before_read"] != index["database_sha256"]
+                or snapshot["database_sha256_after_read"] != index["database_sha256"]
+            ):
+                raise ValidationError("snapshot_reconstruction_mismatch", expected_index)
+            try:
+                validate_canonical_snapshot(snapshot, expected_snapshot)
+                validate_snapshot_schedule(snapshot, self.contract.plan, number, checkpoint_id)
+            except ContractError as exc:
+                raise ValidationError(exc.code, exc.detail) from exc
+            table_counts = row["table_row_counts"]
+            if any(table_counts[table["logical_role"]] != table["row_count"] for table in snapshot["tables"]):
+                raise ValidationError("schema_snapshot_mismatch", expected_snapshot)
+            reread = [
+                {
+                    "role": table["logical_role"],
+                    "row_count": table["row_count"],
+                    "rolling_sha256": table["rolling_row_sha256"],
+                }
+                for table in snapshot["tables"]
+            ]
+            if row["dao_reread"] != reread:
+                raise ValidationError("schema_snapshot_mismatch", expected_snapshot)
+            indexes[checkpoint_id], snapshots[checkpoint_id], previous = index, snapshot, hashes
+        checkpoints = {row["checkpoint_id"]: row for row in checkpoint_rows}
+        self._growth(observation, checkpoints)
+        logical = sum(index["file_size_bytes"] for index in indexes.values())
+        changed_total = sum(len(index["changed_page_indices"]) for index in indexes.values())
+        inserted_total = 0
+        previous_counts = {role: 0 for role in self.contract.plan["tables"]["logical_roles"]}
+        for row in checkpoint_rows:
+            counts = row["table_row_counts"]
+            inserted_total += sum(max(0, counts[role] - previous_counts[role]) for role in counts)
+            previous_counts = counts
+        for growth in observation["growth_observations"]:
+            ordinal = self.contract.checkpoint_ids.index(growth["checkpoint_id"])
+            role = growth["checkpoint_id"].split("_", 1)[0]
+            before = checkpoint_rows[ordinal - 1]["table_row_counts"][role]
+            if growth["rows"] != checkpoint_rows[ordinal]["table_row_counts"][role] - before:
+                raise ValidationError("growth_observation_mismatch", growth["checkpoint_id"])
+        if (
+            observation["logical_checkpoint_read_bytes"] != logical
+            or observation["changed_hash_entries"] != changed_total
+            or observation["inserted_rows_total"] != inserted_total
+            or logical > int(self.bounds["max_logical_checkpoint_read_bytes_per_replica"])
+            or observation["inserted_rows_total"] > int(self.bounds["max_inserted_rows_per_replica"])
+            or changed_total > int(self.bounds["max_changed_hash_entries_per_replica"])
+        ):
+            raise ValidationError("resource_bound_breach", f"replica {number} counters")
+        required = {environment_path, observation_path}
+        required |= {
+            f"page-indexes/replica-{number:02d}/{ordinal:02d}-{checkpoint}.json"
+            for ordinal, checkpoint in enumerate(self.contract.checkpoint_ids)
+        }
+        required |= {
+            f"schema-snapshots/replica-{number:02d}/{ordinal:02d}-{checkpoint}.json"
+            for ordinal, checkpoint in enumerate(self.contract.checkpoint_ids)
+        }
+        replica_digests = {digest for index in indexes.values() for digest in index["ordered_page_sha256"]}
+        required |= {f"page-store/{digest}.page" for digest in replica_digests}
+        listed = {row["path"] for row in artifact["files"]}
+        allowed_logs = {path for path in listed if entries.get(path, {}).get("role") == "acquisition_log"}
+        if listed != required | allowed_logs:
+            raise ValidationError("replica_inventory_not_closed", str(number))
+        for item in artifact["files"]:
+            if item != entries.get(item["path"]):
+                raise ValidationError("replica_inventory_outer_mismatch", item["path"])
+        return Replica(number, environment, artifact, observation, indexes, snapshots, store)
+
+    def _environment_closure(
+        self, manifest: Mapping[str, Any], replicas: Mapping[int, Replica], entries: Mapping[str, Any]
+    ) -> None:
+        environments = [replicas[number].environment for number in (1, 2, 3)]
+        exact = [
+            (
+                value["provider"]["prog_id"],
+                value["provider"]["clsid"],
+                value["provider"]["server_sha256"],
+                value["host"]["process_architecture"],
+                value["host"]["powershell_version"].split(".", 1)[0],
+                value["host"]["windows_ansi_code_page"],
+            )
+            for value in environments
+        ]
+        jobs = {value["matrix_job_id"] for value in environments}
+        env_paths = [f"environment/replica-{number:02d}.json" for number in (1, 2, 3)]
+        artifact_paths = [f"replica-artifacts/replica-{number:02d}-manifest.json" for number in (1, 2, 3)]
+        if (
+            any(value != exact[0] for value in exact[1:])
+            or exact[0][2] != manifest["provider_sha256"]
+            or len(jobs) != 3
+            or manifest["replica_environment_sha256"] != [entries[path]["sha256"] for path in env_paths]
+            or manifest["replica_artifact_manifest_sha256"]
+            != [entries[path]["sha256"] for path in artifact_paths]
+        ):
+            raise ValidationError("cross_replica_environment_mismatch")
+        listed_logs = {
+            item["path"]
+            for replica in replicas.values()
+            for item in replica.artifact_manifest["files"]
+            if item["role"] == "acquisition_log"
+        }
+        outer_logs = {
+            path for path, entry in entries.items() if entry["role"] == "acquisition_log"
+        }
+        if listed_logs != outer_logs:
+            raise ValidationError("acquisition_log_inventory_mismatch")
+
+    def _analysis_documents(
+        self,
+        manifest: Mapping[str, Any],
+        entries: Mapping[str, Mapping[str, Any]],
+        roles: Mapping[str, list[str]],
+    ) -> tuple[
+        Mapping[str, Any], bytes, Mapping[str, Any], Mapping[str, Any], Mapping[str, Any] | None, bytes | None
+    ]:
+        frozen_path = "analysis/derivation-candidates.json"
+        report_path = "analysis/analysis-report.json"
+        receipt_path = "analysis/holdout-structure-receipt.json"
+        if (
+            roles["frozen_candidate_set"] != [frozen_path]
+            or roles["analysis_report"] != [report_path]
+            or roles["holdout_structure_receipt"] != [receipt_path]
+        ):
+            raise ValidationError("analysis_artifact_path_mismatch")
+        frozen = self._document(frozen_path, entries[frozen_path])
+        report = self._document(report_path, entries[report_path])
+        receipt = self._document(receipt_path, entries[receipt_path])
+        self._validate(frozen, "dao_a4_frozen_derivation_candidates", frozen_path)
+        self._validate(report, "dao_a4_analysis_report", report_path)
+        self._validate(receipt, "dao_a4_holdout_structure_receipt", receipt_path)
+        for path, value in ((frozen_path, frozen), (report_path, report), (receipt_path, receipt)):
+            self._common_binding(value, manifest, path)
+        frozen_raw = self._raw[frozen_path]
+        if canonical_json_bytes(frozen) != frozen_raw:
+            raise ValidationError("frozen_set_not_canonical")
+        frozen_sha = sha256_bytes(frozen_raw)
+        if (
+            report["derivation_candidate_set_sha256"] != frozen_sha
+            or receipt["derivation_candidate_set_sha256"] != frozen_sha
+            or receipt["replica_artifact_manifest_sha256"]
+            != entries["replica-artifacts/replica-03-manifest.json"]["sha256"]
+            or manifest["holdout_structure_receipt_sha256"] != entries[receipt_path]["sha256"]
+        ):
+            raise ValidationError("frozen_file_hash_mismatch")
+        reference = frozen["h4_occurrence_evidence"]
+        occurrence: Mapping[str, Any] | None = None
+        occurrence_raw: bytes | None = None
+        occurrence_paths = roles.get("h4_occurrence_evidence", [])
+        if reference is None:
+            if occurrence_paths or report["h4_occurrence_evidence"] is not None:
+                raise ValidationError("occurrence_evidence_link_mismatch")
+        else:
+            expected = "analysis/h4-occurrence-evidence.json"
+            entry = entries.get(expected)
+            if occurrence_paths != [expected] or entry is None or reference != {
+                "path": expected,
+                "sha256": entry["sha256"],
+                "size_bytes": entry["size_bytes"],
+            } or report["h4_occurrence_evidence"] != reference:
+                raise ValidationError("occurrence_evidence_link_mismatch")
+            occurrence = self._document(expected, entry)
+            occurrence_raw = self._raw[expected]
+            self._validate(occurrence, "dao_a4_h4_occurrence_evidence", expected)
+            self._common_binding(occurrence, manifest, expected)
+            if canonical_json_bytes(occurrence) != occurrence_raw:
+                raise ValidationError("occurrence_evidence_not_canonical")
+        expected_scientific = {
+            "one_or_more_layers_predict_holdout": "one_or_more_submodels_predict_holdout",
+            "no_layer_predicts_holdout": "no_submodel_predicts_holdout",
+        }.get(report["scientific_outcome"])
+        if (
+            manifest["analysis_scientific_outcome"] != expected_scientific
+            or manifest["bundle_status"]
+            != (
+                "decisive_pending_independent_validation"
+                if expected_scientific == "one_or_more_submodels_predict_holdout"
+                else "complete_no_scientific_outcome"
+            )
+        ):
+            raise ValidationError("analysis_manifest_projection_mismatch")
+        return frozen, frozen_raw, report, receipt, occurrence, occurrence_raw
+
+    def load(self, *, open_holdout: bool = True) -> LoadedBundle:
+        manifest, manifest_raw = self._manifest()
+        entries, page_paths = self._inventory(manifest)
+        roles = self._roles(entries)
+        plan_path = "plan/a4-row-anchored-maps.plan.json"
+        plan_entry = entries.get(plan_path)
+        if (
+            roles["plan"] != [plan_path]
+            or plan_entry is None
+            or plan_entry["sha256"] != PLAN_SHA256
+            or self._raw[plan_path] != self.contract.plan_raw
+        ):
+            raise ValidationError("plan_binding_mismatch")
+        store = PageStore(page_paths, int(self.bounds["max_unique_page_blobs"]),
+                          int(self.bounds["max_retained_page_store_bytes"]))
+        replicas = {number: self._replica(number, manifest, entries, store)
+                    for number in (1, 2)}
+
+        def verify_replica(replica: Replica) -> None:
+            for checkpoint_id in self.contract.checkpoint_ids:
+                index = replica.index(checkpoint_id)
+                digest = hashlib.sha256()
+                for page_number in range(index["page_count"]):
+                    payload = replica.page(checkpoint_id, page_number)
+                    if payload is None:
+                        raise ValidationError("snapshot_page_absent")
+                    digest.update(payload)
+                if digest.hexdigest() != index["database_sha256"]:
+                    raise ValidationError(
+                        "snapshot_database_hash_mismatch",
+                        f"r{replica.number}:{checkpoint_id}",
+                    )
+
+        for replica in replicas.values():
+            verify_replica(replica)
+        frozen, frozen_raw, report, receipt, occurrence, occurrence_raw = self._analysis_documents(
+            manifest, entries, roles
+        )
+        replicas[3] = self._replica(3, manifest, entries, store)
+        referenced = {
+            digest
+            for replica in replicas.values()
+            for index in replica.indexes.values()
+            for digest in index["ordered_page_sha256"]
+        }
+        if referenced != set(page_paths):
+            raise ValidationError("page_store_not_closed")
+        if open_holdout:
+            verify_replica(replicas[3])
+        self._environment_closure(manifest, replicas, entries)
+        return LoadedBundle(
+            self.root,
+            manifest,
+            manifest_raw,
+            sha256_bytes(manifest_raw),
+            self.contract.plan,
+            PLAN_SHA256,
+            entries,
+            replicas,
+            frozen,
+            frozen_raw,
+            report,
+            receipt,
+            occurrence,
+            occurrence_raw,
+            store,
+        )

--- a/oracle/windows-dao/scripts/a4_independent_campaign.py
+++ b/oracle/windows-dao/scripts/a4_independent_campaign.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""Independent A4 campaign predicates and frozen transcript projection."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from a4_independent_bundle import (
+    LoadedBundle,
+    ValidationError,
+    canonical_document_bytes,
+    canonical_json_bytes,
+)
+from a4_independent_contract import (
+    CONTRACT,
+    ContractError,
+    validate_canonical_snapshot,
+    validate_snapshot_schedule,
+)
+
+
+_CAMPAIGN_IDS = tuple(CONTRACT.campaign_predicates)
+_TRANSCRIPT_NAMES = (
+    "row_directories",
+    "locators",
+    "map_transitions",
+    "reference_bitmaps",
+    "catalog_roots",
+    "catalog_fields",
+)
+_TRANSCRIPT_KINDS = {
+    "row_directories": "row_directory",
+    "locators": "locator",
+    "map_transitions": "map_transition",
+    "reference_bitmaps": "reference_bitmap",
+    "catalog_roots": "catalog_root",
+    "catalog_fields": "catalog_field",
+}
+_CATEGORY_CODES = {
+    name: code for name, code in zip(
+        ("locators", "row_directories", "map_transitions", "reference_bitmaps",
+         "catalog_roots", "catalog_fields"),
+        range(1, 7),
+        strict=True,
+    )
+}
+_PAGE_MARKER = hashlib.sha256(b"dao-a4-qualified-page-transcript-v1").digest()[:15]
+
+
+@dataclass(frozen=True)
+class CampaignFailure:
+    """The first preregistered campaign terminal reached by the bundle."""
+
+    predicate_id: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class CampaignEvaluation:
+    """Ordered campaign rows plus independently measured resource counters."""
+
+    predicate_rows: tuple[Mapping[str, Any], ...]
+    first_failure: CampaignFailure | None
+    resources: Mapping[str, int]
+
+    @property
+    def passed(self) -> bool:
+        return self.first_failure is None
+
+
+class _Mismatch(Exception):
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _entry_bytes(bundle: LoadedBundle, relative: str, value: Mapping[str, Any]) -> bytes:
+    """Rebuild canonical JSON bytes and bind them to the retained inventory."""
+    entry = bundle.entries.get(relative)
+    encoded = canonical_document_bytes(value)
+    if entry is None or entry.get("media_type") != "application/json":
+        raise _Mismatch(f"missing JSON inventory entry {relative}")
+    if entry.get("size_bytes") != len(encoded):
+        raise _Mismatch(f"size differs for {relative}")
+    if entry.get("sha256") != hashlib.sha256(encoded).hexdigest():
+        raise _Mismatch(f"hash differs for {relative}")
+    try:
+        actual = (Path(bundle.root) / relative).read_bytes()
+    except OSError as exc:
+        raise _Mismatch(f"unreadable artifact {relative}") from exc
+    if actual != encoded:
+        raise _Mismatch(f"canonical bytes differ for {relative}")
+    return encoded
+
+
+def _checkpoint_rows(bundle: LoadedBundle, replica: int) -> Mapping[str, Mapping[str, Any]]:
+    rows = bundle.replicas[replica].observation["checkpoints"]
+    return {row["checkpoint_id"]: row for row in rows}
+
+
+def _check_idle(bundle: LoadedBundle) -> None:
+    idle_pairs = CONTRACT.plan["checkpoint_design"]["idle_pairs"]
+    for replica_number in (1, 2, 3):
+        replica = bundle.replicas[replica_number]
+        for left, right in idle_pairs:
+            left_index, right_index = replica.index(left), replica.index(right)
+            left_hashes = tuple(left_index["ordered_page_sha256"])
+            right_hashes = tuple(right_index["ordered_page_sha256"])
+            if left_hashes != right_hashes:
+                raise _Mismatch(f"replica {replica_number} index {left}/{right}")
+            if left_index["database_sha256"] != right_index["database_sha256"]:
+                raise _Mismatch(f"replica {replica_number} MDB digest {left}/{right}")
+            for page_number in range(len(left_hashes)):
+                if replica.page(left, page_number) != replica.page(right, page_number):
+                    raise _Mismatch(
+                        f"replica {replica_number} MDB byte {left}/{right} page {page_number}"
+                    )
+            if replica.snapshots[left]["tables"] != replica.snapshots[right]["tables"]:
+                raise _Mismatch(f"replica {replica_number} snapshot tables {left}/{right}")
+
+
+def _common_snapshot_binding(
+    bundle: LoadedBundle,
+    replica_number: int,
+    checkpoint_id: str,
+    ordinal: int,
+    snapshot: Mapping[str, Any],
+) -> None:
+    replica = bundle.replicas[replica_number]
+    manifest = bundle.manifest
+    expected = {
+        "experiment_id": manifest["experiment_id"],
+        "plan_sha256": manifest["plan_sha256"],
+        "revision_plan_sha256": manifest["revision_plan_sha256"],
+        "producer_commit": manifest["producer_commit"],
+        "campaign_id": manifest["campaign_id"],
+        "environment_sha256": bundle.entries[
+            f"environment/replica-{replica_number:02d}.json"
+        ]["sha256"],
+        "provider_sha256": manifest["provider_sha256"],
+        "replica": replica_number,
+        "checkpoint_id": checkpoint_id,
+        "ordinal": ordinal,
+    }
+    for key, value in expected.items():
+        if snapshot.get(key) != value:
+            raise _Mismatch(f"snapshot binding r{replica_number}:{checkpoint_id}:{key}")
+    index = replica.index(checkpoint_id)
+    if not (
+        snapshot.get("database_sha256_before_read")
+        == snapshot.get("database_sha256_after_read")
+        == index.get("database_sha256")
+    ):
+        raise _Mismatch(f"snapshot before/after r{replica_number}:{checkpoint_id}")
+
+
+def _check_schema(bundle: LoadedBundle) -> None:
+    for replica_number in (1, 2, 3):
+        replica = bundle.replicas[replica_number]
+        observations = list(replica.observation["checkpoints"])
+        if len(replica.snapshots) != 25 or len(observations) != 25:
+            raise _Mismatch(f"snapshot cardinality replica {replica_number}")
+        for ordinal, checkpoint_id in enumerate(CONTRACT.checkpoint_ids):
+            try:
+                snapshot = replica.snapshots[checkpoint_id]
+                CONTRACT.validate_document(snapshot, "dao_a4_schema_snapshot")
+                validate_canonical_snapshot(snapshot, checkpoint_id)
+                validate_snapshot_schedule(
+                    snapshot, CONTRACT.plan, replica_number, checkpoint_id
+                )
+            except (KeyError, ContractError) as exc:
+                detail = getattr(exc, "detail", str(exc))
+                raise _Mismatch(
+                    f"snapshot contract r{replica_number}:{checkpoint_id}: {detail}"
+                ) from exc
+            row = observations[ordinal]
+            if row.get("checkpoint_id") != checkpoint_id or row.get("ordinal") != ordinal:
+                raise _Mismatch(f"snapshot ordinal r{replica_number}:{checkpoint_id}")
+            _common_snapshot_binding(
+                bundle, replica_number, checkpoint_id, ordinal, snapshot
+            )
+            relative = (
+                f"schema-snapshots/replica-{replica_number:02d}/"
+                f"{ordinal:02d}-{checkpoint_id}.json"
+            )
+            reference = row.get("dao_schema_snapshot", {})
+            entry = bundle.entries.get(relative)
+            if entry is None or reference != {
+                "path": relative,
+                "sha256": entry["sha256"],
+                "size_bytes": entry["size_bytes"],
+            }:
+                raise _Mismatch(f"snapshot reference r{replica_number}:{checkpoint_id}")
+            _entry_bytes(bundle, relative, snapshot)
+            tables = snapshot["tables"]
+            counts = row["table_row_counts"]
+            actual_counts = {table["logical_role"]: table["row_count"] for table in tables}
+            if any(counts[role] != actual_counts.get(role, 0) for role in counts):
+                raise _Mismatch(f"snapshot row counts r{replica_number}:{checkpoint_id}")
+            reread = [
+                {
+                    "role": table["logical_role"],
+                    "row_count": table["row_count"],
+                    "rolling_sha256": table["rolling_row_sha256"],
+                }
+                for table in tables
+            ]
+            if row["dao_reread"] != reread:
+                raise _Mismatch(f"snapshot reread r{replica_number}:{checkpoint_id}")
+
+
+def _changed_indices(previous: Sequence[str], current: Sequence[str]) -> list[int]:
+    return [
+        page
+        for page in range(max(len(previous), len(current)))
+        if (previous[page] if page < len(previous) else None)
+        != (current[page] if page < len(current) else None)
+    ]
+
+
+def _check_reconstruction(bundle: LoadedBundle) -> None:
+    for replica_number in (1, 2, 3):
+        replica = bundle.replicas[replica_number]
+        observations = _checkpoint_rows(bundle, replica_number)
+        previous: Sequence[str] = ()
+        if len(replica.indexes) != 25:
+            raise _Mismatch(f"page-index cardinality replica {replica_number}")
+        for ordinal, checkpoint_id in enumerate(CONTRACT.checkpoint_ids):
+            try:
+                index = replica.index(checkpoint_id)
+                CONTRACT.validate_document(index, "dao_a4_page_index")
+            except (KeyError, ContractError) as exc:
+                raise _Mismatch(f"page index contract r{replica_number}:{checkpoint_id}") from exc
+            hashes = index["ordered_page_sha256"]
+            expected_previous = None if ordinal == 0 else CONTRACT.checkpoint_ids[ordinal - 1]
+            if (
+                index["replica"] != replica_number
+                or index["checkpoint_id"] != checkpoint_id
+                or index["ordinal"] != ordinal
+                or index["predecessor_checkpoint_id"] != expected_previous
+                or index["page_count"] != len(hashes)
+                or index["file_size_bytes"] != len(hashes) * 2048
+                or index["changed_page_indices"]
+                != ([] if ordinal == 0 else _changed_indices(previous, hashes))
+            ):
+                raise _Mismatch(f"page index structure r{replica_number}:{checkpoint_id}")
+            row = observations[checkpoint_id]
+            if (
+                row["actual_file_pages"] != len(hashes)
+                or row["actual_size_bytes"] != len(hashes) * 2048
+            ):
+                raise _Mismatch(f"observation size r{replica_number}:{checkpoint_id}")
+            digest = hashlib.sha256()
+            for page_number, expected_hash in enumerate(hashes):
+                payload = replica.page(checkpoint_id, page_number)
+                if payload is None or len(payload) != 2048:
+                    raise _Mismatch(f"missing page r{replica_number}:{checkpoint_id}:{page_number}")
+                actual_hash = hashlib.sha256(payload).hexdigest()
+                if actual_hash != expected_hash:
+                    raise _Mismatch(f"ordered page hash r{replica_number}:{checkpoint_id}:{page_number}")
+                digest.update(payload)
+            if digest.hexdigest() != index["database_sha256"]:
+                raise _Mismatch(f"database hash r{replica_number}:{checkpoint_id}")
+            previous = hashes
+
+
+def _resource_measurements(bundle: LoadedBundle) -> dict[str, int]:
+    bounds = CONTRACT.bounds
+    result: dict[str, int] = {
+        "unique_page_blobs": len(bundle.page_store.paths),
+        "retained_page_store_bytes": len(bundle.page_store.paths) * 2048,
+        "bundle_bytes": sum(int(entry["size_bytes"]) for entry in bundle.entries.values()),
+    }
+    union = {
+        digest
+        for replica in bundle.replicas.values()
+        for index in replica.indexes.values()
+        for digest in index["ordered_page_sha256"]
+    }
+    if union != set(bundle.page_store.paths):
+        raise _Mismatch("page-store digest union")
+    roles = tuple(CONTRACT.plan["tables"]["logical_roles"])
+    for replica_number in (1, 2, 3):
+        replica = bundle.replicas[replica_number]
+        previous_hashes: Sequence[str] = ()
+        previous_counts = {role: 0 for role in roles}
+        changed = inserted = logical = maximum_pages = maximum_companion = 0
+        for ordinal, checkpoint_id in enumerate(CONTRACT.checkpoint_ids):
+            index = replica.index(checkpoint_id)
+            hashes = index["ordered_page_sha256"]
+            if ordinal:
+                changed += len(_changed_indices(previous_hashes, hashes))
+            logical += len(hashes) * 2048
+            maximum_pages = max(maximum_pages, len(hashes))
+            snapshot_counts = {
+                table["logical_role"]: table["row_count"]
+                for table in replica.snapshots[checkpoint_id]["tables"]
+            }
+            counts = {role: snapshot_counts.get(role, 0) for role in roles}
+            inserted += sum(max(0, counts[role] - previous_counts[role]) for role in roles)
+            previous_counts, previous_hashes = counts, hashes
+            checkpoint = replica.checkpoint_observation(checkpoint_id)
+            if checkpoint["inserted_rows_total"] != inserted:
+                raise _Mismatch(
+                    f"retained cumulative inserts replica {replica_number}:{checkpoint_id}"
+                )
+            companion = checkpoint["post_close_companion"]
+            maximum_companion = max(maximum_companion, companion["observed_size_bytes"])
+        prefix = f"replica_{replica_number}_"
+        result.update({
+            prefix + "checkpoints": len(replica.indexes),
+            prefix + "final_pages": maximum_pages,
+            prefix + "logical_checkpoint_read_bytes": logical,
+            prefix + "inserted_rows": inserted,
+            prefix + "changed_hash_entries": changed,
+            prefix + "max_companion_bytes": maximum_companion,
+        })
+        observation = replica.observation
+        if (
+            observation["logical_checkpoint_read_bytes"] != logical
+            or observation["inserted_rows_total"] != inserted
+            or observation["changed_hash_entries"] != changed
+        ):
+            raise _Mismatch(f"retained resource counter replica {replica_number}")
+    if bundle.manifest["page_blob_count"] != result["unique_page_blobs"]:
+        raise _Mismatch("manifest page blob count")
+    if bundle.manifest["bundle_size_bytes_excluding_manifest"] != result["bundle_bytes"]:
+        raise _Mismatch("manifest bundle size")
+    comparisons = {
+        "unique_page_blobs": "max_unique_page_blobs",
+        "retained_page_store_bytes": "max_retained_page_store_bytes",
+        "bundle_bytes": "max_bundle_bytes",
+    }
+    for replica_number in (1, 2, 3):
+        prefix = f"replica_{replica_number}_"
+        comparisons.update({
+            prefix + "checkpoints": "max_checkpoints_per_replica",
+            prefix + "final_pages": "max_final_pages_per_replica",
+            prefix + "logical_checkpoint_read_bytes":
+                "max_logical_checkpoint_read_bytes_per_replica",
+            prefix + "inserted_rows": "max_inserted_rows_per_replica",
+            prefix + "changed_hash_entries": "max_changed_hash_entries_per_replica",
+            prefix + "max_companion_bytes": "max_companion_bytes_per_checkpoint",
+        })
+    for measurement, bound in comparisons.items():
+        if result[measurement] > int(bounds[bound]):
+            raise _Mismatch(f"{measurement}={result[measurement]} exceeds {bound}={bounds[bound]}")
+    return result
+
+
+def _campaign_row(predicate_id: str, status: str) -> dict[str, Any]:
+    contract = next(
+        row for row in CONTRACT.plan["predicate_registry"]["predicate_contracts"]
+        if row["predicate_id"] == predicate_id
+    )
+    return {
+        "predicate_id": predicate_id,
+        "order": contract["order"],
+        "scope": "campaign",
+        "status": status,
+        "terminal_predicate_id": predicate_id if status == "fail" else None,
+        "predicate_measured_survivor_count": 0,
+        "derivation_survivor_count": 0,
+        "reachability_fixture_id": contract["reachability_fixture_id"],
+    }
+
+
+def recompute_campaign(bundle: LoadedBundle) -> CampaignEvaluation:
+    """Execute the four campaign predicates in their registered terminal order."""
+    checks = (_check_idle, _check_schema, _check_reconstruction)
+    rows: list[Mapping[str, Any]] = []
+    failure: CampaignFailure | None = None
+    resources: Mapping[str, int] = {}
+    for index, predicate_id in enumerate(_CAMPAIGN_IDS):
+        if failure is not None:
+            rows.append(_campaign_row(predicate_id, "not_applicable"))
+            continue
+        try:
+            if index < len(checks):
+                checks[index](bundle)
+            else:
+                resources = _resource_measurements(bundle)
+        except _Mismatch as exc:
+            failure = CampaignFailure(predicate_id, exc.detail)
+            rows.append(_campaign_row(predicate_id, "fail"))
+        except (ContractError, ValidationError, KeyError, TypeError, ValueError, IndexError) as exc:
+            failure = CampaignFailure(predicate_id, f"invalid campaign input: {exc}")
+            rows.append(_campaign_row(predicate_id, "fail"))
+        else:
+            rows.append(_campaign_row(predicate_id, "pass"))
+    return CampaignEvaluation(tuple(rows), failure, resources)
+
+
+def require_campaign(bundle: LoadedBundle) -> CampaignEvaluation:
+    """Return a passing evaluation or raise the reached predicate id as its code."""
+    result = recompute_campaign(bundle)
+    if result.first_failure is not None:
+        raise ValidationError(
+            result.first_failure.predicate_id, result.first_failure.detail
+        )
+    return result
+
+
+def _all_results(frozen: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    layers = frozen["layers"]
+    h4 = layers["h4_catalog_bootstrap"]
+    return (
+        layers["h1_tdef_to_map_row"],
+        layers["h2_row_identity_map_role"],
+        layers["h3_indirect_traversal"],
+        h4["root_result"], h4["structural_result"], h4["encoding_result"],
+    )
+
+
+def _all_candidates(frozen: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    output: list[Mapping[str, Any]] = []
+    for result in _all_results(frozen):
+        output.extend(result["candidates"])
+        evidence = result.get("terminal_evidence")
+        if isinstance(evidence, Mapping) and evidence.get("kind") == "replica_pair":
+            output.extend(row["complete_candidate"] for row in evidence["entries"])
+    return tuple(output)
+
+
+def _interval(start: str, end: str) -> tuple[str, ...]:
+    first = CONTRACT.checkpoint_ids.index(start)
+    last = CONTRACT.checkpoint_ids.index(end)
+    if first > last:
+        raise ValidationError("frozen_set_recomputation_mismatch", "reversed checkpoint interval")
+    return CONTRACT.checkpoint_ids[first:last + 1]
+
+
+def _append(
+    output: dict[str, list[dict[str, Any]]],
+    category: str,
+    checkpoint: str,
+    page: int,
+    detail: bytes,
+) -> None:
+    output[category].append({
+        "kind": _TRANSCRIPT_KINDS[category],
+        "checkpoint_id": checkpoint,
+        "page": page,
+        "detail_hex": detail.hex(),
+    })
+
+
+def _h1_projection(
+    bundle: LoadedBundle,
+    output: dict[str, list[dict[str, Any]]],
+    *,
+    h2_reached: bool,
+    h3_reached: bool,
+) -> tuple[
+    set[tuple[int, str, int]],
+    set[tuple[int, str, int]],
+    set[tuple[int, str, int]],
+]:
+    tdefs: set[tuple[int, str, int]] = set()
+    targets: set[tuple[int, str, int]] = set()
+    references: set[tuple[int, str, int]] = set()
+    qualified = {
+        (row["replica"], row["checkpoint_id"], row["page_number"])
+        for row in bundle.frozen["qualified_pages"]
+    }
+    terminal_projection = any(
+        result.get("terminal_predicate_id") is not None
+        for result in _all_results(bundle.frozen)
+    )
+    h1_candidates = tuple(
+        row for row in _all_candidates(bundle.frozen)
+        if row["model_type"] == "h1_locator_pair"
+    )
+    h2 = next((row for row in _all_candidates(bundle.frozen)
+               if row["model_type"] == "h2_final_role"), None)
+    if not h1_candidates:
+        return tdefs, targets, references
+    row_mask = int(h2["model"]["row_mask"]) if h2 is not None else 0x1FFF
+    seen: dict[str, set[tuple[int, str, int, bytes]]] = {
+        "locators": set(), "row_directories": set()
+    }
+    for h1 in h1_candidates:
+        offsets = tuple(h1["model"]["locator_offsets"])
+        for binding in h1.get("instance_bindings", ()):
+            replica_number = binding["replica"]
+            replica = bundle.replicas[replica_number]
+            checkpoints = _interval(
+                binding["applicable_checkpoint_range"]["start"],
+                binding["applicable_checkpoint_range"]["end"],
+            )
+            for checkpoint in checkpoints:
+                tdef_page = binding["tdef_page"]
+                payload = replica.page(checkpoint, tdef_page)
+                if payload is None:
+                    raise ValidationError("frozen_set_recomputation_mismatch", "absent TDEF page")
+                tdefs.add((replica_number, checkpoint, tdef_page))
+                detail = b"".join(payload[offset:offset + 4] for offset in offsets)
+                key = (replica_number, checkpoint, tdef_page, detail)
+                if key not in seen["locators"]:
+                    seen["locators"].add(key)
+                    _append(output, "locators", checkpoint, tdef_page, detail)
+                if not h2_reached:
+                    continue
+                for target in binding.get("locator_targets", ()):
+                    page_number = target["page"]
+                    page = replica.page(checkpoint, page_number)
+                    if page is None or len(page) != 2048:
+                        raise ValidationError("frozen_set_recomputation_mismatch", "absent map page")
+                    targets.add((replica_number, checkpoint, page_number))
+                    detail = page[8:14]
+                    key = (replica_number, checkpoint, page_number, detail)
+                    if not terminal_projection or key not in seen["row_directories"]:
+                        seen["row_directories"].add(key)
+                        _append(output, "row_directories", checkpoint, page_number, detail)
+    if not h3_reached:
+        return tdefs, targets, references
+    # H3's registered observation order is replica, lifecycle binding, locator
+    # ordinal, then checkpoint; it is distinct from H1's checkpoint-major rows.
+    h1 = h1_candidates[0]
+    terminal_h3 = terminal_projection
+    seen_h3: dict[str, set[tuple[int, str, int, bytes]]] = {
+        "map_transitions": set(), "reference_bitmaps": set()
+    }
+    for binding in h1.get("instance_bindings", ()):
+        replica_number = binding["replica"]
+        replica = bundle.replicas[replica_number]
+        checkpoints = _interval(
+            binding["applicable_checkpoint_range"]["start"],
+            binding["applicable_checkpoint_range"]["end"],
+        )
+        for target in binding.get("locator_targets", ()):
+            page_number, row = target["page"], target["row"]
+            for checkpoint in checkpoints:
+                page = replica.page(checkpoint, page_number)
+                if page is None or len(page) != 2048:
+                    raise ValidationError("frozen_set_recomputation_mismatch", "absent map page")
+                count = int.from_bytes(page[8:10], "little")
+                if not 0 <= row < count or 10 + 2 * count > 2048:
+                    raise ValidationError("frozen_set_recomputation_mismatch", "invalid map row")
+                starts = [
+                    int.from_bytes(page[10 + 2 * item:12 + 2 * item], "little") & row_mask
+                    for item in range(count)
+                ]
+                start = starts[row]
+                end = 2048 if row == 0 else starts[row - 1]
+                if not 10 + 2 * count <= start < end <= 2048:
+                    raise ValidationError("frozen_set_recomputation_mismatch", "invalid row bound")
+                record = page[start:end]
+                if not record or record[0] not in (0, 1):
+                    raise ValidationError("frozen_set_recomputation_mismatch", "unsupported map row")
+                representation = b"type_0" if record[0] == 0 else b"type_1"
+                map_detail = page[:1] if terminal_h3 else representation
+                map_key = (replica_number, checkpoint, page_number, map_detail)
+                if not terminal_h3 or map_key not in seen_h3["map_transitions"]:
+                    seen_h3["map_transitions"].add(map_key)
+                    _append(output, "map_transitions", checkpoint, page_number, map_detail)
+                if record[0] == 1:
+                    if (len(record) - 1) % 4:
+                        raise ValidationError("frozen_set_recomputation_mismatch", "invalid type-1 row")
+                    for offset in range(1, len(record), 4):
+                        reference = int.from_bytes(record[offset:offset + 4], "little")
+                        if reference:
+                            identity = (replica_number, checkpoint, reference)
+                            if identity not in qualified:
+                                continue
+                            references.add(identity)
+                            detail = reference.to_bytes(4, "little")
+                            key = (*identity, detail)
+                            if not terminal_h3 or key not in seen_h3["reference_bitmaps"]:
+                                seen_h3["reference_bitmaps"].add(key)
+                                _append(
+                                    output, "reference_bitmaps", checkpoint, reference,
+                                    detail,
+                                )
+    return tdefs, targets, references
+
+
+def _h4_projection(
+    bundle: LoadedBundle,
+    output: dict[str, list[dict[str, Any]]],
+) -> tuple[set[int], set[tuple[int, str, int]]]:
+    catalog_pages: set[tuple[int, int]] = set()
+    raw_identities: set[tuple[int, str, int]] = set()
+    for candidate in _all_candidates(bundle.frozen):
+        if candidate["model_type"] == "h4_catalog_root":
+            offsets = bytes(candidate["model"]["locator_offsets"])
+            for binding in candidate["instance_bindings"]:
+                catalog_pages.add((binding["replica"], binding["tdef_page"]))
+                _append(output, "catalog_roots", "EMPTY", binding["tdef_page"], offsets)
+        elif candidate["model_type"] == "h4_operation_record":
+            model = candidate["model"]
+            catalog_pages.add(
+                (model["replica"], model["canonical_record_locator"]["page"])
+            )
+    evidence = bundle.occurrence_evidence
+    if evidence is None:
+        return catalog_pages, raw_identities
+    for group in evidence["replica_groups"]:
+        replica_number = group["replica"]
+        replica = bundle.replicas[replica_number]
+        for operation in group["operation_bindings"]:
+            checkpoint = operation["operation_id"]
+            locator = operation["canonical_record_locator"]
+            page_number = locator["page"]
+            page = replica.page(checkpoint, page_number)
+            if page is None:
+                raise ValidationError("frozen_set_recomputation_mismatch", "absent catalog page")
+            raw_identities.add((replica_number, checkpoint, page_number))
+            catalog_pages.add((replica_number, page_number))
+            _append(
+                output, "catalog_fields", checkpoint, page_number,
+                page[locator["row_start"]:locator["row_end"]][:64],
+            )
+    return catalog_pages, raw_identities
+
+
+def _marker_category(
+    identity: tuple[int, str, int],
+    payload: bytes,
+    tdefs: set[tuple[int, str, int]],
+    targets: set[tuple[int, str, int]],
+    references: set[tuple[int, str, int]],
+    root_pages: set[tuple[int, str, int]],
+    system_maps: set[tuple[int, str, int]],
+    catalog_pages: set[tuple[int, int]],
+    *,
+    h2_reached: bool,
+    h3_reached: bool,
+    h4_reached: bool,
+) -> str:
+    if not h2_reached:
+        return "locators"
+    if not h3_reached:
+        return "row_directories"
+    physical = (identity[0], identity[2])
+    if identity in references or payload[:1] == b"\x05":
+        return "reference_bitmaps"
+    if h4_reached and identity in root_pages:
+        return "catalog_roots"
+    if h4_reached and identity in system_maps:
+        return "row_directories"
+    if h4_reached and physical in catalog_pages and identity not in tdefs:
+        return "catalog_fields"
+    if h4_reached and payload[:1] == b"\x01" and identity not in targets:
+        return "catalog_fields"
+    return "map_transitions"
+
+
+def recompute_frozen_transcripts(bundle: LoadedBundle) -> Mapping[str, tuple[Mapping[str, Any], ...]]:
+    """Rebuild raw and coverage transcripts from frozen identities and bundle pages."""
+    output: dict[str, list[dict[str, Any]]] = {name: [] for name in _TRANSCRIPT_NAMES}
+    layers = bundle.frozen["layers"]
+    h2_reached = layers["h2_row_identity_map_role"]["status"] != "not_applicable"
+    h3_reached = layers["h3_indirect_traversal"]["status"] != "not_applicable"
+    h4_reached = (
+        layers["h4_catalog_bootstrap"]["root_result"]["status"] != "not_applicable"
+    )
+    tdefs, targets, references = _h1_projection(
+        bundle, output, h2_reached=h2_reached, h3_reached=h3_reached
+    )
+    if h4_reached:
+        catalog_pages, raw_catalog = _h4_projection(bundle, output)
+    else:
+        catalog_pages, raw_catalog = set(), set()
+    catalog_pages.update((replica, page) for replica, _, page in tdefs)
+    root_pages: set[tuple[int, str, int]] = set()
+    system_maps: set[tuple[int, str, int]] = set()
+    root_offsets = next(
+        (
+            tuple(candidate["model"]["locator_offsets"])
+            for candidate in _all_candidates(bundle.frozen)
+            if candidate["model_type"] == "h4_catalog_root"
+        ),
+        (),
+    )
+    for replica_number in (1, 2):
+        replica = bundle.replicas[replica_number]
+        for row in bundle.frozen["qualified_pages"]:
+            if row["replica"] != replica_number or row["checkpoint_id"] != "EMPTY":
+                continue
+            page_number = row["page_number"]
+            payload = replica.page("EMPTY", page_number) or b""
+            if payload[:1] != b"\x02" or len(root_offsets) != 2:
+                continue
+            root_physical = page_number
+            for candidate_row in bundle.frozen["qualified_pages"]:
+                if (
+                    candidate_row["replica"] != replica_number
+                    or candidate_row["page_number"] != root_physical
+                ):
+                    continue
+                checkpoint = candidate_row["checkpoint_id"]
+                checkpoint_payload = replica.page(checkpoint, root_physical) or b""
+                root_pages.add((replica_number, checkpoint, root_physical))
+                for offset in root_offsets:
+                    locator = checkpoint_payload[offset:offset + 4]
+                    if len(locator) == 4:
+                        system_maps.add((
+                            replica_number,
+                            checkpoint,
+                            int.from_bytes(locator[1:4], "little"),
+                        ))
+    ordinal = {checkpoint: index for index, checkpoint in enumerate(CONTRACT.checkpoint_ids)}
+    qualified = bundle.frozen["qualified_pages"]
+    keys = [(row["replica"], row["checkpoint_id"], row["page_number"]) for row in qualified]
+    if keys != sorted(set(keys), key=lambda row: (row[0], ordinal[row[1]], row[2])):
+        raise ValidationError("frozen_set_recomputation_mismatch", "qualified page order")
+    for identity in keys:
+        if identity in raw_catalog:
+            continue
+        replica_number, checkpoint, page_number = identity
+        payload = bundle.replicas[replica_number].page(checkpoint, page_number) or b""
+        category = _marker_category(
+            identity, payload, tdefs, targets, references,
+            root_pages, system_maps, catalog_pages,
+            h2_reached=h2_reached, h3_reached=h3_reached, h4_reached=h4_reached,
+        )
+        detail = (
+            _PAGE_MARKER
+            + bytes((replica_number, _CATEGORY_CODES[category]))
+            + hashlib.sha256(payload).digest()[:15]
+        )
+        _append(output, category, checkpoint, page_number, detail)
+    return {name: tuple(output[name]) for name in _TRANSCRIPT_NAMES}
+
+
+def verify_frozen_transcripts(bundle: LoadedBundle) -> Mapping[str, tuple[Mapping[str, Any], ...]]:
+    """Reject any missing, extra, category-moved, or byte-unbound transcript."""
+    expected = recompute_frozen_transcripts(bundle)
+    actual = bundle.frozen.get("transcripts")
+    if not isinstance(actual, Mapping) or set(actual) != set(_TRANSCRIPT_NAMES):
+        raise ValidationError("frozen_set_recomputation_mismatch", "transcript categories")
+    terminal_projection = any(
+        result.get("terminal_predicate_id") is not None
+        for result in _all_results(bundle.frozen)
+    )
+    for name in _TRANSCRIPT_NAMES:
+        rows = tuple(actual[name])
+        if terminal_projection:
+            split = lambda values: (
+                tuple(row for row in values if not bytes.fromhex(row["detail_hex"]).startswith(_PAGE_MARKER)),
+                tuple(row for row in values if bytes.fromhex(row["detail_hex"]).startswith(_PAGE_MARKER)),
+            )
+            raw, markers = split(rows)
+            expected_raw, expected_markers = split(expected[name])
+            matches = (
+                Counter(canonical_json_bytes(row) for row in raw)
+                == Counter(canonical_json_bytes(row) for row in expected_raw)
+                and markers == expected_markers
+                and rows == raw + markers
+            )
+        else:
+            matches = rows == expected[name]
+        if not matches:
+            raise ValidationError(
+                "frozen_set_recomputation_mismatch", f"transcript {name}"
+            )
+    return expected

--- a/oracle/windows-dao/scripts/a4_independent_contract.py
+++ b/oracle/windows-dao/scripts/a4_independent_contract.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Immutable inputs compiled independently for the DAO A4 validator."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from protocol_validation import ValidationError as SchemaError
+from protocol_validation import validate_schema_value
+
+
+DAO_ROOT = Path(__file__).resolve().parents[1]
+A4_ROOT = DAO_ROOT / "experiments" / "a4"
+PLAN_PATH = A4_ROOT / "a4-row-anchored-maps.plan.json"
+PLAN_SHA256 = "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+REVISION_PLAN_SHA256 = PLAN_SHA256
+EXPERIMENT_ID = "DAO-A4-ROW-ANCHORED-MAPS-001"
+
+SCHEMA_FILES: Mapping[str, str] = MappingProxyType({
+    "dao_a4_analysis_report": "analysis-report.schema.json",
+    "dao_a4_bundle_manifest": "bundle-manifest.schema.json",
+    "dao_a4_schema_snapshot": "dao-schema-snapshot.schema.json",
+    "dao_a4_frozen_derivation_candidates": "derivation-candidates.schema.json",
+    "dao_a4_analyzer_dry_run_report": "dry-run-report.schema.json",
+    "dao_a4_environment": "environment.schema.json",
+    "dao_a4_h4_occurrence_evidence": "h4-occurrence-evidence.schema.json",
+    "dao_a4_holdout_structure_receipt": "holdout-structure-receipt.schema.json",
+    "dao_a4_independent_validation_report": "independent-validation-report.schema.json",
+    "dao_a4_page_index": "page-index.schema.json",
+    "dao_a4_row_anchored_maps_plan": "plan.schema.json",
+    "dao_a4_reachability_transcript": "reachability-transcript.schema.json",
+    "dao_a4_replica_artifact_manifest": "replica-artifact-manifest.schema.json",
+    "dao_a4_replica_observation": "replica-observation.schema.json",
+})
+
+SCHEMA_SHA256: Mapping[str, str] = MappingProxyType({
+    "analysis-report.schema.json": "bd1cdd62fdf6dae1ed756c092a90936be1318dc3a66e9d1d6309ecfa0d3d2010",
+    "bundle-manifest.schema.json": "1b051fe4eeaf7dcdb7304cd885cc88d85630ccd76a7ea6d79b408c0d42272791",
+    "dao-schema-snapshot.schema.json": "f890d9c7f710c033b357609ebab73ac51c68153cb067af7e40162930cf5d76c8",
+    "derivation-candidates.schema.json": "1cf5829b14663a68c934ff4d16b1b95668291b21b645ad3ae0e93abe3c839a28",
+    "dry-run-report.schema.json": "c9a47933675749d3c0a631eb902cd0402502687b1cfbe0dbf5ba22ed6c76b3d9",
+    "environment.schema.json": "77f1a95a65d2d202205a8a15ed1a59934bb5d5cca6df2226ae118c90771d131f",
+    "h4-occurrence-evidence.schema.json": "272f591f857fa93e059bd66175eef4c13309fbbc276a7755dcd8859a4c2e1ae8",
+    "holdout-structure-receipt.schema.json": "92c255fa62a94c3855ea23441d3d1b5077dccf3148b3e255fd171c6508c8a769",
+    "independent-validation-report.schema.json": "2771f1cda975ba22b100bb607df2525181fc62721e854a84c7934fd7ea73b233",
+    "page-index.schema.json": "f612f77fb8e3180c15bf45681df3e51e4e8088803b297764d85a655de8ab099f",
+    "plan.schema.json": "9da16374db62251c55c3df26e7a0d066b8ca2ad3e514c51ce2c0c20b00afec49",
+    "reachability-transcript.schema.json": "beaa8179a9c0e5a3d26c1098494f6d0bf32c20ea87d162de65e0637aa3f95bb5",
+    "replica-artifact-manifest.schema.json": "61640502ae032877b43895098dcbf3a466bd207600676390b652ebea1bfa8d2b",
+    "replica-observation.schema.json": "d1ef77f91471935d99c3b9a1c0e7a4329a1d9d77cab8da51153cfb44de3d22cb",
+})
+
+EXPECTED_TAMPERS = (
+    ("T1", "plan_binding_mismatch"),
+    ("T2", "frozen_set_recomputation_mismatch"),
+    ("T3", "schema_snapshot_mismatch"),
+    ("T4", "analysis_report_mismatch"),
+    ("T5", "campaign_timeout_exceeded"),
+    ("T6", "predicate_layer_projection_mismatch"),
+    ("T7", "holdout_projection_mismatch"),
+    ("T8", "candidate_canonicalization_mismatch"),
+    ("T9", "frozen_file_hash_mismatch"),
+)
+
+
+class ContractError(Exception):
+    """A stable failure while loading preregistered validator inputs."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+        self.detail = detail
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _read(path: Path, maximum: int = 67_108_864) -> bytes:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ContractError("contract_file_missing", str(path)) from exc
+    if not 0 < size <= maximum:
+        raise ContractError("contract_file_size", str(path))
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise ContractError("contract_file_read", str(path)) from exc
+
+
+def _decode(raw: bytes, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ContractError("contract_json_invalid", label) from exc
+    if not isinstance(value, dict):
+        raise ContractError("contract_json_not_object", label)
+    return value
+
+
+@dataclass(frozen=True)
+class IndependentContract:
+    plan: Mapping[str, Any]
+    plan_raw: bytes
+    schemas: Mapping[str, Mapping[str, Any]]
+    bounds: Mapping[str, int]
+    checkpoint_ids: tuple[str, ...]
+    predicate_ids: tuple[str, ...]
+    campaign_predicates: tuple[str, ...]
+    layer_predicates: Mapping[str, tuple[str, ...]]
+    holdout_predicates: tuple[str, ...]
+    tamper_cases: tuple[Mapping[str, str], ...]
+
+    def validate_document(self, value: Any, document_type: str) -> None:
+        try:
+            name = SCHEMA_FILES[document_type]
+            schema = self.schemas[name]
+        except KeyError as exc:
+            raise ContractError("unknown_document_type", document_type) from exc
+        try:
+            validate_schema_value(value, dict(schema), dict(schema), "$")
+        except SchemaError as exc:
+            raise ContractError("schema_validation_failed", f"{document_type}: {exc}") from exc
+
+
+def _compile_sequences(plan: Mapping[str, Any]) -> tuple[
+    tuple[str, ...], Mapping[str, tuple[str, ...]], tuple[str, ...], tuple[str, ...]
+]:
+    try:
+        registry = plan["predicate_registry"]
+        predicate_ids = tuple(registry["ids"])
+        campaign = tuple(registry["campaign_evaluated_before_any_layer"])
+        layers = {
+            name: tuple(values)
+            for name, values in registry["per_layer_ordered_predicates"].items()
+        }
+        holdout = tuple(registry["holdout_phase_ordered_predicates"])
+        contracts = registry["predicate_contracts"]
+    except (KeyError, TypeError) as exc:
+        raise ContractError("predicate_contract_invalid") from exc
+    flattened = campaign + tuple(item for values in layers.values() for item in values) + holdout
+    if (
+        len(predicate_ids) != 40
+        or len(set(predicate_ids)) != 40
+        or flattened != predicate_ids
+        or [row.get("predicate_id") for row in contracts] != list(predicate_ids)
+        or [row.get("order") for row in contracts] != list(range(1, 41))
+    ):
+        raise ContractError("predicate_contract_invalid")
+    return predicate_ids, MappingProxyType(layers), campaign, holdout
+
+
+def _canonical_named_rows(rows: Any, label: str, *, contiguous: bool) -> None:
+    if not isinstance(rows, list):
+        raise ContractError("schema_snapshot_mismatch", label)
+    keys: list[tuple[int, bytes]] = []
+    for row in rows:
+        try:
+            name = row["name"]
+            cp1252 = bytes.fromhex(row["name_windows_1252_hex"])
+            encoded16 = name.encode("utf-16-le")
+            units = [
+                encoded16[index] | encoded16[index + 1] << 8
+                for index in range(0, len(encoded16), 2)
+            ]
+            if (
+                name.encode("cp1252", errors="strict") != cp1252
+                or name.encode() != bytes.fromhex(row["name_utf8_hex"])
+                or row["name_utf16_code_units"] != units
+            ):
+                raise ValueError("name encoding differs")
+            keys.append((row["ordinal"], cp1252))
+        except (KeyError, TypeError, ValueError, UnicodeEncodeError) as exc:
+            raise ContractError("schema_snapshot_mismatch", label) from exc
+    if (
+        keys != sorted(keys)
+        or len({key[0] for key in keys}) != len(keys)
+        or len({key[1] for key in keys}) != len(keys)
+        or contiguous and [key[0] for key in keys] != list(range(len(keys)))
+    ):
+        raise ContractError("schema_snapshot_mismatch", label)
+
+
+def validate_canonical_snapshot(snapshot: Mapping[str, Any], label: str) -> None:
+    """Enforce the plan's ordinal-then-CP1252 canonical snapshot ordering."""
+    tables = snapshot["tables"]
+    _canonical_named_rows(tables, f"{label}:tables", contiguous=True)
+    roles: set[str] = set()
+    for table in tables:
+        role = table["logical_role"]
+        if role in roles:
+            raise ContractError("schema_snapshot_mismatch", f"{label}:roles")
+        roles.add(role)
+        _canonical_named_rows(table["fields"], f"{label}:fields", contiguous=True)
+        _canonical_named_rows(table["indexes"], f"{label}:indexes", contiguous=False)
+        for index in table["indexes"]:
+            _canonical_named_rows(index["fields"], f"{label}:index-fields", contiguous=True)
+
+
+def validate_snapshot_schedule(
+    snapshot: Mapping[str, Any], plan: Mapping[str, Any], replica: int, checkpoint: str
+) -> None:
+    """Rebuild the exact scheduled DAO schema tuples from preregistered values."""
+    tables_contract = plan["tables"]
+    binding = next(row for row in tables_contract["role_bindings"] if row["replica"] == replica)
+    descriptors = tables_contract["expected_schema_by_checkpoint"][checkpoint]
+    tables = snapshot["tables"]
+    if len(tables) != len(descriptors):
+        raise ContractError("schema_snapshot_mismatch", checkpoint)
+    definitions = {row["name"]: row for row in tables_contract["definition"]["fields"]}
+    for ordinal, (table, descriptor) in enumerate(zip(tables, descriptors, strict=True)):
+        parts = descriptor.split(":")
+        role = parts[0]
+        shape = parts[-1]
+        lifecycle = f"{role}-v2" if role == "T2" and "v2" in parts else f"{role}-v1"
+        expected_fields = [definitions["Id"]]
+        if "payload" in shape:
+            expected_fields.append(definitions["Payload"])
+        if (
+            table["ordinal"] != ordinal
+            or table["logical_role"] != role
+            or table["lifecycle_instance"] != lifecycle
+            or table["name"] != binding[role]
+            or table["attributes"] != tables_contract["definition"]["table_attributes_numeric"]
+            or len(table["fields"]) != len(expected_fields)
+        ):
+            raise ContractError("schema_snapshot_mismatch", checkpoint)
+        for field_ordinal, (field, expected) in enumerate(
+            zip(table["fields"], expected_fields, strict=True)
+        ):
+            if (
+                field["ordinal"] != field_ordinal
+                or field["name"] != expected["name"]
+                or field["type"] != expected["dao_type_numeric"]
+                or field["size"] != expected["size"]
+                or field["attributes"] != expected["attributes_numeric"]
+                or field["required"] != expected["required"]
+                or field["allow_zero_length"] != expected["allow_zero_length"]
+            ):
+                raise ContractError("schema_snapshot_mismatch", checkpoint)
+        expects_index = "index" in shape
+        if len(table["indexes"]) != int(expects_index):
+            raise ContractError("schema_snapshot_mismatch", checkpoint)
+        if expects_index:
+            index = table["indexes"][0]
+            expected_index = tables_contract["definition"]["index"]
+            if (
+                index["name"] != expected_index["name"]
+                or index["primary"] != expected_index["primary"]
+                or index["unique"] != expected_index["unique"]
+                or index["required"] != expected_index["required"]
+                or index["ignore_nulls"] != expected_index["ignore_nulls"]
+                or len(index["fields"]) != 1
+                or index["fields"][0]["name"] != expected_index["fields"][0]
+                or index["fields"][0]["descending"] != expected_index["descending"]
+            ):
+                raise ContractError("schema_snapshot_mismatch", checkpoint)
+
+
+def load_contract(
+    plan_path: Path = PLAN_PATH,
+    schema_root: Path = A4_ROOT,
+) -> IndependentContract:
+    """Load only the byte-pinned plan and schemas committed before acquisition."""
+    raw = _read(plan_path)
+    if sha256_bytes(raw) != PLAN_SHA256:
+        raise ContractError("plan_binding_mismatch", str(plan_path))
+    plan = _decode(raw, str(plan_path))
+    schemas: dict[str, Mapping[str, Any]] = {}
+    for name, expected in SCHEMA_SHA256.items():
+        schema_raw = _read(schema_root / name)
+        if sha256_bytes(schema_raw) != expected:
+            raise ContractError("schema_binding_mismatch", name)
+        schemas[name] = MappingProxyType(_decode(schema_raw, name))
+    try:
+        validate_schema_value(
+            plan,
+            dict(schemas["plan.schema.json"]),
+            dict(schemas["plan.schema.json"]),
+            "$",
+        )
+    except SchemaError as exc:
+        raise ContractError("plan_schema_mismatch", str(exc)) from exc
+    if (
+        plan.get("experiment_id") != EXPERIMENT_ID
+        or plan.get("implementation_rebinding", {}).get("required_plan_path")
+        != "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json"
+        or plan.get("artifacts", {}).get("plan")
+        != "plan/a4-row-anchored-maps.plan.json"
+    ):
+        raise ContractError("plan_binding_mismatch")
+    predicates, layers, campaign, holdout = _compile_sequences(plan)
+    tampers = tuple(plan["independent_validator_contract"]["tamper_cases"])
+    observed = tuple((row.get("id"), row.get("required_rejection")) for row in tampers)
+    if observed != EXPECTED_TAMPERS or len({row[0] for row in observed}) != len(observed):
+        raise ContractError("tamper_contract_invalid")
+    bounds = plan["bounds"]
+    if (
+        bounds.get("page_size") != 2048
+        or bounds.get("replicas") != 3
+        or bounds.get("planned_checkpoints_per_replica") != 25
+    ):
+        raise ContractError("resource_contract_invalid")
+    return IndependentContract(
+        MappingProxyType(plan),
+        raw,
+        MappingProxyType(schemas),
+        MappingProxyType(bounds),
+        tuple(plan["checkpoint_design"]["checkpoint_ids"]),
+        predicates,
+        campaign,
+        layers,
+        holdout,
+        tampers,
+    )
+
+
+CONTRACT = load_contract()

--- a/oracle/windows-dao/scripts/a4_independent_h1.py
+++ b/oracle/windows-dao/scripts/a4_independent_h1.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""Fresh plan-derived A4 H1 recomputation over captured page bytes."""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from protocol_validation import ValidationError as ProtocolValidationError
+
+
+class ValidationError(ProtocolValidationError):
+    """A stable independent-validator rejection."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def _schedule(plan: Mapping[str, Any]) -> tuple[
+    tuple[tuple[str, str, str, str, str], ...],
+    tuple[tuple[str, str, str], ...],
+]:
+    checkpoints = tuple(plan["checkpoint_design"]["checkpoint_ids"])
+    expected = plan["tables"]["expected_schema_by_checkpoint"]
+    roles = tuple(plan["candidate_grammars"]["h1"]["logical_roles"])
+    if len(checkpoints) != 25 or len(roles) != 4:
+        raise ValidationError("independent_h1_schedule_contract")
+
+    def tokens(checkpoint: str) -> dict[str, str]:
+        output: dict[str, str] = {}
+        rows = expected.get(checkpoint)
+        if not isinstance(rows, list) or len(rows) > len(roles):
+            raise ValidationError("independent_h1_schema_schedule")
+        for value in rows:
+            if not isinstance(value, str) or ":" not in value:
+                raise ValidationError("independent_h1_schema_schedule")
+            role = value.split(":", 1)[0]
+            if role not in roles or role in output:
+                raise ValidationError("independent_h1_schema_schedule")
+            output[role] = value
+        return output
+
+    states = {checkpoint: tokens(checkpoint) for checkpoint in checkpoints}
+    instances: list[tuple[str, str, str, str, str]] = []
+    for role in roles:
+        index = 0
+        while index < len(checkpoints):
+            if role not in states[checkpoints[index]]:
+                index += 1
+                continue
+            start = index
+            token = states[checkpoints[index]][role]
+            version = "v2" if ":v2:" in token else "v1"
+            while index + 1 < len(checkpoints):
+                following = states[checkpoints[index + 1]].get(role)
+                following_version = (
+                    "v2" if following is not None and ":v2:" in following else "v1"
+                )
+                if following is None or following_version != version:
+                    break
+                index += 1
+            before = checkpoints[start - 1] if start else ""
+            if not before:
+                raise ValidationError("independent_h1_schema_schedule")
+            instances.append((role, f"{role}-{version}", before, checkpoints[start], checkpoints[index]))
+            index += 1
+    order = {role: position for position, role in enumerate(roles)}
+    instances.sort(key=lambda row: (order[row[0]], checkpoints.index(row[3])))
+    schema_legs: list[tuple[str, str, str]] = []
+    for left, right in zip(checkpoints, checkpoints[1:]):
+        changed = [role for role in roles if states[left].get(role) != states[right].get(role)]
+        if len(changed) > 1:
+            raise ValidationError("independent_h1_schema_schedule")
+        if changed:
+            schema_legs.append((changed[0], left, right))
+    if len(instances) != 5:
+        raise ValidationError("independent_h1_schema_schedule")
+    return tuple(instances), tuple(schema_legs)
+
+
+@dataclass(frozen=True)
+class H1Recomputation:
+    layer: Mapping[str, Any]
+    predicate_results: tuple[Mapping[str, Any], ...]
+    qualified_pages: tuple[Mapping[str, Any], ...]
+    work_charges: Mapping[str, int]
+    per_replica_candidates: Mapping[int, tuple[Mapping[str, Any], ...]]
+
+
+class _ReplicaState:
+    def __init__(self, replica: object, number: int, checkpoints: Sequence[str], page_size: int):
+        self.replica = replica
+        self.number = number
+        self.checkpoints = tuple(checkpoints)
+        self.page_size = page_size
+        self.pages: dict[tuple[str, int], bytes | None] = {}
+        self.qualified: set[tuple[int, str, int]] = set()
+        self.work = {
+            "tdef_lifecycle_signatures": 0,
+            "raw_locator_windows": 0,
+            "raw_locator_pairs": 0,
+            "h1_target_validity_checks": 0,
+        }
+        self.target_charges: set[tuple[str, str, int, int]] = set()
+        self.locator_charged: set[int] = set()
+        self.tdef_pages: tuple[int, ...] = ()
+        observed = tuple(getattr(replica, "checkpoint_ids", checkpoints))
+        if observed != tuple(checkpoints):
+            raise ValidationError("independent_h1_checkpoint_order")
+
+    def state(self, checkpoint: str, page: int) -> str | None:
+        try:
+            value = self.replica.state(checkpoint, page)
+        except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+            raise ValidationError("independent_h1_state_read") from exc
+        if value is not None and (
+            not isinstance(value, str)
+            or len(value) != 64
+            or any(c not in "0123456789abcdef" for c in value)
+        ):
+            raise ValidationError("independent_h1_state_invalid")
+        return value
+
+    def read(self, checkpoint: str, page: int, *, qualify: bool = False) -> bytes | None:
+        key = (checkpoint, page)
+        if key not in self.pages:
+            try:
+                value = self.replica.page(checkpoint, page)
+            except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+                raise ValidationError("independent_h1_page_read") from exc
+            if value is not None and (
+                not isinstance(value, bytes) or len(value) != self.page_size
+            ):
+                raise ValidationError("independent_h1_page_size")
+            self.pages[key] = value
+        value = self.pages[key]
+        if qualify:
+            self.qualified.add((self.number, checkpoint, page))
+        return value
+
+    def page_count(self, checkpoint: str, limit: int) -> int:
+        try:
+            index = self.replica.index(checkpoint)
+            value = index["page_count"]
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            raise ValidationError("independent_h1_page_count") from exc
+        if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= limit:
+            raise ValidationError("independent_h1_page_count")
+        return value
+
+
+def _sha(value: Any) -> str:
+    try:
+        payload = json.dumps(
+            value,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError, RecursionError) as exc:
+        raise ValidationError("independent_h1_canonicalization") from exc
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _candidate(model_type: str, model: Mapping[str, Any], bindings: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    ordered = [dict(value) for value in bindings]
+    core = {"model_type": model_type, "model": dict(model)}
+    return {
+        "model_type": model_type,
+        "canonical_model_id": _sha(core),
+        "canonical_candidate_id": _sha({**core, "instance_bindings": ordered}),
+        "model": dict(model),
+        "instance_bindings": ordered,
+    }
+
+
+def _contracts(values: Mapping[str, Mapping[str, Any]] | Sequence[Mapping[str, Any]], predicate_ids: Sequence[str]) -> dict[str, Mapping[str, Any]]:
+    if isinstance(values, Mapping):
+        rows = dict(values)
+    else:
+        if len(values) > 64:
+            raise ValidationError("independent_h1_contract_bound")
+        rows = {str(row.get("predicate_id")): row for row in values}
+    if len(predicate_ids) != 8 or any(predicate not in rows for predicate in predicate_ids):
+        raise ValidationError("independent_h1_contract_missing")
+    return rows
+
+
+def _replicas(values: Mapping[int, object] | Sequence[object], numbers: Sequence[int]) -> dict[int, object]:
+    if isinstance(values, Mapping):
+        output = {number: values[number] for number in numbers if number in values}
+    else:
+        if len(values) > 3:
+            raise ValidationError("independent_h1_replica_bound")
+        output = {int(getattr(value, "number")): value for value in values}
+    if tuple(sorted(output)) != tuple(numbers):
+        raise ValidationError("independent_h1_replicas")
+    return output
+
+
+def _tag(page: bytes | None) -> int | None:
+    return None if page is None else page[0]
+
+
+def _qualified_pool(state: _ReplicaState, max_pages: int) -> tuple[int, ...]:
+    pages: set[int] = set()
+    for checkpoint in state.checkpoints:
+        for page in range(state.page_count(checkpoint, max_pages)):
+            if _tag(state.read(checkpoint, page)) == 2:
+                pages.add(page)
+                if len(pages) > 16:
+                    raise ValidationError("A4-RESOURCE-BOUND")
+    return tuple(sorted(pages))
+
+
+def _applicable(checkpoints: Sequence[str], start: str, end: str) -> tuple[str, ...]:
+    try:
+        left, right = checkpoints.index(start), checkpoints.index(end)
+    except ValueError as exc:
+        raise ValidationError("independent_h1_lifecycle_checkpoint") from exc
+    if left > right:
+        raise ValidationError("independent_h1_lifecycle_range")
+    return tuple(checkpoints[left : right + 1])
+
+
+def _signature_fits(
+    state: _ReplicaState,
+    page: int,
+    signature: str,
+    role: str,
+    instance: str,
+    before: str,
+    after: str,
+    end: str,
+    idle_pairs: Sequence[tuple[str, str]],
+    schema_legs: Sequence[tuple[str, str, str]],
+) -> bool:
+    applicable = _applicable(state.checkpoints, after, end)
+    blobs = [state.read(cp, page, qualify=True) for cp in applicable]
+    if any(_tag(blob) != 2 for blob in blobs):
+        return False
+    prior = state.read(before, page, qualify=True)
+    first = state.read(after, page, qualify=True)
+    if signature == "new_tag_02_at_role_create":
+        if _tag(prior) == 2 or _tag(first) != 2:
+            return False
+        return instance != "T2-v1" or _tag(state.read("T2_DROP", page, qualify=True)) != 2
+    if signature != "preexisting_tag_02_hash_transition":
+        raise ValidationError("independent_h1_signature")
+    if _tag(prior) != 2 or _tag(first) != 2 or prior == first:
+        return False
+    for changed_role, left, right in schema_legs:
+        if changed_role != role and left in applicable and right in applicable:
+            left_blob = state.read(left, page, qualify=True)
+            right_blob = state.read(right, page, qualify=True)
+            if left_blob != right_blob:
+                return False
+    for left, right in idle_pairs:
+        if left not in applicable or right not in applicable:
+            continue
+        left_blob = state.read(left, page, qualify=True)
+        right_blob = state.read(right, page, qualify=True)
+        if left_blob != right_blob:
+            return False
+    if instance == "T2-v1":
+        if state.state("T2_CREATE", page) == state.state("T2_DROP", page):
+            return False
+    if instance == "T2-v2":
+        if state.state("T2_DROP", page) == state.state("T2_RECREATE", page):
+            return False
+    return True
+
+
+def _tdef_stage(
+    state: _ReplicaState,
+    plan: Mapping[str, Any],
+    max_pages: int,
+    max_candidates: int,
+    instances: Sequence[tuple[str, str, str, str, str]],
+    schema_legs: Sequence[tuple[str, str, str]],
+) -> list[dict[str, Any]]:
+    grammar = plan["candidate_grammars"]["h1"]
+    signatures = tuple(grammar["tdef_lifecycle_signatures"])
+    if signatures != ("new_tag_02_at_role_create", "preexisting_tag_02_hash_transition"):
+        raise ValidationError("independent_h1_signature_contract")
+    pool = _qualified_pool(state, max_pages)
+    state.tdef_pages = pool
+    for page in pool:
+        for checkpoint in state.checkpoints:
+            state.read(checkpoint, page, qualify=True)
+    state.work["tdef_lifecycle_signatures"] += len(pool) * len(signatures) * len(state.checkpoints)
+    idle_pairs = tuple(tuple(value) for value in plan["checkpoint_design"]["idle_pairs"])
+    output: list[dict[str, Any]] = []
+    for signature in signatures:
+        choices: list[list[dict[str, Any]]] = []
+        for role, instance, before, after, end in instances:
+            rows = []
+            for page in pool:
+                if _signature_fits(
+                    state, page, signature, role, instance, before, after, end,
+                    idle_pairs, schema_legs,
+                ):
+                    rows.append({
+                        "replica": state.number,
+                        "logical_role": role,
+                        "lifecycle_instance": instance,
+                        "tdef_page": page,
+                        "applicable_checkpoint_range": {"start": after, "end": end},
+                    })
+            choices.append(rows)
+        if any(not rows for rows in choices):
+            continue
+        count = 1
+        for rows in choices:
+            count *= len(rows)
+            if count > max_candidates:
+                raise ValidationError("A4-RESOURCE-BOUND")
+        for bindings in itertools.product(*choices):
+            output.append(_candidate("h1_tdef", {"tdef_lifecycle_signature": signature}, bindings))
+            if len(output) > max_candidates:
+                raise ValidationError("A4-RESOURCE-BOUND")
+    return sorted(output, key=lambda row: row["canonical_candidate_id"])
+
+
+def _decode_window(blob: bytes, offset: int, layout: str) -> tuple[int, int]:
+    raw = blob[offset : offset + 4]
+    if len(raw) != 4:
+        raise ValidationError("independent_h1_window_bounds")
+    if layout == "u24le_page_then_u8_row":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    if layout == "u8_row_then_u24le_page":
+        return int.from_bytes(raw[1:], "little"), raw[0]
+    raise ValidationError("independent_h1_layout")
+
+
+def _window_stage(state: _ReplicaState, tdef: Mapping[str, Any], plan: Mapping[str, Any], page_limit: int) -> dict[str, dict[int, tuple[int, ...]]]:
+    layouts = tuple(plan["candidate_grammars"]["h1"]["locator_layouts"])
+    pages = sorted({binding["tdef_page"] for binding in tdef["instance_bindings"]})
+    output: dict[str, dict[int, tuple[int, ...]]] = {layout: {} for layout in layouts}
+    for page in state.tdef_pages:
+        if page not in state.locator_charged:
+            state.locator_charged.add(page)
+            state.work["raw_locator_windows"] += 4090
+            state.work["raw_locator_pairs"] += 4_167_722
+    for page in pages:
+        blobs = [state.read(cp, page, qualify=True) for cp in state.checkpoints]
+        for layout in layouts:
+            preserved: list[int] = []
+            for offset in range(2045):
+                if all(blob is not None and _decode_window(blob, offset, layout)[0] < page_limit for blob in blobs):
+                    preserved.append(offset)
+            output[layout][page] = tuple(preserved)
+    return output
+
+
+def _mask_matches(blob: bytes, signature: Mapping[str, Any]) -> bool:
+    start, end = signature["record_bounds"]
+    value = bytes.fromhex(signature["value_hex"])
+    mask = bytearray.fromhex(signature["mask_hex"])
+    if len(value) != end - start or len(mask) != end - start or end > len(blob):
+        raise ValidationError("independent_h1_signature_bounds")
+    if "mask_derivation" in signature:
+        for override in signature["mask_derivation"]["overrides"]:
+            left, right = override["interval"]
+            mask[left - start : right - start] = bytes.fromhex(override["mask_hex"])
+    record = blob[start:end]
+    if any((actual & bitmask) != (expected & bitmask) for actual, expected, bitmask in zip(record, value, mask)):
+        return False
+    for relation in signature.get("equal_byte_intervals", ()):
+        left, right = relation["left"], relation["right"]
+        if blob[left[0] : left[1]] != blob[right[0] : right[1]]:
+            return False
+    inequality = signature.get("mutual_exclusion_inequality")
+    if inequality is not None:
+        left = inequality["left"]
+        if blob[left[0] : left[1]] == bytes.fromhex(inequality["right"]["fixed_value_hex"]):
+            return False
+    return True
+
+
+def _structural_stage(state: _ReplicaState, tdef: Mapping[str, Any], windows: Mapping[str, Mapping[int, Sequence[int]]], plan: Mapping[str, Any]) -> list[dict[str, Any]]:
+    grammar = plan["candidate_grammars"]["h1"]
+    specs = (grammar["table_record_signature"], grammar["pair_multiple_reachability_signature"])
+    base_spec = grammar["table_record_signature"]
+    pages = sorted({binding["tdef_page"] for binding in tdef["instance_bindings"]})
+    output: list[dict[str, Any]] = []
+    for layout in grammar["locator_layouts"]:
+        common = set(range(2045))
+        for page in pages:
+            common.intersection_update(windows[layout][page])
+        for spec in specs:
+            effective_spec = dict(spec)
+            effective_spec.setdefault("value_hex", base_spec["value_hex"])
+            effective_spec.setdefault("mask_hex", base_spec["mask_hex"])
+            holes = tuple(tuple(value) for value in spec["locator_holes"])
+            pairs = ((holes[0][0], holes[1][0]),) if len(holes) == 2 else tuple(
+                (left[0], right[0]) for left, right in itertools.combinations(holes, 2)
+            )
+            for offsets in pairs:
+                if offsets[0] not in common or offsets[1] not in common or offsets[1] - offsets[0] < 4:
+                    continue
+                bindings: list[dict[str, Any]] = []
+                fits = True
+                for binding in tdef["instance_bindings"]:
+                    checkpoints = _applicable(state.checkpoints, binding["applicable_checkpoint_range"]["start"], binding["applicable_checkpoint_range"]["end"])
+                    observed: tuple[tuple[int, int], tuple[int, int]] | None = None
+                    for checkpoint in checkpoints:
+                        blob = state.read(checkpoint, binding["tdef_page"], qualify=True)
+                        if blob is None or not _mask_matches(blob, effective_spec):
+                            fits = False
+                            break
+                        targets = (_decode_window(blob, offsets[0], layout), _decode_window(blob, offsets[1], layout))
+                        if observed is None:
+                            observed = targets
+                        elif observed != targets:
+                            fits = False
+                            break
+                    if not fits or observed is None:
+                        break
+                    bindings.append({**binding, "locator_targets": [
+                        {"page": observed[0][0], "row": observed[0][1]},
+                        {"page": observed[1][0], "row": observed[1][1]},
+                    ]})
+                if fits:
+                    output.append(_candidate("h1_locator_pair", {
+                        "layout": layout,
+                        "table_signature_id": spec["signature_id"],
+                        "locator_offsets": list(offsets),
+                    }, bindings))
+    return sorted(output, key=lambda row: row["canonical_candidate_id"])
+
+
+def _target_stage(state: _ReplicaState, candidates: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for candidate in candidates:
+        layout = candidate["model"]["layout"]
+        valid = True
+        for binding in candidate["instance_bindings"]:
+            targets = tuple((row["page"], row["row"]) for row in binding["locator_targets"])
+            if targets[0] == targets[1]:
+                valid = False
+                break
+            checkpoints = _applicable(state.checkpoints, binding["applicable_checkpoint_range"]["start"], binding["applicable_checkpoint_range"]["end"])
+            for checkpoint in checkpoints:
+                for page, row in targets:
+                    charge = (checkpoint, layout, page, row)
+                    if charge not in state.target_charges:
+                        state.target_charges.add(charge)
+                        state.work["h1_target_validity_checks"] += 1
+                    blob = state.read(checkpoint, page, qualify=True)
+                    if blob is None or blob[0] != 1 or row >= int.from_bytes(blob[8:10], "little"):
+                        valid = False
+                        break
+                if not valid:
+                    break
+            if not valid:
+                break
+        if valid:
+            output.append(dict(candidate))
+    return output
+
+
+def _layout_candidates(candidates: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for candidate in candidates:
+        key = (candidate["model"]["layout"], candidate["model"]["table_signature_id"])
+        grouped.setdefault(key, candidate)
+    output = []
+    for (layout, signature), source in grouped.items():
+        output.append(_candidate("h1_target_valid_layout", {
+            "layout": layout, "table_signature_id": signature,
+        }, source["instance_bindings"]))
+    return sorted(output, key=lambda row: row["canonical_candidate_id"])
+
+
+def _predicate_row(contract: Mapping[str, Any], status: str, measured: int, survivor: int, terminal: str | None) -> dict[str, Any]:
+    return {
+        "predicate_id": contract["predicate_id"],
+        "order": contract["order"],
+        "scope": contract["scope"],
+        "status": status,
+        "terminal_predicate_id": terminal,
+        "predicate_measured_survivor_count": measured,
+        "derivation_survivor_count": survivor,
+        "reachability_fixture_id": contract["reachability_fixture_id"],
+    }
+
+
+def _layer(status: str, candidates: Sequence[Mapping[str, Any]], measured: int, terminal: str | None, kind: str | None, stage: str | None, evidence: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    rows = sorted((dict(value) for value in candidates), key=lambda row: row["canonical_candidate_id"])
+    return {
+        "status": status,
+        "predicate_measured_survivor_count": measured,
+        "derivation_survivor_count": 1 if status == "model" else 0,
+        "terminal_predicate_id": terminal,
+        "terminal_payload_kind": kind,
+        "terminal_candidate_stage": stage,
+        "candidates": rows,
+        "terminal_evidence": None if evidence is None else dict(evidence),
+        "canonical_candidates_sha256": _sha(rows),
+    }
+
+
+def recompute_h1(
+    replicas: Mapping[int, object] | Sequence[object],
+    *,
+    plan: Mapping[str, Any],
+    predicate_contracts: Mapping[str, Mapping[str, Any]] | Sequence[Mapping[str, Any]],
+    derivation_replica_numbers: Sequence[int] = (1, 2),
+) -> H1Recomputation:
+    """Recompute H1 with registered predicate-major cutoff and work accounting."""
+    try:
+        predicate_ids = tuple(
+            plan["predicate_registry"]["per_layer_ordered_predicates"][
+                "h1_tdef_to_map_row"
+            ]
+        )
+    except (KeyError, TypeError) as exc:
+        raise ValidationError("independent_h1_predicate_contract") from exc
+    contracts = _contracts(predicate_contracts, predicate_ids)
+    numbers = tuple(derivation_replica_numbers)
+    if numbers != (1, 2):
+        raise ValidationError("independent_h1_derivation_replicas")
+    source = _replicas(replicas, numbers)
+    checkpoints = tuple(plan["checkpoint_design"]["checkpoint_ids"])
+    bounds = plan["bounds"]
+    if (
+        len(checkpoints) != 25
+        or bounds["page_size"] != 2048
+        or bounds["max_final_pages_per_replica"] != 20480
+        or bounds["max_candidate_models"] != 4096
+    ):
+        raise ValidationError("independent_h1_plan_bounds")
+    page_limit = int(bounds["max_final_pages_per_replica"])
+    max_candidates = int(bounds["max_candidate_models"])
+    instances, schema_legs = _schedule(plan)
+    states = {number: _ReplicaState(source[number], number, checkpoints, 2048) for number in numbers}
+    tdefs: dict[int, list[dict[str, Any]]] = {}
+    predicates: list[dict[str, Any]] = []
+
+    for number in numbers:
+        tdefs[number] = _tdef_stage(
+            states[number], plan, page_limit, max_candidates, instances, schema_legs
+        )
+        if not tdefs[number]:
+            predicate = predicate_ids[0]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 0, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 0, predicate, "candidate_set", "h1_tdef"), predicates, tdefs)
+    predicates.append(_predicate_row(contracts[predicate_ids[0]], "pass", min(len(v) for v in tdefs.values()), 1, None))
+    for number in numbers:
+        if len(tdefs[number]) > 1:
+            predicate = predicate_ids[1]
+            predicates.append(_predicate_row(contracts[predicate], "fail", len(tdefs[number]), 0, predicate))
+            return _finish(states, _layer("no_outcome", tdefs[number], len(tdefs[number]), predicate, "candidate_set", "h1_tdef"), predicates, tdefs)
+    predicates.append(_predicate_row(contracts[predicate_ids[1]], "pass", 1, 1, None))
+
+    windows: dict[int, dict[str, dict[int, tuple[int, ...]]]] = {}
+    for number in numbers:
+        windows[number] = _window_stage(states[number], tdefs[number][0], plan, page_limit)
+        layouts = sum(
+            any(values for values in windows[number][layout].values())
+            for layout in windows[number]
+        )
+        if layouts == 0:
+            predicate = predicate_ids[2]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 0, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 0, predicate, "candidate_set", "h1_target_valid_layout"), predicates, tdefs)
+    predicates.append(_predicate_row(
+        contracts[predicate_ids[2]],
+        "pass",
+        min(
+            sum(
+                any(values for values in windows[number][layout].values())
+                for layout in windows[number]
+            )
+            for number in numbers
+        ),
+        1,
+        None,
+    ))
+
+    structural: dict[int, list[dict[str, Any]]] = {}
+    for number in numbers:
+        structural[number] = _structural_stage(states[number], tdefs[number][0], windows[number], plan)
+        if not structural[number]:
+            predicate = predicate_ids[3]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 0, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 0, predicate, "candidate_set", "h1_locator_pair"), predicates, structural)
+    predicates.append(_predicate_row(contracts[predicate_ids[3]], "pass", min(len(v) for v in structural.values()), 1, None))
+
+    targets: dict[int, list[dict[str, Any]]] = {}
+    for number in numbers:
+        targets[number] = _target_stage(states[number], structural[number])
+        if not targets[number]:
+            predicate = predicate_ids[4]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 0, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 0, predicate, "candidate_set", "h1_locator_pair"), predicates, targets)
+    predicates.append(_predicate_row(contracts[predicate_ids[4]], "pass", min(len(v) for v in targets.values()), 1, None))
+
+    layouts = {number: _layout_candidates(targets[number]) for number in numbers}
+    for number in numbers:
+        unique_layouts = {row["model"]["layout"] for row in layouts[number]}
+        if len(unique_layouts) > 1:
+            predicate = predicate_ids[5]
+            candidates = layouts[number]
+            predicates.append(_predicate_row(contracts[predicate], "fail", len(unique_layouts), 0, predicate))
+            return _finish(states, _layer("no_outcome", candidates, len(unique_layouts), predicate, "candidate_set", "h1_target_valid_layout"), predicates, layouts)
+    predicates.append(_predicate_row(contracts[predicate_ids[5]], "pass", 1, 1, None))
+    for number in numbers:
+        if len(targets[number]) > 1:
+            predicate = predicate_ids[6]
+            predicates.append(_predicate_row(contracts[predicate], "fail", len(targets[number]), 0, predicate))
+            return _finish(states, _layer("no_outcome", targets[number], len(targets[number]), predicate, "candidate_set", "h1_locator_pair"), predicates, targets)
+    predicates.append(_predicate_row(contracts[predicate_ids[6]], "pass", 1, 1, None))
+
+    left, right = targets[1][0], targets[2][0]
+    if left["canonical_model_id"] != right["canonical_model_id"]:
+        predicate = predicate_ids[7]
+        evidence = {"kind": "replica_pair", "entries": [
+            {"replica": number, "canonical_model_id": targets[number][0]["canonical_model_id"], "canonical_candidate_id": targets[number][0]["canonical_candidate_id"], "complete_candidate": targets[number][0]}
+            for number in numbers
+        ]}
+        predicates.append(_predicate_row(contracts[predicate], "fail", 2, 0, predicate))
+        return _finish(states, _layer("no_outcome", [], 2, predicate, "replica_pair", "h1_locator_pair", evidence), predicates, targets)
+    predicates.append(_predicate_row(contracts[predicate_ids[7]], "pass", 1, 1, None))
+    merged_bindings = [binding for number in numbers for binding in targets[number][0]["instance_bindings"]]
+    final = _candidate("h1_locator_pair", left["model"], merged_bindings)
+    return _finish(
+        states,
+        _layer("model", [final], 1, None, None, None),
+        predicates,
+        targets,
+    )
+
+
+def apply_h1_holdout(
+    replica3: object,
+    frozen_h1_result: Mapping[str, Any],
+    *,
+    plan: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Apply the frozen H1 model to replica 3 without selecting a new model."""
+    layer = frozen_h1_result.get("layer", frozen_h1_result)
+    candidates = layer.get("candidates") if isinstance(layer, Mapping) else None
+    if (
+        not isinstance(candidates, list)
+        or len(candidates) != 1
+        or candidates[0].get("model_type") != "h1_locator_pair"
+    ):
+        raise ValidationError("independent_h1_holdout_frozen_model")
+    frozen = candidates[0]
+    checkpoints = tuple(plan["checkpoint_design"]["checkpoint_ids"])
+    bounds = plan["bounds"]
+    state = _ReplicaState(replica3, 3, checkpoints, bounds["page_size"])
+    instances, schema_legs = _schedule(plan)
+    tdefs = _tdef_stage(
+        state,
+        plan,
+        bounds["max_final_pages_per_replica"],
+        bounds["max_candidate_models"],
+        instances,
+        schema_legs,
+    )
+    matches: list[dict[str, Any]] = []
+    for tdef in tdefs:
+        windows = _window_stage(
+            state, tdef, plan, bounds["max_final_pages_per_replica"]
+        )
+        structural = _structural_stage(state, tdef, windows, plan)
+        for candidate in _target_stage(state, structural):
+            if candidate["model"] == frozen["model"]:
+                matches.append(candidate)
+                if len(matches) > 1:
+                    return None
+    return matches[0] if len(matches) == 1 else None
+
+
+def predict_h1_holdout(
+    replica3: object,
+    frozen_h1_result: Mapping[str, Any],
+    *,
+    plan: Mapping[str, Any],
+) -> bool:
+    """Return whether replica 3 uniquely satisfies the unchanged H1 model."""
+    return apply_h1_holdout(replica3, frozen_h1_result, plan=plan) is not None
+
+
+def _finish(states: Mapping[int, _ReplicaState], layer: Mapping[str, Any], predicates: Sequence[Mapping[str, Any]], candidates: Mapping[int, Sequence[Mapping[str, Any]]]) -> H1Recomputation:
+    qualified = sorted({identity for state in states.values() for identity in state.qualified}, key=lambda row: (row[0], states[row[0]].checkpoints.index(row[1]), row[2]))
+    work = {name: sum(state.work[name] for state in states.values()) for name in next(iter(states.values())).work}
+    return H1Recomputation(
+        dict(layer), tuple(dict(row) for row in predicates),
+        tuple({"replica": replica, "checkpoint_id": checkpoint, "page_number": page} for replica, checkpoint, page in qualified),
+        work,
+        {number: tuple(dict(row) for row in candidates.get(number, ())) for number in states},
+    )

--- a/oracle/windows-dao/scripts/a4_independent_h2.py
+++ b/oracle/windows-dao/scripts/a4_independent_h2.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""Fresh plan-derived A4 H2 recomputation over H1-located page rows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from protocol_validation import ValidationError as ProtocolValidationError
+
+
+class ValidationError(ProtocolValidationError):
+    """A stable independent-validator rejection."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class H2Recomputation:
+    layer: Mapping[str, Any]
+    predicate_results: tuple[Mapping[str, Any], ...]
+    qualified_pages: tuple[Mapping[str, Any], ...]
+    work_charges: Mapping[str, int]
+    per_replica_candidates: Mapping[int, tuple[Mapping[str, Any], ...]]
+
+
+@dataclass(frozen=True)
+class _Located:
+    replica: int
+    role: str
+    instance: str
+    checkpoint: str
+    ordinal: int
+    page: int
+    slot: int
+    raw_entry: int
+    rows: Mapping[int, bytes]
+    bounds: Mapping[int, tuple[int, int]]
+
+
+class _State:
+    def __init__(self, replica: object, number: int, checkpoints: Sequence[str], page_size: int):
+        self.replica = replica
+        self.number = number
+        self.checkpoints = tuple(checkpoints)
+        self.page_size = page_size
+        self.cache: dict[tuple[str, int], bytes | None] = {}
+        self.qualified: set[tuple[int, str, int]] = set()
+        self.work = {
+            "valid_path_row_directory_entries": 0,
+            "invalid_path_row_directory_entries": 0,
+            "type_1_slots": 0,
+            "type_0_and_tag_05_bitmap_bits": 0,
+            "role_transition_evaluations": 0,
+        }
+        self.row_work: set[tuple[str, int, int, int]] = set()
+
+    def read(self, checkpoint: str, page: int) -> bytes | None:
+        key = (checkpoint, page)
+        if key not in self.cache:
+            try:
+                value = self.replica.page(checkpoint, page)
+            except (AttributeError, KeyError, OSError, TypeError, ValueError) as exc:
+                raise ValidationError("independent_h2_page_read") from exc
+            if value is not None and (
+                not isinstance(value, bytes) or len(value) != self.page_size
+            ):
+                raise ValidationError("independent_h2_page_size")
+            self.cache[key] = value
+        value = self.cache[key]
+        if value is not None:
+            self.qualified.add((self.number, checkpoint, page))
+        return value
+
+    def page_count(self, checkpoint: str, limit: int) -> int:
+        try:
+            index = self.replica.index(checkpoint)
+            value = index["page_count"]
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            raise ValidationError("independent_h2_page_count") from exc
+        if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= limit:
+            raise ValidationError("independent_h2_page_count")
+        return value
+
+
+def _sha(value: Any) -> str:
+    try:
+        raw = json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError, RecursionError) as exc:
+        raise ValidationError("independent_h2_canonicalization") from exc
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _candidate(model: Mapping[str, Any]) -> dict[str, Any]:
+    core = {"model_type": "h2_final_role", "model": dict(model)}
+    return {"model_type": "h2_final_role", "canonical_candidate_id": _sha(core), "model": dict(model)}
+
+
+def _contracts(values: Mapping[str, Mapping[str, Any]] | Sequence[Mapping[str, Any]], predicate_ids: Sequence[str]) -> dict[str, Mapping[str, Any]]:
+    if isinstance(values, Mapping):
+        rows = dict(values)
+    else:
+        if len(values) > 64:
+            raise ValidationError("independent_h2_contract_bound")
+        rows = {str(row.get("predicate_id")): row for row in values}
+    if len(predicate_ids) != 7 or any(predicate not in rows for predicate in predicate_ids):
+        raise ValidationError("independent_h2_contract_missing")
+    return rows
+
+
+def _sources(values: Mapping[int, object] | Sequence[object]) -> dict[int, object]:
+    if isinstance(values, Mapping):
+        output = {number: values[number] for number in (1, 2) if number in values}
+    else:
+        if len(values) > 3:
+            raise ValidationError("independent_h2_replica_bound")
+        output = {int(getattr(value, "number")): value for value in values}
+    if tuple(sorted(output)) != (1, 2):
+        raise ValidationError("independent_h2_replicas")
+    return output
+
+
+def _h1_candidate(h1: object) -> Mapping[str, Any]:
+    layer = h1.get("layer", h1) if isinstance(h1, Mapping) else getattr(h1, "layer", None)
+    if not isinstance(layer, Mapping) or layer.get("status") != "model":
+        raise ValidationError("independent_h2_h1_not_model")
+    candidates = layer.get("candidates")
+    if not isinstance(candidates, list) or len(candidates) != 1:
+        raise ValidationError("independent_h2_h1_cardinality")
+    candidate = candidates[0]
+    if not isinstance(candidate, Mapping) or candidate.get("model_type") != "h1_locator_pair":
+        raise ValidationError("independent_h2_h1_candidate")
+    return candidate
+
+
+def _per_replica_h1(
+    h1: object, merged: Mapping[str, Any]
+) -> dict[int, Mapping[str, Any]]:
+    supplied = (
+        h1.get("per_replica_candidates")
+        if isinstance(h1, Mapping)
+        else getattr(h1, "per_replica_candidates", None)
+    )
+    output: dict[int, Mapping[str, Any]] = {}
+    for replica in (1, 2):
+        if isinstance(supplied, Mapping):
+            rows = supplied.get(replica)
+            if isinstance(rows, (list, tuple)) and len(rows) == 1:
+                output[replica] = rows[0]
+                continue
+        bindings = [
+            dict(row)
+            for row in merged["instance_bindings"]
+            if row.get("replica") == replica
+        ]
+        if len(bindings) != 5:
+            raise ValidationError("independent_h2_h1_replica_bindings")
+        core = {
+            "model_type": "h1_locator_pair",
+            "model": dict(merged["model"]),
+        }
+        output[replica] = {
+            **core,
+            "canonical_model_id": _sha(core),
+            "canonical_candidate_id": _sha(
+                {**core, "instance_bindings": bindings}
+            ),
+            "instance_bindings": bindings,
+        }
+    for replica, candidate in output.items():
+        if (
+            candidate.get("model") != merged.get("model")
+            or {row.get("replica") for row in candidate["instance_bindings"]}
+            != {replica}
+        ):
+            raise ValidationError("independent_h2_h1_replica_bindings")
+    return output
+
+
+def _applicable(checkpoints: Sequence[str], bounds: Mapping[str, Any]) -> tuple[str, ...]:
+    try:
+        left = checkpoints.index(bounds["start"])
+        right = checkpoints.index(bounds["end"])
+    except (KeyError, ValueError, TypeError) as exc:
+        raise ValidationError("independent_h2_lifecycle_range") from exc
+    if left > right:
+        raise ValidationError("independent_h2_lifecycle_range")
+    return tuple(checkpoints[left : right + 1])
+
+
+def _directory(blob: bytes, mask: int) -> tuple[tuple[tuple[int, int], ...] | None, tuple[int, int, str] | None, int]:
+    row_count = int.from_bytes(blob[8:10], "little")
+    directory_end = 10 + 2 * row_count
+    if row_count > 1019 or directory_end > len(blob):
+        return None, (0, 0, "row_count_exceeds_capacity"), row_count
+    starts = [int.from_bytes(blob[10 + 2 * slot : 12 + 2 * slot], "little") & mask for slot in range(row_count)]
+    bounds: list[tuple[int, int]] = []
+    prior = len(blob)
+    for slot, start in enumerate(starts):
+        reason = None
+        if start < directory_end:
+            reason = "start_below_directory_end"
+        elif start >= prior:
+            reason = (
+                "start_not_below_end" if slot == 0 else "overlap_in_directory_order"
+            )
+        elif prior > len(blob):
+            reason = "end_above_page"
+        elif slot and start >= starts[slot - 1]:
+            reason = "overlap_in_directory_order"
+        if reason is not None:
+            raw = int.from_bytes(blob[10 + 2 * slot : 12 + 2 * slot], "little")
+            return None, (slot, raw, reason), row_count
+        bounds.append((start, prior))
+        prior = start
+    return tuple(bounds), None, row_count
+
+
+def _invalid_directory_evidence(input_id: str, state: _State, checkpoint: str, page: int, blob: bytes, slot: int, raw: int, reason: str) -> dict[str, Any]:
+    return {
+        "kind": "row_directory", "input_model_id": input_id,
+        "observation": {
+            "replica": state.number, "checkpoint_id": checkpoint, "page": page,
+            "row_count": min(int.from_bytes(blob[8:10], "little"), 1019), "slot": min(slot, 255),
+            "raw_entry_u16le": raw, "masked_start_8191": raw & 8191,
+            "masked_start_4095": raw & 4095, "reason": reason,
+        },
+    }
+
+
+def _directory_stage(
+    state: _State,
+    h1: Mapping[str, Any],
+    masks: Sequence[int],
+    role_order: Mapping[str, int],
+) -> tuple[list[_Located], tuple[int, ...], Mapping[str, Any] | None]:
+    bindings = [row for row in h1["instance_bindings"] if row["replica"] == state.number]
+    bindings.sort(key=lambda row: (role_order[row["logical_role"]], row["lifecycle_instance"]))
+    located: list[_Located] = []
+    page_results: dict[tuple[str, int], dict[int, tuple[tuple[int, int], ...] | None]] = {}
+    entries_seen = 0
+    for binding in bindings:
+        for checkpoint in _applicable(state.checkpoints, binding["applicable_checkpoint_range"]):
+            for ordinal, target in enumerate(binding["locator_targets"]):
+                page, slot = target["page"], target["row"]
+                blob = state.read(checkpoint, page)
+                if blob is None or blob[0] != 1:
+                    raise ValidationError("independent_h2_h1_target_changed")
+                key = (checkpoint, page)
+                if key not in page_results:
+                    page_results[key] = {}
+                    first_failure = None
+                    row_count = int.from_bytes(blob[8:10], "little")
+                    if row_count <= 1019:
+                        entries_seen += row_count
+                    for mask in masks:
+                        bounds, failure, _ = _directory(blob, mask)
+                        page_results[key][mask] = bounds
+                        if first_failure is None and failure is not None:
+                            first_failure = failure
+                    valid = [mask for mask in masks if page_results[key][mask] is not None]
+                    if not valid:
+                        state.work["invalid_path_row_directory_entries"] = entries_seen
+                        assert first_failure is not None
+                        return [], (), _invalid_directory_evidence(
+                            h1["canonical_candidate_id"],
+                            state,
+                            checkpoint,
+                            page,
+                            blob,
+                            *first_failure,
+                        )
+                valid_rows: dict[int, bytes] = {}
+                valid_bounds: dict[int, tuple[int, int]] = {}
+                raw_entry = int.from_bytes(blob[10 + 2 * slot : 12 + 2 * slot], "little")
+                for mask in masks:
+                    bounds = page_results[key][mask]
+                    if bounds is not None:
+                        if slot >= len(bounds):
+                            raise ValidationError("independent_h2_slot_range")
+                        start, end = bounds[slot]
+                        valid_rows[mask] = blob[start:end]
+                        valid_bounds[mask] = (start, end)
+                located.append(_Located(state.number, binding["logical_role"], binding["lifecycle_instance"], checkpoint, ordinal, page, slot, raw_entry, valid_rows, valid_bounds))
+    state.work["valid_path_row_directory_entries"] = entries_seen
+    surviving = [mask for mask in masks if all(mask in row.rows for row in located)]
+    representatives: list[int] = []
+    fingerprints: set[tuple[tuple[int, int], ...]] = set()
+    for mask in surviving:
+        fingerprint = tuple(row.bounds[mask] for row in located)
+        if fingerprint not in fingerprints:
+            fingerprints.add(fingerprint)
+            representatives.append(mask)
+    return located, tuple(representatives), None
+
+
+def _flags_evidence(input_id: str, row: _Located) -> dict[str, Any]:
+    return {
+        "kind": "row_flags", "input_model_id": input_id,
+        "observation": {
+            "replica": row.replica, "checkpoint_id": row.checkpoint, "page": row.page,
+            "slot": row.slot, "raw_entry_u16le": row.raw_entry,
+            "deleted_flag_0x8000": bool(row.raw_entry & 0x8000),
+            "overflow_flag_0x4000": bool(row.raw_entry & 0x4000),
+        },
+    }
+
+
+def _tag_evidence(input_id: str, row: _Located, mask: int, reason: str) -> dict[str, Any]:
+    start, end = row.bounds[mask]
+    payload = row.rows[mask]
+    return {
+        "kind": "map_tag", "input_model_id": input_id,
+        "observation": {
+            "replica": row.replica, "checkpoint_id": row.checkpoint, "page": row.page,
+            "slot": row.slot, "row_start": start, "row_end": end,
+            "tag_byte": payload[0] if payload else 255, "reason": reason,
+        },
+    }
+
+
+def _supported_masks(located: Sequence[_Located], masks: Sequence[int], input_id: str) -> tuple[tuple[int, ...], Mapping[str, Any] | None]:
+    output = []
+    first = None
+    for mask in masks:
+        valid = True
+        for row in located:
+            payload = row.rows[mask]
+            reason = None
+            if not payload or payload[0] not in (0, 1):
+                reason = "unsupported_tag"
+            elif payload[0] == 1 and (len(payload) - 1) % 4:
+                reason = "type_1_payload_not_u32_multiple"
+            if reason:
+                valid = False
+                if first is None:
+                    first = _tag_evidence(input_id, row, mask, reason)
+                break
+        if valid:
+            output.append(mask)
+    return tuple(output), first
+
+
+def _decode(state: _State, row: _Located, mask: int, polarity: str) -> set[int] | None:
+    payload = row.rows[mask]
+    key = (row.checkpoint, row.page, row.bounds[mask][0], row.bounds[mask][1])
+    if payload[0] == 1:
+        if key not in state.row_work:
+            state.row_work.add(key)
+            state.work["type_1_slots"] += (len(payload) - 1) // 4
+        return None
+    if len(payload) < 5:
+        return set()
+    if key not in state.row_work:
+        state.row_work.add(key)
+        state.work["type_0_and_tag_05_bitmap_bits"] += (len(payload) - 5) * 8
+    base = int.from_bytes(payload[1:5], "little")
+    owned_when_set = polarity == "set_bit_owned_in_use"
+    return {
+        base + byte_index * 8 + bit
+        for byte_index, value in enumerate(payload[5:])
+        for bit in range(8)
+        if bool(value & (1 << bit)) == owned_when_set
+    }
+
+
+def _row_counts(values: Mapping[int, Mapping[str, Mapping[str, int]]], replica: int, checkpoint: str, role: str) -> int:
+    try:
+        value = values[replica][checkpoint][role]
+    except (KeyError, TypeError) as exc:
+        raise ValidationError("independent_h2_snapshot_row_count") from exc
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 200000:
+        raise ValidationError("independent_h2_snapshot_row_count")
+    return value
+
+
+def _static_candidates(state: _State, located: Sequence[_Located], masks: Sequence[int], plan: Mapping[str, Any], row_counts: Mapping[int, Mapping[str, Mapping[str, int]]], page_limit: int) -> tuple[list[dict[str, Any]], dict[str, dict[tuple[str, str, int], set[int] | None]]]:
+    grammar = plan["candidate_grammars"]["h2"]
+    output = []
+    decoded_by_id: dict[str, dict[tuple[str, str, int], set[int] | None]] = {}
+    for mask in masks:
+        for polarity in grammar["type_0_polarities"]:
+            decoded = {(row.instance, row.checkpoint, row.ordinal): _decode(state, row, mask, polarity) for row in located}
+            for assignment in grammar["locator_role_assignments"]:
+                owned_ordinal = 0 if assignment.startswith("ordinal_0") else 1
+                available_ordinal = 1 - owned_ordinal
+                fits = True
+                grouped = sorted({(row.instance, row.checkpoint, row.role) for row in located})
+                for instance, checkpoint, role in grouped:
+                    owned = decoded[(instance, checkpoint, owned_ordinal)]
+                    available = decoded[(instance, checkpoint, available_ordinal)]
+                    if owned is None or available is None:
+                        continue
+                    page_count = state.page_count(checkpoint, page_limit)
+                    if any(page >= page_count for page in owned | available) or not available <= owned:
+                        fits = False
+                        break
+                    if _row_counts(row_counts, state.number, checkpoint, role) > 0 and not owned:
+                        fits = False
+                        break
+                if fits:
+                    candidate = _candidate({
+                        "row_mask": mask, "polarity": polarity,
+                        "owned_in_use_locator_ordinal": owned_ordinal,
+                        "available_locator_ordinal": available_ordinal,
+                    })
+                    output.append(candidate)
+                    decoded_by_id[candidate["canonical_candidate_id"]] = decoded
+    output.sort(key=lambda row: row["canonical_candidate_id"])
+    return output, decoded_by_id
+
+
+def _transition_ok(state: _State, candidate: Mapping[str, Any], decoded: Mapping[tuple[str, str, int], set[int] | None], located: Sequence[_Located], plan: Mapping[str, Any]) -> bool:
+    owned_ordinal = candidate["model"]["owned_in_use_locator_ordinal"]
+    available_ordinal = 1 - owned_ordinal
+    by_instance = {row.role: row.instance for row in located}
+
+    def sets(role: str, checkpoint: str) -> tuple[set[int] | None, set[int] | None]:
+        instance = by_instance.get(role)
+        if instance is None:
+            return None, None
+        return decoded.get((instance, checkpoint, owned_ordinal)), decoded.get((instance, checkpoint, available_ordinal))
+
+    coverage = plan["checkpoint_design"]["transition_coverage"]
+    transition_kinds = tuple(plan["candidate_grammars"]["h2"]["transition_signature"])
+    roles = tuple(plan["candidate_grammars"]["h1"]["logical_roles"])
+    state.work["role_transition_evaluations"] += (
+        len(transition_kinds) * len(roles) * len(state.checkpoints)
+    )
+    growth_keys = tuple(
+        key
+        for key in coverage
+        if key.endswith(("_growth", "_absolute", "_relative"))
+    )
+    if len(growth_keys) != 3:
+        raise ValidationError("independent_h2_transition_contract")
+    for key in growth_keys:
+        role = key.split("_", 1)[0].upper()
+        sequence = tuple(coverage[key])
+        for left, right in zip(sequence, sequence[1:]):
+            old_owned, old_available = sets(role, left)
+            new_owned, new_available = sets(role, right)
+            if None in (old_owned, old_available, new_owned, new_available):
+                continue
+            assert old_owned is not None and old_available is not None and new_owned is not None and new_available is not None
+            gained = new_owned - old_owned
+            if not old_owned <= new_owned or gained & (new_available - old_available):
+                return False
+    churn_keys = tuple(key for key in coverage if key.endswith("_churn"))
+    if len(churn_keys) != 1:
+        raise ValidationError("independent_h2_transition_contract")
+    churn = tuple(coverage[churn_keys[0]])
+    if len(churn) != 4:
+        raise ValidationError("independent_h2_transition_contract")
+    churn_role = churn_keys[0].split("_", 1)[0].upper()
+    for left, right, kind in ((churn[0], churn[1], "delete"), (churn[1], churn[2], "reinsert")):
+        old_owned, old_available = sets(churn_role, left)
+        new_owned, new_available = sets(churn_role, right)
+        if None in (old_owned, old_available, new_owned, new_available):
+            continue
+        assert old_owned is not None and old_available is not None and new_owned is not None and new_available is not None
+        if kind == "delete" and (not new_owned <= old_owned or not old_available <= new_available):
+            return False
+        if kind == "reinsert" and (not old_owned <= new_owned or not new_available <= old_available):
+            return False
+    payloads = {(row.role, row.checkpoint, row.ordinal): row.rows[candidate["model"]["row_mask"]] for row in located}
+    for left, right in plan["checkpoint_design"]["idle_pairs"]:
+        for role in plan["candidate_grammars"]["h1"]["logical_roles"]:
+            for ordinal in (0, 1):
+                old = payloads.get((role, left, ordinal))
+                new = payloads.get((role, right, ordinal))
+                if old is None and new is None:
+                    continue
+                if old != new:
+                    return False
+    return True
+
+
+def _predicate_row(contract: Mapping[str, Any], status: str, measured: int, survivor: int, terminal: str | None) -> dict[str, Any]:
+    return {
+        "predicate_id": contract["predicate_id"], "order": contract["order"],
+        "scope": contract["scope"], "status": status, "terminal_predicate_id": terminal,
+        "predicate_measured_survivor_count": measured, "derivation_survivor_count": survivor,
+        "reachability_fixture_id": contract["reachability_fixture_id"],
+    }
+
+
+def _layer(status: str, candidates: Sequence[Mapping[str, Any]], measured: int, terminal: str | None, kind: str | None, evidence: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    rows = sorted((dict(row) for row in candidates), key=lambda row: row["canonical_candidate_id"])
+    return {
+        "status": status, "predicate_measured_survivor_count": measured,
+        "derivation_survivor_count": 1 if status == "model" else 0,
+        "terminal_predicate_id": terminal, "terminal_payload_kind": kind,
+        "terminal_candidate_stage": "h2_final_role" if kind in ("candidate_set", "replica_pair") else None,
+        "candidates": rows, "terminal_evidence": None if evidence is None else dict(evidence),
+        "canonical_candidates_sha256": _sha(rows),
+    }
+
+
+def recompute_h2(
+    replicas: Mapping[int, object] | Sequence[object],
+    h1: object,
+    *,
+    plan: Mapping[str, Any],
+    predicate_contracts: Mapping[str, Mapping[str, Any]] | Sequence[Mapping[str, Any]],
+    snapshot_row_counts: Mapping[int, Mapping[str, Mapping[str, int]]],
+    derivation_replica_numbers: Sequence[int] = (1, 2),
+) -> H2Recomputation:
+    """Recompute H2 without consulting analyzer models or expected results."""
+    if tuple(derivation_replica_numbers) != (1, 2):
+        raise ValidationError("independent_h2_derivation_replicas")
+    try:
+        predicate_ids = tuple(
+            plan["predicate_registry"]["per_layer_ordered_predicates"][
+                "h2_row_identity_map_role"
+            ]
+        )
+    except (KeyError, TypeError) as exc:
+        raise ValidationError("independent_h2_predicate_contract") from exc
+    contracts = _contracts(predicate_contracts, predicate_ids)
+    source = _sources(replicas)
+    h1_candidate = _h1_candidate(h1)
+    h1_by_replica = _per_replica_h1(h1, h1_candidate)
+    checkpoints = tuple(plan["checkpoint_design"]["checkpoint_ids"])
+    bounds = plan["bounds"]
+    if (
+        len(checkpoints) != 25
+        or bounds["page_size"] != 2048
+        or bounds["max_final_pages_per_replica"] != 20480
+        or bounds["max_candidate_models"] != 4096
+    ):
+        raise ValidationError("independent_h2_plan_bounds")
+    states = {number: _State(source[number], number, checkpoints, 2048) for number in (1, 2)}
+    masks = tuple(plan["candidate_grammars"]["h2"]["row_masks"])
+    roles = tuple(plan["candidate_grammars"]["h1"]["logical_roles"])
+    if len(roles) != 4 or len(set(roles)) != 4:
+        raise ValidationError("independent_h2_role_contract")
+    role_order = {role: index for index, role in enumerate(roles)}
+    located: dict[int, list[_Located]] = {}
+    valid_masks: dict[int, tuple[int, ...]] = {}
+    predicates: list[dict[str, Any]] = []
+
+    for number in (1, 2):
+        located[number], valid_masks[number], evidence = _directory_stage(
+            states[number], h1_by_replica[number], masks, role_order
+        )
+        if evidence is not None:
+            for state in states.values():
+                state.work["invalid_path_row_directory_entries"] += state.work[
+                    "valid_path_row_directory_entries"
+                ]
+                state.work["valid_path_row_directory_entries"] = 0
+            predicate = predicate_ids[0]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 1, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 1, predicate, "invalid_observation", evidence), predicates, {})
+    predicates.append(_predicate_row(contracts[predicate_ids[0]], "pass", 1, 1, None))
+
+    for number in (1, 2):
+        flagged = next((row for row in located[number] if row.raw_entry & 0xC000), None)
+        if flagged is not None:
+            predicate = predicate_ids[1]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 1, 0, predicate))
+            evidence = _flags_evidence(
+                h1_by_replica[number]["canonical_candidate_id"], flagged
+            )
+            return _finish(states, _layer("no_outcome", [], 1, predicate, "invalid_observation", evidence), predicates, {})
+    predicates.append(_predicate_row(contracts[predicate_ids[1]], "pass", 1, 1, None))
+
+    supported: dict[int, tuple[int, ...]] = {}
+    for number in (1, 2):
+        supported[number], evidence = _supported_masks(
+            located[number],
+            valid_masks[number],
+            h1_by_replica[number]["canonical_candidate_id"],
+        )
+        if not supported[number]:
+            predicate = predicate_ids[2]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 1, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 1, predicate, "invalid_observation", evidence), predicates, {})
+    predicates.append(_predicate_row(contracts[predicate_ids[2]], "pass", 1, 1, None))
+
+    candidates: dict[int, list[dict[str, Any]]] = {}
+    decoded: dict[int, dict[str, dict[tuple[str, str, int], set[int] | None]]] = {}
+    for number in (1, 2):
+        candidates[number], decoded[number] = _static_candidates(states[number], located[number], supported[number], plan, snapshot_row_counts, bounds["max_final_pages_per_replica"])
+        if not candidates[number]:
+            predicate = predicate_ids[3]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 0, 0, predicate))
+            return _finish(states, _layer("no_outcome", [], 0, predicate, "candidate_set"), predicates, candidates)
+    predicates.append(_predicate_row(contracts[predicate_ids[3]], "pass", min(len(rows) for rows in candidates.values()), 1, None))
+    for number in (1, 2):
+        if len(candidates[number]) > 1:
+            predicate = predicate_ids[4]
+            predicates.append(_predicate_row(contracts[predicate], "fail", len(candidates[number]), 0, predicate))
+            return _finish(states, _layer("no_outcome", candidates[number], len(candidates[number]), predicate, "candidate_set"), predicates, candidates)
+    predicates.append(_predicate_row(contracts[predicate_ids[4]], "pass", 1, 1, None))
+
+    for number in (1, 2):
+        candidate = candidates[number][0]
+        if not _transition_ok(states[number], candidate, decoded[number][candidate["canonical_candidate_id"]], located[number], plan):
+            predicate = predicate_ids[5]
+            predicates.append(_predicate_row(contracts[predicate], "fail", 1, 0, predicate))
+            return _finish(states, _layer("no_outcome", [candidate], 1, predicate, "candidate_set"), predicates, candidates)
+    predicates.append(_predicate_row(contracts[predicate_ids[5]], "pass", 1, 1, None))
+
+    if candidates[1][0]["canonical_candidate_id"] != candidates[2][0]["canonical_candidate_id"]:
+        predicate = predicate_ids[6]
+        evidence = {"kind": "replica_pair", "entries": [
+            {"replica": number, "canonical_model_id": candidates[number][0]["canonical_candidate_id"], "canonical_candidate_id": candidates[number][0]["canonical_candidate_id"], "complete_candidate": candidates[number][0]}
+            for number in (1, 2)
+        ]}
+        predicates.append(_predicate_row(contracts[predicate], "fail", 2, 0, predicate))
+        return _finish(states, _layer("no_outcome", [], 2, predicate, "replica_pair", evidence), predicates, candidates)
+    predicates.append(_predicate_row(contracts[predicate_ids[6]], "pass", 1, 1, None))
+    final = candidates[1][0]
+    return _finish(states, _layer("model", [final], 1, None, None), predicates, {1: [final], 2: [final]})
+
+
+def _frozen_candidate(value: Mapping[str, Any], model_type: str) -> Mapping[str, Any]:
+    if value.get("model_type") == model_type:
+        return value
+    layer = value.get("layer", value)
+    candidates = layer.get("candidates") if isinstance(layer, Mapping) else None
+    if (
+        not isinstance(candidates, list)
+        or len(candidates) != 1
+        or candidates[0].get("model_type") != model_type
+    ):
+        raise ValidationError("independent_h2_holdout_frozen_model")
+    return candidates[0]
+
+
+def _frozen_static_ok(
+    state: _State,
+    located: Sequence[_Located],
+    model: Mapping[str, Any],
+    row_counts: Mapping[int, Mapping[str, Mapping[str, int]]],
+    page_limit: int,
+) -> tuple[bool, dict[tuple[str, str, int], set[int] | None]]:
+    mask = model["row_mask"]
+    polarity = model["polarity"]
+    owned_ordinal = model["owned_in_use_locator_ordinal"]
+    available_ordinal = model["available_locator_ordinal"]
+    if {owned_ordinal, available_ordinal} != {0, 1}:
+        raise ValidationError("independent_h2_holdout_role_model")
+    decoded = {
+        (row.instance, row.checkpoint, row.ordinal): _decode(
+            state, row, mask, polarity
+        )
+        for row in located
+    }
+    for instance, checkpoint, role in sorted(
+        {(row.instance, row.checkpoint, row.role) for row in located}
+    ):
+        owned = decoded[(instance, checkpoint, owned_ordinal)]
+        available = decoded[(instance, checkpoint, available_ordinal)]
+        if owned is None or available is None:
+            continue
+        if (
+            any(page >= state.page_count(checkpoint, page_limit) for page in owned | available)
+            or not available <= owned
+            or (_row_counts(row_counts, 3, checkpoint, role) > 0 and not owned)
+        ):
+            return False, decoded
+    return True, decoded
+
+
+def predict_h2_holdout(
+    replica3: object,
+    holdout_h1_candidate: Mapping[str, Any],
+    frozen_h2_result: Mapping[str, Any],
+    *,
+    plan: Mapping[str, Any],
+    snapshot_row_counts: Mapping[int, Mapping[str, Mapping[str, int]]],
+) -> bool:
+    """Apply frozen H1 bindings and the unchanged H2 model to replica 3.
+
+    ``holdout_h1_candidate`` is the unique candidate returned by
+    :func:`a4_independent_h1.apply_h1_holdout`; accepting it explicitly keeps
+    this module independent of the H1 implementation and prevents H2 refit.
+    """
+    h1_candidate = _frozen_candidate(holdout_h1_candidate, "h1_locator_pair")
+    if {row.get("replica") for row in h1_candidate["instance_bindings"]} != {3}:
+        raise ValidationError("independent_h2_holdout_h1_binding")
+    h2_candidate = _frozen_candidate(frozen_h2_result, "h2_final_role")
+    checkpoints = tuple(plan["checkpoint_design"]["checkpoint_ids"])
+    bounds = plan["bounds"]
+    state = _State(replica3, 3, checkpoints, bounds["page_size"])
+    roles = tuple(plan["candidate_grammars"]["h1"]["logical_roles"])
+    role_order = {role: index for index, role in enumerate(roles)}
+    mask = h2_candidate["model"]["row_mask"]
+    located, masks, evidence = _directory_stage(
+        state, h1_candidate, (mask,), role_order
+    )
+    if evidence is not None or masks != (mask,):
+        return False
+    if any(row.raw_entry & 0xC000 for row in located):
+        return False
+    supported, _ = _supported_masks(
+        located, masks, h1_candidate["canonical_candidate_id"]
+    )
+    if supported != (mask,):
+        return False
+    fits, decoded = _frozen_static_ok(
+        state,
+        located,
+        h2_candidate["model"],
+        snapshot_row_counts,
+        bounds["max_final_pages_per_replica"],
+    )
+    return fits and _transition_ok(
+        state, h2_candidate, decoded, located, plan
+    )
+
+
+def _finish(states: Mapping[int, _State], layer: Mapping[str, Any], predicates: Sequence[Mapping[str, Any]], candidates: Mapping[int, Sequence[Mapping[str, Any]]]) -> H2Recomputation:
+    qualified = sorted({identity for state in states.values() for identity in state.qualified}, key=lambda row: (row[0], states[row[0]].checkpoints.index(row[1]), row[2]))
+    names = next(iter(states.values())).work
+    work = {name: sum(state.work[name] for state in states.values()) for name in names}
+    return H2Recomputation(
+        dict(layer), tuple(dict(row) for row in predicates),
+        tuple({"replica": replica, "checkpoint_id": checkpoint, "page_number": page} for replica, checkpoint, page in qualified),
+        work, {number: tuple(dict(row) for row in candidates.get(number, ())) for number in states},
+    )

--- a/oracle/windows-dao/scripts/a4_independent_h3.py
+++ b/oracle/windows-dao/scripts/a4_independent_h3.py
@@ -1,0 +1,764 @@
+#!/usr/bin/env python3
+"""Fresh H3 recomputation from retained pages and explicit H1/H2 models.
+
+This module is deliberately dependency-free with respect to the A4 producer.
+Its inputs are plain mappings or duck-typed replica readers; every format
+constant used below is registered by the A4 plan or SRC-0020.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+class H3ValidationError(ValueError):
+    """A fail-closed independent H3 recomputation error."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+
+
+def _canonical(value: object) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise H3ValidationError("canonical_json_invalid") from exc
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _candidate(model_type: str, model: dict[str, object]) -> dict[str, object]:
+    identity = {"model_type": model_type, "model": model}
+    return {"model_type": model_type, "canonical_candidate_id": _digest(identity), "model": model}
+
+
+def _unwrap(source: Any, replica: int) -> Mapping[str, Any]:
+    per_replica = getattr(source, "per_replica_candidates", None)
+    if isinstance(per_replica, Mapping):
+        source = per_replica
+    elif isinstance(source, Mapping) and isinstance(source.get("per_replica"), Mapping):
+        source = source["per_replica"]
+    if isinstance(source, Mapping):
+        value: Any = source.get(replica, source.get(str(replica), source))
+    else:
+        layer = getattr(source, "layer", None)
+        if not isinstance(layer, Mapping):
+            raise H3ValidationError("upstream_model_invalid", str(replica))
+        value = layer
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if len(value) != 1:
+            raise H3ValidationError("upstream_model_not_decisive", str(replica))
+        value = value[0]
+    if not isinstance(value, Mapping):
+        raise H3ValidationError("upstream_model_invalid", str(replica))
+    return value
+
+
+def _model(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = value.get("model", value)
+    if not isinstance(nested, Mapping):
+        raise H3ValidationError("upstream_model_invalid")
+    return nested
+
+
+def _bindings(value: Mapping[str, Any], replica: int) -> list[Mapping[str, Any]]:
+    raw = value.get("instance_bindings", value.get("bindings"))
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        raise H3ValidationError("h1_bindings_missing", str(replica))
+    result = [item for item in raw if isinstance(item, Mapping) and item.get("replica") == replica]
+    if not result:
+        raise H3ValidationError("h1_bindings_missing", str(replica))
+    return result
+
+
+def _replica(replicas: Mapping[Any, Any], number: int) -> Any:
+    try:
+        return replicas[number] if number in replicas else replicas[str(number)]
+    except (KeyError, TypeError) as exc:
+        raise H3ValidationError("replica_missing", str(number)) from exc
+
+
+def _checkpoints(replica: Any) -> list[str]:
+    if hasattr(replica, "checkpoint_ids"):
+        raw = replica.checkpoint_ids
+    elif isinstance(replica, Mapping):
+        raw = replica.get("checkpoint_ids")
+        if raw is None:
+            points = replica.get("checkpoints")
+            raw = list(points) if isinstance(points, Mapping) else None
+    else:
+        raw = None
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        raise H3ValidationError("checkpoint_order_missing")
+    result = list(raw)
+    if not result or any(not isinstance(item, str) for item in result) or len(set(result)) != len(result):
+        raise H3ValidationError("checkpoint_order_invalid")
+    return result
+
+
+def _page(replica: Any, checkpoint: str, number: int) -> bytes | None:
+    if number < 0:
+        return None
+    if hasattr(replica, "page"):
+        value = replica.page(checkpoint, number)
+    elif isinstance(replica, Mapping):
+        points = replica.get("checkpoints")
+        point = points.get(checkpoint) if isinstance(points, Mapping) else None
+        pages = point.get("pages") if isinstance(point, Mapping) else None
+        if isinstance(pages, Mapping):
+            value = pages.get(number, pages.get(str(number)))
+        elif isinstance(pages, Sequence) and not isinstance(pages, (str, bytes, bytearray)):
+            value = pages[number] if number < len(pages) else None
+        else:
+            value = None
+    else:
+        value = None
+    if value is None:
+        return None
+    if not isinstance(value, bytes) or len(value) != 2048:
+        raise H3ValidationError("page_invalid", f"{checkpoint}:{number}")
+    return value
+
+
+def _page_count(replica: Any, checkpoint: str) -> int:
+    if hasattr(replica, "index"):
+        value = replica.index(checkpoint).get("page_count")
+    elif isinstance(replica, Mapping):
+        point = replica.get("checkpoints", {}).get(checkpoint, {})
+        pages = point.get("pages") if isinstance(point, Mapping) else None
+        value = point.get("page_count") if isinstance(point, Mapping) else None
+        if value is None and isinstance(pages, Sequence) and not isinstance(pages, (str, bytes)):
+            value = len(pages)
+    else:
+        value = None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise H3ValidationError("page_count_invalid", checkpoint)
+    return value
+
+
+def _range(binding: Mapping[str, Any], order: list[str]) -> list[str]:
+    raw = binding.get("applicable_checkpoint_range")
+    if not isinstance(raw, Mapping):
+        raise H3ValidationError("lifecycle_range_invalid")
+    first = raw.get("start", raw.get("first_checkpoint_id", raw.get("start_checkpoint_id")))
+    last = raw.get("end", raw.get("last_checkpoint_id", raw.get("end_checkpoint_id")))
+    try:
+        left, right = order.index(first), order.index(last)
+    except ValueError as exc:
+        raise H3ValidationError("lifecycle_range_invalid") from exc
+    if left > right:
+        raise H3ValidationError("lifecycle_range_invalid")
+    return order[left : right + 1]
+
+
+def _row(page: bytes, row: int, mask: int) -> tuple[bytes, int, int]:
+    if page[0] != 1 or not isinstance(row, int) or not 0 <= row <= 255:
+        raise H3ValidationError("map_row_invalid")
+    count = int.from_bytes(page[8:10], "little")
+    if row >= count or 10 + 2 * count > 2048:
+        raise H3ValidationError("map_row_invalid")
+    entries = [int.from_bytes(page[10 + 2 * i : 12 + 2 * i], "little") for i in range(count)]
+    if any(raw & 0xC000 for raw in entries):
+        raise H3ValidationError("map_row_flags_invalid")
+    starts = [raw & mask for raw in entries]
+    start, end = starts[row], 2048 if row == 0 else starts[row - 1]
+    if not (10 + 2 * count <= start < end <= 2048):
+        raise H3ValidationError("map_row_bounds_invalid")
+    if any(not (starts[i] < starts[i - 1]) for i in range(1, count)):
+        raise H3ValidationError("map_row_bounds_invalid")
+    return page[start:end], start, end
+
+
+def _target(binding: Mapping[str, Any], ordinal: int) -> tuple[int, int]:
+    targets = binding.get("locator_targets")
+    if not isinstance(targets, Sequence) or len(targets) != 2 or not isinstance(targets[ordinal], Mapping):
+        raise H3ValidationError("locator_targets_invalid")
+    page, row = targets[ordinal].get("page"), targets[ordinal].get("row")
+    if not isinstance(page, int) or not isinstance(row, int):
+        raise H3ValidationError("locator_targets_invalid")
+    return page, row
+
+
+def _bitmap(row: bytes, polarity: str) -> set[int]:
+    if len(row) < 5 or row[0] != 0:
+        raise H3ValidationError("type0_row_invalid")
+    base = int.from_bytes(row[1:5], "little")
+    wanted = polarity == "set_bit_owned_in_use"
+    return {
+        base + bit
+        for bit in range((len(row) - 5) * 8)
+        if bool(row[5 + bit // 8] & (1 << (bit % 8))) == wanted
+    }
+
+
+def _slots(row: bytes) -> list[int]:
+    if not row or row[0] != 1 or (len(row) - 1) % 4:
+        raise H3ValidationError("type1_row_invalid")
+    return [int.from_bytes(row[pos : pos + 4], "little") for pos in range(1, len(row), 4)]
+
+
+def _decode_reference(page: bytes, slot: int, reference: int, formula: str) -> set[int]:
+    result: set[int] = set()
+    for bit in range(16352):
+        if not page[4 + bit // 8] & (1 << (bit % 8)):
+            continue
+        if formula == "slot_ordinal_times_16352_plus_bit_index":
+            value = slot * 16352 + bit
+        elif formula == "referenced_page_times_16352_plus_bit_index":
+            value = reference * 16352 + bit
+        elif formula == "slot_ordinal_times_16352_plus_bit_index_minus_one":
+            value = slot * 16352 + bit - 1
+        elif formula == "slot_ordinal_times_16352_plus_bit_index_plus_one":
+            value = slot * 16352 + bit + 1
+        else:
+            raise H3ValidationError("base_formula_unregistered", formula)
+        if value >= 0:
+            result.add(value)
+    return result
+
+
+def _make_result(
+    candidates: list[dict[str, object]], terminal: str | None, measured: int,
+    stage: str | None, evidence: object = None,
+) -> dict[str, object]:
+    return {
+        "status": "model" if terminal is None else "no_outcome",
+        "predicate_measured_survivor_count": measured,
+        "derivation_survivor_count": 1 if terminal is None else 0,
+        "terminal_predicate_id": terminal,
+        "terminal_payload_kind": None if terminal is None else (
+            "invalid_observation" if terminal == "A4-H3-REFERENCE-INVALID" else
+            "replica_pair" if terminal == "A4-H3-REPLICA-DISAGREEMENT" else "candidate_set"
+        ),
+        "terminal_candidate_stage": stage,
+        "candidates": candidates,
+        "terminal_evidence": evidence,
+        "canonical_candidates_sha256": _digest(candidates),
+    }
+
+
+def _formula_transition_ok(
+    states: list[dict[str, Any]], decoded: Mapping[tuple[int, str, int], set[int]],
+    owned: int, available: int, plan: Mapping[str, Any],
+) -> bool:
+    def pages(state: Mapping[str, Any], ordinal: int) -> set[int]:
+        row = state["rows"][ordinal]
+        return row["decoded"] if row["tag"] == 0 else decoded[
+            (state["binding"], state["checkpoint"], ordinal)
+        ]
+
+    by_role_checkpoint = {(state["role"], state["checkpoint"]): state for state in states}
+    coverage = plan.get("checkpoint_design", {}).get("transition_coverage", {})
+    growth = [key for key in coverage if key.endswith(("_growth", "_absolute", "_relative"))]
+    if len(growth) != 3:
+        return False
+    for key in growth:
+        role = key.split("_", 1)[0].upper()
+        for left, right in zip(coverage[key], coverage[key][1:]):
+            old, new = by_role_checkpoint.get((role, left)), by_role_checkpoint.get((role, right))
+            if old is None or new is None:
+                continue
+            old_owned, new_owned = pages(old, owned), pages(new, owned)
+            old_available, new_available = pages(old, available), pages(new, available)
+            gained = new_owned - old_owned
+            if not old_owned <= new_owned or gained & (new_available - old_available):
+                return False
+    churn = [key for key in coverage if key.endswith("_churn")]
+    if len(churn) != 1 or len(coverage[churn[0]]) != 4:
+        return False
+    role = churn[0].split("_", 1)[0].upper()
+    sequence = coverage[churn[0]]
+    for left, right, deleting in ((sequence[0], sequence[1], True),
+                                  (sequence[1], sequence[2], False)):
+        old, new = by_role_checkpoint.get((role, left)), by_role_checkpoint.get((role, right))
+        if old is None or new is None:
+            continue
+        old_owned, new_owned = pages(old, owned), pages(new, owned)
+        old_available, new_available = pages(old, available), pages(new, available)
+        if deleting and (not new_owned <= old_owned or not old_available <= new_available):
+            return False
+        if not deleting and (not old_owned <= new_owned or not new_available <= old_available):
+            return False
+    for left, right in plan.get("checkpoint_design", {}).get("idle_pairs", []):
+        roles = {state["role"] for state in states}
+        for role in roles:
+            old, new = by_role_checkpoint.get((role, left)), by_role_checkpoint.get((role, right))
+            if old is None and new is None:
+                continue
+            if old is None or new is None or any(pages(old, ordinal) != pages(new, ordinal)
+                                                 for ordinal in (owned, available)):
+                return False
+    return True
+
+
+def _ordered_predicates(plan: Mapping[str, Any], expected: list[str]) -> list[str]:
+    registry = plan.get("predicate_registry")
+    contracts = registry.get("predicate_contracts") if isinstance(registry, Mapping) else None
+    if not isinstance(contracts, list):
+        raise H3ValidationError("predicate_registry_invalid")
+    selected = [
+        row
+        for row in contracts
+        if isinstance(row, Mapping)
+        and isinstance(row.get("predicate_id"), str)
+        and row["predicate_id"].startswith("A4-H3-")
+        and "HOLDOUT" not in row["predicate_id"]
+    ]
+    if any(not isinstance(row.get("order"), int) for row in selected):
+        raise H3ValidationError("predicate_registry_invalid")
+    selected.sort(key=lambda row: row["order"])
+    actual = [row["predicate_id"] for row in selected]
+    if actual != expected or len({row["order"] for row in selected}) != len(selected):
+        raise H3ValidationError("predicate_registry_invalid")
+    return actual
+
+
+def _predicate_row(
+    plan: Mapping[str, Any], predicate: str, status: str, measured: int,
+) -> dict[str, object]:
+    contract = next(row for row in plan["predicate_registry"]["predicate_contracts"]
+                    if row.get("predicate_id") == predicate)
+    return {"predicate_id": predicate, "order": contract["order"], "scope": contract["scope"],
+            "status": status, "terminal_predicate_id": predicate if status == "fail" else None,
+            "predicate_measured_survivor_count": measured,
+            "derivation_survivor_count": 1 if status == "pass" else 0,
+            "reachability_fixture_id": contract["reachability_fixture_id"]}
+
+
+def _compatible_identifier_indexes(
+    values: Mapping[str, Mapping[int, int]], lifecycle: str,
+) -> dict[str, set[int]]:
+    """Return occurrence indexes participating in a registered identifier matching."""
+    operations = list(values)
+    left, right = "T2_CREATE", "T2_RECREATE"
+    if left not in values or right not in values:
+        return {}
+
+    def distinct_exists(sets: Mapping[str, set[int]], forced: tuple[str, int] | None = None) -> bool:
+        chosen: dict[int, str] = {}
+        if forced is not None:
+            operation, identifier = forced
+            chosen[identifier] = operation
+        def visit(operation: str, seen: set[int]) -> bool:
+            for identifier in sets[operation]:
+                if identifier in seen or (forced and operation == forced[0] and identifier != forced[1]):
+                    continue
+                seen.add(identifier)
+                prior = chosen.get(identifier)
+                if prior is None or (prior != forced[0] and visit(prior, seen)):
+                    chosen[identifier] = operation
+                    return True
+            return False
+        return all(operation == (forced[0] if forced else None) or visit(operation, set())
+                   for operation in sets)
+
+    identifier_sets = {operation: set(rows.values()) for operation, rows in values.items()}
+    participation = {operation: set() for operation in operations}
+    for operation in operations:
+        for index, identifier in values[operation].items():
+            if lifecycle == "stable_for_same_operation_instance_and_distinct_for_t2_v1_v2":
+                fits = distinct_exists(identifier_sets, (operation, identifier))
+            elif lifecycle == "stable_for_same_physical_name_including_t2_v1_v2":
+                fits = False
+                for shared in identifier_sets[left] & identifier_sets[right]:
+                    if operation in (left, right) and identifier != shared:
+                        continue
+                    remaining = {key: choices - {shared} for key, choices in identifier_sets.items()
+                                 if key not in (left, right)}
+                    forced = None if operation in (left, right) else (operation, identifier)
+                    if distinct_exists(remaining, forced):
+                        fits = True
+                        break
+            else:
+                fits = False
+            if fits:
+                participation[operation].add(index)
+    return participation if all(participation.values()) else {}
+
+
+def _replica_stages(
+    number: int, replica: Any, h1: Mapping[str, Any], h2: Mapping[str, Any],
+    checkpoints: list[str], conversion: dict[str, object], conversions: list[str],
+    formulas: list[str], bounds: Mapping[str, Any], plan: Mapping[str, Any],
+    qualified: set[tuple[int, str, int]], work: dict[str, int],
+):
+    actual_order = _checkpoints(replica)
+    if actual_order != checkpoints:
+        raise H3ValidationError("checkpoint_order_mismatch", str(number))
+    mask, polarity = h2.get("row_mask"), h2.get("polarity")
+    owned, available = h2.get("owned_in_use_locator_ordinal"), h2.get("available_locator_ordinal")
+    if mask not in (0x1FFF, 0x0FFF) or polarity not in (
+        "set_bit_owned_in_use", "clear_bit_owned_in_use"
+    ) or sorted((owned, available)) != [0, 1]:
+        raise H3ValidationError("h2_model_invalid", str(number))
+    states: list[dict[str, Any]] = []
+    for binding_index, binding in enumerate(_bindings(h1, number)):
+        for checkpoint in _range(binding, actual_order):
+            rows: dict[int, dict[str, Any]] = {}
+            for ordinal in (0, 1):
+                page_number, row_number = _target(binding, ordinal)
+                page = _page(replica, checkpoint, page_number)
+                if page is None:
+                    raise H3ValidationError("map_page_missing")
+                raw, start, end = _row(page, row_number, mask)
+                qualified.add((number, checkpoint, page_number))
+                entry: dict[str, Any] = {"tag": raw[0], "raw": raw, "page": page_number,
+                                        "row": row_number, "start": start, "end": end}
+                if raw[0] == 0:
+                    entry["decoded"] = _bitmap(raw, polarity)
+                elif raw[0] == 1:
+                    entry["slots"] = _slots(raw)
+                else:
+                    raise H3ValidationError("map_tag_unsupported")
+                rows[ordinal] = entry
+            states.append({"binding": binding_index, "role": binding.get("logical_role"),
+                           "checkpoint": checkpoint, "rows": rows})
+    by_binding: dict[int, list[dict[str, Any]]] = {}
+    for state in states:
+        by_binding.setdefault(state["binding"], []).append(state)
+    conversion_legs = []
+    for sequence in by_binding.values():
+        for left, right in zip(sequence, sequence[1:]):
+            before, after = left["rows"][owned], right["rows"][owned]
+            if before["tag"] == 0 and after["tag"] == 1 and any(after["slots"]):
+                conversion_legs.append((before, after))
+    if not conversion_legs:
+        yield {"terminal": 0, "candidates": [], "measured": 0}
+        return
+    yield {"terminal": None, "candidates": [conversion], "measured": 1}
+    type1 = [(state, ordinal, row) for state in states for ordinal, row in state["rows"].items()
+             if row["tag"] == 1]
+    inactive = any(0 in row["slots"] for _, _, row in type1)
+    if not inactive:
+        yield {"terminal": 1, "candidates": [conversion], "measured": 1}
+        return
+    yield {"terminal": None, "candidates": [conversion], "measured": 1}
+    bad: dict[str, Any] | None = None
+    referenced: dict[tuple[str, int], bytes] = {}
+    reference_pages: dict[str, set[int]] = {}
+    for state, _ordinal, row in type1:
+        for slot, reference in enumerate(row["slots"]):
+            if reference == 0:
+                continue
+            count = _page_count(replica, state["checkpoint"])
+            reached = reference_pages.setdefault(state["checkpoint"], set())
+            if reference < count and reference not in reached and len(reached) >= bounds.get(
+                "max_qualified_pages_per_submodel", 16
+            ):
+                raise H3ValidationError("resource_bound_breach", "tag05 references")
+            if reference < count:
+                reached.add(reference)
+            page = _page(replica, state["checkpoint"], reference) if reference < count else None
+            reason = "out_of_range" if reference >= count else "missing_page" if page is None else (
+                "not_tag_05" if page[:4] != b"\x05\x01\x00\x00" else None
+            )
+            if reason:
+                bad = {"kind": "reference", "input_model_id": conversion["canonical_candidate_id"],
+                       "observation": {"replica": number, "checkpoint_id": state["checkpoint"],
+                       "page": row["page"], "slot_ordinal": slot, "referenced_page": reference,
+                       "observed_tag_byte": None if page is None else page[0], "reason": reason}}
+                break
+            qualified.add((number, state["checkpoint"], reference))
+            referenced[(state["checkpoint"], reference)] = page
+        if bad:
+            break
+    if bad:
+        yield {"terminal": 2, "candidates": [conversion], "measured": 1, "evidence": bad}
+        return
+    yield {"terminal": None, "candidates": [conversion], "measured": 1}
+    work["type_0_and_tag_05_bitmap_bits"] += 16352 * len(referenced)
+    regions = {"inactive": inactive, "active": False, "bit0": False, "nonzero": False,
+               "boundary_last": False, "boundary_next": False}
+    for state, _ordinal, row in type1:
+        active_slots = {slot for slot, ref in enumerate(row["slots"]) if ref}
+        regions["active"] |= bool(active_slots)
+        set_bits: dict[int, set[int]] = {}
+        for slot in active_slots:
+            page = referenced[(state["checkpoint"], row["slots"][slot])]
+            bits = {bit for bit in range(16352) if page[4 + bit // 8] & (1 << (bit % 8))}
+            set_bits[slot] = bits
+            regions["bit0"] |= 0 in bits
+            regions["nonzero"] |= any(bit > 0 for bit in bits)
+            regions["boundary_last"] |= 16351 in bits
+        regions["boundary_next"] |= any(
+            slot + 1 in active_slots and 16351 in bits and 0 in set_bits.get(slot + 1, set())
+            for slot, bits in set_bits.items()
+        )
+    if not all(regions.values()):
+        yield {"terminal": 3, "candidates": [conversion], "measured": 1}
+        return
+    yield {"terminal": None, "candidates": [conversion], "measured": 1}
+    fitting = []
+    decoded_by_formula: dict[str, dict[tuple[int, str, int], set[int]]] = {}
+    for formula in formulas:
+        decoded: dict[tuple[int, str, int], set[int]] = {}
+        for state, ordinal, row in type1:
+            pages: set[int] = set()
+            for slot, reference in enumerate(row["slots"]):
+                if reference:
+                    pages |= _decode_reference(referenced[(state["checkpoint"], reference)], slot,
+                                               reference, formula)
+            decoded[(state["binding"], state["checkpoint"], ordinal)] = pages
+        ok = True
+        for before, after in conversion_legs:
+            target = next(state for state in states if state["rows"][owned] is after)
+            if not before["decoded"] <= decoded[(target["binding"], target["checkpoint"], owned)]:
+                ok = False
+                break
+        if ok:
+            ok = _formula_transition_ok(states, decoded, owned, available, plan)
+        work["base_formula_evaluations"] += sum(state["rows"][owned]["tag"] == 1 for state in states)
+        if ok:
+            fitting.append(_candidate("h3_final_base_formula", {
+                "conversion": conversions[0], "base_formula": formula,
+            }))
+            decoded_by_formula[formula] = decoded
+        if len(fitting) > bounds.get("max_candidate_models"):
+            raise H3ValidationError("resource_bound_breach", "candidate 4097")
+    if not fitting:
+        yield {"terminal": 4, "candidates": [], "measured": 0}
+        return
+    yield {"terminal": None, "candidates": fitting, "measured": len(fitting)}
+    if len(fitting) > 1:
+        yield {"terminal": 5, "candidates": fitting, "measured": len(fitting)}
+        return
+    formula = fitting[0]["model"]["base_formula"]
+    yield {"terminal": None, "candidates": fitting, "measured": 1,
+           "admitted": decoded_by_formula[formula]}
+
+
+def recompute_h3(
+    replicas: Mapping[Any, Any], h1_models: Any,
+    h2_models: Any, plan: Mapping[str, Any],
+) -> dict[str, object]:
+    """Recompute derivation H3 for replicas 1 and 2 from retained page bytes."""
+    grammar = plan.get("candidate_grammars", {}).get("h3", {})
+    bounds = plan.get("bounds", {})
+    formulas = grammar.get("base_formulas")
+    conversions = grammar.get("conversion_candidates")
+    if conversions != ["structural_type_0_to_type_1_with_nonzero_u32_slots"]:
+        raise H3ValidationError("conversion_grammar_invalid")
+    if not isinstance(formulas, list) or len(formulas) != 4 or len(set(formulas)) != 4:
+        raise H3ValidationError("base_formula_grammar_invalid")
+    checkpoints = plan.get("checkpoint_design", {}).get("checkpoint_ids")
+    if not isinstance(checkpoints, list) or len(checkpoints) > bounds.get("max_checkpoints_per_replica", -1):
+        raise H3ValidationError("checkpoint_plan_invalid")
+    conversion = _candidate("h3_conversion", {"conversion": conversions[0]})
+    qualified: set[tuple[int, str, int]] = set()
+    work = {"type_0_and_tag_05_bitmap_bits": 0, "base_formula_evaluations": 0}
+    per_replica: dict[int, dict[str, Any]] = {}
+    predicate_ids = _ordered_predicates(plan, [
+        "A4-H3-CONVERSION-NONE", "A4-H3-INACTIVE-SLOT-NONE", "A4-H3-REFERENCE-INVALID",
+        "A4-H3-BASE-DISCRIMINATION", "A4-H3-BASE-NONE", "A4-H3-BASE-MULTIPLE",
+        "A4-H3-REPLICA-DISAGREEMENT",
+    ])
+    runners = {number: _replica_stages(
+        number, _replica(replicas, number), _unwrap(h1_models, number),
+        _model(_unwrap(h2_models, number)), checkpoints, conversion, conversions,
+        formulas, bounds, plan, qualified, work,
+    ) for number in (1, 2)}
+    terminal_number = None
+    for index in range(6):
+        for number in (1, 2):
+            try:
+                state = next(runners[number])
+            except StopIteration as exc:
+                raise H3ValidationError("predicate_stage_incomplete", str(number)) from exc
+            per_replica[number] = state
+            if state["terminal"] is not None:
+                state["terminal"] = predicate_ids[index]
+                terminal_number = number
+                break
+        if terminal_number is not None:
+            break
+    rows = []
+    if terminal_number is not None:
+        state = per_replica[terminal_number]
+        terminal = state["terminal"]
+        terminal_index = predicate_ids.index(terminal)
+        for index, predicate in enumerate(predicate_ids):
+            status = "fail" if index == terminal_index else "pass" if index < terminal_index else "not_applicable"
+            if index in (0, 1, 2, 3):
+                count = 0 if index == terminal_index and index == 0 else 1
+            elif index in (4, 5):
+                count = state["measured"] if terminal_index >= 4 else 0
+            else:
+                count = 2 if index == terminal_index else 0
+            rows.append(_predicate_row(plan, predicate, status, count if status != "not_applicable" else 0))
+        result = _make_result(state["candidates"], terminal, state["measured"],
+                              "h3_conversion" if predicate_ids.index(terminal) <= 3 else
+                              "h3_final_base_formula", state.get("evidence"))
+    else:
+        first, second = per_replica[1]["candidates"][0], per_replica[2]["candidates"][0]
+        if first["model"] != second["model"]:
+            terminal = predicate_ids[-1]
+            evidence = {"kind": "replica_pair", "entries": [
+                {"replica": number, "canonical_model_id": None,
+                 "canonical_candidate_id": per_replica[number]["candidates"][0]["canonical_candidate_id"],
+                 "complete_candidate": per_replica[number]["candidates"][0]} for number in (1, 2)
+            ]}
+            result = _make_result([], terminal, 2, "h3_final_base_formula", evidence)
+            rows = [_predicate_row(plan, predicate, "fail" if predicate == terminal else "pass",
+                                   2 if predicate == terminal else 1) for predicate in predicate_ids]
+        else:
+            terminal = None
+            result = _make_result([first], None, 1, None)
+            rows = [_predicate_row(plan, predicate, "pass", 1) for predicate in predicate_ids]
+    admitted: dict[int, dict[str, list[int]]] = {}
+    for number, state in per_replica.items():
+        if "admitted" in state:
+            combined: dict[str, set[int]] = {}
+            for (_binding, checkpoint, ordinal), pages in state["admitted"].items():
+                if ordinal == _model(_unwrap(h2_models, number))["owned_in_use_locator_ordinal"]:
+                    combined.setdefault(checkpoint, set()).update(pages)
+            admitted[number] = {checkpoint: sorted(pages) for checkpoint, pages in combined.items()}
+    return {"result": result, "predicates": rows, "qualified_pages": [
+        {"replica": r, "checkpoint_id": c, "page_number": p} for r, c, p in sorted(qualified)
+    ], "work_charges": work, "admitted_pages": admitted, "per_replica": per_replica}
+
+
+def _single_candidate(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(value.get("result"), Mapping):
+        value = value["result"]
+    candidates = value.get("candidates")
+    if isinstance(candidates, list):
+        if len(candidates) != 1 or not isinstance(candidates[0], Mapping):
+            raise H3ValidationError("frozen_model_not_decisive")
+        value = candidates[0]
+    return value
+
+
+def _single_model(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _model(_single_candidate(value))
+
+
+def predict_h3_holdout(
+    replica3: Any,
+    h1_result: Mapping[str, Any],
+    h2_result: Mapping[str, Any],
+    h3_result: Mapping[str, Any],
+    plan: Mapping[str, Any],
+) -> bool:
+    """Apply the one frozen H3 formula to replica 3 without fitting a new one."""
+    try:
+        order = _checkpoints(replica3)
+        if order != plan.get("checkpoint_design", {}).get("checkpoint_ids"):
+            return False
+        h1_model = _single_model(h1_result)
+        h2_model = _single_model(h2_result)
+        h3_model = _single_model(h3_result)
+        formula = h3_model.get("base_formula")
+        registered = plan.get("candidate_grammars", {}).get("h3", {}).get("base_formulas")
+        if formula not in registered:
+            return False
+        mask = h2_model.get("row_mask")
+        polarity = h2_model.get("polarity")
+        owned = h2_model.get("owned_in_use_locator_ordinal")
+        available = h2_model.get("available_locator_ordinal")
+        if mask not in (0x1FFF, 0x0FFF) or sorted((owned, available)) != [0, 1]:
+            return False
+        states: list[dict[str, Any]] = []
+        qualified_references: dict[tuple[str, int], bytes] = {}
+        reference_pages: dict[str, set[int]] = {}
+        for binding_index, binding in enumerate(_bindings(_single_candidate(h1_result), 3)):
+            for checkpoint in _range(binding, order):
+                rows: dict[int, dict[str, Any]] = {}
+                for ordinal in (0, 1):
+                    page_number, row_number = _target(binding, ordinal)
+                    page = _page(replica3, checkpoint, page_number)
+                    if page is None:
+                        return False
+                    raw, _start, _end = _row(page, row_number, mask)
+                    entry: dict[str, Any] = {"tag": raw[0], "page": page_number}
+                    if raw[0] == 0:
+                        entry["decoded"] = _bitmap(raw, polarity)
+                    elif raw[0] == 1:
+                        entry["slots"] = _slots(raw)
+                    else:
+                        return False
+                    rows[ordinal] = entry
+                states.append({"binding": binding_index, "checkpoint": checkpoint, "rows": rows})
+        type1 = [(state, ordinal, row) for state in states for ordinal, row in state["rows"].items()
+                 if row["tag"] == 1]
+        if not type1:
+            return False
+        for state, _ordinal, row in type1:
+            for reference in row["slots"]:
+                if reference == 0:
+                    continue
+                if reference >= _page_count(replica3, state["checkpoint"]):
+                    return False
+                reached = reference_pages.setdefault(state["checkpoint"], set())
+                if reference not in reached and len(reached) >= plan["bounds"].get(
+                    "max_qualified_pages_per_submodel", 16
+                ):
+                    raise H3ValidationError("resource_bound_breach", "tag05 references")
+                reached.add(reference)
+                page = _page(replica3, state["checkpoint"], reference)
+                if page is None or page[:4] != b"\x05\x01\x00\x00":
+                    return False
+                qualified_references[(state["checkpoint"], reference)] = page
+        regions = {"inactive": False, "active": False, "bit0": False, "nonzero": False,
+                   "boundary_last": False, "boundary_next": False}
+        decoded: dict[tuple[int, str, int], set[int]] = {}
+        for state, ordinal, row in type1:
+            active = {slot for slot, reference in enumerate(row["slots"]) if reference}
+            regions["inactive"] |= 0 in row["slots"]
+            regions["active"] |= bool(active)
+            set_bits: dict[int, set[int]] = {}
+            pages: set[int] = set()
+            for slot in active:
+                reference = row["slots"][slot]
+                page = qualified_references[(state["checkpoint"], reference)]
+                bits = {bit for bit in range(16352) if page[4 + bit // 8] & (1 << (bit % 8))}
+                set_bits[slot] = bits
+                regions["bit0"] |= 0 in bits
+                regions["nonzero"] |= any(bit > 0 for bit in bits)
+                regions["boundary_last"] |= 16351 in bits
+                pages |= _decode_reference(page, slot, reference, formula)
+            regions["boundary_next"] |= any(
+                slot + 1 in active and 16351 in bits and 0 in set_bits.get(slot + 1, set())
+                for slot, bits in set_bits.items()
+            )
+            decoded[(state["binding"], state["checkpoint"], ordinal)] = pages
+        if not all(regions.values()):
+            return False
+        sequences: dict[int, list[dict[str, Any]]] = {}
+        for state in states:
+            sequences.setdefault(state["binding"], []).append(state)
+        saw_conversion = False
+        idle_pairs = {tuple(pair) for pair in plan.get("checkpoint_design", {}).get("idle_pairs", [])}
+        for sequence in sequences.values():
+            for left, right in zip(sequence, sequence[1:]):
+                before, after = left["rows"][owned], right["rows"][owned]
+                if before["tag"] == 0 and after["tag"] == 1 and any(after["slots"]):
+                    saw_conversion = True
+                    if not before["decoded"] <= decoded[(right["binding"], right["checkpoint"], owned)]:
+                        return False
+                if (left["checkpoint"], right["checkpoint"]) in idle_pairs:
+                    for ordinal in (owned, available):
+                        if left["rows"][ordinal]["tag"] != right["rows"][ordinal]["tag"]:
+                            return False
+                        if left["rows"][ordinal]["tag"] == 1 and decoded[
+                            (left["binding"], left["checkpoint"], ordinal)
+                        ] != decoded[(right["binding"], right["checkpoint"], ordinal)]:
+                            return False
+        return saw_conversion
+    except H3ValidationError as exc:
+        if exc.code == "resource_bound_breach":
+            raise
+        return False
+    except (KeyError, TypeError, ValueError, IndexError):
+        return False

--- a/oracle/windows-dao/scripts/a4_independent_h4.py
+++ b/oracle/windows-dao/scripts/a4_independent_h4.py
@@ -1,0 +1,800 @@
+#!/usr/bin/env python3
+"""Fresh A4 H4 recomputation from bundle pages and explicit upstream models."""
+from __future__ import annotations
+import hashlib
+import itertools
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+from a4_independent_h4_contract import H4ValidationError, catalog_rows as _all_rows, first_cardinality_failure, is_resource_error
+from a4_independent_h3 import (
+    H3ValidationError,
+    _bindings,
+    _bitmap,
+    _canonical,
+    _compatible_identifier_indexes,
+    _digest,
+    _model,
+    _page,
+    _page_count,
+    _predicate_row,
+    _replica,
+    _range,
+    _row,
+    _single_candidate,
+    _single_model,
+    _slots,
+    _target,
+    _unwrap,
+)
+def _candidate(
+    model_type: str, model: dict[str, object], bindings: list[dict[str, object]] | None = None
+) -> dict[str, object]:
+    model_identity = {"model_type": model_type, "model": model}
+    candidate_identity = dict(model_identity)
+    result: dict[str, object] = {"model_type": model_type}
+    if bindings is not None:
+        result["canonical_model_id"] = _digest(model_identity)
+        candidate_identity["instance_bindings"] = bindings
+    result["canonical_candidate_id"] = _digest(candidate_identity)
+    result["model"] = model
+    if bindings is not None:
+        result["instance_bindings"] = bindings
+    if len(_canonical(result)) > 4096:
+        raise H4ValidationError("resource_bound_breach", "candidate byte 4097")
+    return result
+def _layout_target(raw: bytes, layout: str) -> tuple[int, int]:
+    if len(raw) != 4:
+        raise H4ValidationError("locator_window_invalid")
+    if layout == "u24le_page_then_u8_row":
+        return int.from_bytes(raw[:3], "little"), raw[3]
+    if layout == "u8_row_then_u24le_page":
+        return int.from_bytes(raw[1:], "little"), raw[0]
+    raise H4ValidationError("locator_layout_invalid")
+def _formula_pages(page: bytes, slot: int, reference: int, formula: str) -> set[int]:
+    if page[:4] != b"\x05\x01\x00\x00":
+        raise H4ValidationError("tag05_page_invalid")
+    pages: set[int] = set()
+    for bit in range(16352):
+        if not page[4 + bit // 8] & (1 << (bit % 8)):
+            continue
+        base = slot if formula.startswith("slot_ordinal") else reference
+        value = base * 16352 + bit
+        if formula.endswith("minus_one"):
+            value -= 1
+        elif formula.endswith("plus_one"):
+            value += 1
+        if value >= 0:
+            pages.add(value)
+    return pages
+def _traverse(
+    replica: Any,
+    number: int,
+    checkpoint: str,
+    tdef_page: int,
+    h1: Mapping[str, Any],
+    h2: Mapping[str, Any],
+    h3: Mapping[str, Any],
+    qualified: set[tuple[int, str, int]],
+    work: dict[str, int],
+) -> tuple[tuple[tuple[int, int], tuple[int, int]], set[int]]:
+    tdef = _page(replica, checkpoint, tdef_page)
+    if tdef is None or tdef[0] != 2:
+        raise H4ValidationError("system_tdef_invalid")
+    qualified.add((number, checkpoint, tdef_page))
+    offsets = h1.get("locator_offsets")
+    if not isinstance(offsets, Sequence) or list(offsets) != sorted(offsets) or len(offsets) != 2:
+        raise H4ValidationError("locator_offsets_invalid")
+    targets = tuple(_layout_target(tdef[offset : offset + 4], h1.get("layout")) for offset in offsets)
+    decoded: dict[int, set[int]] = {}
+    references: set[int] = set()
+    for ordinal, (page_number, row_number) in enumerate(targets):
+        page = _page(replica, checkpoint, page_number)
+        if page is None:
+            raise H4ValidationError("system_map_page_missing")
+        raw, _start, _end = _row(page, row_number, h2.get("row_mask"))
+        qualified.add((number, checkpoint, page_number))
+        if raw[0] == 0:
+            decoded[ordinal] = _bitmap(raw, h2.get("polarity"))
+        elif raw[0] == 1:
+            slots = _slots(raw)
+            decoded[ordinal] = set()
+            for slot, reference in enumerate(slots):
+                if reference == 0:
+                    continue
+                if reference >= _page_count(replica, checkpoint):
+                    raise H4ValidationError("system_reference_out_of_range")
+                if reference not in references and len(references) >= 16:
+                    raise H4ValidationError("resource_bound_breach", "system references")
+                references.add(reference)
+                reference_page = _page(replica, checkpoint, reference)
+                if reference_page is None:
+                    raise H4ValidationError("system_reference_missing")
+                qualified.add((number, checkpoint, reference))
+                decoded[ordinal].update(_formula_pages(
+                    reference_page, slot, reference, h3.get("base_formula")
+                ))
+        else:
+            raise H4ValidationError("system_map_tag_invalid")
+    owned = h2.get("owned_in_use_locator_ordinal")
+    available = h2.get("available_locator_ordinal")
+    if sorted((owned, available)) != [0, 1] or not decoded[available] <= decoded[owned]:
+        raise H4ValidationError("system_role_model_invalid")
+    return targets, decoded[owned]
+def _state_digest(replica: Any, checkpoint: str, page: int) -> str | None:
+    if hasattr(replica, "state"):
+        value = replica.state(checkpoint, page)
+        if value is not None and (not isinstance(value, str) or len(value) != 64):
+            raise H4ValidationError("page_state_invalid")
+        return value
+    raw = _page(replica, checkpoint, page)
+    return None if raw is None else hashlib.sha256(raw).hexdigest()
+def _changed(replica: Any, left: str, right: str, maximum: int) -> set[int]:
+    count = max(_page_count(replica, left), _page_count(replica, right))
+    if count > maximum:
+        raise H4ValidationError("resource_bound_breach", "page count")
+    return {page for page in range(count) if _state_digest(replica, left, page) != _state_digest(replica, right, page)}
+def _retained_rows(
+    replica: Any, operation: str, pages: set[int], checkpoints: list[str], mask: int,
+    qualified: set[tuple[int, str, int]], number: int, work: dict[str, int] | None,
+    charged: set[tuple[int, str, int, int]],
+) -> list[tuple[int, int, int, int, bytes]]:
+    before = checkpoints[checkpoints.index(operation) - 1]
+    result = []
+    for page_number in sorted(pages):
+        page = _page(replica, operation, page_number)
+        if page is None or page[0] != 1:
+            continue
+        qualified.add((number, operation, page_number))
+        before_page = _page(replica, before, page_number)
+        if before_page is not None:
+            qualified.add((number, before, page_number))
+        before_rows = {} if before_page is None or before_page[0] != 1 else {
+            row_number: raw for row_number, _start, _end, raw in _all_rows(
+                before_page, mask, (number, before, page_number), work, charged)
+        }
+        for row_number, start, end, raw in _all_rows(
+                page, mask, (number, operation, page_number), work, charged):
+            if before_rows.get(row_number) == raw:
+                continue
+            last = operation if operation == "T2_CREATE" else checkpoints[-1]
+            stable = True
+            for checkpoint in checkpoints[checkpoints.index(operation) : checkpoints.index(last) + 1]:
+                retained = _page(replica, checkpoint, page_number)
+                if retained is None or retained[0] != 1:
+                    stable = False
+                    break
+                qualified.add((number, checkpoint, page_number))
+                retained_rows = _all_rows(
+                    retained, mask, (number, checkpoint, page_number), work, charged)
+                if row_number >= len(retained_rows) or retained_rows[row_number][3] != raw:
+                    stable = False
+                    break
+            if stable:
+                result.append((page_number, row_number, start, end, raw))
+    return result
+def _operation_patterns(plan: Mapping[str, Any], replica: int, operation: str) -> list[tuple[str, bytes]]:
+    role = {
+        "T1_CREATE_ID": "T1", "T2_CREATE": "T2", "T2_RECREATE": "T2",
+        "T3_CREATE": "T3", "T4_CREATE": "T4",
+    }.get(operation)
+    if operation == "T1_ADD_TEXT":
+        name = "Payload"
+    elif operation == "T1_ADD_INDEX":
+        name = "A4IX_ID"
+    else:
+        bindings = plan.get("tables", {}).get("role_bindings", [])
+        row = next((item for item in bindings if item.get("replica") == replica), None)
+        if not isinstance(row, Mapping) or not isinstance(row.get(role), str):
+            raise H4ValidationError("role_binding_missing")
+        name = row[role]
+    candidates = [(f"{operation}_CP1252", name.encode("cp1252")),
+                  (f"{operation}_UTF8", name.encode("utf-8"))]
+    unique: list[tuple[str, bytes]] = []
+    for item in candidates:
+        if item[1] not in [raw for _identifier, raw in unique]:
+            unique.append(item)
+    return unique
+def _occurrences(row: bytes, patterns: list[tuple[str, bytes]]) -> list[dict[str, object]]:
+    found: list[tuple[int, str, bytes]] = []
+    for identifier, pattern in patterns:
+        start = 0
+        while True:
+            position = row.find(pattern, start)
+            if position < 0:
+                break
+            found.append((position, identifier, pattern))
+            start = position + 1
+    found.sort(key=lambda item: (item[0], item[1]))
+    return [
+        {"occurrence_index": index, "name_start": start,
+         "matched_registered_pattern_id": identifier, "matched_bytes_hex": raw.hex()}
+        for index, (start, identifier, raw) in enumerate(found)
+    ]
+def _bitmap_hex(indexes: set[int], size: int) -> str:
+    raw = bytearray((size + 7) // 8)
+    for index in indexes:
+        if not 0 <= index < size:
+            raise H4ValidationError("occurrence_index_invalid")
+        raw[index // 8] |= 1 << (index % 8)
+    return raw.hex()
+def _structural_candidates(
+    number: int,
+    operation_rows: Mapping[str, tuple[dict[str, object], bytes, list[dict[str, object]]]],
+    occurrence_hash: str,
+    grammar: Mapping[str, Any],
+    work: dict[str, int],
+) -> list[tuple[dict[str, object], dict[str, Any]]]:
+    operations = grammar["operation_binding_order"]
+    total_occurrences = sum(len(operation_rows[operation][2]) for operation in operations)
+    work["h4_name_length_structural_tuples"] += total_occurrences * 165888
+    equivalence: dict[tuple[object, ...], dict[str, Any]] = {}
+    dimensions = itertools.product(
+        grammar["kind_start_deltas"], grammar["kind_widths"], grammar["identifier_widths"],
+        grammar["endianness"], grammar["name_length_start_deltas"], grammar["name_length_widths"],
+        grammar["identifier_lifecycle_relations"],
+    )
+    for kind_delta, kind_width, identifier_width, endian, length_delta, length_width, lifecycle in dimensions:
+        compatible: dict[str, set[int]] = {}
+        decoded: dict[str, dict[int, tuple[int, int, int]]] = {}
+        for operation in operations:
+            _locator, row, occurrences = operation_rows[operation]
+            compatible[operation], decoded[operation] = set(), {}
+            for occurrence in occurrences:
+                index, name_start = occurrence["occurrence_index"], occurrence["name_start"]
+                kind_start = name_start - kind_delta
+                identifier_start = kind_start - identifier_width
+                length_start = name_start - length_delta
+                spans = [(identifier_start, kind_start), (kind_start, kind_start + kind_width),
+                         (length_start, length_start + length_width),
+                         (name_start, name_start + len(bytes.fromhex(occurrence["matched_bytes_hex"])))]
+                if any(start < 0 or end > len(row) or start >= end for start, end in spans):
+                    continue
+                if any(max(a, c) < min(b, d) for i, (a, b) in enumerate(spans)
+                       for c, d in spans[i + 1 :]):
+                    continue
+                kind = int.from_bytes(row[kind_start : kind_start + kind_width], endian)
+                identifier = int.from_bytes(row[identifier_start:kind_start], endian)
+                stored_length = int.from_bytes(row[length_start : length_start + length_width], endian)
+                pattern = bytes.fromhex(occurrence["matched_bytes_hex"])
+                try:
+                    scalar_count = len(pattern.decode("utf-8")) if "UTF8" in occurrence[
+                        "matched_registered_pattern_id"
+                    ] else len(pattern.decode("cp1252"))
+                except UnicodeDecodeError:
+                    continue
+                if stored_length not in {len(pattern), scalar_count}:
+                    continue
+                compatible[operation].add(index)
+                decoded[operation][index] = (kind, identifier, stored_length)
+        if any(not compatible[operation] for operation in operations):
+            continue
+        kind_values = {value[0] for rows in decoded.values() for value in rows.values()}
+        if len(kind_values) != 3:
+            continue
+        for table, field, index_kind in itertools.permutations(sorted(kind_values)):
+            kind_map = {"table": table, "field": field, "index": index_kind}
+            identifiers: dict[str, dict[int, int]] = {}
+            for operation in operations:
+                role = "field" if operation == "T1_ADD_TEXT" else (
+                    "index" if operation == "T1_ADD_INDEX" else "table")
+                identifiers[operation] = {occurrence: value[1] for occurrence, value in
+                                          decoded[operation].items() if value[0] == kind_map[role]}
+            participating = _compatible_identifier_indexes(identifiers, lifecycle)
+            if not participating:
+                continue
+            observed = tuple((operation, tuple((occurrence, decoded[operation][occurrence])
+                             for occurrence in sorted(participating[operation])))
+                             for operation in operations) + (lifecycle, tuple(kind_map.values()))
+            entry = equivalence.get(observed)
+            if entry is None:
+                model = {"kind_start_delta": kind_delta, "kind_width": kind_width,
+                         "identifier_width": identifier_width, "endianness": endian,
+                         "name_length_start_delta": length_delta, "name_length_width": length_width,
+                         "kind_mapping": kind_map, "identifier_lifecycle": lifecycle}
+                filtered = {operation: {index: decoded[operation][index]
+                            for index in participating[operation]} for operation in operations}
+                equivalence[observed] = {"model": model, "count": 1,
+                                         "compatible": participating, "decoded": filtered}
+                if len(equivalence) > 4096:
+                    raise H4ValidationError("resource_bound_breach", "candidate 4097")
+            else:
+                entry["count"] += 1
+    result = []
+    for entry in equivalence.values():
+        compatible_rows = []
+        for operation in operations:
+            maximum = 290 if operation in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254
+            indexes = entry["compatible"][operation]
+            compatible_rows.append({"operation_id": operation,
+                                    "compatible_occurrence_count": len(indexes),
+                                    "compatible_occurrence_bitmap_hex": _bitmap_hex(indexes, maximum)})
+        binding = {"replica": number, "occurrence_evidence_sha256": occurrence_hash,
+                   "value_equivalent_tuple_count": entry["count"],
+                   "compatible_occurrences_by_operation": compatible_rows}
+        result.append((_candidate("h4_structural_field", entry["model"], [binding]), entry))
+    result.sort(key=lambda item: item[0]["canonical_candidate_id"])
+    return result
+def _merge(candidate_1: dict[str, object], candidate_2: dict[str, object]) -> dict[str, object]:
+    if candidate_1.get("model") != candidate_2.get("model"):
+        raise H4ValidationError("replica_model_disagreement")
+    bindings = list(candidate_1.get("instance_bindings", [])) + list(candidate_2.get("instance_bindings", []))
+    return _candidate(candidate_1["model_type"], candidate_1["model"], bindings)
+def _slot(
+    candidates: list[dict[str, object]], terminal: str | None = None, measured: int | None = None,
+    kind: str | None = None, stage: str | None = None, evidence: object = None,
+) -> dict[str, object]:
+    applicable = terminal != "not_applicable"
+    return {"status": "not_applicable" if not applicable else "no_outcome" if terminal else "model",
+            "predicate_measured_survivor_count": 0 if not applicable else len(candidates) if measured is None else measured,
+            "derivation_survivor_count": 1 if applicable and terminal is None else 0,
+            "terminal_predicate_id": None if terminal in (None, "not_applicable") else terminal,
+            "terminal_payload_kind": kind, "terminal_candidate_stage": stage,
+            "candidates": candidates, "terminal_evidence": evidence,
+            "canonical_candidates_sha256": _digest(candidates)}
+
+def _ordered_predicates(plan: Mapping[str, Any], expected: list[str]) -> list[str]:
+    registry = plan.get("predicate_registry")
+    contracts = registry.get("predicate_contracts") if isinstance(registry, Mapping) else None
+    if not isinstance(contracts, list):
+        raise H4ValidationError("predicate_registry_invalid")
+    selected = [
+        row
+        for row in contracts
+        if isinstance(row, Mapping)
+        and isinstance(row.get("predicate_id"), str)
+        and row["predicate_id"].startswith("A4-H4-")
+        and "HOLDOUT" not in row["predicate_id"]
+    ]
+    if any(not isinstance(row.get("order"), int) for row in selected):
+        raise H4ValidationError("predicate_registry_invalid")
+    selected.sort(key=lambda row: row["order"])
+    actual = [row["predicate_id"] for row in selected]
+    if actual != expected or len({row["order"] for row in selected}) != len(selected):
+        raise H4ValidationError("predicate_registry_invalid")
+    return actual
+def recompute_h4(
+    bundle: Mapping[str, Any], replicas: Mapping[Any, Any], h1_models: Any,
+    h2_models: Any, h3_models: Mapping[Any, Any], plan: Mapping[str, Any],
+) -> dict[str, object]:
+    """Recompute all derivation H4 stages and registered H4 terminals."""
+    grammar = plan.get("candidate_grammars", {}).get("h4", {})
+    operations = grammar.get("operation_binding_order")
+    if operations != grammar.get("required_operations") or not isinstance(operations, list) or len(operations) != 7:
+        raise H4ValidationError("operation_order_invalid")
+    checkpoints = plan.get("checkpoint_design", {}).get("checkpoint_ids")
+    maximum_pages = plan.get("bounds", {}).get("max_final_pages_per_replica")
+    maximum_candidates = plan.get("bounds", {}).get("max_candidate_models")
+    if not isinstance(checkpoints, list) or not isinstance(maximum_pages, int) or maximum_candidates != 4096:
+        raise H4ValidationError("plan_bounds_invalid")
+    previous = {checkpoint: checkpoints[checkpoints.index(checkpoint) - 1] for checkpoint in operations}
+    required_root_changes = {"T1_CREATE_ID", "T2_CREATE", "T2_RECREATE", "T3_CREATE", "T4_CREATE"}
+    qualified: set[tuple[int, str, int]] = set()
+    work = {"catalog_root_signatures": 0, "catalog_raw_rows": 0,
+            "encoding_union_anchor_bytes": 0, "h4_name_length_structural_tuples": 0,
+            "encoding_length_equivalence_candidates": 0}
+    roots: dict[int, list[dict[str, object]]] = {}
+    traversals: dict[int, dict[int, dict[str, Any]]] = {}
+    for number in (1, 2):
+        replica = _replica(replicas, number)
+        if list(getattr(replica, "checkpoint_ids", checkpoints)) != checkpoints:
+            raise H4ValidationError("checkpoint_order_mismatch")
+        h1 = _model(_unwrap(h1_models, number))
+        h2 = _model(_unwrap(h2_models, number))
+        h3_source = _unwrap(h3_models, number)
+        h3 = _model(h3_source.get("candidates", [h3_source])[0] if isinstance(
+            h3_source.get("candidates"), list
+        ) and h3_source.get("candidates") else h3_source)
+        found, attempted = [], 0
+        traversals[number] = {}
+        for tdef_page in range(_page_count(replica, "EMPTY")):
+            page = _page(replica, "EMPTY", tdef_page)
+            if page is None or page[0] != 2:
+                continue
+            if attempted >= plan["bounds"]["max_qualified_pages_per_submodel"]:
+                raise H4ValidationError("resource_bound_breach", "catalog root pages")
+            attempted += 1
+            streams: dict[str, set[int]] = {}
+            signatures: dict[str, tuple[tuple[int, str | None], ...]] = {}
+            locator_targets: dict[str, object] = {}
+            valid = True
+            for checkpoint in checkpoints:
+                work["catalog_root_signatures"] += 1
+                try:
+                    targets, admitted = _traverse(replica, number, checkpoint, tdef_page,
+                                                   h1, h2, h3, qualified, work)
+                except (H4ValidationError, H3ValidationError) as exc:
+                    if is_resource_error(exc):
+                        raise
+                    valid = False
+                    break
+                streams[checkpoint], locator_targets[checkpoint] = admitted, targets
+                signatures[checkpoint] = tuple((page, _state_digest(replica, checkpoint, page))
+                                               for page in sorted(admitted))
+            if not valid or any(signatures[operation] == signatures[previous[operation]]
+                                for operation in required_root_changes):
+                continue
+            model = {"root_selection_signature": "operation_delta_non_name_structure",
+                     "locator_offsets": list(h1["locator_offsets"])}
+            candidate = _candidate("h4_catalog_root", model,
+                                   [{"replica": number, "tdef_page": tdef_page}])
+            found.append(candidate)
+            traversals[number][tdef_page] = {"admitted": streams, "targets": locator_targets}
+            if len(found) > maximum_candidates:
+                raise H4ValidationError("resource_bound_breach", "candidate 4097")
+        roots[number] = sorted(found, key=lambda item: item["canonical_candidate_id"])
+    root_failure = first_cardinality_failure({number: [len(roots[number])] for number in (1, 2)})
+    predicate_ids = _ordered_predicates(plan, [
+        "A4-H4-CATALOG-ROOT-NONE", "A4-H4-CATALOG-ROOT-MULTIPLE",
+        "A4-H4-SCHEMA-DELTA-OUTSIDE-OWNED", "A4-H4-CATALOG-RECORD-NONE",
+        "A4-H4-CATALOG-RECORD-MULTIPLE", "A4-H4-FIELD-MODEL-NONE",
+        "A4-H4-FIELD-MODEL-MULTIPLE", "A4-H4-ENCODING-AMBIGUOUS",
+        "A4-H4-REPLICA-DISAGREEMENT",
+    ])
+    if root_failure is not None:
+        number, count, kind = root_failure
+        terminal = predicate_ids[kind]
+        return _finish_h4(_slot(roots[number], terminal, count, "candidate_set",
+                                "h4_catalog_root"), _slot([], "not_applicable"),
+                          _slot([], "not_applicable"), terminal, count, predicate_ids,
+                          qualified, work, None, plan)
+    if roots[1][0]["model"] != roots[2][0]["model"]:
+        raise H4ValidationError("root_replica_model_disagreement")
+    root = _merge(roots[1][0], roots[2][0])
+    root_result = _slot([root])
+    deltas: dict[int, dict[str, set[int]]] = {1: {}, 2: {}}
+    outside: dict[str, object] | None = None
+    for number in (1, 2):
+        replica = _replica(replicas, number)
+        root_page = roots[number][0]["instance_bindings"][0]["tdef_page"]
+        root_streams = traversals[number][root_page]["admitted"]
+        excluded_user: dict[str, set[int]] = {checkpoint: {0, 1} for checkpoint in checkpoints}
+        for binding in _bindings(_unwrap(h1_models, number), number):
+            for checkpoint in checkpoints:
+                excluded_user[checkpoint].add(binding["tdef_page"])
+                for ordinal in (0, 1):
+                    excluded_user[checkpoint].add(_target(binding, ordinal)[0])
+        admitted_source = h3_models.get("admitted_pages", {}) if isinstance(h3_models, Mapping) else {}
+        admitted_by_checkpoint = admitted_source.get(number, admitted_source.get(str(number), {}))
+        for checkpoint, pages in admitted_by_checkpoint.items():
+            excluded_user.setdefault(checkpoint, {0, 1}).update(pages)
+        for operation in operations:
+            changed = _changed(replica, previous[operation], operation, maximum_pages)
+            isolated = changed - excluded_user[operation]
+            deltas[number][operation] = isolated
+            unexpected = sorted(isolated - root_streams[operation])
+            if unexpected and outside is None:
+                page = unexpected[0]
+                outside = {"kind": "schema_delta_outside", "input_model_id": root["canonical_candidate_id"],
+                           "observation": {"replica": number, "operation_id": operation,
+                           "checkpoint_before": previous[operation], "checkpoint_after": operation,
+                           "page": page, "page_sha256_before": _state_digest(replica, previous[operation], page),
+                           "page_sha256_after": _state_digest(replica, operation, page)}}
+    if outside:
+        terminal = predicate_ids[2]
+        return _finish_h4(root_result, _slot([], terminal, 1, "invalid_observation", None, outside),
+                          _slot([], "not_applicable"), terminal, 1, predicate_ids,
+                          qualified, work, None, plan)
+    groups: dict[int, dict[str, list[tuple[dict[str, object], bytes]]]] = {1: {}, 2: {}}
+    catalog_charges: set[tuple[int, str, int, int]] = set()
+    for number in (1, 2):
+        replica = _replica(replicas, number)
+        mask = _model(_unwrap(h2_models, number))["row_mask"]
+        root_page = roots[number][0]["instance_bindings"][0]["tdef_page"]
+        streams = traversals[number][root_page]["admitted"]
+        for operation in operations:
+            rows = []
+            retained = _retained_rows(replica, operation, deltas[number][operation] & streams[operation],
+                                      checkpoints, mask, qualified, number, work, catalog_charges)
+            for page_number, row_number, start, end, raw in retained:
+                locator = {"page": page_number, "row": row_number, "row_start": start, "row_end": end}
+                model = {"replica": number, "root_candidate_id": root["canonical_candidate_id"],
+                         "operation_id": operation, "canonical_record_locator": locator}
+                rows.append((_candidate("h4_operation_record", model), raw))
+                if sum(len(group) for by_operation in groups.values() for group in by_operation.values()
+                       ) + len(rows) > maximum_candidates:
+                    raise H4ValidationError("resource_bound_breach", "candidate 4097")
+            groups[number][operation] = sorted(rows, key=lambda item: item[0]["canonical_candidate_id"])
+    group_failure = first_cardinality_failure({number: [len(groups[number][operation])
+                                                 for operation in operations] for number in (1, 2)})
+    if group_failure is not None:
+        number, measured, kind = group_failure
+        terminal = predicate_ids[3 + kind]
+        candidates = sorted((item[0] for operation in operations for item in groups[number][operation]),
+                            key=lambda item: item["canonical_candidate_id"])
+        evidence = {"kind": "operation_groups", "groups": [
+            {"operation_id": operation, "cardinality": len(groups[number][operation]),
+             "candidate_ids": [item[0]["canonical_candidate_id"] for item in groups[number][operation]]}
+            for operation in operations]}
+        return _finish_h4(root_result, _slot(candidates, terminal, measured,
+                          "grouped_candidate_set", "h4_operation_record", evidence),
+                          _slot([], "not_applicable"), terminal, measured, predicate_ids,
+                          qualified, work, None, plan)
+    occurrence_groups = []
+    operation_rows: dict[int, dict[str, tuple[dict[str, object], bytes, list[dict[str, object]]]]] = {1: {}, 2: {}}
+    total_occurrences = 0
+    for number in (1, 2):
+        bindings = []
+        for operation in operations:
+            candidate, raw = groups[number][operation][0]
+            patterns = _operation_patterns(plan, number, operation)
+            work["encoding_union_anchor_bytes"] += len(raw) * len(patterns)
+            occurrences = _occurrences(raw, patterns)
+            total_occurrences += len(occurrences)
+            maximum = 290 if operation in ("T1_ADD_TEXT", "T1_ADD_INDEX") else 254
+            if len(occurrences) > maximum:
+                raise H4ValidationError("resource_bound_breach", "occurrence identity")
+            locator = candidate["model"]["canonical_record_locator"]
+            bindings.append({"operation_id": operation, "canonical_record_locator": locator,
+                             "occurrences": occurrences})
+            operation_rows[number][operation] = (locator, raw, occurrences)
+        occurrence_groups.append({"replica": number, "operation_bindings": bindings})
+    if total_occurrences > plan["bounds"]["max_h4_occurrence_identities"]:
+        raise H4ValidationError("resource_bound_breach", "occurrence 3701")
+    occurrence = {"protocol_version": bundle.get("protocol_version", plan.get("protocol_version")),
+                  "document_type": "dao_a4_h4_occurrence_evidence",
+                  "experiment_id": plan.get("experiment_id"), "plan_sha256": bundle.get("plan_sha256"),
+                  "revision_plan_sha256": bundle.get("revision_plan_sha256"),
+                  "campaign_id": bundle.get("campaign_id"), "root_candidate_id": root["canonical_candidate_id"],
+                  "replica_groups": occurrence_groups}
+    occurrence_bytes = _canonical(occurrence)
+    if len(occurrence_bytes) > plan["bounds"]["max_h4_occurrence_evidence_bytes"]:
+        raise H4ValidationError("resource_bound_breach", "occurrence evidence bytes")
+    occurrence_hash = hashlib.sha256(occurrence_bytes).hexdigest()
+    structural = {number: _structural_candidates(number, operation_rows[number], occurrence_hash,
+                                                  grammar, work) for number in (1, 2)}
+    structural_failure = first_cardinality_failure({number: [len(structural[number])]
+                                                     for number in (1, 2)})
+    if structural_failure is not None:
+        number, count, kind = structural_failure
+        terminal = predicate_ids[5 + kind]
+        candidates = [item[0] for item in structural[number]]
+        return _finish_h4(root_result, _slot(candidates, terminal, count, "candidate_set",
+                          "h4_structural_field"), _slot([], "not_applicable"), terminal,
+                          count, predicate_ids, qualified, work, occurrence, plan)
+    merged_structural = _merge(structural[1][0][0], structural[2][0][0]) if (
+        structural[1][0][0]["model"] == structural[2][0][0]["model"]
+    ) else None
+    structural_result = _slot([merged_structural] if merged_structural else
+                              [structural[1][0][0], structural[2][0][0]])
+    finals: dict[int, list[dict[str, object]]] = {1: [], 2: []}
+    classes = grammar.get("name_length_equivalence_classes", [])
+    for number in (1, 2):
+        candidate, internal = structural[number][0]
+        for equivalence in classes:
+            selected = []
+            for operation in operations:
+                work["encoding_length_equivalence_candidates"] += 1
+                matches = []
+                for index in sorted(internal["compatible"][operation]):
+                    occurrence_row = operation_rows[number][operation][2][index]
+                    pattern_id = occurrence_row["matched_registered_pattern_id"]
+                    length = internal["decoded"][operation][index][2]
+                    raw_length = len(bytes.fromhex(occurrence_row["matched_bytes_hex"]))
+                    scalar_length = len(bytes.fromhex(occurrence_row["matched_bytes_hex"]).decode(
+                        "utf-8" if "UTF8" in pattern_id else "cp1252"))
+                    registered = _operation_patterns(plan, number, operation)
+                    matched = bytes.fromhex(occurrence_row["matched_bytes_hex"])
+                    class_id = equivalence["id"]
+                    fits = (class_id == "cp1252_single_byte_per_scalar" and matched == registered[0][1] and
+                            length == raw_length == scalar_length) or (
+                            class_id == "utf8_encoded_byte_count" and matched == registered[-1][1] and
+                            length == raw_length) or (
+                            class_id == "utf8_unicode_scalar_or_code_unit_count" and matched == registered[-1][1] and
+                            length == scalar_length)
+                    if fits:
+                        matches.append(index)
+                if not matches:
+                    break
+                selected.append({"operation_id": operation, "occurrence_index": matches[0]})
+            if len(selected) == len(operations):
+                model = {"structural_model_id": candidate["canonical_model_id"],
+                         "encoding_length_equivalence_class": equivalence["id"]}
+                binding = {"replica": number,
+                           "structural_candidate_id": (merged_structural or candidate)["canonical_candidate_id"],
+                           "selected_operation_occurrences": selected}
+                finals[number].append(_candidate("h4_final_encoded_field", model, [binding]))
+    for number in (1, 2):
+        if len(finals[number]) != 1:
+            terminal = predicate_ids[7]
+            return _finish_h4(root_result, structural_result,
+                              _slot(finals[number], terminal, len(finals[number]), "candidate_set",
+                                    "h4_final_encoded_field"), terminal, len(finals[number]),
+                              predicate_ids, qualified, work, occurrence, plan)
+    if merged_structural is None or finals[1][0]["model"] != finals[2][0]["model"]:
+        terminal = predicate_ids[8]
+        structural_evidence = {"kind": "replica_pair", "entries": [
+            {"replica": number, "canonical_model_id": structural[number][0][0]["canonical_model_id"],
+             "canonical_candidate_id": structural[number][0][0]["canonical_candidate_id"],
+             "complete_candidate": structural[number][0][0]} for number in (1, 2)]}
+        final_evidence = {"kind": "replica_pair", "entries": [
+            {"replica": number, "canonical_model_id": finals[number][0]["canonical_model_id"],
+             "canonical_candidate_id": finals[number][0]["canonical_candidate_id"],
+             "complete_candidate": finals[number][0]} for number in (1, 2)]}
+        structural_result = _slot([], terminal, 2, "replica_pair", "h4_structural_field",
+                                  structural_evidence)
+        encoding_result = _slot([], terminal, 2, "replica_pair", "h4_final_encoded_field",
+                                final_evidence)
+        return _finish_h4(root_result, structural_result, encoding_result, terminal, 2,
+                          predicate_ids, qualified, work, occurrence, plan)
+    final = _merge(finals[1][0], finals[2][0])
+    return _finish_h4(root_result, structural_result, _slot([final]), None, 1,
+                      predicate_ids, qualified, work, occurrence, plan)
+def _finish_h4(
+    root: dict[str, object], structural: dict[str, object], encoding: dict[str, object],
+    terminal: str | None, measured: int, predicates: list[str],
+    qualified: set[tuple[int, str, int]], work: dict[str, int], occurrence: object,
+    plan: Mapping[str, Any],
+) -> dict[str, object]:
+    terminal_index = len(predicates) if terminal is None else predicates.index(terminal)
+    counts = [1] * len(predicates)
+    if terminal is not None:
+        counts[terminal_index] = measured
+        if terminal_index in (1, 6):
+            counts[terminal_index - 1] = measured
+        counts[terminal_index + 1 :] = [0] * (len(predicates) - terminal_index - 1)
+    rows = [_predicate_row(plan, predicate, "fail" if index == terminal_index else
+                           "pass" if index < terminal_index else "not_applicable", counts[index])
+            for index, predicate in enumerate(predicates)]
+    return {"result": {"root_result": root, "structural_result": structural,
+                       "encoding_result": encoding}, "predicates": rows,
+            "qualified_pages": [{"replica": replica, "checkpoint_id": checkpoint,
+                                 "page_number": page} for replica, checkpoint, page in sorted(qualified)],
+            "work_charges": work, "occurrence_evidence": occurrence,
+            "occurrence_evidence_bytes": None if occurrence is None else _canonical(occurrence)}
+def _holdout_root_context(
+    replica3: Any, h1_result: Mapping[str, Any], h2_result: Mapping[str, Any],
+    h3_result: Mapping[str, Any], h4_result: Mapping[str, Any], plan: Mapping[str, Any],
+) -> tuple[int, dict[str, set[int]], dict[str, int]]:
+    checkpoints = plan["checkpoint_design"]["checkpoint_ids"]
+    if list(getattr(replica3, "checkpoint_ids", checkpoints)) != checkpoints:
+        raise H4ValidationError("checkpoint_order_mismatch")
+    h1, h2, h3 = (_single_model(value) for value in (h1_result, h2_result, h3_result))
+    frozen = h4_result.get("result", h4_result)
+    if "root_result" in frozen:
+        frozen = frozen["root_result"]
+    root = _single_candidate(frozen)
+    root_model = _model(root)
+    if root_model.get("locator_offsets") != h1.get("locator_offsets"):
+        raise H4ValidationError("holdout_root_model_mismatch")
+    work: dict[str, int] = {}
+    qualified: set[tuple[int, str, int]] = set()
+    found, attempted = [], 0
+    required = {"T1_CREATE_ID", "T2_CREATE", "T2_RECREATE", "T3_CREATE", "T4_CREATE"}
+    for page_number in range(_page_count(replica3, "EMPTY")):
+        page = _page(replica3, "EMPTY", page_number)
+        if page is None or page[0] != 2:
+            continue
+        if attempted >= plan["bounds"]["max_qualified_pages_per_submodel"]:
+            raise H4ValidationError("resource_bound_breach", "catalog root pages")
+        attempted += 1
+        streams: dict[str, set[int]] = {}
+        signatures: dict[str, tuple[tuple[int, str | None], ...]] = {}
+        try:
+            for checkpoint in checkpoints:
+                _targets, streams[checkpoint] = _traverse(
+                    replica3, 3, checkpoint, page_number, h1, h2, h3, qualified, work
+                )
+                signatures[checkpoint] = tuple((page, _state_digest(replica3, checkpoint, page))
+                                               for page in sorted(streams[checkpoint]))
+        except (H3ValidationError, H4ValidationError) as exc:
+            if is_resource_error(exc):
+                raise
+            continue
+        if all(signatures[operation] != signatures[checkpoints[checkpoints.index(operation) - 1]]
+               for operation in required):
+            found.append((page_number, streams))
+    if len(found) != 1:
+        raise H4ValidationError("holdout_root_cardinality")
+    return found[0][0], found[0][1], work
+
+def predict_h4_root_holdout(
+    replica3: Any, h1_result: Mapping[str, Any], h2_result: Mapping[str, Any],
+    h3_result: Mapping[str, Any], h4_result: Mapping[str, Any], plan: Mapping[str, Any],
+) -> bool:
+    try:
+        _holdout_root_context(replica3, h1_result, h2_result, h3_result, h4_result, plan)
+        return True
+    except (H3ValidationError, H4ValidationError) as exc:
+        if is_resource_error(exc):
+            raise
+        return False
+    except (KeyError, TypeError, ValueError, IndexError):
+        return False
+def predict_h4_fields_holdout(
+    replica3: Any, h1_result: Mapping[str, Any], h2_result: Mapping[str, Any],
+    h3_result: Mapping[str, Any], h4_result: Mapping[str, Any], plan: Mapping[str, Any],
+) -> bool:
+    try:
+        _root_page, streams, work = _holdout_root_context(
+            replica3, h1_result, h2_result, h3_result, h4_result, plan
+        )
+        checkpoints = plan["checkpoint_design"]["checkpoint_ids"]
+        grammar = plan["candidate_grammars"]["h4"]
+        operations = grammar["operation_binding_order"]
+        h1, h2, h3 = (_single_model(value) for value in (h1_result, h2_result, h3_result))
+        h1_candidate = _single_candidate(h1_result)
+        frozen = h4_result.get("result", h4_result)
+        structural = _single_candidate(frozen["structural_result"])
+        final = _single_candidate(frozen["encoding_result"])
+        structural_model, final_model = _model(structural), _model(final)
+        if final_model.get("structural_model_id") != structural.get("canonical_model_id"):
+            return False
+        records: dict[str, bytes] = {}
+        for operation in operations:
+            before = checkpoints[checkpoints.index(operation) - 1]
+            excluded = {0, 1}
+            for binding in _bindings(h1_candidate, 3):
+                if operation not in _range(binding, checkpoints):
+                    continue
+                excluded.add(binding["tdef_page"])
+                excluded.update(_target(binding, ordinal)[0] for ordinal in (0, 1))
+                _targets, user_pages = _traverse(
+                    replica3, 3, operation, binding["tdef_page"], h1, h2, h3, set(), work
+                )
+                excluded.update(user_pages)
+            changed = _changed(replica3, before, operation, plan["bounds"]["max_final_pages_per_replica"])
+            candidates = [raw for _page_number, _row_number, _start, _end, raw in _retained_rows(
+                replica3, operation, (changed - excluded) & streams[operation], checkpoints,
+                h2["row_mask"], set(), 3, None, set()
+            )]
+            if len(candidates) != 1:
+                return False
+            records[operation] = candidates[0]
+        choices: dict[str, dict[int, list[int]]] = {}
+        for operation in operations:
+            choices[operation] = {}
+            for occurrence in _occurrences(records[operation], _operation_patterns(plan, 3, operation)):
+                name_start = occurrence["name_start"]
+                kind_start = name_start - structural_model["kind_start_delta"]
+                identifier_start = kind_start - structural_model["identifier_width"]
+                length_start = name_start - structural_model["name_length_start_delta"]
+                spans = [(identifier_start, kind_start), (kind_start, kind_start + structural_model[
+                    "kind_width"]), (length_start, length_start + structural_model["name_length_width"])]
+                if any(start < 0 or end > name_start or start >= end for start, end in spans):
+                    continue
+                if any(max(a, c) < min(b, d) for index, (a, b) in enumerate(spans)
+                       for c, d in spans[index + 1 :]):
+                    continue
+                row, endian = records[operation], structural_model["endianness"]
+                kind = int.from_bytes(row[kind_start : kind_start + structural_model["kind_width"]], endian)
+                expected_kind = "field" if operation == "T1_ADD_TEXT" else (
+                    "index" if operation == "T1_ADD_INDEX" else "table")
+                if kind != structural_model["kind_mapping"][expected_kind]:
+                    continue
+                identifier = int.from_bytes(row[identifier_start:kind_start], endian)
+                length = int.from_bytes(row[length_start : length_start + structural_model[
+                    "name_length_width"]], endian)
+                raw = bytes.fromhex(occurrence["matched_bytes_hex"])
+                pattern_id = occurrence["matched_registered_pattern_id"]
+                scalar = len(raw.decode("utf-8" if "UTF8" in pattern_id else "cp1252"))
+                class_id = final_model["encoding_length_equivalence_class"]
+                registered = _operation_patterns(plan, 3, operation)
+                fits = (class_id == "cp1252_single_byte_per_scalar" and raw == registered[0][1]
+                        and length == len(raw) == scalar) or (class_id == "utf8_encoded_byte_count"
+                        and raw == registered[-1][1] and length == len(raw)) or (
+                        class_id == "utf8_unicode_scalar_or_code_unit_count" and raw == registered[-1][1]
+                        and length == scalar)
+                if fits:
+                    choices[operation].setdefault(identifier, []).append(occurrence["occurrence_index"])
+            if not choices[operation]:
+                return False
+        relation = structural_model["identifier_lifecycle"]
+        t2_left, t2_right = choices["T2_CREATE"], choices["T2_RECREATE"]
+        if relation == "stable_for_same_physical_name_including_t2_v1_v2":
+            seeds = [(value, {value}) for value in set(t2_left) & set(t2_right)]
+        else:
+            seeds = [(None, {left, right}) for left in t2_left for right in t2_right if left != right]
+        remaining = [operation for operation in operations if operation not in ("T2_CREATE", "T2_RECREATE")]
+        def match(index: int, used: set[int]) -> bool:
+            if index == len(remaining):
+                return True
+            return any(value not in used and match(index + 1, used | {value})
+                       for value in choices[remaining[index]])
+        return any(match(0, used) for _value, used in seeds)
+    except (H3ValidationError, H4ValidationError) as exc:
+        if is_resource_error(exc):
+            raise
+        return False
+    except (KeyError, TypeError, ValueError, IndexError):
+        return False

--- a/oracle/windows-dao/scripts/a4_independent_h4_contract.py
+++ b/oracle/windows-dao/scripts/a4_independent_h4_contract.py
@@ -1,0 +1,54 @@
+"""Small resource and plan-order helpers for independent H4 stages."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from a4_independent_h3 import H3ValidationError, _row
+
+
+class H4ValidationError(ValueError):
+    """A fail-closed independent H4 recomputation error."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        super().__init__(f"{code}: {detail}" if detail else code)
+        self.code = code
+
+
+def first_cardinality_failure(
+    counts: Mapping[int, Sequence[int]],
+) -> tuple[int, int, int] | None:
+    """Return replica, count, and NONE/MULTIPLE offset in predicate order."""
+    for kind in (0, 1):
+        for number in (1, 2):
+            count = min(counts[number]) if kind == 0 else max(counts[number])
+            if (count == 0) if kind == 0 else (count > 1):
+                return number, count, kind
+    return None
+
+
+def catalog_rows(
+    page: bytes, mask: int, charge_prefix: tuple[int, str, int] | None = None,
+    work: dict[str, int] | None = None, charged: set[tuple[int, str, int, int]] | None = None,
+) -> list[tuple[int, int, int, bytes]]:
+    """Decode one catalog inventory and charge each physical row identity once."""
+    if page[0] != 1:
+        return []
+    count = int.from_bytes(page[8:10], "little")
+    if count > 679:
+        raise H4ValidationError("catalog_row_bound")
+    result = []
+    for ordinal in range(count):
+        try:
+            raw, start, end = _row(page, ordinal, mask)
+        except H3ValidationError as exc:
+            raise H4ValidationError("catalog_directory_invalid") from exc
+        identity = None if charge_prefix is None else (*charge_prefix, ordinal)
+        if identity is not None and work is not None and charged is not None and identity not in charged:
+            charged.add(identity)
+            work["catalog_raw_rows"] += 1
+        result.append((ordinal, start, end, raw))
+    return result
+
+
+def is_resource_error(error: BaseException) -> bool:
+    return getattr(error, "code", None) == "resource_bound_breach"

--- a/oracle/windows-dao/scripts/a4_independent_projection.py
+++ b/oracle/windows-dao/scripts/a4_independent_projection.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Plan-derived output projections for the independent A4 validator."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping, Sequence
+
+from a4_independent_bundle import LoadedBundle, ValidationError
+from a4_independent_contract import REVISION_PLAN_SHA256
+
+
+LAYER_NAMES = (
+    "h1_tdef_to_map_row",
+    "h2_row_identity_map_role",
+    "h3_indirect_traversal",
+    "h4_catalog_bootstrap",
+)
+HOLDOUT_NAMES = ("h1", "h2", "h3", "h4_root", "h4_fields")
+
+
+def compare_frozen_report(bundle: LoadedBundle) -> None:
+    """Require every report field copied from the freeze to be byte-equivalent."""
+    frozen = bundle.frozen
+    report = bundle.report
+    pairs = (
+        ("qualified_pages", "qualified_pages"),
+        ("work_charges", "work_charges"),
+        ("h4_occurrence_evidence", "h4_occurrence_evidence"),
+        ("layers", "layers"),
+        ("transcripts", "transcripts"),
+    )
+    if any(frozen[left] != report[right] for left, right in pairs):
+        raise ValidationError("analysis_report_mismatch")
+    frozen_sha256 = hashlib.sha256(bundle.frozen_raw).hexdigest()
+    if report.get("derivation_candidate_set_sha256") != frozen_sha256:
+        raise ValidationError("frozen_file_hash_mismatch")
+    if report.get("campaign_id") != frozen.get("campaign_id"):
+        raise ValidationError("analysis_report_mismatch")
+
+
+def compare_recomputation(
+    bundle: LoadedBundle,
+    recomputed: Mapping[str, Any],
+) -> None:
+    """Compare independently recomputed physical and predicate projections."""
+    frozen = bundle.frozen
+    report = bundle.report
+    for field in ("layers", "qualified_pages", "work_charges", "transcripts"):
+        if recomputed.get(field) != frozen.get(field):
+            raise ValidationError("frozen_set_recomputation_mismatch")
+    if recomputed.get("predicate_results") != report.get("predicate_results"):
+        raise ValidationError("predicate_layer_projection_mismatch")
+    if recomputed.get("holdout_results") != report.get("holdout_results"):
+        raise ValidationError("holdout_projection_mismatch")
+    if recomputed.get("scientific_outcome") != report.get("scientific_outcome"):
+        raise ValidationError("holdout_projection_mismatch")
+
+
+def validate_claims(bundle: LoadedBundle) -> None:
+    claims = bundle.report.get("claims")
+    if not isinstance(claims, Mapping) or set(claims) != set(bundle.plan["claims"]):
+        raise ValidationError("analysis_report_mismatch")
+    if claims != bundle.plan["claims"]:
+        raise ValidationError("analysis_report_mismatch")
+    if claims.get("descriptive_provider_observation_only") is not True:
+        raise ValidationError("analysis_report_mismatch")
+    if any(
+        value is not False
+        for name, value in claims.items()
+        if name != "descriptive_provider_observation_only"
+    ):
+        raise ValidationError("analysis_report_mismatch")
+
+
+def logical_read_projection(
+    bundle: LoadedBundle,
+) -> list[dict[str, int]]:
+    analyzer = bundle.report.get("analyzer_logical_read_bytes_by_replica")
+    if not isinstance(analyzer, list) or len(analyzer) != 3:
+        raise ValidationError("analysis_report_mismatch")
+    output: list[dict[str, int]] = []
+    for index, replica in enumerate((1, 2, 3)):
+        source = bundle.replicas[replica]
+        producer = sum(row["page_count"] for row in source.indexes.values()) * 2048
+        independent = bundle.page_store.logical_read_bytes(replica)
+        analyzer_value = analyzer[index]
+        if not all(
+            isinstance(value, int) and not isinstance(value, bool) and value >= 0
+            for value in (producer, analyzer_value, independent)
+        ):
+            raise ValidationError("logical_read_accounting_mismatch")
+        total = producer + analyzer_value + independent
+        if total > 1_317_011_456:
+            raise ValidationError("resource_bound_breach")
+        output.append({
+            "replica": replica,
+            "producer": producer,
+            "analyzer": analyzer_value,
+            "independent_validator": independent,
+            "total": total,
+        })
+    return output
+
+
+def recompute_only_document(
+    bundle: LoadedBundle,
+    recomputed: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_independent_recomputation",
+        "source_experiment_id": bundle.manifest["experiment_id"],
+        "source_bundle_manifest_sha256": bundle.manifest_sha256,
+        "derivation_replicas": [1, 2],
+        "holdout_opened": False,
+        "qualified_pages": recomputed["qualified_pages"],
+        "work_charges": recomputed["work_charges"],
+        "layers": recomputed["layers"],
+    }
+
+
+def pair_projection_document(
+    bundle: LoadedBundle,
+    recomputed: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_independent_pair_projection",
+        "source_experiment_id": bundle.manifest["experiment_id"],
+        "source_bundle_manifest_sha256": bundle.manifest_sha256,
+        "derivation_replicas": [1, 2],
+        "holdout_opened": True,
+        "bundle_contract_rejection": None,
+        "independent_projection": {
+            "layers": recomputed["layers"],
+            "predicate_results": recomputed["predicate_results"],
+            "holdout_results": recomputed["holdout_results"],
+            "scientific_outcome": recomputed["scientific_outcome"],
+        },
+    }
+
+
+def verdict(
+    bundle: LoadedBundle | None,
+    validator_commit: str,
+    *,
+    accepted: bool,
+    discrepancy_codes: Sequence[str],
+    tamper_results: Sequence[Mapping[str, Any]],
+    logical_reads: Sequence[Mapping[str, int]] | None = None,
+) -> dict[str, Any]:
+    manifest: Mapping[str, Any] = {} if bundle is None else bundle.manifest
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_independent_validation_report",
+        "experiment_id": "DAO-A4-ROW-ANCHORED-MAPS-001",
+        "plan_sha256": "0" * 64 if bundle is None else bundle.plan_sha256,
+        "revision_plan_sha256": (
+            "0" * 64 if bundle is None else REVISION_PLAN_SHA256
+        ),
+        "campaign_id": manifest.get("campaign_id", "unavailable"),
+        "bundle_manifest_sha256": (
+            "0" * 64 if bundle is None else bundle.manifest_sha256
+        ),
+        "validator_commit": validator_commit,
+        "implementation_independence_attested": True,
+        "frozen_set_parsed": True,
+        "frozen_set_matches_recomputation": accepted,
+        "frozen_set_matches_report": accepted,
+        "predicate_registry_recomputed": accepted,
+        "holdout_recomputed": accepted,
+        "tamper_results": [dict(row) for row in tamper_results],
+        "accepted": accepted,
+        "independent_validation_status": (
+            "independently_validated" if accepted else "not_independently_validated"
+        ),
+        "discrepancy_codes": list(discrepancy_codes),
+        "logical_read_bytes_by_replica": (
+            [dict(row) for row in logical_reads]
+            if logical_reads is not None
+            else [
+                {
+                    "replica": replica,
+                    "producer": 0,
+                    "analyzer": 0,
+                    "independent_validator": 0,
+                    "total": 0,
+                }
+                for replica in (1, 2, 3)
+            ]
+        ),
+    }
+
+
+def failure_document(
+    bundle: LoadedBundle | None,
+    validator_commit: str,
+    discrepancy_code: str,
+    tamper_results: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return a truthful diagnostic, not a schema-valid acceptance report."""
+    return {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_independent_validation_failure",
+        "experiment_id": "DAO-A4-ROW-ANCHORED-MAPS-001",
+        "validator_commit": validator_commit,
+        "bundle_manifest_sha256": (
+            None if bundle is None else bundle.manifest_sha256
+        ),
+        "frozen_set_parsed": bundle is not None,
+        "tamper_results_executed": [dict(row) for row in tamper_results],
+        "accepted": False,
+        "independent_validation_status": "not_independently_validated",
+        "discrepancy_codes": [discrepancy_code],
+    }

--- a/oracle/windows-dao/scripts/a4_independent_validator.py
+++ b/oracle/windows-dao/scripts/a4_independent_validator.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Independently recompute and validate one retained DAO A4 bundle."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from a4_independent_bundle import (
+    BundleLoader,
+    LoadedBundle,
+    ValidationError,
+    canonical_document_bytes,
+    canonical_json_bytes,
+)
+from a4_independent_campaign import require_campaign, verify_frozen_transcripts
+from a4_independent_contract import (
+    CONTRACT,
+    EXPECTED_TAMPERS,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    ContractError,
+    validate_canonical_snapshot,
+    validate_snapshot_schedule,
+)
+from a4_independent_h1 import apply_h1_holdout, recompute_h1
+from a4_independent_h2 import predict_h2_holdout, recompute_h2
+from a4_independent_h3 import predict_h3_holdout, recompute_h3
+from a4_independent_h4 import (
+    predict_h4_fields_holdout,
+    predict_h4_root_holdout,
+    recompute_h4,
+)
+from a4_independent_projection import (
+    compare_frozen_report,
+    compare_recomputation,
+    failure_document,
+    logical_read_projection,
+    pair_projection_document,
+    recompute_only_document,
+    validate_claims,
+    verdict,
+)
+
+
+_HOLDOUT_NAMES = {
+    "A4-H1-HOLDOUT-PREDICTION": "h1",
+    "A4-H2-HOLDOUT-PREDICTION": "h2",
+    "A4-H3-HOLDOUT-PREDICTION": "h3",
+    "A4-H4-HOLDOUT-ROOT": "h4_root",
+    "A4-H4-HOLDOUT-FIELDS": "h4_fields",
+}
+
+
+def _candidate_hash(candidates: Sequence[Mapping[str, Any]]) -> str:
+    return hashlib.sha256(canonical_json_bytes(list(candidates))).hexdigest()
+
+
+def _not_applicable() -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+    return {
+        "status": "not_applicable",
+        "predicate_measured_survivor_count": 0,
+        "derivation_survivor_count": 0,
+        "terminal_predicate_id": None,
+        "terminal_payload_kind": None,
+        "terminal_candidate_stage": None,
+        "candidates": candidates,
+        "terminal_evidence": None,
+        "canonical_candidates_sha256": _candidate_hash(candidates),
+    }
+
+
+def _h4_not_applicable() -> dict[str, Any]:
+    return {
+        "root_result": _not_applicable(),
+        "structural_result": _not_applicable(),
+        "encoding_result": _not_applicable(),
+    }
+
+
+def _is_model(result: Mapping[str, Any]) -> bool:
+    return result.get("status") == "model" and len(result.get("candidates", ())) == 1
+
+
+def _snapshot_row_counts(
+    bundle: LoadedBundle, numbers: Sequence[int]
+) -> dict[int, dict[str, dict[str, int]]]:
+    return {
+        number: {
+            checkpoint: {
+                table["logical_role"]: table["row_count"]
+                for table in replica.snapshots[checkpoint]["tables"]
+            }
+            for checkpoint in CONTRACT.checkpoint_ids
+        }
+        for number in numbers
+        for replica in (bundle.replicas[number],)
+    }
+
+
+def _all_results(layers: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    h4 = layers["h4_catalog_bootstrap"]
+    return (
+        layers["h1_tdef_to_map_row"],
+        layers["h2_row_identity_map_role"],
+        layers["h3_indirect_traversal"],
+        h4["root_result"],
+        h4["structural_result"],
+        h4["encoding_result"],
+    )
+
+
+def _charged_candidates(result: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    candidates = list(result.get("candidates", ()))
+    evidence = result.get("terminal_evidence")
+    if result.get("terminal_payload_kind") == "replica_pair" and isinstance(
+        evidence, Mapping
+    ):
+        entries = evidence.get("entries")
+        if isinstance(entries, list):
+            candidates.extend(
+                entry["complete_candidate"]
+                for entry in entries
+                if isinstance(entry, Mapping)
+                and isinstance(entry.get("complete_candidate"), Mapping)
+            )
+    return candidates
+
+
+def _work_document(
+    plan: Mapping[str, Any],
+    layers: Mapping[str, Any],
+    work_parts: Sequence[Mapping[str, int]],
+) -> dict[str, int]:
+    model = plan["work_model"]
+    limits = {
+        **{name: row["units"] for name, row in model["terms"].items()},
+        **{
+            name: row["units"]
+            for name, row in model["terminal_path_maxima"]["alternative_terms"].items()
+        },
+    }
+    work = {name: 0 for name in limits}
+    for part in work_parts:
+        for name, value in part.items():
+            if name not in work or isinstance(value, bool) or not isinstance(value, int):
+                raise ValidationError("resource_bound_breach", f"unknown work term {name}")
+            work[name] += value
+    payloads = {
+        canonical_json_bytes(dict(candidate))
+        for result in _all_results(layers)
+        for candidate in _charged_candidates(result)
+    }
+    if any(len(payload) > int(plan["bounds"]["max_canonical_candidate_bytes"]) for payload in payloads):
+        raise ValidationError("resource_bound_breach", "canonical candidate bytes")
+    work["candidate_serializations"] = len(payloads)
+    if any(value < 0 or value > limits[name] for name, value in work.items()):
+        raise ValidationError("resource_bound_breach", "work term")
+    total = sum(work.values())
+    if total > int(plan["bounds"]["max_analysis_work_units"]):
+        raise ValidationError("resource_bound_breach", "total work")
+    return {**work, "total_work_units": total}
+
+
+def _qualified_pages(
+    parts: Sequence[Sequence[Mapping[str, Any]]],
+) -> list[dict[str, Any]]:
+    ordinal = {checkpoint: index for index, checkpoint in enumerate(CONTRACT.checkpoint_ids)}
+    identities = {
+        (row["replica"], row["checkpoint_id"], row["page_number"])
+        for part in parts
+        for row in part
+    }
+    return [
+        {"replica": replica, "checkpoint_id": checkpoint, "page_number": page}
+        for replica, checkpoint, page in sorted(
+            identities, key=lambda row: (row[0], ordinal[row[1]], row[2])
+        )
+    ]
+
+
+def _module_rows(*groups: Sequence[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    output: dict[str, Mapping[str, Any]] = {}
+    for group in groups:
+        for row in group:
+            predicate = row["predicate_id"]
+            if predicate in output:
+                raise ValidationError("predicate_layer_projection_mismatch")
+            output[predicate] = row
+    return output
+
+
+def _predicate_document(
+    module_rows: Mapping[str, Mapping[str, Any]],
+    holdout: Mapping[str, bool | None],
+    campaign_rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    contracts = CONTRACT.plan["predicate_registry"]["predicate_contracts"]
+    campaign = {row["predicate_id"]: row for row in campaign_rows}
+    output: list[dict[str, Any]] = []
+    for contract in contracts:
+        predicate = contract["predicate_id"]
+        if contract["scope"] == "campaign":
+            source = campaign.get(predicate)
+            status, measured = (
+                ("not_applicable", 0)
+                if source is None
+                else (source["status"], source["predicate_measured_survivor_count"])
+            )
+        elif predicate in _HOLDOUT_NAMES:
+            value = holdout[_HOLDOUT_NAMES[predicate]]
+            status = "not_applicable" if value is None else "pass" if value else "fail"
+            measured = 0 if value is None else 1
+        else:
+            source = module_rows.get(predicate)
+            if source is None:
+                status, measured = "not_applicable", 0
+            else:
+                status = source["status"]
+                measured = source.get(
+                    "predicate_measured_survivor_count",
+                    source.get("measured_survivor_count"),
+                )
+                if measured is None:
+                    raise ValidationError(
+                        "predicate_layer_projection_mismatch",
+                        f"missing measurement for {predicate}",
+                    )
+        retains = (
+            contract["scope"] != "campaign"
+            and status != "not_applicable"
+            and (status == "pass" or predicate in _HOLDOUT_NAMES)
+        )
+        output.append({
+            "predicate_id": predicate,
+            "order": contract["order"],
+            "scope": contract["scope"],
+            "status": status,
+            "terminal_predicate_id": predicate if status == "fail" else None,
+            "predicate_measured_survivor_count": measured,
+            "derivation_survivor_count": 1 if retains else 0,
+            "reachability_fixture_id": contract["reachability_fixture_id"],
+        })
+    return output
+
+
+def recompute_bundle(
+    bundle: LoadedBundle, *, open_holdout: bool = True
+) -> dict[str, Any]:
+    """Rebuild derivation and holdout projections without analyzer code."""
+    plan = bundle.plan
+    campaign_rows = (
+        require_campaign(bundle).predicate_rows if open_holdout else ()
+    )
+    contracts = plan["predicate_registry"]["predicate_contracts"]
+    rows = _snapshot_row_counts(bundle, (1, 2, 3) if open_holdout else (1, 2))
+    h1 = recompute_h1(bundle.replicas, plan=plan, predicate_contracts=contracts)
+    h2_result = _not_applicable()
+    h3_result = _not_applicable()
+    h4_result = _h4_not_applicable()
+    h2 = h3 = h4 = None
+    row_groups: list[Sequence[Mapping[str, Any]]] = [h1.predicate_results]
+    page_groups: list[Sequence[Mapping[str, Any]]] = [h1.qualified_pages]
+    work_groups: list[Mapping[str, int]] = [h1.work_charges]
+    if _is_model(h1.layer):
+        h2 = recompute_h2(
+            bundle.replicas,
+            h1,
+            plan=plan,
+            predicate_contracts=contracts,
+            snapshot_row_counts=rows,
+        )
+        h2_result = dict(h2.layer)
+        row_groups.append(h2.predicate_results)
+        page_groups.append(h2.qualified_pages)
+        work_groups.append(h2.work_charges)
+    if h2 is not None and _is_model(h2_result):
+        h3 = recompute_h3(bundle.replicas, h1, h2, plan)
+        h3_result = dict(h3["result"])
+        row_groups.append(h3["predicates"])
+        page_groups.append(h3["qualified_pages"])
+        work_groups.append(h3["work_charges"])
+    if h3 is not None and _is_model(h3_result):
+        h4 = recompute_h4(
+            {
+                "protocol_version": bundle.manifest["protocol_version"],
+                "plan_sha256": bundle.plan_sha256,
+                "revision_plan_sha256": bundle.manifest["revision_plan_sha256"],
+                "campaign_id": bundle.manifest["campaign_id"],
+            },
+            bundle.replicas,
+            h1,
+            h2,
+            h3,
+            plan,
+        )
+        h4_result = dict(h4["result"])
+        row_groups.append(h4["predicates"])
+        page_groups.append(h4["qualified_pages"])
+        work_groups.append(h4["work_charges"])
+    layers = {
+        "h1_tdef_to_map_row": dict(h1.layer),
+        "h2_row_identity_map_role": h2_result,
+        "h3_indirect_traversal": h3_result,
+        "h4_catalog_bootstrap": h4_result,
+    }
+
+    holdout: dict[str, bool | None] = dict.fromkeys(_HOLDOUT_NAMES.values())
+    holdout_h1 = None
+    if open_holdout and _is_model(h1.layer):
+        holdout_h1 = apply_h1_holdout(bundle.replicas[3], h1.layer, plan=plan)
+        holdout["h1"] = holdout_h1 is not None
+    if holdout_h1 is not None and _is_model(h2_result):
+        holdout["h2"] = predict_h2_holdout(
+            bundle.replicas[3], holdout_h1, h2_result,
+            plan=plan, snapshot_row_counts=rows,
+        )
+    if holdout_h1 is not None and holdout["h2"] and _is_model(h3_result):
+        holdout["h3"] = predict_h3_holdout(
+            bundle.replicas[3], holdout_h1, h2_result, h3_result, plan
+        )
+    if holdout_h1 is not None and holdout["h3"] and _is_model(h4_result["root_result"]):
+        args = (bundle.replicas[3], holdout_h1, h2_result, h3_result, h4_result, plan)
+        holdout["h4_root"] = predict_h4_root_holdout(*args)
+        if holdout["h4_root"] and _is_model(h4_result["encoding_result"]):
+            holdout["h4_fields"] = predict_h4_fields_holdout(*args)
+    holdout_document = {
+        name: {
+            "status": "not_applicable" if value is None else "pass" if value else "fail",
+            "terminal_predicate_id": (
+                next(key for key, item in _HOLDOUT_NAMES.items() if item == name)
+                if value is False else None
+            ),
+        }
+        for name, value in holdout.items()
+    }
+    module_rows = _module_rows(*row_groups)
+    return {
+        "layers": layers,
+        "qualified_pages": _qualified_pages(page_groups),
+        "work_charges": _work_document(plan, layers, work_groups),
+        "predicate_results": _predicate_document(module_rows, holdout, campaign_rows),
+        "holdout_results": holdout_document,
+        "scientific_outcome": (
+            "one_or_more_layers_predict_holdout"
+            if any(value is True for value in holdout.values())
+            else "no_layer_predicts_holdout"
+        ),
+        "h4_occurrence_evidence": None if h4 is None else h4["occurrence_evidence"],
+        "h4_occurrence_evidence_bytes": (
+            None if h4 is None else h4["occurrence_evidence_bytes"]
+        ),
+        "transcripts": {
+            name: list(rows)
+            for name, rows in verify_frozen_transcripts(bundle).items()
+        },
+    }
+
+
+def _validate_bindings(bundle: LoadedBundle) -> None:
+    values: list[Mapping[str, Any]] = [bundle.manifest, bundle.frozen, bundle.report, bundle.receipt]
+    values.extend(replica.environment for replica in bundle.replicas.values())
+    values.extend(replica.artifact_manifest for replica in bundle.replicas.values())
+    values.extend(replica.observation for replica in bundle.replicas.values())
+    values.extend(index for replica in bundle.replicas.values() for index in replica.indexes.values())
+    values.extend(snapshot for replica in bundle.replicas.values() for snapshot in replica.snapshots.values())
+    if any(
+        value.get("plan_sha256") != PLAN_SHA256
+        or value.get("revision_plan_sha256") != REVISION_PLAN_SHA256
+        for value in values
+    ):
+        raise ValidationError("plan_binding_mismatch")
+
+
+def _validate_timing(bundle: LoadedBundle) -> None:
+    elapsed = bundle.manifest.get("campaign_elapsed_seconds")
+    if isinstance(elapsed, bool) or not isinstance(elapsed, int) or elapsed < 0:
+        raise ValidationError("campaign_timing_mismatch")
+    if elapsed > int(CONTRACT.bounds["campaign_timeout_seconds"]):
+        raise ValidationError("campaign_timeout_exceeded")
+
+
+def _validate_snapshots(bundle: LoadedBundle) -> None:
+    for number, replica in bundle.replicas.items():
+        for checkpoint, snapshot in replica.snapshots.items():
+            validate_canonical_snapshot(snapshot, f"replica {number} {checkpoint}")
+            validate_snapshot_schedule(snapshot, bundle.plan, number, checkpoint)
+            try:
+                ordinal = CONTRACT.checkpoint_ids.index(checkpoint)
+                path = f"schema-snapshots/replica-{number:02d}/{ordinal:02d}-{checkpoint}.json"
+                entry = bundle.entries[path]
+            except KeyError as exc:
+                raise ValidationError("schema_snapshot_mismatch") from exc
+            raw = canonical_document_bytes(snapshot)
+            if (
+                hashlib.sha256(raw).hexdigest() != entry["sha256"]
+                or len(raw) != entry["size_bytes"]
+            ):
+                raise ValidationError("schema_snapshot_mismatch")
+
+
+def _candidate_identity(candidate: Mapping[str, Any]) -> tuple[str, str]:
+    model_type = candidate.get("model_type")
+    model = candidate.get("model")
+    bindings = candidate.get("instance_bindings")
+    if not isinstance(model_type, str) or not isinstance(model, Mapping):
+        raise ValidationError("candidate_canonicalization_mismatch")
+    model_id = hashlib.sha256(canonical_json_bytes({
+        "model_type": model_type, "model": dict(model),
+    })).hexdigest()
+    candidate_identity: dict[str, Any] = {"model_type": model_type, "model": dict(model)}
+    if bindings is not None:
+        if not isinstance(bindings, list):
+            raise ValidationError("candidate_canonicalization_mismatch")
+        candidate_identity["instance_bindings"] = bindings
+    candidate_id = hashlib.sha256(canonical_json_bytes(candidate_identity)).hexdigest()
+    return model_id, candidate_id
+
+
+def _validate_locator_order(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if key == "locator_offsets" and (
+                not isinstance(child, list)
+                or any(isinstance(item, bool) or not isinstance(item, int) for item in child)
+                or child != sorted(child)
+                or len(set(child)) != len(child)
+            ):
+                raise ValidationError("candidate_canonicalization_mismatch")
+            _validate_locator_order(child)
+    elif isinstance(value, list):
+        for child in value:
+            _validate_locator_order(child)
+
+
+def _validate_candidates(layers: Mapping[str, Any]) -> None:
+    for result in _all_results(layers):
+        candidates = result.get("candidates")
+        if not isinstance(candidates, list) or result.get("canonical_candidates_sha256") != _candidate_hash(candidates):
+            raise ValidationError("candidate_canonicalization_mismatch")
+        for candidate in candidates:
+            model_id, candidate_id = _candidate_identity(candidate)
+            expected_model_id = model_id if "instance_bindings" in candidate else None
+            if candidate.get("canonical_model_id") != expected_model_id or candidate.get(
+                "canonical_candidate_id"
+            ) != candidate_id:
+                raise ValidationError("candidate_canonicalization_mismatch")
+            _validate_locator_order(candidate)
+        for candidate in _charged_candidates(result)[len(candidates) :]:
+            model_id, candidate_id = _candidate_identity(candidate)
+            expected_model_id = model_id if "instance_bindings" in candidate else None
+            if candidate.get("canonical_model_id") != expected_model_id or candidate.get(
+                "canonical_candidate_id"
+            ) != candidate_id:
+                raise ValidationError("candidate_canonicalization_mismatch")
+            _validate_locator_order(candidate)
+
+
+def _validate_occurrence(bundle: LoadedBundle, recomputed: Mapping[str, Any]) -> None:
+    expected = recomputed["h4_occurrence_evidence_bytes"]
+    if expected != bundle.occurrence_evidence_raw:
+        raise ValidationError("frozen_set_recomputation_mismatch")
+
+
+def _validate_report_order(report: Mapping[str, Any]) -> None:
+    rows = report.get("predicate_results")
+    if not isinstance(rows, list) or [row.get("predicate_id") for row in rows] != list(
+        CONTRACT.predicate_ids
+    ) or [row.get("order") for row in rows] != list(range(1, 41)):
+        raise ValidationError("analysis_report_mismatch")
+
+
+def _validate_predicate_layer_projection(report: Mapping[str, Any]) -> None:
+    rows = {row["predicate_id"]: row for row in report["predicate_results"]}
+    results = _all_results(report["layers"])
+    terminals = [
+        result["terminal_predicate_id"]
+        for result in results
+        if result.get("status") == "no_outcome"
+    ]
+    for result in results:
+        status = result.get("status")
+        candidates = result.get("candidates")
+        if status == "not_applicable" and candidates:
+            raise ValidationError("predicate_layer_projection_mismatch")
+        if status == "model" and (
+            not isinstance(candidates, list)
+            or len(candidates) != 1
+            or result.get("terminal_predicate_id") is not None
+        ):
+            raise ValidationError("predicate_layer_projection_mismatch")
+    layer_ids = tuple(
+        predicate
+        for predicates in CONTRACT.layer_predicates.values()
+        for predicate in predicates
+    )
+    if not terminals:
+        if not all(result.get("status") == "model" for result in results) or any(
+            rows[predicate]["status"] != "pass" for predicate in layer_ids
+        ):
+            raise ValidationError("predicate_layer_projection_mismatch")
+        return
+    unique_terminals = set(terminals)
+    if len(unique_terminals) != 1 or next(iter(unique_terminals)) not in layer_ids:
+        raise ValidationError("predicate_layer_projection_mismatch")
+    terminal_index = layer_ids.index(next(iter(unique_terminals)))
+    expected = ["pass"] * terminal_index + ["fail"] + [
+        "not_applicable"
+    ] * (len(layer_ids) - terminal_index - 1)
+    if [rows[predicate]["status"] for predicate in layer_ids] != expected:
+        raise ValidationError("predicate_layer_projection_mismatch")
+
+
+def _validate_holdout_projection(
+    report: Mapping[str, Any], recomputed: Mapping[str, Any]
+) -> None:
+    if report.get("holdout_results") != recomputed.get("holdout_results"):
+        raise ValidationError("holdout_projection_mismatch")
+    rows = {row["predicate_id"]: row for row in report["predicate_results"]}
+    for predicate, name in _HOLDOUT_NAMES.items():
+        result = report["holdout_results"][name]
+        if (
+            rows[predicate]["status"] != result["status"]
+            or rows[predicate]["terminal_predicate_id"]
+            != result["terminal_predicate_id"]
+        ):
+            raise ValidationError("holdout_projection_mismatch")
+    outcome = (
+        "one_or_more_layers_predict_holdout"
+        if any(row["status"] == "pass" for row in report["holdout_results"].values())
+        else "no_layer_predicts_holdout"
+    )
+    if report.get("scientific_outcome") != outcome or outcome != recomputed.get(
+        "scientific_outcome"
+    ):
+        raise ValidationError("holdout_projection_mismatch")
+
+
+def validate_bundle(bundle: LoadedBundle, recomputed: Mapping[str, Any]) -> None:
+    _validate_bindings(bundle)
+    _validate_timing(bundle)
+    _validate_snapshots(bundle)
+    _validate_candidates(bundle.frozen["layers"])
+    _validate_report_order(bundle.report)
+    compare_frozen_report(bundle)
+    _validate_predicate_layer_projection(bundle.report)
+    _validate_holdout_projection(bundle.report, recomputed)
+    compare_recomputation(bundle, recomputed)
+    _validate_occurrence(bundle, recomputed)
+    validate_claims(bundle)
+
+
+def _replace_candidate_ids(candidate: dict[str, Any]) -> None:
+    model_id, candidate_id = _candidate_identity(candidate)
+    if "instance_bindings" in candidate:
+        candidate["canonical_model_id"] = model_id
+    candidate["canonical_candidate_id"] = candidate_id
+
+
+def _tamper_h1_candidate(result: dict[str, Any]) -> dict[str, Any]:
+    candidates = result["candidates"]
+    if candidates:
+        candidate = candidates[0]
+    else:
+        grammar = CONTRACT.plan["candidate_grammars"]["h1"]
+        candidate = {
+            "model_type": "h1_locator_pair",
+            "model": {
+                "layout": grammar["locator_layouts"][0],
+                "table_signature_id": grammar["table_record_signature"]["signature_id"],
+                "locator_offsets": [35, 39],
+            },
+            "instance_bindings": [{
+                "replica": 1,
+                "logical_role": "T1",
+                "lifecycle_instance": "T1-v1",
+                "tdef_page": 1,
+                "applicable_checkpoint_range": {
+                    "start": "T1_CREATE_ID", "end": "T4_IDLE_R",
+                },
+                "locator_targets": [
+                    {"page": 1, "row": 0}, {"page": 1, "row": 1},
+                ],
+            }],
+        }
+        _replace_candidate_ids(candidate)
+        candidates.append(candidate)
+    return candidate
+
+
+def _expect_rejection(
+    identifier: str,
+    expected: str,
+    action: Callable[[], None],
+) -> dict[str, Any]:
+    try:
+        action()
+    except (ValidationError, ContractError) as exc:
+        code = getattr(exc, "code", "malformed_bundle")
+        if code == expected:
+            return {"id": identifier, "rejected": True, "discrepancy_code": code}
+        raise ValidationError("tamper_rejection_mismatch", f"{identifier}: {code}") from exc
+    raise ValidationError("tamper_not_rejected", identifier)
+
+
+def execute_tamper_suite(
+    bundle: LoadedBundle, recomputed: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    """Execute all preregistered mutations against semantic checks."""
+    actions: dict[str, Callable[[], None]] = {}
+
+    t1_manifest = copy.deepcopy(bundle.manifest)
+    t1_manifest["plan_sha256"] = "0" * 64
+    actions["T1"] = lambda: _validate_bindings(replace(bundle, manifest=t1_manifest))
+
+    t2_frozen = copy.deepcopy(bundle.frozen)
+    t2_candidates = t2_frozen["layers"]["h1_tdef_to_map_row"]["candidates"]
+    t2_candidate = _tamper_h1_candidate(
+        t2_frozen["layers"]["h1_tdef_to_map_row"]
+    )
+    target = t2_candidate["instance_bindings"][0]["locator_targets"][0]
+    target["row"] = target["row"] - 1 if target["row"] == 255 else target["row"] + 1
+    _replace_candidate_ids(t2_candidate)
+    t2_frozen["layers"]["h1_tdef_to_map_row"]["canonical_candidates_sha256"] = _candidate_hash(t2_candidates)
+    actions["T2"] = lambda: compare_recomputation(replace(bundle, frozen=t2_frozen), recomputed)
+
+    snapshots = dict(bundle.replicas[1].snapshots)
+    checkpoint = CONTRACT.checkpoint_ids[-1]
+    snapshots[checkpoint] = copy.deepcopy(snapshots[checkpoint])
+    payload = next(
+        field
+        for table in snapshots[checkpoint]["tables"]
+        for field in table["fields"]
+        if field["name"] == "Payload"
+    )
+    payload["attributes"] += 1
+    replicas = dict(bundle.replicas)
+    replicas[1] = replace(replicas[1], snapshots=snapshots)
+    entries = dict(bundle.entries)
+    ordinal = CONTRACT.checkpoint_ids.index(checkpoint)
+    snapshot_path = f"schema-snapshots/replica-01/{ordinal:02d}-{checkpoint}.json"
+    entries[snapshot_path] = dict(entries[snapshot_path])
+    snapshot_raw = canonical_document_bytes(snapshots[checkpoint])
+    entries[snapshot_path]["sha256"] = hashlib.sha256(snapshot_raw).hexdigest()
+    entries[snapshot_path]["size_bytes"] = len(snapshot_raw)
+    actions["T3"] = lambda: _validate_snapshots(
+        replace(bundle, replicas=replicas, entries=entries)
+    )
+
+    t4_report = copy.deepcopy(bundle.report)
+    t4_report["predicate_results"] = list(reversed(t4_report["predicate_results"]))
+    actions["T4"] = lambda: _validate_report_order(t4_report)
+
+    t5_manifest = copy.deepcopy(bundle.manifest)
+    t5_manifest["campaign_elapsed_seconds"] = 2701
+    actions["T5"] = lambda: _validate_timing(replace(bundle, manifest=t5_manifest))
+
+    t6_report = copy.deepcopy(bundle.report)
+    inapplicable = next(
+        (result for result in _all_results(t6_report["layers"])
+         if result["status"] == "not_applicable"),
+        None,
+    )
+    if inapplicable is not None:
+        inapplicable["candidates"].append({"retained": "tamper"})
+    else:
+        first = t6_report["layers"]["h1_tdef_to_map_row"]
+        first["status"] = "no_outcome"
+        first["terminal_predicate_id"] = CONTRACT.layer_predicates[
+            "h1_tdef_to_map_row"
+        ][0]
+    actions["T6"] = lambda: _validate_predicate_layer_projection(t6_report)
+
+    t7_report = copy.deepcopy(bundle.report)
+    holdout_name = next(iter(t7_report["holdout_results"]))
+    original = t7_report["holdout_results"][holdout_name]["status"]
+    t7_report["holdout_results"][holdout_name]["status"] = "fail" if original != "fail" else "pass"
+    actions["T7"] = lambda: _validate_holdout_projection(t7_report, recomputed)
+
+    t8_frozen = copy.deepcopy(bundle.frozen)
+    t8_candidates = t8_frozen["layers"]["h1_tdef_to_map_row"]["candidates"]
+    t8_candidate = _tamper_h1_candidate(
+        t8_frozen["layers"]["h1_tdef_to_map_row"]
+    )
+    t8_frozen["layers"]["h1_tdef_to_map_row"]["canonical_candidates_sha256"] = _candidate_hash(t8_candidates)
+    offsets = t8_candidate["model"]["locator_offsets"]
+    offsets.reverse()
+    actions["T8"] = lambda: _validate_candidates(t8_frozen["layers"])
+
+    t9_report = copy.deepcopy(bundle.report)
+    t9_report["derivation_candidate_set_sha256"] = "0" * 64
+    actions["T9"] = lambda: compare_frozen_report(replace(bundle, report=t9_report))
+
+    return [
+        _expect_rejection(identifier, expected, actions[identifier])
+        for identifier, expected in EXPECTED_TAMPERS
+    ]
+
+
+def _validator_commit() -> str:
+    root = Path(__file__).resolve().parents[3]
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=root, check=True,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise SystemExit("cannot resolve validator commit") from exc
+
+
+def _write_output(value: Mapping[str, Any], output: Path | None, root: Path) -> None:
+    raw = canonical_document_bytes(value)
+    if output is None:
+        sys.stdout.buffer.write(raw)
+        return
+    destination = output.resolve()
+    bundle_root = root.resolve()
+    if destination == bundle_root or bundle_root in destination.parents:
+        raise ValidationError("output_inside_bundle")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(raw)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-root", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--validator-commit")
+    parser.add_argument("--recompute-only", action="store_true")
+    parser.add_argument("--pair-projection", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.recompute_only and args.pair_projection:
+        raise SystemExit("--recompute-only and --pair-projection are mutually exclusive")
+    validator_commit = args.validator_commit or _validator_commit()
+    if len(validator_commit) != 40 or any(character not in "0123456789abcdef" for character in validator_commit):
+        raise SystemExit("--validator-commit must be 40 lowercase hexadecimal characters")
+    bundle: LoadedBundle | None = None
+    tamper_results: list[dict[str, Any]] = []
+    try:
+        bundle = BundleLoader(args.bundle_root).load(
+            open_holdout=not args.recompute_only
+        )
+        recomputed = recompute_bundle(bundle, open_holdout=not args.recompute_only)
+        if args.recompute_only:
+            _write_output(recompute_only_document(bundle, recomputed), args.output, args.bundle_root)
+            return 0
+        if args.pair_projection:
+            _write_output(pair_projection_document(bundle, recomputed), args.output, args.bundle_root)
+            return 0
+        validate_bundle(bundle, recomputed)
+        tamper_results = execute_tamper_suite(bundle, recomputed)
+        reads = logical_read_projection(bundle)
+        result = verdict(
+            bundle, validator_commit, accepted=True, discrepancy_codes=[],
+            tamper_results=tamper_results, logical_reads=reads,
+        )
+        CONTRACT.validate_document(result, "dao_a4_independent_validation_report")
+        _write_output(result, args.output, args.bundle_root)
+        return 0
+    except (ValidationError, ContractError) as exc:
+        code = getattr(exc, "code", "malformed_bundle")
+    except (KeyError, TypeError, ValueError, IndexError, OSError, OverflowError, json.JSONDecodeError):
+        code = "malformed_bundle"
+    result = failure_document(
+        bundle, validator_commit, code, tamper_results,
+    )
+    _write_output(result, args.output, args.bundle_root)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/tests/test_a4_independent_bundle.py
+++ b/oracle/windows-dao/tests/test_a4_independent_bundle.py
@@ -1,0 +1,386 @@
+"""Focused tests for the independent A4 contract and bundle trust boundary."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_independent_bundle import (  # noqa: E402
+    BundleLoader,
+    PageStore,
+    ValidationError,
+    canonical_document_bytes,
+)
+from a4_independent_contract import (  # noqa: E402
+    CONTRACT,
+    EXPECTED_TAMPERS,
+    PLAN_PATH,
+    PLAN_SHA256,
+    ContractError,
+    load_contract,
+    validate_canonical_snapshot,
+)
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+from a4_analysis import analyze  # noqa: E402
+
+
+def _write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _entry(path: str, role: str, payload: bytes, media: str = "application/json") -> dict[str, object]:
+    return {
+        "path": path,
+        "role": role,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size_bytes": len(payload),
+        "media_type": media,
+    }
+
+
+def _build_bundle(root: Path) -> None:
+    inputs = _inputs()
+    result = analyze("a4-synthetic", _COMMIT, inputs)
+    surfaces = {1: inputs[1], 2: inputs[2], 3: inputs.acquire_holdout(result.frozen.canonical_bytes, result.frozen.sha256)}
+    outer: dict[str, dict[str, object]] = {}
+    plan_path = "plan/a4-row-anchored-maps.plan.json"
+    plan_raw = PLAN_PATH.read_bytes()
+    _write(root / plan_path, plan_raw)
+    outer[plan_path] = _entry(plan_path, "plan", plan_raw)
+    artifact_hashes: list[str] = []
+    environment_hashes: list[str] = []
+    for number, surface in surfaces.items():
+        environment_path = f"environment/replica-{number:02d}.json"
+        observation_path = f"observations/replica-{number:02d}.json"
+        artifact_path = f"replica-artifacts/replica-{number:02d}-manifest.json"
+        documents = {
+            environment_path: (surface.environment_payload, "environment"),
+            observation_path: (canonical_document_bytes(surface.replica_observation), "replica_observation"),
+            artifact_path: (canonical_document_bytes(surface.artifact_manifest), "replica_artifact_manifest"),
+        }
+        for checkpoint, index in surface.page_indexes.items():
+            ordinal = CONTRACT.checkpoint_ids.index(checkpoint)
+            path = f"page-indexes/replica-{number:02d}/{ordinal:02d}-{checkpoint}.json"
+            documents[path] = (canonical_document_bytes(index), "page_index")
+        for checkpoint, snapshot in surface.schema_snapshots.items():
+            ordinal = CONTRACT.checkpoint_ids.index(checkpoint)
+            path = f"schema-snapshots/replica-{number:02d}/{ordinal:02d}-{checkpoint}.json"
+            documents[path] = (canonical_document_bytes(snapshot), "dao_schema_snapshot")
+        for path, (payload, role) in documents.items():
+            assert isinstance(payload, bytes)
+            _write(root / path, payload)
+            outer[path] = _entry(path, role, payload)
+        environment_hashes.append(outer[environment_path]["sha256"])
+        artifact_hashes.append(outer[artifact_path]["sha256"])
+        for checkpoint in CONTRACT.checkpoint_ids:
+            for digest in surface.source.ordered_page_sha256[checkpoint]:
+                path = f"page-store/{digest}.page"
+                if path not in outer:
+                    payload = surface.source.page_bytes(digest)
+                    _write(root / path, payload)
+                    outer[path] = _entry(path, "page_blob", payload, "application/octet-stream")
+    frozen_path = "analysis/derivation-candidates.json"
+    report_path = "analysis/analysis-report.json"
+    evidence_path = "analysis/h4-occurrence-evidence.json"
+    receipt_path = "analysis/holdout-structure-receipt.json"
+    report_raw = canonical_document_bytes(dict(result.report))
+    _write(root / frozen_path, result.frozen.canonical_bytes)
+    _write(root / report_path, report_raw)
+    outer[frozen_path] = _entry(frozen_path, "frozen_candidate_set", result.frozen.canonical_bytes)
+    outer[report_path] = _entry(report_path, "analysis_report", report_raw)
+    if result.frozen.occurrence_evidence_bytes is not None:
+        _write(root / evidence_path, result.frozen.occurrence_evidence_bytes)
+        outer[evidence_path] = _entry(
+            evidence_path, "h4_occurrence_evidence", result.frozen.occurrence_evidence_bytes
+        )
+    receipt = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_holdout_structure_receipt",
+        "experiment_id": "DAO-A4-ROW-ANCHORED-MAPS-001",
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": PLAN_SHA256,
+        "producer_commit": _COMMIT,
+        "campaign_id": "a4-synthetic",
+        "derivation_candidate_set_sha256": result.frozen.sha256,
+        "replica": 3,
+        "replica_artifact_manifest_sha256": artifact_hashes[2],
+        "validated_after_candidate_freeze": True,
+        "page_bytes_exposed_to_analyzer": False,
+        "result": "pass",
+    }
+    receipt_raw = canonical_document_bytes(receipt)
+    _write(root / receipt_path, receipt_raw)
+    outer[receipt_path] = _entry(receipt_path, "holdout_structure_receipt", receipt_raw)
+    files = [outer[path] for path in sorted(outer)]
+    scientific = {
+        "one_or_more_layers_predict_holdout": "one_or_more_submodels_predict_holdout",
+        "no_layer_predicts_holdout": "no_submodel_predicts_holdout",
+    }[result.report["scientific_outcome"]]
+    manifest = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_bundle_manifest",
+        "experiment_id": "DAO-A4-ROW-ANCHORED-MAPS-001",
+        "campaign_id": "a4-synthetic",
+        "producer_commit": _COMMIT,
+        "repository_url": "https://github.com/oglassdev/jet3-rs.git",
+        "created_utc": "2026-08-25T00:10:00Z",
+        "campaign_started_utc": "2026-08-25T00:00:00Z",
+        "campaign_elapsed_seconds": 600,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": PLAN_SHA256,
+        "replica_environment_sha256": environment_hashes,
+        "provider_sha256": "2" * 64,
+        "replica_count": 3,
+        "replica_artifact_manifest_sha256": artifact_hashes,
+        "checkpoint_count": 75,
+        "page_blob_count": sum(row["role"] == "page_blob" for row in files),
+        "bundle_size_bytes_excluding_manifest": sum(row["size_bytes"] for row in files),
+        "inventory_closed": True,
+        "hashes_verified": True,
+        "paths_closed": True,
+        "execution_status": "analysis_complete",
+        "campaign_failed": False,
+        "holdout_structure_receipt_sha256": outer[receipt_path]["sha256"],
+        "analysis_report_retained": True,
+        "analysis_scientific_outcome": scientific,
+        "bundle_status": (
+            "decisive_pending_independent_validation"
+            if scientific == "one_or_more_submodels_predict_holdout"
+            else "complete_no_scientific_outcome"
+        ),
+        "independent_validation_status": "not_independently_validated",
+        "files": files,
+    }
+    _write(root / "bundle-manifest.json", canonical_document_bytes(manifest))
+
+
+class IndependentContractTests(unittest.TestCase):
+    def test_contract_pins_plan_schemas_predicates_and_nine_tampers(self) -> None:
+        self.assertEqual(hashlib.sha256(CONTRACT.plan_raw).hexdigest(), PLAN_SHA256)
+        self.assertEqual(len(CONTRACT.schemas), 14)
+        self.assertEqual(len(CONTRACT.checkpoint_ids), 25)
+        self.assertEqual(len(CONTRACT.predicate_ids), 40)
+        flattened = (
+            CONTRACT.campaign_predicates
+            + tuple(item for rows in CONTRACT.layer_predicates.values() for item in rows)
+            + CONTRACT.holdout_predicates
+        )
+        self.assertEqual(flattened, CONTRACT.predicate_ids)
+        self.assertEqual(
+            tuple((row["id"], row["required_rejection"]) for row in CONTRACT.tamper_cases),
+            EXPECTED_TAMPERS,
+        )
+
+    def test_contract_rejects_replacement_plan_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            replacement = Path(directory) / PLAN_PATH.name
+            replacement.write_bytes(PLAN_PATH.read_bytes() + b" ")
+            with self.assertRaisesRegex(ContractError, "plan_binding_mismatch"):
+                load_contract(replacement)
+
+    def test_independent_modules_have_closed_imports(self) -> None:
+        forbidden = (
+            "a4_analysis",
+            "a4_model",
+            "a4_layer",
+            "a4_generator",
+            "a4_spec",
+        )
+        for path in SCRIPTS.glob("a4_independent_*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            imports = [
+                alias.name
+                for node in ast.walk(tree)
+                if isinstance(node, (ast.Import, ast.ImportFrom))
+                for alias in (node.names if isinstance(node, ast.Import) else [ast.alias(node.module or "")])
+            ]
+            self.assertFalse(
+                [name for name in imports if name.startswith(forbidden)],
+                path.name,
+            )
+
+
+class IndependentBundleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(prefix="a4-independent-bundle-")
+        cls.bundle = Path(cls.temporary.name) / "bundle"
+        _build_bundle(cls.bundle)
+        cls.loaded = BundleLoader(cls.bundle).load()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def _copy(self, directory: str) -> Path:
+        target = Path(directory) / "bundle"
+        shutil.copytree(self.bundle, target, copy_function=os.link)
+        manifest = target / "bundle-manifest.json"
+        payload = manifest.read_bytes()
+        manifest.unlink()
+        manifest.write_bytes(payload)
+        return target
+
+    @staticmethod
+    def _replace(root: Path, relative: str, payload: bytes) -> None:
+        path = root / relative
+        path.unlink()
+        path.write_bytes(payload)
+
+    def _relink_replica_json(
+        self, root: Path, manifest: dict[str, object], number: int, relative: str, value: dict[str, object]
+    ) -> None:
+        payload = canonical_document_bytes(value)
+        self._replace(root, relative, payload)
+        entry = next(row for row in manifest["files"] if row["path"] == relative)
+        entry.update(sha256=hashlib.sha256(payload).hexdigest(), size_bytes=len(payload))
+        observation_path = f"observations/replica-{number:02d}.json"
+        if relative.startswith("schema-snapshots/") or relative.startswith("page-indexes/"):
+            observation = json.loads((root / observation_path).read_text(encoding="utf-8"))
+            key = "dao_schema_snapshot" if relative.startswith("schema-snapshots/") else "page_index"
+            reference = next(row for row in observation["checkpoints"] if row[key]["path"] == relative)[key]
+            reference.update(sha256=entry["sha256"], size_bytes=entry["size_bytes"])
+            self._relink_replica_json(root, manifest, number, observation_path, observation)
+            return
+        artifact_path = f"replica-artifacts/replica-{number:02d}-manifest.json"
+        if relative == artifact_path:
+            manifest["replica_artifact_manifest_sha256"][number - 1] = entry["sha256"]
+            return
+        artifact = json.loads((root / artifact_path).read_text(encoding="utf-8"))
+        artifact_entry = next(row for row in artifact["files"] if row["path"] == relative)
+        artifact_entry.clear()
+        artifact_entry.update(entry)
+        self._relink_replica_json(root, manifest, number, artifact_path, artifact)
+
+    @staticmethod
+    def _finish_manifest(root: Path, manifest: dict[str, object]) -> None:
+        manifest["bundle_size_bytes_excluding_manifest"] = sum(
+            row["size_bytes"] for row in manifest["files"]
+        )
+        (root / "bundle-manifest.json").write_bytes(canonical_document_bytes(manifest))
+
+    def test_loads_complete_bundle_and_reads_each_blob_once(self) -> None:
+        bundle = self.loaded
+        page_count = bundle.manifest["page_blob_count"]
+        self.assertEqual(bundle.page_store.physical_read_count, page_count)
+        self.assertEqual(set(bundle.replicas), {1, 2, 3})
+        self.assertEqual(sum(len(replica.indexes) for replica in bundle.replicas.values()), 75)
+        self.assertEqual(sum(len(replica.snapshots) for replica in bundle.replicas.values()), 75)
+        first = bundle.replicas[1].page("EMPTY", 0)
+        self.assertIs(first, bundle.replicas[1].page("EMPTY", 0))
+        self.assertEqual(bundle.page_store.physical_read_count, page_count)
+
+    def test_rejects_duplicate_snapshot_name_and_matrix_job(self) -> None:
+        snapshot = copy.deepcopy(self.loaded.replicas[1].snapshots["T1_ADD_TEXT"])
+        fields = next(table for table in snapshot["tables"] if table["logical_role"] == "T1")["fields"]
+        for key in ("name", "name_utf16_code_units", "name_windows_1252_hex", "name_utf8_hex"):
+            fields[1][key] = fields[0][key]
+        with self.assertRaisesRegex(ContractError, "schema_snapshot_mismatch"):
+            validate_canonical_snapshot(snapshot, "tampered")
+        replicas = dict(self.loaded.replicas)
+        environment = copy.deepcopy(replicas[3].environment)
+        environment["matrix_job_id"] = replicas[2].environment["matrix_job_id"]
+        replicas[3] = replace(replicas[3], environment=environment)
+        loader = BundleLoader(self.bundle)
+        with self.assertRaisesRegex(ValidationError, "cross_replica_environment_mismatch"):
+            loader._environment_closure(self.loaded.manifest, replicas, self.loaded.entries)
+
+    def test_aggregate_preflight_happens_before_page_access(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._copy(directory)
+            manifest_path = root / "bundle-manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["page_blob_count"] += 1
+            manifest_path.write_bytes(canonical_document_bytes(manifest))
+            with mock.patch.object(PageStore, "read", side_effect=AssertionError("page opened")):
+                with self.assertRaisesRegex(ValidationError, "aggregate page store"):
+                    BundleLoader(root).load()
+
+    def test_coherently_relinked_t1_t3_t5_reach_registered_failures(self) -> None:
+        def t1(root: Path, manifest: dict[str, object]) -> None:
+            relative = "plan/a4-row-anchored-maps.plan.json"
+            plan = json.loads((root / relative).read_text(encoding="utf-8"))
+            plan["question"] += " "
+            payload = canonical_document_bytes(plan)
+            self._replace(root, relative, payload)
+            entry = next(row for row in manifest["files"] if row["path"] == relative)
+            entry.update(sha256=hashlib.sha256(payload).hexdigest(), size_bytes=len(payload))
+
+        def t3(root: Path, manifest: dict[str, object]) -> None:
+            relative = "schema-snapshots/replica-01/03-T1_ADD_TEXT.json"
+            snapshot = json.loads((root / relative).read_text(encoding="utf-8"))
+            table = next(row for row in snapshot["tables"] if row["logical_role"] == "T1")
+            table["fields"][1]["attributes"] = 0
+            self._relink_replica_json(root, manifest, 1, relative, snapshot)
+
+        def t5(_root: Path, manifest: dict[str, object]) -> None:
+            manifest["campaign_elapsed_seconds"] = 2701
+            manifest["created_utc"] = "2026-08-25T00:45:01Z"
+
+        for name, mutate, expected in (
+            ("T1", t1, "plan_binding_mismatch"),
+            ("T3", t3, "schema_snapshot_mismatch"),
+            ("T5", t5, "campaign_timeout_exceeded"),
+        ):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = self._copy(directory)
+                manifest = json.loads(
+                    (root / "bundle-manifest.json").read_text(encoding="utf-8")
+                )
+                mutate(root, manifest)
+                self._finish_manifest(root, manifest)
+                with self.assertRaisesRegex(ValidationError, expected):
+                    BundleLoader(root).load()
+
+    def test_rejects_uninventoried_file_and_symlink(self) -> None:
+        for name, mutate, expected in (
+            ("extra", lambda root: _write(root / "extra.txt", b"x"), "manifest_inventory_not_closed"),
+            (
+                "symlink",
+                lambda root: (root / "linked").symlink_to(root / "analysis", target_is_directory=True),
+                "bundle_symlink",
+            ),
+        ):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = self._copy(directory)
+                mutate(root)
+                with self.assertRaisesRegex(ValidationError, expected):
+                    BundleLoader(root).load()
+
+    def test_rejects_noncanonical_frozen_even_when_inventory_is_relinked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._copy(directory)
+            frozen_path = root / "analysis/derivation-candidates.json"
+            frozen = json.loads(frozen_path.read_text(encoding="utf-8"))
+            frozen_raw = json.dumps(frozen, ensure_ascii=False, indent=2).encode() + b"\n"
+            frozen_path.unlink()
+            frozen_path.write_bytes(frozen_raw)
+            manifest_path = root / "bundle-manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            entry = next(row for row in manifest["files"] if row["path"] == "analysis/derivation-candidates.json")
+            manifest["bundle_size_bytes_excluding_manifest"] += len(frozen_raw) - entry["size_bytes"]
+            entry["size_bytes"] = len(frozen_raw)
+            entry["sha256"] = hashlib.sha256(frozen_raw).hexdigest()
+            manifest_path.write_bytes(canonical_document_bytes(manifest))
+            with self.assertRaisesRegex(ValidationError, "frozen_set_not_canonical"):
+                BundleLoader(root).load()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_independent_campaign.py
+++ b/oracle/windows-dao/tests/test_a4_independent_campaign.py
@@ -1,0 +1,292 @@
+"""Focused campaign-predicate and transcript tests for the A4 validator."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_independent_bundle import (  # noqa: E402
+    BundleLoader,
+    ValidationError,
+    canonical_document_bytes,
+)
+from a4_independent_campaign import (  # noqa: E402
+    recompute_campaign,
+    require_campaign,
+    verify_frozen_transcripts,
+)
+from a4_independent_contract import CONTRACT  # noqa: E402
+import a4_layers  # noqa: E402
+import test_a4_independent_bundle as fixture  # noqa: E402
+from a4_layer_h3 import SlotObservation  # noqa: E402
+from a4_layer_h4 import (  # noqa: E402
+    CatalogRecordLocator,
+    CheckpointRecordEvidence,
+    OperationRecord,
+)
+from test_a4_independent_bundle import _build_bundle  # noqa: E402
+
+
+class IndependentCampaignTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(prefix="a4-independent-campaign-")
+        cls.root = Path(cls.temporary.name)
+        _build_bundle(cls.root)
+        cls.bundle = BundleLoader(cls.root).load()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_normal_bundle_passes_campaign_and_exact_transcripts(self) -> None:
+        result = require_campaign(self.bundle)
+        self.assertTrue(result.passed)
+        self.assertIsNone(result.first_failure)
+        self.assertEqual(
+            [row["predicate_id"] for row in result.predicate_rows],
+            list(CONTRACT.campaign_predicates),
+        )
+        self.assertEqual([row["status"] for row in result.predicate_rows], ["pass"] * 4)
+        self.assertEqual(
+            result.resources["retained_page_store_bytes"],
+            result.resources["unique_page_blobs"] * 2048,
+        )
+        rebuilt = verify_frozen_transcripts(self.bundle)
+        self.assertEqual(
+            {name: list(rows) for name, rows in rebuilt.items()},
+            self.bundle.frozen["transcripts"],
+        )
+
+    def test_initial_index_has_no_changed_pages(self) -> None:
+        for replica in self.bundle.replicas.values():
+            self.assertEqual(replica.index("EMPTY")["changed_page_indices"], [])
+        result = recompute_campaign(self.bundle)
+        self.assertEqual(result.predicate_rows[2]["status"], "pass")
+
+    def test_idle_difference_is_first_terminal_and_later_rows_are_na(self) -> None:
+        replica = self.bundle.replicas[1]
+        indexes = dict(replica.indexes)
+        changed = dict(indexes["EMPTY_R"])
+        hashes = list(changed["ordered_page_sha256"])
+        hashes[0] = next(digest for digest in self.bundle.page_store.paths if digest != hashes[0])
+        changed["ordered_page_sha256"] = hashes
+        indexes["EMPTY_R"] = changed
+        replicas = dict(self.bundle.replicas)
+        replicas[1] = replace(replica, indexes=indexes)
+        bundle = replace(self.bundle, replicas=replicas)
+
+        result = recompute_campaign(bundle)
+        self.assertEqual(result.first_failure.predicate_id, "A4-IDLE-EQUALITY")
+        self.assertEqual(
+            [row["status"] for row in result.predicate_rows],
+            ["fail", "not_applicable", "not_applicable", "not_applicable"],
+        )
+        with self.assertRaises(ValidationError) as raised:
+            require_campaign(bundle)
+        self.assertEqual(raised.exception.code, "A4-IDLE-EQUALITY")
+
+    def test_semantic_snapshot_mutation_with_coherent_entry_is_schema_terminal(self) -> None:
+        checkpoint = "T1_CREATE_ID"
+        ordinal = CONTRACT.checkpoint_ids.index(checkpoint)
+        relative = f"schema-snapshots/replica-01/{ordinal:02d}-{checkpoint}.json"
+        original_bytes = (self.root / relative).read_bytes()
+        replica = self.bundle.replicas[1]
+        snapshot = copy.deepcopy(replica.snapshots[checkpoint])
+        snapshot["tables"][0]["attributes"] += 1
+        encoded = canonical_document_bytes(snapshot)
+        digest = hashlib.sha256(encoded).hexdigest()
+        entries = dict(self.bundle.entries)
+        entries[relative] = {
+            **entries[relative], "sha256": digest, "size_bytes": len(encoded)
+        }
+        snapshots = dict(replica.snapshots)
+        snapshots[checkpoint] = snapshot
+        observation = copy.deepcopy(replica.observation)
+        reference = observation["checkpoints"][ordinal]["dao_schema_snapshot"]
+        reference.update({"sha256": digest, "size_bytes": len(encoded)})
+        replicas = dict(self.bundle.replicas)
+        replicas[1] = replace(replica, snapshots=snapshots, observation=observation)
+        bundle = replace(self.bundle, entries=entries, replicas=replicas)
+        try:
+            (self.root / relative).write_bytes(encoded)
+            result = recompute_campaign(bundle)
+        finally:
+            (self.root / relative).write_bytes(original_bytes)
+        self.assertEqual(result.first_failure.predicate_id, "A4-SCHEMA-SNAPSHOT")
+        self.assertEqual(
+            [row["status"] for row in result.predicate_rows],
+            ["pass", "fail", "not_applicable", "not_applicable"],
+        )
+
+    def test_corrupt_reconstructed_page_is_reconstruction_terminal(self) -> None:
+        idle_digests = {
+            digest
+            for replica in self.bundle.replicas.values()
+            for pair in CONTRACT.plan["checkpoint_design"]["idle_pairs"]
+            for checkpoint in pair
+            for digest in replica.index(checkpoint)["ordered_page_sha256"]
+        }
+        target = next(
+            digest
+            for replica in self.bundle.replicas.values()
+            for checkpoint in CONTRACT.checkpoint_ids
+            for digest in replica.index(checkpoint)["ordered_page_sha256"]
+            if digest not in idle_digests
+        )
+        original = self.bundle.page_store._cache[target]
+        try:
+            self.bundle.page_store._cache[target] = b"\xff" * 2048
+            result = recompute_campaign(self.bundle)
+        finally:
+            self.bundle.page_store._cache[target] = original
+        self.assertEqual(
+            result.first_failure.predicate_id, "A4-SNAPSHOT-RECONSTRUCTION"
+        )
+        self.assertEqual(
+            [row["status"] for row in result.predicate_rows],
+            ["pass", "pass", "fail", "not_applicable"],
+        )
+
+    def test_claimed_resource_counter_difference_is_resource_terminal(self) -> None:
+        replica = self.bundle.replicas[1]
+        observation = dict(replica.observation)
+        observation["changed_hash_entries"] += 1
+        replicas = dict(self.bundle.replicas)
+        replicas[1] = replace(replica, observation=observation)
+        result = recompute_campaign(replace(self.bundle, replicas=replicas))
+        self.assertEqual(result.first_failure.predicate_id, "A4-RESOURCE-BOUND")
+        self.assertEqual(
+            [row["status"] for row in result.predicate_rows],
+            ["pass", "pass", "pass", "fail"],
+        )
+
+    def test_schema_valid_transcript_payload_and_order_tampering_are_rejected(self) -> None:
+        frozen = copy.deepcopy(self.bundle.frozen)
+        row = frozen["transcripts"]["locators"][0]
+        row["detail_hex"] = "00" * (len(row["detail_hex"]) // 2)
+        bundle = replace(self.bundle, frozen=frozen)
+        with self.assertRaises(ValidationError) as raised:
+            verify_frozen_transcripts(bundle)
+        self.assertEqual(raised.exception.code, "frozen_set_recomputation_mismatch")
+
+        frozen = copy.deepcopy(self.bundle.frozen)
+        rows = frozen["transcripts"]["catalog_fields"]
+        rows[0], rows[1] = rows[1], rows[0]
+        with self.assertRaises(ValidationError) as raised:
+            verify_frozen_transcripts(replace(self.bundle, frozen=frozen))
+        self.assertEqual(raised.exception.code, "frozen_set_recomputation_mismatch")
+
+    def _assert_generated_terminal(self, patcher: object, expected: str) -> None:
+        with tempfile.TemporaryDirectory(prefix="a4-campaign-terminal-") as temporary:
+            root = Path(temporary)
+            with patcher:
+                fixture._build_bundle(root)
+            bundle = BundleLoader(root).load()
+            terminals = {
+                result.get("terminal_predicate_id")
+                for layer in bundle.frozen["layers"].values()
+                for result in (
+                    layer.values()
+                    if "root_result" in layer
+                    else (layer,)
+                )
+            }
+            self.assertIn(expected, terminals)
+            verify_frozen_transcripts(bundle)
+
+    def test_early_h3_terminals_rebuild_exact_reached_transcripts(self) -> None:
+        original = a4_layers.h3_observations
+
+        def conversion_none(view: object, rows: object, work: object) -> object:
+            return original(view, rows, work)[:1]
+
+        self._assert_generated_terminal(
+            mock.patch.object(
+                a4_layers, "h3_observations", side_effect=conversion_none
+            ),
+            "A4-H3-CONVERSION-NONE",
+        )
+
+        def inactive_none(view: object, rows: object, work: object) -> object:
+            observations = original(view, rows, work)
+            active = next(
+                slot
+                for observation in observations
+                for slot in observation.slots
+                if slot.reference
+            )
+            return tuple(
+                replace(
+                    observation,
+                    slots=tuple(
+                        slot
+                        if slot.reference
+                        else SlotObservation(
+                            slot.slot_ordinal,
+                            active.reference,
+                            active.referenced_page_tag,
+                            active.set_bits,
+                        )
+                        for slot in observation.slots
+                    ),
+                )
+                for observation in observations
+            )
+
+        self._assert_generated_terminal(
+            mock.patch.object(
+                a4_layers, "h3_observations", side_effect=inactive_none
+            ),
+            "A4-H3-INACTIVE-SLOT-NONE",
+        )
+
+    def test_early_h4_record_terminals_rebuild_exact_catalog_markers(self) -> None:
+        original = a4_layers.operation_records
+        self._assert_generated_terminal(
+            mock.patch.object(a4_layers, "operation_records", return_value=()),
+            "A4-H4-CATALOG-RECORD-NONE",
+        )
+
+        def multiple(*args: object, **kwargs: object) -> object:
+            records = original(*args, **kwargs)
+            base = records[0]
+            evidence = tuple(
+                CheckpointRecordEvidence(
+                    row.checkpoint_id,
+                    CatalogRecordLocator(
+                        row.locator.page,
+                        row.locator.row + 1,
+                        row.locator.row_start,
+                        row.locator.row_end,
+                    ),
+                    row.row_bytes,
+                )
+                for row in base.checkpoint_evidence
+            )
+            duplicate = OperationRecord(
+                base.replica, base.operation_id, evidence
+            )
+            return tuple(records) + (duplicate,)
+
+        self._assert_generated_terminal(
+            mock.patch.object(
+                a4_layers, "operation_records", side_effect=multiple
+            ),
+            "A4-H4-CATALOG-RECORD-MULTIPLE",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_independent_h1_h2.py
+++ b/oracle/windows-dao/tests/test_a4_independent_h1_h2.py
@@ -1,0 +1,288 @@
+"""Focused fake-replica tests for fresh A4 H1/H2 recomputation."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+TESTS = ROOT / "oracle" / "windows-dao" / "tests"
+sys.path[:0] = [str(SCRIPTS), str(TESTS)]
+
+from a4_independent_contract import CONTRACT  # noqa: E402
+from a4_independent_h1 import (  # noqa: E402
+    _ReplicaState,
+    _sha as h1_sha,
+    _structural_stage,
+    predict_h1_holdout,
+    recompute_h1,
+)
+from a4_independent_h2 import (  # noqa: E402
+    ValidationError as H2ValidationError,
+    _candidate as h2_candidate,
+    predict_h2_holdout,
+    recompute_h2,
+)
+
+
+class FakeReplica:
+    def __init__(self, number: int, pages: dict[tuple[str, int], bytes] | None = None):
+        self.number = number
+        self.checkpoint_ids = tuple(CONTRACT.checkpoint_ids)
+        self.pages = {} if pages is None else dict(pages)
+        self.page_calls = 0
+
+    def state(self, checkpoint: str, page: int) -> str | None:
+        value = self.pages.get((checkpoint, page))
+        return None if value is None else __import__("hashlib").sha256(value).hexdigest()
+
+    def page(self, checkpoint: str, page: int) -> bytes | None:
+        self.page_calls += 1
+        return self.pages.get((checkpoint, page))
+
+    def index(self, checkpoint: str) -> dict[str, int]:
+        return {"page_count": 32}
+
+
+class ViewReplica:
+    def __init__(self, view: object):
+        self.view = view
+        self.number = view.replica
+        self.checkpoint_ids = tuple(CONTRACT.checkpoint_ids)
+
+    def state(self, checkpoint: str, page: int) -> str | None:
+        return self.view.hash_at(checkpoint, page)
+
+    def page(self, checkpoint: str, page: int) -> bytes | None:
+        return self.view.page_optional(checkpoint, page)
+
+    def index(self, checkpoint: str) -> dict[str, int]:
+        return {"page_count": self.view.page_count(checkpoint)}
+
+
+def _contracts() -> list[dict[str, object]]:
+    return [dict(row) for row in CONTRACT.plan["predicate_registry"]["predicate_contracts"]]
+
+
+def _invalid_directory_page() -> bytes:
+    page = bytearray(2048)
+    page[0] = 1
+    page[8:10] = (1).to_bytes(2, "little")
+    page[10:12] = (10).to_bytes(2, "little")
+    return bytes(page)
+
+
+def _valid_directory_page() -> bytes:
+    page = bytearray(2048)
+    page[0] = 1
+    page[8:10] = (1).to_bytes(2, "little")
+    page[10:12] = (2040).to_bytes(2, "little")
+    page[2040:] = bytes([0, 0, 0, 0, 0, 0, 0, 0])
+    return bytes(page)
+
+
+def _frozen_h1() -> dict[str, object]:
+    bindings = []
+    for replica in (1, 2):
+        for role, instance in (
+            ("T1", "T1-v1"),
+            ("T2", "T2-v1"),
+            ("T2", "T2-v2"),
+            ("T3", "T3-v1"),
+            ("T4", "T4-v1"),
+        ):
+            bindings.append({
+                "replica": replica,
+                "logical_role": role,
+                "lifecycle_instance": instance,
+                "tdef_page": 23,
+                "locator_targets": [{"page": 5, "row": 0}, {"page": 5, "row": 0}],
+                "applicable_checkpoint_range": {"start": "T1_CREATE_ID", "end": "T1_CREATE_ID"},
+            })
+    candidate = {
+        "model_type": "h1_locator_pair",
+        "canonical_model_id": "1" * 64,
+        "canonical_candidate_id": "2" * 64,
+        "model": {
+            "layout": "u8_row_then_u24le_page",
+            "table_signature_id": "a3_page23_masked_record_0_92",
+            "locator_offsets": [35, 39],
+        },
+        "instance_bindings": bindings,
+    }
+    return {"status": "model", "candidates": [candidate]}
+
+
+class IndependentH1H2Tests(unittest.TestCase):
+    def test_candidate_hash_vector_has_no_trailing_newline(self) -> None:
+        model = {
+            "row_mask": 8191,
+            "polarity": "set_bit_owned_in_use",
+            "owned_in_use_locator_ordinal": 0,
+            "available_locator_ordinal": 1,
+        }
+        self.assertEqual(
+            h2_candidate(model)["canonical_candidate_id"],
+            "a4f9d35e77e42704310d90264128698a8581855df4460bd7b499dcb015538def",
+        )
+        self.assertEqual(
+            h1_sha({"model_type": "h2_final_role", "model": model}),
+            "a4f9d35e77e42704310d90264128698a8581855df4460bd7b499dcb015538def",
+        )
+
+    def test_h1_tdef_none_stops_before_replica_two(self) -> None:
+        replicas = {1: FakeReplica(1), 2: FakeReplica(2)}
+        result = recompute_h1(
+            replicas, plan=CONTRACT.plan, predicate_contracts=_contracts()
+        )
+        self.assertEqual(result.layer["terminal_predicate_id"], "A4-H1-TDEF-NONE")
+        self.assertEqual(result.layer["predicate_measured_survivor_count"], 0)
+        self.assertEqual(result.work_charges["tdef_lifecycle_signatures"], 0)
+        self.assertEqual(replicas[2].page_calls, 0)
+
+    def test_duplicate_signature_is_derived_from_pinned_base_mask(self) -> None:
+        grammar = CONTRACT.plan["candidate_grammars"]["h1"]
+        page = bytearray(2048)
+        value = bytes.fromhex(grammar["table_record_signature"]["value_hex"])
+        page[: len(value)] = value
+        page[43:47] = page[39:43]
+        pages = {(checkpoint, 23): bytes(page) for checkpoint in CONTRACT.checkpoint_ids}
+        state = _ReplicaState(FakeReplica(1, pages), 1, CONTRACT.checkpoint_ids, 2048)
+        binding = {
+            "replica": 1,
+            "logical_role": "T1",
+            "lifecycle_instance": "T1-v1",
+            "tdef_page": 23,
+            "applicable_checkpoint_range": {"start": "T1_CREATE_ID", "end": "T4_IDLE_R"},
+        }
+        tdef = {"instance_bindings": [binding]}
+        windows = {
+            layout: {23: (35, 39, 43)} for layout in grammar["locator_layouts"]
+        }
+        candidates = _structural_stage(state, tdef, windows, CONTRACT.plan)
+        self.assertEqual(len(candidates), 6)
+        self.assertEqual(
+            {row["model"]["table_signature_id"] for row in candidates},
+            {"a4_pair_multiple_duplicate_locator_0_92"},
+        )
+
+    def test_h2_invalid_directory_is_structured_and_cut_off(self) -> None:
+        pages = {("T1_CREATE_ID", 5): _invalid_directory_page()}
+        replicas = {1: FakeReplica(1, pages), 2: FakeReplica(2, pages)}
+        result = recompute_h2(
+            replicas,
+            _frozen_h1(),
+            plan=CONTRACT.plan,
+            predicate_contracts=_contracts(),
+            snapshot_row_counts={},
+        )
+        self.assertEqual(
+            result.layer["terminal_predicate_id"], "A4-H2-ROW-DIRECTORY-INVALID"
+        )
+        self.assertEqual(result.layer["terminal_evidence"]["kind"], "row_directory")
+        self.assertEqual(result.work_charges["invalid_path_row_directory_entries"], 1)
+        self.assertEqual(result.work_charges["valid_path_row_directory_entries"], 0)
+        self.assertEqual(replicas[2].page_calls, 0)
+
+    def test_h2_replica_two_invalid_reclassifies_prior_valid_work(self) -> None:
+        replicas = {
+            1: FakeReplica(1, {("T1_CREATE_ID", 5): _valid_directory_page()}),
+            2: FakeReplica(2, {("T1_CREATE_ID", 5): _invalid_directory_page()}),
+        }
+        result = recompute_h2(
+            replicas, _frozen_h1(), plan=CONTRACT.plan,
+            predicate_contracts=_contracts(), snapshot_row_counts={},
+        )
+        self.assertEqual(result.layer["terminal_predicate_id"], "A4-H2-ROW-DIRECTORY-INVALID")
+        self.assertEqual(result.work_charges["valid_path_row_directory_entries"], 0)
+        self.assertEqual(result.work_charges["invalid_path_row_directory_entries"], 2)
+
+    def test_holdout_predictors_fail_closed_without_bindings(self) -> None:
+        replica = FakeReplica(3)
+        self.assertFalse(
+            predict_h1_holdout(replica, _frozen_h1(), plan=CONTRACT.plan)
+        )
+        with self.assertRaises(H2ValidationError) as raised:
+            predict_h2_holdout(
+                replica,
+                _frozen_h1(),
+                {"status": "model", "candidates": [h2_candidate({
+                    "row_mask": 8191,
+                    "polarity": "set_bit_owned_in_use",
+                    "owned_in_use_locator_ordinal": 0,
+                    "available_locator_ordinal": 1,
+                })]},
+                plan=CONTRACT.plan,
+                snapshot_row_counts={},
+            )
+        self.assertEqual(raised.exception.code, "independent_h2_holdout_h1_binding")
+
+    def test_decisive_synthetic_matches_h1_h2_oracle_projection(self) -> None:
+        from test_a4_analyzer import _COMMIT, _inputs
+        from a4_analysis_input import check_analysis_input
+        from a4_layer_h1 import agree_h1_replicas, derive_h1_replica
+        from a4_layer_h2 import agree_h2_replicas, derive_h2_replica
+        from a4_model import WorkLedger
+
+        inputs = _inputs()
+        checked = check_analysis_input("a4-synthetic", _COMMIT, inputs)
+        replicas = {
+            number: ViewReplica(checked.views[number]) for number in (1, 2)
+        }
+        contracts = _contracts()
+        independent_h1 = recompute_h1(
+            replicas, plan=CONTRACT.plan, predicate_contracts=contracts
+        )
+        independent_h2 = recompute_h2(
+            replicas,
+            independent_h1,
+            plan=CONTRACT.plan,
+            predicate_contracts=contracts,
+            snapshot_row_counts={
+                number: checked.replicas[number].table_row_counts
+                for number in (1, 2)
+            },
+        )
+
+        ledger = WorkLedger()
+        oracle_h1_by = {
+            number: derive_h1_replica(
+                checked.views[number], checked.qualified_tdef_pages[number], ledger
+            )
+            for number in (1, 2)
+        }
+        oracle_h1 = agree_h1_replicas(oracle_h1_by[1], oracle_h1_by[2])
+        oracle_h2_by = {
+            number: derive_h2_replica(
+                checked.views[number],
+                oracle_h1_by[number],
+                checked.replicas[number].table_row_counts,
+                ledger,
+            )
+            for number in (1, 2)
+        }
+        oracle_h2 = agree_h2_replicas(oracle_h2_by[1], oracle_h2_by[2])
+
+        self.assertEqual(independent_h1.layer["candidates"], [oracle_h1.document()])
+        self.assertEqual(independent_h2.layer["candidates"], [oracle_h2.document()])
+        oracle_work = ledger.document()
+        for name, value in independent_h1.work_charges.items():
+            self.assertEqual(value, oracle_work[name], name)
+        for name, value in independent_h2.work_charges.items():
+            self.assertEqual(value, oracle_work[name], name)
+        independent_pages = {
+            (row["replica"], row["checkpoint_id"], row["page_number"])
+            for row in (*independent_h1.qualified_pages, *independent_h2.qualified_pages)
+        }
+        oracle_pages = {
+            (page.replica, page.checkpoint_id, page.page_number)
+            for page in ledger.qualified_pages()
+        }
+        self.assertEqual(independent_pages, oracle_pages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_independent_h3_h4.py
+++ b/oracle/windows-dao/tests/test_a4_independent_h3_h4.py
@@ -1,0 +1,434 @@
+"""Focused fake-page tests for fresh independent A4 H3/H4 recomputation."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import a4_independent_h3 as h3  # noqa: E402
+import a4_independent_h4 as h4  # noqa: E402
+import a4_independent_h4_contract as h4_contract  # noqa: E402
+from a4_independent_bundle import BundleLoader  # noqa: E402
+from a4_independent_h1 import apply_h1_holdout, recompute_h1  # noqa: E402
+from a4_independent_h2 import recompute_h2  # noqa: E402
+from a4_independent_validator import _snapshot_row_counts  # noqa: E402
+from test_a4_independent_bundle import _build_bundle  # noqa: E402
+
+
+H3_IDS = [
+    "A4-H3-CONVERSION-NONE",
+    "A4-H3-INACTIVE-SLOT-NONE",
+    "A4-H3-REFERENCE-INVALID",
+    "A4-H3-BASE-DISCRIMINATION",
+    "A4-H3-BASE-NONE",
+    "A4-H3-BASE-MULTIPLE",
+    "A4-H3-REPLICA-DISAGREEMENT",
+]
+
+
+def _plan_h3() -> dict[str, object]:
+    return {
+        "bounds": {"max_candidate_models": 4096, "max_checkpoints_per_replica": 2},
+        "checkpoint_design": {"checkpoint_ids": ["C0", "C1"], "idle_pairs": [],
+                              "transition_coverage": {"t1_growth": ["C0", "C1"],
+                              "t3_absolute": ["C0", "C1"], "t4_relative": ["C0", "C1"],
+                              "t1_churn": ["X0", "X1", "X2", "X3"]}},
+        "candidate_grammars": {"h3": {
+            "conversion_candidates": ["structural_type_0_to_type_1_with_nonzero_u32_slots"],
+            "base_formulas": [
+                "slot_ordinal_times_16352_plus_bit_index",
+                "referenced_page_times_16352_plus_bit_index",
+                "slot_ordinal_times_16352_plus_bit_index_minus_one",
+                "slot_ordinal_times_16352_plus_bit_index_plus_one",
+            ],
+        }},
+        "predicate_registry": {"predicate_contracts": [
+            {"predicate_id": identifier, "order": 20 + index, "scope": "h3_indirect_traversal",
+             "reachability_fixture_id": f"A4-R{22 + index:02d}-TEST"}
+            for index, identifier in enumerate(H3_IDS)
+        ]},
+    }
+
+
+def _data_page(rows: list[bytes]) -> bytes:
+    page = bytearray(2048)
+    page[0] = 1
+    page[8:10] = len(rows).to_bytes(2, "little")
+    cursor = 2048
+    starts = []
+    for raw in rows:
+        cursor -= len(raw)
+        page[cursor : cursor + len(raw)] = raw
+        starts.append(cursor)
+    for index, start in enumerate(starts):
+        page[10 + 2 * index : 12 + 2 * index] = start.to_bytes(2, "little")
+    return bytes(page)
+
+
+def _tag05(*bits: int) -> bytes:
+    page = bytearray(2048)
+    page[:4] = b"\x05\x01\x00\x00"
+    for bit in bits:
+        page[4 + bit // 8] |= 1 << (bit % 8)
+    return bytes(page)
+
+
+def _h3_fixture() -> tuple[dict[int, object], dict[int, object], dict[int, object]]:
+    type0_owned = bytes([0]) + (0).to_bytes(4, "little") + bytes([1])
+    type0_available = bytes([0]) + (0).to_bytes(4, "little")
+    type1_owned = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in (3, 4, 0))
+    type1_available = bytes([1]) + (0).to_bytes(4, "little")
+    c0 = [bytes(2048), _data_page([type0_owned, type0_available]), bytes(2048),
+          _tag05(0, 7, 16351), _tag05(0)]
+    c1 = [bytes(2048), _data_page([type1_owned, type1_available]), bytes(2048),
+          _tag05(0, 7, 16351), _tag05(0)]
+    replicas = {number: {"checkpoint_ids": ["C0", "C1"], "checkpoints": {
+        "C0": {"pages": c0}, "C1": {"pages": c1},
+    }} for number in (1, 2)}
+    h1_models = {number: {"model": {}, "instance_bindings": [{
+        "replica": number, "logical_role": "T1", "lifecycle_instance": "T1-v1",
+        "tdef_page": 2, "locator_targets": [{"page": 1, "row": 0}, {"page": 1, "row": 1}],
+        "applicable_checkpoint_range": {"start": "C0", "end": "C1"},
+    }]} for number in (1, 2)}
+    h2_models = {number: {"model": {"row_mask": 8191, "polarity": "set_bit_owned_in_use",
+        "owned_in_use_locator_ordinal": 0, "available_locator_ordinal": 1}}
+        for number in (1, 2)}
+    return replicas, h1_models, h2_models
+
+
+class A4IndependentH3H4Tests(unittest.TestCase):
+    def test_canonical_known_vector_has_sorted_keys_and_no_newline(self) -> None:
+        value = {"z": 1, "a": [3, "é"]}
+        expected = bytes.fromhex("7b2261223a5b332c22c3a9225d2c227a223a317d")
+        self.assertEqual(h3._canonical(value), expected)
+        self.assertEqual(h4._canonical(value), expected)
+        self.assertEqual(h3._digest(value), "7f99f4654f8d09362fad7519a2670728e1e7e420cb8af180a0dca86fb1610822")
+
+    def test_h3_recomputes_unique_slot_formula_from_pages(self) -> None:
+        replicas, h1_models, h2_models = _h3_fixture()
+        result = h3.recompute_h3(replicas, h1_models, h2_models, _plan_h3())
+        self.assertEqual(result["result"]["status"], "model")
+        self.assertEqual(result["result"]["candidates"][0]["model"]["base_formula"],
+                         "slot_ordinal_times_16352_plus_bit_index")
+        self.assertIn(0, result["admitted_pages"][1]["C1"])
+        self.assertEqual([row["predicate_id"] for row in result["predicates"]], H3_IDS)
+        self.assertEqual([row["predicate_measured_survivor_count"]
+                          for row in result["predicates"]], [1] * len(H3_IDS))
+
+    def test_h3_reference_tag_tamper_is_the_registered_terminal(self) -> None:
+        replicas, h1_models, h2_models = _h3_fixture()
+        bad = bytearray(replicas[1]["checkpoints"]["C1"]["pages"][3])
+        bad[0] = 1
+        replicas[1]["checkpoints"]["C1"]["pages"][3] = bytes(bad)
+        result = h3.recompute_h3(replicas, h1_models, h2_models, _plan_h3())
+        self.assertEqual(result["result"]["terminal_predicate_id"], "A4-H3-REFERENCE-INVALID")
+        self.assertEqual(result["result"]["terminal_evidence"]["observation"]["observed_tag_byte"], 1)
+        self.assertEqual([row["predicate_measured_survivor_count"]
+                          for row in result["predicates"]], [1, 1, 1, 0, 0, 0, 0])
+
+    def test_h3_conflicting_replica_terminals_use_predicate_major_cutoff(self) -> None:
+        replicas, h1_models, h2_models = _h3_fixture()
+        invalid_reference = bytearray(replicas[1]["checkpoints"]["C1"]["pages"][3])
+        invalid_reference[0] = 1
+        replicas[1]["checkpoints"]["C1"]["pages"][3] = bytes(invalid_reference)
+        replicas[2]["checkpoints"]["C1"]["pages"][1] = replicas[2]["checkpoints"]["C0"]["pages"][1]
+        result = h3.recompute_h3(replicas, h1_models, h2_models, _plan_h3())
+        self.assertEqual(result["result"]["terminal_predicate_id"], "A4-H3-CONVERSION-NONE")
+        self.assertNotIn(
+            {"replica": 1, "checkpoint_id": "C1", "page_number": 3},
+            result["qualified_pages"],
+        )
+        self.assertEqual(result["work_charges"], {
+            "type_0_and_tag_05_bitmap_bits": 0, "base_formula_evaluations": 0,
+        })
+
+    def test_h3_reference_bound_deduplicates_and_spans_both_map_rows(self) -> None:
+        replicas, h1_models, h2_models = _h3_fixture()
+        duplicate = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in ([3] * 17 + [0]))
+        replicas[1]["checkpoints"]["C1"]["pages"][1] = _data_page([duplicate, duplicate])
+        replicas[2]["checkpoints"]["C1"]["pages"][1] = _data_page([duplicate, duplicate])
+        h3.recompute_h3(replicas, h1_models, h2_models, _plan_h3())
+
+        distinct = list(range(3, 20))
+        owned = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in (distinct[:9] + [0]))
+        available = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in (distinct[9:] + [0]))
+        for number in (1, 2):
+            pages = replicas[number]["checkpoints"]["C1"]["pages"]
+            pages[1] = _data_page([owned, available])
+            pages.extend(_tag05() for _ in range(20 - len(pages)))
+        with self.assertRaises(h3.H3ValidationError) as raised:
+            h3.recompute_h3(replicas, h1_models, h2_models, _plan_h3())
+        self.assertEqual(raised.exception.code, "resource_bound_breach")
+
+    def test_h3_holdout_propagates_resource_terminal(self) -> None:
+        with patch.object(h3, "_checkpoints", side_effect=h3.H3ValidationError(
+                "resource_bound_breach")):
+            with self.assertRaises(h3.H3ValidationError):
+                h3.predict_h3_holdout({}, {}, {}, {}, _plan_h3())
+
+    def test_h3_holdout_applies_frozen_formula_without_refit(self) -> None:
+        replicas, h1_models, h2_models = _h3_fixture()
+        binding = dict(h1_models[1]["instance_bindings"][0])
+        binding["replica"] = 3
+        h1_candidate = {"model": {}, "instance_bindings": [binding]}
+        h3_candidate = {"model": {"base_formula":
+            "slot_ordinal_times_16352_plus_bit_index"}}
+        self.assertTrue(h3.predict_h3_holdout(
+            replicas[1], h1_candidate, h2_models[1], h3_candidate, _plan_h3()
+        ))
+        page = bytearray(replicas[1]["checkpoints"]["C1"]["pages"][3])
+        page[4 + 16351 // 8] &= ~(1 << (16351 % 8))
+        replicas[1]["checkpoints"]["C1"]["pages"][3] = bytes(page)
+        self.assertFalse(h3.predict_h3_holdout(
+            replicas[1], h1_candidate, h2_models[1], h3_candidate, _plan_h3()
+        ))
+
+    def test_h4_recomputes_root_none_from_empty_pages(self) -> None:
+        plan = json.loads(
+            (ROOT / "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json")
+            .read_text(encoding="utf-8")
+        )
+        checkpoints = plan["checkpoint_design"]["checkpoint_ids"]
+        replicas = {number: {"checkpoints": {
+            checkpoint: {"pages": [bytes(2048)]} for checkpoint in checkpoints
+        }} for number in (1, 2)}
+        h1_models = {number: {"model": {"layout": "u8_row_then_u24le_page",
+            "locator_offsets": [35, 39]}, "instance_bindings": [{"replica": number}]}
+            for number in (1, 2)}
+        h2_models = {number: {"model": {"row_mask": 8191, "polarity": "set_bit_owned_in_use",
+            "owned_in_use_locator_ordinal": 0, "available_locator_ordinal": 1}}
+            for number in (1, 2)}
+        h3_models = {number: {"model": {"base_formula":
+            "slot_ordinal_times_16352_plus_bit_index"}} for number in (1, 2)}
+        result = h4.recompute_h4({}, replicas, h1_models, h2_models, h3_models, plan)
+        self.assertEqual(result["result"]["root_result"]["terminal_predicate_id"],
+                         "A4-H4-CATALOG-ROOT-NONE")
+        self.assertEqual(result["predicates"][0]["status"], "fail")
+        self.assertEqual([row["predicate_measured_survivor_count"]
+                          for row in result["predicates"]], [0] * 9)
+        frozen = {"root_result": result["result"]["root_result"],
+                  "structural_result": result["result"]["structural_result"],
+                  "encoding_result": result["result"]["encoding_result"]}
+        self.assertFalse(h4.predict_h4_root_holdout(
+            replicas[1], h1_models[1], h2_models[1], h3_models[1], frozen, plan
+        ))
+        self.assertFalse(h4.predict_h4_fields_holdout(
+            replicas[1], h1_models[1], h2_models[1], h3_models[1], frozen, plan
+        ))
+
+    def test_h4_conflicting_root_counts_choose_none_before_multiple(self) -> None:
+        plan = json.loads(
+            (ROOT / "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json")
+            .read_text(encoding="utf-8")
+        )
+        checkpoints = plan["checkpoint_design"]["checkpoint_ids"]
+        replicas = {number: {"number": number} for number in (1, 2)}
+        h1_models = {number: {"model": {"locator_offsets": [35, 39]},
+            "instance_bindings": [{"replica": number}]} for number in (1, 2)}
+        h2_models = {number: {"model": {"row_mask": 8191}} for number in (1, 2)}
+        h3_models = {number: {"model": {"base_formula":
+            "slot_ordinal_times_16352_plus_bit_index"}} for number in (1, 2)}
+
+        def page_count(replica: dict[str, int], checkpoint: str) -> int:
+            return 2 if replica["number"] == 1 and checkpoint == "EMPTY" else 0
+
+        def page(_replica: object, checkpoint: str, _number: int) -> bytes:
+            return bytes([2 if checkpoint == "EMPTY" else 1]) + bytes(2047)
+
+        def traverse(_replica: object, _number: int, checkpoint: str, *_args: object):
+            admitted = {10 + checkpoints.index(checkpoint)}
+            return ((1, 0), (1, 1)), admitted
+
+        with patch.object(h4, "_page_count", side_effect=page_count), \
+             patch.object(h4, "_page", side_effect=page), \
+             patch.object(h4, "_traverse", side_effect=traverse), \
+             patch.object(h4, "_state_digest", side_effect=lambda _r, c, p: f"{c}:{p}"):
+            result = h4.recompute_h4({}, replicas, h1_models, h2_models, h3_models, plan)
+        root = result["result"]["root_result"]
+        self.assertEqual(root["terminal_predicate_id"], "A4-H4-CATALOG-ROOT-NONE")
+        self.assertEqual(root["predicate_measured_survivor_count"], 0)
+
+    def test_h4_root_attempt_bound_precedes_seventeenth_traversal(self) -> None:
+        plan = json.loads(
+            (ROOT / "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json")
+            .read_text(encoding="utf-8")
+        )
+        replicas = {number: {"number": number} for number in (1, 2)}
+        h1_models = {number: {"model": {"locator_offsets": [35, 39]},
+            "instance_bindings": [{"replica": number}]} for number in (1, 2)}
+        h2_models = {number: {"model": {"row_mask": 8191}} for number in (1, 2)}
+        h3_models = {number: {"model": {"base_formula":
+            "slot_ordinal_times_16352_plus_bit_index"}} for number in (1, 2)}
+        page_count = lambda replica, checkpoint: 17 if replica["number"] == 1 and checkpoint == "EMPTY" else 0
+        page = bytes([2]) + bytes(2047)
+        with patch.object(h4, "_page_count", side_effect=page_count), \
+             patch.object(h4, "_page", return_value=page), \
+             patch.object(h4, "_traverse", side_effect=h4.H4ValidationError("system_tdef_invalid")) as traverse:
+            with self.assertRaises(h4.H4ValidationError) as raised:
+                h4.recompute_h4({}, replicas, h1_models, h2_models, h3_models, plan)
+        self.assertEqual(raised.exception.code, "resource_bound_breach")
+        self.assertEqual(traverse.call_count, 16)
+        one_root = lambda replica, checkpoint: 1 if replica["number"] == 1 and checkpoint == "EMPTY" else 0
+        with patch.object(h4, "_page_count", side_effect=one_root), \
+             patch.object(h4, "_page", return_value=page), \
+             patch.object(h4, "_traverse", side_effect=h4.H4ValidationError("resource_bound_breach")):
+            with self.assertRaises(h4.H4ValidationError) as propagated:
+                h4.recompute_h4({}, replicas, h1_models, h2_models, h3_models, plan)
+        self.assertEqual(propagated.exception.code, "resource_bound_breach")
+
+    def test_h4_system_reference_bound_is_distinct_across_both_rows(self) -> None:
+        tdef = bytearray(2048)
+        tdef[0] = 2
+        tdef[35:39] = bytes([0, 1, 0, 0])
+        tdef[39:43] = bytes([1, 1, 0, 0])
+        duplicate = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in ([2] * 17 + [0]))
+        replica = {"checkpoints": {"C": {"pages": [bytes(tdef),
+            _data_page([duplicate, duplicate]), _tag05()]}}}
+        h1_model = {"locator_offsets": [35, 39], "layout": "u8_row_then_u24le_page"}
+        h2_model = {"row_mask": 8191, "polarity": "set_bit_owned_in_use",
+                    "owned_in_use_locator_ordinal": 0, "available_locator_ordinal": 1}
+        h3_model = {"base_formula": "slot_ordinal_times_16352_plus_bit_index"}
+        h4._traverse(replica, 1, "C", 0, h1_model, h2_model, h3_model, set(), {})
+
+        references = list(range(2, 19))
+        owned = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in references[:9])
+        available = bytes([1]) + b"".join(value.to_bytes(4, "little") for value in references[9:])
+        replica["checkpoints"]["C"]["pages"] = [bytes(tdef), _data_page([owned, available])]
+        replica["checkpoints"]["C"]["pages"].extend(_tag05() for _ in references)
+        with self.assertRaises(h4.H4ValidationError) as raised:
+            h4._traverse(replica, 1, "C", 0, h1_model, h2_model, h3_model, set(), {})
+        self.assertEqual(raised.exception.code, "resource_bound_breach")
+
+    def test_h4_resource_errors_propagate_and_catalog_rows_charge_once(self) -> None:
+        resource = h4.H4ValidationError("resource_bound_breach")
+        with patch.object(h4, "_holdout_root_context", side_effect=resource):
+            with self.assertRaises(h4.H4ValidationError):
+                h4.predict_h4_root_holdout({}, {}, {}, {}, {}, {})
+            with self.assertRaises(h4.H4ValidationError):
+                h4.predict_h4_fields_holdout({}, {}, {}, {}, {}, {})
+        page = _data_page([bytes([1]), bytes([1])])
+        work = {"catalog_raw_rows": 0}
+        charged: set[tuple[int, str, int, int]] = set()
+        h4_contract.catalog_rows(page, 8191, (1, "C1", 4), work, charged)
+        h4_contract.catalog_rows(page, 8191, (1, "C1", 4), work, charged)
+        self.assertEqual(work["catalog_raw_rows"], 2)
+
+    def test_plan_predicate_reordering_fails_closed(self) -> None:
+        replicas, h1_models, h2_models = _h3_fixture()
+        plan = _plan_h3()
+        plan["predicate_registry"]["predicate_contracts"][0]["order"] = 99
+        with self.assertRaisesRegex(h3.H3ValidationError, "predicate_registry_invalid"):
+            h3.recompute_h3(replicas, h1_models, h2_models, plan)
+
+    def test_structural_scan_uses_registered_occurrence_rows(self) -> None:
+        plan = json.loads(
+            (ROOT / "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json")
+            .read_text(encoding="utf-8")
+        )
+        grammar = plan["candidate_grammars"]["h4"]
+        operations = grammar["operation_binding_order"]
+        rows = {}
+        identifiers = [10, 11, 12, 13, 14, 15, 16]
+        for operation, identifier in zip(operations, identifiers):
+            pattern_id, pattern = h4._operation_patterns(plan, 1, operation)[0]
+            raw = bytearray(40)
+            raw[16], raw[17] = len(pattern), identifier
+            raw[18] = 2 if operation == "T1_ADD_TEXT" else 3 if operation == "T1_ADD_INDEX" else 1
+            raw[20 : 20 + len(pattern)] = pattern
+            occurrence = {"occurrence_index": 0, "name_start": 20,
+                          "matched_registered_pattern_id": pattern_id,
+                          "matched_bytes_hex": pattern.hex()}
+            rows[operation] = ({"page": 5, "row": 0, "row_start": 2000, "row_end": 2040},
+                               bytes(raw), [occurrence])
+        work = {"h4_name_length_structural_tuples": 0}
+        candidates = h4._structural_candidates(1, rows, "0" * 64, grammar, work)
+        self.assertTrue(any(candidate[0]["model"]["kind_start_delta"] == 2 for candidate in candidates))
+        self.assertEqual(work["h4_name_length_structural_tuples"], 7 * 165888)
+
+    def test_independent_modules_do_not_import_producer_symbols(self) -> None:
+        forbidden = ("a4_analysis", "a4_model", "a4_layer", "a4_generator", "a4_spec")
+        for path in (SCRIPTS / "a4_independent_h3.py", SCRIPTS / "a4_independent_h4.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            names = []
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names.extend(alias.name for alias in node.names)
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names.append(node.module)
+            self.assertFalse([name for name in names if name.startswith(forbidden)])
+
+    def test_synthetic_bundle_recomputes_exact_frozen_h3_h4(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "bundle"
+            _build_bundle(root)
+            bundle = BundleLoader(root).load()
+            plan = bundle.plan
+            contracts = plan["predicate_registry"]["predicate_contracts"]
+            first = recompute_h1(bundle.replicas, plan=plan, predicate_contracts=contracts)
+            second = recompute_h2(
+                bundle.replicas, first, plan=plan, predicate_contracts=contracts,
+                snapshot_row_counts=_snapshot_row_counts(bundle, (1, 2)),
+            )
+            third = h3.recompute_h3(bundle.replicas, first, second, plan)
+            metadata = {
+                "protocol_version": bundle.manifest["protocol_version"],
+                "plan_sha256": bundle.plan_sha256,
+                "revision_plan_sha256": bundle.manifest["revision_plan_sha256"],
+                "campaign_id": bundle.manifest["campaign_id"],
+            }
+            fourth = h4.recompute_h4(metadata, bundle.replicas, first, second, third, plan)
+            frozen = json.loads(
+                (root / "analysis/derivation-candidates.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            occurrence = json.loads(
+                (root / "analysis/h4-occurrence-evidence.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(third["result"], frozen["layers"]["h3_indirect_traversal"])
+            self.assertEqual(fourth["result"], frozen["layers"]["h4_catalog_bootstrap"])
+            self.assertEqual(fourth["occurrence_evidence"], occurrence)
+            self.assertEqual(third["work_charges"]["base_formula_evaluations"], 88)
+            self.assertEqual(fourth["work_charges"], {
+                "catalog_root_signatures": 100, "catalog_raw_rows": 236,
+                "encoding_union_anchor_bytes": 172,
+                "h4_name_length_structural_tuples": 2322432,
+                "encoding_length_equivalence_candidates": 40,
+            })
+            qualified = {(row["replica"], row["checkpoint_id"], row["page_number"])
+                         for row in fourth["qualified_pages"]}
+            self.assertIn((1, "EMPTY_R", 4), qualified)
+            self.assertIn((2, "EMPTY_R", 4), qualified)
+            self.assertNotIn((1, "EMPTY", 4), qualified)
+            self.assertNotIn((2, "EMPTY", 4), qualified)
+            all_qualified = {
+                (row["replica"], row["checkpoint_id"], row["page_number"])
+                for rows in (first.qualified_pages, second.qualified_pages,
+                             third["qualified_pages"], fourth["qualified_pages"])
+                for row in rows
+            }
+            frozen_qualified = {(row["replica"], row["checkpoint_id"], row["page_number"])
+                                for row in frozen["qualified_pages"]}
+            self.assertEqual(all_qualified, frozen_qualified)
+            holdout_h1 = apply_h1_holdout(bundle.replicas[3], first.layer, plan=plan)
+            self.assertIsNotNone(holdout_h1)
+            args = (bundle.replicas[3], holdout_h1, second.layer, third, fourth["result"], plan)
+            self.assertTrue(h4.predict_h4_root_holdout(*args))
+            self.assertTrue(h4.predict_h4_fields_holdout(*args))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_independent_terminal_paths.py
+++ b/oracle/windows-dao/tests/test_a4_independent_terminal_paths.py
@@ -1,0 +1,126 @@
+"""Integration coverage for independent A4 derivation-terminal paths."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+TESTS = Path(__file__).resolve().parent
+
+import sys
+
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(TESTS))
+
+import test_a4_independent_bundle as fixture  # noqa: E402
+from a4_generator import SyntheticParameters  # noqa: E402
+from a4_independent_bundle import BundleLoader, ValidationError  # noqa: E402
+from a4_independent_contract import CONTRACT, EXPECTED_TAMPERS  # noqa: E402
+from a4_independent_validator import (  # noqa: E402
+    execute_tamper_suite,
+    recompute_bundle,
+    validate_bundle,
+)
+from test_a4_analyzer import _inputs  # noqa: E402
+
+
+def _parameters_h1_pair_multiple() -> SyntheticParameters:
+    signature = CONTRACT.plan["candidate_grammars"]["h1"][
+        "pair_multiple_reachability_signature"
+    ]
+    return SyntheticParameters(
+        signature_id=signature["signature_id"],
+        locator_offsets=tuple(interval[0] for interval in signature["locator_holes"]),
+    )
+
+
+def _build(root: Path, parameters: SyntheticParameters) -> None:
+    with mock.patch.object(
+        fixture, "_inputs", side_effect=lambda: _inputs(parameters)
+    ):
+        fixture._build_bundle(root)
+
+
+def _assert_exact_derivation(
+    case: unittest.TestCase, bundle: object, recomputed: dict[str, object]
+) -> None:
+    for field in ("layers", "qualified_pages", "work_charges"):
+        case.assertEqual(recomputed[field], bundle.frozen[field])
+        case.assertEqual(bundle.report[field], bundle.frozen[field])
+    case.assertEqual(
+        recomputed["predicate_results"][:35], bundle.report["predicate_results"][:35]
+    )
+
+
+def _assert_t1_t9(
+    case: unittest.TestCase, bundle: object, recomputed: dict[str, object]
+) -> None:
+    results = execute_tamper_suite(bundle, recomputed)
+    case.assertEqual(
+        [(row["id"], row["discrepancy_code"]) for row in results],
+        list(EXPECTED_TAMPERS),
+    )
+    case.assertTrue(all(row["rejected"] for row in results))
+
+
+class A4IndependentTerminalPathTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(prefix="a4-independent-terminals-")
+        base = Path(cls.temporary.name)
+        cls.h1_root = base / "h1-pair-multiple"
+        cls.h2_root = base / "h2-replica-disagreement"
+        _build(cls.h1_root, _parameters_h1_pair_multiple())
+        _build(
+            cls.h2_root,
+            SyntheticParameters(owned_ordinal_by_replica={2: 1}),
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_h1_first_terminal_recomputes_projects_and_rejects_t1_t9(self) -> None:
+        bundle = BundleLoader(self.h1_root).load()
+        recomputed = recompute_bundle(bundle)
+        h1 = recomputed["layers"]["h1_tdef_to_map_row"]
+        self.assertEqual(h1["terminal_predicate_id"], "A4-H1-LOCATOR-PAIR-MULTIPLE")
+        self.assertTrue(
+            all(row["status"] == "not_applicable"
+                for row in recomputed["holdout_results"].values())
+        )
+        _assert_exact_derivation(self, bundle, recomputed)
+        validate_bundle(bundle, recomputed)
+        _assert_t1_t9(self, bundle, recomputed)
+
+    def test_h2_terminal_exposes_analyzer_holdout_projection_conflict(self) -> None:
+        bundle = BundleLoader(self.h2_root).load()
+        recomputed = recompute_bundle(bundle)
+        h2 = recomputed["layers"]["h2_row_identity_map_role"]
+        self.assertEqual(h2["terminal_predicate_id"], "A4-H2-REPLICA-DISAGREEMENT")
+        _assert_exact_derivation(self, bundle, recomputed)
+
+        h1_contract = next(
+            row for row in CONTRACT.plan["predicate_registry"]["predicate_contracts"]
+            if row["predicate_id"] == "A4-H1-HOLDOUT-PREDICTION"
+        )
+        self.assertEqual(
+            h1_contract["prerequisites"], ["derivation_candidate_set_sha256"]
+        )
+        self.assertEqual(recomputed["holdout_results"]["h1"]["status"], "pass")
+        self.assertEqual(bundle.report["holdout_results"]["h1"]["status"], "not_applicable")
+        for name in ("h2", "h3", "h4_root", "h4_fields"):
+            self.assertEqual(recomputed["holdout_results"][name]["status"], "not_applicable")
+            self.assertEqual(bundle.report["holdout_results"][name]["status"], "not_applicable")
+        with self.assertRaisesRegex(ValidationError, "holdout_projection_mismatch"):
+            validate_bundle(bundle, recomputed)
+        _assert_t1_t9(self, bundle, recomputed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_independent_validator.py
+++ b/oracle/windows-dao/tests/test_a4_independent_validator.py
@@ -1,0 +1,193 @@
+"""Executable independence and orchestration contracts for the A4 validator."""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from a4_independent_bundle import BundleLoader  # noqa: E402
+from a4_independent_contract import CONTRACT, EXPECTED_TAMPERS  # noqa: E402
+from a4_independent_projection import logical_read_projection, verdict  # noqa: E402
+from a4_independent_validator import (  # noqa: E402
+    execute_tamper_suite,
+    recompute_bundle,
+    validate_bundle,
+)
+from test_a4_independent_bundle import _build_bundle  # noqa: E402
+
+
+class A4IndependentImportTests(unittest.TestCase):
+    def test_every_validator_module_is_closed_against_analyzer_science(self) -> None:
+        forbidden = (
+            "a4_analysis",
+            "a4_model",
+            "a4_layer",
+            "a4_layers",
+            "a4_generator",
+            "a4_spec",
+            "a4_frozen",
+            "a4_derivation",
+            "a4_campaign",
+            "a4_catalog",
+            "a4_predicate",
+            "a4_terminal",
+        )
+        paths = sorted(SCRIPTS.glob("a4_independent_*.py"))
+        self.assertGreaterEqual(len(paths), 7)
+        for path in paths:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            imports: list[str] = []
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    imports.extend(alias.name for alias in node.names)
+                elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                    imports.append(node.module)
+            with self.subTest(path=path.name):
+                self.assertFalse(
+                    any(name.startswith(forbidden) for name in imports),
+                    imports,
+                )
+
+    def test_cli_rejects_conflicting_projection_modes_before_bundle_access(self) -> None:
+        script = SCRIPTS / "a4_independent_validator.py"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                str(script),
+                "--bundle-root",
+                str(ROOT / "does-not-exist"),
+                "--recompute-only",
+                "--pair-projection",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("mutually exclusive", completed.stderr)
+
+    def test_cli_failure_is_truthful_diagnostic_not_acceptance_report(self) -> None:
+        script = SCRIPTS / "a4_independent_validator.py"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                str(script),
+                "--bundle-root",
+                str(ROOT / "does-not-exist"),
+                "--validator-commit",
+                "1" * 40,
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        self.assertEqual(completed.returncode, 1)
+        document = json.loads(completed.stdout)
+        self.assertEqual(
+            document["document_type"], "dao_a4_independent_validation_failure"
+        )
+        self.assertFalse(document["frozen_set_parsed"])
+        self.assertEqual(document["tamper_results_executed"], [])
+
+
+class A4IndependentEndToEndTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(prefix="a4-independent-validator-")
+        cls.bundle_root = Path(cls.temporary.name) / "bundle"
+        _build_bundle(cls.bundle_root)
+        cls.bundle = BundleLoader(cls.bundle_root).load()
+        cls.recomputed = recompute_bundle(cls.bundle)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_exact_recomputation_and_schema_valid_verdict(self) -> None:
+        self.assertEqual(self.recomputed["layers"], self.bundle.frozen["layers"])
+        self.assertEqual(
+            self.recomputed["qualified_pages"], self.bundle.frozen["qualified_pages"]
+        )
+        self.assertEqual(
+            self.recomputed["work_charges"], self.bundle.frozen["work_charges"]
+        )
+        self.assertEqual(
+            self.recomputed["predicate_results"], self.bundle.report["predicate_results"]
+        )
+        self.assertEqual(
+            self.recomputed["holdout_results"], self.bundle.report["holdout_results"]
+        )
+        validate_bundle(self.bundle, self.recomputed)
+        tampers = execute_tamper_suite(self.bundle, self.recomputed)
+        self.assertEqual(
+            [(row["id"], row["discrepancy_code"]) for row in tampers],
+            list(EXPECTED_TAMPERS),
+        )
+        document = verdict(
+            self.bundle,
+            "1" * 40,
+            accepted=True,
+            discrepancy_codes=[],
+            tamper_results=tampers,
+            logical_reads=logical_read_projection(self.bundle),
+        )
+        CONTRACT.validate_document(document, "dao_a4_independent_validation_report")
+
+    def test_recompute_only_does_not_evaluate_holdout(self) -> None:
+        bundle = BundleLoader(self.bundle_root).load(open_holdout=False)
+        self.assertEqual(bundle.page_store.logical_read_bytes(3), 0)
+        recomputed = recompute_bundle(bundle, open_holdout=False)
+        self.assertEqual(bundle.page_store.logical_read_bytes(3), 0)
+        self.assertTrue(
+            all(
+                row["status"] == "not_applicable"
+                for row in recomputed["holdout_results"].values()
+            )
+        )
+        self.assertEqual(recomputed["layers"], bundle.frozen["layers"])
+
+    def test_normal_cli_writes_an_accepted_report_outside_bundle(self) -> None:
+        output = Path(self.temporary.name) / "independent-report.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                str(SCRIPTS / "a4_independent_validator.py"),
+                "--bundle-root",
+                str(self.bundle_root),
+                "--validator-commit",
+                "1" * 40,
+                "--output",
+                str(output),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        document = json.loads(output.read_text(encoding="utf-8"))
+        self.assertTrue(document["accepted"])
+        CONTRACT.validate_document(document, "dao_a4_independent_validation_report")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a separately implemented, plan/schema-only A4 P1 independent validator for campaign predicates, H1-H4 derivation, frozen/report projections, and the five holdouts
- enforce bounded clean-room bundle loading, canonical inventory/hash bindings, freeze-before-holdout ordering, exact decisive and terminal projections, and T1-T9 tamper rejection
- cover all registered scientific terminal shapes, early H3/H4 transcript cutoffs, resource boundaries, and the analyzer's currently incorrect partial-holdout terminal projection

## Validation

- `python3 -B -m unittest discover -s oracle/windows-dao/tests -p 'test_a4_independent_*.py' -v` (49 passed)
- `mise exec -- just ready`
- `git diff --check`
- production source files remain at or below 800 lines

## Review notes

- Production validator modules do not import analyzer science modules or external MDB implementations.
- The validator intentionally rejects the current analyzer output for an H2 derivation terminal because the preregistered dependency rule leaves H1 holdout applicable. That producer correction is the next narrow PR after this validator is merged.
- No immutable plan or provenance history is modified, and this PR makes no DAO-verification claim.

Roadmap: #75 (A4 P1 Step 2)
