### PR TITLE
feat(jet3): add page image and usage-map encoders

### DIFF
--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -27,6 +27,7 @@ pub mod long_value;
 pub mod map_location;
 pub mod offset;
 pub mod page;
+pub mod page_image;
 pub mod page_kind;
 mod physical_index_definition;
 pub mod raw_page_stream;
@@ -38,6 +39,7 @@ pub mod source;
 pub mod table_definition;
 pub mod text;
 pub mod usage_map;
+pub mod usage_map_writer;
 pub mod value;
 
 pub use allocation::{
@@ -92,6 +94,7 @@ pub use long_value::{
 pub use map_location::{MapLocationError, MapRowLocator, TableMapLocations, locate_table_maps};
 pub use offset::{ByteCount, ByteOffset};
 pub use page::{PageGeometry, PageNumber, PageOffset};
+pub use page_image::{DataPageBuilder, PAGE_BYTES, PageImage, PageImageError, page_tag};
 pub use page_kind::{ClassifiedPage, PageClassificationError, PageKind, classify_page};
 pub use raw_page_stream::{RawPage, RawPageCursor};
 pub use relationships::{Relationship, Relationships};
@@ -102,6 +105,10 @@ pub use source::{FileSource, ReadAt, SliceSource};
 pub use table_definition::{TableDefinition, TableDefinitionError};
 pub use text::{DecodedText, TextCodePage, TextError};
 pub use usage_map::{UsageMapError, UsageMapRecord, locate_usage_map};
+pub use usage_map_writer::{
+    EXTENDED_BITMAP_BITS, ExtendedUsageMapEncoder, InlineUsageMapEncoder, UsageMapWriteError,
+    encode_indirect_references, indirect_record_len,
+};
 pub use value::{CurrencyValue, DateTimeValue, DecodedValue, GuidValue, ValueError, ValueKind};
 
 /// Human-readable name of the only database format targeted by this crate.

--- a/crates/jet3/src/page_image.rs
+++ b/crates/jet3/src/page_image.rs
@@ -104,10 +104,6 @@ impl PageImage {
     pub const fn into_bytes(self) -> [u8; PAGE_BYTES] {
         self.bytes
     }
-
-    pub(crate) const fn bytes_mut(&mut self) -> &mut [u8; PAGE_BYTES] {
-        &mut self.bytes
-    }
 }
 
 /// A structured failure while appending rows to a data page image.

--- a/crates/jet3/src/page_image.rs
+++ b/crates/jet3/src/page_image.rs
@@ -1,0 +1,289 @@
+//! Owned, checked builders for complete Jet 3 page images.
+//!
+//! A [`PageImage`] is a zero-filled 2,048-byte page with its `SRC-0020`
+//! byte-zero tag. [`DataPageBuilder`] appends rows to a tag-`01` page using
+//! the reverse-packed directory grammar of `SRC-0020` and `EXP-0060`, the
+//! exact inverse of the crate's row-directory decoder. Neither type performs
+//! I/O or chooses page numbers.
+
+use std::fmt;
+
+use crate::{
+    BinaryWriter, ByteCount, ByteOffset, Error, JET3_PAGE_SIZE, PageKind, PageNumber, PageOffset,
+    ResourceBudget,
+};
+
+/// Byte length of one complete Jet 3 page (`SRC-0020`).
+pub const PAGE_BYTES: usize = JET3_PAGE_SIZE.get() as usize;
+
+// SRC-0020: byte-zero page tags.
+const DATABASE_DEFINITION_TAG: u8 = 0x00;
+const DATA_TAG: u8 = 0x01;
+const TABLE_DEFINITION_TAG: u8 = 0x02;
+const INTERMEDIATE_INDEX_TAG: u8 = 0x03;
+const LEAF_INDEX_TAG: u8 = 0x04;
+const EXTENDED_USAGE_BITMAP_TAG: u8 = 0x05;
+
+// EXP-0060: a data page stores its table-definition root as u32 at [4,8).
+const OWNER_OFFSET: u64 = 4;
+// SRC-0020: little-endian u16 row count at [8,10), two-byte entries from 10.
+const ROW_COUNT_OFFSET: u64 = 8;
+const DIRECTORY_OFFSET: usize = 10;
+const ENTRY_LEN: usize = 2;
+// EXP-0060: the low 13 bits of a directory entry select the row start; the
+// remaining bits are flags, which this builder never sets.
+const OFFSET_MASK: u16 = 0x1fff;
+// Row slots are addressed publicly by `u8` (`RowLocator`), so a builder page
+// holds at most 256 rows.
+const MAX_BUILT_ROWS: u16 = 256;
+
+/// Returns the `SRC-0020` byte-zero tag for a page classification.
+#[must_use]
+pub const fn page_tag(kind: PageKind) -> u8 {
+    match kind {
+        PageKind::DatabaseDefinition => DATABASE_DEFINITION_TAG,
+        PageKind::Data => DATA_TAG,
+        PageKind::TableDefinition => TABLE_DEFINITION_TAG,
+        PageKind::IntermediateIndex => INTERMEDIATE_INDEX_TAG,
+        PageKind::LeafIndex => LEAF_INDEX_TAG,
+        PageKind::ExtendedUsageBitmap => EXTENDED_USAGE_BITMAP_TAG,
+        PageKind::Unknown(tag) => tag,
+    }
+}
+
+/// An owned, complete Jet 3 page under construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageImage {
+    bytes: [u8; PAGE_BYTES],
+}
+
+impl PageImage {
+    /// Creates a zero-filled page carrying the tag for `kind` at byte zero.
+    #[must_use]
+    pub const fn new(kind: PageKind) -> Self {
+        let mut bytes = [0; PAGE_BYTES];
+        bytes[0] = page_tag(kind);
+        Self { bytes }
+    }
+
+    /// Wraps an existing complete page without inspecting it.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; PAGE_BYTES]) -> Self {
+        Self { bytes }
+    }
+
+    /// Returns the byte-zero tag.
+    #[must_use]
+    pub const fn tag(&self) -> u8 {
+        self.bytes[0]
+    }
+
+    /// Writes `bytes` at a page-local offset after bounds and budget checks.
+    ///
+    /// The write is all-or-nothing: no byte changes when the range or the
+    /// encoded-byte budget is rejected.
+    pub fn write_at(
+        &mut self,
+        offset: PageOffset,
+        bytes: &[u8],
+        budget: &mut ResourceBudget,
+    ) -> Result<(), Error> {
+        let mut writer = BinaryWriter::new(&mut self.bytes, budget)?;
+        writer.seek(ByteOffset::new(offset.get()))?;
+        writer.write_exact(bytes)
+    }
+
+    /// Returns the complete page bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; PAGE_BYTES] {
+        &self.bytes
+    }
+
+    /// Consumes the builder and returns the complete page bytes.
+    #[must_use]
+    pub const fn into_bytes(self) -> [u8; PAGE_BYTES] {
+        self.bytes
+    }
+
+    pub(crate) const fn bytes_mut(&mut self) -> &mut [u8; PAGE_BYTES] {
+        &mut self.bytes
+    }
+}
+
+/// A structured failure while appending rows to a data page image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PageImageError {
+    /// The owner page does not fit the four-byte owner field.
+    OwnerNotRepresentable {
+        /// Rejected table-definition root.
+        owner: PageNumber,
+    },
+    /// A zero-length primary row cannot be distinguished from a deleted slot.
+    EmptyRow,
+    /// The row plus its directory entry do not fit the remaining free space.
+    PageFull {
+        /// Bytes needed for the row and its directory entry.
+        needed: ByteCount,
+        /// Free bytes between the directory end and the lowest row start.
+        available: ByteCount,
+    },
+    /// All addressable row slots are in use.
+    RowSlotsExhausted {
+        /// Maximum rows one built page may hold.
+        maximum: u16,
+    },
+    /// Checked encoding into the page image failed.
+    Encoding(Error),
+}
+
+impl fmt::Display for PageImageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OwnerNotRepresentable { owner } => write!(
+                formatter,
+                "data-page owner {} does not fit a four-byte field",
+                owner.get()
+            ),
+            Self::EmptyRow => write!(formatter, "data-page rows must not be empty"),
+            Self::PageFull { needed, available } => write!(
+                formatter,
+                "data page is full: {} bytes needed, {} available",
+                needed.get(),
+                available.get()
+            ),
+            Self::RowSlotsExhausted { maximum } => {
+                write!(formatter, "data page already holds {maximum} rows")
+            }
+            Self::Encoding(source) => write!(formatter, "data-page encoding failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for PageImageError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Encoding(source) => Some(source),
+            Self::OwnerNotRepresentable { .. }
+            | Self::EmptyRow
+            | Self::PageFull { .. }
+            | Self::RowSlotsExhausted { .. } => None,
+        }
+    }
+}
+
+/// Appends primary rows to a tag-`01` data page image.
+///
+/// Rows are packed downward from the page end; directory entries grow upward
+/// from byte 10, so slot `n` is the `n`th row appended. No flag bits are ever
+/// written. Header bytes without a provenance-established meaning stay zero.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataPageBuilder {
+    image: PageImage,
+    row_count: u16,
+    free_end: usize,
+}
+
+impl DataPageBuilder {
+    /// Starts an empty data page owned by the table-definition root `owner`.
+    pub fn new(owner: PageNumber, budget: &mut ResourceBudget) -> Result<Self, PageImageError> {
+        let owner_value = u32::try_from(owner.get())
+            .map_err(|_| PageImageError::OwnerNotRepresentable { owner })?;
+        let mut image = PageImage::new(PageKind::Data);
+        image
+            .write_at(
+                PageOffset::new(OWNER_OFFSET),
+                &owner_value.to_le_bytes(),
+                budget,
+            )
+            .map_err(PageImageError::Encoding)?;
+        Ok(Self {
+            image,
+            row_count: 0,
+            free_end: PAGE_BYTES,
+        })
+    }
+
+    /// Returns the number of rows appended so far.
+    #[must_use]
+    pub const fn row_count(&self) -> u16 {
+        self.row_count
+    }
+
+    /// Returns the bytes available for one more row and its directory entry.
+    #[must_use]
+    pub fn free_bytes(&self) -> ByteCount {
+        let directory_end = DIRECTORY_OFFSET + ENTRY_LEN * usize::from(self.row_count);
+        ByteCount::new(self.free_end.saturating_sub(directory_end) as u64)
+    }
+
+    /// Appends one primary row and returns its zero-based slot.
+    ///
+    /// Nothing changes when the row does not fit or the slot space is
+    /// exhausted. A budget rejection may leave row bytes in free space, but
+    /// the declared row count never advances on failure.
+    pub fn append_row(
+        &mut self,
+        row: &[u8],
+        budget: &mut ResourceBudget,
+    ) -> Result<u8, PageImageError> {
+        if row.is_empty() {
+            return Err(PageImageError::EmptyRow);
+        }
+        if self.row_count >= MAX_BUILT_ROWS {
+            return Err(PageImageError::RowSlotsExhausted {
+                maximum: MAX_BUILT_ROWS,
+            });
+        }
+        let slot = u8::try_from(self.row_count).map_err(|_| PageImageError::RowSlotsExhausted {
+            maximum: MAX_BUILT_ROWS,
+        })?;
+        let needed = ByteCount::from_usize(row.len().saturating_add(ENTRY_LEN))
+            .map_err(PageImageError::Encoding)?;
+        let available = self.free_bytes();
+        if needed.get() > available.get() {
+            return Err(PageImageError::PageFull { needed, available });
+        }
+        let start = self.free_end - row.len();
+        let entry_offset = DIRECTORY_OFFSET + ENTRY_LEN * usize::from(self.row_count);
+        let raw_offset = u16::try_from(start)
+            .ok()
+            .filter(|value| value & !OFFSET_MASK == 0)
+            .ok_or(PageImageError::Encoding(Error::Arithmetic {
+                operation: "encode data-page row offset",
+            }))?;
+
+        // The row count is written last, so a budget rejection part-way
+        // leaves the declared directory unchanged and the page decodable.
+        let mut writer =
+            BinaryWriter::new(&mut self.image.bytes, budget).map_err(PageImageError::Encoding)?;
+        let write = |writer: &mut BinaryWriter<'_, '_>| -> Result<(), Error> {
+            writer.seek(ByteOffset::new(start as u64))?;
+            writer.write_exact(row)?;
+            writer.seek(ByteOffset::new(entry_offset as u64))?;
+            writer.write_u16_le(raw_offset)?;
+            writer.seek(ByteOffset::new(ROW_COUNT_OFFSET))?;
+            writer.write_u16_le(self.row_count + 1)
+        };
+        write(&mut writer).map_err(PageImageError::Encoding)?;
+        self.row_count += 1;
+        self.free_end = start;
+        Ok(slot)
+    }
+
+    /// Returns the page built so far.
+    #[must_use]
+    pub const fn image(&self) -> &PageImage {
+        &self.image
+    }
+
+    /// Consumes the builder and returns the complete page image.
+    #[must_use]
+    pub fn finish(self) -> PageImage {
+        self.image
+    }
+}
+
+#[cfg(test)]
+#[path = "page_image_tests.rs"]
+mod tests;

