### PR TITLE
ci: cut PR oracle checks from an hour to minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   changes:
     name: Detect heavy-job paths
@@ -142,12 +146,31 @@ jobs:
         run: python3 tools/validate_g6_evidence.py inventory
       - name: Test validation and acceptance tooling
         run: python3 -m unittest discover -s tools/tests -v
-      - name: Validate DAO oracle protocol without claiming provider coverage
-        run: |
-          python3 oracle/windows-dao/scripts/validate_protocol.py schemas
-          python3 -m unittest discover -s oracle/windows-dao/tests -v
+      - name: Validate DAO oracle schemas without claiming provider coverage
+        run: python3 oracle/windows-dao/scripts/validate_protocol.py schemas
       - name: Reconcile checked test inventory with Rust tests
         run: python3 tools/reconcile_tests.py --repo-root "$GITHUB_WORKSPACE"
+
+  oracle-contracts:
+    name: Portable oracle contracts (${{ matrix.shard }})
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.oracle == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Exercise one deterministic portable oracle shard
+        run: >-
+          python3 oracle/windows-dao/scripts/run_contract_tests.py
+          portable-shard --shard-index ${{ matrix.shard }} --shard-count 4
 
   g6-coverage:
     name: Exact-commit G6 coverage evidence
@@ -202,7 +225,12 @@ jobs:
           python-version: "3.13"
       - name: Validate DAO oracle schemas
         run: python oracle/windows-dao/scripts/validate_protocol.py schemas
-      - name: Exercise Windows-only oracle and process contracts
+      - name: Exercise focused Windows and process contracts on pull requests
+        if: github.event_name == 'pull_request'
+        run: >-
+          python oracle/windows-dao/scripts/run_contract_tests.py windows-pr
+      - name: Exercise the complete Windows oracle contract after merge
+        if: github.event_name == 'push'
         run: python -m unittest discover -s oracle/windows-dao/tests -v
       - name: Exercise Windows release-evidence contracts
         if: always()

