### PR TITLE
fix(a4): evaluate applicable terminal holdouts

### DIFF
--- a/oracle/windows-dao/scripts/a4_analysis.py
+++ b/oracle/windows-dao/scripts/a4_analysis.py
@@ -18,7 +18,7 @@ from a4_analysis_input import (
 )
 from a4_analysis_state import FrozenDerivation, freeze_derivation, resume_derivation
 from a4_analysis_holdout import HoldoutResults, evaluate_holdout
-from a4_frozen_models import load_frozen_models
+from a4_frozen_models import load_frozen_model_prefix, load_frozen_models
 from a4_layers import DerivationLayers, derive_layers
 from a4_model import WorkLedger
 from a4_measurements import PredicateMeasurement
@@ -189,6 +189,7 @@ def analyze(
         frozen.occurrence_evidence_bytes,
     )
     if isinstance(layers, DerivationTerminal):
+        frozen_models = load_frozen_model_prefix(resumed)
         measurements = layers.measurements
         occurrence_evidence = MappingProxyType(
             {} if layers.h4_occurrence_evidence is None else dict(layers.h4_occurrence_evidence)
@@ -203,15 +204,25 @@ def analyze(
             provider,
             frozen.occurrence_evidence_bytes,
         )
+        prior_work_units = ledger.total_work_units
         del layers, derivation_input, ledger, resumed
-        holdout_campaign = open_holdout_campaign(ticket, frozen.canonical_bytes)
+        if frozen_models.h1 is None:
+            holdout_input = open_holdout_campaign(ticket, frozen.canonical_bytes)
+            holdout = None
+        else:
+            holdout_input = open_holdout(ticket, frozen.canonical_bytes)
+            holdout = evaluate_holdout(
+                holdout_input,
+                frozen_models,
+                WorkLedger(prior_work_units),
+            )
         del ticket
         report = _report(
             campaign_id,
             producer_commit,
             frozen,
-            None,
-            [*derivation_reads, holdout_campaign.view.logical_read_bytes],
+            holdout,
+            [*derivation_reads, holdout_input.view.logical_read_bytes],
             measurements,
         )
         return AnalysisResult(frozen, occurrence_evidence, MappingProxyType(report))

--- a/oracle/windows-dao/scripts/a4_analysis_holdout.py
+++ b/oracle/windows-dao/scripts/a4_analysis_holdout.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from a4_analysis_input import HoldoutAnalysisInput
 from a4_derivation import isolated_operation_deltas
-from a4_frozen_models import FrozenModels
+from a4_frozen_models import FrozenModelPrefix, FrozenModels
 from a4_layer_h1 import predict_h1
 from a4_layer_h2 import decode_frozen_owned_rows
 from a4_layer_h3 import predicts_h3
@@ -18,7 +18,7 @@ from a4_model import A4AnalysisError, WorkLedger
 
 @dataclass(frozen=True)
 class HoldoutResults:
-    h1: bool
+    h1: bool | None
     h2: bool | None
     h3: bool | None
     h4_root: bool | None
@@ -27,7 +27,7 @@ class HoldoutResults:
 
 def evaluate_holdout(
     inputs: HoldoutAnalysisInput,
-    frozen: FrozenModels,
+    frozen: FrozenModelPrefix | FrozenModels,
     ledger: WorkLedger | None = None,
 ) -> HoldoutResults:
     """Open replica 3 only after derivation freeze and apply unchanged models."""
@@ -40,11 +40,15 @@ def evaluate_holdout(
 
     work = ledger or WorkLedger()
     view = inputs.view
+    if frozen.h1 is None:
+        return HoldoutResults(None, None, None, None, None)
     holdout_h1 = predict_h1(
         view, inputs.qualified_tdef_pages, frozen.h1, work
     )
     if holdout_h1 is None:
         return HoldoutResults(False, None, None, None, None)
+    if frozen.h2 is None:
+        return HoldoutResults(True, None, None, None, None)
     h2_ok = predicts_h2(
         view,
         holdout_h1,
@@ -53,6 +57,8 @@ def evaluate_holdout(
     )
     if not h2_ok:
         return HoldoutResults(True, False, None, None, None)
+    if frozen.h3 is None:
+        return HoldoutResults(True, True, None, None, None)
     try:
         frozen_rows = decode_frozen_owned_rows(
             view, holdout_h1, frozen.h2, work
@@ -67,6 +73,8 @@ def evaluate_holdout(
     )
     if not h3_ok:
         return HoldoutResults(True, True, False, None, None)
+    if frozen.h4_root is None:
+        return HoldoutResults(True, True, True, None, None)
     roots = catalog_root_observations(
         view,
         inputs.qualified_tdef_pages,
@@ -80,6 +88,8 @@ def evaluate_holdout(
     )
     if len(matching_roots) != 1:
         return HoldoutResults(True, True, True, False, None)
+    if frozen.h4 is None:
+        return HoldoutResults(True, True, True, True, None)
     root = matching_roots[0]
     try:
         deltas = isolated_operation_deltas(view, holdout_h1, rows, frozen.h3)

--- a/oracle/windows-dao/scripts/a4_frozen_models.py
+++ b/oracle/windows-dao/scripts/a4_frozen_models.py
@@ -14,8 +14,19 @@ from a4_spec import canonical_json_bytes, sha256_hex
 
 
 @dataclass(frozen=True)
+class FrozenModelPrefix:
+    """The dependency-complete model prefix permitted across the boundary."""
+
+    h1: H1ReplicaCandidate | None
+    h2: H2ReplicaCandidate | None
+    h3: H3Candidate | None
+    h4_root: H4Candidate | None
+    h4: EncodedDerivation | None
+
+
+@dataclass(frozen=True)
 class FrozenModels:
-    """The replica-invariant models permitted to cross the holdout boundary."""
+    """Every replica-invariant model from a decisive derivation."""
 
     h1: H1ReplicaCandidate
     h2: H2ReplicaCandidate
@@ -101,17 +112,71 @@ def _h4(candidate: Mapping[str, Any], stage: str) -> H4Candidate:
     return result
 
 
-def load_frozen_models(document: Mapping[str, Any]) -> FrozenModels:
-    """Recompute every canonical identity from one validated frozen document."""
+def load_frozen_model_prefix(document: Mapping[str, Any]) -> FrozenModelPrefix:
+    """Recompute the dependency-complete decisive prefix of frozen models."""
     layers = document["layers"]
     h4 = layers["h4_catalog_bootstrap"]
-    h1 = _h1(_only_model(layers["h1_tdef_to_map_row"], "H1"))
-    h2 = _h2(_only_model(layers["h2_row_identity_map_role"], "H2"))
-    h3 = _plain(_only_model(layers["h3_indirect_traversal"], "H3"), "H3")
-    root = _h4(_only_model(h4["root_result"], "H4 root"), "H4 root")
-    structural = _h4(
-        _only_model(h4["structural_result"], "H4 structural"),
-        "H4 structural",
+
+    def present(result: Mapping[str, Any]) -> bool:
+        return result.get("status") == "model"
+
+    h1 = (
+        _h1(_only_model(layers["h1_tdef_to_map_row"], "H1"))
+        if present(layers["h1_tdef_to_map_row"])
+        else None
     )
-    final = _h4(_only_model(h4["encoding_result"], "H4 encoding"), "H4 encoding")
-    return FrozenModels(h1, h2, h3, root, EncodedDerivation(structural, final))
+    h2 = (
+        _h2(_only_model(layers["h2_row_identity_map_role"], "H2"))
+        if present(layers["h2_row_identity_map_role"])
+        else None
+    )
+    h3 = (
+        _plain(_only_model(layers["h3_indirect_traversal"], "H3"), "H3")
+        if present(layers["h3_indirect_traversal"])
+        else None
+    )
+    root = (
+        _h4(_only_model(h4["root_result"], "H4 root"), "H4 root")
+        if present(h4["root_result"])
+        else None
+    )
+    structural = (
+        _h4(
+            _only_model(h4["structural_result"], "H4 structural"),
+            "H4 structural",
+        )
+        if present(h4["structural_result"])
+        else None
+    )
+    final = (
+        _h4(_only_model(h4["encoding_result"], "H4 encoding"), "H4 encoding")
+        if present(h4["encoding_result"])
+        else None
+    )
+    ordered = (h1, h2, h3, root)
+    if any(value is not None for value in ordered[1:]) and h1 is None:
+        raise ValueError("A4 frozen model prefix omits H1")
+    if any(value is not None for value in ordered[2:]) and h2 is None:
+        raise ValueError("A4 frozen model prefix omits H2")
+    if root is not None and h3 is None:
+        raise ValueError("A4 frozen model prefix omits H3")
+    if (structural is not None or final is not None) and root is None:
+        raise ValueError("A4 frozen model prefix omits H4 root")
+    if final is not None and structural is None:
+        raise ValueError("A4 frozen model prefix omits H4 structural model")
+    encoded = (
+        EncodedDerivation(structural, final)
+        if structural is not None and final is not None
+        else None
+    )
+    return FrozenModelPrefix(h1, h2, h3, root, encoded)
+
+
+def load_frozen_models(document: Mapping[str, Any]) -> FrozenModels:
+    """Require and recompute every model from a decisive frozen document."""
+    models = load_frozen_model_prefix(document)
+    h1, h2, h3 = models.h1, models.h2, models.h3
+    root, h4 = models.h4_root, models.h4
+    if h1 is None or h2 is None or h3 is None or root is None or h4 is None:
+        raise ValueError("A4 frozen derivation does not contain every model")
+    return FrozenModels(h1, h2, h3, root, h4)

--- a/oracle/windows-dao/tests/test_a4_independent_terminal_paths.py
+++ b/oracle/windows-dao/tests/test_a4_independent_terminal_paths.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(TESTS))
 
 import test_a4_independent_bundle as fixture  # noqa: E402
 from a4_generator import SyntheticParameters  # noqa: E402
-from a4_independent_bundle import BundleLoader, ValidationError  # noqa: E402
+from a4_independent_bundle import BundleLoader  # noqa: E402
 from a4_independent_contract import CONTRACT, EXPECTED_TAMPERS  # noqa: E402
 from a4_independent_validator import (  # noqa: E402
     execute_tamper_suite,
@@ -98,7 +98,7 @@ class A4IndependentTerminalPathTests(unittest.TestCase):
         validate_bundle(bundle, recomputed)
         _assert_t1_t9(self, bundle, recomputed)
 
-    def test_h2_terminal_exposes_analyzer_holdout_projection_conflict(self) -> None:
+    def test_h2_terminal_preserves_applicable_h1_holdout(self) -> None:
         bundle = BundleLoader(self.h2_root).load()
         recomputed = recompute_bundle(bundle)
         h2 = recomputed["layers"]["h2_row_identity_map_role"]
@@ -113,12 +113,11 @@ class A4IndependentTerminalPathTests(unittest.TestCase):
             h1_contract["prerequisites"], ["derivation_candidate_set_sha256"]
         )
         self.assertEqual(recomputed["holdout_results"]["h1"]["status"], "pass")
-        self.assertEqual(bundle.report["holdout_results"]["h1"]["status"], "not_applicable")
+        self.assertEqual(bundle.report["holdout_results"]["h1"]["status"], "pass")
         for name in ("h2", "h3", "h4_root", "h4_fields"):
             self.assertEqual(recomputed["holdout_results"][name]["status"], "not_applicable")
             self.assertEqual(bundle.report["holdout_results"][name]["status"], "not_applicable")
-        with self.assertRaisesRegex(ValidationError, "holdout_projection_mismatch"):
-            validate_bundle(bundle, recomputed)
+        validate_bundle(bundle, recomputed)
         _assert_t1_t9(self, bundle, recomputed)
 
 

--- a/oracle/windows-dao/tests/test_a4_layer_boundaries.py
+++ b/oracle/windows-dao/tests/test_a4_layer_boundaries.py
@@ -360,7 +360,7 @@ class A4LayerBoundaryTests(unittest.TestCase):
             qualified_tdef_pages=(),
             replica=SimpleNamespace(table_row_counts={}),
         )
-        frozen = SimpleNamespace(h1=object(), h2=object())
+        frozen = SimpleNamespace(h1=object(), h2=object(), h3=object())
         with patch.object(
             a4_analysis_holdout, "predict_h1", return_value=object()
         ), patch.object(

--- a/oracle/windows-dao/tests/test_a4_terminals.py
+++ b/oracle/windows-dao/tests/test_a4_terminals.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import sys
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
@@ -13,6 +15,7 @@ sys.path.insert(0, str(SCRIPTS))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from a4_analysis import analyze  # noqa: E402
+import a4_layers  # noqa: E402
 from a4_analysis_input import check_analysis_input  # noqa: E402
 from a4_generator import SyntheticParameters  # noqa: E402
 from a4_layer_h1 import (  # noqa: E402
@@ -293,6 +296,61 @@ class A4TerminalTests(unittest.TestCase):
             frozen.document["layers"]["h3_indirect_traversal"]["status"],
             "not_applicable",
         )
+
+    def test_derivation_terminals_evaluate_only_the_decisive_holdout_prefix(self) -> None:
+        cases: list[tuple[object, SyntheticParameters, dict[str, str]]] = []
+        cases.append((
+            nullcontext(),
+            SyntheticParameters(owned_ordinal_by_replica={2: 1}),
+            {
+                "h1": "pass",
+                "h2": "not_applicable",
+                "h3": "not_applicable",
+                "h4_root": "not_applicable",
+                "h4_fields": "not_applicable",
+            },
+        ))
+
+        original_h3 = a4_layers.h3_observations
+
+        def conversion_none(view: object, rows: object, work: object) -> object:
+            return original_h3(view, rows, work)[:1]
+
+        cases.append((
+            mock.patch.object(
+                a4_layers, "h3_observations", side_effect=conversion_none
+            ),
+            SyntheticParameters(),
+            {
+                "h1": "pass",
+                "h2": "pass",
+                "h3": "not_applicable",
+                "h4_root": "not_applicable",
+                "h4_fields": "not_applicable",
+            },
+        ))
+        cases.append((
+            mock.patch.object(a4_layers, "operation_records", return_value=()),
+            SyntheticParameters(),
+            {
+                "h1": "pass",
+                "h2": "pass",
+                "h3": "pass",
+                "h4_root": "pass",
+                "h4_fields": "not_applicable",
+            },
+        ))
+
+        for patcher, parameters, expected in cases:
+            with self.subTest(expected=expected), patcher:
+                analysis = analyze("a4-synthetic", _COMMIT, _inputs(parameters))
+            self.assertEqual(
+                {
+                    name: result["status"]
+                    for name, result in analysis.report["holdout_results"].items()
+                },
+                expected,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- reconstruct the decisive frozen-model prefix after a derivation terminal instead of treating every holdout as unavailable
- evaluate only holdouts whose unchanged upstream derivation models exist, preserving prerequisite order and stopping at the first missing model
- keep the normal decisive model type strict and retain the existing H1-terminal campaign-only path

## Corrected projections

- H2 derivation terminal: evaluate H1 holdout; H2 and downstream are `not_applicable`
- H3 derivation terminal: evaluate H1 and H2; H3 and downstream are `not_applicable`
- pre-field H4 terminal: evaluate H1, H2, H3, and H4 root where their models exist; H4 fields remain `not_applicable`

## Validation

- `python3 tools/validate_repository_contract.py`
- `python3 -B -m unittest oracle/windows-dao/tests/test_a4_terminals.py oracle/windows-dao/tests/test_a4_independent_terminal_paths.py -v` (11 passed)
- full independent validator sweep (49 passed)
- focused analyzer/frozen/terminal sweep (75 passed after its test-double update)
- `mise exec -- just ready`
- independent code and contract reviews found no blockers

## Review notes

- This implements the immutable plan's derivation-prefix and holdout-prerequisite rules; it does not edit a plan or provenance history.
- The H2 terminal bundle now agrees with the separately implemented validator rather than being rejected with `holdout_projection_mismatch`.
- No DAO acquisition, evidence claim, support-matrix movement, or compatibility claim is included.

Roadmap follow-up: #75 (A4 P1 Step 2 maintenance)