--- a/crates/jet3/src/page_image_tests.rs
+++ b/crates/jet3/src/page_image_tests.rs
@@ -1,0 +1,151 @@
+use super::{DataPageBuilder, PAGE_BYTES, PageImage, PageImageError};
+use crate::data_page_directory::DataPageDirectory;
+use crate::limits::ReadLimits;
+use crate::row_directory::RowDirectory;
+use crate::{
+    ByteCount, ByteOffset, Error, MapRowLocator, PageKind, PageNumber, PageOffset, ResourceBudget,
+    ResourceLimits, classify_page, locate_usage_map,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+
+fn budget_with_encoded_limit(bytes: u64) -> ResourceBudget {
+    ResourceBudget::new(
+        ResourceLimits::new(ReadLimits::default()).with_max_encoded_bytes(ByteCount::new(bytes)),
+    )
+}
+
+#[test]
+fn new_image_carries_only_its_tag() {
+    let image = PageImage::new(PageKind::TableDefinition);
+    assert_eq!(image.tag(), 0x02);
+    assert!(image.as_bytes()[1..].iter().all(|byte| *byte == 0));
+    assert_eq!(PageImage::new(PageKind::Unknown(0x08)).tag(), 0x08);
+}
+
+#[test]
+fn write_at_accepts_last_byte_and_rejects_past_end() -> TestResult {
+    let mut image = PageImage::new(PageKind::Data);
+    let mut budget = budget();
+    image.write_at(PageOffset::new(2047), &[0xaa], &mut budget)?;
+    assert_eq!(image.as_bytes()[2047], 0xaa);
+    assert_eq!(
+        image.write_at(PageOffset::new(2047), &[1, 2], &mut budget),
+        Err(Error::OutputCapacityExceeded {
+            offset: ByteOffset::new(2047),
+            needed: ByteCount::new(2),
+            available: ByteCount::new(1),
+        })
+    );
+    assert_eq!(image.as_bytes()[2047], 0xaa);
+    Ok(())
+}
+
+#[test]
+fn appended_rows_round_trip_through_directory_decoders() -> TestResult {
+    let owner = PageNumber::new(20);
+    let mut budget = budget();
+    let mut builder = DataPageBuilder::new(owner, &mut budget)?;
+    let rows: [&[u8]; 3] = [&[0x00, 1, 2, 3], &[0x01, 0, 0, 0, 0, 9], &[0xff]];
+    for (index, row) in rows.iter().enumerate() {
+        assert_eq!(builder.append_row(row, &mut budget)?, index as u8);
+    }
+    assert_eq!(builder.row_count(), 3);
+    let image = builder.finish();
+    let raw = image.as_bytes();
+
+    let classified = classify_page(PageNumber::new(21), raw, &mut budget)?;
+    assert_eq!(classified.kind(), PageKind::Data);
+    RowDirectory::validate_owner(owner, raw)?;
+    let mut directory =
+        DataPageDirectory::validate(raw, &mut budget).map_err(|error| format!("{error:?}"))?;
+    let mut end = PAGE_BYTES;
+    for row in rows {
+        let entry = directory.next_entry(raw).ok_or("missing entry")?;
+        assert_eq!(entry.range(), end - row.len()..end);
+        assert!(!entry.overflow() && !entry.hidden());
+        assert_eq!(&raw[entry.range()], row);
+        end -= row.len();
+    }
+    assert!(directory.next_entry(raw).is_none());
+
+    let record = locate_usage_map(
+        classified,
+        MapRowLocator::new(PageNumber::new(21), 1),
+        &mut budget,
+    )?;
+    assert_eq!(record.raw(), rows[1]);
+    Ok(())
+}
+
+#[test]
+fn page_full_boundary_is_exact() -> TestResult {
+    let mut budget = budget();
+    let mut builder = DataPageBuilder::new(PageNumber::new(20), &mut budget)?;
+    let free = builder.free_bytes().get() as usize;
+    let too_big = vec![7; free - 1];
+    assert_eq!(
+        builder.append_row(&too_big, &mut budget),
+        Err(PageImageError::PageFull {
+            needed: ByteCount::new(free as u64 + 1),
+            available: ByteCount::new(free as u64),
+        })
+    );
+    builder.append_row(&too_big[..free - 2], &mut budget)?;
+    assert_eq!(builder.free_bytes(), ByteCount::new(0));
+    assert_eq!(
+        builder.append_row(&[1], &mut budget),
+        Err(PageImageError::PageFull {
+            needed: ByteCount::new(3),
+            available: ByteCount::new(0),
+        })
+    );
+    assert_eq!(
+        builder.append_row(&[], &mut budget),
+        Err(PageImageError::EmptyRow)
+    );
+    Ok(())
+}
+
+#[test]
+fn slot_space_ends_at_256_rows() -> TestResult {
+    let mut budget = budget();
+    let mut builder = DataPageBuilder::new(PageNumber::new(20), &mut budget)?;
+    for _ in 0..256 {
+        builder.append_row(&[1], &mut budget)?;
+    }
+    assert_eq!(
+        builder.append_row(&[1], &mut budget),
+        Err(PageImageError::RowSlotsExhausted { maximum: 256 })
+    );
+    Ok(())
+}
+
+#[test]
+fn owner_beyond_u32_is_rejected() {
+    assert_eq!(
+        DataPageBuilder::new(PageNumber::new(u64::from(u32::MAX) + 1), &mut budget()).err(),
+        Some(PageImageError::OwnerNotRepresentable {
+            owner: PageNumber::new(u64::from(u32::MAX) + 1),
+        })
+    );
+}
+
+#[test]
+fn budget_exhaustion_leaves_row_count_unchanged() -> TestResult {
+    let mut budget = budget_with_encoded_limit(4 + 3);
+    let mut builder = DataPageBuilder::new(PageNumber::new(20), &mut budget)?;
+    assert!(matches!(
+        builder.append_row(&[1, 2, 3], &mut budget),
+        Err(PageImageError::Encoding(
+            Error::ResourceLimitExceeded { .. }
+        ))
+    ));
+    assert_eq!(builder.row_count(), 0);
+    assert_eq!(&builder.image().as_bytes()[8..10], &[0, 0]);
+    Ok(())
+}

--- a/crates/jet3/src/page_image_tests.rs
+++ b/crates/jet3/src/page_image_tests.rs
@@ -137,15 +137,26 @@ fn owner_beyond_u32_is_rejected() {
 
 #[test]
 fn budget_exhaustion_leaves_row_count_unchanged() -> TestResult {
-    let mut budget = budget_with_encoded_limit(4 + 3);
-    let mut builder = DataPageBuilder::new(PageNumber::new(20), &mut budget)?;
+    // The row bytes and directory entry fit the budget; only the final row
+    // count write is rejected.
+    let mut limited_budget = budget_with_encoded_limit(4 + 3 + 2);
+    let mut builder = DataPageBuilder::new(PageNumber::new(20), &mut limited_budget)?;
     assert!(matches!(
-        builder.append_row(&[1, 2, 3], &mut budget),
+        builder.append_row(&[1, 2, 3], &mut limited_budget),
         Err(PageImageError::Encoding(
             Error::ResourceLimitExceeded { .. }
         ))
     ));
     assert_eq!(builder.row_count(), 0);
     assert_eq!(&builder.image().as_bytes()[8..10], &[0, 0]);
+
+    let mut retry_budget = budget();
+    assert_eq!(builder.append_row(&[1, 2, 3], &mut retry_budget)?, 0);
+    let mut directory = DataPageDirectory::validate(builder.image().as_bytes(), &mut retry_budget)
+        .map_err(|error| format!("{error:?}"))?;
+    let entry = directory
+        .next_entry(builder.image().as_bytes())
+        .ok_or("missing retried row")?;
+    assert_eq!(&builder.image().as_bytes()[entry.range()], &[1, 2, 3]);
     Ok(())
 }

--- a/crates/jet3/src/usage_map_writer.rs
+++ b/crates/jet3/src/usage_map_writer.rs
@@ -1,0 +1,334 @@
+//! Encoders for Jet 3 usage (allocation) maps.
+//!
+//! These invert the crate's `SRC-0020` / `EXP-0057` decoders: an inline
+//! type-0 record, an indirect type-1 reference row, and a complete type-`05`
+//! extended bitmap page. Bits are manipulated directly; the meaning of a set
+//! bit is the caller's concern (`SRC-0020` table maps: set means allocated;
+//! `EXP-0051` global map: set means not in use). Nothing here chooses pages.
+
+use std::fmt;
+
+use crate::allocation::EXTENDED_BITMAP_BITS as CRATE_EXTENDED_BITMAP_BITS;
+use crate::{
+    BinaryWriter, ByteCount, Error, PageImage, PageKind, PageNumber, PageOffset, ResourceBudget,
+};
+
+/// Pages represented by one complete type-`05` bitmap page (`SRC-0020`).
+pub const EXTENDED_BITMAP_BITS: u64 = CRATE_EXTENDED_BITMAP_BITS;
+
+// SRC-0020: record type bytes and fixed field lengths.
+const INLINE_RECORD_TYPE: u8 = 0x00;
+const INDIRECT_RECORD_TYPE: u8 = 0x01;
+const INLINE_HEADER_LEN: u64 = 5;
+const REFERENCE_LEN: u64 = 4;
+// SRC-0020: a Jet 3 type-05 page is `05 01 00 00` followed by 2,044 bitmap
+// bytes, low-order bit first.
+const EXTENDED_HEADER: [u8; 4] = [0x05, 0x01, 0x00, 0x00];
+const EXTENDED_BITMAP_OFFSET: usize = 4;
+
+/// A structured failure while building or encoding a usage map.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UsageMapWriteError {
+    /// The page is not represented by this map's bit range.
+    PageOutOfMap {
+        /// Rejected page.
+        page: PageNumber,
+        /// First page represented by bit zero.
+        first: PageNumber,
+        /// Number of pages the map represents.
+        page_count: u64,
+    },
+    /// A page does not fit a four-byte little-endian field.
+    PageNotRepresentable {
+        /// Rejected page.
+        page: PageNumber,
+    },
+    /// Checked arithmetic, budget, or output-capacity validation failed.
+    Encoding(Error),
+}
+
+impl fmt::Display for UsageMapWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PageOutOfMap {
+                page,
+                first,
+                page_count,
+            } => write!(
+                formatter,
+                "page {} is outside the map covering {} pages from {}",
+                page.get(),
+                page_count,
+                first.get()
+            ),
+            Self::PageNotRepresentable { page } => write!(
+                formatter,
+                "page {} does not fit a four-byte reference",
+                page.get()
+            ),
+            Self::Encoding(source) => write!(formatter, "usage-map encoding failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for UsageMapWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Encoding(source) => Some(source),
+            Self::PageOutOfMap { .. } | Self::PageNotRepresentable { .. } => None,
+        }
+    }
+}
+
+impl From<Error> for UsageMapWriteError {
+    fn from(source: Error) -> Self {
+        Self::Encoding(source)
+    }
+}
+
+/// Resolves a map-relative bit into its byte index and low-bit-first mask.
+fn bit_location(
+    page: PageNumber,
+    first: PageNumber,
+    page_count: u64,
+) -> Result<(usize, u8), UsageMapWriteError> {
+    let relative = page
+        .get()
+        .checked_sub(first.get())
+        .filter(|relative| *relative < page_count)
+        .ok_or(UsageMapWriteError::PageOutOfMap {
+            page,
+            first,
+            page_count,
+        })?;
+    let byte = usize::try_from(relative / 8).map_err(|_| Error::IntegerConversion {
+        value: u128::from(relative / 8),
+        target: "usize",
+    })?;
+    // SRC-0020: low-order bit first within each bitmap byte.
+    let mask = 1_u8 << (relative % 8);
+    Ok((byte, mask))
+}
+
+/// Builds a type-0 record: tag, four-byte starting page, inline bitmap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineUsageMapEncoder {
+    start_page: u32,
+    bitmap: Vec<u8>,
+}
+
+impl InlineUsageMapEncoder {
+    /// Starts an all-clear map of `bitmap_len` bytes beginning at `start_page`.
+    ///
+    /// The bitmap allocation is charged to `budget` before it is made.
+    pub fn new(
+        start_page: PageNumber,
+        bitmap_len: ByteCount,
+        budget: &mut ResourceBudget,
+    ) -> Result<Self, UsageMapWriteError> {
+        let start = u32::try_from(start_page.get())
+            .map_err(|_| UsageMapWriteError::PageNotRepresentable { page: start_page })?;
+        budget.charge_allocation(bitmap_len)?;
+        let len = bitmap_len.to_usize()?;
+        Ok(Self {
+            start_page: start,
+            bitmap: vec![0; len],
+        })
+    }
+
+    /// Returns the page represented by bit zero.
+    #[must_use]
+    pub const fn start_page(&self) -> PageNumber {
+        PageNumber::new(self.start_page as u64)
+    }
+
+    /// Returns the number of pages the bitmap represents.
+    #[must_use]
+    pub fn page_count(&self) -> u64 {
+        (self.bitmap.len() as u64).saturating_mul(8)
+    }
+
+    /// Returns the complete encoded record length.
+    #[must_use]
+    pub fn encoded_len(&self) -> ByteCount {
+        ByteCount::new(INLINE_HEADER_LEN.saturating_add(self.bitmap.len() as u64))
+    }
+
+    /// Sets the bit for `page`.
+    pub fn set_page(&mut self, page: PageNumber) -> Result<(), UsageMapWriteError> {
+        self.update(page, true)
+    }
+
+    /// Clears the bit for `page`.
+    pub fn clear_page(&mut self, page: PageNumber) -> Result<(), UsageMapWriteError> {
+        self.update(page, false)
+    }
+
+    /// Returns whether the bit for `page` is set.
+    pub fn is_set(&self, page: PageNumber) -> Result<bool, UsageMapWriteError> {
+        let (byte, mask) = self.locate(page)?;
+        Ok(self.bitmap.get(byte).is_some_and(|value| value & mask != 0))
+    }
+
+    /// Encodes the record into the front of `output`, returning its length.
+    pub fn encode_into(
+        &self,
+        output: &mut [u8],
+        budget: &mut ResourceBudget,
+    ) -> Result<ByteCount, UsageMapWriteError> {
+        let mut writer = BinaryWriter::new(output, budget)?;
+        writer.write_u8(INLINE_RECORD_TYPE)?;
+        writer.write_u32_le(self.start_page)?;
+        writer.write_exact(&self.bitmap)?;
+        Ok(self.encoded_len())
+    }
+
+    fn locate(&self, page: PageNumber) -> Result<(usize, u8), UsageMapWriteError> {
+        bit_location(page, self.start_page(), self.page_count())
+    }
+
+    fn update(&mut self, page: PageNumber, set: bool) -> Result<(), UsageMapWriteError> {
+        let (byte, mask) = self.locate(page)?;
+        let target = self.bitmap.get_mut(byte).ok_or(Error::Arithmetic {
+            operation: "locate inline usage-map bitmap byte",
+        })?;
+        write_bit(target, mask, set);
+        Ok(())
+    }
+}
+
+/// Builds a complete type-`05` extended bitmap page for one type-1 slot.
+///
+/// The page represents absolute pages `slot * 16_352 + bit` (`EXP-0057`),
+/// regardless of which physical page eventually stores it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtendedUsageMapEncoder {
+    slot: u64,
+    first: PageNumber,
+    image: PageImage,
+}
+
+impl ExtendedUsageMapEncoder {
+    /// Starts an all-clear bitmap page for the zero-based type-1 `slot`.
+    pub fn new(slot: u64, budget: &mut ResourceBudget) -> Result<Self, UsageMapWriteError> {
+        let first = slot
+            .checked_mul(EXTENDED_BITMAP_BITS)
+            .map(PageNumber::new)
+            .ok_or(Error::Arithmetic {
+                operation: "extended usage-map slot to first page multiplication",
+            })?;
+        let mut image = PageImage::new(PageKind::ExtendedUsageBitmap);
+        image.write_at(PageOffset::new(0), &EXTENDED_HEADER, budget)?;
+        Ok(Self { slot, first, image })
+    }
+
+    /// Returns the zero-based type-1 slot ordinal.
+    #[must_use]
+    pub const fn slot(&self) -> u64 {
+        self.slot
+    }
+
+    /// Returns the page represented by bit zero.
+    #[must_use]
+    pub const fn first_page(&self) -> PageNumber {
+        self.first
+    }
+
+    /// Sets the bit for `page`.
+    pub fn set_page(&mut self, page: PageNumber) -> Result<(), UsageMapWriteError> {
+        self.update(page, true)
+    }
+
+    /// Clears the bit for `page`.
+    pub fn clear_page(&mut self, page: PageNumber) -> Result<(), UsageMapWriteError> {
+        self.update(page, false)
+    }
+
+    /// Returns whether the bit for `page` is set.
+    pub fn is_set(&self, page: PageNumber) -> Result<bool, UsageMapWriteError> {
+        let index = self.locate(page)?;
+        Ok(self
+            .image
+            .as_bytes()
+            .get(index.0)
+            .is_some_and(|value| value & index.1 != 0))
+    }
+
+    /// Returns the complete page image.
+    #[must_use]
+    pub const fn image(&self) -> &PageImage {
+        &self.image
+    }
+
+    /// Consumes the encoder and returns the complete page image.
+    #[must_use]
+    pub fn into_image(self) -> PageImage {
+        self.image
+    }
+
+    fn locate(&self, page: PageNumber) -> Result<(usize, u8), UsageMapWriteError> {
+        let (byte, mask) = bit_location(page, self.first, EXTENDED_BITMAP_BITS)?;
+        let index = byte
+            .checked_add(EXTENDED_BITMAP_OFFSET)
+            .ok_or(Error::Arithmetic {
+                operation: "extended usage-map bitmap byte offset addition",
+            })?;
+        Ok((index, mask))
+    }
+
+    fn update(&mut self, page: PageNumber, set: bool) -> Result<(), UsageMapWriteError> {
+        let (index, mask) = self.locate(page)?;
+        let target = self
+            .image
+            .bytes_mut()
+            .get_mut(index)
+            .ok_or(Error::Arithmetic {
+                operation: "locate extended usage-map bitmap byte",
+            })?;
+        write_bit(target, mask, set);
+        Ok(())
+    }
+}
+
+/// Returns the encoded length of a type-1 row holding `reference_count` slots.
+pub fn indirect_record_len(reference_count: u64) -> Result<ByteCount, Error> {
+    reference_count
+        .checked_mul(REFERENCE_LEN)
+        .and_then(|payload| payload.checked_add(1))
+        .map(ByteCount::new)
+        .ok_or(Error::Arithmetic {
+            operation: "indirect usage-map record length",
+        })
+}
+
+/// Encodes a type-1 row: tag `01` then each reference as little-endian `u32`.
+///
+/// A zero reference is an unused slot (`EXP-0057`). Returns the encoded
+/// length; the output must hold the complete row.
+pub fn encode_indirect_references(
+    references: &[PageNumber],
+    output: &mut [u8],
+    budget: &mut ResourceBudget,
+) -> Result<ByteCount, UsageMapWriteError> {
+    let mut writer = BinaryWriter::new(output, budget)?;
+    writer.write_u8(INDIRECT_RECORD_TYPE)?;
+    for &page in references {
+        let value = u32::try_from(page.get())
+            .map_err(|_| UsageMapWriteError::PageNotRepresentable { page })?;
+        writer.write_u32_le(value)?;
+    }
+    Ok(indirect_record_len(references.len() as u64)?)
+}
+
+fn write_bit(target: &mut u8, mask: u8, set: bool) {
+    if set {
+        *target |= mask;
+    } else {
+        *target &= !mask;
+    }
+}
+
+#[cfg(test)]
+#[path = "usage_map_writer_tests.rs"]
+mod tests;

