### PR TITLE
feat(a4): add the fail-closed hosted acquisition lane

### DIFF
--- a/.github/workflows/windows-dao-a4.yml
+++ b/.github/workflows/windows-dao-a4.yml
@@ -1,0 +1,691 @@
+name: Windows DAO A4 campaign
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute_a4_campaign:
+        description: Authorize the licensed A4 three-replica acquisition
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: windows-dao-a4-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    name: Validate the checked A4 contract
+    runs-on: windows-2022
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13.7"
+
+      - name: Parse checked A4 PowerShell sources without execution
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          if ($PSVersionTable.PSEdition -cne "Desktop" -or
+              $PSVersionTable.PSVersion.Major -ne 5) {
+            throw "A4 contract parsing requires Windows PowerShell 5 Desktop."
+          }
+          $entrypoint = "oracle/windows-dao/scripts/run-a4-replica.ps1"
+          $a4Directory = "oracle/windows-dao/scripts/a4"
+          if (-not (Test-Path -LiteralPath $entrypoint -PathType Leaf) -or
+              -not (Test-Path -LiteralPath $a4Directory -PathType Container)) {
+            throw "The checked A4 PowerShell source inventory is incomplete."
+          }
+          $sourcePaths = @($entrypoint) + @(
+            Get-ChildItem -LiteralPath $a4Directory -Filter "*.ps1" -File |
+              Sort-Object -Property Name |
+              ForEach-Object { $_.FullName }
+          )
+          if ($sourcePaths.Count -lt 2 -or $sourcePaths.Count -gt 32) {
+            throw "The checked A4 PowerShell source count violates its bound."
+          }
+          foreach ($sourcePath in $sourcePaths) {
+            $item = Get-Item -LiteralPath $sourcePath -Force
+            if ($item.PSIsContainer -or $item.Length -lt 1 -or
+                $item.Length -gt 2MB -or
+                ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+              throw "A checked A4 PowerShell source violates its file bound."
+            }
+            $tokens = $null
+            $errors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile(
+              $item.FullName,
+              [ref]$tokens,
+              [ref]$errors
+            )
+            if (@($errors).Count -ne 0) {
+              [string]$detail = [Convert]::ToString((@($errors | ForEach-Object {
+                "line $($_.Extent.StartLineNumber): $($_.Message)"
+              }) -join "; "))
+              if ($detail.Length -gt 2000) {
+                $detail = $detail.Substring(0, 2000)
+              }
+              throw "A4 PowerShell parser errors in $sourcePath`: $detail"
+            }
+          }
+
+      - name: Run the checked A4 Python contract tests
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          & python -B oracle/windows-dao/scripts/a4_spec.py `
+            oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json
+          if ($LASTEXITCODE -ne 0) { throw "The checked A4 plan failed." }
+          $planPath = "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json"
+          $plan = (Get-Content -LiteralPath $planPath -Raw) | ConvertFrom-Json
+          if ([string]$plan.experiment_id -cne "DAO-A4-ROW-ANCHORED-MAPS-001") {
+            throw "The A4 workflow refuses a plan whose experiment_id is not A4."
+          }
+          & python -B -m unittest `
+            oracle/windows-dao/tests/test_a4_plan_contract.py `
+            oracle/windows-dao/tests/test_a4_powershell_contract.py `
+            oracle/windows-dao/tests/test_windows_dao_a4_workflow.py
+          if ($LASTEXITCODE -ne 0) {
+            throw "The checked A4 contract tests failed."
+          }
+
+  a4-replica:
+    name: Acquire A4 replica ${{ matrix.replica }}
+    needs: contract
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.execute_a4_campaign &&
+      needs.contract.result == 'success'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        replica: [1, 2, 3]
+    runs-on: windows-2022
+    timeout-minutes: 37
+    env:
+      FROZEN_WORKER_TIMEOUT_SECONDS: "1700"
+      HOSTED_REPLICA_TIMEOUT_SECONDS: "2120"
+      FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"
+      REPLICA_MAXIMUM_OUTPUT_BYTES: "1048576"
+      FROZEN_PLAN_SHA256: "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+      FROZEN_REVISION_PLAN_SHA256: "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13.7"
+
+      - name: Bind the exact clean pushed producer commit
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs") {
+            throw "The workflow repository differs from the canonical repository."
+          }
+          & git remote set-url origin https://github.com/oglassdev/jet3-rs.git
+          if ($LASTEXITCODE -ne 0) { throw "Could not bind the canonical origin." }
+          $head = (& git rev-parse --verify HEAD).Trim()
+          $origin = (& git remote get-url origin).Trim()
+          if ($LASTEXITCODE -ne 0 -or $head -cne $env:GITHUB_SHA -or
+              $origin -cne "https://github.com/oglassdev/jet3-rs.git") {
+            throw "The checkout identity differs from the dispatched commit."
+          }
+          $remoteRows = @(& git ls-remote --exit-code origin refs/heads/main)
+          if ($LASTEXITCODE -ne 0 -or $remoteRows.Count -ne 1) {
+            throw "The pushed main-branch identity is unavailable."
+          }
+          $remoteFields = @($remoteRows[0] -split "\s+")
+          if ($remoteFields.Count -ne 2 -or $remoteFields[0] -cne $env:GITHUB_SHA) {
+            throw "The dispatched producer commit is not the pushed main commit."
+          }
+          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+            throw "The A4 producer checkout is not exact and clean."
+          }
+
+      - name: Run bounded A4 replica ${{ matrix.replica }}
+        id: replica
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          . "oracle/windows-dao/scripts/remote/Remote.Process.ps1"
+
+          function Get-A4LogBytes {
+            param([Parameter(Mandatory = $true)][string[]]$Paths)
+            [long]$total = 0
+            foreach ($path in $Paths) {
+              if (Test-Path -LiteralPath $path -PathType Leaf) {
+                [long]$length = (Get-Item -LiteralPath $path -Force).Length
+                if ($length -gt ([long]::MaxValue - $total)) {
+                  throw "A4 log byte accounting overflowed."
+                }
+                $total += $length
+              }
+            }
+            return $total
+          }
+
+          $repository = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+          $replica = [int]${{ matrix.replica }}
+          $replicaName = $replica.ToString("00")
+          $outputRoot = Join-Path $env:RUNNER_TEMP "jet3-a4-output-$replicaName"
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a4-diagnostics-$replicaName"
+          New-Item -ItemType Directory -Path $outputRoot, $diagnostics | Out-Null
+          $stdoutPath = Join-Path $diagnostics "replica.stdout.log"
+          $stderrPath = Join-Path $diagnostics "replica.stderr.log"
+          $hostedRecord = [ordered]@{
+            document_type = "jet3_windows_dao_a4_hosted_replica"
+            producer_commit = $env:GITHUB_SHA
+            campaign_id = "a4-run-$env:GITHUB_RUN_ID"
+            plan_sha256 = $env:FROZEN_PLAN_SHA256
+            revision_plan_sha256 = $env:FROZEN_REVISION_PLAN_SHA256
+            replica = $replica
+            worker_timeout_seconds = [int]$env:FROZEN_WORKER_TIMEOUT_SECONDS
+            hosted_timeout_seconds = [int]$env:HOSTED_REPLICA_TIMEOUT_SECONDS
+            campaign_timeout_seconds = [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+            started_utc = [DateTimeOffset]::UtcNow.ToString("o")
+          }
+          [IO.File]::WriteAllText(
+            (Join-Path $diagnostics "hosted-replica.json"),
+            ($hostedRecord | ConvertTo-Json -Compress),
+            (New-Object Text.UTF8Encoding($false))
+          )
+          $x86PowerShell = Join-Path $env:WINDIR `
+            "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+          $entrypoint = Join-Path $repository `
+            "oracle/windows-dao/scripts/run-a4-replica.ps1"
+          if (-not (Test-Path -LiteralPath $x86PowerShell -PathType Leaf)) {
+            throw "x86 Windows PowerShell 5 is unavailable."
+          }
+          $process = $null
+          $clock = $null
+          $replicaExit = $null
+          $replicaError = $null
+          $cleanupErrors = New-Object Collections.ArrayList
+          $elapsedSeconds = 0.0
+          try {
+            $process = Start-Process -FilePath $x86PowerShell -PassThru `
+              -RedirectStandardOutput $stdoutPath `
+              -RedirectStandardError $stderrPath `
+              -ArgumentList @(
+                "-NoLogo", "-NoProfile", "-NonInteractive",
+                "-ExecutionPolicy", "Bypass", "-File", $entrypoint,
+                "-RepositoryRoot", $repository,
+                "-OutputRoot", $outputRoot,
+                "-DiagnosticsRoot", $diagnostics,
+                "-GitCommit", $env:GITHUB_SHA,
+                "-RunId", $env:GITHUB_RUN_ID,
+                "-Replica", $replica,
+                "-MatrixJobId", "a4-replica-$replica"
+              )
+            $null = $process.Handle
+            $clock = [Diagnostics.Stopwatch]::StartNew()
+            while (-not $process.WaitForExit(1000)) {
+              if ((Get-A4LogBytes -Paths @($stdoutPath, $stderrPath)) -gt
+                  [long]$env:REPLICA_MAXIMUM_OUTPUT_BYTES) {
+                throw "A4 replica output exceeded its byte ceiling."
+              }
+              if ($clock.Elapsed.TotalSeconds -ge
+                  [int]$env:HOSTED_REPLICA_TIMEOUT_SECONDS) {
+                throw "A4 replica exceeded its hosted wall-clock ceiling."
+              }
+            }
+            if ((Get-A4LogBytes -Paths @($stdoutPath, $stderrPath)) -gt
+                [long]$env:REPLICA_MAXIMUM_OUTPUT_BYTES) {
+              throw "A4 replica output exceeded its byte ceiling."
+            }
+            $process.WaitForExit()
+            $process.Refresh()
+            $exitCode = $process.ExitCode
+            if ($null -eq $exitCode) {
+              throw "A4 replica exit code was unavailable after completion."
+            }
+            $replicaExit = [int]$exitCode
+          }
+          catch {
+            $replicaError = $_
+          }
+          finally {
+            if ($null -ne $process) {
+              try {
+                Stop-Jet3BootstrapProcessTree -Process $process `
+                  -Label "A4 hosted replica $replica"
+              }
+              catch { [void]$cleanupErrors.Add($_) }
+            }
+            if ($null -ne $clock) {
+              $clock.Stop()
+              $elapsedSeconds = $clock.Elapsed.TotalSeconds
+            }
+            if ($null -ne $process) {
+              try { $process.Dispose() }
+              catch { [void]$cleanupErrors.Add($_) }
+            }
+            try {
+              $hostedRecord.completed_utc = [DateTimeOffset]::UtcNow.ToString("o")
+              $hostedRecord.elapsed_seconds = [Math]::Round($elapsedSeconds, 3)
+              [IO.File]::WriteAllText(
+                (Join-Path $diagnostics "hosted-replica.json"),
+                ($hostedRecord | ConvertTo-Json -Compress),
+                (New-Object Text.UTF8Encoding($false))
+              )
+            }
+            catch { [void]$cleanupErrors.Add($_) }
+          }
+          if ($null -ne $replicaError) { throw $replicaError }
+          if ($cleanupErrors.Count -ne 0) {
+            throw "A4 hosted replica cleanup failed."
+          }
+          if ($replicaExit -ne 0) {
+            throw "The checked A4 replica worker returned nonzero."
+          }
+          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+            throw "A4 acquisition changed the exact producer checkout."
+          }
+
+      - name: Upload retained A4 replica tree
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a4-replica-${{ matrix.replica }}
+          path: ${{ runner.temp }}\jet3-a4-output-0${{ matrix.replica }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+      - name: Upload bounded A4 replica diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a4-diagnostics-${{ matrix.replica }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\jet3-a4-diagnostics-0${{ matrix.replica }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+  fan-in:
+    name: Assemble and analyze the complete A4 bundle
+    needs: [contract, a4-replica]
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.execute_a4_campaign &&
+      needs.contract.result == 'success' &&
+      needs.a4-replica.result == 'success'
+    runs-on: windows-2022
+    # Equals the plan's fan_in_timeout_seconds bound (900 s).
+    timeout-minutes: 15
+    env:
+      FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"
+      FROZEN_PLAN_SHA256: "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+      FROZEN_REVISION_PLAN_SHA256: "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13.7"
+
+      - name: Bind the hosted run-attempt start observable
+        id: campaign_start
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a4-fanin-diagnostics"
+          New-Item -ItemType Directory -Path $diagnostics -Force | Out-Null
+          $uri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/runs/" +
+            "$env:GITHUB_RUN_ID/attempts/$env:GITHUB_RUN_ATTEMPT"
+          $headers = @{
+            Accept = "application/vnd.github+json"
+            Authorization = "Bearer $env:GH_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          $attempt = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+          $started = [string]$attempt.run_started_at
+          if ([string]$attempt.id -cne $env:GITHUB_RUN_ID -or
+              [string]$attempt.run_attempt -cne $env:GITHUB_RUN_ATTEMPT -or
+              $started -cnotmatch "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") {
+            throw "The hosted run-attempt start observable is unavailable or unbound."
+          }
+          $record = [ordered]@{
+            document_type = "jet3_windows_dao_a4_campaign_start"
+            producer_commit = $env:GITHUB_SHA
+            github_run_id = $env:GITHUB_RUN_ID
+            github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+            run_started_at = $started
+          }
+          [IO.File]::WriteAllText(
+            (Join-Path $diagnostics "campaign-start.json"),
+            (($record | ConvertTo-Json -Compress) + "`n"),
+            (New-Object Text.UTF8Encoding($false))
+          )
+          "run_started_at=$started" | Out-File -FilePath $env:GITHUB_OUTPUT `
+            -Encoding utf8 -Append
+
+      - name: Download A4 replica 1 through the REST API
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          & oracle/windows-dao/scripts/a4/Download-A4Artifact.ps1 `
+            -ArtifactName "windows-dao-a4-replica-1" `
+            -Destination (Join-Path $env:RUNNER_TEMP "jet3-a4-replicas\replica-01")
+
+      - name: Require A4 replica 1 download
+        if: always()
+        shell: powershell
+        run: |
+          $replica = Join-Path $env:RUNNER_TEMP "jet3-a4-replicas\replica-01"
+          if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
+            throw "The A4 replica 1 download did not produce its directory."
+          }
+
+      - name: Download A4 replica 2 through the REST API
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          & oracle/windows-dao/scripts/a4/Download-A4Artifact.ps1 `
+            -ArtifactName "windows-dao-a4-replica-2" `
+            -Destination (Join-Path $env:RUNNER_TEMP "jet3-a4-replicas\replica-02")
+
+      - name: Require A4 replica 2 download
+        if: always()
+        shell: powershell
+        run: |
+          $replica = Join-Path $env:RUNNER_TEMP "jet3-a4-replicas\replica-02"
+          if (-not (Test-Path -LiteralPath $replica -PathType Container)) {
+            throw "The A4 replica 2 download did not produce its directory."
+          }
+
+      - name: Assemble the two derivation replica trees
+        id: assemble
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $replicas = Join-Path $env:RUNNER_TEMP "jet3-a4-replicas"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a4-bundle"
+          $campaignId = "a4-run-$env:GITHUB_RUN_ID"
+          & python -B oracle/windows-dao/scripts/a4_bundle.py assemble `
+            --replica-root (Join-Path $replicas "replica-01") `
+            --replica-root (Join-Path $replicas "replica-02") `
+            --bundle-root $bundle --campaign-id $campaignId `
+            --producer-commit $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw "A4 replica assembly failed." }
+
+      - name: Freeze, download, validate, and analyze the A4 holdout
+        id: analyze
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a4-bundle"
+          $holdout = Join-Path $env:RUNNER_TEMP "jet3-a4-holdout\replica-03"
+          $download = [IO.Path]::GetFullPath(
+            "oracle/windows-dao/scripts/a4/Download-A4Artifact.ps1"
+          )
+          & python -B oracle/windows-dao/scripts/a4_bundle.py analyze `
+            --bundle-root $bundle `
+            --holdout-root $holdout `
+            --campaign-id "a4-run-$env:GITHUB_RUN_ID" `
+            --producer-commit $env:GITHUB_SHA `
+            --holdout-command-executable "powershell.exe" `
+            --holdout-command-argument=-NoLogo `
+            --holdout-command-argument=-NoProfile `
+            --holdout-command-argument=-NonInteractive `
+            --holdout-command-argument=-ExecutionPolicy `
+            --holdout-command-argument=Bypass `
+            --holdout-command-argument=-File `
+            --holdout-command-argument=$download `
+            --holdout-command-argument=-ArtifactName `
+            --holdout-command-argument=windows-dao-a4-replica-3 `
+            --holdout-command-argument=-Destination `
+            --holdout-command-argument=$holdout
+          if ($LASTEXITCODE -ne 0) { throw "A4 analysis failed." }
+
+      - name: Finalize the retained A4 bundle manifest
+        id: finalize
+        shell: powershell
+        env:
+          CAMPAIGN_STARTED_UTC: ${{ steps.campaign_start.outputs.run_started_at }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a4-bundle"
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a4-fanin-diagnostics"
+          New-Item -ItemType Directory -Path $diagnostics -Force | Out-Null
+          $summary = @(& python -B oracle/windows-dao/scripts/a4_bundle.py finalize `
+            --bundle-root $bundle `
+            --campaign-id "a4-run-$env:GITHUB_RUN_ID" `
+            --producer-commit $env:GITHUB_SHA `
+            --campaign-started-utc $env:CAMPAIGN_STARTED_UTC)
+          if ($LASTEXITCODE -ne 0) { throw "A4 bundle finalization failed." }
+          [IO.File]::WriteAllText(
+            (Join-Path $diagnostics "finalize-summary.json"),
+            (($summary -join "`n") + "`n"),
+            (New-Object Text.UTF8Encoding($false))
+          )
+
+      - name: Validate the complete A4 bundle with the producer contract
+        id: validate
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a4-bundle"
+          & python -B oracle/windows-dao/scripts/a4_bundle.py validate $bundle `
+            --campaign-id "a4-run-$env:GITHUB_RUN_ID" `
+            --producer-commit $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) {
+            throw "Complete A4 bundle contract validation failed."
+          }
+          $dirty = @(& git status --porcelain=v1 --untracked-files=all)
+          if ($LASTEXITCODE -ne 0 -or $dirty.Count -ne 0) {
+            throw "A4 fan-in changed the exact producer checkout."
+          }
+
+      - name: Independently recompute the retained A4 bundle
+        id: independent
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundle = Join-Path $env:RUNNER_TEMP "jet3-a4-bundle"
+          $report = Join-Path $env:RUNNER_TEMP `
+            "jet3-a4-fanin-diagnostics\validation\independent-validation-report.json"
+          & python -B oracle/windows-dao/scripts/a4_independent_validator.py `
+            --bundle-root $bundle `
+            --validator-commit $env:GITHUB_SHA `
+            --output $report
+          if ($LASTEXITCODE -ne 0) {
+            throw "The independent recomputing A4 validator rejected the bundle."
+          }
+
+      - name: Record retained A4 fan-in status
+        id: fan_in_status
+        if: always()
+        shell: powershell
+        env:
+          ASSEMBLE_OUTCOME: ${{ steps.assemble.outcome }}
+          ANALYZE_OUTCOME: ${{ steps.analyze.outcome }}
+          FINALIZE_OUTCOME: ${{ steps.finalize.outcome }}
+          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+          INDEPENDENT_OUTCOME: ${{ steps.independent.outcome }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $diagnostics = Join-Path $env:RUNNER_TEMP "jet3-a4-fanin-diagnostics"
+          New-Item -ItemType Directory -Path $diagnostics -Force | Out-Null
+          $completed = [DateTimeOffset]::UtcNow
+          $campaignElapsed = $null
+          $campaignStarted = $null
+          $bundleCreated = $null
+          $timingComplete = $false
+          try {
+            $startPath = Join-Path $diagnostics "campaign-start.json"
+            $manifestPath = Join-Path $env:RUNNER_TEMP "jet3-a4-bundle\bundle-manifest.json"
+            $startItem = Get-Item -LiteralPath $startPath -Force
+            $manifestItem = Get-Item -LiteralPath $manifestPath -Force
+            if ($startItem.Length -lt 1 -or $startItem.Length -gt 4096 -or
+                $manifestItem.Length -lt 1 -or $manifestItem.Length -gt 64MB) {
+              throw "Campaign timing input violates its byte bound."
+            }
+            $startRecord = Get-Content -LiteralPath $startPath -Raw | ConvertFrom-Json
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            if ([string]$startRecord.producer_commit -cne $env:GITHUB_SHA -or
+                [string]$startRecord.github_run_id -cne $env:GITHUB_RUN_ID -or
+                [string]$startRecord.github_run_attempt -cne $env:GITHUB_RUN_ATTEMPT -or
+                [string]$manifest.campaign_id -cne "a4-run-$env:GITHUB_RUN_ID" -or
+                [string]$manifest.campaign_started_utc -cne
+                  [string]$startRecord.run_started_at) {
+              throw "Campaign timing binding mismatch."
+            }
+            $campaignStarted = [DateTimeOffset]::Parse([string]$manifest.campaign_started_utc)
+            $bundleCreated = [DateTimeOffset]::Parse([string]$manifest.created_utc)
+            $campaignElapsed = [long][Math]::Floor(
+              ($bundleCreated - $campaignStarted).TotalSeconds
+            )
+            $timingComplete = $campaignElapsed -ge 0 -and
+              $campaignElapsed -eq [long]$manifest.campaign_elapsed_seconds
+          }
+          catch {
+            $timingComplete = $false
+          }
+          $withinPlan = $timingComplete -and `
+            $campaignElapsed -le [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+          $contractPassed = (
+            $env:ASSEMBLE_OUTCOME -ceq "success" -and
+            $env:ANALYZE_OUTCOME -ceq "success" -and
+            $env:FINALIZE_OUTCOME -ceq "success" -and
+            $env:VALIDATE_OUTCOME -ceq "success"
+          )
+          $bundleStatus = $null
+          $summaryPath = Join-Path $diagnostics "finalize-summary.json"
+          if (Test-Path -LiteralPath $summaryPath -PathType Leaf) {
+            try {
+              $summaryItem = Get-Item -LiteralPath $summaryPath -Force
+              if ($summaryItem.Length -lt 1 -or $summaryItem.Length -gt 4096) {
+                throw "Finalize summary violates its byte bound."
+              }
+              $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json
+              $bundleStatus = [string]$summary.bundle_status
+            }
+            catch { $bundleStatus = $null }
+          }
+          $independentAccepted = $false
+          $independentStatus = "not_independently_validated"
+          $discrepancyCodes = @()
+          $reportPath = Join-Path $diagnostics `
+            "validation\independent-validation-report.json"
+          if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
+            try {
+              $reportItem = Get-Item -LiteralPath $reportPath -Force
+              if ($reportItem.Length -lt 1 -or $reportItem.Length -gt 65536) {
+                throw "Independent validation report violates its byte bound."
+              }
+              $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json
+              if ([string]$report.document_type -cne
+                    "dao_a4_independent_validation_report" -or
+                  [string]$report.campaign_id -cne "a4-run-$env:GITHUB_RUN_ID") {
+                throw "Independent validation report binding mismatch."
+              }
+              $independentAccepted = ($report.accepted -eq $true)
+              $independentStatus = [string]$report.independent_validation_status
+              $discrepancyCodes = @($report.discrepancy_codes | Select-Object -First 8)
+            }
+            catch {
+              $independentAccepted = $false
+              $independentStatus = "not_independently_validated"
+              $discrepancyCodes = @("report_unreadable")
+            }
+          }
+          if ($env:INDEPENDENT_OUTCOME -cne "success") { $independentAccepted = $false }
+          $status = [ordered]@{
+            document_type = "jet3_windows_dao_a4_fan_in_status"
+            producer_commit = $env:GITHUB_SHA
+            campaign_id = "a4-run-$env:GITHUB_RUN_ID"
+            plan_sha256 = $env:FROZEN_PLAN_SHA256
+            revision_plan_sha256 = $env:FROZEN_REVISION_PLAN_SHA256
+            assemble = $env:ASSEMBLE_OUTCOME
+            analyze = $env:ANALYZE_OUTCOME
+            finalize = $env:FINALIZE_OUTCOME
+            validate = $env:VALIDATE_OUTCOME
+            independent = $env:INDEPENDENT_OUTCOME
+            producer_contract_passed = $contractPassed
+            bundle_status = $bundleStatus
+            independent_validation_accepted = $independentAccepted
+            independent_validation_status = $independentStatus
+            independent_validation_discrepancy_codes = $discrepancyCodes
+            timing_records_complete = $timingComplete
+            campaign_started_utc = if ($null -eq $campaignStarted) {
+              $null
+            } else { $campaignStarted.ToString("o") }
+            bundle_created_utc = if ($null -eq $bundleCreated) {
+              $null
+            } else { $bundleCreated.ToString("o") }
+            campaign_elapsed_seconds = $campaignElapsed
+            plan_campaign_timeout_seconds = `
+              [int]$env:FROZEN_CAMPAIGN_TIMEOUT_SECONDS
+            within_plan_campaign_timeout = $withinPlan
+            completed_utc = $completed.ToString("o")
+            github_run_id = $env:GITHUB_RUN_ID
+            github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+          }
+          $statusJson = ($status | ConvertTo-Json -Depth 3 -Compress) + "`n"
+          $statusBytes = [Text.Encoding]::UTF8.GetBytes($statusJson)
+          if ($statusBytes.Length -gt 4096) {
+            throw "A4 fan-in status exceeds its byte ceiling."
+          }
+          [IO.File]::WriteAllBytes(
+            (Join-Path $diagnostics "fan-in-status.json"),
+            $statusBytes
+          )
+          if (-not $withinPlan) {
+            throw "A4 campaign exceeded the plan's campaign timeout or lacks complete timing."
+          }
+
+      - name: Upload retained A4 bundle
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a4-bundle-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}\jet3-a4-bundle
+            ${{ runner.temp }}\jet3-a4-fanin-diagnostics\fan-in-status.json
+            ${{ runner.temp }}\jet3-a4-fanin-diagnostics\validation\independent-validation-report.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+      - name: Upload bounded A4 fan-in diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-a4-fanin-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}\jet3-a4-fanin-diagnostics
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/oracle/windows-dao/scripts/a4/A4.PageStore.ps1
+++ b/oracle/windows-dao/scripts/a4/A4.PageStore.ps1
@@ -1,0 +1,83 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# A4 reuses the proven A1 capture primitives under A4's preregistered bounds.
+. (Join-Path (Split-Path $PSScriptRoot -Parent) "a1/A1.PageStore.ps1")
+
+$script:A1PageBytes = 2048L
+$script:A1MaximumPagesPerReplica = 20480L
+$script:A1MaximumUniqueBlobs = 65536L
+$script:A1MaximumPageStoreBytes = 128MB
+$script:A1MaximumChangedEntries = 65536L
+$script:A1MaximumLogicalReadBytes = 2GB
+
+function Get-A1Payload {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][int]$Id
+    )
+    return Get-A4Payload -Role $Role -Id $Id
+}
+function Invoke-A1WithDatabase {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [switch]$Create
+    )
+    return Invoke-A4WithDatabase -Action $Action -Create:$Create
+}
+
+function New-A4PageStore {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Session)
+    return New-A1PageStore -Session $Session
+}
+
+function Set-A4ExpectedSemanticDirty {
+    param([Parameter(Mandatory = $true)][string]$Role)
+    Set-A1ExpectedSemanticDirty -Role $Role
+}
+
+function Read-A4SemanticTables {
+    $expectedByRole = @{}
+    foreach ($role in $script:A4Roles) {
+        if ([bool]$script:A1Extant[$role]) {
+            $expectedByRole[$role] = Get-A1ExpectedSemanticResult `
+                -Role $role -Rows $script:A1Rows[$role]
+        }
+    }
+    $documents = Invoke-A4WithDatabase -Action {
+        param($database)
+        foreach ($role in $script:A4Roles) {
+            if ([bool]$script:A1Extant[$role]) {
+                Read-A1SemanticTable -Database $database -Role $role `
+                    -Expected $expectedByRole[$role]
+            }
+        }
+    }
+    return @($documents)
+}
+
+function Read-A4PageSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Store,
+        [Parameter(Mandatory = $true)][string]$DatabasePath,
+        [AllowNull()][string[]]$PriorHashes,
+        [AllowNull()][byte[]]$PriorPages
+    )
+    return Read-A1PageSnapshot -Store $Store -DatabasePath $DatabasePath `
+        -PriorHashes $PriorHashes -PriorPages $PriorPages
+}
+
+function Get-A4LowerSha256 {
+    param([Parameter(Mandatory = $true)][byte[]]$Bytes)
+    return Get-A1LowerSha256 -Bytes $Bytes
+}
+
+function Write-A4CreateNewBytes {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][byte[]]$Bytes,
+        [Parameter(Mandatory = $true)][long]$MaximumBytes
+    )
+    Write-A1CreateNewBytes -Path $Path -Bytes $Bytes `
+        -MaximumBytes $MaximumBytes
+}

