### PR TITLE
feat(oracle): prepare DAO read differential

### DIFF
--- a/.github/workflows/windows-dao-hosted.yml
+++ b/.github/workflows/windows-dao-hosted.yml
@@ -1,4 +1,4 @@
-name: Windows DAO hosted probe
+name: Windows DAO read differential
 
 on:
   workflow_dispatch:
@@ -8,6 +8,20 @@ on:
         required: true
         type: boolean
         default: false
+      run_acquisition:
+        description: Run the preregistered protocol 1.2 read acquisition
+        required: true
+        type: boolean
+        default: false
+      approve_acquisition:
+        description: Approve the single preregistered DAO acquisition
+        required: true
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the reviewed acquisition plan
+        required: false
+        type: string
   push:
     branches:
       - codex/windows-dao-hosted-probe
@@ -16,20 +30,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: windows-dao-hosted-probe-${{ github.ref }}
+  group: windows-dao-read-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   provider-probe:
-    name: Probe x86 DAO (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - windows-2025
-          - windows-2022
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    name: Probe x86 DAO and optionally acquire
+    runs-on: windows-2022
+    timeout-minutes: 240
     env:
       ODT_URL: https://download.microsoft.com/download/6c1eeb25-cf8b-41d9-8d0d-cc1dbc032140/officedeploymenttool_20228-20124.exe
       ODT_SHA256: 92a3cbd56191533e36bde1c6e4640883c900c00d1b5d43a974c870893681e0d4
@@ -38,6 +46,30 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify preregistration and human approval
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          APPROVED: ${{ inputs.approve_acquisition }}
+          EXPECTED_PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:APPROVED -cne "true") {
+            throw "The DAO acquisition requires explicit human approval."
+          }
+          if ($env:EXPECTED_PLAN_SHA256 -cnotmatch "^[0-9a-f]{64}$") {
+            throw "The reviewed plan SHA-256 is required."
+          }
+          $plan = "oracle/windows-dao/acquisition/read-v1_2.plan.json"
+          $actual = (Get-FileHash -LiteralPath $plan -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -cne $env:EXPECTED_PLAN_SHA256) {
+            throw "The checked-in acquisition plan does not match the approved digest."
+          }
+          python oracle/windows-dao/scripts/dao_read_diff.py plan $plan .
+          if ($LASTEXITCODE -ne 0) {
+            throw "The acquisition plan inputs do not match their pinned digests."
+          }
 
       - name: Record runner identity
         shell: powershell
@@ -50,7 +82,7 @@ jobs:
             github_sha = $env:GITHUB_SHA
             github_run_id = $env:GITHUB_RUN_ID
             github_run_attempt = $env:GITHUB_RUN_ATTEMPT
-            requested_image = "${{ matrix.os }}"
+            requested_image = "windows-2022"
             image_os = $env:ImageOS
             image_version = $env:ImageVersion
             windows_version = [Environment]::OSVersion.VersionString
@@ -80,7 +112,7 @@ jobs:
               "-NoLogo", "-NoProfile", "-NonInteractive",
               "-ExecutionPolicy", "Bypass",
               "-File", "oracle/windows-dao/scripts/probe-provider.ps1",
-              "-ProtocolVersion", "1.1.0", "-OutputPath", $output
+              "-ProtocolVersion", "1.2.0", "-OutputPath", $output
             ) `
             -Label "Stock DAO provider probe" `
             -TimeoutSeconds 120 -MaximumOutputBytes 1MB
@@ -229,7 +261,7 @@ jobs:
               "-NoLogo", "-NoProfile", "-NonInteractive",
               "-ExecutionPolicy", "Bypass",
               "-File", "oracle/windows-dao/scripts/probe-provider.ps1",
-              "-ProtocolVersion", "1.1.0", "-OutputPath", $output
+              "-ProtocolVersion", "1.2.0", "-OutputPath", $output
             ) `
             -Label "Installed DAO provider probe" `
             -TimeoutSeconds 120 -MaximumOutputBytes 1MB
@@ -251,6 +283,42 @@ jobs:
           "artifacts/dao-hosted-probe/environment-stock.json"
           -Destination "artifacts/dao-hosted-probe/environment.json"
 
+      - name: Build the Rust snapshot producer
+        if: inputs.run_acquisition
+        shell: powershell
+        run: cargo build --locked --release -p jet3-cli
+
+      - name: Acquire the DAO scenario databases and snapshots
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $x86PowerShell = Join-Path $env:WINDIR `
+            "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+          $output = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-read-v1_2"
+          & $x86PowerShell -NoLogo -NoProfile -NonInteractive `
+            -ExecutionPolicy Bypass `
+            -File "oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1" `
+            -InventoryPath "oracle/windows-dao/protocol/v1_2/scenarios.json" `
+            -EnvironmentPath "artifacts/dao-hosted-probe/environment.json" `
+            -OutputRoot $output `
+            -SourceRevision $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) {
+            throw "The DAO producer failed with exit $LASTEXITCODE."
+          }
+
+      - name: Evaluate every DAO and Rust artifact pair
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_read_diff.py evaluate `
+            artifacts/dao-read-v1_2/dao-manifest.raw.json `
+            artifacts/dao-read-v1_2 `
+            target/release/jet3-cli.exe `
+            oracle/windows-dao/protocol/v1_2/scenarios.json `
+            $env:GITHUB_SHA `
+            artifacts/dao-read-v1_2/report.json
+
       - name: Summarize the provider result
         if: always()
         shell: powershell
@@ -260,7 +328,7 @@ jobs:
           $summary = @(
             "## Windows DAO hosted probe",
             "",
-            "- Image: ``${{ matrix.os }}`` / ``$env:ImageVersion``",
+            "- Image: ``windows-2022`` / ``$env:ImageVersion``",
             "- Commit: ``$env:GITHUB_SHA``",
             "- Probe exit: ``$env:PROBE_EXIT_CODE``"
           )
@@ -280,8 +348,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: windows-dao-hosted-${{ matrix.os }}-${{ github.sha }}-${{ github.run_attempt }}
-          path: artifacts/dao-hosted-probe
+          name: windows-dao-read-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
           if-no-files-found: error
           retention-days: 14
 

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -44,5 +44,6 @@ delivered in this order:
 
 ## Current next step
 
-Run the DAO read differential tracked in #98, using the protocol-v1.2
-inventory and the lean Rust snapshot adapter.
+Review and approve the SHA-256-pinned #98 acquisition plan, then run the DAO
+read differential once. The producer, evaluator, hosted workflow, and
+non-evidentiary synthetic dry run are ready.

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -8,9 +8,11 @@ The retained tooling has three purposes:
 - `protocol/v1_2/` defines the shared read scenario and snapshot contract.
 - `scripts/dev/` plus `scripts/windows-dao-dev.py` support private exploratory
   runs in the local Windows VM described by `docs/LOCAL_WINDOWS_VM.md`.
-- `.github/workflows/windows-dao-hosted.yml` proves that a hosted Windows
-  runner can provide the required x86 DAO environment. A preregistered
-  differential or allocation experiment adds its own minimal producer.
+- `scripts/Invoke-DaoReadV12.ps1` is the bounded DAO producer for #98;
+  `scripts/dao_read_diff.py` canonicalizes, validates, and compares its output.
+- `.github/workflows/windows-dao-hosted.yml` probes the x86 DAO environment
+  and, only when explicitly approved against the pinned plan, runs the single
+  protocol-v1.2 acquisition.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.
@@ -22,10 +24,30 @@ python3 -B oracle/windows-dao/scripts/build_v1_2_inventory.py --check
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py schemas
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py inventory \
   oracle/windows-dao/protocol/v1_2/scenarios.json
+python3 -B oracle/windows-dao/scripts/dao_read_diff.py plan \
+  oracle/windows-dao/acquisition/read-v1_2.plan.json .
+python3 -B oracle/windows-dao/scripts/dao_read_diff.py synthetic-dry-run \
+  /tmp/jet3-dao-read-dry-run.json
 python3 -B -m unittest discover -s oracle/windows-dao/tests -v
 ```
 
 These checks execute no DAO operation and make no compatibility claim.