--- a/crates/jet3/src/usage_map_writer.rs
+++ b/crates/jet3/src/usage_map_writer.rs
@@ -131,9 +131,15 @@ impl InlineUsageMapEncoder {
             .map_err(|_| UsageMapWriteError::PageNotRepresentable { page: start_page })?;
         budget.charge_allocation(bitmap_len)?;
         let len = bitmap_len.to_usize()?;
+        let mut bitmap = Vec::new();
+        bitmap.try_reserve_exact(len).map_err(|_| Error::Io {
+            operation: "reserve inline usage-map bitmap",
+            kind: std::io::ErrorKind::OutOfMemory,
+        })?;
+        bitmap.resize(len, 0);
         Ok(Self {
             start_page: start,
-            bitmap: vec![0; len],
+            bitmap,
         })
     }
 
@@ -235,14 +241,22 @@ impl ExtendedUsageMapEncoder {
         self.first
     }
 
-    /// Sets the bit for `page`.
-    pub fn set_page(&mut self, page: PageNumber) -> Result<(), UsageMapWriteError> {
-        self.update(page, true)
+    /// Sets the bit for `page`, charging the one-byte image update to `budget`.
+    pub fn set_page(
+        &mut self,
+        page: PageNumber,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), UsageMapWriteError> {
+        self.update(page, true, budget)
     }
 
-    /// Clears the bit for `page`.
-    pub fn clear_page(&mut self, page: PageNumber) -> Result<(), UsageMapWriteError> {
-        self.update(page, false)
+    /// Clears the bit for `page`, charging the one-byte image update to `budget`.
+    pub fn clear_page(
+        &mut self,
+        page: PageNumber,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), UsageMapWriteError> {
+        self.update(page, false, budget)
     }
 
     /// Returns whether the bit for `page` is set.
@@ -277,16 +291,20 @@ impl ExtendedUsageMapEncoder {
         Ok((index, mask))
     }
 
-    fn update(&mut self, page: PageNumber, set: bool) -> Result<(), UsageMapWriteError> {
+    fn update(
+        &mut self,
+        page: PageNumber,
+        set: bool,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), UsageMapWriteError> {
         let (index, mask) = self.locate(page)?;
-        let target = self
-            .image
-            .bytes_mut()
-            .get_mut(index)
-            .ok_or(Error::Arithmetic {
-                operation: "locate extended usage-map bitmap byte",
-            })?;
-        write_bit(target, mask, set);
+        let current = *self.image.as_bytes().get(index).ok_or(Error::Arithmetic {
+            operation: "locate extended usage-map bitmap byte",
+        })?;
+        let mut updated = current;
+        write_bit(&mut updated, mask, set);
+        self.image
+            .write_at(PageOffset::from_usize(index)?, &[updated], budget)?;
         Ok(())
     }
 }

--- a/crates/jet3/src/usage_map_writer_tests.rs
+++ b/crates/jet3/src/usage_map_writer_tests.rs
@@ -1,0 +1,196 @@
+use super::{
+    EXTENDED_BITMAP_BITS, ExtendedUsageMapEncoder, InlineUsageMapEncoder, UsageMapWriteError,
+    encode_indirect_references, indirect_record_len,
+};
+use crate::limits::ReadLimits;
+use crate::{
+    AllocationMap, ByteCount, Error, JET3_PAGE_SIZE, PageGeometry, PageNumber, ReachedMapPage,
+    ResourceBudget, ResourceLimits, classify_page, decode_allocation_map,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+
+fn out_of_map(page: u64, first: u64, page_count: u64) -> UsageMapWriteError {
+    UsageMapWriteError::PageOutOfMap {
+        page: PageNumber::new(page),
+        first: PageNumber::new(first),
+        page_count,
+    }
+}
+
+#[test]
+fn inline_record_round_trips_through_decoder() -> TestResult {
+    let mut budget = budget();
+    let mut encoder =
+        InlineUsageMapEncoder::new(PageNumber::new(100), ByteCount::new(2), &mut budget)?;
+    for page in [100, 107, 115] {
+        encoder.set_page(PageNumber::new(page))?;
+    }
+    encoder.clear_page(PageNumber::new(107))?;
+    assert_eq!(encoder.is_set(PageNumber::new(115)), Ok(true));
+    assert_eq!(encoder.is_set(PageNumber::new(107)), Ok(false));
+
+    let mut record = [0xee; 8];
+    assert_eq!(
+        encoder.encode_into(&mut record, &mut budget)?,
+        ByteCount::new(7)
+    );
+    assert_eq!(record, [0x00, 100, 0, 0, 0, 0b0000_0001, 0b1000_0000, 0xee]);
+
+    let geometry = PageGeometry::new(ByteCount::new(200 * JET3_PAGE_SIZE.get()), JET3_PAGE_SIZE)?;
+    let AllocationMap::Inline(map) = decode_allocation_map(&record[..7], &mut budget)? else {
+        return Err("expected inline map".into());
+    };
+    let mut pages = map.allocated_pages(geometry);
+    let mut decoded = Vec::new();
+    while let Some(page) = pages.next_page(&mut budget)? {
+        decoded.push(page.get());
+    }
+    assert_eq!(decoded, [100, 115]);
+    Ok(())
+}
+
+#[test]
+fn inline_map_rejects_pages_outside_its_range() -> TestResult {
+    let mut encoder =
+        InlineUsageMapEncoder::new(PageNumber::new(100), ByteCount::new(2), &mut budget())?;
+    assert_eq!(
+        encoder.set_page(PageNumber::new(99)),
+        Err(out_of_map(99, 100, 16))
+    );
+    assert_eq!(
+        encoder.set_page(PageNumber::new(116)),
+        Err(out_of_map(116, 100, 16))
+    );
+    assert_eq!(
+        InlineUsageMapEncoder::new(
+            PageNumber::new(u64::from(u32::MAX) + 1),
+            ByteCount::new(1),
+            &mut budget()
+        )
+        .err(),
+        Some(UsageMapWriteError::PageNotRepresentable {
+            page: PageNumber::new(u64::from(u32::MAX) + 1),
+        })
+    );
+    Ok(())
+}
+
+#[test]
+fn inline_encoding_rejects_short_output_and_exhausted_budgets() -> TestResult {
+    let allocation_limited =
+        ResourceLimits::new(ReadLimits::default()).with_max_allocation_bytes(ByteCount::new(1));
+    assert!(matches!(
+        InlineUsageMapEncoder::new(
+            PageNumber::new(0),
+            ByteCount::new(2),
+            &mut ResourceBudget::new(allocation_limited)
+        ),
+        Err(UsageMapWriteError::Encoding(
+            Error::ResourceLimitExceeded { .. }
+        ))
+    ));
+
+    let encoder = InlineUsageMapEncoder::new(PageNumber::new(0), ByteCount::new(2), &mut budget())?;
+    assert!(matches!(
+        encoder.encode_into(&mut [0; 6], &mut budget()),
+        Err(UsageMapWriteError::Encoding(
+            Error::OutputCapacityExceeded { .. }
+        ))
+    ));
+    let encoded_limited =
+        ResourceLimits::new(ReadLimits::default()).with_max_encoded_bytes(ByteCount::new(6));
+    assert!(matches!(
+        encoder.encode_into(&mut [0; 7], &mut ResourceBudget::new(encoded_limited)),
+        Err(UsageMapWriteError::Encoding(
+            Error::ResourceLimitExceeded { .. }
+        ))
+    ));
+    Ok(())
+}
+
+#[test]
+fn extended_page_round_trips_through_traversal_decoder() -> TestResult {
+    let mut budget = budget();
+    let mut encoder = ExtendedUsageMapEncoder::new(1, &mut budget)?;
+    assert_eq!(encoder.first_page(), PageNumber::new(EXTENDED_BITMAP_BITS));
+    let first = EXTENDED_BITMAP_BITS;
+    let last = 2 * EXTENDED_BITMAP_BITS - 1;
+    encoder.set_page(PageNumber::new(first))?;
+    encoder.set_page(PageNumber::new(first + 9))?;
+    encoder.set_page(PageNumber::new(last))?;
+    encoder.clear_page(PageNumber::new(first + 9))?;
+    assert_eq!(
+        encoder.set_page(PageNumber::new(first - 1)),
+        Err(out_of_map(first - 1, first, EXTENDED_BITMAP_BITS))
+    );
+    assert_eq!(
+        encoder.set_page(PageNumber::new(last + 1)),
+        Err(out_of_map(last + 1, first, EXTENDED_BITMAP_BITS))
+    );
+
+    let image = encoder.into_image();
+    assert_eq!(&image.as_bytes()[..4], &[0x05, 0x01, 0x00, 0x00]);
+    let classified = classify_page(PageNumber::new(7041), image.as_bytes(), &mut budget)?;
+    let mut reached = ReachedMapPage::new(1, classified)?;
+    let mut pages = Vec::new();
+    while let Some(bit) = reached.relative_bits().next_bit(&mut budget)? {
+        pages.push(reached.absolute_page(bit)?.get());
+    }
+    assert_eq!(pages, [first, last]);
+    Ok(())
+}
+
+#[test]
+fn extended_slot_overflow_is_structured() {
+    assert!(matches!(
+        ExtendedUsageMapEncoder::new(u64::MAX, &mut budget()),
+        Err(UsageMapWriteError::Encoding(Error::Arithmetic { .. }))
+    ));
+}
+
+#[test]
+fn indirect_row_round_trips_and_rejects_wide_references() -> TestResult {
+    let mut budget = budget();
+    let references = [
+        PageNumber::new(21),
+        PageNumber::new(0),
+        PageNumber::new(7041),
+    ];
+    let mut row = [0; 13];
+    assert_eq!(
+        encode_indirect_references(&references, &mut row, &mut budget)?,
+        indirect_record_len(3)?
+    );
+    let AllocationMap::Indirect(map) = decode_allocation_map(&row, &mut budget)? else {
+        return Err("expected indirect map".into());
+    };
+    let mut cursor = map.map_page_references();
+    let mut decoded = Vec::new();
+    while let Some(reference) = cursor.next_reference(&mut budget)? {
+        decoded.push(u64::from(reference));
+    }
+    assert_eq!(decoded, [21, 0, 7041]);
+
+    assert_eq!(
+        encode_indirect_references(
+            &[PageNumber::new(u64::from(u32::MAX) + 1)],
+            &mut [0; 5],
+            &mut budget
+        ),
+        Err(UsageMapWriteError::PageNotRepresentable {
+            page: PageNumber::new(u64::from(u32::MAX) + 1),
+        })
+    );
+    assert!(matches!(
+        encode_indirect_references(&references, &mut [0; 12], &mut budget),
+        Err(UsageMapWriteError::Encoding(
+            Error::OutputCapacityExceeded { .. }
+        ))
+    ));
+    Ok(())
+}

--- a/crates/jet3/src/usage_map_writer_tests.rs
+++ b/crates/jet3/src/usage_map_writer_tests.rs
@@ -95,6 +95,21 @@ fn inline_encoding_rejects_short_output_and_exhausted_budgets() -> TestResult {
         ))
     ));
 
