### PR TITLE
docs: advance implemented index capabilities

### DIFF
--- a/docs/validation/support-matrix.json
+++ b/docs/validation/support-matrix.json
@@ -147,19 +147,29 @@
     },
     {
       "id": "indexes.primary_unique_non_unique",
-      "implementation": "partial",
+      "implementation": "implemented",
       "verification": "internal_only",
       "evidence": [
         "crates/jet3/src/index_definition.rs",
+        "crates/jet3/src/physical_index_definition.rs",
+        "crates/jet3/src/index_tree.rs",
+        "crates/jet3/src/index_tree_page.rs",
+        "crates/jet3/src/index_tree_rows.rs",
+        "crates/jet3/src/index_tree_tests.rs",
         "crates/jet3/src/table_definition_tests.rs"
       ]
     },
     {
       "id": "indexes.composite_ascending_descending",
-      "implementation": "partial",
+      "implementation": "implemented",
       "verification": "internal_only",
       "evidence": [
         "crates/jet3/src/index_definition.rs",
+        "crates/jet3/src/physical_index_definition.rs",
+        "crates/jet3/src/index_tree.rs",
+        "crates/jet3/src/index_tree_page.rs",
+        "crates/jet3/src/index_tree_rows.rs",
+        "crates/jet3/src/index_tree_tests.rs",
         "crates/jet3/src/table_definition_tests.rs"
       ]
     },


### PR DESCRIPTION
Index-tree traversal has been implemented since #91, but the support matrix still described primary, unique, non-unique, composite, and descending indexes as partial. This updates their implementation state and points at the index-tree implementation and tests. Verification remains internal-only until the DAO read differential.

Checks:
- `python3 tools/validate_contract.py`
- `python3 -m unittest discover -s tools/tests -v`
- `git diff --check`

Closes #96