--- a/oracle/windows-dao/scripts/a4/A4.Progress.ps1
+++ b/oracle/windows-dao/scripts/a4/A4.Progress.ps1
@@ -1,0 +1,33 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# The A4 progress log is byte-for-byte the A2 implementation; only the
+# callers' names are rebound.
+. (Join-Path (Split-Path $PSScriptRoot -Parent) "a2/A2.Progress.ps1")
+
+function New-A4ProgressFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$Replica
+    )
+    return New-A2ProgressFile -DiagnosticsRoot $DiagnosticsRoot -Replica $Replica
+}
+
+function Open-A4WorkerProgress {
+    param(
+        [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$Replica
+    )
+    return Open-A2WorkerProgress -DiagnosticsRoot $DiagnosticsRoot `
+        -Replica $Replica
+}
+
+function Add-A4ProgressRecord {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Progress,
+        [Parameter(Mandatory = $true)][string]$CheckpointId,
+        [Parameter(Mandatory = $true)][long]$PageCount
+    )
+    Add-A2ProgressRecord -Progress $Progress -CheckpointId $CheckpointId `
+        -PageCount $PageCount
+}

--- a/oracle/windows-dao/scripts/a4/A4.SchemaSnapshot.ps1
+++ b/oracle/windows-dao/scripts/a4/A4.SchemaSnapshot.ps1
@@ -1,0 +1,339 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:A4Canonicalization =
+    "after each Refresh require exactly the extant scheduled physical table names from expected_schema_by_checkpoint and exactly the extant scheduled index name A4IX_ID; include every field and index field; use no implementation-defined hidden/system index test; assign zero-based ordinals after those exact filters; sort each filtered collection by ordinal then strict Windows-1252 name bytes; reject duplicate ordinals or names; retain exact BSTR UTF-16 code units plus strict Windows-1252 and UTF-8 expected bytes without comparing either to physical bytes; emit integers as JSON integers and lowercase SHA-256"
+
+function ConvertTo-A4Hex {
+    param([Parameter(Mandatory = $true)][byte[]]$Bytes)
+    return ([BitConverter]::ToString($Bytes)).Replace("-", "").ToLowerInvariant()
+}
+
+function Get-A4NameProjection {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    $strict = New-Object Text.EncoderExceptionFallback
+    $cp1252 = [Text.Encoding]::GetEncoding(
+        1252, $strict, (New-Object Text.DecoderExceptionFallback)
+    )
+    $utf8 = New-Object Text.UTF8Encoding($false, $true)
+    $units = New-Object Collections.ArrayList
+    foreach ($character in $Name.ToCharArray()) {
+        [void]$units.Add([int][char]$character)
+    }
+    return [ordered]@{
+        name = $Name
+        name_utf16_code_units = @($units)
+        name_windows_1252_hex = ConvertTo-A4Hex -Bytes $cp1252.GetBytes($Name)
+        name_utf8_hex = ConvertTo-A4Hex -Bytes $utf8.GetBytes($Name)
+    }
+}
+
+function Get-A4ExpectedDescriptors {
+    param([Parameter(Mandatory = $true)][string]$CheckpointId)
+    $property = $script:A4Plan.tables.expected_schema_by_checkpoint.PSObject.Properties[
+        $CheckpointId
+    ]
+    if ($null -eq $property) {
+        throw "A4 schema checkpoint is absent from the checked plan."
+    }
+    return @($property.Value)
+}
+
+function Get-A4Descriptor {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    $parts = @($Value -split ":")
+    if ($parts.Count -lt 2 -or $parts.Count -gt 3) {
+        throw "A4 schema descriptor is malformed."
+    }
+    $role = [string]$parts[0]
+    $layout = [string]$parts[$parts.Count - 1]
+    $instance = if ($parts.Count -eq 3) {
+        "$role-$([string]$parts[1])"
+    } else { "$role-v1" }
+    if ($role -notin $script:A4Roles -or
+        $layout -notin @("id", "id+payload", "id+payload+index")) {
+        throw "A4 schema descriptor is outside the checked grammar."
+    }
+    return [pscustomobject]@{
+        Role = $role
+        Instance = $instance
+        HasPayload = $layout.Contains("+payload")
+        HasIndex = $layout.Contains("+index")
+    }
+}
+
+function Get-A4ScheduledTableNames {
+    param([Parameter(Mandatory = $true)][object[]]$Descriptors)
+    return @($Descriptors | ForEach-Object {
+        $descriptor = Get-A4Descriptor -Value ([string]$_)
+        [string]$script:A1RoleNames[$descriptor.Role]
+    })
+}
+
+function Get-A4FilteredTableNames {
+    param([Parameter(Mandatory = $true)][object]$TableDefinitions)
+    $allNames = @($script:A4Plan.tables.physical_names)
+    $found = New-Object Collections.ArrayList
+    foreach ($table in @($TableDefinitions)) {
+        $name = [string]$table.Name
+        if ($name -cin $allNames) { [void]$found.Add($name) }
+        Release-M1ComObject $table (New-Object Collections.ArrayList) `
+            "A4 filtered table release"
+    }
+    return @($found)
+}
+
+function Get-A4FieldDocument {
+    param(
+        [Parameter(Mandatory = $true)][object]$Field,
+        [Parameter(Mandatory = $true)][int]$Ordinal
+    )
+    $name = [string]$Field.Name
+    $projection = Get-A4NameProjection -Name $name
+    return [ordered]@{
+        ordinal = $Ordinal
+        ordinal_source = "Fields zero-based position after Refresh and the all-fields filter"
+        name = $projection.name
+        name_utf16_code_units = $projection.name_utf16_code_units
+        name_windows_1252_hex = $projection.name_windows_1252_hex
+        type = [int]$Field.Type
+        size = [int]$Field.Size
+        attributes = [int]$Field.Attributes
+        required = [bool]$Field.Required
+        allow_zero_length = if ($name -ceq "Payload") {
+            [bool]$Field.AllowZeroLength
+        } else { $null }
+        name_utf8_hex = $projection.name_utf8_hex
+    }
+}
+
+function Get-A4IndexFieldDocument {
+    param(
+        [Parameter(Mandatory = $true)][object]$Field,
+        [Parameter(Mandatory = $true)][int]$Ordinal
+    )
+    $projection = Get-A4NameProjection -Name ([string]$Field.Name)
+    return [ordered]@{
+        ordinal = $Ordinal
+        ordinal_source = "Index.Fields zero-based position after Refresh and the all-fields filter"
+        name = $projection.name
+        name_utf16_code_units = $projection.name_utf16_code_units
+        name_windows_1252_hex = $projection.name_windows_1252_hex
+        descending = (([int]$Field.Attributes -band 1) -ne 0)
+        name_utf8_hex = $projection.name_utf8_hex
+    }
+}
+
+function Get-A4IndexDocument {
+    param(
+        [Parameter(Mandatory = $true)][object]$Index,
+        [Parameter(Mandatory = $true)][int]$Ordinal
+    )
+    $projection = Get-A4NameProjection -Name ([string]$Index.Name)
+    $fields = $null; $fieldRows = New-Object Collections.ArrayList
+    $cleanup = New-Object Collections.ArrayList; $primary = $null
+    try {
+        $fields = $Index.Fields
+        $fields.Refresh()
+        $fieldOrdinal = 0
+        foreach ($field in @($fields)) {
+            try {
+                [void]$fieldRows.Add((Get-A4IndexFieldDocument `
+                    -Field $field -Ordinal $fieldOrdinal))
+                $fieldOrdinal++
+            }
+            finally {
+                Release-M1ComObject $field $cleanup "A4 index snapshot field release"
+            }
+        }
+    }
+    catch { $primary = $_ }
+    finally {
+        Release-M1ComObject $fields $cleanup "A4 index snapshot fields release"
+    }
+    Complete-M1DaoHelper $primary $cleanup "A4 index snapshot"
+    return [ordered]@{
+        ordinal = $Ordinal
+        ordinal_source = "Indexes zero-based position after Refresh and exact A4IX_ID scheduled-name filtering"
+        name = $projection.name
+        name_utf16_code_units = $projection.name_utf16_code_units
+        name_windows_1252_hex = $projection.name_windows_1252_hex
+        attributes = [int]$Index.Attributes
+        primary = [bool]$Index.Primary
+        unique = [bool]$Index.Unique
+        required = [bool]$Index.Required
+        ignore_nulls = [bool]$Index.IgnoreNulls
+        fields = @($fieldRows)
+        name_utf8_hex = $projection.name_utf8_hex
+    }
+}
+
+function Get-A4TableDocument {
+    param(
+        [Parameter(Mandatory = $true)][object]$Database,
+        [Parameter(Mandatory = $true)][object]$Table,
+        [Parameter(Mandatory = $true)][pscustomobject]$Descriptor,
+        [Parameter(Mandatory = $true)][int]$Ordinal
+    )
+    $fields = $null; $indexes = $null
+    $fieldRows = New-Object Collections.ArrayList
+    $indexRows = New-Object Collections.ArrayList
+    $cleanup = New-Object Collections.ArrayList; $primary = $null
+    $semantic = $null
+    try {
+        $fields = $Table.Fields
+        $fields.Refresh()
+        foreach ($field in @($fields)) {
+            try {
+                [void]$fieldRows.Add((Get-A4FieldDocument `
+                    -Field $field -Ordinal $fieldRows.Count))
+            }
+            finally {
+                Release-M1ComObject $field $cleanup "A4 schema field release"
+            }
+        }
+        $expectedFieldCount = if ($Descriptor.HasPayload) { 2 } else { 1 }
+        if ($fieldRows.Count -ne $expectedFieldCount -or
+            [string]$fieldRows[0].name -cne "Id" -or
+            ($Descriptor.HasPayload -and [string]$fieldRows[1].name -cne "Payload")) {
+            throw "A4 table fields differ from the scheduled schema."
+        }
+
+        $indexes = $Table.Indexes
+        $indexes.Refresh()
+        foreach ($index in @($indexes)) {
+            try {
+                if ([string]$index.Name -ceq
+                    [string]$script:A4Plan.tables.definition.index.name) {
+                    [void]$indexRows.Add((Get-A4IndexDocument `
+                        -Index $index -Ordinal $indexRows.Count))
+                }
+            }
+            finally {
+                Release-M1ComObject $index $cleanup "A4 schema index release"
+            }
+        }
+        if ($indexRows.Count -ne [int]$Descriptor.HasIndex) {
+            throw "A4 scheduled index inventory differs."
+        }
+
+        if ($Descriptor.HasPayload) {
+            $expected = Get-A1ExpectedSemanticResult `
+                -Role $Descriptor.Role -Rows $script:A1Rows[$Descriptor.Role]
+            $semantic = Read-A1SemanticTable -Database $Database `
+                -Role $Descriptor.Role -Expected $expected
+        }
+        else {
+            if ($script:A1Rows[$Descriptor.Role].Count -ne 0) {
+                throw "A4 Id-only table unexpectedly has rows."
+            }
+            $semantic = [ordered]@{
+                role = $Descriptor.Role; row_count = 0
+                rolling_sha256 =
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            }
+        }
+    }
+    catch { $primary = $_ }
+    finally {
+        Release-M1ComObject $indexes $cleanup "A4 schema indexes release"
+        Release-M1ComObject $fields $cleanup "A4 schema fields release"
+    }
+    Complete-M1DaoHelper $primary $cleanup "A4 table schema snapshot"
+    $projection = Get-A4NameProjection -Name ([string]$Table.Name)
+    return [pscustomobject]@{
+        Document = [ordered]@{
+            ordinal = $Ordinal
+            ordinal_source = "TableDefs zero-based position after Refresh and exact extant scheduled-name filtering"
+            logical_role = $Descriptor.Role
+            lifecycle_instance = $Descriptor.Instance
+            name = $projection.name
+            name_utf16_code_units = $projection.name_utf16_code_units
+            name_windows_1252_hex = $projection.name_windows_1252_hex
+            attributes = [int]$Table.Attributes
+            row_count = [int]$semantic.row_count
+            rolling_row_sha256 = [string]$semantic.rolling_sha256
+            fields = @($fieldRows)
+            indexes = @($indexRows)
+            name_utf8_hex = $projection.name_utf8_hex
+        }
+        Semantic = $semantic
+    }
+}
+
+function Read-A4SchemaSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$CheckpointId,
+        [Parameter(Mandatory = $true)][int]$Ordinal
+    )
+    Assert-A4Quiescent
+    $before = Get-M1FileSha256 -Path $script:A4DatabasePath
+    $descriptors = @(Get-A4ExpectedDescriptors -CheckpointId $CheckpointId)
+    $expectedNames = @(Get-A4ScheduledTableNames -Descriptors $descriptors)
+    $database = $null; $definitions = $null
+    $tables = New-Object Collections.ArrayList
+    $semantic = New-Object Collections.ArrayList
+    $cleanup = New-Object Collections.ArrayList; $primary = $null
+    try {
+        $database = $script:A4Workspace.OpenDatabase(
+            $script:A4DatabasePath, $false, $true, ""
+        )
+        $definitions = $database.TableDefs
+        $definitions.Refresh()
+        $actualNames = @(Get-A4FilteredTableNames -TableDefinitions $definitions)
+        if (($actualNames -join "`n") -cne ($expectedNames -join "`n")) {
+            throw "A4 scheduled table inventory differs after read-only reopen."
+        }
+        for ($ordinalIndex = 0; $ordinalIndex -lt $descriptors.Count; $ordinalIndex++) {
+            $descriptor = Get-A4Descriptor -Value ([string]$descriptors[$ordinalIndex])
+            $table = $null
+            try {
+                $table = $definitions.Item([string]$expectedNames[$ordinalIndex])
+                $row = Get-A4TableDocument -Database $database -Table $table `
+                    -Descriptor $descriptor -Ordinal $ordinalIndex
+                [void]$tables.Add($row.Document)
+                [void]$semantic.Add($row.Semantic)
+            }
+            finally {
+                Release-M1ComObject $table $cleanup "A4 schema table release"
+            }
+        }
+    }
+    catch { $primary = $_ }
+    finally {
+        Release-M1ComObject $definitions $cleanup "A4 schema definitions release"
+        Close-M1ComObject $database $cleanup "A4 read-only schema database close"
+        Release-M1ComObject $database $cleanup "A4 read-only schema database release"
+    }
+    Complete-M1DaoHelper $primary $cleanup "A4 read-only schema snapshot"
+    Assert-A4Quiescent
+    $after = Get-M1FileSha256 -Path $script:A4DatabasePath
+    if ($before -cne $after) {
+        throw "A4 read-only schema observation changed the database bytes."
+    }
+    return [pscustomobject]@{
+        Semantic = @($semantic)
+        Document = [ordered]@{
+            protocol_version = "1.0.0"
+            document_type = "dao_a4_schema_snapshot"
+            experiment_id = $script:A4ExperimentId
+            plan_sha256 = $script:A4PlanSha256
+            revision_plan_sha256 = $script:A4RevisionPlanSha256
+            producer_commit = $script:A4ProducerCommit
+            campaign_id = $script:A4CampaignId
+            environment_sha256 = $script:A4EnvironmentSha256
+            provider_sha256 = $script:A4ProviderSha256
+            replica = $script:A4Replica
+            checkpoint_id = $CheckpointId
+            ordinal = $Ordinal
+            windows_ansi_code_page = 1252
+            database_sha256_before_read = $before
+            database_sha256_after_read = $after
+            database_unchanged_by_read = $true
+            dao_identifier_observable = $false
+            identity_oracle = "listed_operation_instance_equality_only"
+            canonicalization = $script:A4Canonicalization
+            tables = @($tables)
+        }
+    }
+}

--- a/oracle/windows-dao/scripts/a4/A4.Worker.ps1
+++ b/oracle/windows-dao/scripts/a4/A4.Worker.ps1
@@ -1,0 +1,884 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+    [Parameter(Mandatory = $true)][string]$OutputRoot,
+    [Parameter(Mandatory = $true)][string]$WorkingRoot,
+    [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+    [Parameter(Mandatory = $true)][string]$PlanPath,
+    [Parameter(Mandatory = $true)][string]$EnvironmentPath,
+    [Parameter(Mandatory = $true)][string]$ProducerCommit,
+    [Parameter(Mandatory = $true)][string]$CampaignId,
+    [Parameter(Mandatory = $true)][string]$MatrixJobId,
+    [Parameter(Mandatory = $true)][string]$PlanSha256,
+    [Parameter(Mandatory = $true)][string]$RevisionPlanSha256,
+    [Parameter(Mandatory = $true)][string]$EnvironmentSha256,
+    [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$Replica
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$m1Root = Join-Path $RepositoryRoot "oracle/windows-dao/scripts/m1"
+. (Join-Path $m1Root "M1.Preflight.ps1")
+. (Join-Path $m1Root "M1.Publication.ps1")
+. (Join-Path $m1Root "M1.DaoValues.ps1")
+. (Join-Path $PSScriptRoot "A4.PageStore.ps1")
+. (Join-Path $PSScriptRoot "A4.Progress.ps1")
+. (Join-Path $PSScriptRoot "A4.SchemaSnapshot.ps1")
+
+$script:A4ExperimentId = "DAO-A4-ROW-ANCHORED-MAPS-001"
+$script:A4FrozenPlanSha256 = `
+    "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+$script:A4RequiredPlanPath = `
+    "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json"
+$script:A4RevisionPlanSha256 = `
+    "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+$script:A1DbVersion30 = 32
+$script:A1DbLong = 4
+$script:A1DbText = 10
+$script:A1DbFixedField = 1
+$script:A1DbOpenSnapshot = 4
+$script:A4Locale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
+
+function Assert-A4PlanChain {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Plan)
+    if ([string]$Plan.preregistration.status -cne "frozen_before_acquisition" -or
+        $Plan.preregistration.acquisition_started -ne $false -or
+        [string]$Plan.implementation_rebinding.required_plan_path -cne
+            $script:A4RequiredPlanPath -or
+        [string]$Plan.implementation_rebinding.required_experiment_id -cne
+            $script:A4ExperimentId) {
+        throw "A4 base-plan chain or implementation binding drifted."
+    }
+}
+
+function Assert-A4WorkerPlan {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Plan)
+    $ids = @($Plan.checkpoint_design.checkpoint_ids)
+    $names = @($Plan.tables.physical_names)
+    $roles = @($Plan.tables.logical_roles)
+    $binding = @($Plan.tables.role_bindings | Where-Object {
+        [int]$_.replica -eq $script:A4Replica
+    })
+    if ([string]$Plan.experiment_id -cne $script:A4ExperimentId -or
+        [string]$Plan.document_type -cne "dao_a4_row_anchored_maps_plan" -or
+        [int]$Plan.replicas.count -ne 3 -or $binding.Count -ne 1 -or
+        $names.Count -ne 4 -or @($names | Select-Object -Unique).Count -ne 4 -or
+        ($roles -join ",") -cne "T1,T2,T3,T4" -or
+        @($names | ForEach-Object { $_.Length } | Select-Object -Unique).Count -ne 1) {
+        throw "A4 plan identity, replica, or table design drifted."
+    }
+    if ($ids.Count -ne 25 -or $ids.Count -ne [int]$Plan.checkpoint_design.count -or
+        $ids.Count -ne [int]$Plan.bounds.planned_checkpoints_per_replica -or
+        $ids.Count -gt [int]$Plan.bounds.max_checkpoints_per_replica -or
+        @($ids | Select-Object -Unique).Count -ne $ids.Count) {
+        throw "A4 checkpoint enumeration is not exact or bounded."
+    }
+    foreach ($id in $ids) {
+        if ($null -eq $Plan.tables.checkpoint_operations.PSObject.Properties[$id]) {
+            throw "A4 checkpoint lacks its plan-derived DAO operation."
+        }
+    }
+    $definition = $Plan.tables.definition
+    $row = $Plan.tables.row_algorithm
+    $bounds = $Plan.bounds
+    if (@($definition.fields).Count -ne 2 -or
+        [string]$definition.fields[0].name -cne "Id" -or
+        [string]$definition.fields[0].dao_type -cne "dbLong" -or
+        [string]$definition.fields[1].name -cne "Payload" -or
+        [string]$definition.fields[1].dao_type -cne "dbText" -or
+        [int]$definition.fields[1].size -ne 240 -or
+        $definition.fields[1].fixed_length -ne $true -or
+        [string]$definition.index.name -cne "A4IX_ID" -or
+        $definition.index.unique -ne $false -or
+        [int]$row.growth_batch_rows -ne 32 -or
+        [int]$Plan.page_capture.page_size -ne 2048 -or
+        [long]$bounds.max_final_pages_per_replica -ne 20480 -or
+        [long]$bounds.max_logical_checkpoint_read_bytes_per_replica -ne 2GB -or
+        [long]$bounds.max_inserted_rows_per_replica -ne 200000 -or
+        [long]$bounds.max_changed_hash_entries_per_replica -ne 65536 -or
+        [long]$bounds.max_unique_page_blobs -ne 65536 -or
+        [long]$bounds.max_retained_page_store_bytes -ne 128MB -or
+        [long]$bounds.max_bundle_bytes -ne 768MB -or
+        [long]$bounds.max_json_bytes -ne 64MB -or
+        [int]$bounds.worker_timeout_seconds_per_replica -ne 1700 -or
+        [long]$bounds.max_child_log_bytes -ne 1MB -or
+        [long]$bounds.max_companion_bytes_per_checkpoint -ne 64KB) {
+        throw "A4 schema, row algorithm, or resource bounds drifted."
+    }
+    return $binding[0]
+}
+
+function Get-A4Payload {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][int]$Id
+    )
+    $seed = "A4|$Role|$($Id.ToString('D10'))|"
+    $builder = New-Object Text.StringBuilder 240
+    while ($builder.Length -lt 240) { [void]$builder.Append($seed) }
+    return $builder.ToString(0, 240)
+}
+
+function Invoke-A4WithDatabase {
+    param(
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [switch]$Create
+    )
+    $database = $null
+    $cleanup = New-Object Collections.ArrayList
+    $primary = $null
+    $result = $null
+    try {
+        if ($Create) {
+            $database = $script:A4Workspace.CreateDatabase(
+                $script:A4DatabasePath, $script:A4Locale,
+                $script:A1DbVersion30
+            )
+        }
+        else { $database = $script:A4Workspace.OpenDatabase($script:A4DatabasePath) }
+        if ([string]$database.Version -cne "3.0") {
+            throw "A4 database version differs from Jet 3."
+        }
+        $result = & $Action $database
+    }
+    catch { $primary = $_ }
+    finally {
+        Close-M1ComObject -Value $database -CleanupErrors $cleanup `
+            -Label "A4 database close"
+        Release-M1ComObject -Value $database -CleanupErrors $cleanup `
+            -Label "A4 database release"
+    }
+    Complete-M1DaoHelper -PrimaryError $primary -CleanupErrors $cleanup `
+        -Label "A4 database action"
+    return $result
+}
+
+function Add-A4Table {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [switch]$WithPayload
+    )
+    $name = [string]$script:A1RoleNames[$Role]
+    Invoke-A4WithDatabase -Action {
+        param($database)
+        $table = $null; $fields = $null; $idField = $null
+        $payloadField = $null; $tableDefinitions = $null
+        $cleanup = New-Object Collections.ArrayList; $primary = $null
+        try {
+            $table = $database.CreateTableDef($name)
+            $table.Attributes = [int]$script:A4Plan.tables.definition.table_attributes_numeric
+            $fields = $table.Fields
+            $idField = $table.CreateField("Id", $script:A1DbLong)
+            $idField.Attributes = 0
+            $idField.Required = $false
+            $fields.Append($idField)
+            if ($WithPayload) {
+                $payloadField = $table.CreateField("Payload", $script:A1DbText, 240)
+                $payloadField.Attributes = $script:A1DbFixedField
+                $payloadField.Required = $false
+                $payloadField.AllowZeroLength = $false
+                $fields.Append($payloadField)
+            }
+            $tableDefinitions = $database.TableDefs
+            $tableDefinitions.Append($table)
+        }
+        catch { $primary = $_ }
+        finally {
+            Release-M1ComObject $tableDefinitions $cleanup "A4 table definitions release"
+            Release-M1ComObject $payloadField $cleanup "A4 payload field release"
+            Release-M1ComObject $idField $cleanup "A4 id field release"
+            Release-M1ComObject $fields $cleanup "A4 fields release"
+            Release-M1ComObject $table $cleanup "A4 table release"
+        }
+        Complete-M1DaoHelper $primary $cleanup "A4 table creation"
+    } | Out-Null
+    $script:A1Extant[$Role] = $true
+    $script:A1Rows[$Role].Clear()
+    $script:A1NextId[$Role] = 1
+    Set-A4ExpectedSemanticDirty -Role $Role
+}
+
+function Add-A4PayloadField {
+    param([Parameter(Mandatory = $true)][string]$Role)
+    $name = [string]$script:A1RoleNames[$Role]
+    Invoke-A4WithDatabase -Action {
+        param($database)
+        $definitions = $null; $table = $null; $fields = $null; $field = $null
+        $cleanup = New-Object Collections.ArrayList; $primary = $null
+        try {
+            $definitions = $database.TableDefs
+            $definitions.Refresh()
+            $table = $definitions.Item($name)
+            $fields = $table.Fields
+            $field = $table.CreateField("Payload", $script:A1DbText, 240)
+            $field.Attributes = $script:A1DbFixedField
+            $field.Required = $false
+            $field.AllowZeroLength = $false
+            $fields.Append($field)
+        }
+        catch { $primary = $_ }
+        finally {
+            Release-M1ComObject $field $cleanup "A4 appended field release"
+            Release-M1ComObject $fields $cleanup "A4 appended fields release"
+            Release-M1ComObject $table $cleanup "A4 appended table release"
+            Release-M1ComObject $definitions $cleanup "A4 appended definitions release"
+        }
+        Complete-M1DaoHelper $primary $cleanup "A4 payload field append"
+    } | Out-Null
+    Set-A4ExpectedSemanticDirty -Role $Role
+}
+
+function Add-A4Index {
+    param([Parameter(Mandatory = $true)][string]$Role)
+    $name = [string]$script:A1RoleNames[$Role]
+    $indexName = [string]$script:A4Plan.tables.definition.index.name
+    Invoke-A4WithDatabase -Action {
+        param($database)
+        $definitions = $null; $table = $null; $indexes = $null
+        $index = $null; $indexFields = $null; $indexField = $null
+        $cleanup = New-Object Collections.ArrayList; $primary = $null
+        try {
+            $definitions = $database.TableDefs
+            $definitions.Refresh()
+            $table = $definitions.Item($name)
+            $indexes = $table.Indexes
+            $index = $table.CreateIndex($indexName)
+            $index.Primary = $false
+            $index.Unique = $false
+            $index.Required = $false
+            $index.IgnoreNulls = $false
+            $indexFields = $index.Fields
+            $indexField = $index.CreateField("Id")
+            $indexField.Attributes = 0
+            $indexFields.Append($indexField)
+            $indexes.Append($index)
+        }
+        catch { $primary = $_ }
+        finally {
+            Release-M1ComObject $indexField $cleanup "A4 index field release"
+            Release-M1ComObject $indexFields $cleanup "A4 index fields release"
+            Release-M1ComObject $index $cleanup "A4 index release"
+            Release-M1ComObject $indexes $cleanup "A4 indexes release"
+            Release-M1ComObject $table $cleanup "A4 indexed table release"
+            Release-M1ComObject $definitions $cleanup "A4 indexed definitions release"
+        }
+        Complete-M1DaoHelper $primary $cleanup "A4 index append"
+    } | Out-Null
+}
+
+function Remove-A4Table {
+    param([Parameter(Mandatory = $true)][string]$Role)
+    $name = [string]$script:A1RoleNames[$Role]
+    Invoke-A4WithDatabase -Action {
+        param($database)
+        $definitions = $null; $cleanup = New-Object Collections.ArrayList
+        $primary = $null
+        try { $definitions = $database.TableDefs; $definitions.Delete($name) }
+        catch { $primary = $_ }
+        finally { Release-M1ComObject $definitions $cleanup "A4 table definitions release" }
+        Complete-M1DaoHelper $primary $cleanup "A4 table deletion"
+    } | Out-Null
+    $script:A1Extant[$Role] = $false
+    $script:A1Rows[$Role].Clear()
+    $script:A1NextId[$Role] = 1
+    Set-A4ExpectedSemanticDirty -Role $Role
+}
+
+function Add-A4Ids {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][int[]]$Ids
+    )
+    if ($Ids.Count -lt 1 -or
+        $script:A4InsertedRows -gt (200000 - $Ids.Count)) {
+        throw "A4 insertion would violate its row ceiling."
+    }
+    $name = [string]$script:A1RoleNames[$Role]
+    Invoke-A4WithDatabase -Action {
+        param($database)
+        $recordset = $null; $fields = $null; $idField = $null
+        $payloadField = $null; $cleanup = New-Object Collections.ArrayList
+        $primary = $null
+        try {
+            $recordset = $database.OpenRecordset($name, 2, 0)
+            $fields = $recordset.Fields
+            $idField = $fields.Item("Id")
+            $payloadField = $fields.Item("Payload")
+            foreach ($id in $Ids) {
+                $recordset.AddNew()
+                $idField.Value = [Int32]$id
+                $payloadField.Value = [string](Get-A4Payload -Role $Role -Id $id)
+                $recordset.Update()
+            }
+        }
+        catch { $primary = $_ }
+        finally {
+            Release-M1ComObject $payloadField $cleanup "A4 payload field release"
+            Release-M1ComObject $idField $cleanup "A4 id field release"
+            Release-M1ComObject $fields $cleanup "A4 recordset fields release"
+            Close-M1ComObject $recordset $cleanup "A4 insert recordset close"
+            Release-M1ComObject $recordset $cleanup "A4 insert recordset release"
+        }
+        Complete-M1DaoHelper $primary $cleanup "A4 row insertion"
+    } | Out-Null
+    foreach ($id in $Ids) { [void]$script:A1Rows[$Role].Add([int]$id) }
+    $script:A4InsertedRows += $Ids.Count
+    Set-A4ExpectedSemanticDirty -Role $Role
+}
+
+function Add-A4RowBatch {
+    param([Parameter(Mandatory = $true)][string]$Role)
+    $first = [int]$script:A1NextId[$Role]
+    $ids = New-Object int[] 32
+    for ($offset = 0; $offset -lt 32; $offset++) {
+        $ids[$offset] = [int]($first + $offset)
+    }
+    Add-A4Ids -Role $Role -Ids $ids
+    $script:A1NextId[$Role] = [int]($first + 32)
+}
+
+function Remove-A4AllT1Rows {
+    $script:A4DeletedT1Ids = [int[]]@($script:A1Rows["T1"] | Sort-Object)
+    if ($script:A4DeletedT1Ids.Count -lt 1) {
+        throw "A4 full-delete checkpoint requires nonempty T1."
+    }
+    $name = [string]$script:A1RoleNames["T1"]
+    $expectedIds = [int[]]$script:A4DeletedT1Ids
+    Invoke-A4WithDatabase -Action {
+        param($database)
+        $recordset = $null; $fields = $null; $idField = $null
+        $cleanup = New-Object Collections.ArrayList; $primary = $null
+        try {
+            $sql = "SELECT Id FROM [$name] ORDER BY Id"
+            $recordset = $database.OpenRecordset($sql, 2, 0)
+            $fields = $recordset.Fields
+            $idField = $fields.Item("Id")
+            foreach ($expectedId in $expectedIds) {
+                if ($recordset.EOF -or [int]$idField.Value -ne $expectedId) {
+                    throw "A4 T1 delete order differs from expected Id order."
+                }
+                $recordset.Delete()
+                $recordset.MoveNext()
+            }
+            if (-not $recordset.EOF) { throw "A4 T1 delete left unexpected rows." }
+        }
+        catch { $primary = $_ }
+        finally {
+            Release-M1ComObject $idField $cleanup "A4 delete id field release"
+            Release-M1ComObject $fields $cleanup "A4 delete fields release"
+            Close-M1ComObject $recordset $cleanup "A4 delete recordset close"
+            Release-M1ComObject $recordset $cleanup "A4 delete recordset release"
+        }
+        Complete-M1DaoHelper $primary $cleanup "A4 full T1 deletion"
+    } | Out-Null
+    $script:A1Rows["T1"].Clear()
+    Set-A4ExpectedSemanticDirty -Role "T1"
+}
+
+function Restore-A4AllT1Rows {
+    $ids = [int[]]@($script:A4DeletedT1Ids)
+    if ($ids.Count -lt 1) { throw "A4 T1 reinsert set is empty." }
+    Add-A4Ids -Role "T1" -Ids $ids
+}
+
+function Get-A4ClosedPageCount {
+    Assert-M1NoReparseComponents -Path $script:A4DatabasePath
+    $stream = $null
+    try {
+        try {
+            $stream = New-Object IO.FileStream(
+                $script:A4DatabasePath, [IO.FileMode]::Open,
+                [IO.FileAccess]::Read, [IO.FileShare]::None, 2048,
+                [IO.FileOptions]::SequentialScan
+            )
+        }
+        catch [IO.IOException] {
+            $nativeCode = ($_.Exception.HResult -band 0xffff)
+            if ($nativeCode -notin @(32, 33)) { throw }
+            [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+            $stream = New-Object IO.FileStream(
+                $script:A4DatabasePath, [IO.FileMode]::Open,
+                [IO.FileAccess]::Read, [IO.FileShare]::None, 2048,
+                [IO.FileOptions]::SequentialScan
+            )
+        }
+        if ($stream.Length -lt 2048 -or ($stream.Length % 2048) -ne 0) {
+            throw "A4 database length is not an exact page sequence."
+        }
+        $pages = [long]($stream.Length / 2048)
+        if ($pages -gt 20480) { throw "A4 final-page ceiling was exceeded." }
+        return $pages
+    }
+    finally { if ($null -ne $stream) { $stream.Dispose() } }
+}
+
+function Assert-A4Quiescent {
+    $companion = [IO.Path]::ChangeExtension($script:A4DatabasePath, ".ldb")
+    if ([IO.File]::Exists($companion)) {
+        $item = Get-Item -LiteralPath $companion -Force
+        if ($item.Length -gt 64KB) {
+            throw "A4 companion exceeded its checkpoint byte ceiling."
+        }
+        throw "A4 DAO lock companion remains after close."
+    }
+    if ([IO.Directory]::Exists($companion)) {
+        throw "A4 DAO lock companion was replaced by a directory."
+    }
+}
+
+function Add-A4Checkpoint {
+    param(
+        [Parameter(Mandatory = $true)][string]$CheckpointId,
+        [AllowNull()][object]$Target,
+        [long]$BaselinePages = -1
+    )
+    Assert-A4Quiescent
+    $ordinal = [int]$script:A4Checkpoints.Count
+    $schema = Read-A4SchemaSnapshot -CheckpointId $CheckpointId `
+        -Ordinal $ordinal
+    $semantic = @($schema.Semantic)
+    $schemaLocator = "schema-snapshots/replica-{0:D2}/{1:D2}-{2}.json" -f @(
+        $script:A4Replica, $ordinal, $CheckpointId
+    )
+    $schemaBytes = Write-A4JsonArtifact -RelativePath $schemaLocator `
+        -Document $schema.Document
+    Assert-A4Quiescent
+    $snapshot = Read-A4PageSnapshot -Store $script:A4Store `
+        -DatabasePath $script:A4DatabasePath `
+        -PriorHashes $script:A4PriorHashes -PriorPages $script:A4PriorPages
+    if ([string]$snapshot.file_sha256 -cne
+        [string]$schema.Document.database_sha256_after_read) {
+        throw "A4 schema snapshot and physical capture database hashes differ."
+    }
+    $threshold = $null; $overshoot = $null
+    if ($null -ne $Target) {
+        if ([string]$Target.kind -ceq "relative") {
+            $threshold = [long]($BaselinePages + [long]$Target.pages)
+        }
+        else { $threshold = [long]$Target.pages }
+        if ([long]$snapshot.page_count -lt $threshold) {
+            throw "A4 checkpoint missed its frozen growth target."
+        }
+        $overshoot = [long]($snapshot.page_count - $threshold)
+    }
+    $indexDocument = [ordered]@{
+        protocol_version = "1.0.0"; document_type = "dao_a4_page_index"
+        experiment_id = $script:A4ExperimentId; plan_sha256 = $script:A4PlanSha256
+        revision_plan_sha256 = $script:A4RevisionPlanSha256
+        producer_commit = $script:A4ProducerCommit; campaign_id = $script:A4CampaignId
+        environment_sha256 = $script:A4EnvironmentSha256
+        provider_sha256 = $script:A4ProviderSha256; replica = $script:A4Replica
+        checkpoint_id = $CheckpointId; ordinal = $ordinal
+        predecessor_checkpoint_id = $script:A4PriorCheckpoint
+        page_count = [long]$snapshot.page_count
+        file_size_bytes = [long]$snapshot.file_bytes
+        database_sha256 = [string]$snapshot.file_sha256
+        ordered_page_sha256 = @($snapshot.hashes)
+        changed_page_indices = @($snapshot.changed_pages | ForEach-Object {
+            [long]$_.page_index
+        })
+    }
+    $indexBytes = (New-Object Text.UTF8Encoding($false)).GetBytes(
+        (($indexDocument | ConvertTo-Json -Depth 8 -Compress) + "`n")
+    )
+    if ($indexBytes.Length -gt 64MB -or
+        $indexBytes.Length -gt (768MB - $script:A4Store.RetainedBytes)) {
+        throw "A4 page index exceeds its retained byte ceiling."
+    }
+    $locator = "page-indexes/replica-{0:D2}/{1:D2}-{2}.json" -f @(
+        $script:A4Replica, $ordinal, $CheckpointId
+    )
+    $path = Get-M1PayloadPath -Session $script:A4Store.Session `
+        -RelativePath $locator
+    Write-A4CreateNewBytes -Path $path -Bytes $indexBytes -MaximumBytes 64MB
+    $script:A4Store.RetainedBytes += [long]$indexBytes.Length
+    [void]$script:A4Checkpoints.Add([ordered]@{
+        checkpoint_id = $CheckpointId; ordinal = $ordinal
+        actual_file_pages = [long]$snapshot.page_count
+        actual_size_bytes = [long]$snapshot.file_bytes
+        target_baseline_pages = if ($BaselinePages -ge 0) { $BaselinePages } else { $null }
+        target_threshold_pages = $threshold; target_overshoot_pages = $overshoot
+        inserted_rows_total = [long]$script:A4InsertedRows
+        table_row_counts = [ordered]@{
+            T1 = [int]$script:A1Rows["T1"].Count
+            T2 = [int]$script:A1Rows["T2"].Count
+            T3 = [int]$script:A1Rows["T3"].Count
+            T4 = [int]$script:A1Rows["T4"].Count
+        }
+        dao_reread = @($semantic); quiescent = $true
+        post_close_companion = [ordered]@{
+            present_after_close = $false; observed_size_bytes = 0
+            retained_for_physical_analysis = $false
+        }
+        page_index = [ordered]@{
+            path = $locator; sha256 = Get-A4LowerSha256 -Bytes $indexBytes
+            size_bytes = [long]$indexBytes.Length
+        }
+        dao_schema_snapshot = [ordered]@{
+            path = $schemaLocator
+            sha256 = Get-A4LowerSha256 -Bytes $schemaBytes
+            size_bytes = [long]$schemaBytes.Length
+        }
+    })
+    $script:A4PriorHashes = [string[]]$snapshot.hashes
+    $script:A4PriorPages = [byte[]]$snapshot.pages
+    $script:A4PriorCheckpoint = $CheckpointId
+    Add-A4ProgressRecord -Progress $script:A4Progress `
+        -CheckpointId $CheckpointId -PageCount ([long]$snapshot.page_count)
+}
+
+function Add-A4UntilTarget {
+    param(
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][long]$ThresholdPages
+    )
+    do {
+        Add-A4RowBatch -Role $Role
+        Assert-A4Quiescent
+        $pages = Get-A4ClosedPageCount
+    } while ($pages -lt $ThresholdPages)
+}
+
+function Invoke-A4Schedule {
+    Invoke-A4WithDatabase -Create -Action { param($database) } | Out-Null
+    Assert-A4Quiescent
+    foreach ($value in @($script:A4Plan.checkpoint_design.checkpoint_ids)) {
+        $id = [string]$value
+        $operation = $script:A4Plan.tables.checkpoint_operations.PSObject.Properties[
+            $id
+        ]
+        if ($null -eq $operation -or [string]::IsNullOrWhiteSpace(
+            [string]$operation.Value
+        )) { throw "A4 checkpoint operation is absent from the plan." }
+        if ($id -in @("EMPTY", "EMPTY_R", "T1_IDLE_R", "T4_IDLE_R")) {
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -ceq "T1_CREATE_ID") {
+            Add-A4Table -Role "T1"
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -ceq "T1_ADD_TEXT") {
+            Add-A4PayloadField -Role "T1"
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -ceq "T1_ADD_INDEX") {
+            Add-A4Index -Role "T1"
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -in @("T2_CREATE", "T2_RECREATE")) {
+            Add-A4Table -Role "T2" -WithPayload
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -ceq "T2_DROP") {
+            Remove-A4Table -Role "T2"
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -in @("T3_CREATE", "T4_CREATE")) {
+            $role = $id.Substring(0, 2)
+            Add-A4Table -Role $role -WithPayload
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            if ($id -ceq "T4_CREATE") {
+                $latest = $script:A4Checkpoints[$script:A4Checkpoints.Count - 1]
+                $script:A4Baselines["T1"] = [long]$latest.actual_file_pages
+            }
+            continue
+        }
+        if ($id -ceq "T1_DELETE_ALL") {
+            Remove-A4AllT1Rows
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -ceq "T1_REINSERT_SAME") {
+            Restore-A4AllT1Rows
+            Add-A4Checkpoint -CheckpointId $id -Target $null
+            continue
+        }
+        if ($id -match "^(T1|T4)_REL_([0-9]{4})$") {
+            $role = [string]$Matches[1]; $targetPages = [long]$Matches[2]
+            if (-not $script:A4Baselines.ContainsKey($role)) {
+                throw "A4 relative baseline was not captured at its plan checkpoint."
+            }
+            $baseline = [long]$script:A4Baselines[$role]
+            Add-A4UntilTarget -Role $role -ThresholdPages ($baseline + $targetPages)
+            Add-A4Checkpoint -CheckpointId $id `
+                -Target ([pscustomobject]@{ kind = "relative"; pages = $targetPages }) `
+                -BaselinePages $baseline
+            continue
+        }
+        if ($id -match "^T3_ABS_([0-9]{5})$") {
+            $targetPages = [long]$Matches[1]
+            Add-A4UntilTarget -Role "T3" -ThresholdPages $targetPages
+            Add-A4Checkpoint -CheckpointId $id `
+                -Target ([pscustomobject]@{ kind = "absolute"; pages = $targetPages })
+            if ($id -ceq "T3_ABS_16480") {
+                $latest = $script:A4Checkpoints[$script:A4Checkpoints.Count - 1]
+                $script:A4Baselines["T4"] = [long]$latest.actual_file_pages
+            }
+            continue
+        }
+        throw "A4 checkpoint operation is not implemented: $id"
+    }
+}
+
+function Write-A4JsonArtifact {
+    param(
+        [Parameter(Mandatory = $true)][string]$RelativePath,
+        [Parameter(Mandatory = $true)][Collections.IDictionary]$Document
+    )
+    $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes(
+        (($Document | ConvertTo-Json -Depth 32 -Compress) + "`n")
+    )
+    if ($bytes.Length -gt 64MB -or
+        $bytes.Length -gt (768MB - $script:A4Store.RetainedBytes)) {
+        throw "A4 JSON artifact exceeds its byte ceiling."
+    }
+    $path = Get-M1PayloadPath -Session $script:A4Store.Session `
+        -RelativePath $RelativePath
+    Write-A4CreateNewBytes -Path $path -Bytes $bytes -MaximumBytes 64MB
+    $script:A4Store.RetainedBytes += [long]$bytes.Length
+    return $bytes
+}
+
+function Get-A4ArtifactRole {
+    param([Parameter(Mandatory = $true)][string]$Relative)
+    if ($Relative -ceq ("environment/replica-{0:D2}.json" -f $script:A4Replica)) {
+        return "environment"
+    }
+    if ($Relative -ceq ("observations/replica-{0:D2}.json" -f $script:A4Replica)) {
+        return "replica_observation"
+    }
+    $pageIndexPattern =
+        "^page-indexes/replica-{0:D2}/[0-9]{{2}}-[A-Z0-9_]+\.json$" -f `
+        $script:A4Replica
+    if ($Relative -match $pageIndexPattern) {
+        return "page_index"
+    }
+    $schemaSnapshotPattern =
+        "^schema-snapshots/replica-{0:D2}/[0-9]{{2}}-[A-Z0-9_]+\.json$" -f `
+        $script:A4Replica
+    if ($Relative -match $schemaSnapshotPattern) {
+        return "dao_schema_snapshot"
+    }
+    if ($Relative -match "^page-store/[0-9a-f]{64}\.page$") { return "page_blob" }
+    throw "A4 output contains an unexpected artifact path: $Relative"
+}
+
+function Write-A4ReplicaManifest {
+    $manifestRelative = "replica-artifacts/replica-{0:D2}-manifest.json" -f $script:A4Replica
+    $files = @([IO.Directory]::EnumerateFiles(
+        $script:A4Output, "*", [IO.SearchOption]::AllDirectories
+    ))
+    $records = New-Object Collections.ArrayList
+    $pageBlobs = 0; $pageIndexes = 0; $schemaSnapshots = 0; $total = [long]0
+    foreach ($path in @($files | Sort-Object)) {
+        $item = Get-Item -LiteralPath $path -Force
+        if ($item.PSIsContainer -or
+            ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or
+            $item.Length -lt 1 -or $item.Length -gt 64MB) {
+            throw "A4 output artifact violates its file bound."
+        }
+        $relative = $path.Substring($script:A4Output.TrimEnd('\').Length + 1).Replace('\', '/')
+        if ($relative -ceq $manifestRelative) { throw "A4 manifest already exists." }
+        $role = Get-A4ArtifactRole -Relative $relative
+        if ($role -ceq "page_blob") {
+            $pageBlobs++
+            if ($item.Length -ne 2048) { throw "A4 page blob has a non-page length." }
+        }
+        elseif ($role -ceq "page_index") { $pageIndexes++ }
+        elseif ($role -ceq "dao_schema_snapshot") { $schemaSnapshots++ }
+        if ($item.Length -gt (768MB - $total)) {
+            throw "A4 replica output exceeds its retained-byte ceiling."
+        }
+        $total += [long]$item.Length
+        [void]$records.Add([ordered]@{
+            path = $relative; role = $role
+            sha256 = Get-M1FileSha256 -Path $path
+            size_bytes = [long]$item.Length
+            media_type = if ($role -ceq "page_blob") {
+                "application/octet-stream"
+            } else { "application/json" }
+        })
+    }
+    if ($pageIndexes -ne 25 -or $schemaSnapshots -ne 25 -or
+        $pageBlobs -lt 1 -or $pageBlobs -gt 65536) {
+        throw "A4 replica inventory does not contain its exact checkpoint artifacts."
+    }
+    $manifest = [ordered]@{
+        protocol_version = "1.0.0"
+        document_type = "dao_a4_replica_artifact_manifest"
+        experiment_id = $script:A4ExperimentId; plan_sha256 = $script:A4PlanSha256
+        revision_plan_sha256 = $script:A4RevisionPlanSha256
+        producer_commit = $script:A4ProducerCommit; campaign_id = $script:A4CampaignId
+        matrix_job_id = $script:A4MatrixJobId; replica = $script:A4Replica
+        environment_sha256 = $script:A4EnvironmentSha256
+        provider_sha256 = $script:A4ProviderSha256; checkpoint_count = 25
+        inventory_closed = $true; hashes_verified = $true; paths_closed = $true
+        files = @($records)
+    }
+    [void](Write-A4JsonArtifact -RelativePath $manifestRelative -Document $manifest)
+}
+
+function Invoke-A4Worker {
+    if ([IntPtr]::Size -ne 4 -or $PSVersionTable.PSVersion.Major -ne 5) {
+        throw "A4 worker requires x86 Windows PowerShell 5."
+    }
+    $script:A4Replica = $Replica; $script:A4ProducerCommit = $ProducerCommit
+    $script:A4CampaignId = $CampaignId; $script:A4MatrixJobId = $MatrixJobId
+    $script:A4PlanSha256 = $PlanSha256
+    $script:A4EnvironmentSha256 = $EnvironmentSha256
+    $requiredPlan = [IO.Path]::GetFullPath(
+        (Join-Path $RepositoryRoot $script:A4RequiredPlanPath)
+    )
+    if (-not ([IO.Path]::GetFullPath($PlanPath)).Equals(
+        $requiredPlan, [StringComparison]::OrdinalIgnoreCase
+    )) { throw "A4 worker rejects any plan other than the required A4 plan path." }
+    $planInput = Read-A1CheckedJson -Path $PlanPath -MaximumBytes 1MB
+    $environmentInput = Read-A1CheckedJson -Path $EnvironmentPath -MaximumBytes 1MB
+    if ($PlanSha256 -cne $script:A4FrozenPlanSha256 -or
+        $RevisionPlanSha256 -cne $script:A4RevisionPlanSha256 -or
+        $planInput.sha256 -cne $PlanSha256 -or
+        $environmentInput.sha256 -cne $EnvironmentSha256) {
+        throw "A4 worker input bytes differ from controller bindings."
+    }
+    $script:A4Plan = $planInput.document
+    $roleBinding = Assert-A4WorkerPlan -Plan $script:A4Plan
+    Assert-A4PlanChain -Plan $script:A4Plan
+    $environment = $environmentInput.document
+    if ([string]$environment.document_type -cne "dao_a4_environment" -or
+        [string]$environment.experiment_id -cne $script:A4ExperimentId -or
+        [string]$environment.plan_sha256 -cne $PlanSha256 -or
+        [string]$environment.revision_plan_sha256 -cne $RevisionPlanSha256 -or
+        [string]$environment.producer_commit -cne $ProducerCommit -or
+        [string]$environment.repository_url -cne
+            "https://github.com/oglassdev/jet3-rs.git" -or
+        [string]$environment.campaign_id -cne $CampaignId -or
+        [int]$environment.replica -ne $Replica -or
+        [string]$environment.matrix_job_id -cne $MatrixJobId -or
+        [string]$environment.status -cne "ready" -or
+        [string]$environment.host.process_architecture -cne "x86" -or
+        [int]$environment.host.windows_ansi_code_page -ne 1252 -or
+        [string]$environment.provider.prog_id -cne "DAO.DBEngine.36") {
+        throw "A4 published environment differs from the worker binding."
+    }
+    $accepted = $environment.provider
+    [void](Assert-M1CurrentRegistration -AcceptedProvider $accepted)
+    if ((Get-M1FileSha256 -Path ([string]$accepted.server_path)) -cne
+        [string]$accepted.server_sha256) {
+        throw "A4 provider binary differs from its environment digest."
+    }
+    $script:A4ProviderSha256 = [string]$accepted.server_sha256
+    $providerType = [Type]::GetTypeFromProgID([string]$accepted.prog_id, $false)
+    if ($null -eq $providerType -or
+        $providerType.GUID.ToString("B").ToUpperInvariant() -cne
+        ([string]$accepted.clsid).ToUpperInvariant()) {
+        throw "A4 provider activation binding differs from preflight."
+    }
+    $script:A4Output = [IO.Path]::GetFullPath($OutputRoot)
+    $working = [IO.Path]::GetFullPath($WorkingRoot)
+    Assert-M1NoReparseComponents -Path $script:A4Output
+    Assert-M1NoReparseComponents -Path $working
+    $script:A4Progress = Open-A4WorkerProgress `
+        -DiagnosticsRoot $DiagnosticsRoot -Replica $Replica
+    $replicaRoot = Join-Path $working ("replica-{0:D2}" -f $Replica)
+    if ([IO.Directory]::Exists($replicaRoot)) {
+        throw "A4 private replica directory already exists."
+    }
+    [void][IO.Directory]::CreateDirectory($replicaRoot)
+    $script:A4DatabasePath = Join-Path $replicaRoot "ACQUISITION.MDB"
+    $script:A1RoleNames = @{}
+    $script:A4Roles = @($script:A4Plan.tables.logical_roles)
+    foreach ($role in $script:A4Roles) {
+        $script:A1RoleNames[$role] = [string]$roleBinding.$role
+    }
+    $script:A1Extant = @{}
+    $script:A1Rows = @{}; $script:A1NextId = @{}
+    $script:A1ExpectedSemanticCache = @{}
+    foreach ($role in $script:A4Roles) {
+        $script:A1Extant[$role] = $false
+        $script:A1Rows[$role] = New-Object 'Collections.Generic.HashSet[int]'
+        $script:A1NextId[$role] = 1
+    }
+    $script:A4Baselines = @{}; $script:A4InsertedRows = 0
+    $script:A4Checkpoints = New-Object Collections.ArrayList
+    $script:A4PriorHashes = $null; $script:A4PriorPages = $null
+    $script:A4PriorCheckpoint = $null
+    $session = [pscustomobject]@{ StagingBundle = $script:A4Output }
+    $script:A4Store = New-A4PageStore -Session $session
+    $engine = $null; $workspaces = $null; $workspace = $null
+    $cleanup = New-Object Collections.ArrayList; $primary = $null
+    try {
+        $engine = [Activator]::CreateInstance($providerType)
+        if ([string]$engine.Version -cne [string]$accepted.provider_version) {
+            throw "A4 DBEngine version differs from the bound provider."
+        }
+        $workspaces = $engine.Workspaces
+        $workspace = $workspaces.Item([int]0)
+        $script:A4Workspace = $workspace
+        Invoke-A4Schedule
+    }
+    catch { $primary = $_ }
+    finally {
+        Release-M1ComObject $workspace $cleanup "A4 workspace release"
+        Release-M1ComObject $workspaces $cleanup "A4 workspaces release"
+        Release-M1ComObject $engine $cleanup "A4 engine release"
+    }
+    Complete-M1DaoHelper $primary $cleanup "A4 replica acquisition"
+    if ($script:A4Checkpoints.Count -ne 25) {
+        throw "A4 worker did not complete the exact checkpoint schedule."
+    }
+    $growthObservations = New-Object Collections.ArrayList
+    foreach ($checkpoint in $script:A4Checkpoints) {
+        if ($null -eq $checkpoint.target_threshold_pages) { continue }
+        $role = if ([string]$checkpoint.checkpoint_id -like "T1_REL_*") {
+            "T1"
+        } elseif ([string]$checkpoint.checkpoint_id -like "T3_ABS_*") {
+            "T3"
+        } elseif ([string]$checkpoint.checkpoint_id -like "T4_REL_*") {
+            "T4"
+        } else {
+            throw "A4 growth checkpoint has no plan-defined role."
+        }
+        [void]$growthObservations.Add([ordered]@{
+            checkpoint_id = [string]$checkpoint.checkpoint_id
+            baseline_pages = $checkpoint.target_baseline_pages
+            target_pages = [long]$checkpoint.target_threshold_pages
+            achieved_pages = [long]$checkpoint.actual_file_pages
+            overshoot_pages = [long]$checkpoint.target_overshoot_pages
+            rows = [int]$checkpoint.table_row_counts[$role]
+        })
+    }
+    $observation = [ordered]@{
+        protocol_version = "1.0.0"; document_type = "dao_a4_replica_observation"
+        experiment_id = $script:A4ExperimentId; plan_sha256 = $PlanSha256
+        revision_plan_sha256 = $script:A4RevisionPlanSha256
+        producer_commit = $ProducerCommit
+        repository_url = "https://github.com/oglassdev/jet3-rs.git"
+        campaign_id = $CampaignId
+        matrix_job = [ordered]@{
+            job_id = $MatrixJobId; replica_only = $true; shared_mutable_state = $false
+        }
+        environment_sha256 = $EnvironmentSha256
+        provider_sha256 = $script:A4ProviderSha256; replica = $Replica
+        role_binding = [ordered]@{
+            T1 = [string]$roleBinding.T1; T2 = [string]$roleBinding.T2
+            T3 = [string]$roleBinding.T3; T4 = [string]$roleBinding.T4
+        }
+        growth_observations = @($growthObservations)
+        logical_checkpoint_read_bytes = [long]$script:A4Store.LogicalReadBytes
+        inserted_rows_total = [long]$script:A4InsertedRows
+        changed_hash_entries = [long]$script:A4Store.ChangedEntries
+        checkpoints = @($script:A4Checkpoints)
+    }
+    $observationRelative = "observations/replica-{0:D2}.json" -f $Replica
+    [void](Write-A4JsonArtifact -RelativePath $observationRelative `
+        -Document $observation)
+    Write-A4ReplicaManifest
+}
+
+Invoke-A4Worker

--- a/oracle/windows-dao/scripts/a4/Download-A4Artifact.ps1
+++ b/oracle/windows-dao/scripts/a4/Download-A4Artifact.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ArtifactName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Destination
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-A4ArtifactRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Operation
+    )
+
+    for ($attempt = 1; $attempt -le 5; $attempt++) {
+        try {
+            return & $Operation
+        }
+        catch {
+            if ($attempt -eq 5) {
+                throw
+            }
+            Start-Sleep -Seconds ([Math]::Min(2 * $attempt, 10))
+        }
+    }
+}
+
+$headers = @{
+    Accept = "application/vnd.github+json"
+    Authorization = "Bearer $env:GITHUB_TOKEN"
+    "X-GitHub-Api-Version" = "2022-11-28"
+}
+$encodedName = [Uri]::EscapeDataString($ArtifactName)
+$listUri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/runs/" +
+    "$env:GITHUB_RUN_ID/artifacts?name=$encodedName&per_page=100"
+$response = Invoke-A4ArtifactRequest {
+    Invoke-RestMethod -Method Get -Uri $listUri -Headers $headers
+}
+$artifact = @(
+    $response.artifacts |
+        Where-Object { $_.name -ceq $ArtifactName -and -not $_.expired } |
+        Sort-Object -Property id -Descending |
+        Select-Object -First 1
+)
+if ($artifact.Count -ne 1) {
+    throw "The current run has no unexpired artifact named '$ArtifactName'."
+}
+
+$nonce = [Guid]::NewGuid().ToString("N")
+$archive = Join-Path $env:RUNNER_TEMP "$ArtifactName-$nonce.zip"
+$staging = "$Destination.rest-$nonce"
+$downloadUri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions/artifacts/" +
+    "$($artifact[0].id)/zip"
+
+try {
+    if ((Test-Path -LiteralPath $Destination)) {
+        throw "The A4 artifact destination already exists."
+    }
+    $parent = Split-Path -Parent $Destination
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $null = Invoke-A4ArtifactRequest {
+        Invoke-WebRequest -UseBasicParsing -Uri $downloadUri -Headers $headers `
+            -OutFile $archive
+    }
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [IO.Compression.ZipFile]::ExtractToDirectory($archive, $staging)
+    Move-Item -LiteralPath $staging -Destination $Destination
+}
+finally {
+    if ((Test-Path -LiteralPath $archive)) {
+        Remove-Item -LiteralPath $archive -Force
+    }
+    if ((Test-Path -LiteralPath $staging)) {
+        Remove-Item -LiteralPath $staging -Recurse -Force
+    }
+}

--- a/oracle/windows-dao/scripts/a4_bundle.py
+++ b/oracle/windows-dao/scripts/a4_bundle.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""Assemble, finalize, and separately validate DAO A4 bundle trees.
+
+This producer-side check is not the plan's independent recomputing validator."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from a4_analysis_input import ReplicaAnalysisInput
+
+from a4_bundle_io import (
+    ArtifactCache,
+    TreeFile,
+    copy_cached as _copy_cached,
+    expected_directories as _expected_directories,
+    inventory as _inventory,
+    safe_locator as _safe_locator,
+)
+from a4_spec import (
+    BOUNDS,
+    CHECKED_PLAN_PATH,
+    CHECKPOINT_IDS,
+    EXPERIMENT_ID,
+    LOGICAL_ROLES,
+    PLAN,
+    PLAN_SHA256,
+    REVISION_PLAN_SHA256,
+    validate_schema,
+)
+from protocol_validation import ValidationError, canonical_json_bytes
+
+PAGE_SIZE = 2_048
+REPLICA_COUNT = 3
+DERIVATION_REPLICA_COUNT = 2
+CHECKPOINT_COUNT = 25
+MAX_JSON_BYTES = 67_108_864
+MAX_PAGE_BLOBS = 65_536
+MAX_PAGE_STORE_BYTES = 134_217_728
+MAX_BUNDLE_BYTES = 805_306_368
+REPOSITORY_URL = "https://github.com/oglassdev/jet3-rs.git"
+MANIFEST_PATH = "bundle-manifest.json"
+PLAN_PATH = "plan/a4-row-anchored-maps.plan.json"
+ROLES = tuple(LOGICAL_ROLES)
+ROLE_BINDINGS = tuple(
+    {role: row[role] for role in ROLES}
+    for row in sorted(PLAN["tables"]["role_bindings"], key=lambda row: row["replica"])
+)
+
+_PINNED_BOUNDS = {
+    "page_size": PAGE_SIZE,
+    "replicas": REPLICA_COUNT,
+    "planned_checkpoints_per_replica": CHECKPOINT_COUNT,
+    "max_json_bytes": MAX_JSON_BYTES,
+    "max_unique_page_blobs": MAX_PAGE_BLOBS,
+    "max_retained_page_store_bytes": MAX_PAGE_STORE_BYTES,
+    "max_bundle_bytes": MAX_BUNDLE_BYTES,
+}
+for _bound_name, _bound_value in _PINNED_BOUNDS.items():
+    if BOUNDS[_bound_name] != _bound_value:
+        raise RuntimeError(f"checked A4 bound drifted: {_bound_name}")
+if len(CHECKPOINT_IDS) != CHECKPOINT_COUNT or len(ROLE_BINDINGS) != REPLICA_COUNT:
+    raise RuntimeError("checked A4 checkpoint or replica count drifted")
+if PLAN["artifacts"]["plan"] != PLAN_PATH:
+    raise RuntimeError("checked A4 plan artifact path drifted")
+@dataclass(frozen=True)
+class ReplicaResult:
+    root: Path
+    cache: ArtifactCache
+    replica: int
+    manifest_path: str
+    manifest: dict[str, Any]
+    manifest_sha256: str
+    manifest_size: int
+    entries: dict[str, dict[str, Any]]
+    environment: dict[str, Any]
+    environment_sha256: str
+    observation: dict[str, Any]
+    provider_sha256: str
+    producer_commit: str
+    campaign_id: str
+    page_paths: frozenset[str]
+@dataclass(frozen=True)
+class PayloadResult:
+    tree: dict[str, TreeFile]
+    directories: set[str]
+    cache: ArtifactCache
+    replicas: tuple[ReplicaResult, ...]
+    expected_paths: frozenset[str]
+    analysis: dict[str, Any] | None
+    receipt: dict[str, Any] | None
+    frozen_sha256: str | None
+
+
+@dataclass(frozen=True)
+class BundleReplicaSource:
+    """Bounded page source backed by a structurally checked replica tree."""
+
+    checkpoint_ids: tuple[str, ...]
+    page_count: dict[str, int]
+    ordered_page_sha256: dict[str, tuple[str, ...]]
+    cache: ArtifactCache
+
+    def page_bytes(self, sha256: str) -> bytes:
+        return self.cache.read(f"page-store/{sha256}.page", PAGE_SIZE)
+def _json_artifact(
+    cache: ArtifactCache, locator: str
+) -> tuple[dict[str, Any], bytes]:
+    return cache.json(locator, MAX_JSON_BYTES)
+def _require(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{label}: binding mismatch")
+def _validate_typed(document: dict[str, Any], document_type: str, label: str) -> None:
+    _require(document.get("document_type"), document_type, f"{label} document type")
+    validate_schema(document, document_type)
+def _validate_page_index(index: dict[str, Any], observation: dict[str, Any],
+                         checkpoint: dict[str, Any], ordinal: int,
+                         prior_hashes: list[str] | None) -> list[str]:
+    _validate_typed(index, "dao_a4_page_index", checkpoint["page_index"]["path"])
+    bindings = {
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "producer_commit": observation["producer_commit"],
+        "campaign_id": observation["campaign_id"],
+        "environment_sha256": observation["environment_sha256"],
+        "provider_sha256": observation["provider_sha256"],
+        "replica": observation["replica"],
+        "checkpoint_id": CHECKPOINT_IDS[ordinal],
+        "ordinal": ordinal,
+        "predecessor_checkpoint_id": CHECKPOINT_IDS[ordinal - 1] if ordinal else None,
+        "page_count": checkpoint["actual_file_pages"],
+        "file_size_bytes": checkpoint["actual_size_bytes"],
+    }
+    for key, expected in bindings.items():
+        _require(index[key], expected, f"page index {ordinal:02d} {key}")
+    _require((checkpoint["checkpoint_id"], checkpoint["ordinal"]), (CHECKPOINT_IDS[ordinal], ordinal),
+             f"checkpoint {ordinal:02d} identity")
+    hashes = list(index["ordered_page_sha256"])
+    _require((len(hashes), len(hashes) * PAGE_SIZE), (index["page_count"], index["file_size_bytes"]),
+             f"page index {ordinal:02d} page accounting")
+    expected_changed = [] if prior_hashes is None else [
+        page for page in range(max(len(prior_hashes), len(hashes)))
+        if page >= len(prior_hashes) or page >= len(hashes)
+        or prior_hashes[page] != hashes[page]
+    ]
+    _require(index["changed_page_indices"], expected_changed, f"page index {ordinal:02d} changed pages")
+    return hashes
+def _entry_map(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    folded: set[str] = set()
+    for index, entry in enumerate(manifest["files"]):
+        locator = _safe_locator(entry["path"], f"$.files[{index}].path")
+        if locator in entries or locator.casefold() in folded:
+            raise ValidationError(f"$.files: duplicate path {locator!r}")
+        entries[locator] = entry
+        folded.add(locator.casefold())
+    return entries
+def _entry_payload(
+    cache: ArtifactCache, entry: dict[str, Any]
+) -> tuple[bytes, dict[str, Any] | None]:
+    maximum = PAGE_SIZE if entry["role"] == "page_blob" else MAX_JSON_BYTES
+    payload = cache.read(entry["path"], maximum)
+    _require(len(payload), entry["size_bytes"], f"{entry['path']} size")
+    _require(cache.sha256(entry["path"], maximum), entry["sha256"], f"{entry['path']} sha256")
+    expected_media = "application/octet-stream" if entry["role"] == "page_blob" else "application/json"
+    _require(entry["media_type"], expected_media, f"{entry['path']} media type")
+    document = None if expected_media != "application/json" else cache.json(
+        entry["path"], maximum
+    )[0]
+    return payload, document
+
+
+def _validate_plan_entries(entries: dict[str, dict[str, Any]]) -> None:
+    expected = {PLAN_PATH: ("plan", PLAN_SHA256)}
+    for locator, (role, digest) in expected.items():
+        entry = entries.get(locator)
+        if entry is None:
+            raise ValidationError(f"{locator}: missing retained plan inventory entry")
+        _require(entry["role"], role, f"{locator} role")
+        _require(entry["media_type"], "application/json", f"{locator} media type")
+        _require(entry["sha256"], digest, f"{locator} pinned hash")
+
+
+def _validate_replica(
+    root: Path,
+    tree: dict[str, TreeFile],
+    directories: set[str],
+    cache: ArtifactCache,
+    replica: int,
+    campaign_id: str | None,
+    *,
+    closed: bool,
+) -> ReplicaResult:
+    manifest_path = f"replica-artifacts/replica-{replica:02d}-manifest.json"
+    manifest, manifest_payload = _json_artifact(cache, manifest_path)
+    _validate_typed(manifest, "dao_a4_replica_artifact_manifest", manifest_path)
+    _require(manifest["checkpoint_count"], CHECKPOINT_COUNT, f"replica {replica} checkpoint count")
+    _require(manifest["replica"], replica, f"replica {replica} manifest replica")
+    if campaign_id is not None:
+        _require(manifest["campaign_id"], campaign_id, f"replica {replica} campaign")
+    entries = _entry_map(manifest)
+    if any(entry["role"] == "acquisition_log" for entry in entries.values()):
+        raise ValidationError("replica outputs may not contain acquisition logs")
+    expected_files = set(entries) | {manifest_path}
+    if closed:
+        _require(set(tree), expected_files, f"replica {replica} closed inventory")
+        _require(directories, _expected_directories(expected_files), f"replica {replica} directory closure")
+
+    documents: dict[str, dict[str, Any]] = {}
+    for entry in entries.values():
+        _, document = _entry_payload(cache, entry)
+        if document is not None:
+            documents[entry["path"]] = document
+
+    environment_path = f"environment/replica-{replica:02d}.json"
+    observation_path = f"observations/replica-{replica:02d}.json"
+    environment_entry = entries.get(environment_path)
+    observation_entry = entries.get(observation_path)
+    if environment_entry is None or environment_entry["role"] != "environment":
+        raise ValidationError(f"{environment_path}: missing environment role")
+    if observation_entry is None or observation_entry["role"] != "replica_observation":
+        raise ValidationError(f"{observation_path}: missing observation role")
+    environment = documents[environment_path]
+    observation = documents[observation_path]
+    _validate_typed(environment, "dao_a4_environment", environment_path)
+    _validate_typed(observation, "dao_a4_replica_observation", observation_path)
+    _require(len(observation["checkpoints"]), CHECKPOINT_COUNT, f"{observation_path} checkpoints")
+    expected_binding = {
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "producer_commit": manifest["producer_commit"],
+        "campaign_id": manifest["campaign_id"],
+        "replica": replica,
+    }
+    for key, expected in expected_binding.items():
+        _require(environment[key], expected, f"{environment_path} {key}")
+        _require(observation[key], expected, f"{observation_path} {key}")
+    _require(environment["matrix_job_id"], manifest["matrix_job_id"], "environment matrix job")
+    _require(observation["matrix_job"]["job_id"], manifest["matrix_job_id"], "observation matrix job")
+    _require(environment_entry["sha256"], manifest["environment_sha256"], "environment manifest hash")
+    _require(observation["environment_sha256"], environment_entry["sha256"], "observation environment hash")
+    provider_sha256 = environment["provider"]["server_sha256"]
+    _require(provider_sha256, manifest["provider_sha256"], "manifest provider hash")
+    _require(observation["provider_sha256"], provider_sha256, "observation provider hash")
+    _require(observation["repository_url"], REPOSITORY_URL, "observation repository URL")
+    _require(observation["role_binding"], dict(ROLE_BINDINGS[replica - 1]), "observation role binding")
+
+    referenced_pages: set[str] = set()
+    prior_hashes: list[str] | None = None
+    changed_total = 0
+    schema_snapshots: dict[str, dict[str, Any]] = {}
+    page_indexes: dict[str, dict[str, Any]] = {}
+    for ordinal, checkpoint in enumerate(observation["checkpoints"]):
+        checkpoint_id = CHECKPOINT_IDS[ordinal]
+        expected_path = f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint_id}.json"
+        reference = checkpoint["page_index"]
+        _require(reference["path"], expected_path, f"replica {replica} page index path")
+        entry = entries.get(expected_path)
+        if entry is None or entry["role"] != "page_index":
+            raise ValidationError(f"{expected_path}: missing page-index role")
+        _require(reference["sha256"], entry["sha256"], f"{expected_path} reference hash")
+        _require(reference["size_bytes"], entry["size_bytes"], f"{expected_path} reference size")
+        index = documents[expected_path]
+        page_indexes[checkpoint_id] = index
+        hashes = _validate_page_index(index, observation, checkpoint, ordinal, prior_hashes)
+        reconstruction = hashlib.sha256()
+        for digest in hashes:
+            page_path = f"page-store/{digest}.page"
+            page_entry = entries.get(page_path)
+            if page_entry is None or page_entry["role"] != "page_blob":
+                raise ValidationError(f"{page_path}: referenced blob is absent")
+            payload = cache.read(page_path, PAGE_SIZE)
+            _require(len(payload), PAGE_SIZE, f"{page_path} page size")
+            _require(cache.sha256(page_path, PAGE_SIZE), digest, f"{page_path} content address")
+            reconstruction.update(payload)
+            referenced_pages.add(page_path)
+        _require(reconstruction.hexdigest(), index["database_sha256"], f"{expected_path} database hash")
+        changed_total += len(index["changed_page_indices"])
+        prior_hashes = hashes
+        schema_path = (
+            f"schema-snapshots/replica-{replica:02d}/"
+            f"{ordinal:02d}-{checkpoint_id}.json"
+        )
+        schema_reference = checkpoint["dao_schema_snapshot"]
+        _require(schema_reference["path"], schema_path,
+                 f"replica {replica} schema snapshot path")
+        schema_entry = entries.get(schema_path)
+        if schema_entry is None or schema_entry["role"] != "dao_schema_snapshot":
+            raise ValidationError(f"{schema_path}: missing DAO schema-snapshot role")
+        _require(schema_reference["sha256"], schema_entry["sha256"],
+                 f"{schema_path} reference hash")
+        _require(schema_reference["size_bytes"], schema_entry["size_bytes"],
+                 f"{schema_path} reference size")
+        snapshot = documents[schema_path]
+        _validate_typed(snapshot, "dao_a4_schema_snapshot", schema_path)
+        schema_snapshots[checkpoint_id] = snapshot
+    _require(observation["changed_hash_entries"], changed_total, f"replica {replica} changed-hash total")
+    _validate_target_disclosures(observation)
+    page_paths = {path for path, entry in entries.items() if entry["role"] == "page_blob"}
+    _require(page_paths, referenced_pages, f"replica {replica} page-store closure")
+    if len(page_paths) > MAX_PAGE_BLOBS or len(page_paths) * PAGE_SIZE > MAX_PAGE_STORE_BYTES:
+        raise ValidationError(f"replica {replica}: page-store bound exceeded")
+    return ReplicaResult(
+        root,
+        cache,
+        replica,
+        manifest_path,
+        manifest,
+        cache.sha256(manifest_path, MAX_JSON_BYTES),
+        len(manifest_payload),
+        entries,
+        environment,
+        environment_entry["sha256"],
+        observation,
+        provider_sha256,
+        manifest["producer_commit"],
+        manifest["campaign_id"],
+        frozenset(page_paths),
+    )
+def _validate_environments(replicas: Iterable[ReplicaResult]) -> None:
+    rows = tuple(replicas)
+    for attribute in ("campaign_id", "producer_commit", "provider_sha256"):
+        if len({getattr(row, attribute) for row in rows}) != 1:
+            raise ValidationError(f"cross-replica {attribute} differs")
+    exact = (
+        lambda row: row.environment["provider"]["prog_id"],
+        lambda row: row.environment["provider"]["clsid"],
+        lambda row: row.environment["provider"]["server_sha256"],
+        lambda row: row.environment["host"]["process_architecture"],
+        lambda row: int(row.environment["host"]["powershell_version"].split(".", 1)[0]),
+    )
+    for projection in exact:
+        if len({projection(row) for row in rows}) != 1:
+            raise ValidationError("cross-replica exact environment field differs")
+
+
+def _validate_target_disclosures(observation: dict[str, Any]) -> None:
+    checkpoints = {row["checkpoint_id"]: row for row in observation["checkpoints"]}
+    baselines = {
+        "T1": checkpoints["T4_CREATE"]["actual_file_pages"],
+        "T4": checkpoints["T3_ABS_16480"]["actual_file_pages"],
+    }
+    for checkpoint_id, checkpoint in checkpoints.items():
+        role = checkpoint_id.split("_", 1)[0]
+        if role in baselines and checkpoint_id.startswith(f"{role}_REL_"):
+            baseline = baselines[role]
+            target = int(checkpoint_id.rsplit("_", 1)[1])
+            threshold = baseline + target
+        elif checkpoint_id.startswith("T3_ABS_"):
+            baseline = None
+            threshold = int(checkpoint_id.rsplit("_", 1)[1])
+        else:
+            continue
+        _require(checkpoint["target_baseline_pages"], baseline,
+                 f"{checkpoint_id} target baseline")
+        _require(checkpoint["target_threshold_pages"], threshold,
+                 f"{checkpoint_id} target threshold")
+        _require(checkpoint["target_overshoot_pages"],
+                 checkpoint["actual_file_pages"] - threshold,
+                 f"{checkpoint_id} target overshoot")
+        if checkpoint["actual_file_pages"] < threshold:
+            raise ValidationError(f"{checkpoint_id}: target threshold was not reached")
+
+
+def _validate_frozen(document: dict[str, Any], payload: bytes, campaign_id: str) -> None:
+    validate_schema(document, "dao_a4_frozen_derivation_candidates")
+    _require(payload, canonical_json_bytes(document).rstrip(b"\n"),
+             "frozen candidate canonical bytes")
+    bindings = {
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "campaign_id": campaign_id,
+        "derivation_replicas": [1, 2],
+    }
+    for key, expected in bindings.items():
+        _require(document[key], expected, f"frozen candidate {key}")
+def _validate_analysis_payload(
+    cache: ArtifactCache, replicas: tuple[ReplicaResult, ...]
+) -> tuple[dict[str, Any], dict[str, Any], str]:
+    frozen_path = "analysis/derivation-candidates.json"
+    analysis_path = "analysis/analysis-report.json"
+    receipt_path = "analysis/holdout-structure-receipt.json"
+    frozen, frozen_payload = _json_artifact(cache, frozen_path)
+    report, _ = _json_artifact(cache, analysis_path)
+    receipt, _ = _json_artifact(cache, receipt_path)
+    campaign_id = replicas[0].campaign_id
+    frozen_sha256 = cache.sha256(frozen_path, MAX_JSON_BYTES)
+    _validate_frozen(frozen, frozen_payload, campaign_id)
+    occurrence_reference = frozen.get("h4_occurrence_evidence")
+    if occurrence_reference is not None:
+        occurrence_path = occurrence_reference["path"]
+        occurrence_payload = cache.read(occurrence_path, MAX_JSON_BYTES)
+        _require(len(occurrence_payload), occurrence_reference["size_bytes"],
+                 "H4 occurrence evidence size")
+        _require(hashlib.sha256(occurrence_payload).hexdigest(),
+                 occurrence_reference["sha256"], "H4 occurrence evidence hash")
+        occurrence = cache.json(occurrence_path, MAX_JSON_BYTES)[0]
+        validate_schema(occurrence, "dao_a4_h4_occurrence_evidence")
+    _require(report.get("document_type"), "dao_a4_analysis_report", f"{analysis_path} document type")
+    validate_schema(report, "dao_a4_analysis_report")
+    _validate_typed(receipt, "dao_a4_holdout_structure_receipt", receipt_path)
+    _require(report["plan_sha256"], PLAN_SHA256, "analysis plan_sha256")
+    _require(report["holdout_replica"], REPLICA_COUNT, "analysis holdout replica")
+    _require(receipt["replica"], REPLICA_COUNT, "holdout receipt replica")
+    _require(receipt["result"], "pass", "holdout receipt result")
+    bindings = {
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "campaign_id": campaign_id,
+        "producer_commit": replicas[0].producer_commit,
+        "derivation_candidate_set_sha256": frozen_sha256,
+    }
+    for key, expected in bindings.items():
+        _require(report[key], expected, f"analysis {key}")
+        _require(receipt[key], expected, f"holdout receipt {key}")
+    _require(
+        receipt["replica_artifact_manifest_sha256"],
+        replicas[2].manifest_sha256,
+        "holdout receipt replica manifest hash",
+    )
+    return report, receipt, frozen_sha256
+def _validate_payload(root: Path, *, require_analysis: bool,
+                      allow_manifest: bool = False,
+                      replica_count: int = REPLICA_COUNT,
+                      tree: dict[str, TreeFile] | None = None,
+                      directories: set[str] | None = None,
+                      cache: ArtifactCache | None = None) -> PayloadResult:
+    root = root.absolute()
+    if tree is None or directories is None:
+        if tree is not None or directories is not None or cache is not None:
+            raise ValidationError("partial A4 validation context")
+        tree, directories = _inventory(root)
+    if cache is None:
+        cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+    elif cache.root != root or cache.tree is not tree:
+        raise ValidationError("A4 validation cache does not match its inventory")
+    retained_plans = {PLAN_PATH: (CHECKED_PLAN_PATH, PLAN_SHA256)}
+    for locator, (checked_path, digest) in retained_plans.items():
+        plan_payload = cache.read(locator, MAX_JSON_BYTES)
+        _require(cache.sha256(locator, MAX_JSON_BYTES), digest,
+                 f"retained {locator} hash")
+        _require(plan_payload, checked_path.read_bytes(), f"retained checked {locator}")
+    replicas = tuple(
+        _validate_replica(
+            root, tree, directories, cache, replica, None, closed=False
+        )
+        for replica in range(1, replica_count + 1)
+    )
+    _validate_environments(replicas)
+    expected = set(retained_plans)
+    for replica in replicas:
+        expected.add(replica.manifest_path)
+        expected.update(replica.entries)
+    report = None
+    receipt = None
+    frozen_sha256 = None
+    if require_analysis:
+        analysis_paths = {
+            "analysis/derivation-candidates.json",
+            "analysis/analysis-report.json",
+            "analysis/holdout-structure-receipt.json",
+        }
+        report, receipt, frozen_sha256 = _validate_analysis_payload(cache, replicas)
+        frozen = cache.json("analysis/derivation-candidates.json", MAX_JSON_BYTES)[0]
+        if frozen.get("h4_occurrence_evidence") is not None:
+            analysis_paths.add(frozen["h4_occurrence_evidence"]["path"])
+        expected.update(analysis_paths)
+    complete_expected = expected | ({MANIFEST_PATH} if allow_manifest else set())
+    _require(set(tree), complete_expected, "A4 payload closed inventory")
+    _require(directories, _expected_directories(complete_expected),
+             "A4 payload directory closure")
+    page_paths = set().union(*(row.page_paths for row in replicas))
+    if len(page_paths) > MAX_PAGE_BLOBS or len(page_paths) * PAGE_SIZE > MAX_PAGE_STORE_BYTES:
+        raise ValidationError("A4 merged page store exceeds its fixed bound")
+    if sum(item.size for item in tree.values()) > MAX_BUNDLE_BYTES:
+        raise ValidationError("A4 bundle exceeds its fixed byte bound")
+    return PayloadResult(tree, directories, cache, replicas, frozenset(expected),
+                         report, receipt, frozen_sha256)
+def _copy_replica(
+    replica: ReplicaResult,
+    destination: Path,
+    copied: dict[str, tuple[int, str]],
+) -> None:
+    _copy_cached(
+        replica.cache, destination, replica.manifest_path,
+        replica.manifest_size, replica.manifest_sha256, MAX_JSON_BYTES, copied,
+    )
+    for entry in replica.entries.values():
+        maximum = PAGE_SIZE if entry["role"] == "page_blob" else MAX_JSON_BYTES
+        _copy_cached(
+            replica.cache, destination, entry["path"],
+            entry["size_bytes"], entry["sha256"], maximum, copied,
+        )
+
+
+def _analysis_input(replica: ReplicaResult) -> ReplicaAnalysisInput:
+    indexes: dict[str, dict[str, Any]] = {}
+    snapshots: dict[str, dict[str, Any]] = {}
+    counts: dict[str, dict[str, int]] = {}
+    page_counts: dict[str, int] = {}
+    page_hashes: dict[str, tuple[str, ...]] = {}
+    for ordinal, checkpoint in enumerate(replica.observation["checkpoints"]):
+        checkpoint_id = CHECKPOINT_IDS[ordinal]
+        index_path = checkpoint["page_index"]["path"]
+        snapshot_path = checkpoint["dao_schema_snapshot"]["path"]
+        index = replica.cache.json(index_path, MAX_JSON_BYTES)[0]
+        snapshot = replica.cache.json(snapshot_path, MAX_JSON_BYTES)[0]
+        indexes[checkpoint_id] = index
+        snapshots[checkpoint_id] = snapshot
+        counts[checkpoint_id] = dict(checkpoint["table_row_counts"])
+        page_counts[checkpoint_id] = int(index["page_count"])
+        page_hashes[checkpoint_id] = tuple(index["ordered_page_sha256"])
+    environment_path = f"environment/replica-{replica.replica:02d}.json"
+    source = BundleReplicaSource(
+        CHECKPOINT_IDS, page_counts, page_hashes, replica.cache
+    )
+    return ReplicaAnalysisInput(
+        source=source,
+        table_row_counts=counts,
+        replica_observation=replica.observation,
+        page_indexes=indexes,
+        schema_snapshots=snapshots,
+        artifact_manifest=replica.manifest,
+        environment_payload=replica.cache.read(environment_path, MAX_JSON_BYTES),
+    )
+
+
+def analyze_bundle(
+    bundle_root: Path,
+    holdout_root: Path,
+    campaign_id: str,
+    producer_commit: str,
+    holdout_command: tuple[str, ...] | None = None,
+) -> dict[str, Any]:
+    """Freeze derivation bytes, materialize replica 3, then run A4 analysis."""
+    from a4_analysis import analyze
+    from a4_holdout import run_holdout_process
+
+    bundle_root = bundle_root.absolute()
+    holdout_root = holdout_root.absolute()
+    payload = _validate_payload(
+        bundle_root, require_analysis=False,
+        replica_count=DERIVATION_REPLICA_COUNT,
+    )
+    _require(payload.replicas[0].campaign_id, campaign_id, "expected campaign")
+    _require(payload.replicas[0].producer_commit, producer_commit, "expected producer")
+    if holdout_root.exists():
+        raise ValidationError("holdout root existed before derivation freeze")
+    analysis_root = bundle_root / "analysis"
+    analysis_root.mkdir()
+    candidate_path = analysis_root / "derivation-candidates.json"
+    occurrence_path = analysis_root / "h4-occurrence-evidence.json"
+    report_path = analysis_root / "analysis-report.json"
+    receipt_path = analysis_root / "holdout-structure-receipt.json"
+    freeze_state = bundle_root.parent / f".{bundle_root.name}-a4-freeze.json"
+    if freeze_state.exists():
+        raise ValidationError("A4 freeze-state path already exists")
+
+    def acquire_holdout(frozen_bytes: bytes, frozen_sha256: str) -> ReplicaAnalysisInput:
+        with candidate_path.open("xb") as handle:
+            handle.write(frozen_bytes)
+        state = {
+            "document_type": "dao_a4_internal_freeze_phase",
+            "campaign_id": campaign_id,
+            "producer_commit": producer_commit,
+            "derivation_candidate_set_sha256": frozen_sha256,
+            "freeze_phase_completed": True,
+            "replica_3_artifact_existed_before_freeze_phase_completed": False,
+            "analyzer_replica_3_opens_before_receipt": 0,
+        }
+        with freeze_state.open("xb") as handle:
+            handle.write(canonical_json_bytes(state))
+        if holdout_command is None:
+            raise ValidationError("holdout materialization command is required")
+        try:
+            completed = subprocess.run(
+                holdout_command, check=False, timeout=300,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise ValidationError(f"holdout materialization failed: {exc}") from exc
+        if completed.returncode != 0:
+            raise ValidationError("holdout materialization returned nonzero")
+        run_holdout_process(
+            bundle_root, holdout_root, candidate_path, frozen_sha256,
+            campaign_id, producer_commit, receipt_path, freeze_state,
+        )
+        tree, directories = _inventory(bundle_root)
+        cache = ArtifactCache(bundle_root, tree, MAX_BUNDLE_BYTES)
+        holdout = _validate_replica(
+            bundle_root, tree, directories, cache, 3, campaign_id, closed=False
+        )
+        return _analysis_input(holdout)
+
+    try:
+        result = analyze(
+            campaign_id,
+            producer_commit,
+            {replica.replica: _analysis_input(replica) for replica in payload.replicas},
+            acquire_holdout,
+        )
+        if result.frozen.occurrence_evidence_bytes is not None:
+            with occurrence_path.open("xb") as handle:
+                handle.write(result.frozen.occurrence_evidence_bytes)
+        with report_path.open("xb") as handle:
+            handle.write(canonical_json_bytes(dict(result.report)))
+    finally:
+        try:
+            freeze_state.unlink()
+        except FileNotFoundError:
+            pass
+    return {
+        "campaign_id": campaign_id,
+        "derivation_candidate_set_sha256": result.frozen.sha256,
+        "scientific_outcome": result.report["scientific_outcome"],
+    }
+def assemble_bundle(replica_roots: Iterable[Path], bundle_root: Path,
+                    campaign_id: str, producer_commit: str) -> dict[str, Any]:
+    """Assemble the derivation replicas only; the holdout is grafted after the freeze."""
+    roots = tuple(Path(root).absolute() for root in replica_roots)
+    if len(roots) != DERIVATION_REPLICA_COUNT:
+        raise ValidationError("assemble requires exactly the two derivation replica roots")
+    if bundle_root.exists():
+        raise ValidationError("bundle root already exists")
+    validated = []
+    for replica, root in enumerate(roots, start=1):
+        tree, directories = _inventory(root)
+        cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+        validated.append(_validate_replica(
+            root, tree, directories, cache, replica, campaign_id, closed=True))
+    replicas = tuple(validated)
+    _validate_environments(replicas)
+    _require(replicas[0].producer_commit, producer_commit, "expected producer commit")
+    bundle_parent = bundle_root.absolute().parent
+    bundle_parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".a4-assemble-", dir=bundle_parent))
+    try:
+        plan_path = staging.joinpath(*PLAN_PATH.split("/"))
+        plan_path.parent.mkdir(parents=True)
+        plan_path.write_bytes(CHECKED_PLAN_PATH.read_bytes())
+        copied: dict[str, tuple[int, str]] = {}
+        for replica in replicas:
+            _copy_replica(replica, staging, copied)
+        result = _validate_payload(staging, require_analysis=False,
+                                   replica_count=DERIVATION_REPLICA_COUNT)
+        os.replace(staging, bundle_root)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return {
+        "bundle_root": str(bundle_root),
+        "campaign_id": campaign_id,
+        "producer_commit": result.replicas[0].producer_commit,
+        "provider_sha256": result.replicas[0].provider_sha256,
+    }
+def validate_holdout_replica(bundle_root: Path, candidate_path: Path,
+                             candidate_sha256: str, campaign_id: str,
+                             producer_commit: str) -> ReplicaResult:
+    root = bundle_root.absolute()
+    tree, directories = _inventory(root)
+    cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+    replica = _validate_replica(
+        root, tree, directories, cache, REPLICA_COUNT, None, closed=False
+    )
+    _require(replica.campaign_id, campaign_id, "expected holdout campaign")
+    _require(replica.producer_commit, producer_commit, "expected holdout producer")
+    candidate_locator = candidate_path.absolute().relative_to(root).as_posix()
+    payload = cache.read(candidate_locator, MAX_JSON_BYTES)
+    _require(
+        cache.sha256(candidate_locator, MAX_JSON_BYTES),
+        candidate_sha256,
+        "frozen candidate hash",
+    )
+    frozen = cache.json(candidate_locator, MAX_JSON_BYTES)[0]
+    _validate_frozen(frozen, payload, replica.campaign_id)
+    return replica
+def _role_for_path(path: str, replicas: tuple[ReplicaResult, ...]) -> str:
+    fixed = {
+        PLAN_PATH: "plan",
+        "analysis/derivation-candidates.json": "frozen_candidate_set",
+        "analysis/analysis-report.json": "analysis_report",
+        "analysis/h4-occurrence-evidence.json": "h4_occurrence_evidence",
+        "analysis/holdout-structure-receipt.json": "holdout_structure_receipt",
+    }
+    if path in fixed:
+        return fixed[path]
+    for replica in replicas:
+        if path == replica.manifest_path:
+            return "replica_artifact_manifest"
+        if path in replica.entries:
+            return replica.entries[path]["role"]
+    raise ValidationError(f"{path}: cannot assign bundle role")
+
+
+def _utc_epoch(value: str, label: str) -> float:
+    try:
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+    except (AttributeError, ValueError) as exc:
+        raise ValidationError(f"{label}: invalid UTC timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValidationError(f"{label}: timestamp lacks a UTC offset")
+    return parsed.timestamp()
+
+
+def _campaign_elapsed(campaign_started_utc: str, created_utc: str) -> int:
+    elapsed = math.floor(
+        _utc_epoch(created_utc, "created_utc")
+        - _utc_epoch(campaign_started_utc, "campaign_started_utc")
+    )
+    if elapsed < 0 or elapsed > BOUNDS["campaign_timeout_seconds"]:
+        raise ValidationError("campaign elapsed seconds exceed the retained-evidence bound")
+    return elapsed
+
+
+def _created_utc_now() -> str:
+    return datetime.now(timezone.utc).replace(
+        microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def finalize_bundle(bundle_root: Path, campaign_id: str, producer_commit: str,
+                    campaign_started_utc: str, *, created_utc: str | None = None) -> dict[str, Any]:
+    bundle_root = bundle_root.absolute()
+    if (bundle_root / MANIFEST_PATH).exists():
+        raise ValidationError("bundle manifest already exists")
+    payload = _validate_payload(bundle_root, require_analysis=True)
+    assert payload.analysis is not None and payload.receipt is not None
+    _require(payload.replicas[0].campaign_id, campaign_id, "expected campaign")
+    _require(payload.replicas[0].producer_commit, producer_commit, "expected producer")
+    files = []
+    for path in sorted(payload.expected_paths):
+        item = payload.tree[path]
+        role = _role_for_path(path, payload.replicas)
+        maximum = PAGE_SIZE if role == "page_blob" else MAX_JSON_BYTES
+        digest = payload.cache.sha256(path, maximum)
+        files.append(
+            {
+                "path": path,
+                "role": role,
+                "sha256": digest,
+                "size_bytes": item.size,
+                "media_type": "application/octet-stream" if role == "page_blob" else "application/json",
+            }
+        )
+    created_utc = created_utc or _created_utc_now()
+    campaign_elapsed_seconds = _campaign_elapsed(campaign_started_utc, created_utc)
+    receipt_sha256 = next(
+        row["sha256"]
+        for row in files
+        if row["path"] == "analysis/holdout-structure-receipt.json"
+    )
+    decisive = payload.analysis["scientific_outcome"] == "one_or_more_layers_predict_holdout"
+    manifest = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_bundle_manifest",
+        "experiment_id": EXPERIMENT_ID,
+        "campaign_id": payload.replicas[0].campaign_id,
+        "producer_commit": payload.replicas[0].producer_commit,
+        "repository_url": REPOSITORY_URL,
+        "created_utc": created_utc,
+        "campaign_started_utc": campaign_started_utc,
+        "campaign_elapsed_seconds": campaign_elapsed_seconds,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "replica_environment_sha256": [row.environment_sha256 for row in payload.replicas],
+        "provider_sha256": payload.replicas[0].provider_sha256,
+        "replica_count": REPLICA_COUNT,
+        "replica_artifact_manifest_sha256": [row.manifest_sha256 for row in payload.replicas],
+        "checkpoint_count": REPLICA_COUNT * CHECKPOINT_COUNT,
+        "page_blob_count": sum(1 for row in files if row["role"] == "page_blob"),
+        "bundle_size_bytes_excluding_manifest": sum(row["size_bytes"] for row in files),
+        "inventory_closed": True,
+        "hashes_verified": True,
+        "paths_closed": True,
+        "execution_status": "analysis_complete",
+        "campaign_failed": False,
+        "holdout_structure_receipt_sha256": receipt_sha256,
+        "analysis_report_retained": True,
+        "analysis_scientific_outcome": (
+            "one_or_more_submodels_predict_holdout"
+            if decisive else "no_submodel_predicts_holdout"
+        ),
+        "bundle_status": (
+            "decisive_pending_independent_validation"
+            if decisive
+            else "complete_no_scientific_outcome"
+        ),
+        "independent_validation_status": "not_independently_validated",
+        "files": files,
+    }
+    validate_schema(manifest, "dao_a4_bundle_manifest")
+    manifest_bytes = canonical_json_bytes(manifest)
+    if len(manifest_bytes) > MAX_JSON_BYTES:
+        raise ValidationError("bundle manifest exceeds its fixed JSON bound")
+    if manifest["bundle_size_bytes_excluding_manifest"] + len(manifest_bytes) > MAX_BUNDLE_BYTES:
+        raise ValidationError("complete A4 bundle exceeds its fixed byte bound")
+    with (bundle_root / MANIFEST_PATH).open("xb") as handle:
+        handle.write(manifest_bytes)
+    return manifest
+def validate_bundle(bundle_root: Path, campaign_id: str,
+                    producer_commit: str) -> dict[str, Any]:
+    bundle_root = bundle_root.absolute()
+    tree, directories = _inventory(bundle_root)
+    cache = ArtifactCache(bundle_root, tree, MAX_BUNDLE_BYTES)
+    manifest, _ = _json_artifact(cache, MANIFEST_PATH)
+    _validate_typed(manifest, "dao_a4_bundle_manifest", MANIFEST_PATH)
+    _require(
+        manifest["campaign_elapsed_seconds"],
+        _campaign_elapsed(manifest["campaign_started_utc"], manifest["created_utc"]),
+        "bundle manifest campaign timing",
+    )
+    entries = _entry_map(manifest)
+    _validate_plan_entries(entries)
+    _require(set(tree), set(entries) | {MANIFEST_PATH}, "complete bundle inventory")
+    _require(directories, _expected_directories(entries), "complete bundle directories")
+    for entry in entries.values():
+        _entry_payload(cache, entry)
+    payload = _validate_payload(bundle_root, require_analysis=True,
+                                allow_manifest=True, tree=tree,
+                                directories=directories, cache=cache)
+    assert payload.analysis is not None and payload.receipt is not None
+    _require(manifest["campaign_id"], campaign_id, "expected campaign")
+    _require(manifest["producer_commit"], producer_commit, "expected producer commit")
+    expected = {
+        "experiment_id": EXPERIMENT_ID,
+        "campaign_id": payload.replicas[0].campaign_id,
+        "producer_commit": payload.replicas[0].producer_commit,
+        "repository_url": REPOSITORY_URL,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "replica_environment_sha256": [row.environment_sha256 for row in payload.replicas],
+        "provider_sha256": payload.replicas[0].provider_sha256,
+        "replica_artifact_manifest_sha256": [row.manifest_sha256 for row in payload.replicas],
+        "holdout_structure_receipt_sha256": entries["analysis/holdout-structure-receipt.json"]["sha256"],
+        "analysis_scientific_outcome": (
+            "one_or_more_submodels_predict_holdout"
+            if payload.analysis["scientific_outcome"]
+            == "one_or_more_layers_predict_holdout"
+            else "no_submodel_predicts_holdout"
+        ),
+    }
+    for key, value in expected.items():
+        _require(manifest[key], value, f"bundle manifest {key}")
+    _require(
+        manifest["bundle_size_bytes_excluding_manifest"],
+        sum(entry["size_bytes"] for entry in entries.values()),
+        "bundle manifest retained bytes",
+    )
+    _require(
+        manifest["page_blob_count"],
+        sum(entry["role"] == "page_blob" for entry in entries.values()),
+        "bundle manifest page count",
+    )
+    observed_tree, observed_directories = _inventory(bundle_root)
+    _require(observed_tree, tree, "bundle stability")
+    _require(observed_directories, directories, "bundle directory stability")
+    return {
+        "manifest": manifest,
+        "manifest_sha256": cache.sha256(MANIFEST_PATH, MAX_JSON_BYTES),
+        "analysis": payload.analysis,
+        "replicas": [row.observation for row in payload.replicas],
+    }
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    assemble = subparsers.add_parser("assemble")
+    assemble.add_argument("--replica-root", action="append", type=Path, required=True)
+    assemble.add_argument("--bundle-root", type=Path, required=True)
+    assemble.add_argument("--campaign-id", required=True)
+    assemble.add_argument("--producer-commit", required=True)
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--bundle-root", type=Path, required=True)
+    finalize.add_argument("--campaign-id", required=True)
+    finalize.add_argument("--producer-commit", required=True)
+    finalize.add_argument("--campaign-started-utc", required=True)
+    analyze_command = subparsers.add_parser("analyze")
+    analyze_command.add_argument("--bundle-root", type=Path, required=True)
+    analyze_command.add_argument("--holdout-root", type=Path, required=True)
+    analyze_command.add_argument("--campaign-id", required=True)
+    analyze_command.add_argument("--producer-commit", required=True)
+    analyze_command.add_argument("--holdout-command-executable", required=True)
+    analyze_command.add_argument(
+        "--holdout-command-argument", action="append", default=[]
+    )
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("bundle", type=Path)
+    validate.add_argument("--campaign-id", required=True)
+    validate.add_argument("--producer-commit", required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        if arguments.command == "assemble":
+            result = assemble_bundle(arguments.replica_root, arguments.bundle_root,
+                                     arguments.campaign_id, arguments.producer_commit)
+        elif arguments.command == "analyze":
+            result = analyze_bundle(
+                arguments.bundle_root,
+                arguments.holdout_root,
+                arguments.campaign_id,
+                arguments.producer_commit,
+                (
+                    arguments.holdout_command_executable,
+                    *arguments.holdout_command_argument,
+                ),
+            )
+        elif arguments.command == "finalize":
+            manifest = finalize_bundle(
+                arguments.bundle_root, arguments.campaign_id, arguments.producer_commit,
+                arguments.campaign_started_utc)
+            result = {
+                "bundle_root": str(arguments.bundle_root),
+                "campaign_id": manifest["campaign_id"],
+                "bundle_status": manifest["bundle_status"],
+                "file_count": len(manifest["files"]),
+            }
+        else:
+            bundle_root = arguments.bundle
+            validation = validate_bundle(
+                bundle_root, arguments.campaign_id, arguments.producer_commit)
+            result = {
+                "bundle_root": str(bundle_root),
+                "campaign_id": validation["manifest"]["campaign_id"],
+                "bundle_status": validation["manifest"]["bundle_status"],
+                "manifest_sha256": validation["manifest_sha256"],
+            }
+    except (OSError, ValidationError) as exc:
+        print(f"A4 bundle {arguments.command} failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, default=str))
+    return 0
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/a4_bundle_io.py
+++ b/oracle/windows-dao/scripts/a4_bundle_io.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Bounded, link-safe filesystem reads for A4 bundle validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from protocol_validation import ValidationError
+
+MAX_TREE_ENTRIES = 65_750
+MAX_TREE_DEPTH = 8
+FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+
+
+@dataclass(frozen=True)
+class TreeFile:
+    size: int
+    modified_ns: int
+    device: int
+    inode: int
+    links: int
+
+
+@dataclass
+class ArtifactCache:
+    """Process-local retained bytes, digests, and parsed JSON from checked reads."""
+
+    root: Path
+    tree: dict[str, TreeFile]
+    maximum_bytes: int
+    _payloads: dict[str, bytes] = field(default_factory=dict)
+    _digests: dict[str, str] = field(default_factory=dict)
+    _documents: dict[str, dict[str, Any]] = field(default_factory=dict)
+    _retained_bytes: int = 0
+
+    def read(self, locator: str, maximum: int) -> bytes:
+        payload = self._payloads.get(locator)
+        if payload is None:
+            payload = read_checked(self.root, locator, self.tree, maximum)
+            retained = self._retained_bytes + len(payload)
+            if retained > self.maximum_bytes:
+                raise ValidationError("A4 cached artifacts exceed their byte ceiling")
+            self._payloads[locator] = payload
+            self._retained_bytes = retained
+        elif len(payload) > maximum:
+            raise ValidationError(f"{locator}: artifact violates its byte ceiling")
+        return payload
+
+    def sha256(self, locator: str, maximum: int) -> str:
+        digest = self._digests.get(locator)
+        if digest is None:
+            digest = hashlib.sha256(self.read(locator, maximum)).hexdigest()
+            self._digests[locator] = digest
+        return digest
+
+    def json(self, locator: str, maximum: int) -> tuple[dict[str, Any], bytes]:
+        payload = self.read(locator, maximum)
+        document = self._documents.get(locator)
+        if document is None:
+            document = parse_json(payload, locator)
+            self._documents[locator] = document
+        return document, payload
+
+
+def copy_cached(
+    cache: ArtifactCache,
+    destination_root: Path,
+    locator: str,
+    size: int,
+    digest: str,
+    maximum: int,
+    copied: dict[str, tuple[int, str]],
+) -> None:
+    destination = destination_root.joinpath(*locator.split("/"))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = cache.read(locator, maximum)
+    if len(payload) != size or cache.sha256(locator, maximum) != digest:
+        raise ValidationError(f"{locator}: cached copy binding mismatch")
+    if destination.exists():
+        metadata = destination.lstat()
+        if (
+            destination.is_symlink()
+            or is_reparse(metadata)
+            or not stat.S_ISREG(metadata.st_mode)
+        ):
+            raise ValidationError(f"{locator}: merge collision is not a regular file")
+        if metadata.st_size != size or copied.get(locator) != (size, digest):
+            raise ValidationError(f"{locator}: merge collision differs")
+        return
+    created = False
+    try:
+        with destination.open("xb") as writer:
+            created = True
+            writer.write(payload)
+    except Exception:
+        if created and destination.exists():
+            destination.unlink()
+        raise
+    copied[locator] = (size, digest)
+
+
+def is_reparse(metadata: os.stat_result) -> bool:
+    return bool(
+        getattr(metadata, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def safe_locator(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 512 or "\\" in value:
+        raise ValidationError(f"{label}: unsafe artifact path")
+    candidate = Path(value)
+    if candidate.is_absolute() or any(part in ("", ".", "..") for part in candidate.parts):
+        raise ValidationError(f"{label}: unsafe artifact path")
+    if candidate.as_posix() != value:
+        raise ValidationError(f"{label}: non-canonical artifact path")
+    return value
+
+
+def _identity(metadata: os.stat_result) -> tuple[int, int, int]:
+    return metadata.st_dev, metadata.st_ino, metadata.st_nlink
+
+
+def _path_identity(path: Path, metadata: os.stat_result) -> tuple[int, int, int]:
+    if os.name != "nt":
+        return _identity(metadata)
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        return _identity(os.fstat(descriptor))
+    finally:
+        os.close(descriptor)
+
+
+def inventory(root: Path) -> tuple[dict[str, TreeFile], set[str]]:
+    root = root.absolute()
+    try:
+        metadata = root.lstat()
+    except OSError as exc:
+        raise ValidationError(f"{root}: cannot inspect tree root: {exc}") from exc
+    if root.is_symlink() or is_reparse(metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise ValidationError(f"{root}: tree root must be a regular directory")
+    files: dict[str, TreeFile] = {}
+    directories: set[str] = set()
+    folded: dict[str, str] = {}
+    identities: set[tuple[int, int]] = set()
+    pending = [(root, 0)]
+    seen = 0
+    try:
+        while pending:
+            directory, depth = pending.pop()
+            with os.scandir(directory) as children:
+                for child in children:
+                    seen += 1
+                    if seen > MAX_TREE_ENTRIES:
+                        raise ValidationError("A4 tree exceeds its entry ceiling")
+                    child_metadata = child.stat(follow_symlinks=False)
+                    if child.is_symlink() or is_reparse(child_metadata):
+                        raise ValidationError(f"{child.path}: links are forbidden")
+                    locator = Path(child.path).relative_to(root).as_posix()
+                    safe_locator(locator, child.path)
+                    prior = folded.get(locator.casefold())
+                    if prior is not None and prior != locator:
+                        raise ValidationError(f"{locator}: case-colliding tree entry")
+                    folded[locator.casefold()] = locator
+                    if stat.S_ISDIR(child_metadata.st_mode):
+                        if depth >= MAX_TREE_DEPTH:
+                            raise ValidationError("A4 tree exceeds its depth ceiling")
+                        directories.add(locator)
+                        pending.append((Path(child.path), depth + 1))
+                    elif stat.S_ISREG(child_metadata.st_mode):
+                        file_identity = _path_identity(Path(child.path), child_metadata)
+                        identity = file_identity[:2]
+                        if file_identity[2] != 1 or identity in identities:
+                            raise ValidationError(f"{locator}: hard links are forbidden")
+                        identities.add(identity)
+                        files[locator] = TreeFile(
+                            child_metadata.st_size, child_metadata.st_mtime_ns,
+                            *file_identity,
+                        )
+                    else:
+                        raise ValidationError(f"{locator}: non-regular tree entry")
+    except ValidationError:
+        raise
+    except OSError as exc:
+        raise ValidationError(f"{root}: cannot enumerate tree: {exc}") from exc
+    return files, directories
+
+
+def expected_directories(paths: Iterable[str]) -> set[str]:
+    return {
+        parent.as_posix()
+        for locator in paths
+        for parent in Path(locator).parents
+        if parent != Path(".")
+    }
+
+
+def read_checked(root: Path, locator: str, tree: dict[str, TreeFile], maximum: int) -> bytes:
+    try:
+        expected = tree[locator]
+    except KeyError as exc:
+        raise ValidationError(f"{locator}: missing artifact") from exc
+    if expected.size < 1 or expected.size > maximum:
+        raise ValidationError(f"{locator}: artifact violates its byte ceiling")
+    path = root.joinpath(*locator.split("/"))
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        before = path.lstat()
+        expected_identity = (expected.device, expected.inode, expected.links)
+        if (
+            path.is_symlink() or is_reparse(before) or not stat.S_ISREG(before.st_mode)
+            or before.st_size != expected.size or before.st_mtime_ns != expected.modified_ns
+            or _identity(before) != expected_identity
+        ):
+            raise ValidationError(f"{locator}: artifact identity changed before read")
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as handle:
+            opened = os.fstat(handle.fileno())
+            if _identity(opened) != expected_identity:
+                raise ValidationError(f"{locator}: artifact identity changed while opening")
+            payload = handle.read(maximum + 1)
+            after_open = os.fstat(handle.fileno())
+        after = path.lstat()
+    except ValidationError:
+        raise
+    except OSError as exc:
+        raise ValidationError(f"{locator}: cannot read artifact: {exc}") from exc
+    if (
+        len(payload) != expected.size or len(payload) > maximum
+        or _identity(after_open) != expected_identity
+        or path.is_symlink() or is_reparse(after) or not stat.S_ISREG(after.st_mode)
+        or after.st_size != expected.size or after.st_mtime_ns != expected.modified_ns
+        or _identity(after) != expected_identity
+    ):
+        raise ValidationError(f"{locator}: artifact changed during read")
+    return payload
+
+
+def parse_json(payload: bytes, locator: str) -> dict[str, Any]:
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise ValidationError(f"{locator}: UTF-8 byte-order marks are forbidden")
+
+    def unique(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate object key {key!r}")
+            result[key] = value
+        return result
+
+    def reject(value: str) -> None:
+        raise ValueError(f"non-finite JSON number {value}")
+
+    try:
+        document = json.loads(
+            payload.decode("utf-8"), object_pairs_hook=unique, parse_constant=reject
+        )
+    except (UnicodeError, json.JSONDecodeError, ValueError, RecursionError) as exc:
+        raise ValidationError(f"{locator}: invalid JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValidationError(f"{locator}: JSON root must be an object")
+    return document

--- a/oracle/windows-dao/scripts/a4_holdout.py
+++ b/oracle/windows-dao/scripts/a4_holdout.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Post-freeze structural validation for the DAO A4 holdout replica."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from a4_bundle import (
+    DERIVATION_REPLICA_COUNT,
+    MAX_BUNDLE_BYTES,
+    MAX_JSON_BYTES,
+    PLAN_PATH,
+    REPLICA_COUNT,
+    ReplicaResult,
+    _copy_replica,
+    _inventory,
+    _validate_environments,
+    _validate_frozen,
+    _validate_replica,
+)
+from a4_bundle_io import ArtifactCache, TreeFile
+from a4_spec import (
+    BOUNDS, EXPERIMENT_ID, PLAN_SHA256, REVISION_PLAN_SHA256,
+    load_bounded_json, validate_schema,
+)
+from protocol_validation import ValidationError, canonical_json_bytes
+
+FAN_IN_TIMEOUT_SECONDS = 900
+HOLDOUT_TIMEOUT_SECONDS = 300
+if BOUNDS["fan_in_timeout_seconds"] != FAN_IN_TIMEOUT_SECONDS:
+    raise RuntimeError("checked A4 fan-in bound drifted")
+
+
+def holdout_absent(bundle_root: Path) -> bool:
+    """True while no holdout-replica artifact exists anywhere under the bundle."""
+    tree, _ = _inventory(bundle_root.absolute())
+    marker = f"replica-{REPLICA_COUNT:02d}"
+    return not any(marker in path for path in tree)
+
+
+def graft_holdout_replica(
+    holdout_root: Path,
+    bundle_root: Path,
+    candidate_set: Path,
+    candidate_sha256: str,
+    campaign_id: str,
+    producer_commit: str,
+    *,
+    bundle_tree: dict[str, TreeFile] | None = None,
+    bundle_directories: set[str] | None = None,
+    bundle_cache: ArtifactCache | None = None,
+) -> ReplicaResult:
+    """Copy the closed holdout replica into a bundle that holds only the frozen derivation set.
+
+    The retained frozen candidate bytes are hash-checked before a single holdout
+    byte is inventoried, so the graft itself is the freeze-order observable."""
+    bundle_root = bundle_root.absolute()
+    if bundle_tree is None or bundle_directories is None:
+        if (
+            bundle_tree is not None
+            or bundle_directories is not None
+            or bundle_cache is not None
+        ):
+            raise ValidationError("partial A4 holdout validation context")
+        bundle_tree, bundle_directories = _inventory(bundle_root)
+    if bundle_cache is None:
+        bundle_cache = ArtifactCache(bundle_root, bundle_tree, MAX_BUNDLE_BYTES)
+    elif bundle_cache.root != bundle_root or bundle_cache.tree is not bundle_tree:
+        raise ValidationError("A4 holdout cache does not match its inventory")
+    if any(f"replica-{REPLICA_COUNT:02d}" in path for path in bundle_tree):
+        raise ValidationError("holdout replica artifacts already present before graft")
+    candidate_locator = candidate_set.absolute().relative_to(bundle_root).as_posix()
+    derivation = tuple(
+        _validate_replica(
+            bundle_root, bundle_tree, bundle_directories, bundle_cache,
+            replica, campaign_id, closed=False,
+        )
+        for replica in range(1, DERIVATION_REPLICA_COUNT + 1)
+    )
+    expected = {PLAN_PATH, candidate_locator}
+    for replica in derivation:
+        expected.add(replica.manifest_path)
+        expected.update(replica.entries)
+    if set(bundle_tree) != expected:
+        raise ValidationError(
+            "bundle holds more than the plan, derivation replicas, and frozen set"
+        )
+    frozen_payload = bundle_cache.read(candidate_locator, MAX_JSON_BYTES)
+    if bundle_cache.sha256(candidate_locator, MAX_JSON_BYTES) != candidate_sha256:
+        raise ValidationError(f"frozen candidate hash: expected {candidate_sha256}")
+    frozen = bundle_cache.json(candidate_locator, MAX_JSON_BYTES)[0]
+    _validate_frozen(frozen, frozen_payload, campaign_id)
+    root = Path(holdout_root).absolute()
+    tree, directories = _inventory(root)
+    holdout_cache = ArtifactCache(root, tree, MAX_BUNDLE_BYTES)
+    holdout = _validate_replica(
+        root, tree, directories, holdout_cache,
+        REPLICA_COUNT, campaign_id, closed=True,
+    )
+    _validate_environments((*derivation, holdout))
+    if holdout.producer_commit != producer_commit:
+        raise ValidationError("expected holdout producer commit")
+    copied = {
+        replica.manifest_path: (replica.manifest_size, replica.manifest_sha256)
+        for replica in derivation
+    }
+    for replica in derivation:
+        copied.update({
+            path: (entry["size_bytes"], entry["sha256"])
+            for path, entry in replica.entries.items()
+        })
+    _copy_replica(holdout, bundle_root, copied)
+
+    grafted_tree, grafted_directories = _inventory(bundle_root)
+    if any(grafted_tree.get(path) != item for path, item in bundle_tree.items()):
+        raise ValidationError("derivation bundle changed while grafting the holdout")
+    bundle_cache.tree = grafted_tree
+    grafted = _validate_replica(
+        bundle_root, grafted_tree, grafted_directories, bundle_cache,
+        REPLICA_COUNT, campaign_id, closed=False,
+    )
+    if grafted.producer_commit != producer_commit:
+        raise ValidationError("expected grafted holdout producer commit")
+    if grafted.manifest_sha256 != holdout.manifest_sha256:
+        raise ValidationError("grafted holdout replica changed during structural validation")
+    return grafted
+
+
+def run_holdout_process(
+    bundle_root: Path,
+    holdout_root: Path,
+    candidate_set: Path,
+    candidate_sha256: str,
+    campaign_id: str,
+    producer_commit: str,
+    output: Path,
+    freeze_state: Path,
+) -> None:
+    command = [
+        sys.executable,
+        "-B",
+        str(Path(__file__)),
+        "--bundle-root",
+        str(bundle_root),
+        "--holdout-replica-root",
+        str(holdout_root),
+        "--candidate-set",
+        str(candidate_set),
+        "--candidate-sha256",
+        candidate_sha256,
+        "--campaign-id",
+        campaign_id,
+        "--producer-commit",
+        producer_commit,
+        "--output",
+        str(output),
+        "--freeze-state",
+        str(freeze_state),
+    ]
+    try:
+        completed = subprocess.run(
+            command, check=False, timeout=HOLDOUT_TIMEOUT_SECONDS
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ValidationError(f"holdout structural validator failed: {exc}") from exc
+    if completed.returncode != 0:
+        raise ValidationError("holdout structural validator returned nonzero")
+
+
+def write_receipt(
+    bundle_root: Path,
+    holdout_root: Path,
+    candidate_set: Path,
+    candidate_sha256: str,
+    campaign_id: str,
+    producer_commit: str,
+    output: Path,
+    freeze_state: Path,
+) -> dict[str, object]:
+    # Read the workflow's completed freeze marker and retained candidate bytes before
+    # touching the separately downloaded holdout root.
+    state = load_bounded_json(freeze_state, MAX_JSON_BYTES)
+    resolved_bundle = bundle_root.absolute()
+    candidate_locator = candidate_set.absolute().relative_to(resolved_bundle).as_posix()
+    bundle_tree, bundle_directories = _inventory(resolved_bundle)
+    bundle_cache = ArtifactCache(resolved_bundle, bundle_tree, MAX_BUNDLE_BYTES)
+    absent_before_graft = not any(
+        f"replica-{REPLICA_COUNT:02d}" in path for path in bundle_tree
+    )
+    frozen_digest = bundle_cache.sha256(candidate_locator, MAX_JSON_BYTES)
+    validated_after_candidate_freeze = (
+        absent_before_graft
+        and frozen_digest == candidate_sha256
+        and state.get("document_type") == "dao_a4_internal_freeze_phase"
+        and state.get("campaign_id") == campaign_id
+        and state.get("producer_commit") == producer_commit
+        and state.get("derivation_candidate_set_sha256") == frozen_digest
+        and state.get("freeze_phase_completed") is True
+        and state.get(
+            "replica_3_artifact_existed_before_freeze_phase_completed"
+        ) is False
+    )
+    opens = state.get("analyzer_replica_3_opens_before_receipt")
+    page_bytes_exposed_to_analyzer = (
+        not isinstance(opens, bool) and isinstance(opens, int) and opens > 0
+    )
+    if not validated_after_candidate_freeze:
+        raise ValidationError("holdout replica reached the bundle before the candidate freeze")
+    if page_bytes_exposed_to_analyzer or opens != 0:
+        raise ValidationError("analyzer opened replica 3 before receipt acceptance")
+    replica = graft_holdout_replica(
+        holdout_root,
+        bundle_root,
+        candidate_set,
+        candidate_sha256,
+        campaign_id,
+        producer_commit,
+        bundle_tree=bundle_tree,
+        bundle_directories=bundle_directories,
+        bundle_cache=bundle_cache,
+    )
+    receipt: dict[str, object] = {
+        "protocol_version": "1.0.0",
+        "document_type": "dao_a4_holdout_structure_receipt",
+        "experiment_id": EXPERIMENT_ID,
+        "plan_sha256": PLAN_SHA256,
+        "revision_plan_sha256": REVISION_PLAN_SHA256,
+        "producer_commit": replica.producer_commit,
+        "campaign_id": replica.campaign_id,
+        "derivation_candidate_set_sha256": candidate_sha256,
+        "replica": replica.replica,
+        "replica_artifact_manifest_sha256": replica.manifest_sha256,
+        "validated_after_candidate_freeze": validated_after_candidate_freeze,
+        "page_bytes_exposed_to_analyzer": page_bytes_exposed_to_analyzer,
+        "result": "pass",
+    }
+    validate_schema(receipt, "dao_a4_holdout_structure_receipt")
+    payload = canonical_json_bytes(receipt)
+    if len(payload) > MAX_JSON_BYTES:
+        raise ValidationError("holdout receipt exceeds its fixed JSON bound")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("xb") as handle:
+        handle.write(payload)
+    return receipt
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--holdout-replica-root", type=Path, required=True)
+    parser.add_argument("--candidate-set", type=Path, required=True)
+    parser.add_argument("--candidate-sha256", required=True)
+    parser.add_argument("--campaign-id", required=True)
+    parser.add_argument("--producer-commit", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--freeze-state", type=Path, required=True)
+    arguments = parser.parse_args(argv)
+    try:
+        if len(arguments.candidate_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in arguments.candidate_sha256
+        ):
+            raise ValidationError("candidate SHA-256 is not lowercase hexadecimal")
+        receipt = write_receipt(
+            arguments.bundle_root,
+            arguments.holdout_replica_root,
+            arguments.candidate_set,
+            arguments.candidate_sha256,
+            arguments.campaign_id,
+            arguments.producer_commit,
+            arguments.output,
+            arguments.freeze_state,
+        )
+    except (OSError, ValidationError, ValueError) as exc:
+        print(f"A4 holdout validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "output": str(arguments.output),
+                "replica_artifact_manifest_sha256": receipt[
+                    "replica_artifact_manifest_sha256"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/run-a4-replica.ps1
+++ b/oracle/windows-dao/scripts/run-a4-replica.ps1
@@ -1,0 +1,795 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+    [Parameter(Mandatory = $true)][string]$OutputRoot,
+    [Parameter(Mandatory = $true)][string]$DiagnosticsRoot,
+    [Parameter(Mandatory = $true)][string]$GitCommit,
+    [Parameter(Mandatory = $true)][string]$RunId,
+    [Parameter(Mandatory = $true)][ValidateRange(1, 3)][int]$Replica,
+    [Parameter(Mandatory = $true)][string]$MatrixJobId
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:A4Stage = "bootstrap"
+$script:A4RepositoryUrl = "https://github.com/oglassdev/jet3-rs.git"
+$script:A4PlanSha256 = `
+    "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+$script:A4RevisionPlanSha256 = `
+    "3e74e67a213611596aaa0f5a4c3e433b2528a438bfa74708f4937e0233ed9aa1"
+$script:A4ExperimentId = "DAO-A4-ROW-ANCHORED-MAPS-001"
+$script:A4RequiredPlanPath = `
+    "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json"
+
+function Write-A4Failure {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][string]$Stage,
+        [AllowNull()][object]$Message
+    )
+    $diagnostics = [IO.Path]::GetFullPath($Root)
+    [void][IO.Directory]::CreateDirectory($diagnostics)
+    $text = [Convert]::ToString($Message)
+    if ($text.Length -gt 4000) { $text = $text.Substring(0, 4000) }
+    $document = [ordered]@{ stage = $Stage; message = $text }
+    $bytes = (New-Object Text.UTF8Encoding($false)).GetBytes(
+        (($document | ConvertTo-Json -Depth 3 -Compress) + "`n")
+    )
+    $path = Join-Path $diagnostics "failure.json"
+    $stream = New-Object IO.FileStream(
+        $path, [IO.FileMode]::Create, [IO.FileAccess]::Write,
+        [IO.FileShare]::Read, 4096, [IO.FileOptions]::WriteThrough
+    )
+    try { $stream.Write($bytes, 0, $bytes.Length); $stream.Flush($true) }
+    finally { $stream.Dispose() }
+}
+
+function Assert-A4Bootstrap {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Commit
+    )
+    if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT -or
+        [IntPtr]::Size -ne 4 -or $PSVersionTable.PSEdition -cne "Desktop" -or
+        $PSVersionTable.PSVersion.Major -ne 5) {
+        throw "A4 requires x86 Windows PowerShell 5 Desktop."
+    }
+    if ($Commit -cnotmatch "^[0-9a-f]{40}$") {
+        throw "A4 producer commit must be lowercase SHA-1 hex."
+    }
+    if ($RunId -cnotmatch "^[A-Za-z0-9][A-Za-z0-9._-]{0,115}$" -or
+        $MatrixJobId -cnotmatch "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$") {
+        throw "A4 run or matrix job identifier is not protocol-valid."
+    }
+    $entry = Join-Path $Repository `
+        "oracle/windows-dao/scripts/run-a4-replica.ps1"
+    if (-not ([IO.Path]::GetFullPath($PSCommandPath)).Equals(
+        [IO.Path]::GetFullPath($entry), [StringComparison]::OrdinalIgnoreCase
+    )) { throw "A4 entrypoint differs from its repository binding." }
+    $cursor = [IO.Path]::GetFullPath($Repository)
+    while ($true) {
+        $item = Get-Item -LiteralPath $cursor -Force
+        if (-not $item.PSIsContainer -or
+            ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "A4 repository has a reparse component."
+        }
+        $parent = [IO.Path]::GetDirectoryName($cursor)
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent -ceq $cursor) { break }
+        $cursor = $parent
+    }
+    $git = [IO.Path]::GetFullPath((Get-Command git -CommandType Application `
+        -ErrorAction Stop | Select-Object -First 1).Source)
+    $head = @(& $git -C $Repository rev-parse --verify HEAD 2>&1)
+    $headExit = $LASTEXITCODE
+    $dirty = @(& $git -C $Repository status --porcelain=v1 `
+        --untracked-files=all 2>&1)
+    $dirtyExit = $LASTEXITCODE
+    $origin = @(& $git -C $Repository remote get-url origin 2>&1)
+    $originExit = $LASTEXITCODE
+    if ($headExit -ne 0 -or $head.Count -ne 1 -or
+        [string]$head[0] -cne $Commit -or $dirtyExit -ne 0 -or
+        $dirty.Count -ne 0 -or $originExit -ne 0 -or
+        $origin.Count -ne 1 -or [string]$origin[0] -cne $script:A4RepositoryUrl) {
+        throw "A4 requires the exact clean repository and origin binding."
+    }
+    return $git
+}
+
+function Open-A4BootstrapSources {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Commit,
+        [Parameter(Mandatory = $true)][string]$Git,
+        [Parameter(Mandatory = $true)][string[]]$RelativePaths
+    )
+    $streams = New-Object Collections.ArrayList
+    try {
+        foreach ($relative in $RelativePaths) {
+            if ($relative -cnotmatch "^[A-Za-z0-9._/-]+$" -or
+                $relative.Contains("..") -or $relative.Contains("//")) {
+                throw "A4 bootstrap source locator is unsafe."
+            }
+            $path = [IO.Path]::GetFullPath((Join-Path $Repository $relative))
+            $item = Get-Item -LiteralPath $path -Force
+            if ($item.PSIsContainer -or $item.Length -gt 2MB -or
+                ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                throw "A4 bootstrap source is not a bounded ordinary file."
+            }
+            $expected = @(& $Git -C $Repository rev-parse `
+                "${Commit}:$relative" 2>&1)
+            $expectedExit = $LASTEXITCODE
+            $actual = @(& $Git -C $Repository hash-object -- $path 2>&1)
+            $actualExit = $LASTEXITCODE
+            if ($expectedExit -ne 0 -or $actualExit -ne 0 -or
+                $expected.Count -ne 1 -or $actual.Count -ne 1 -or
+                [string]$actual[0] -cne [string]$expected[0]) {
+                throw "A4 bootstrap source differs from the producer commit."
+            }
+            $stream = New-Object IO.FileStream(
+                $path, [IO.FileMode]::Open, [IO.FileAccess]::Read,
+                [IO.FileShare]::Read
+            )
+            [void]$streams.Add($stream)
+        }
+        return ,$streams.ToArray()
+    }
+    catch {
+        foreach ($stream in $streams) { try { $stream.Dispose() } catch { } }
+        throw
+    }
+}
+
+function Read-A4JsonInput {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [long]$MaximumBytes = 64MB
+    )
+    Assert-M1NoReparseComponents -Path $Path
+    $item = Get-Item -LiteralPath $Path -Force
+    if ($item.PSIsContainer -or $item.Length -lt 2 -or
+        $item.Length -gt $MaximumBytes) {
+        throw "A4 JSON input violates its byte or file bound."
+    }
+    $bytes = [IO.File]::ReadAllBytes($item.FullName)
+    if ($bytes.Length -ne $item.Length -or
+        ($bytes.Length -ge 3 -and $bytes[0] -eq 0xef -and
+            $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf)) {
+        throw "A4 JSON input changed or contains a BOM."
+    }
+    $text = (New-Object Text.UTF8Encoding($false, $true)).GetString($bytes)
+    return [pscustomobject]@{
+        bytes = $bytes; document = ($text | ConvertFrom-Json)
+        sha256 = Get-M1ByteArraySha256 -Bytes $bytes
+    }
+}
+
+function Write-A4NewFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][byte[]]$Bytes,
+        [long]$MaximumBytes = 64MB
+    )
+    if ($Bytes.Length -lt 1 -or $Bytes.Length -gt $MaximumBytes) {
+        throw "A4 output violates its artifact byte ceiling."
+    }
+    $parent = [IO.Path]::GetDirectoryName([IO.Path]::GetFullPath($Path))
+    [void][IO.Directory]::CreateDirectory($parent)
+    Assert-M1NoReparseComponents -Path $parent
+    $stream = New-Object IO.FileStream(
+        $Path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write,
+        [IO.FileShare]::None, 65536, [IO.FileOptions]::WriteThrough
+    )
+    try { $stream.Write($Bytes, 0, $Bytes.Length); $stream.Flush($true) }
+    finally { $stream.Dispose() }
+}
+
+function Invoke-A4PythonValidation {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Context,
+        [Parameter(Mandatory = $true)][string]$Validator,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+    [void](Invoke-BoundedChildProcess -Executable $Context.PythonPath `
+        -Arguments @("-B", $Validator, $Path) -CallerLabel $Label `
+        -TimeoutSeconds 120 -MaximumOutputBytes 1MB)
+}
+
+function Assert-A4PythonRuntime {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Context)
+    $result = Invoke-BoundedChildProcess -Executable $Context.PythonPath `
+        -Arguments @("-B", "-c", "import sys;print('.'.join(map(str,sys.version_info[:3])))") `
+        -CallerLabel "A4 Python runtime" -TimeoutSeconds 30 `
+        -MaximumOutputBytes 1KB
+    $text = ([Convert]::ToString($result.stdout)).Trim()
+    if ($text -cnotmatch "^3\.13\.[0-9]+$" -or
+        [string]$Context.Python.Version -cne $text) {
+        throw "A4 requires the preflight-bound Python 3.13 runtime."
+    }
+    return $text
+}
+
+function Assert-A4ExactPushedCommit {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Context)
+    $remote = Invoke-BoundedChildProcess -Executable $Context.GitExecutable `
+        -Arguments @(
+            "-c", "credential.interactive=never", "-c", "core.askPass=",
+            "ls-remote", "--heads", $script:A4RepositoryUrl
+        ) -CallerLabel "A4 pushed commit binding" -TimeoutSeconds 30 `
+        -MaximumOutputBytes 1MB
+    $advertised = @([Convert]::ToString($remote.stdout) -split "\r?\n" | Where-Object {
+        $_.StartsWith($Context.GitCommit + "`t", [StringComparison]::Ordinal)
+    })
+    if ($advertised.Count -lt 1) {
+        throw "A4 producer commit is not advertised by a pushed branch."
+    }
+}
+
+function Invoke-A4ProviderProbe {
+    param(
+        [Parameter(Mandatory = $true)][string]$PowerShellPath,
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$ProbePath
+    )
+    if ([IO.File]::Exists($ProbePath)) {
+        throw "A4 provider probe output already exists."
+    }
+    $scriptPath = Join-Path $Repository "oracle/windows-dao/scripts/probe-provider.ps1"
+    [void](Invoke-BoundedChildProcess -Executable $PowerShellPath `
+        -Arguments @(
+            "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy",
+            "Bypass", "-File", $scriptPath, "-ProtocolVersion", "1.1.0",
+            "-OutputPath", $ProbePath
+        ) -CallerLabel "A4 DAO provider probe" -TimeoutSeconds 120 `
+        -MaximumOutputBytes 1MB)
+}
+
+function New-A4EnvironmentBytes {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Context,
+        [Parameter(Mandatory = $true)][string]$CampaignId,
+        [Parameter(Mandatory = $true)][string]$PythonVersion
+    )
+    $accepted = $Context.AcceptedProvider
+    if ($null -eq ("Jet3.A4.NativeCodePages" -as [type])) {
+        Add-Type -TypeDefinition @"
+using System.Runtime.InteropServices;
+namespace Jet3.A4 {
+    public static class NativeCodePages {
+        [DllImport("kernel32.dll")]
+        public static extern uint GetACP();
+        [DllImport("kernel32.dll")]
+        public static extern uint GetOEMCP();
+    }
+}
+"@
+    }
+    $ansiCodePage = [int][Jet3.A4.NativeCodePages]::GetACP()
+    $oemCodePage = [int][Jet3.A4.NativeCodePages]::GetOEMCP()
+    if ($ansiCodePage -ne 1252 -or $oemCodePage -lt 1 -or
+        $oemCodePage -gt 65535) {
+        throw "A4 requires Windows GetACP() to return 1252."
+    }
+    $runnerImage = [Environment]::GetEnvironmentVariable("ImageOS")
+    if ([string]::IsNullOrWhiteSpace($runnerImage)) {
+        $runnerImage = [Environment]::OSVersion.VersionString
+    }
+    if ($runnerImage.Length -gt 128) { $runnerImage = $runnerImage.Substring(0, 128) }
+    $document = [ordered]@{
+        protocol_version = "1.0.0"; document_type = "dao_a4_environment"
+        experiment_id = $script:A4ExperimentId
+        plan_sha256 = $script:A4PlanSha256
+        revision_plan_sha256 = $script:A4RevisionPlanSha256
+        producer_commit = $Context.GitCommit
+        repository_url = $script:A4RepositoryUrl; campaign_id = $CampaignId
+        replica = $Replica; matrix_job_id = $MatrixJobId; status = "ready"
+        host = [ordered]@{
+            windows_version = [string]$Context.Environment.host.os_version
+            process_architecture = "x86"
+            powershell_version = $PSVersionTable.PSVersion.ToString()
+            python_version = $PythonVersion; runner_image = $runnerImage
+            windows_ansi_code_page = $ansiCodePage
+            windows_oem_code_page = $oemCodePage
+            locale_name = [Globalization.CultureInfo]::CurrentCulture.Name
+        }
+        provider = [ordered]@{
+            prog_id = [string]$accepted.prog_id; clsid = [string]$accepted.clsid
+            provider_version = [string]$accepted.provider_version
+            server_path = [string]$accepted.server_path
+            server_file_version = [string]$accepted.server_file_version
+            server_sha256 = [string]$accepted.server_sha256
+        }
+    }
+    return ,(New-Object Text.UTF8Encoding($false)).GetBytes(
+        (($document | ConvertTo-Json -Depth 8 -Compress) + "`n")
+    )
+}
+
+function Assert-A4PlanIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Plan)
+    if ([string]$Plan.experiment_id -cne $script:A4ExperimentId -or
+        [string]$Plan.document_type -cne "dao_a4_row_anchored_maps_plan" -or
+        [string]$Plan.implementation_rebinding.required_experiment_id -cne
+            $script:A4ExperimentId -or
+        [string]$Plan.implementation_rebinding.required_plan_path -cne
+            $script:A4RequiredPlanPath) {
+        throw "A4 rejects any plan other than the frozen row-anchored-maps plan."
+    }
+}
+
+function Assert-A4RuntimeGate {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Plan)
+    $expected = @(
+        "checked_a4_analyzer_and_synthetic_generator",
+        "independent_recomputing_a4_validator",
+        "a4_worker_and_workflow_with_fail_closed_binding",
+        "passing_a4_dry_runs_disclosed_additively",
+        "a4_contract_validator_accepts_decisive_and_no_outcome_reports",
+        "exact_clean_pushed_producer_commit",
+        "licensed_x86_dao_host_with_ansi_code_page_1252"
+    )
+    $actual = @($Plan.execution_gate.blocking_requirements)
+    if ([string]$Plan.execution_gate.status -cne "BLOCKED" -or
+        $actual.Count -ne $expected.Count -or
+        [int]$Plan.bounds.worker_timeout_seconds_per_replica -ne 1700 -or
+        [int]$Plan.checkpoint_design.count -ne 25) {
+        throw "A4 preregistration runtime gate or worker bounds drifted."
+    }
+    for ($index = 0; $index -lt $expected.Count; $index++) {
+        if ([string]$actual[$index] -cne [string]$expected[$index]) {
+            throw "A4 preregistration blocking-requirement set drifted."
+        }
+    }
+}
+
+function Assert-A4ReplicaOutput {
+    param(
+        [Parameter(Mandatory = $true)][pscustomobject]$Context,
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][string]$Validator,
+        [Parameter(Mandatory = $true)][string]$EnvironmentSha256,
+        [Parameter(Mandatory = $true)][string]$CampaignId
+    )
+    $rootPath = [IO.Path]::GetFullPath($Root).TrimEnd('\')
+    $replicaId = "replica-{0:D2}" -f $Replica
+    $environmentRelative = "environment/$replicaId.json"
+    $observationRelative = "observations/$replicaId.json"
+    $manifestRelative = "replica-artifacts/$replicaId-manifest.json"
+    $allowedDirectories = @(
+        "environment", "observations", "replica-artifacts", "page-indexes",
+        "page-indexes/$replicaId", "page-store", "schema-snapshots",
+        "schema-snapshots/$replicaId"
+    )
+    $directories = @([IO.Directory]::EnumerateDirectories(
+        $rootPath, "*", [IO.SearchOption]::AllDirectories
+    ) | ForEach-Object {
+        $_.Substring($rootPath.Length + 1).Replace('\', '/')
+    } | Sort-Object)
+    if ($directories.Count -ne $allowedDirectories.Count) {
+        throw "A4 output directory inventory is not closed."
+    }
+    foreach ($directory in $directories) {
+        if ($directory -cnotin $allowedDirectories) {
+            throw "A4 output contains an unexpected directory."
+        }
+    }
+    $manifestPath = Join-Path $rootPath $manifestRelative.Replace('/', '\')
+    $manifestInput = Read-A4JsonInput -Path $manifestPath
+    $manifest = $manifestInput.document
+    $records = @($manifest.files)
+    $recordByPath = @{}
+    foreach ($record in $records) {
+        $relative = [string]$record.path
+        if ($recordByPath.ContainsKey($relative)) {
+            throw "A4 manifest contains a duplicate path."
+        }
+        $recordByPath[$relative] = $record
+    }
+    $files = @([IO.Directory]::EnumerateFiles(
+        $rootPath, "*", [IO.SearchOption]::AllDirectories
+    ))
+    if ($files.Count -ne ($records.Count + 1)) {
+        throw "A4 output file inventory differs from its manifest."
+    }
+    foreach ($path in $files) {
+        $item = Get-Item -LiteralPath $path -Force
+        if ($item.PSIsContainer -or
+            ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "A4 output artifact is not a bounded ordinary file."
+        }
+        $relative = $path.Substring($rootPath.Length + 1).Replace('\', '/')
+        if ($relative -ceq $manifestRelative) { continue }
+        if (-not $recordByPath.ContainsKey($relative)) {
+            throw "A4 output contains an unmanifested artifact."
+        }
+        $record = $recordByPath[$relative]
+        if ([long]$record.size_bytes -ne [long]$item.Length -or
+            [string]$record.sha256 -cne (Get-M1FileSha256 -Path $path)) {
+            throw "A4 artifact differs from its manifest hash or size."
+        }
+        if ([string]$record.role -ceq "page_blob") {
+            if ($item.Length -ne 2048 -or
+                [IO.Path]::GetFileNameWithoutExtension($path) -cne
+                [string]$record.sha256) {
+                throw "A4 page-store blob is not canonical content-addressed data."
+            }
+        }
+    }
+    $environmentPath = Join-Path $rootPath $environmentRelative.Replace('/', '\')
+    $observationPath = Join-Path $rootPath $observationRelative.Replace('/', '\')
+    $environment = (Read-A4JsonInput -Path $environmentPath).document
+    $observation = (Read-A4JsonInput -Path $observationPath).document
+    foreach ($document in @($environment, $observation, $manifest)) {
+        if ([string]$document.plan_sha256 -cne $script:A4PlanSha256 -or
+            [string]$document.revision_plan_sha256 -cne
+                $script:A4RevisionPlanSha256 -or
+            [string]$document.producer_commit -cne $Context.GitCommit -or
+            [string]$document.campaign_id -cne $CampaignId -or
+            [int]$document.replica -ne $Replica) {
+            throw "A4 output document differs from its campaign binding."
+        }
+    }
+    if ([string]$manifest.environment_sha256 -cne $EnvironmentSha256 -or
+        [string]$recordByPath[$environmentRelative].sha256 -cne
+            $EnvironmentSha256 -or
+        [string]$observation.environment_sha256 -cne $EnvironmentSha256 -or
+        [string]$manifest.provider_sha256 -cne
+            [string]$environment.provider.server_sha256 -or
+        [string]$observation.provider_sha256 -cne
+            [string]$environment.provider.server_sha256) {
+        throw "A4 output environment or provider binding drifted."
+    }
+    if ([string]$environment.matrix_job_id -cne $MatrixJobId -or
+        [string]$manifest.matrix_job_id -cne $MatrixJobId -or
+        [string]$observation.matrix_job.job_id -cne $MatrixJobId) {
+        throw "A4 output matrix-job binding drifted."
+    }
+    $checkpoints = @($observation.checkpoints)
+    if ($checkpoints.Count -ne 25) { throw "A4 observation checkpoint count drifted." }
+    $changedEntries = [long]0
+    foreach ($checkpoint in $checkpoints) {
+        $relative = [string]$checkpoint.page_index.path
+        if (-not $recordByPath.ContainsKey($relative)) {
+            throw "A4 checkpoint references an unmanifested page index."
+        }
+        $indexPath = Join-Path $rootPath $relative.Replace('/', '\')
+        $indexInput = Read-A4JsonInput -Path $indexPath
+        if ($indexInput.sha256 -cne [string]$checkpoint.page_index.sha256 -or
+            $indexInput.bytes.Length -ne [long]$checkpoint.page_index.size_bytes) {
+            throw "A4 checkpoint page-index reference is not byte-exact."
+        }
+        $indexDocument = $indexInput.document
+        if ([string]$indexDocument.plan_sha256 -cne $script:A4PlanSha256 -or
+            [string]$indexDocument.revision_plan_sha256 -cne
+                $script:A4RevisionPlanSha256 -or
+            [string]$indexDocument.producer_commit -cne $Context.GitCommit -or
+            [string]$indexDocument.campaign_id -cne $CampaignId -or
+            [string]$indexDocument.environment_sha256 -cne $EnvironmentSha256 -or
+            [string]$indexDocument.provider_sha256 -cne
+                [string]$environment.provider.server_sha256 -or
+            [int]$indexDocument.replica -ne $Replica) {
+            throw "A4 page index differs from its campaign binding."
+        }
+        $hashes = @($indexDocument.ordered_page_sha256)
+        if ($hashes.Count -ne [long]$indexDocument.page_count) {
+            throw "A4 ordered page hash count differs from page_count."
+        }
+        foreach ($digest in $hashes) {
+            $blob = "page-store/$digest.page"
+            if (-not $recordByPath.ContainsKey($blob)) {
+                throw "A4 snapshot cannot be reconstructed from its page store."
+            }
+        }
+        $changedEntries += @($indexDocument.changed_page_indices).Count
+        Invoke-A4PythonValidation -Context $Context -Validator $Validator `
+            -Path $indexPath -Label "A4 page-index schema validation"
+        $schemaRelative = [string]$checkpoint.dao_schema_snapshot.path
+        if (-not $recordByPath.ContainsKey($schemaRelative)) {
+            throw "A4 checkpoint references an unmanifested DAO schema snapshot."
+        }
+        $schemaPath = Join-Path $rootPath $schemaRelative.Replace('/', '\')
+        $schemaInput = Read-A4JsonInput -Path $schemaPath
+        if ($schemaInput.sha256 -cne
+                [string]$checkpoint.dao_schema_snapshot.sha256 -or
+            $schemaInput.bytes.Length -ne
+                [long]$checkpoint.dao_schema_snapshot.size_bytes) {
+            throw "A4 checkpoint schema-snapshot reference is not byte-exact."
+        }
+        Invoke-A4PythonValidation -Context $Context -Validator $Validator `
+            -Path $schemaPath -Label "A4 DAO schema-snapshot validation"
+    }
+    if ($changedEntries -ne [long]$observation.changed_hash_entries -or
+        $changedEntries -gt 65536) {
+        throw "A4 changed-page accounting differs from the observation."
+    }
+    foreach ($validation in @(
+        [pscustomobject]@{ path = $environmentPath; label = "A4 environment validation" },
+        [pscustomobject]@{ path = $observationPath; label = "A4 observation validation" },
+        [pscustomobject]@{ path = $manifestPath; label = "A4 replica manifest validation" }
+    )) {
+        Invoke-A4PythonValidation -Context $Context -Validator $Validator `
+            -Path $validation.path -Label $validation.label
+    }
+}
+
+function Remove-A4PrivateWorkingRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingRoot,
+        [Parameter(Mandatory = $true)][string]$Diagnostics
+    )
+    $working = [IO.Path]::GetFullPath($WorkingRoot)
+    $expected = Join-Path ([IO.Path]::GetFullPath($Diagnostics)) "private"
+    if (-not $working.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing A4 cleanup outside its private diagnostics boundary."
+    }
+    if (-not [IO.Directory]::Exists($working)) { return }
+    Assert-M1NoReparseComponents -Path $working
+    Assert-M1CleanupTreeBounded -Root $working -MaxBytes 256MB -MaxEntries 64
+    [IO.Directory]::Delete($working, $true)
+}
+
+function Move-A4FailedDatabase {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingRoot,
+        [Parameter(Mandatory = $true)][string]$Diagnostics,
+        [Parameter(Mandatory = $true)][int]$Replica
+    )
+    $working = [IO.Path]::GetFullPath($WorkingRoot)
+    $diagnosticsPath = [IO.Path]::GetFullPath($Diagnostics)
+    $expected = Join-Path $diagnosticsPath "private"
+    if (-not $working.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing A4 failed-database retention outside its private boundary."
+    }
+    $replicaRoot = Join-Path $working ("replica-{0:D2}" -f $Replica)
+    $source = Join-Path $replicaRoot "ACQUISITION.MDB"
+    if (-not [IO.File]::Exists($source)) { return }
+    Assert-M1NoReparseComponents -Path $source
+    $item = Get-Item -LiteralPath $source -Force
+    if ($item.PSIsContainer -or
+        ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 -or
+        $item.Length -lt 1 -or $item.Length -gt 128MB) {
+        throw "A4 failed database is not a bounded ordinary file."
+    }
+    $destination = Join-Path $diagnosticsPath `
+        ("failed-replica-{0:D2}.mdb" -f $Replica)
+    if ([IO.File]::Exists($destination) -or
+        [IO.Directory]::Exists($destination)) {
+        throw "A4 failed-database diagnostic already exists."
+    }
+    [IO.File]::Move($item.FullName, $destination)
+}
+
+function Invoke-A4ReplicaCampaign {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Output,
+        [Parameter(Mandatory = $true)][string]$Diagnostics,
+        [Parameter(Mandatory = $true)][string]$PowerShellPath,
+        [Parameter(Mandatory = $true)][string[]]$ExecutedSources
+    )
+    $context = $null
+    $working = Join-Path $Diagnostics "private"
+    $primary = $null
+    $secondaryErrors = New-Object Collections.ArrayList
+    try {
+        $script:A4Stage = "output-preflight"
+        [void][IO.Directory]::CreateDirectory($Output)
+        [void][IO.Directory]::CreateDirectory($Diagnostics)
+        Assert-M1NoReparseComponents -Path $Output
+        Assert-M1NoReparseComponents -Path $Diagnostics
+        if ((Test-M1PathWithin -Path $Output -Parent $Repository) -or
+            (Test-M1PathWithin -Path $Diagnostics -Parent $Repository) -or
+            (Test-M1PathWithin -Path $Diagnostics -Parent $Output)) {
+            throw "A4 output and diagnostics must remain outside the repository and separate."
+        }
+        if (@([IO.Directory]::EnumerateFileSystemEntries($Output)).Count -ne 0) {
+            throw "A4 OutputRoot must be empty."
+        }
+        $script:A4Stage = "plan-identity"
+        $planPath = Join-Path $Repository $script:A4RequiredPlanPath
+        $planInput = Read-A4JsonInput -Path $planPath -MaximumBytes 1MB
+        if ($planInput.sha256 -cne $script:A4PlanSha256) {
+            throw "A4 plan bytes differ from the frozen preregistration."
+        }
+        Assert-A4PlanIdentity -Plan $planInput.document
+        $probePath = Join-Path $Diagnostics "provider-environment.json"
+        $script:A4Stage = "provider-probe"
+        Invoke-A4ProviderProbe -PowerShellPath $PowerShellPath `
+            -Repository $Repository -ProbePath $probePath
+        $preflightOutput = Join-Path $Diagnostics "preflight-output"
+        [void][IO.Directory]::CreateDirectory($preflightOutput)
+        $preflightRunId = [DateTime]::UtcNow.ToString("yyyyMMddTHHmmssZ") +
+            "-a4-r$Replica"
+        $script:A4Stage = "preflight"
+        $context = Invoke-M1Preflight -RepositoryRoot $Repository `
+            -EnvironmentPath $probePath -OutputRoot $preflightOutput `
+            -GitCommit $GitCommit -RunId $preflightRunId `
+            -ExecutedRepoRelativeSourcePaths $ExecutedSources
+        if ([string]$context.AcceptedProvider.prog_id -cne "DAO.DBEngine.36" -or
+            [string]$context.AcceptedProvider.server_path -match '"' -or
+            [string]$context.ProviderSha256 -cne
+                [string]$context.AcceptedProvider.server_sha256) {
+            throw "A4 requires one quote-free, hash-bound DAO.DBEngine.36 provider."
+        }
+        $pythonVersion = Assert-A4PythonRuntime -Context $context
+        Assert-A4ExactPushedCommit -Context $context
+        [void](Assert-M1RuntimeBinding -Context $context)
+        $validator = Join-Path $Repository "oracle/windows-dao/scripts/a4_spec.py"
+        Invoke-A4PythonValidation -Context $context -Validator $validator `
+            -Path $planPath -Label "A4 immutable plan validation"
+        Assert-A4RuntimeGate -Plan $planInput.document
+        $campaignId = "a4-run-$RunId"
+        if ($campaignId.Length -gt 128) { throw "A4 campaign id exceeds its bound." }
+        foreach ($directory in @(
+            "environment", "observations", "replica-artifacts", "page-indexes",
+            ("page-indexes/replica-{0:D2}" -f $Replica), "page-store",
+            "schema-snapshots",
+            ("schema-snapshots/replica-{0:D2}" -f $Replica)
+        )) {
+            [void][IO.Directory]::CreateDirectory((Join-Path $Output $directory))
+        }
+        $environmentBytes = New-A4EnvironmentBytes -Context $context `
+            -CampaignId $campaignId -PythonVersion $pythonVersion
+        $environmentSha = Get-M1ByteArraySha256 -Bytes $environmentBytes
+        $environmentPath = Join-Path $Output `
+            ("environment/replica-{0:D2}.json" -f $Replica)
+        Write-A4NewFile -Path $environmentPath -Bytes $environmentBytes
+        Invoke-A4PythonValidation -Context $context -Validator $validator `
+            -Path $environmentPath -Label "A4 environment validation"
+        [void][IO.Directory]::CreateDirectory($working)
+        [void](New-A4ProgressFile -DiagnosticsRoot $Diagnostics -Replica $Replica)
+        $workerPath = Join-Path $Repository `
+            "oracle/windows-dao/scripts/a4/A4.Worker.ps1"
+        $script:A4Stage = "replica-worker"
+        [void](Invoke-BoundedChildProcess -Executable $PowerShellPath `
+            -Arguments @(
+                "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy",
+                "Bypass", "-File", $workerPath, "-RepositoryRoot", $Repository,
+                "-OutputRoot", $Output, "-WorkingRoot", $working,
+                "-DiagnosticsRoot", $Diagnostics, "-PlanPath", $planPath,
+                "-EnvironmentPath", $environmentPath,
+                "-ProducerCommit", $GitCommit, "-CampaignId", $campaignId,
+                "-MatrixJobId", $MatrixJobId, "-PlanSha256", $script:A4PlanSha256,
+                "-RevisionPlanSha256", $script:A4RevisionPlanSha256,
+                "-EnvironmentSha256", $environmentSha,
+                "-Replica", $Replica.ToString()
+            ) -CallerLabel "A4 replica worker" -TimeoutSeconds 1700 `
+            -MaximumOutputBytes 1MB -ReviewedTimeoutCeilingSeconds 1700)
+        $script:A4Stage = "self-verification"
+        Assert-A4ReplicaOutput -Context $context -Root $Output `
+            -Validator $validator -EnvironmentSha256 $environmentSha `
+            -CampaignId $campaignId
+        [void](Assert-M1RuntimeBinding -Context $context)
+        Assert-A4ExactPushedCommit -Context $context
+    }
+    catch { $primary = $_ }
+    finally {
+        $removePrivate = $true
+        if ($null -ne $primary) {
+            try {
+                Move-A4FailedDatabase -WorkingRoot $working `
+                    -Diagnostics $Diagnostics -Replica $Replica
+            }
+            catch {
+                $removePrivate = $false
+                [void]$secondaryErrors.Add(
+                    "A4 failed-database retention also failed: " +
+                    [Convert]::ToString($_.Exception.Message)
+                )
+            }
+        }
+        if ($removePrivate -and [IO.Directory]::Exists($working)) {
+            try {
+                Remove-A4PrivateWorkingRoot -WorkingRoot $working `
+                    -Diagnostics $Diagnostics
+            }
+            catch {
+                [void]$secondaryErrors.Add(
+                    "A4 private cleanup also failed: " +
+                    [Convert]::ToString($_.Exception.Message)
+                )
+            }
+        }
+        if ($null -ne $context) {
+            try { Close-M1PreflightContext -Context $context }
+            catch {
+                [void]$secondaryErrors.Add(
+                    "A4 preflight cleanup also failed: " +
+                    [Convert]::ToString($_.Exception.Message)
+                )
+            }
+        }
+    }
+    if ($null -ne $primary) {
+        if ($secondaryErrors.Count -ne 0) {
+            $detail = @($secondaryErrors) -join " "
+            if ($detail.Length -gt 2000) { $detail = $detail.Substring(0, 2000) }
+            throw ([Convert]::ToString($primary.Exception.Message) + " " + $detail)
+        }
+        throw $primary
+    }
+    if ($secondaryErrors.Count -ne 0) {
+        throw (@($secondaryErrors) -join " ")
+    }
+}
+
+$streams = @()
+try {
+    $repository = [IO.Path]::GetFullPath($RepositoryRoot)
+    $diagnostics = [IO.Path]::GetFullPath($DiagnosticsRoot)
+    [void][IO.Directory]::CreateDirectory($diagnostics)
+    $git = Assert-A4Bootstrap -Repository $repository -Commit $GitCommit
+    $sources = @(
+        "oracle/windows-dao/scripts/run-a4-replica.ps1",
+        "oracle/windows-dao/scripts/a4/A4.Worker.ps1",
+        "oracle/windows-dao/scripts/a4/A4.PageStore.ps1",
+        "oracle/windows-dao/scripts/a4/A4.Progress.ps1",
+        "oracle/windows-dao/scripts/a4/A4.SchemaSnapshot.ps1",
+        "oracle/windows-dao/scripts/a2/A2.Progress.ps1",
+        "oracle/windows-dao/scripts/a1/A1.PageStore.ps1",
+        "oracle/windows-dao/scripts/a4_spec.py",
+        "oracle/windows-dao/scripts/protocol_validation.py",
+        "oracle/windows-dao/scripts/probe-provider.ps1",
+        "oracle/windows-dao/scripts/shared/BoundedProcess.ps1",
+        "oracle/windows-dao/scripts/shared/BoundedProcess.Native.cs",
+        "oracle/windows-dao/scripts/m1/M1.Preflight.ps1",
+        "oracle/windows-dao/scripts/m1/M1.Provider.ps1",
+        "oracle/windows-dao/scripts/m1/M1.Publication.ps1",
+        "oracle/windows-dao/scripts/m1/M1.PublicationPaths.ps1",
+        "oracle/windows-dao/scripts/m1/M1.DaoValues.ps1",
+        "oracle/windows-dao/scripts/m1_bundle_validation.py",
+        "oracle/windows-dao/scripts/protocol_cli.py",
+        "oracle/windows-dao/scripts/validate_m1_protocol.py",
+        "oracle/windows-dao/examples/m1-inventory.json",
+        "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json",
+        "oracle/windows-dao/experiments/a4/plan.schema.json",
+        "oracle/windows-dao/experiments/a4/replica-observation.schema.json",
+        "oracle/windows-dao/experiments/a4/dao-schema-snapshot.schema.json",
+        "oracle/windows-dao/experiments/a4/page-index.schema.json",
+        "oracle/windows-dao/experiments/a4/replica-artifact-manifest.schema.json",
+        "oracle/windows-dao/experiments/a4/environment.schema.json",
+        "oracle/windows-dao/experiments/a4/analysis-report.schema.json",
+        "oracle/windows-dao/experiments/a4/bundle-manifest.schema.json",
+        "oracle/windows-dao/experiments/a4/dry-run-report.schema.json",
+        "oracle/windows-dao/experiments/a4/holdout-structure-receipt.schema.json",
+        "oracle/windows-dao/experiments/a4/derivation-candidates.schema.json",
+        "oracle/windows-dao/experiments/a4/h4-occurrence-evidence.schema.json",
+        "oracle/windows-dao/experiments/a4/independent-validation-report.schema.json"
+    )
+    $streams = @(Open-A4BootstrapSources -Repository $repository `
+        -Commit $GitCommit -Git $git -RelativePaths $sources)
+    . (Join-Path $repository `
+        "oracle/windows-dao/scripts/shared/BoundedProcess.ps1")
+    . (Join-Path $repository "oracle/windows-dao/scripts/m1/M1.Preflight.ps1")
+    . (Join-Path $repository "oracle/windows-dao/scripts/m1/M1.Publication.ps1")
+    . (Join-Path $repository "oracle/windows-dao/scripts/m1/M1.DaoValues.ps1")
+    . (Join-Path $repository "oracle/windows-dao/scripts/a4/A4.Progress.ps1")
+    $powerShellPath = [IO.Path]::GetFullPath(
+        [Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+    )
+    Invoke-A4ReplicaCampaign -Repository $repository `
+        -Output ([IO.Path]::GetFullPath($OutputRoot)) `
+        -Diagnostics $diagnostics -PowerShellPath $powerShellPath `
+        -ExecutedSources $sources
+    Write-Output ("PASS: retained A4 replica {0:D2}" -f $Replica)
+    exit 0
+}
+catch {
+    $failure = $_
+    try {
+        Write-A4Failure -Root $DiagnosticsRoot -Stage $script:A4Stage `
+            -Message $failure.Exception.Message
+    }
+    catch {
+        [Console]::Error.WriteLine(
+            "A4 failure diagnostic retention also failed: " + $_.Exception.Message
+        )
+    }
+    [Console]::Error.WriteLine(
+        $failure.Exception.GetType().FullName + ": " + $failure.Exception.Message
+    )
+    exit 1
+}
+finally {
+    foreach ($stream in $streams) { try { $stream.Dispose() } catch { } }
+}

--- a/oracle/windows-dao/tests/a4_test_bundle.py
+++ b/oracle/windows-dao/tests/a4_test_bundle.py
@@ -1,0 +1,70 @@
+"""Materialize worker-shaped A4 replica trees for hosted-lane tests."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import hashlib
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a4_spec import CHECKPOINT_IDS  # noqa: E402
+from protocol_validation import canonical_json_bytes  # noqa: E402
+from test_a4_analyzer import _COMMIT, _inputs  # noqa: E402
+
+CAMPAIGN_ID = "a4-synthetic"
+PRODUCER_COMMIT = _COMMIT
+
+
+def _write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def write_replica_tree(root: Path, replica: int, surface: object) -> None:
+    """Write one exact replica-only artifact tree."""
+    if root.exists():
+        raise FileExistsError(root)
+    root.mkdir(parents=True)
+    environment_path = f"environment/replica-{replica:02d}.json"
+    observation_path = f"observations/replica-{replica:02d}.json"
+    manifest_path = f"replica-artifacts/replica-{replica:02d}-manifest.json"
+    _write(root / environment_path, surface.environment_payload)
+    _write(root / observation_path, canonical_json_bytes(surface.replica_observation))
+    _write(root / manifest_path, canonical_json_bytes(surface.artifact_manifest))
+    for ordinal, checkpoint in enumerate(CHECKPOINT_IDS):
+        _write(
+            root / f"page-indexes/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json",
+            canonical_json_bytes(surface.page_indexes[checkpoint]),
+        )
+        _write(
+            root / f"schema-snapshots/replica-{replica:02d}/{ordinal:02d}-{checkpoint}.json",
+            canonical_json_bytes(surface.schema_snapshots[checkpoint]),
+        )
+        for digest in surface.source.ordered_page_sha256[checkpoint]:
+            page = root / f"page-store/{digest}.page"
+            if not page.exists():
+                _write(page, surface.source.page_bytes(digest))
+
+
+def write_replica_trees(root: Path) -> tuple[tuple[Path, ...], str, str]:
+    """Write three deterministic replicas and return campaign bindings."""
+    root.mkdir(parents=True, exist_ok=True)
+    inputs = _inputs()
+    surfaces = {1: inputs[1], 2: inputs[2]}
+    frozen = b"{}"
+    surfaces[3] = inputs.acquire_holdout(
+        frozen, hashlib.sha256(frozen).hexdigest()
+    )
+    roots = tuple(root / f"replica-{replica:02d}" for replica in (1, 2, 3))
+    for replica, replica_root in enumerate(roots, start=1):
+        write_replica_tree(replica_root, replica, surfaces[replica])
+    return roots, CAMPAIGN_ID, PRODUCER_COMMIT
+
+
+def materialize_holdout(source: Path, destination: Path) -> None:
+    """Copy replica 3 only when invoked by the post-freeze callback."""
+    shutil.copytree(source, destination)

--- a/oracle/windows-dao/tests/test_a4_bundle.py
+++ b/oracle/windows-dao/tests/test_a4_bundle.py
@@ -1,0 +1,167 @@
+"""Synthetic contracts for A4 hosted fan-in and the holdout boundary."""
+
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+TESTS = ROOT / "oracle" / "windows-dao" / "tests"
+for location in (SCRIPTS, TESTS):
+    if str(location) not in sys.path:
+        sys.path.insert(0, str(location))
+
+from a4_bundle import (  # noqa: E402
+    CHECKPOINT_COUNT,
+    DERIVATION_REPLICA_COUNT,
+    MAX_BUNDLE_BYTES,
+    MAX_JSON_BYTES,
+    MAX_PAGE_BLOBS,
+    MAX_PAGE_STORE_BYTES,
+    PAGE_SIZE,
+    REPLICA_COUNT,
+    _validate_target_disclosures,
+    analyze_bundle,
+    assemble_bundle,
+    finalize_bundle,
+    validate_bundle,
+)
+from a4_spec import BOUNDS, EXPERIMENT_ID, PLAN_SHA256  # noqa: E402
+from a4_test_bundle import write_replica_trees  # noqa: E402
+from protocol_validation import ValidationError  # noqa: E402
+
+
+class A4BundleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(prefix="a4-hosted-")
+        cls.root = Path(cls.temporary.name)
+        cls.replica_roots, cls.campaign_id, cls.producer_commit = write_replica_trees(
+            cls.root / "source-replicas"
+        )
+        cls.bundle = cls.root / "bundle"
+        assemble_bundle(
+            cls.replica_roots[:2], cls.bundle, cls.campaign_id, cls.producer_commit
+        )
+        cls.holdout_root = cls.root / "downloaded-holdout"
+        copy_command = (
+            sys.executable,
+            "-c",
+            "import shutil,sys;shutil.copytree(sys.argv[1],sys.argv[2])",
+            str(cls.replica_roots[2]),
+            str(cls.holdout_root),
+        )
+        cls.analysis = analyze_bundle(
+            cls.bundle,
+            cls.holdout_root,
+            cls.campaign_id,
+            cls.producer_commit,
+            copy_command,
+        )
+        cls.manifest = finalize_bundle(
+            cls.bundle,
+            cls.campaign_id,
+            cls.producer_commit,
+            "2026-08-25T10:00:00Z",
+            created_utc="2026-08-25T10:45:00Z",
+        )
+        cls.validation = validate_bundle(
+            cls.bundle, cls.campaign_id, cls.producer_commit
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_fixed_bounds_match_the_checked_plan(self) -> None:
+        self.assertEqual(PAGE_SIZE, 2_048)
+        self.assertEqual(REPLICA_COUNT, 3)
+        self.assertEqual(DERIVATION_REPLICA_COUNT, 2)
+        self.assertEqual(CHECKPOINT_COUNT, 25)
+        self.assertEqual(MAX_JSON_BYTES, 67_108_864)
+        self.assertEqual(MAX_PAGE_BLOBS, 65_536)
+        self.assertEqual(MAX_PAGE_STORE_BYTES, 134_217_728)
+        self.assertEqual(MAX_BUNDLE_BYTES, 805_306_368)
+        self.assertEqual(BOUNDS["fan_in_timeout_seconds"], 900)
+
+    def test_holdout_is_materialized_only_after_frozen_bytes_exist(self) -> None:
+        self.assertTrue(self.holdout_root.is_dir())
+        candidate = self.bundle / "analysis/derivation-candidates.json"
+        receipt = json.loads(
+            (self.bundle / "analysis/holdout-structure-receipt.json").read_bytes()
+        )
+        self.assertEqual(receipt["derivation_candidate_set_sha256"],
+                         self.analysis["derivation_candidate_set_sha256"])
+        self.assertTrue(receipt["validated_after_candidate_freeze"])
+        self.assertFalse(receipt["page_bytes_exposed_to_analyzer"])
+        self.assertGreater(candidate.stat().st_size, 0)
+
+    def test_complete_bundle_is_closed_and_bound(self) -> None:
+        manifest = self.validation["manifest"]
+        self.assertEqual(manifest, self.manifest)
+        self.assertEqual(manifest["experiment_id"], EXPERIMENT_ID)
+        self.assertEqual(manifest["plan_sha256"], PLAN_SHA256)
+        self.assertEqual(manifest["revision_plan_sha256"], PLAN_SHA256)
+        self.assertEqual(manifest["checkpoint_count"], 75)
+        self.assertEqual(manifest["campaign_elapsed_seconds"], 2_700)
+        paths = {entry["path"] for entry in manifest["files"]}
+        self.assertIn("plan/a4-row-anchored-maps.plan.json", paths)
+        self.assertEqual(
+            len([path for path in paths if path.startswith("schema-snapshots/")]),
+            75,
+        )
+        discovered = {
+            path.relative_to(self.bundle).as_posix()
+            for path in self.bundle.rglob("*") if path.is_file()
+        }
+        self.assertEqual(discovered, paths | {"bundle-manifest.json"})
+
+    def test_manifest_translates_legacy_outcome_vocabulary_only_at_boundary(self) -> None:
+        report = json.loads(
+            (self.bundle / "analysis/analysis-report.json").read_bytes()
+        )
+        expected = (
+            "one_or_more_submodels_predict_holdout"
+            if report["scientific_outcome"] == "one_or_more_layers_predict_holdout"
+            else "no_submodel_predicts_holdout"
+        )
+        self.assertEqual(self.manifest["analysis_scientific_outcome"], expected)
+
+    def test_target_disclosures_use_t1_t3_t4_plan_baselines(self) -> None:
+        observation = self.validation["replicas"][0]
+        _validate_target_disclosures(observation)
+        changed = copy.deepcopy(observation)
+        checkpoint = next(
+            row for row in changed["checkpoints"]
+            if row["checkpoint_id"] == "T4_REL_0064"
+        )
+        checkpoint["target_baseline_pages"] += 1
+        with self.assertRaisesRegex(ValidationError, "target baseline"):
+            _validate_target_disclosures(changed)
+
+    def test_preexisting_holdout_is_rejected_before_analysis(self) -> None:
+        root = self.root / "preexisting-case"
+        roots, campaign, commit = write_replica_trees(root / "replicas")
+        bundle = root / "bundle"
+        assemble_bundle(roots[:2], bundle, campaign, commit)
+        preexisting = root / "holdout"
+        shutil.copytree(roots[2], preexisting)
+        with self.assertRaisesRegex(ValidationError, "existed before"):
+            analyze_bundle(bundle, preexisting, campaign, commit, (sys.executable, "-V"))
+
+    def test_producer_does_not_import_independent_validator(self) -> None:
+        for script in ("a4_bundle.py", "a4_holdout.py"):
+            source = (SCRIPTS / script).read_text(encoding="utf-8")
+            self.assertNotIn("a4_independent", source)
+            self.assertNotIn("os.environ", source)
+            self.assertNotIn("os.getenv", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_a4_powershell_contract.py
+++ b/oracle/windows-dao/tests/test_a4_powershell_contract.py
@@ -1,0 +1,128 @@
+"""Static contracts for the checked A4 PowerShell worker."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle/windows-dao/scripts"
+PLAN_PATH = ROOT / "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a4_spec import CHECKPOINT_IDS, EXPERIMENT_ID, PLAN_SHA256  # noqa: E402
+
+
+class A4PowerShellContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.plan = json.loads(PLAN_PATH.read_bytes())
+        cls.entry = (SCRIPTS / "run-a4-replica.ps1").read_text(encoding="utf-8")
+        cls.worker = (SCRIPTS / "a4/A4.Worker.ps1").read_text(encoding="utf-8")
+        cls.store = (SCRIPTS / "a4/A4.PageStore.ps1").read_text(encoding="utf-8")
+        cls.snapshot = (SCRIPTS / "a4/A4.SchemaSnapshot.ps1").read_text(
+            encoding="utf-8"
+        )
+        cls.progress = (SCRIPTS / "a4/A4.Progress.ps1").read_text(encoding="utf-8")
+
+    def test_identity_is_exact_and_contains_no_retired_a4_binding(self) -> None:
+        for source in (self.entry, self.worker):
+            self.assertIn(EXPERIMENT_ID, source)
+            self.assertIn(PLAN_SHA256, source)
+            self.assertIn("a4-row-anchored-maps.plan.json", source)
+            self.assertNotIn("DAO-A4-ALLOCATION-MAPS-001", source)
+            self.assertNotIn("a4-allocation-maps", source)
+        self.assertEqual(PLAN_SHA256, hashlib.sha256(PLAN_PATH.read_bytes()).hexdigest())
+
+    def test_schedule_and_role_binding_are_plan_derived(self) -> None:
+        self.assertIn("$Plan.checkpoint_design.checkpoint_ids", self.worker)
+        self.assertIn("$Plan.tables.logical_roles", self.worker)
+        self.assertIn("$Plan.tables.role_bindings", self.worker)
+        self.assertIn("checkpoint_operations.PSObject.Properties[$id]", self.worker)
+        self.assertIn("foreach ($value in @($script:A4Plan.checkpoint_design.checkpoint_ids))", self.worker)
+        self.assertEqual(tuple(self.plan["checkpoint_design"]["checkpoint_ids"]), CHECKPOINT_IDS)
+        self.assertEqual(self.plan["tables"]["logical_roles"], ["T1", "T2", "T3", "T4"])
+        for legacy in ('@("D", "L", "P", "H")', "d_growth_observation"):
+            self.assertNotIn(legacy, self.worker)
+
+    def test_dao_mutations_match_the_preregistered_call_shapes(self) -> None:
+        for token in (
+            ".CreateDatabase(",
+            ".CreateTableDef(",
+            ".CreateField(",
+            ".CreateIndex(",
+            ".AddNew()",
+            ".Update()",
+            ".Delete()",
+            "OpenRecordset($name, 2, 0)",
+        ):
+            self.assertIn(token, self.worker)
+        self.assertIn("$script:A4Locale = \";LANGID=0x0409;CP=1252;COUNTRY=0\"", self.worker)
+        for forbidden in ("BeginTrans", "CommitTrans", "Rollback", "CompactDatabase"):
+            self.assertNotIn(forbidden, self.worker)
+
+    def test_every_checkpoint_gets_read_only_schema_and_physical_capture(self) -> None:
+        capture = self.worker.index("function Add-A4Checkpoint")
+        schema = self.worker.index("Read-A4SchemaSnapshot", capture)
+        physical = self.worker.index("Read-A4PageSnapshot", schema)
+        self.assertLess(schema, physical)
+        self.assertIn("$script:A4Workspace.OpenDatabase(", self.snapshot)
+        self.assertIn('$script:A4DatabasePath, $false, $true, ""', self.snapshot)
+        self.assertIn("database_sha256_before_read", self.snapshot)
+        self.assertIn("database_sha256_after_read", self.snapshot)
+        self.assertIn("name_windows_1252_hex", self.snapshot)
+        self.assertIn("name_utf8_hex", self.snapshot)
+        self.assertIn("dao_schema_snapshot", self.worker)
+        self.assertIn("$schemaSnapshots -ne 25", self.worker)
+
+    def test_worker_bounds_match_the_frozen_plan(self) -> None:
+        for token in (
+            "max_final_pages_per_replica -ne 20480",
+            "max_inserted_rows_per_replica -ne 200000",
+            "max_unique_page_blobs -ne 65536",
+            "max_retained_page_store_bytes -ne 128MB",
+            "max_bundle_bytes -ne 768MB",
+            "worker_timeout_seconds_per_replica -ne 1700",
+        ):
+            self.assertIn(token, self.worker)
+        self.assertIn("$script:A1MaximumPagesPerReplica = 20480L", self.store)
+        self.assertIn("$script:A1MaximumPageStoreBytes = 128MB", self.store)
+        self.assertIn("-TimeoutSeconds 1700", self.entry)
+
+    def test_controller_requires_x86_dao_cp1252_and_clean_pushed_source(self) -> None:
+        for token in (
+            "x86 Windows PowerShell 5 Desktop",
+            'prog_id -cne "DAO.DBEngine.36"',
+            "windows_ansi_code_page =",
+            "GetACP()",
+            "GetOEMCP()",
+            "windows_ansi_code_page -ne 1252",
+            "Assert-A4ExactPushedCommit",
+            "status --porcelain=v1",
+            "Assert-M1CurrentRegistration",
+            "server_sha256",
+        ):
+            self.assertIn(token, self.entry + self.worker)
+
+    def test_output_inventory_includes_exact_schema_snapshot_tree(self) -> None:
+        self.assertIn('"schema-snapshots/$replicaId"', self.entry)
+        self.assertIn('"schema-snapshots/replica-{0:D2}"', self.entry)
+        self.assertIn("DAO schema-snapshot validation", self.entry)
+        self.assertIn("unmanifested DAO schema snapshot", self.entry)
+        self.assertIn("dao-schema-snapshot.schema.json", self.entry)
+        self.assertIn("A4.SchemaSnapshot.ps1", self.entry)
+
+    def test_progress_and_failure_artifacts_are_bounded(self) -> None:
+        self.assertIn("Set-StrictMode -Version Latest", self.progress)
+        self.assertIn("Write-A4Failure", self.entry)
+        self.assertIn("$text.Length -gt 4000", self.entry)
+        self.assertIn("MaximumOutputBytes 1MB", self.entry)
+        self.assertIn("failed-replica-{0:D2}.mdb", self.entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_windows_dao_a4_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_a4_workflow.py
@@ -1,0 +1,147 @@
+"""Fail-closed source contract for the manual DAO A4 workflow."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github/workflows/windows-dao-a4.yml"
+SCRIPTS = ROOT / "oracle/windows-dao/scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from a4_spec import BOUNDS, EXPERIMENT_ID, PLAN_SHA256  # noqa: E402
+
+
+class WindowsDaoA4WorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.contract, remainder = cls.workflow.split("  a4-replica:", 1)
+        cls.replica, cls.fan_in = remainder.split("  fan-in:", 1)
+
+    def test_dispatch_is_manual_read_only_and_default_denied(self) -> None:
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertIn("execute_a4_campaign:", self.workflow)
+        self.assertIn("type: boolean", self.workflow)
+        self.assertIn("default: false", self.workflow)
+        for trigger in ("push:", "pull_request:", "schedule:"):
+            self.assertNotIn(trigger, self.workflow)
+        permissions = self.workflow.split("permissions:", 1)[1].split(
+            "concurrency:", 1
+        )[0]
+        self.assertEqual(
+            {line.strip() for line in permissions.splitlines() if line.strip()},
+            {"actions: read", "contents: read"},
+        )
+        self.assertIn("cancel-in-progress: false", self.workflow)
+
+    def test_jobs_and_timeouts_match_the_frozen_plan(self) -> None:
+        self.assertEqual(self.workflow.count("runs-on: windows-2022"), 3)
+        self.assertIn("timeout-minutes: 15", self.contract)
+        self.assertIn("timeout-minutes: 37", self.replica)
+        self.assertEqual(
+            int(re.search(r"timeout-minutes: (\d+)", self.fan_in).group(1)) * 60,
+            BOUNDS["fan_in_timeout_seconds"],
+        )
+        self.assertIn("replica: [1, 2, 3]", self.replica)
+        self.assertIn("max-parallel: 3", self.replica)
+        self.assertIn("fail-fast: false", self.replica)
+        for section in (self.replica, self.fan_in):
+            self.assertIn(f'FROZEN_PLAN_SHA256: "{PLAN_SHA256}"', section)
+            self.assertIn(f'FROZEN_REVISION_PLAN_SHA256: "{PLAN_SHA256}"', section)
+        self.assertIn('FROZEN_CAMPAIGN_TIMEOUT_SECONDS: "2700"', self.workflow)
+
+    def test_contract_and_worker_are_bound_to_row_anchored_a4(self) -> None:
+        self.assertEqual(
+            self.workflow.count(
+                "oracle/windows-dao/experiments/a4/a4-row-anchored-maps.plan.json"
+            ),
+            2,
+        )
+        self.assertIn(f'experiment_id -cne "{EXPERIMENT_ID}"', self.contract)
+        self.assertNotIn("a4-allocation-maps", self.workflow)
+        self.assertNotIn("DAO-A4-ALLOCATION-MAPS", self.workflow)
+        self.assertIn("test_a4_powershell_contract.py", self.contract)
+        self.assertIn("test_windows_dao_a4_workflow.py", self.contract)
+        self.assertIn("ParseFile", self.contract)
+        self.assertIn('"SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"', self.replica)
+        self.assertIn("WaitForExit(1000)", self.replica)
+        self.assertIn("Stop-Jet3BootstrapProcessTree", self.replica)
+
+    def test_exact_clean_pushed_main_commit_is_required(self) -> None:
+        self.assertIn('$env:GITHUB_REPOSITORY -cne "oglassdev/jet3-rs"', self.replica)
+        self.assertIn("git ls-remote --exit-code origin refs/heads/main", self.replica)
+        self.assertIn("$head -cne $env:GITHUB_SHA", self.replica)
+        self.assertGreaterEqual(
+            self.workflow.count("status --porcelain=v1 --untracked-files=all"), 2
+        )
+        gate = (
+            r"github\.event_name == 'workflow_dispatch' &&\s+"
+            r"github\.ref == 'refs/heads/main' &&\s+"
+            r"inputs\.execute_a4_campaign"
+        )
+        self.assertRegex(self.replica, gate)
+        self.assertRegex(self.fan_in, gate)
+
+    def test_fan_in_materializes_holdout_inside_lazy_analyzer_callback(self) -> None:
+        self.assertEqual(self.fan_in.count("Download-A4Artifact.ps1"), 3)
+        assemble = self.fan_in.index("a4_bundle.py assemble")
+        analyze = self.fan_in.index("a4_bundle.py analyze", assemble)
+        finalize = self.fan_in.index("a4_bundle.py finalize", analyze)
+        validate = self.fan_in.index("a4_bundle.py validate", finalize)
+        independent = self.fan_in.index("a4_independent_validator.py", validate)
+        self.assertLess(assemble, analyze)
+        self.assertLess(analyze, finalize)
+        self.assertLess(finalize, validate)
+        self.assertLess(validate, independent)
+        self.assertEqual(self.fan_in.count("--replica-root"), 2)
+        self.assertIn("--holdout-command-executable", self.fan_in)
+        self.assertIn("--holdout-command-argument=windows-dao-a4-replica-3", self.fan_in)
+        self.assertNotIn("--freeze-only", self.workflow)
+        self.assertNotIn("--resume", self.workflow)
+        bundle_source = (SCRIPTS / "a4_bundle.py").read_text(encoding="utf-8")
+        freeze = bundle_source.index('with candidate_path.open("xb")')
+        materialize = bundle_source.index("subprocess.run(", freeze)
+        provider = bundle_source.index("run_holdout_process(", materialize)
+        self.assertLess(freeze, materialize)
+        self.assertLess(materialize, provider)
+
+    def test_independent_validator_is_a_separate_process_and_report(self) -> None:
+        step = self.fan_in.split(
+            "      - name: Independently recompute the retained A4 bundle", 1
+        )[1].split("      - name: Record retained A4 fan-in status", 1)[0]
+        self.assertIn("id: independent", step)
+        self.assertIn("--validator-commit $env:GITHUB_SHA", step)
+        self.assertIn("--output $report", step)
+        self.assertNotIn("--plan", step)
+        self.assertNotIn("--revision", step)
+        self.assertNotIn("jet3-a4-bundle\\validation", step)
+
+    def test_retention_and_campaign_timing_are_fail_closed(self) -> None:
+        self.assertIn("campaign-start.json", self.fan_in)
+        self.assertIn("campaign_elapsed_seconds", self.fan_in)
+        self.assertIn("if (-not $withinPlan)", self.fan_in)
+        self.assertIn("fan-in-status.json", self.fan_in)
+        self.assertIn("if: success()", self.fan_in.split(
+            "Upload retained A4 bundle", 1
+        )[1].split("Upload bounded A4 fan-in diagnostics", 1)[0])
+        diagnostics = self.fan_in.split(
+            "Upload bounded A4 fan-in diagnostics", 1
+        )[1]
+        self.assertIn("if: always()", diagnostics)
+        self.assertIn("retention-days: 14", diagnostics)
+
+    def test_all_actions_are_commit_pinned(self) -> None:
+        actions = re.findall(r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE)
+        self.assertEqual(len(actions), 10)
+        for action in actions:
+            self.assertRegex(action, r"^[^@]+@[0-9a-f]{40}$")
+        self.assertEqual(self.workflow.count("persist-credentials: false"), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A4 had checked analyzer/generator and independent-validator implementations, but no hosted path capable of producing plan-bound replicas without exposing the holdout before the derivation freeze. This adds that missing P1 execution lane while keeping actual acquisition default-denied.

The manual workflow now runs three isolated Windows Server 2022 DAO workers, captures a canonical read-only schema snapshot at every checkpoint, and assembles replicas 1/2 before a lazy callback downloads and separately validates replica 3. Producer fan-in and independent recomputation remain separate processes, all inputs and retained bytes are bounded/link-safe, GetACP must be 1252, and failed jobs cannot publish a successful evidence artifact.

No DAO campaign is dispatched by this PR, no capability is advanced, and no immutable plan or provenance history is changed.

Validation:
- `mise exec -- just ready`
- `mise exec -- python -m unittest discover -s oracle/windows-dao/tests -p 'test_a4*.py'` (219 passed, 1 skipped)
- `mise exec -- python -m unittest oracle.windows-dao.tests.test_windows_dao_a4_workflow`