+    let reserve_limited = ResourceLimits::new(ReadLimits::default())
+        .with_max_allocation_bytes(ByteCount::new(u64::MAX))
+        .with_max_total_work_units(u64::MAX);
+    assert!(matches!(
+        InlineUsageMapEncoder::new(
+            PageNumber::new(0),
+            ByteCount::from_usize(usize::MAX)?,
+            &mut ResourceBudget::new(reserve_limited)
+        ),
+        Err(UsageMapWriteError::Encoding(Error::Io {
+            kind: std::io::ErrorKind::OutOfMemory,
+            ..
+        }))
+    ));
+
     let encoder = InlineUsageMapEncoder::new(PageNumber::new(0), ByteCount::new(2), &mut budget())?;
     assert!(matches!(
         encoder.encode_into(&mut [0; 6], &mut budget()),
@@ -120,16 +135,16 @@ fn extended_page_round_trips_through_traversal_decoder() -> TestResult {
     assert_eq!(encoder.first_page(), PageNumber::new(EXTENDED_BITMAP_BITS));
     let first = EXTENDED_BITMAP_BITS;
     let last = 2 * EXTENDED_BITMAP_BITS - 1;
-    encoder.set_page(PageNumber::new(first))?;
-    encoder.set_page(PageNumber::new(first + 9))?;
-    encoder.set_page(PageNumber::new(last))?;
-    encoder.clear_page(PageNumber::new(first + 9))?;
+    encoder.set_page(PageNumber::new(first), &mut budget)?;
+    encoder.set_page(PageNumber::new(first + 9), &mut budget)?;
+    encoder.set_page(PageNumber::new(last), &mut budget)?;
+    encoder.clear_page(PageNumber::new(first + 9), &mut budget)?;
     assert_eq!(
-        encoder.set_page(PageNumber::new(first - 1)),
+        encoder.set_page(PageNumber::new(first - 1), &mut budget),
         Err(out_of_map(first - 1, first, EXTENDED_BITMAP_BITS))
     );
     assert_eq!(
-        encoder.set_page(PageNumber::new(last + 1)),
+        encoder.set_page(PageNumber::new(last + 1), &mut budget),
         Err(out_of_map(last + 1, first, EXTENDED_BITMAP_BITS))
     );
 
@@ -151,6 +166,24 @@ fn extended_slot_overflow_is_structured() {
         ExtendedUsageMapEncoder::new(u64::MAX, &mut budget()),
         Err(UsageMapWriteError::Encoding(Error::Arithmetic { .. }))
     ));
+}
+
+#[test]
+fn extended_updates_are_budgeted_and_atomic() -> TestResult {
+    let encoded_limited =
+        ResourceLimits::new(ReadLimits::default()).with_max_encoded_bytes(ByteCount::new(4));
+    let mut budget = ResourceBudget::new(encoded_limited);
+    let mut encoder = ExtendedUsageMapEncoder::new(0, &mut budget)?;
+    let before = *encoder.image().as_bytes();
+
+    assert!(matches!(
+        encoder.set_page(PageNumber::new(0), &mut budget),
+        Err(UsageMapWriteError::Encoding(
+            Error::ResourceLimitExceeded { .. }
+        ))
+    ));
+    assert_eq!(encoder.image().as_bytes(), &before);
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
First write-side building block for database creation (#100). The reader can decode every Jet 3 page kind but nothing in the crate could produce one, so the writer had nowhere to start.

This adds pure, I/O-free encoders that are exact inverses of the existing decoders:

- `PageImage` / `DataPageBuilder`: build a 2,048-byte page with its tag and append rows to a tag-`01` page through the reverse-packed row directory (`SRC-0020`, `EXP-0060`).
- `InlineUsageMapEncoder` / `ExtendedUsageMapEncoder` / `encode_indirect_references`: set and clear page bits in type-0 records and type-`05` bitmap pages and emit type-1 reference rows, with checked `slot * 16352 + bit` arithmetic (`EXP-0057`).

Everything goes through `BinaryWriter` + `ResourceBudget`; every constant cites an existing provenance entry, and round-trip tests decode the output with the crate's own decoders. Page selection policy is deliberately not here — it waits on the A9 result (#99).

Not established by provenance and therefore left zero: data-page header bytes `[1,4)` and the internal layout of the `EXP-0051` global map record.

Checks: `just ready` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)