--- a/oracle/windows-dao/scripts/run_contract_tests.py
+++ b/oracle/windows-dao/scripts/run_contract_tests.py
@@ -66,6 +66,7 @@ WINDOWS_PR_MODULES = frozenset(
         "test_m4_phase_contract",
         "test_m4r1_powershell_contract",
         "test_m5_powershell_contract",
+        "test_validate_protocol",
         "test_windows_dao_a3_workflow",
         "test_windows_dao_a4_workflow",
         "test_windows_dao_hosted_workflow",

--- a/oracle/windows-dao/scripts/run_contract_tests.py
+++ b/oracle/windows-dao/scripts/run_contract_tests.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Run the DAO contract suite in deterministic CI lanes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+TEST_ROOT = ROOT / "oracle" / "windows-dao" / "tests"
+FOUR_SHARD_COUNT = 4
+
+# These modules account for nearly all portable-suite runtime. Keeping the
+# measured heavy modules explicit makes the four CI lanes predictably balanced;
+# every other module is assigned by a stable hash.
+FOUR_SHARD_OVERRIDES = {
+    "test_a4_independent_campaign": 0,
+    "test_a4_terminals": 0,
+    "test_a4_frozen_projection": 0,
+    "test_a4_manifest_closure": 0,
+    "test_a4_predicate_major": 0,
+    "test_a4_independent_h1_h2": 0,
+    "test_a4_bundle": 1,
+    "test_a4_independent_validator": 1,
+    "test_a3_independent_validator": 1,
+    "test_a3_dryrun": 1,
+    "test_a4_generator": 1,
+    "test_m4r1_bundle_integration": 1,
+    "test_a4_analyzer": 2,
+    "test_a4_independent_terminal_paths": 2,
+    "test_a4_campaign_semantics": 2,
+    "test_m4_bundle_integration": 2,
+    "test_a4_catalog_accounting": 2,
+    "test_a4_measurements": 2,
+    "test_a4_independent_bundle": 3,
+    "test_a4_dryrun": 3,
+    "test_a4_independent_h3_h4": 3,
+    "test_a3_bundle": 3,
+    "test_a4_frozen_terminal": 3,
+    "test_m3_contract": 3,
+    "test_m5_contract": 3,
+}
+
+# PRs exercise modules whose behavior depends on Windows or PowerShell. The
+# complete suite still runs on Windows after merge, while every portable module
+# runs in the Linux shards before merge.
+WINDOWS_PR_MODULES = frozenset(
+    {
+        "test_a3_powershell_contract",
+        "test_a4_powershell_contract",
+        "test_bounded_process_contract",
+        "test_m1_dao_adapter",
+        "test_m1_executor_preflight",
+        "test_m1_preflight_contract",
+        "test_m1_publication",
+        "test_m1_runner_contract",
+        "test_m3_contract",
+        "test_m4_clone_contract",
+        "test_m4_contract",
+        "test_m4_controller_contract",
+        "test_m4_phase_contract",
+        "test_m4r1_powershell_contract",
+        "test_m5_powershell_contract",
+        "test_windows_dao_a3_workflow",
+        "test_windows_dao_a4_workflow",
+        "test_windows_dao_hosted_workflow",
+        "test_windows_dao_ssh_contract",
+    }
+)
+
+
+def iter_cases(suite: unittest.TestSuite) -> Iterator[unittest.TestCase]:
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            yield from iter_cases(item)
+        else:
+            yield item
+
+
+def discover_cases() -> tuple[unittest.TestCase, ...]:
+    sys.path.insert(0, str(TEST_ROOT))
+    try:
+        suite = unittest.defaultTestLoader.discover(
+            str(TEST_ROOT), pattern="test_*.py", top_level_dir=str(TEST_ROOT)
+        )
+        return tuple(iter_cases(suite))
+    finally:
+        sys.path.pop(0)
+
+
+def module_name(case: unittest.TestCase) -> str:
+    return case.id().split(".", maxsplit=1)[0]
+
+
+def shard_for_module(module: str, shard_count: int) -> int:
+    if shard_count < 1:
+        raise ValueError("shard count must be positive")
+    if shard_count == FOUR_SHARD_COUNT and module in FOUR_SHARD_OVERRIDES:
+        return FOUR_SHARD_OVERRIDES[module]
+    digest = hashlib.sha256(module.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % shard_count
+
+
+def discovered_modules(cases: tuple[unittest.TestCase, ...]) -> frozenset[str]:
+    return frozenset(module_name(case) for case in cases)
+
+
+def validate_inventory(cases: tuple[unittest.TestCase, ...]) -> None:
+    if not cases:
+        raise RuntimeError("DAO contract discovery found no tests")
+    modules = discovered_modules(cases)
+    missing_overrides = FOUR_SHARD_OVERRIDES.keys() - modules
+    missing_windows = WINDOWS_PR_MODULES - modules
+    if missing_overrides:
+        raise RuntimeError(
+            "portable shard overrides name missing modules: "
+            + ", ".join(sorted(missing_overrides))
+        )
+    if missing_windows:
+        raise RuntimeError(
+            "Windows PR inventory names missing modules: "
+            + ", ".join(sorted(missing_windows))
+        )
+
+
+def selected_cases(
+    cases: tuple[unittest.TestCase, ...],
+    *,
+    lane: str,
+    shard_index: int | None,
+    shard_count: int | None,
+) -> tuple[unittest.TestCase, ...]:
+    validate_inventory(cases)
+    if lane == "windows-pr":
+        return tuple(case for case in cases if module_name(case) in WINDOWS_PR_MODULES)
+    if shard_index is None or shard_count is None:
+        raise ValueError("portable lane requires a shard index and count")
+    if shard_count < 1 or not 0 <= shard_index < shard_count:
+        raise ValueError("portable shard index is outside the configured count")
+    return tuple(
+        case
+        for case in cases
+        if shard_for_module(module_name(case), shard_count) == shard_index
+    )
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="lane", required=True)
+    portable = subparsers.add_parser("portable-shard")
+    portable.add_argument("--shard-index", type=int, required=True)
+    portable.add_argument("--shard-count", type=int, default=FOUR_SHARD_COUNT)
+    subparsers.add_parser("windows-pr")
+    return parser
+
+
+def main() -> int:
+    args = argument_parser().parse_args()
+    cases = discover_cases()
+    selected = selected_cases(
+        cases,
+        lane=args.lane,
+        shard_index=getattr(args, "shard_index", None),
+        shard_count=getattr(args, "shard_count", None),
+    )
+    if not selected:
+        raise RuntimeError(f"{args.lane} selected no DAO contract tests")
+    modules = discovered_modules(selected)
+    print(
+        f"DAO contract lane {args.lane}: "
+        f"{len(selected)} tests across {len(modules)} modules"
+    )
+    result = unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite(selected))
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/tests/test_contract_test_runner.py
+++ b/oracle/windows-dao/tests/test_contract_test_runner.py
@@ -40,7 +40,14 @@ class ContractTestRunnerTests(unittest.TestCase):
         self.assertLessEqual(set(RUNNER.WINDOWS_PR_MODULES), self.modules)
 
     def test_windows_inventory_covers_every_platform_sensitive_module(self) -> None:
-        markers = ("POWERSHELL", "PowerShell", "os.name", "sys.platform")
+        markers = (
+            "POWERSHELL",
+            "PowerShell",
+            "os.name",
+            "sys.platform",
+            'shutil.which("pwsh")',
+            'shutil.which("powershell")',
+        )
         marked_modules = {
             path.stem
             for path in RUNNER.TEST_ROOT.glob("test_*.py")
@@ -59,6 +66,7 @@ class ContractTestRunnerTests(unittest.TestCase):
         modules = RUNNER.discovered_modules(selected)
         self.assertEqual(modules, RUNNER.WINDOWS_PR_MODULES)
         self.assertIn("test_bounded_process_contract", modules)
+        self.assertIn("test_validate_protocol", modules)
         self.assertNotIn("test_a4_independent_campaign", modules)
 
     def test_nonstandard_shard_counts_use_stable_hash_routing(self) -> None:

--- a/oracle/windows-dao/tests/test_contract_test_runner.py
+++ b/oracle/windows-dao/tests/test_contract_test_runner.py
@@ -1,0 +1,75 @@
+"""Contracts for deterministic DAO test routing in CI."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+RUNNER_PATH = ROOT / "oracle" / "windows-dao" / "scripts" / "run_contract_tests.py"
+SPEC = importlib.util.spec_from_file_location("run_contract_tests", RUNNER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+RUNNER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RUNNER)
+
+
+class ContractTestRunnerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cases = RUNNER.discover_cases()
+        cls.modules = RUNNER.discovered_modules(cls.cases)
+
+    def test_four_portable_shards_partition_every_discovered_test(self) -> None:
+        routed_ids: list[str] = []
+        for shard_index in range(RUNNER.FOUR_SHARD_COUNT):
+            selected = RUNNER.selected_cases(
+                self.cases,
+                lane="portable-shard",
+                shard_index=shard_index,
+                shard_count=RUNNER.FOUR_SHARD_COUNT,
+            )
+            self.assertTrue(selected)
+            routed_ids.extend(case.id() for case in selected)
+        self.assertEqual(len(routed_ids), len(self.cases))
+        self.assertEqual(len(set(routed_ids)), len(self.cases))
+
+    def test_curated_inventories_name_discovered_modules(self) -> None:
+        self.assertLessEqual(set(RUNNER.FOUR_SHARD_OVERRIDES), self.modules)
+        self.assertLessEqual(set(RUNNER.WINDOWS_PR_MODULES), self.modules)
+
+    def test_windows_inventory_covers_every_platform_sensitive_module(self) -> None:
+        markers = ("POWERSHELL", "PowerShell", "os.name", "sys.platform")
+        marked_modules = {
+            path.stem
+            for path in RUNNER.TEST_ROOT.glob("test_*.py")
+            if path != Path(__file__)
+            if any(marker in path.read_text(encoding="utf-8") for marker in markers)
+        }
+        self.assertLessEqual(marked_modules, RUNNER.WINDOWS_PR_MODULES)
+
+    def test_windows_lane_includes_platform_contracts_not_heavy_portable_work(self) -> None:
+        selected = RUNNER.selected_cases(
+            self.cases,
+            lane="windows-pr",
+            shard_index=None,
+            shard_count=None,
+        )
+        modules = RUNNER.discovered_modules(selected)
+        self.assertEqual(modules, RUNNER.WINDOWS_PR_MODULES)
+        self.assertIn("test_bounded_process_contract", modules)
+        self.assertNotIn("test_a4_independent_campaign", modules)
+
+    def test_nonstandard_shard_counts_use_stable_hash_routing(self) -> None:
+        module = "test_future_contract"
+        self.assertEqual(
+            RUNNER.shard_for_module(module, 3),
+            RUNNER.shard_for_module(module, 3),
+        )
+        with self.assertRaises(ValueError):
+            RUNNER.shard_for_module(module, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_ci_oracle_lanes.py
+++ b/tools/tests/test_ci_oracle_lanes.py
@@ -1,0 +1,54 @@
+"""Static coverage contracts for the pull-request oracle CI lanes."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class CiOracleLaneTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_superseded_pull_request_runs_cancel_without_cancelling_main(self) -> None:
+        self.assertIn(
+            "group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+            self.workflow,
+        )
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            self.workflow,
+        )
+
+    def test_portable_contracts_run_once_across_four_shards(self) -> None:
+        self.assertIn("shard: [0, 1, 2, 3]", self.workflow)
+        self.assertIn(
+            "portable-shard --shard-index ${{ matrix.shard }} --shard-count 4",
+            self.workflow,
+        )
+        self.assertNotIn(
+            "python3 -m unittest discover -s oracle/windows-dao/tests -v",
+            self.workflow,
+        )
+
+    def test_windows_pr_is_focused_and_main_retains_complete_replay(self) -> None:
+        self.assertIn(
+            "python oracle/windows-dao/scripts/run_contract_tests.py windows-pr",
+            self.workflow,
+        )
+        self.assertEqual(
+            self.workflow.count(
+                "python -m unittest discover -s oracle/windows-dao/tests -v"
+            ),
+            1,
+        )
+        self.assertIn("if: github.event_name == 'push'", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Oracle-related pull requests currently wait close to an hour even though most of that time is the same portable Python contract suite running serially on both Linux and Windows. This keeps the contract coverage while moving PR feedback onto focused, parallel lanes.

The portable oracle suite is partitioned exactly once across four deterministic Linux shards, with the measured heavy modules balanced explicitly and all other modules assigned by a stable hash. Pull requests run a conservative inventory of Windows- and PowerShell-sensitive modules on Windows; pushes to `main` retain the complete Windows replay. Superseded pull-request runs now cancel automatically without cancelling `main` runs.

Hosted PR verification at `9cdbbce` completed successfully in 5m23s after Actions started the run:

- validation contracts: 39s, previously 21m01s
- Windows oracle and bounded-process contracts: 2m53s, previously 57m20s
- four portable oracle shards: 3m40s–5m11s, covering 727 tests exactly once
- all 17 resulting checks passed

Focused local verification:

- complete portable oracle suite: 727 tests across four shards, all passed; 2m41s local wall-clock
- focused Windows selection on Linux: 282 tests passed or platform-skipped in 7.4s
- validation tooling: 309 tests passed
- runner and workflow coverage contracts: passed
- DAO protocol schemas, repository contract, support matrix, source-size policy, and diff checks: passed

This is CI-only preparation for the next implementation slice in #75. It does not alter product behavior, evidence status, preregistered campaigns, or release claims.