+The committed `acquisition/read-v1_2.synthetic.json` is the reproducible output
+of the synthetic command; it proves only that the comparison harness accepts a
+match and rejects a controlled mismatch.
+
+## Hosted acquisition
+
+`oracle/windows-dao/acquisition/read-v1_2.plan.json` pins the inventory,
+producer, evaluator, validator, workflow, and Rust dependency lock. The
+workflow rejects acquisition before its first DAO mutation unless all three
+manual inputs are supplied: `run_acquisition=true`,
+`approve_acquisition=true`, and the exact lowercase SHA-256 of that plan.
+
+One accepted run must cover all 98 scenarios. The evaluator checks every MDB
+digest, Rust coverage verdict, snapshot pair, and comparison projection before
+writing `report.json`. The artifact upload may contain MDB bytes for review,
+but those bytes and provider binaries are never committed.
 
 ## Experiment discipline
 

--- a/oracle/windows-dao/acquisition/read-v1_2.plan.json
+++ b/oracle/windows-dao/acquisition/read-v1_2.plan.json
@@ -1,0 +1,47 @@
+{
+  "document_type": "dao_read_acquisition_plan",
+  "protocol_version": "1.2.0",
+  "issue": 98,
+  "purpose": "Run the single hosted DAO-versus-Rust read differential required for v1 verification.",
+  "inputs": {
+    ".github/workflows/windows-dao-hosted.yml": "a436f4b849031c39d94f7bab3d4acc5684300ad812d265f588d455216e8d3881",
+    "Cargo.lock": "eb8c67b84f06190369a8de28efe2a1fabdd37b2abf894989a9b076d8fe1ba3c0",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "oracle/windows-dao/protocol/v1_2/scenarios.json": "b418ebee090d2b6112ee72f5d75fef3b03a21a4008afa9edceb02bcd41a621ef",
+    "oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1": "262db0c5d08b6a41469f336029f5a20e8b306898204255f06aadc725f56968d4",
+    "oracle/windows-dao/scripts/dao_read_diff.py": "696e3b8192fc8b110b020e00dfdcbf479bd3ca3f83648b7c5a1bb17c4a017d26",
+    "oracle/windows-dao/scripts/validate_protocol_v1_2.py": "5e822535a7b66ecafd8f8f62edf2601d23d53e4b5afe0e9e00d0cb790f4415b9",
+    "rust-toolchain.toml": "fa0addad5676243d360310f981a69528b0341d295cb5012253d9721aba4d30c0"
+  },
+  "source_trees": {
+    "crates/jet3": "ac9e5760031098e0160a85cab47dca02b2ceddd2be7377b8cdd22ec919ba284c",
+    "crates/jet3-cli": "8920ad6aef637ebe49fb07cb04f05754229e75bf2f09ae472c6de3b9d61c2296",
+    "crates/jet3-testkit": "ee0b226d16c2c2c5e58756f0e05670bf1c311d8911c3e87d45f50e39a2706ae3"
+  },
+  "execution": {
+    "runner": "windows-2022",
+    "process_architecture": "x86",
+    "scenario_count": 98,
+    "attempts": 1,
+    "workflow_timeout_minutes": 240,
+    "rust_scenario_timeout_seconds": 900
+  },
+  "decision_rule": {
+    "accept": "The provider is ready, all 98 inventory scenarios execute once, every artifact validates, every Rust coverage verdict is satisfied, and every successful DAO/Rust comparison projection is byte-identical.",
+    "reject": "Any provider, generation, validation, coverage, comparison, completeness, or artifact-integrity failure rejects the acquisition.",
+    "retry": "A failure after the first DAO mutation is a scientific result and is not retried without a new human decision."
+  },
+  "publication": {
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "result_record": "One additive EXP entry derived from the validated report JSON.",
+    "support_matrix": "Only verification states directly demonstrated by an accepted acquisition may change."
+  },
+  "synthetic_dry_run": {
+    "compatibility_claim": false,
+    "required_checks": [
+      "matching_pair_accepted",
+      "mismatched_pair_rejected"
+    ]
+  }
+}

--- a/oracle/windows-dao/acquisition/read-v1_2.synthetic.json
+++ b/oracle/windows-dao/acquisition/read-v1_2.synthetic.json
@@ -1,0 +1,1 @@
+{"compatibility_claim":false,"document_type":"dao_read_synthetic_dry_run","matching_pair_accepted":true,"mismatched_pair_rejected":true,"protocol_version":"1.2.0"}

--- a/oracle/windows-dao/protocol/v1_2/README.md
+++ b/oracle/windows-dao/protocol/v1_2/README.md
@@ -130,6 +130,8 @@ When the reader rejects the header (`unsupported_version`,
 python3 -B oracle/windows-dao/scripts/build_v1_2_inventory.py --check
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py schemas
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py inventory oracle/windows-dao/protocol/v1_2/scenarios.json
+python3 -B oracle/windows-dao/scripts/dao_read_diff.py plan oracle/windows-dao/acquisition/read-v1_2.plan.json .
+python3 -B oracle/windows-dao/scripts/dao_read_diff.py synthetic-dry-run /tmp/jet3-dao-read-dry-run.json
 python3 -B -m unittest discover -s oracle/windows-dao/tests -p 'test_protocol_validation.py' -v
 ```
 

--- a/oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1
+++ b/oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1
@@ -1,0 +1,635 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$InventoryPath,
+    [Parameter(Mandatory = $true)][string]$EnvironmentPath,
+    [Parameter(Mandatory = $true)][string]$OutputRoot,
+    [Parameter(Mandatory = $true)][string]$SourceRevision,
+    [string]$ScenarioId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# DAO API constants recorded by SRC-0002, SRC-0003, SRC-0009, SRC-0014,
+# and SRC-0030. They are adapter inputs, not MDB-format assertions.
+$DaoTypes = @{
+    dbBoolean = 1; dbByte = 2; dbInteger = 3; dbLong = 4; dbCurrency = 5
+    dbSingle = 6; dbDouble = 7; dbDate = 8; dbBinary = 9; dbText = 10
+    dbLongBinary = 11; dbMemo = 12; dbGUID = 15
+}
+$DaoTypeNames = @{}
+foreach ($entry in $DaoTypes.GetEnumerator()) {
+    $DaoTypeNames[[int]$entry.Value] = [string]$entry.Key
+}
+$DbVersion30 = 32
+$DbVersion40 = 64
+$DbEncrypt = 2
+$DbAutoIncrField = 16
+$DbSystemObject = -2147483646
+$DbDescending = 1
+$RelationUpdateCascade = 256
+$RelationDeleteCascade = 4096
+$MaximumGeneratedRows = 10000000
+$Utf8 = New-Object Text.UTF8Encoding($false)
+$CodePage = [Text.Encoding]::GetEncoding(
+    1252,
+    (New-Object Text.EncoderExceptionFallback),
+    (New-Object Text.DecoderExceptionFallback)
+)
+
+function Release-ComObject {
+    param([object]$Value)
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+
+function Write-JsonDocument {
+    param([string]$Path, [object]$Document)
+    [IO.File]::WriteAllText(
+        [IO.Path]::GetFullPath($Path),
+        (($Document | ConvertTo-Json -Depth 32 -Compress) + "`n"),
+        $Utf8
+    )
+}
+
+function Convert-ToLowerHex {
+    param([byte[]]$Bytes)
+    return ([BitConverter]::ToString($Bytes)).Replace("-", "").ToLowerInvariant()
+}
+
+function Convert-FromLowerHex {
+    param([string]$Text)
+    if ($Text -cnotmatch "^(?:[0-9a-f]{2})*$") {
+        throw "Expected lowercase even-length hexadecimal text."
+    }
+    $bytes = New-Object byte[] ($Text.Length / 2)
+    for ($index = 0; $index -lt $bytes.Length; $index++) {
+        $bytes[$index] = [Convert]::ToByte($Text.Substring($index * 2, 2), 16)
+    }
+    return ,$bytes
+}
+
+function Get-FileSha256 {
+    param([string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-DeclaredValue {
+    param([object]$Plan, [string]$DaoType)
+    $culture = [Globalization.CultureInfo]::InvariantCulture
+    switch ([string]$Plan.encoding) {
+        "null" { return $null }
+        "boolean" { return [bool]$Plan.value }
+        "integer" {
+            switch ($DaoType) {
+                "dbByte" { return [byte]$Plan.value }
+                "dbInteger" { return [int16]$Plan.value }
+                "dbLong" { return [int32]$Plan.value }
+                default { return [long]$Plan.value }
+            }
+        }
+        "invariant_decimal" {
+            return [decimal]::Parse([string]$Plan.value, $culture)
+        }
+        "ieee_bits_hex" {
+            $bytes = Convert-FromLowerHex -Text ([string]$Plan.value)
+            if ($DaoType -ceq "dbSingle" -and $bytes.Length -eq 4) {
+                [Array]::Reverse($bytes)
+                return [BitConverter]::ToSingle($bytes, 0)
+            }
+            if ($DaoType -ceq "dbDouble" -and $bytes.Length -eq 8) {
+                [Array]::Reverse($bytes)
+                return [BitConverter]::ToDouble($bytes, 0)
+            }
+            throw "IEEE bit width does not match the declared DAO type."
+        }
+        "invariant_datetime" {
+            return [datetime]::Parse(
+                [string]$Plan.value,
+                $culture,
+                [Globalization.DateTimeStyles]::AllowWhiteSpaces
+            )
+        }
+        "lowercase_hex" { return ,(Convert-FromLowerHex -Text ([string]$Plan.value)) }
+        "unicode_string" { return [string]$Plan.value }
+        "repeat_byte" {
+            $unit = [Convert]::ToByte([string]$Plan.value.unit, 16)
+            $bytes = New-Object byte[] ([int]$Plan.value.length)
+            for ($index = 0; $index -lt $bytes.Length; $index++) { $bytes[$index] = $unit }
+            return ,$bytes
+        }
+        "repeat_ascii" { return ([string]$Plan.value.unit) * [int]$Plan.value.length }
+        "guid" { return [guid]([string]$Plan.value) }
+        default { throw "Unsupported value encoding $($Plan.encoding)." }
+    }
+}
+
+function Set-RecordsetValue {
+    param([object]$Recordset, [object]$Plan, [hashtable]$FieldTypes)
+    $field = $null
+    try {
+        $field = $Recordset.Fields.Item([string]$Plan.field)
+        $daoType = [string]$FieldTypes[[string]$Plan.field]
+        $value = Get-DeclaredValue -Plan $Plan -DaoType $daoType
+        if ($null -eq $value) {
+            $field.Value = [DBNull]::Value
+        }
+        elseif ($daoType -ceq "dbLongBinary") {
+            $field.AppendChunk([byte[]]$value)
+        }
+        elseif ($daoType -ceq "dbMemo") {
+            $field.AppendChunk([string]$value)
+        }
+        else {
+            $field.Value = $value
+        }
+    }
+    finally { Release-ComObject -Value $field }
+}
+
+function Add-RecipeRows {
+    param(
+        [object]$Database,
+        [string]$TableName,
+        [object[]]$Rows,
+        [int]$Repeat,
+        [string]$DatabasePath,
+        [int]$TargetPageCount = 0
+    )
+    $recordset = $null
+    try {
+        $recordset = $Database.OpenRecordset($TableName)
+        $types = @{}
+        for ($ordinal = 0; $ordinal -lt $recordset.Fields.Count; $ordinal++) {
+            $field = $null
+            try {
+                $field = $recordset.Fields.Item($ordinal)
+                $types[[string]$field.Name] = $DaoTypeNames[[int]$field.Type]
+            }
+            finally { Release-ComObject -Value $field }
+        }
+        $generated = 0
+        do {
+            foreach ($values in $Rows) {
+                $recordset.AddNew()
+                foreach ($plan in $values) {
+                    Set-RecordsetValue -Recordset $recordset -Plan $plan -FieldTypes $types
+                }
+                $recordset.Update()
+                $generated++
+                if ($generated -gt $MaximumGeneratedRows) {
+                    throw "The DAO row-generation ceiling was exceeded."
+                }
+                if ($TargetPageCount -gt 0) {
+                    $pages = [int]((Get-Item -LiteralPath $DatabasePath).Length / 2048)
+                    if ($pages -gt $TargetPageCount) {
+                        throw "DAO overshot the exact page-count target."
+                    }
+                    if ($pages -eq $TargetPageCount) { return }
+                }
+            }
+            $Repeat--
+        } while ($TargetPageCount -gt 0 -or $Repeat -gt 0)
+        if ($TargetPageCount -gt 0) {
+            throw "DAO did not reach the exact page-count target."
+        }
+    }
+    finally {
+        if ($null -ne $recordset) { try { $recordset.Close() } catch { } }
+        Release-ComObject -Value $recordset
+    }
+}
+
+function New-RecipeTable {
+    param([object]$Database, [object]$Step)
+    $table = $null
+    try {
+        $table = $Database.CreateTableDef([string]$Step.name)
+        foreach ($fieldPlan in $Step.fields) {
+            $field = $null
+            try {
+                $type = [int]$DaoTypes[[string]$fieldPlan.dao_type]
+                if ($null -ne $fieldPlan.size) {
+                    $field = $table.CreateField([string]$fieldPlan.name, $type, [int]$fieldPlan.size)
+                }
+                else {
+                    $field = $table.CreateField([string]$fieldPlan.name, $type)
+                }
+                $field.Required = [bool]$fieldPlan.required
+                $table.Fields.Append($field)
+            }
+            finally { Release-ComObject -Value $field }
+        }
+        foreach ($indexPlan in $Step.indexes) {
+            $index = $null
+            try {
+                $index = $table.CreateIndex([string]$indexPlan.name)
+                $index.Primary = [bool]$indexPlan.primary
+                $index.Unique = [bool]$indexPlan.unique
+                $index.Required = [bool]$indexPlan.required
+                $index.IgnoreNulls = [bool]$indexPlan.ignore_nulls
+                foreach ($fieldPlan in $indexPlan.fields) {
+                    $field = $null
+                    try {
+                        $field = $index.CreateField([string]$fieldPlan.name)
+                        if ([bool]$fieldPlan.descending) { $field.Attributes = $DbDescending }
+                        $index.Fields.Append($field)
+                    }
+                    finally { Release-ComObject -Value $field }
+                }
+                $table.Indexes.Append($index)
+            }
+            finally { Release-ComObject -Value $index }
+        }
+        $Database.TableDefs.Append($table)
+    }
+    finally { Release-ComObject -Value $table }
+}
+
+function New-RecipeRelationship {
+    param([object]$Database, [object]$Step)
+    $attributes = 0
+    if ([bool]$Step.cascade_updates) { $attributes += $RelationUpdateCascade }
+    if ([bool]$Step.cascade_deletes) { $attributes += $RelationDeleteCascade }
+    $relation = $null
+    try {
+        $relation = $Database.CreateRelation(
+            [string]$Step.name,
+            [string]$Step.table,
+            [string]$Step.foreign_table,
+            $attributes
+        )
+        foreach ($fieldPlan in $Step.fields) {
+            $field = $null
+            try {
+                $field = $relation.CreateField([string]$fieldPlan.field)
+                $field.ForeignName = [string]$fieldPlan.foreign_field
+                $relation.Fields.Append($field)
+            }
+            finally { Release-ComObject -Value $field }
+        }
+        $Database.Relations.Append($relation)
+    }
+    finally { Release-ComObject -Value $relation }
+}
+
+function Remove-RecipeRows {
+    param([object]$Database, [string]$TableName, [object]$Count)
+    $recordset = $null
+    try {
+        $recordset = $Database.OpenRecordset($TableName)
+        $remaining = if ([string]$Count -ceq "all") { [int]::MaxValue } else { [int]$Count }
+        if (-not $recordset.EOF) { $recordset.MoveFirst() }
+        while (-not $recordset.EOF -and $remaining -gt 0) {
+            $recordset.Delete()
+            $remaining--
+            $recordset.MoveNext()
+        }
+        if ([string]$Count -cne "all" -and $remaining -ne 0) {
+            throw "The delete step requested more rows than DAO returned."
+        }
+    }
+    finally {
+        if ($null -ne $recordset) { try { $recordset.Close() } catch { } }
+        Release-ComObject -Value $recordset
+    }
+}
+
+function Get-DateText {
+    param([datetime]$Date)
+    $text = $Date.ToString("yyyy-MM-ddTHH:mm:ss.fffffff", [Globalization.CultureInfo]::InvariantCulture)
+    return $text.TrimEnd("0").TrimEnd(".")
+}
+
+function Get-TypedValue {
+    param([object]$Field)
+    $raw = $Field.Value
+    if ($null -eq $raw -or [Convert]::IsDBNull($raw)) {
+        return [ordered]@{ kind = "null"; value = $null }
+    }
+    switch ([int]$Field.Type) {
+        1 { return [ordered]@{ kind = "boolean"; value = [bool]$raw } }
+        2 { return [ordered]@{ kind = "byte"; raw_hex = Convert-ToLowerHex ([byte[]]@([byte]$raw)); value = [int][byte]$raw } }
+        3 { return [ordered]@{ kind = "integer"; raw_hex = Convert-ToLowerHex ([BitConverter]::GetBytes([int16]$raw)); value = [int][int16]$raw } }
+        4 { return [ordered]@{ kind = "long"; raw_hex = Convert-ToLowerHex ([BitConverter]::GetBytes([int32]$raw)); value = [long][int32]$raw } }
+        5 {
+            $decimal = [decimal]$raw
+            $scaled = [decimal]::ToInt64($decimal * [decimal]10000)
+            return [ordered]@{
+                kind = "currency"
+                raw_hex = Convert-ToLowerHex ([BitConverter]::GetBytes([int64]$scaled))
+                value = $decimal.ToString("0.0000", [Globalization.CultureInfo]::InvariantCulture)
+            }
+        }
+        6 {
+            $number = [single]$raw
+            return [ordered]@{
+                kind = "single"
+                raw_hex = Convert-ToLowerHex ([BitConverter]::GetBytes($number))
+                value = $number.ToString("R", [Globalization.CultureInfo]::InvariantCulture)
+            }
+        }
+        7 {
+            $number = [double]$raw
+            return [ordered]@{
+                kind = "double"
+                raw_hex = Convert-ToLowerHex ([BitConverter]::GetBytes($number))
+                value = $number.ToString("R", [Globalization.CultureInfo]::InvariantCulture)
+            }
+        }
+        8 {
+            $date = [datetime]$raw
+            return [ordered]@{
+                kind = "datetime"
+                raw_hex = Convert-ToLowerHex ([BitConverter]::GetBytes([double]$date.ToOADate()))
+                value = Get-DateText -Date $date
+            }
+        }
+        9 {
+            $bytes = [byte[]]$raw
+            return [ordered]@{ kind = "binary"; raw_hex = Convert-ToLowerHex $bytes; value = Convert-ToLowerHex $bytes }
+        }
+        10 {
+            $text = [string]$raw
+            return [ordered]@{ code_page = 1252; kind = "text"; raw_hex = Convert-ToLowerHex ($CodePage.GetBytes($text)); value = $text }
+        }
+        11 {
+            $bytes = [byte[]]$raw
+            return [ordered]@{ kind = "ole"; raw_hex = Convert-ToLowerHex $bytes; value = Convert-ToLowerHex $bytes }
+        }
+        12 {
+            $text = [string]$raw
+            return [ordered]@{ code_page = 1252; kind = "memo"; raw_hex = Convert-ToLowerHex ($CodePage.GetBytes($text)); value = $text }
+        }
+        15 {
+            $guid = [guid]$raw
+            return [ordered]@{ kind = "guid"; raw_hex = Convert-ToLowerHex ($guid.ToByteArray()); value = $guid.ToString("D").ToLowerInvariant() }
+        }
+        default { throw "DAO returned unsupported field type $($Field.Type)." }
+    }
+}
+
+function Get-NormalizedSize {
+    param([int]$Type, [int]$Declared)
+    switch ($Type) {
+        1 { return 1 }; 2 { return 1 }; 3 { return 2 }; 4 { return 4 }
+        5 { return 8 }; 6 { return 4 }; 7 { return 8 }; 8 { return 8 }
+        15 { return 16 }; 11 { return 0 }; 12 { return 0 }
+        default { return $Declared }
+    }
+}
+
+function Get-DaoSnapshot {
+    param([object]$Database, [string]$Scenario, [string]$Revision, [string]$DatabaseHash)
+    $tables = New-Object Collections.ArrayList
+    for ($tableOrdinal = 0; $tableOrdinal -lt $Database.TableDefs.Count; $tableOrdinal++) {
+        $table = $null
+        try {
+            $table = $Database.TableDefs.Item($tableOrdinal)
+            if (([int]$table.Attributes -band $DbSystemObject) -ne 0) { continue }
+            $columns = New-Object Collections.ArrayList
+            for ($fieldOrdinal = 0; $fieldOrdinal -lt $table.Fields.Count; $fieldOrdinal++) {
+                $field = $null
+                try {
+                    $field = $table.Fields.Item($fieldOrdinal)
+                    $type = [int]$field.Type
+                    $attributes = if ($type -in @(1,2,3,4,5,6,7,8,15)) { 1 } else { 2 }
+                    $auto = (([int]$field.Attributes -band $DbAutoIncrField) -ne 0)
+                    if ($auto) { $attributes += $DbAutoIncrField }
+                    [void]$columns.Add([ordered]@{
+                        attributes = $attributes
+                        auto_increment = $auto
+                        dao_type = [string]$DaoTypeNames[$type]
+                        name = [string]$field.Name
+                        ordinal = [int]$field.OrdinalPosition
+                        properties = [ordered]@{}
+                        size = Get-NormalizedSize -Type $type -Declared ([int]$field.Size)
+                    })
+                }
+                finally { Release-ComObject -Value $field }
+            }
+            $indexes = New-Object Collections.ArrayList
+            for ($indexOrdinal = 0; $indexOrdinal -lt $table.Indexes.Count; $indexOrdinal++) {
+                $index = $null
+                try {
+                    $index = $table.Indexes.Item($indexOrdinal)
+                    $fields = New-Object Collections.ArrayList
+                    for ($fieldOrdinal = 0; $fieldOrdinal -lt $index.Fields.Count; $fieldOrdinal++) {
+                        $field = $null
+                        try {
+                            $field = $index.Fields.Item($fieldOrdinal)
+                            [void]$fields.Add([ordered]@{
+                                descending = (([int]$field.Attributes -band $DbDescending) -ne 0)
+                                name = [string]$field.Name
+                            })
+                        }
+                        finally { Release-ComObject -Value $field }
+                    }
+                    [void]$indexes.Add([ordered]@{
+                        fields = @($fields)
+                        name = [string]$index.Name
+                        primary = [bool]$index.Primary
+                        properties = [ordered]@{}
+                        required = [bool]$index.Required
+                        unique = [bool]$index.Unique
+                    })
+                }
+                finally { Release-ComObject -Value $index }
+            }
+            $rows = New-Object Collections.ArrayList
+            $recordset = $null
+            try {
+                $recordset = $Database.OpenRecordset([string]$table.Name)
+                if (-not $recordset.EOF) { $recordset.MoveFirst() }
+                while (-not $recordset.EOF) {
+                    $values = [ordered]@{}
+                    foreach ($column in @($columns | Sort-Object ordinal)) {
+                        $field = $null
+                        try {
+                            $field = $recordset.Fields.Item([string]$column.name)
+                            $values[[string]$column.name] = Get-TypedValue -Field $field
+                        }
+                        finally { Release-ComObject -Value $field }
+                    }
+                    [void]$rows.Add([ordered]@{
+                        canonical_key = ("0" * 64)
+                        duplicate_ordinal = 0
+                        values = $values
+                    })
+                    $recordset.MoveNext()
+                }
+            }
+            finally {
+                if ($null -ne $recordset) { try { $recordset.Close() } catch { } }
+                Release-ComObject -Value $recordset
+            }
+            [void]$tables.Add([ordered]@{
+                attributes = [int]$table.Attributes
+                columns = @($columns | Sort-Object ordinal)
+                indexes = @($indexes | Sort-Object name)
+                kind = "user"
+                name = [string]$table.Name
+                properties = [ordered]@{}
+                rows = @($rows)
+            })
+        }
+        finally { Release-ComObject -Value $table }
+    }
+    $relationships = New-Object Collections.ArrayList
+    for ($relationOrdinal = 0; $relationOrdinal -lt $Database.Relations.Count; $relationOrdinal++) {
+        $relation = $null
+        try {
+            $relation = $Database.Relations.Item($relationOrdinal)
+            $fields = New-Object Collections.ArrayList
+            for ($fieldOrdinal = 0; $fieldOrdinal -lt $relation.Fields.Count; $fieldOrdinal++) {
+                $field = $null
+                try {
+                    $field = $relation.Fields.Item($fieldOrdinal)
+                    [void]$fields.Add([ordered]@{
+                        field = [string]$field.Name
+                        foreign_field = [string]$field.ForeignName
+                    })
+                }
+                finally { Release-ComObject -Value $field }
+            }
+            [void]$relationships.Add([ordered]@{
+                attributes = [int]$relation.Attributes
+                fields = @($fields)
+                foreign_table = [string]$relation.ForeignTable
+                name = [string]$relation.Name
+                properties = [ordered]@{}
+                table = [string]$relation.Table
+            })
+        }
+        finally { Release-ComObject -Value $relation }
+    }
+    return [ordered]@{
+        comparison_projection = @("/producer", "/producer_extensions")
+        database_properties = [ordered]@{}
+        database_sha256 = $DatabaseHash
+        document_type = "canonical_semantic_snapshot"
+        ordering = [ordered]@{
+            columns = "ordinal_ascending"
+            indexes = "name_codepoint_ascending"
+            object_keys = "unicode_codepoint_ascending"
+            objects = "name_codepoint_ascending"
+            relationships = "name_codepoint_ascending"
+            rows = "values_sha256_then_duplicate_ordinal"
+        }
+        producer = [ordered]@{ kind = "dao"; source_revision = $Revision }
+        producer_extensions = [ordered]@{}
+        protocol_version = "1.2.0"
+        raw_preservation = @()
+        relationships = @($relationships | Sort-Object name)
+        scenario_id = $Scenario
+        tables = @($tables | Sort-Object name)
+    }
+}
+
+function Invoke-Scenario {
+    param([object]$Scenario, [object]$AcceptedProvider)
+    $scenarioRoot = Join-Path $OutputRoot ([string]$Scenario.id)
+    [IO.Directory]::CreateDirectory($scenarioRoot) | Out-Null
+    $databasePath = Join-Path $scenarioRoot "database.mdb"
+    $engine = $null
+    $workspace = $null
+    $database = $null
+    try {
+        $type = [Type]::GetTypeFromProgID([string]$AcceptedProvider.prog_id, $false)
+        if ($null -eq $type) { throw "Accepted DAO provider is unavailable." }
+        $actualClsid = "{" + $type.GUID.ToString().ToUpperInvariant() + "}"
+        if ($actualClsid -ine [string]$AcceptedProvider.clsid) {
+            throw "The active DAO registration differs from the probed provider."
+        }
+        $engine = [Activator]::CreateInstance($type)
+        if ([string]$engine.Version -cne [string]$AcceptedProvider.provider_version) {
+            throw "The active DAO version differs from the probed provider."
+        }
+        $workspace = $engine.Workspaces.Item(0)
+        $recipe = $Scenario.generator_recipe
+        foreach ($step in $recipe.steps) {
+            switch ([string]$step.action) {
+                "create_database" {
+                    $version = if ([string]$recipe.database_version -ceq "dbVersion30") { $DbVersion30 } else { $DbVersion40 }
+                    if ([bool]$recipe.encrypted) { $version += $DbEncrypt }
+                    $database = $workspace.CreateDatabase($databasePath, [string]$recipe.locale, $version)
+                    if ($null -ne $recipe.password) { $database.NewPassword("", [string]$recipe.password) }
+                }
+                "create_table" { New-RecipeTable -Database $database -Step $step }
+                "create_relationship" { New-RecipeRelationship -Database $database -Step $step }
+                "insert_rows" {
+                    Add-RecipeRows -Database $database -TableName ([string]$step.table) `
+                        -Rows @($step.rows) -Repeat ([int]$step.repeat) `
+                        -DatabasePath $databasePath
+                }
+                "insert_until_page_count" {
+                    Add-RecipeRows -Database $database -TableName ([string]$step.table) `
+                        -Rows @(,@($step.row)) -Repeat 1 -DatabasePath $databasePath `
+                        -TargetPageCount ([int]$step.page_count)
+                }
+                "delete_rows" { Remove-RecipeRows -Database $database -TableName ([string]$step.table) -Count $step.count }
+                "drop_table" { $database.TableDefs.Delete([string]$step.name) }
+                "reopen" {
+                    $database.Close(); Release-ComObject -Value $database; $database = $null
+                    $connect = if ($null -eq $recipe.password) { "" } else { ";PWD=$($recipe.password)" }
+                    $database = $engine.OpenDatabase($databasePath, $false, $false, $connect)
+                }
+                "close_database" { $database.Close(); Release-ComObject -Value $database; $database = $null }
+                default { throw "Unsupported recipe action $($step.action)." }
+            }
+        }
+        if ($null -ne $database) { $database.Close(); Release-ComObject -Value $database; $database = $null }
+        $expectedError = ([string]$Scenario.operation.expected_outcome -ceq "expected_error")
+        if (-not $expectedError) {
+            $database = $engine.OpenDatabase($databasePath)
+            $snapshot = Get-DaoSnapshot -Database $database -Scenario ([string]$Scenario.id) `
+                -Revision $SourceRevision -DatabaseHash ("0" * 64)
+            $database.Close(); Release-ComObject -Value $database; $database = $null
+            $databaseHash = Get-FileSha256 -Path $databasePath
+            $snapshot.database_sha256 = $databaseHash
+            Write-JsonDocument -Path (Join-Path $scenarioRoot "dao-snapshot.raw.json") -Document $snapshot
+        }
+        else {
+            $databaseHash = Get-FileSha256 -Path $databasePath
+        }
+        return [ordered]@{
+            database = ([string]$Scenario.id + "/database.mdb")
+            database_sha256 = $databaseHash
+            expected_error = $expectedError
+            scenario_id = [string]$Scenario.id
+            snapshot = if ($expectedError) { $null } else { ([string]$Scenario.id + "/dao-snapshot.raw.json") }
+        }
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $workspace
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+$inventory = Get-Content -LiteralPath $InventoryPath -Raw | ConvertFrom-Json
+$environment = Get-Content -LiteralPath $EnvironmentPath -Raw | ConvertFrom-Json
+if ([IntPtr]::Size -ne 4) { throw "The DAO producer must run in an x86 process." }
+if ([string]$inventory.protocol_version -cne "1.2.0") { throw "Inventory is not protocol 1.2.0." }
+if ([string]$environment.status -cne "ready" -or $null -eq $environment.accepted_provider) {
+    throw "The provider environment is not ready."
+}
+[IO.Directory]::CreateDirectory($OutputRoot) | Out-Null
+$selected = @($inventory.scenarios | Where-Object {
+    [string]::IsNullOrEmpty($ScenarioId) -or [string]$_.id -ceq $ScenarioId
+})
+if ($selected.Count -eq 0) { throw "No inventory scenario matched the selection." }
+$results = New-Object Collections.ArrayList
+foreach ($scenario in $selected) {
+    [void]$results.Add((Invoke-Scenario -Scenario $scenario -AcceptedProvider $environment.accepted_provider))
+}
+Write-JsonDocument -Path (Join-Path $OutputRoot "dao-manifest.raw.json") -Document ([ordered]@{
+    document_type = "dao_read_manifest"
+    protocol_version = "1.2.0"
+    source_revision = $SourceRevision
+    scenarios = @($results)
+})

--- a/oracle/windows-dao/scripts/dao_read_diff.py
+++ b/oracle/windows-dao/scripts/dao_read_diff.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Canonicalize and compare protocol 1.2 DAO read snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import validate_protocol_v1_2 as protocol
+from protocol_validation import ValidationError, load_json
+
+
+def canonical_bytes(document: Any) -> bytes:
+    return (
+        json.dumps(
+            document,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def canonicalize_snapshot(document: dict[str, Any]) -> dict[str, Any]:
+    """Order a producer document and derive content-addressed row identities."""
+    result = copy.deepcopy(document)
+
+    def normalize_typed_values(value: Any) -> None:
+        if isinstance(value, dict):
+            if value.get("kind") in ("single", "double") and isinstance(
+                value.get("value"), str
+            ):
+                parsed = float(value["value"])
+                if not math.isfinite(parsed):
+                    raise ValidationError("DAO snapshot contains a non-finite float")
+                value["value"] = parsed
+            for child in value.values():
+                normalize_typed_values(child)
+        elif isinstance(value, list):
+            for child in value:
+                normalize_typed_values(child)
+
+    normalize_typed_values(result)
+    result["tables"].sort(key=lambda table: table["name"])
+    for table in result["tables"]:
+        table["columns"].sort(key=lambda column: column["ordinal"])
+        table["indexes"].sort(key=lambda index: index["name"])
+        keyed_rows: list[tuple[str, bytes, dict[str, Any]]] = []
+        for row in table["rows"]:
+            values_bytes = canonical_bytes(row["values"])
+            key = hashlib.sha256(values_bytes).hexdigest()
+            row["canonical_key"] = key
+            keyed_rows.append((key, values_bytes, row))
+        keyed_rows.sort(key=lambda item: (item[0], item[1]))
+        duplicate_counts: dict[bytes, int] = {}
+        table["rows"] = []
+        for _, values_bytes, row in keyed_rows:
+            row["duplicate_ordinal"] = duplicate_counts.get(values_bytes, 0)
+            duplicate_counts[values_bytes] = row["duplicate_ordinal"] + 1
+            table["rows"].append(row)
+    result["relationships"].sort(key=lambda relationship: relationship["name"])
+    protocol.validate_document(result)
+    return result
+
+
+def comparison_document(document: dict[str, Any]) -> dict[str, Any]:
+    projection = document["comparison_projection"]
+    if projection != ["/producer", "/producer_extensions"]:
+        raise ValidationError("snapshot has an unexpected comparison projection")
+    result = copy.deepcopy(document)
+    del result["producer"]
+    del result["producer_extensions"]
+    return result
+
+
+def compare_snapshots(
+    dao: dict[str, Any], rust: dict[str, Any]
+) -> dict[str, Any]:
+    if protocol.validate_document(dao) != "canonical_semantic_snapshot":
+        raise ValidationError("DAO input is not a semantic snapshot")
+    if protocol.validate_document(rust) != "canonical_semantic_snapshot":
+        raise ValidationError("Rust input is not a semantic snapshot")
+    if dao["producer"]["kind"] != "dao":
+        raise ValidationError("DAO input has the wrong producer kind")
+    if rust["producer"]["kind"] != "rust":
+        raise ValidationError("Rust input has the wrong producer kind")
+    for field in ("protocol_version", "scenario_id", "database_sha256"):
+        if dao[field] != rust[field]:
+            raise ValidationError(f"snapshot pair differs at {field}")
+    dao_projection = canonical_bytes(comparison_document(dao))
+    rust_projection = canonical_bytes(comparison_document(rust))
+    if dao_projection != rust_projection:
+        raise ValidationError("DAO and Rust comparison projections differ")
+    return {
+        "database_sha256": dao["database_sha256"],
+        "document_type": "dao_read_comparison",
+        "matched": True,
+        "projection_sha256": hashlib.sha256(dao_projection).hexdigest(),
+        "protocol_version": "1.2.0",
+        "scenario_id": dao["scenario_id"],
+    }
+
+
+def write_canonical(path: Path, document: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_bytes(document))
+
+
+def minimal_snapshot(kind: str) -> dict[str, Any]:
+    return {
+        "comparison_projection": ["/producer", "/producer_extensions"],
+        "database_properties": {},
+        "database_sha256": "0" * 64,
+        "document_type": "canonical_semantic_snapshot",
+        "ordering": {
+            "columns": "ordinal_ascending",
+            "indexes": "name_codepoint_ascending",
+            "object_keys": "unicode_codepoint_ascending",
+            "objects": "name_codepoint_ascending",
+            "relationships": "name_codepoint_ascending",
+            "rows": "values_sha256_then_duplicate_ordinal",
+        },
+        "producer": {"kind": kind, "source_revision": "synthetic"},
+        "producer_extensions": {},
+        "protocol_version": "1.2.0",
+        "raw_preservation": [],
+        "relationships": [],
+        "scenario_id": "DAO-READ-OPEN-EMPTY",
+        "tables": [],
+    }
+
+
+def synthetic_dry_run(output: Path) -> None:
+    dao = minimal_snapshot("dao")
+    rust = minimal_snapshot("rust")
+    matching = compare_snapshots(dao, rust)
+    mismatched = copy.deepcopy(rust)
+    mismatched["database_properties"]["Name"] = {
+        "kind": "text",
+        "value": "different",
+        "raw_hex": "646966666572656e74",
+        "code_page": 1252,
+    }
+    rejected = False
+    try:
+        compare_snapshots(dao, mismatched)
+    except ValidationError:
+        rejected = True
+    if not rejected:
+        raise ValidationError("synthetic mismatch was not rejected")
+    write_canonical(
+        output,
+        {
+            "compatibility_claim": False,
+            "document_type": "dao_read_synthetic_dry_run",
+            "matching_pair_accepted": matching["matched"],
+            "mismatched_pair_rejected": rejected,
+            "protocol_version": "1.2.0",
+        },
+    )
+
+
+def evaluate_acquisition(
+    manifest_path: Path,
+    artifact_root: Path,
+    rust_executable: Path,
+    inventory_path: Path,
+    source_revision: str,
+    output: Path,
+) -> None:
+    """Run the Rust producer over one complete DAO acquisition."""
+    manifest = load_json(manifest_path)
+    inventory = load_json(inventory_path)
+    if protocol.validate_document(inventory) != "dao_scenario_inventory":
+        raise ValidationError("acquisition inventory has the wrong document type")
+    if manifest.get("document_type") != "dao_read_manifest":
+        raise ValidationError("acquisition manifest has the wrong document type")
+    if manifest.get("protocol_version") != "1.2.0":
+        raise ValidationError("acquisition manifest has the wrong protocol version")
+    if manifest.get("source_revision") != source_revision:
+        raise ValidationError("acquisition manifest has the wrong source revision")
+    scenarios = {scenario["id"]: scenario for scenario in inventory["scenarios"]}
+    entries = manifest.get("scenarios")
+    if (
+        not isinstance(entries, list)
+        or len(entries) != len(scenarios)
+        or not all(isinstance(entry, dict) for entry in entries)
+        or {entry.get("scenario_id") for entry in entries} != set(scenarios)
+    ):
+        raise ValidationError("acquisition manifest does not cover the inventory exactly")
+    results = []
+    for entry in entries:
+        scenario_id = entry["scenario_id"]
+        if Path(entry["database"]).parts != (scenario_id, "database.mdb"):
+            raise ValidationError(f"{scenario_id}: unsafe database artifact path")
+        scenario = scenarios[scenario_id]
+        expected_error = scenario["operation"]["expected_outcome"] == "expected_error"
+        if entry.get("expected_error") is not expected_error:
+            raise ValidationError(f"{scenario_id}: manifest expected outcome differs")
+        database = artifact_root / entry["database"]
+        database_sha256 = hashlib.sha256(database.read_bytes()).hexdigest()
+        if database_sha256 != entry.get("database_sha256"):
+            raise ValidationError(f"{scenario_id}: database digest differs from manifest")
+        rust_root = artifact_root / scenario_id / "rust"
+        try:
+            completed = subprocess.run(
+                [
+                    str(rust_executable),
+                    "snapshot",
+                    str(database),
+                    "--out",
+                    str(rust_root),
+                    "--scenario",
+                    scenario_id,
+                    "--source-revision",
+                    source_revision,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=900,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ValidationError(
+                f"{scenario_id}: Rust producer exceeded 900 seconds"
+            ) from error
+        if completed.returncode != 0:
+            raise ValidationError(
+                f"{scenario_id}: Rust producer failed: {completed.stderr.strip()}"
+            )
+        coverage = load_json(rust_root / "coverage.json")
+        snapshot_path = rust_root / "snapshot.json"
+        rust_snapshot = None if expected_error else load_json(snapshot_path)
+        protocol.validate_pair(coverage, rust_snapshot)
+        verdict = next(
+            item for item in coverage["scenarios"] if item["id"] == scenario_id
+        )
+        if not verdict["satisfied"]:
+            raise ValidationError(f"{scenario_id}: Rust coverage verdict is unsatisfied")
+        comparison_sha256 = None
+        if expected_error:
+            if entry.get("snapshot") is not None or snapshot_path.exists():
+                raise ValidationError(f"{scenario_id}: opening failure retained a snapshot")
+        else:
+            if Path(entry["snapshot"]).parts != (
+                scenario_id,
+                "dao-snapshot.raw.json",
+            ):
+                raise ValidationError(f"{scenario_id}: unsafe DAO snapshot path")
+            dao_path = artifact_root / scenario_id / "dao-snapshot.json"
+            dao = canonicalize_snapshot(load_json(artifact_root / entry["snapshot"]))
+            write_canonical(dao_path, dao)
+            comparison = compare_snapshots(dao, rust_snapshot)
+            comparison_sha256 = comparison["projection_sha256"]
+            write_canonical(
+                artifact_root / scenario_id / "comparison.json", comparison
+            )
+        results.append(
+            {
+                "comparison_sha256": comparison_sha256,
+                "database_sha256": database_sha256,
+                "expected_error": expected_error,
+                "matched": True,
+                "scenario_id": scenario_id,
+            }
+        )
+    results.sort(key=lambda item: item["scenario_id"])
+    write_canonical(
+        output,
+        {
+            "all_matched": True,
+            "document_type": "dao_read_acquisition_report",
+            "inventory_sha256": hashlib.sha256(inventory_path.read_bytes()).hexdigest(),
+            "protocol_version": "1.2.0",
+            "scenario_count": len(results),
+            "scenarios": results,
+            "source_revision": source_revision,
+        },
+    )
+
+
+def validate_plan(plan_path: Path, repository_root: Path) -> None:
+    plan = load_json(plan_path)
+    if plan.get("document_type") != "dao_read_acquisition_plan":
+        raise ValidationError("acquisition plan has the wrong document type")
+    if plan.get("protocol_version") != "1.2.0":
+        raise ValidationError("acquisition plan has the wrong protocol version")
+    if plan.get("execution", {}).get("attempts") != 1:
+        raise ValidationError("acquisition plan must permit exactly one attempt")
+    inputs = plan.get("inputs")
+    if not isinstance(inputs, dict) or not inputs:
+        raise ValidationError("acquisition plan has no pinned inputs")
+    for relative, expected in inputs.items():
+        path = Path(relative)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValidationError(f"unsafe acquisition input path {relative!r}")
+        if (
+            not isinstance(expected, str)
+            or len(expected) != 64
+            or any(character not in "0123456789abcdef" for character in expected)
+        ):
+            raise ValidationError(f"invalid acquisition input digest for {relative}")
+        actual = hashlib.sha256((repository_root / path).read_bytes()).hexdigest()
+        if actual != expected:
+            raise ValidationError(f"acquisition input digest differs for {relative}")
+    source_trees = plan.get("source_trees")
+    if not isinstance(source_trees, dict) or not source_trees:
+        raise ValidationError("acquisition plan has no pinned source trees")
+    for relative, expected in source_trees.items():
+        path = Path(relative)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValidationError(f"unsafe source-tree path {relative!r}")
+        actual = source_tree_sha256(repository_root / path)
+        if actual != expected:
+            raise ValidationError(f"acquisition source tree differs for {relative}")
+    inventory = load_json(repository_root / "oracle/windows-dao/protocol/v1_2/scenarios.json")
+    if len(inventory["scenarios"]) != plan["execution"]["scenario_count"]:
+        raise ValidationError("acquisition scenario count differs from the inventory")
+
+
+def source_tree_sha256(root: Path) -> str:
+    """Hash relative file names and bytes for one checked source subtree."""
+    if not root.is_dir():
+        raise ValidationError(f"source tree is missing: {root}")
+    hasher = hashlib.sha256()
+    files = sorted(path for path in root.rglob("*") if path.is_file())
+    for path in files:
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        hasher.update(relative)
+        hasher.update(b"\0")
+        hasher.update(hashlib.sha256(path.read_bytes()).digest())
+    return hasher.hexdigest()
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    commands = result.add_subparsers(dest="command", required=True)
+    canonicalize = commands.add_parser("canonicalize")
+    canonicalize.add_argument("input", type=Path)
+    canonicalize.add_argument("output", type=Path)
+    compare = commands.add_parser("compare")
+    compare.add_argument("dao", type=Path)
+    compare.add_argument("rust", type=Path)
+    compare.add_argument("output", type=Path)
+    dry_run = commands.add_parser("synthetic-dry-run")
+    dry_run.add_argument("output", type=Path)
+    evaluate = commands.add_parser("evaluate")
+    evaluate.add_argument("manifest", type=Path)
+    evaluate.add_argument("artifact_root", type=Path)
+    evaluate.add_argument("rust_executable", type=Path)
+    evaluate.add_argument("inventory", type=Path)
+    evaluate.add_argument("source_revision")
+    evaluate.add_argument("output", type=Path)
+    plan = commands.add_parser("plan")
+    plan.add_argument("plan", type=Path)
+    plan.add_argument("repository_root", type=Path)
+    return result
+
+
+def main(arguments: list[str]) -> int:
+    args = parser().parse_args(arguments)
+    try:
+        if args.command == "canonicalize":
+            write_canonical(args.output, canonicalize_snapshot(load_json(args.input)))
+        elif args.command == "compare":
+            write_canonical(
+                args.output,
+                compare_snapshots(load_json(args.dao), load_json(args.rust)),
+            )
+        elif args.command == "synthetic-dry-run":
+            synthetic_dry_run(args.output)
+        elif args.command == "evaluate":
+            evaluate_acquisition(
+                args.manifest,
+                args.artifact_root,
+                args.rust_executable,
+                args.inventory,
+                args.source_revision,
+                args.output,
+            )
+        else:
+            validate_plan(args.plan, args.repository_root)
+    except (OSError, ValueError, ValidationError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/oracle/windows-dao/scripts/probe-provider.ps1
+++ b/oracle/windows-dao/scripts/probe-provider.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [string]$OutputPath,
-    [ValidateSet("1.0.0", "1.1.0")]
+    [ValidateSet("1.0.0", "1.1.0", "1.2.0")]
     [string]$ProtocolVersion = "1.0.0",
     [switch]$SkipDbVersion30Test
 )

--- a/oracle/windows-dao/tests/test_dao_read_acquisition.py
+++ b/oracle/windows-dao/tests/test_dao_read_acquisition.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import dao_read_diff  # noqa: E402
+from protocol_validation import ValidationError  # noqa: E402
+
+
+PLAN = ROOT / "oracle" / "windows-dao" / "acquisition" / "read-v1_2.plan.json"
+SYNTHETIC = (
+    ROOT / "oracle" / "windows-dao" / "acquisition" / "read-v1_2.synthetic.json"
+)
+PRODUCER = SCRIPTS / "Invoke-DaoReadV12.ps1"
+
+
+class DaoReadAcquisitionTests(unittest.TestCase):
+    def test_preregistered_plan_pins_every_execution_input(self) -> None:
+        dao_read_diff.validate_plan(PLAN, ROOT)
+        plan = json.loads(PLAN.read_text(encoding="utf-8"))
+        self.assertEqual(plan["execution"]["attempts"], 1)
+        self.assertEqual(plan["execution"]["scenario_count"], 98)
+        self.assertFalse(plan["publication"]["mdb_bytes_committed"])
+        self.assertFalse(plan["synthetic_dry_run"]["compatibility_claim"])
+
+        broken = copy.deepcopy(plan)
+        first = next(iter(broken["inputs"]))
+        broken["inputs"][first] = "0" * 64
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "plan.json"
+            path.write_text(json.dumps(broken), encoding="utf-8")
+            with self.assertRaisesRegex(ValidationError, "digest differs"):
+                dao_read_diff.validate_plan(path, ROOT)
+
+    def test_dao_producer_covers_the_closed_recipe_grammar(self) -> None:
+        producer = PRODUCER.read_text(encoding="utf-8")
+        for action in (
+            "create_database",
+            "create_table",
+            "create_relationship",
+            "insert_rows",
+            "insert_until_page_count",
+            "delete_rows",
+            "drop_table",
+            "reopen",
+            "close_database",
+        ):
+            self.assertIn(f'"{action}"', producer)
+        for encoding in (
+            "null",
+            "boolean",
+            "integer",
+            "invariant_decimal",
+            "ieee_bits_hex",
+            "invariant_datetime",
+            "lowercase_hex",
+            "unicode_string",
+            "repeat_byte",
+            "repeat_ascii",
+            "guid",
+        ):
+            self.assertIn(f'"{encoding}"', producer)
+        self.assertIn("$MaximumGeneratedRows", producer)
+        self.assertIn("dao-snapshot.raw.json", producer)
+        self.assertIn("dao-manifest.raw.json", producer)
+        self.assertNotIn("Invoke-Expression", producer)
+        self.assertNotIn("CompactDatabase", producer)
+
+    def test_synthetic_report_is_reproducible_and_non_evidentiary(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            generated = Path(temporary) / "synthetic.json"
+            dao_read_diff.synthetic_dry_run(generated)
+            self.assertEqual(generated.read_bytes(), SYNTHETIC.read_bytes())
+        report = json.loads(SYNTHETIC.read_text(encoding="utf-8"))
+        self.assertFalse(report["compatibility_claim"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_protocol_validation.py
+++ b/oracle/windows-dao/tests/test_protocol_validation.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -16,6 +17,7 @@ from protocol_validation import (  # noqa: E402
 )
 import build_v1_2_inventory  # noqa: E402
 import validate_protocol_v1_2 as v1_2  # noqa: E402
+import dao_read_diff  # noqa: E402
 
 
 class SharedProtocolValidationTests(unittest.TestCase):
@@ -416,6 +418,47 @@ class ProtocolV12Tests(unittest.TestCase):
         ]
         with self.assertRaisesRegex(ValidationError, "unknown table"):
             v1_2.validate_document(bad_relationship)
+
+    def test_dao_comparison_ignores_only_declared_producer_fields(self):
+        dao = self._snapshot()
+        dao["producer"] = {"kind": "dao", "source_revision": "dao-test"}
+        rust = self._snapshot()
+        result = dao_read_diff.compare_snapshots(dao, rust)
+        self.assertTrue(result["matched"])
+
+        changed = self._snapshot()
+        changed["tables"][0]["attributes"] = 1
+        with self.assertRaisesRegex(ValidationError, "projections differ"):
+            dao_read_diff.compare_snapshots(dao, changed)
+
+    def test_dao_canonicalizer_derives_and_orders_row_identities(self):
+        snapshot = self._snapshot()
+        snapshot["producer"] = {"kind": "dao", "source_revision": "dao-test"}
+        rows = snapshot["tables"][0]["rows"]
+        rows.reverse()
+        for row in rows:
+            row["canonical_key"] = "0" * 64
+            row["duplicate_ordinal"] = 99
+        snapshot["database_properties"]["Float"] = {
+            "kind": "double",
+            "raw_hex": "000000000000f83f",
+            "value": "1.5",
+        }
+        canonical = dao_read_diff.canonicalize_snapshot(snapshot)
+        self.assertEqual(
+            [row["duplicate_ordinal"] for row in canonical["tables"][0]["rows"]],
+            [0, 1],
+        )
+        self.assertEqual(canonical["database_properties"]["Float"]["value"], 1.5)
+
+    def test_synthetic_dry_run_accepts_match_and_rejects_mismatch(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "report.json"
+            dao_read_diff.synthetic_dry_run(output)
+            report = json.loads(output.read_text(encoding="utf-8"))
+        self.assertFalse(report["compatibility_claim"])
+        self.assertTrue(report["matching_pair_accepted"])
+        self.assertTrue(report["mismatched_pair_rejected"])
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_windows_dao_hosted_workflow.py
+++ b/oracle/windows-dao/tests/test_windows_dao_hosted_workflow.py
@@ -23,10 +23,9 @@ class WindowsDaoHostedWorkflowTests(unittest.TestCase):
         self.assertNotIn("pull_request:", self.workflow)
 
     def test_uses_explicit_windows_images_and_read_only_permissions(self) -> None:
-        self.assertIn("windows-2025", self.workflow)
         self.assertIn("windows-2022", self.workflow)
         self.assertRegex(self.workflow, r"permissions:\n  contents: read\n")
-        self.assertIn("timeout-minutes: 40", self.workflow)
+        self.assertIn("timeout-minutes: 240", self.workflow)
 
     def test_third_party_actions_are_commit_pinned(self) -> None:
         uses = re.findall(r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE)
@@ -51,17 +50,32 @@ class WindowsDaoHostedWorkflowTests(unittest.TestCase):
         self.assertIn("[accept-access-runtime-eula]", self.workflow)
         self.assertIn('AcceptEULA="TRUE"', self.workflow)
 
-    def test_probes_stock_and_installed_x86_protocol_1_1(self) -> None:
+    def test_probes_stock_and_installed_x86_protocol_1_2(self) -> None:
         self.assertIn("environment-stock.json", self.workflow)
         self.assertIn('"SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"', self.workflow)
         self.assertEqual(
-            self.workflow.count('"-ProtocolVersion", "1.1.0"'),
+            self.workflow.count('"-ProtocolVersion", "1.2.0"'),
             2,
         )
         self.assertEqual(self.workflow.count("probe-provider.ps1"), 2)
         self.assertEqual(self.workflow.count("Invoke-Jet3BootstrapProcess"), 2)
         self.assertEqual(self.workflow.count("-MaximumOutputBytes 1MB"), 2)
         self.assertGreaterEqual(self.workflow.count("-Encoding utf8 -Append"), 3)
+
+    def test_acquisition_is_preregistered_approved_and_single_runner(self) -> None:
+        self.assertIn("run_acquisition:", self.workflow)
+        self.assertIn("approve_acquisition:", self.workflow)
+        self.assertIn("plan_sha256:", self.workflow)
+        self.assertIn("Verify preregistration and human approval", self.workflow)
+        self.assertIn("read-v1_2.plan.json", self.workflow)
+        self.assertLess(
+            self.workflow.index("Verify preregistration and human approval"),
+            self.workflow.index("Probe the untouched runner image"),
+        )
+        self.assertIn("dao_read_diff.py plan", self.workflow)
+        self.assertNotIn("matrix.os", self.workflow)
+        self.assertIn("Invoke-DaoReadV12.ps1", self.workflow)
+        self.assertIn("dao_read_diff.py evaluate", self.workflow)
 
     def test_diagnostics_upload_even_when_probe_is_blocked(self) -> None:
         self.assertIn("if: always()", self.workflow)


### PR DESCRIPTION
The reader has a shared protocol and Rust snapshot producer, but #98 still lacks a minimal DAO producer and a controlled hosted path. This adds the complete acquisition machinery without running the evidentiary acquisition.

- generate all 98 protocol-v1.2 scenarios through the exact probed x86 DAO provider and emit DAO semantic snapshots
- canonicalize and compare DAO/Rust snapshots while validating database identity, Rust coverage, completeness, and the fixed comparison projection
- gate the single Windows acquisition on explicit human approval plus the exact SHA-256 of a plan that pins every execution input and Rust source tree
- commit a reproducible synthetic match/mismatch dry-run result that explicitly makes no compatibility claim
- retain artifact upload for review while keeping MDB bytes and provider binaries out of git

Checks:
- `just ready`
- `python3 -B -m unittest discover -s oracle/windows-dao/tests -v` (40 tests)
- protocol-v1.2 inventory reproducibility, schemas, and inventory validation
- acquisition plan pin validation
- reproducible synthetic dry run
- `git diff --check`

The real DAO acquisition remains disabled pending review and approval of plan SHA-256 `1323c3784f761f930a2ec5566056cbb3cd581b79a4634b2ab5626b9057c544a9`.

Refs #98