### PR TITLE
feat(jet3): add table-definition, catalog, and row encoders

### DIFF
--- a/crates/jet3/src/catalog_record_writer.rs
+++ b/crates/jet3/src/catalog_record_writer.rs
@@ -1,0 +1,148 @@
+//! Checked encoder for one minimum `MSysObjects` catalog row, the inverse of
+//! `catalog_record.rs` (`EXP-0058`).
+
+use std::fmt;
+
+use crate::{
+    BinaryWriter, ByteCount, CatalogObjectClass, CatalogObjectKind, Error, ResourceBudget,
+};
+
+/// `EXP-0058`: every catalog record begins with column count 17.
+const CATALOG_COLUMN_COUNT: u8 = 17;
+/// `EXP-0058`: identifier at `[1,5)`, kind at `[9,11)`, flags at `[27,31)`.
+const OBJECT_ID_OFFSET: usize = 1;
+const OBJECT_KIND_OFFSET: usize = 9;
+const OBJECT_FLAGS_OFFSET: usize = 27;
+/// `EXP-0058`: the name starts at byte 31.
+const NAME_START: usize = 31;
+/// `EXP-0058`: six-byte reverse trailer: name end, name start 31, fixed
+/// boundary 11, marker `0xff`, then two bytes with no established meaning.
+const TRAILER_LEN: usize = 6;
+const FIXED_BOUNDARY: u8 = 11;
+const TRAILER_MARKER: u8 = 0xff;
+/// `EXP-0058`: user objects have flags 0, system objects `0x80000000`.
+const USER_FLAGS: u32 = 0;
+const SYSTEM_FLAGS: u32 = 0x8000_0000;
+/// The one-byte name-end offset bounds the name length.
+const MAX_NAME_LEN: usize = u8::MAX as usize - NAME_START;
+
+/// One catalog object row to encode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CatalogRecordSpec<'a> {
+    /// Object identifier; for tables, also the table-definition root page.
+    pub id: u32,
+    /// Object kind.
+    pub kind: CatalogObjectKind,
+    /// User or system classification.
+    pub class: CatalogObjectClass,
+    /// Raw database-code-page name bytes.
+    pub name: &'a [u8],
+}
+
+/// Structured failure while encoding a catalog row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CatalogRecordWriteError {
+    /// The name is empty.
+    EmptyName,
+    /// The name does not fit the one-byte name-end offset.
+    NameTooLong {
+        /// Requested length.
+        length: usize,
+        /// Maximum length.
+        maximum: usize,
+    },
+    /// The output slice cannot hold the complete row.
+    OutputTooSmall {
+        /// Required length.
+        needed: usize,
+        /// Provided length.
+        available: usize,
+    },
+    /// Resource policy or checked arithmetic rejected the encoding.
+    Resource(Error),
+}
+
+impl fmt::Display for CatalogRecordWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "catalog record encoding failed: {self:?}")
+    }
+}
+
+impl std::error::Error for CatalogRecordWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Resource(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Returns the exact encoded row length for a name of `name_len` bytes.
+pub fn catalog_record_len(name_len: usize) -> Result<usize, CatalogRecordWriteError> {
+    if name_len == 0 {
+        return Err(CatalogRecordWriteError::EmptyName);
+    }
+    if name_len > MAX_NAME_LEN {
+        return Err(CatalogRecordWriteError::NameTooLong {
+            length: name_len,
+            maximum: MAX_NAME_LEN,
+        });
+    }
+    Ok(NAME_START + name_len + TRAILER_LEN)
+}
+
+/// Encodes one catalog row into `output`, returning the encoded length.
+///
+/// Bytes with no `EXP-0058` meaning are written as zero.
+pub fn encode_catalog_record(
+    spec: &CatalogRecordSpec<'_>,
+    output: &mut [u8],
+    budget: &mut ResourceBudget,
+) -> Result<ByteCount, CatalogRecordWriteError> {
+    let length = catalog_record_len(spec.name.len())?;
+    if output.len() < length {
+        return Err(CatalogRecordWriteError::OutputTooSmall {
+            needed: length,
+            available: output.len(),
+        });
+    }
+    let name_end = u8::try_from(NAME_START + spec.name.len()).map_err(|_| {
+        CatalogRecordWriteError::NameTooLong {
+            length: spec.name.len(),
+            maximum: MAX_NAME_LEN,
+        }
+    })?;
+    let flags = match spec.class {
+        CatalogObjectClass::User => USER_FLAGS,
+        CatalogObjectClass::System => SYSTEM_FLAGS,
+    };
+    let mut writer =
+        BinaryWriter::new(output, budget).map_err(CatalogRecordWriteError::Resource)?;
+    write_row(&mut writer, spec, name_end, flags).map_err(CatalogRecordWriteError::Resource)?;
+    Ok(ByteCount::new(writer.position().get()))
+}
+
+fn write_row(
+    writer: &mut BinaryWriter<'_, '_>,
+    spec: &CatalogRecordSpec<'_>,
+    name_end: u8,
+    flags: u32,
+) -> Result<(), Error> {
+    writer.write_u8(CATALOG_COLUMN_COUNT)?;
+    writer.write_u32_le(spec.id)?;
+    writer.write_exact(&[0; OBJECT_KIND_OFFSET - OBJECT_ID_OFFSET - 4])?;
+    writer.write_u16_le(spec.kind.raw())?;
+    writer.write_exact(&[0; OBJECT_FLAGS_OFFSET - OBJECT_KIND_OFFSET - 2])?;
+    writer.write_u32_le(flags)?;
+    writer.write_exact(spec.name)?;
+    writer.write_u8(name_end)?;
+    writer.write_u8(NAME_START as u8)?;
+    writer.write_u8(FIXED_BOUNDARY)?;
+    writer.write_u8(TRAILER_MARKER)?;
+    writer.write_exact(&[0; 2])
+}
+
+#[cfg(test)]
+#[path = "catalog_record_writer_tests.rs"]
+mod tests;

--- a/crates/jet3/src/catalog_record_writer.rs
+++ b/crates/jet3/src/catalog_record_writer.rs
@@ -43,6 +43,13 @@ pub struct CatalogRecordSpec<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CatalogRecordWriteError {
+    /// An `Unknown` kind aliases a discriminant with a known interpretation.
+    NonCanonicalObjectKind {
+        /// Rejected physical kind value.
+        raw: u16,
+    },
+    /// A table cannot use database-definition page zero as its TDEF root.
+    NullTableDefinition,
     /// The name is empty.
     EmptyName,
     /// The name does not fit the one-byte name-end offset.
@@ -100,6 +107,7 @@ pub fn encode_catalog_record(
     output: &mut [u8],
     budget: &mut ResourceBudget,
 ) -> Result<ByteCount, CatalogRecordWriteError> {
+    validate_spec(spec)?;
     let length = catalog_record_len(spec.name.len())?;
     if output.len() < length {
         return Err(CatalogRecordWriteError::OutputTooSmall {
@@ -121,6 +129,18 @@ pub fn encode_catalog_record(
         BinaryWriter::new(output, budget).map_err(CatalogRecordWriteError::Resource)?;
     write_row(&mut writer, spec, name_end, flags).map_err(CatalogRecordWriteError::Resource)?;
     Ok(ByteCount::new(writer.position().get()))
+}
+
+fn validate_spec(spec: &CatalogRecordSpec<'_>) -> Result<(), CatalogRecordWriteError> {
+    match spec.kind {
+        CatalogObjectKind::Table if spec.id == 0 => {
+            Err(CatalogRecordWriteError::NullTableDefinition)
+        }
+        CatalogObjectKind::Unknown(raw) if raw == CatalogObjectKind::Table.raw() => {
+            Err(CatalogRecordWriteError::NonCanonicalObjectKind { raw })
+        }
+        CatalogObjectKind::Table | CatalogObjectKind::Unknown(_) => Ok(()),
+    }
 }
 
 fn write_row(

--- a/crates/jet3/src/catalog_record_writer_tests.rs
+++ b/crates/jet3/src/catalog_record_writer_tests.rs
@@ -1,0 +1,95 @@
+use super::{
+    CatalogRecordSpec, CatalogRecordWriteError, catalog_record_len, encode_catalog_record,
+};
+use crate::catalog_record::decode_catalog_record;
+use crate::{
+    ByteCount, CatalogObjectClass, CatalogObjectKind, Error, ReadLimits, ResourceBudget,
+    ResourceLimitKind, ResourceLimits,
+};
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::new(ReadLimits::default()))
+}
+
+#[test]
+fn round_trips_cp1252_name_kind_and_flags() -> Result<(), Box<dyn std::error::Error>> {
+    // EXP-0058: `Café_Euro€` stored as these exact CP1252 bytes.
+    let name = b"\x43\x61\x66\xe9\x5f\x45\x75\x72\x6f\x80";
+    let spec = CatalogRecordSpec {
+        id: 23,
+        kind: CatalogObjectKind::Table,
+        class: CatalogObjectClass::User,
+        name,
+    };
+    let mut output = [0xa5_u8; 64];
+    let mut resources = budget();
+    let length = encode_catalog_record(&spec, &mut output, &mut resources)?;
+    assert_eq!(length.get() as usize, catalog_record_len(name.len())?);
+    let row = &output[..length.get() as usize];
+    let view = decode_catalog_record(row, &mut resources)?;
+    assert_eq!(view.id().get(), 23);
+    assert_eq!(view.kind(), CatalogObjectKind::Table);
+    assert_eq!(view.class(), CatalogObjectClass::User);
+    assert_eq!(view.name_bytes(), name);
+
+    let system = CatalogRecordSpec {
+        id: 2,
+        kind: CatalogObjectKind::Unknown(6),
+        class: CatalogObjectClass::System,
+        name: b"MSysObjects",
+    };
+    let length = encode_catalog_record(&system, &mut output, &mut resources)?;
+    let view = decode_catalog_record(&output[..length.get() as usize], &mut resources)?;
+    assert_eq!(view.kind(), CatalogObjectKind::Unknown(6));
+    assert_eq!(view.class(), CatalogObjectClass::System);
+    assert_eq!(view.name_bytes(), b"MSysObjects");
+    Ok(())
+}
+
+#[test]
+fn rejects_bad_names_small_output_and_exhausted_budget() {
+    let spec = CatalogRecordSpec {
+        id: 1,
+        kind: CatalogObjectKind::Table,
+        class: CatalogObjectClass::User,
+        name: b"T",
+    };
+    let mut output = [0_u8; 64];
+    assert_eq!(
+        catalog_record_len(0),
+        Err(CatalogRecordWriteError::EmptyName)
+    );
+    assert_eq!(
+        catalog_record_len(225),
+        Err(CatalogRecordWriteError::NameTooLong {
+            length: 225,
+            maximum: 224,
+        })
+    );
+    assert!(catalog_record_len(224).is_ok());
+    assert_eq!(
+        encode_catalog_record(&spec, &mut output[..10], &mut budget()),
+        Err(CatalogRecordWriteError::OutputTooSmall {
+            needed: 38,
+            available: 10,
+        })
+    );
+    let mut exhausted = ResourceBudget::new(
+        ResourceLimits::new(ReadLimits::default()).with_max_encoded_bytes(ByteCount::new(4)),
+    );
+    assert_eq!(
+        encode_catalog_record(&spec, &mut output, &mut exhausted),
+        Err(CatalogRecordWriteError::Resource(
+            Error::ResourceLimitExceeded {
+                kind: ResourceLimitKind::EncodedBytes,
+                requested: 5,
+                maximum: 4,
+            }
+        ))
+    );
+    assert!(
+        CatalogRecordWriteError::EmptyName
+            .to_string()
+            .contains("catalog record encoding failed")
+    );
+}

--- a/crates/jet3/src/catalog_record_writer_tests.rs
+++ b/crates/jet3/src/catalog_record_writer_tests.rs
@@ -93,3 +93,31 @@ fn rejects_bad_names_small_output_and_exhausted_budget() {
             .contains("catalog record encoding failed")
     );
 }
+
+#[test]
+fn rejects_noncanonical_kind_and_null_table_root_without_writing() {
+    let mut output = [0xa5_u8; 64];
+    let alias = CatalogRecordSpec {
+        id: 1,
+        kind: CatalogObjectKind::Unknown(CatalogObjectKind::Table.raw()),
+        class: CatalogObjectClass::User,
+        name: b"T",
+    };
+    assert_eq!(
+        encode_catalog_record(&alias, &mut output, &mut budget()),
+        Err(CatalogRecordWriteError::NonCanonicalObjectKind { raw: 1 })
+    );
+    assert_eq!(output, [0xa5; 64]);
+
+    let null_root = CatalogRecordSpec {
+        id: 0,
+        kind: CatalogObjectKind::Table,
+        class: CatalogObjectClass::User,
+        name: b"T",
+    };
+    assert_eq!(
+        encode_catalog_record(&null_root, &mut output, &mut budget()),
+        Err(CatalogRecordWriteError::NullTableDefinition)
+    );
+    assert_eq!(output, [0xa5; 64]);
+}

--- a/crates/jet3/src/column_definition_writer.rs
+++ b/crates/jet3/src/column_definition_writer.rs
@@ -1,0 +1,465 @@
+//! Checked encoders for the fixed-size column and index records inside a Jet 3
+//! table definition: the inverse of `column_definition.rs`,
+//! `physical_index_definition.rs`, and `index_definition.rs`.
+//!
+//! Record layouts come from `EXP-0059`; relationship cascade bytes from
+//! `EXP-0062`. Names are raw database-code-page bytes (`EXP-0059`).
+
+use crate::table_definition_writer::TableDefinitionWriteError;
+use crate::{
+    BinaryWriter, ColumnPhysicalType, ColumnStorageClass, Error, IndexDirection, PageNumber,
+    RelationshipSide,
+};
+
+/// `EXP-0059`: one 18-byte physical record per column.
+pub const COLUMN_RECORD_LEN: usize = 18;
+/// `EXP-0059`: one 39-byte record per physical index.
+pub const PHYSICAL_RECORD_LEN: usize = 39;
+/// `EXP-0059`: eight sourced prefix bytes per physical index, zero in controls.
+pub const PHYSICAL_PREFIX_LEN: usize = 8;
+/// `EXP-0059`: one 20-byte record per logical index.
+pub const LOGICAL_RECORD_LEN: usize = 20;
+/// `EXP-0059`: ten three-byte key slots per physical index.
+pub const KEY_SLOT_COUNT: usize = 10;
+/// `EXP-0059`: names carry a one-byte length prefix.
+pub const MAX_NAME_LEN: usize = u8::MAX as usize;
+
+/// `EXP-0059`: class 2 variable, class 3 fixed, class 7 auto-increment Long.
+const VARIABLE_CLASS: u8 = 2;
+const FIXED_CLASS: u8 = 3;
+const AUTO_INCREMENT_CLASS: u8 = 7;
+/// `EXP-0059`: sourced value 1 at column record bytes `[7,9)`.
+const SOURCED_CONSTANT: u16 = 1;
+/// `EXP-0059`: raw locale context bytes at column record bytes `[9,13)`.
+const ENCODING_CONTEXT: [u8; 4] = [0x09, 0x04, 0xe4, 0x04];
+/// `EXP-0059`: unused key slots hold ordinal `0xffff`.
+const UNUSED_SLOT_ORDINAL: u16 = u16::MAX;
+/// `EXP-0059`: physical flag bits `0x01` unique and `0x08` required.
+const UNIQUE_FLAG: u8 = 0x01;
+const REQUIRED_FLAG: u8 = 0x08;
+/// `EXP-0059`: ordinary/primary logical records hold `0xffffffff` at `[9,13)`
+/// and context `04 04` at `[17,19)`.
+const ORDINARY_RELATION_ORDINAL: u32 = u32::MAX;
+const ORDINARY_CONTEXT: [u8; 2] = [4, 4];
+/// `EXP-0059`: logical class byte 0 ordinary, 1 primary, 2 relationship.
+const ORDINARY_CLASS: u8 = 0;
+const PRIMARY_CLASS: u8 = 1;
+const RELATIONSHIP_CLASS: u8 = 2;
+/// `EXP-0059`: three-byte little-endian usage-map page at `[31,34)`.
+const MAX_U24_PAGE: u64 = 0x00ff_ffff;
+
+/// Whether a column stores at a fixed row offset or through the variable table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ColumnStorageKind {
+    /// Fixed-offset storage; the offset is derived from preceding columns.
+    Fixed,
+    /// Variable storage; the index is derived from preceding columns.
+    Variable,
+}
+
+/// One column to encode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnSpec<'a> {
+    name: &'a [u8],
+    physical_type: ColumnPhysicalType,
+    storage: ColumnStorageKind,
+    size: u16,
+    auto_increment: bool,
+}
+
+impl<'a> ColumnSpec<'a> {
+    /// Describes a column with raw database-code-page name bytes.
+    #[must_use]
+    pub const fn new(
+        name: &'a [u8],
+        physical_type: ColumnPhysicalType,
+        storage: ColumnStorageKind,
+        size: u16,
+    ) -> Self {
+        Self {
+            name,
+            physical_type,
+            storage,
+            size,
+            auto_increment: false,
+        }
+    }
+
+    /// Marks the column as the auto-increment Long (`EXP-0059` class 7).
+    #[must_use]
+    pub const fn with_auto_increment(mut self) -> Self {
+        self.auto_increment = true;
+        self
+    }
+
+    /// Returns the raw name bytes.
+    #[must_use]
+    pub const fn name(&self) -> &'a [u8] {
+        self.name
+    }
+
+    /// Returns the physical type.
+    #[must_use]
+    pub const fn physical_type(&self) -> ColumnPhysicalType {
+        self.physical_type
+    }
+
+    /// Returns the requested storage kind.
+    #[must_use]
+    pub const fn storage(&self) -> ColumnStorageKind {
+        self.storage
+    }
+
+    /// Returns the declared fixed or maximum size.
+    #[must_use]
+    pub const fn size(&self) -> u16 {
+        self.size
+    }
+}
+
+/// One key field of a physical index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IndexFieldSpec {
+    /// Zero-based table column ordinal.
+    pub column: u16,
+    /// Key direction.
+    pub direction: IndexDirection,
+}
+
+/// One physical index to encode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhysicalIndexSpec<'a> {
+    /// Ordered key fields; at most [`KEY_SLOT_COUNT`].
+    pub fields: &'a [IndexFieldSpec],
+    /// Data page holding the index usage-map row.
+    pub usage_map_page: PageNumber,
+    /// Row slot of the index usage map on that page.
+    pub usage_map_row: u8,
+    /// Index-tree root page.
+    pub root: PageNumber,
+    /// Whether keys must be unique (`EXP-0059` flag `0x01`).
+    pub unique: bool,
+    /// Whether keys must be non-null (`EXP-0059` flag `0x08`).
+    pub required: bool,
+}
+
+/// Interpreted class of one logical index to encode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogicalIndexKindSpec {
+    /// Ordinary logical index.
+    Ordinary,
+    /// Primary logical index; its physical index must be unique and required.
+    Primary,
+    /// Minimum relationship record (`EXP-0059`, `EXP-0062`).
+    Relationship {
+        /// Which side of the relation this table plays.
+        side: RelationshipSide,
+        /// Related table-definition root.
+        related_table: PageNumber,
+        /// Sourced selector at `[0,4)`.
+        raw_selector: u32,
+        /// Sourced relationship ordinal at `[9,13)`.
+        relation_ordinal: u32,
+        /// Cascade-update flag.
+        cascade_updates: bool,
+        /// Cascade-delete flag.
+        cascade_deletes: bool,
+    },
+}
+
+/// One named logical index to encode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogicalIndexSpec<'a> {
+    /// Raw database-code-page name bytes.
+    pub name: &'a [u8],
+    /// Referenced physical-index ordinal.
+    pub physical_index: u16,
+    /// Interpreted class.
+    pub kind: LogicalIndexKindSpec,
+}
+
+/// Derived row placement of one column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ResolvedColumn {
+    pub(crate) storage: ColumnStorageClass,
+    pub(crate) variable_counter: u16,
+    pub(crate) class: u8,
+}
+
+/// Validates one column and derives its fixed offset or variable index.
+pub(crate) fn resolve_column(
+    ordinal: u16,
+    column: &ColumnSpec<'_>,
+    next_fixed_offset: &mut u16,
+    variables_seen: &mut u16,
+) -> Result<ResolvedColumn, TableDefinitionWriteError> {
+    let physical_type = column.physical_type;
+    validate_size(ordinal, physical_type, column.size)?;
+    let long_or_binary = matches!(
+        physical_type,
+        ColumnPhysicalType::Binary | ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo
+    );
+    let class_error = TableDefinitionWriteError::UnsupportedColumnClass {
+        ordinal,
+        physical_type,
+        storage: column.storage,
+    };
+    let variable_counter = *variables_seen;
+    match column.storage {
+        ColumnStorageKind::Variable => {
+            if !(long_or_binary || physical_type == ColumnPhysicalType::Text)
+                || column.auto_increment
+            {
+                return Err(class_error);
+            }
+            let index = *variables_seen;
+            *variables_seen = index
+                .checked_add(1)
+                .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+                    operation: "advance variable column count",
+                }))?;
+            Ok(ResolvedColumn {
+                storage: ColumnStorageClass::Variable { index },
+                variable_counter,
+                class: VARIABLE_CLASS,
+            })
+        }
+        ColumnStorageKind::Fixed => {
+            if long_or_binary
+                || (column.auto_increment && physical_type != ColumnPhysicalType::Long)
+            {
+                return Err(class_error);
+            }
+            let offset = *next_fixed_offset;
+            if physical_type != ColumnPhysicalType::Boolean {
+                *next_fixed_offset = offset
+                    .checked_add(column.size)
+                    .ok_or(TableDefinitionWriteError::FixedAreaTooLarge { ordinal })?;
+            }
+            Ok(ResolvedColumn {
+                storage: ColumnStorageClass::Fixed { offset },
+                variable_counter,
+                class: if column.auto_increment {
+                    AUTO_INCREMENT_CLASS
+                } else {
+                    FIXED_CLASS
+                },
+            })
+        }
+    }
+}
+
+fn validate_size(
+    ordinal: u16,
+    physical_type: ColumnPhysicalType,
+    size: u16,
+) -> Result<(), TableDefinitionWriteError> {
+    // EXP-0059: accepted DAO sizes per physical type.
+    let valid = match physical_type {
+        ColumnPhysicalType::Boolean | ColumnPhysicalType::Byte => size == 1,
+        ColumnPhysicalType::Integer => size == 2,
+        ColumnPhysicalType::Long | ColumnPhysicalType::Single => size == 4,
+        ColumnPhysicalType::Currency
+        | ColumnPhysicalType::Double
+        | ColumnPhysicalType::DateTime => size == 8,
+        ColumnPhysicalType::Guid => size == 16,
+        ColumnPhysicalType::Binary | ColumnPhysicalType::Text => (1..=255).contains(&size),
+        ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo => size == 0,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(TableDefinitionWriteError::UnsupportedColumnSize {
+            ordinal,
+            physical_type,
+            size,
+        })
+    }
+}
+
+/// Writes one 18-byte column record.
+pub(crate) fn write_column_record(
+    writer: &mut BinaryWriter<'_, '_>,
+    ordinal: u16,
+    column: &ColumnSpec<'_>,
+    resolved: ResolvedColumn,
+) -> Result<(), Error> {
+    writer.write_u8(column.physical_type.raw())?;
+    writer.write_u16_le(ordinal)?;
+    writer.write_u16_le(resolved.variable_counter)?;
+    writer.write_u16_le(ordinal)?;
+    writer.write_u16_le(SOURCED_CONSTANT)?;
+    writer.write_exact(&ENCODING_CONTEXT)?;
+    writer.write_u8(resolved.class)?;
+    // EXP-0059: bytes [14,16) of variable records have no assigned meaning.
+    let fixed_offset = match resolved.storage {
+        ColumnStorageClass::Fixed { offset } => offset,
+        ColumnStorageClass::Variable { .. } => 0,
+    };
+    writer.write_u16_le(fixed_offset)?;
+    writer.write_u16_le(column.size)
+}
+
+/// Validates a definition name and writes its length prefix and bytes.
+pub(crate) fn write_name(
+    writer: &mut BinaryWriter<'_, '_>,
+    name: &[u8],
+) -> Result<(), TableDefinitionWriteError> {
+    let length = u8::try_from(name.len()).map_err(|_| {
+        TableDefinitionWriteError::Resource(Error::IntegerConversion {
+            value: name.len() as u128,
+            target: "u8",
+        })
+    })?;
+    writer
+        .write_u8(length)
+        .and_then(|()| writer.write_exact(name))
+        .map_err(TableDefinitionWriteError::Resource)
+}
+
+/// Validates one physical index against the table column count.
+pub(crate) fn validate_physical_index(
+    physical_index: u16,
+    index: &PhysicalIndexSpec<'_>,
+    column_count: u16,
+) -> Result<(), TableDefinitionWriteError> {
+    if index.fields.is_empty() {
+        return Err(TableDefinitionWriteError::EmptyPhysicalIndex { physical_index });
+    }
+    if index.fields.len() > KEY_SLOT_COUNT {
+        return Err(TableDefinitionWriteError::TooManyKeyFields {
+            physical_index,
+            count: index.fields.len(),
+            maximum: KEY_SLOT_COUNT,
+        });
+    }
+    for (slot, field) in index.fields.iter().enumerate() {
+        if field.column >= column_count {
+            return Err(TableDefinitionWriteError::InvalidKeyColumn {
+                physical_index,
+                ordinal: field.column,
+                column_count,
+            });
+        }
+        if index.fields[..slot]
+            .iter()
+            .any(|earlier| earlier.column == field.column)
+        {
+            return Err(TableDefinitionWriteError::DuplicateKeyColumn {
+                physical_index,
+                ordinal: field.column,
+            });
+        }
+    }
+    for (role, page, maximum) in [
+        ("usage map", index.usage_map_page, MAX_U24_PAGE),
+        ("index root", index.root, u64::from(u32::MAX)),
+    ] {
+        if page.get() == 0 || page.get() > maximum {
+            return Err(TableDefinitionWriteError::InvalidPhysicalReference {
+                physical_index,
+                role,
+                page,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Returns the `EXP-0059` flag byte for one physical index.
+pub(crate) const fn physical_flags(index: &PhysicalIndexSpec<'_>) -> u8 {
+    let mut flags = 0;
+    if index.unique {
+        flags |= UNIQUE_FLAG;
+    }
+    if index.required {
+        flags |= REQUIRED_FLAG;
+    }
+    flags
+}
+
+/// Writes one validated 39-byte physical-index record.
+pub(crate) fn write_physical_record(
+    writer: &mut BinaryWriter<'_, '_>,
+    index: &PhysicalIndexSpec<'_>,
+) -> Result<(), Error> {
+    for slot in 0..KEY_SLOT_COUNT {
+        match index.fields.get(slot) {
+            Some(field) => {
+                writer.write_u16_le(field.column)?;
+                // EXP-0059: direction 0 descending, 1 ascending.
+                writer.write_u8(match field.direction {
+                    IndexDirection::Descending => 0,
+                    IndexDirection::Ascending => 1,
+                })?;
+            }
+            None => {
+                writer.write_u16_le(UNUSED_SLOT_ORDINAL)?;
+                // EXP-0059: direction bytes of unused slots are uninterpreted.
+                writer.write_u8(0)?;
+            }
+        }
+    }
+    writer.write_u8(index.usage_map_row)?;
+    let page = u32::try_from(index.usage_map_page.get()).map_err(|_| Error::IntegerConversion {
+        value: u128::from(index.usage_map_page.get()),
+        target: "u24",
+    })?;
+    writer.write_exact(&page.to_le_bytes()[..3])?;
+    let root = u32::try_from(index.root.get()).map_err(|_| Error::IntegerConversion {
+        value: u128::from(index.root.get()),
+        target: "u32",
+    })?;
+    writer.write_u32_le(root)?;
+    writer.write_u8(physical_flags(index))
+}
+
+/// Writes one validated 20-byte logical-index record.
+pub(crate) fn write_logical_record(
+    writer: &mut BinaryWriter<'_, '_>,
+    index: &LogicalIndexSpec<'_>,
+) -> Result<(), Error> {
+    let physical = u32::from(index.physical_index);
+    match index.kind {
+        LogicalIndexKindSpec::Ordinary | LogicalIndexKindSpec::Primary => {
+            writer.write_u32_le(physical)?;
+            writer.write_u32_le(physical)?;
+            writer.write_u8(0)?;
+            writer.write_u32_le(ORDINARY_RELATION_ORDINAL)?;
+            writer.write_u32_le(0)?;
+            writer.write_exact(&ORDINARY_CONTEXT)?;
+            writer.write_u8(if index.kind == LogicalIndexKindSpec::Primary {
+                PRIMARY_CLASS
+            } else {
+                ORDINARY_CLASS
+            })
+        }
+        LogicalIndexKindSpec::Relationship {
+            side,
+            related_table,
+            raw_selector,
+            relation_ordinal,
+            cascade_updates,
+            cascade_deletes,
+        } => {
+            writer.write_u32_le(raw_selector)?;
+            writer.write_u32_le(physical)?;
+            // EXP-0059: byte 8 value 1 on the primary table, 2 on the foreign.
+            writer.write_u8(match side {
+                RelationshipSide::PrimaryTable => 1,
+                RelationshipSide::ForeignTable => 2,
+            })?;
+            writer.write_u32_le(relation_ordinal)?;
+            let related =
+                u32::try_from(related_table.get()).map_err(|_| Error::IntegerConversion {
+                    value: u128::from(related_table.get()),
+                    target: "u32",
+                })?;
+            writer.write_u32_le(related)?;
+            // EXP-0062: cascade-update then cascade-delete flag bytes.
+            writer.write_u8(u8::from(cascade_updates))?;
+            writer.write_u8(u8::from(cascade_deletes))?;
+            writer.write_u8(RELATIONSHIP_CLASS)
+        }
+    }
+}

--- a/crates/jet3/src/column_definition_writer.rs
+++ b/crates/jet3/src/column_definition_writer.rs
@@ -321,8 +321,13 @@ pub(crate) fn write_name(
 pub(crate) fn validate_physical_index(
     physical_index: u16,
     index: &PhysicalIndexSpec<'_>,
-    column_count: u16,
+    columns: &[ColumnSpec<'_>],
 ) -> Result<(), TableDefinitionWriteError> {
+    let column_count =
+        u16::try_from(columns.len()).map_err(|_| TableDefinitionWriteError::TooManyColumns {
+            count: columns.len(),
+            maximum: u8::MAX as usize,
+        })?;
     if index.fields.is_empty() {
         return Err(TableDefinitionWriteError::EmptyPhysicalIndex { physical_index });
     }
@@ -339,6 +344,17 @@ pub(crate) fn validate_physical_index(
                 physical_index,
                 ordinal: field.column,
                 column_count,
+            });
+        }
+        let physical_type = columns[usize::from(field.column)].physical_type();
+        if matches!(
+            physical_type,
+            ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo
+        ) {
+            return Err(TableDefinitionWriteError::UnsupportedKeyColumn {
+                physical_index,
+                ordinal: field.column,
+                physical_type,
             });
         }
         if index.fields[..slot]

--- a/crates/jet3/src/data_page_directory.rs
+++ b/crates/jet3/src/data_page_directory.rs
@@ -14,6 +14,9 @@ const OWNER_OFFSET: usize = 4;
 const ROW_COUNT_OFFSET: usize = 8;
 const DIRECTORY_OFFSET: usize = 10;
 const ENTRY_LEN: usize = 2;
+/// `EXP-0060`: maximum bytes available to one row after the page header and
+/// its required directory entry.
+pub(crate) const MAX_STORED_ROW_LEN: usize = PAGE_BYTES - DIRECTORY_OFFSET - ENTRY_LEN;
 const OFFSET_MASK: u16 = 0x1fff;
 const UNKNOWN_FLAG: u16 = 0x2000;
 const OVERFLOW_FLAG: u16 = 0x4000;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -9,7 +9,9 @@ pub mod binary_writer;
 pub mod candidate;
 pub mod catalog;
 pub mod catalog_record;
+pub mod catalog_record_writer;
 pub mod column_definition;
+pub mod column_definition_writer;
 pub mod commit_state;
 mod data_page_directory;
 pub mod database;
@@ -35,8 +37,10 @@ pub mod relationships;
 pub mod resource;
 pub mod row;
 pub mod row_directory;
+pub mod row_writer;
 pub mod source;
 pub mod table_definition;
+pub mod table_definition_writer;
 pub mod text;
 pub mod usage_map;
 pub mod usage_map_writer;
@@ -60,8 +64,15 @@ pub use catalog_record::{
     CatalogName, CatalogNameEncoding, CatalogObjectClass, CatalogObjectId, CatalogObjectKind,
     CatalogRecord, CatalogRecordError,
 };
+pub use catalog_record_writer::{
+    CatalogRecordSpec, CatalogRecordWriteError, catalog_record_len, encode_catalog_record,
+};
 pub use column_definition::{
     ColumnDefinition, ColumnOrdinal, ColumnPhysicalType, ColumnStorageClass,
+};
+pub use column_definition_writer::{
+    ColumnSpec, ColumnStorageKind, IndexFieldSpec, LogicalIndexKindSpec, LogicalIndexSpec,
+    PhysicalIndexSpec,
 };
 pub use commit_state::{
     COMMIT_REGION_LENGTH, COMMIT_REGION_OFFSET, COMMIT_SLOT_COUNT, CommitRegion, CommitSlot,
@@ -101,8 +112,12 @@ pub use relationships::{Relationship, Relationships};
 pub use resource::{ResourceBudget, ResourceLimits};
 pub use row::{RawField, RowCursor, RowError, RowView};
 pub use row_directory::{RowDirectoryError, RowLocator};
+pub use row_writer::{RowColumnLayout, RowValue, RowWriteError, encode_row};
 pub use source::{FileSource, ReadAt, SliceSource};
 pub use table_definition::{TableDefinition, TableDefinitionError};
+pub use table_definition_writer::{
+    TableDefinitionSpec, TableDefinitionWriteError, encode_table_definition, table_definition_len,
+};
 pub use text::{DecodedText, TextCodePage, TextError};
 pub use usage_map::{UsageMapError, UsageMapRecord, locate_usage_map};
 pub use usage_map_writer::{

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -7,6 +7,7 @@
 
 use std::fmt;
 
+use crate::data_page_directory::MAX_STORED_ROW_LEN;
 use crate::{
     BinaryWriter, ByteCount, ByteOffset, ColumnDefinition, ColumnPhysicalType, ColumnStorageClass,
     Error, ResourceBudget,
@@ -195,6 +196,13 @@ pub enum RowWriteError {
         /// Maximum boundary.
         maximum: usize,
     },
+    /// The complete row cannot fit in a Jet 3 data-page row slot.
+    RowTooLong {
+        /// Complete encoded row length.
+        length: usize,
+        /// Maximum length after the page header and one directory entry.
+        maximum: usize,
+    },
     /// The output slice cannot hold the complete row.
     OutputTooSmall {
         /// Required length.
@@ -291,7 +299,12 @@ fn validate(
                 };
                 *slot = true;
                 variable_count += 1;
-                variable_bytes += width;
+                variable_bytes =
+                    variable_bytes
+                        .checked_add(width)
+                        .ok_or(RowWriteError::Resource(Error::Arithmetic {
+                            operation: "sum encoded-row variable bytes",
+                        }))?;
             }
         }
     }
@@ -309,9 +322,20 @@ fn validate(
         }
     }
     let null_len = columns.len().div_ceil(8);
-    let mut length = 1 + fixed_size + variable_bytes + null_len;
+    let mut length = 1_usize
+        .checked_add(fixed_size)
+        .and_then(|value| value.checked_add(variable_bytes))
+        .and_then(|value| value.checked_add(null_len))
+        .ok_or(RowWriteError::Resource(Error::Arithmetic {
+            operation: "size encoded row",
+        }))?;
     if variable_count > 0 {
-        length += variable_count + 1 + 1;
+        length = length
+            .checked_add(variable_count)
+            .and_then(|value| value.checked_add(2))
+            .ok_or(RowWriteError::Resource(Error::Arithmetic {
+                operation: "size encoded-row variable trailer",
+            }))?;
     }
     let wide = length > MAX_NARROW_ROW_LEN && variable_count > 0;
     if wide {
@@ -321,8 +345,17 @@ fn validate(
                 row_length: length,
             });
         }
-        length += 1;
-        let last_boundary = 1 + fixed_size + variable_bytes;
+        length = length
+            .checked_add(1)
+            .ok_or(RowWriteError::Resource(Error::Arithmetic {
+                operation: "size encoded-row jump byte",
+            }))?;
+        let last_boundary = 1_usize
+            .checked_add(fixed_size)
+            .and_then(|value| value.checked_add(variable_bytes))
+            .ok_or(RowWriteError::Resource(Error::Arithmetic {
+                operation: "size encoded-row variable boundary",
+            }))?;
         if last_boundary > MAX_WIDE_BOUNDARY {
             return Err(RowWriteError::BoundaryTooLarge {
                 index: 0,
@@ -330,6 +363,12 @@ fn validate(
                 maximum: MAX_WIDE_BOUNDARY,
             });
         }
+    }
+    if length > MAX_STORED_ROW_LEN {
+        return Err(RowWriteError::RowTooLong {
+            length,
+            maximum: MAX_STORED_ROW_LEN,
+        });
     }
     Ok(RowShape {
         fixed_size,
@@ -537,13 +576,19 @@ fn write_row(
     writer.seek(fixed_end)?;
     let mut boundaries = [0_usize; MAX_COLUMN_COUNT + 1];
     boundaries[0] = fixed_end.to_usize()?;
+    let mut variable_values = [None; MAX_COLUMN_COUNT];
+    for (column, value) in columns.iter().zip(values) {
+        if let ColumnStorageClass::Variable { index } = column.storage {
+            let slot = variable_values
+                .get_mut(usize::from(index))
+                .ok_or(Error::Arithmetic {
+                    operation: "map validated variable column",
+                })?;
+            *slot = Some(*value);
+        }
+    }
     for index in 0..shape.variable_count {
-        let Some((_, value)) = columns.iter().zip(values).find(|(column, _)| {
-            column.storage
-                == ColumnStorageClass::Variable {
-                    index: index as u16,
-                }
-        }) else {
+        let Some(value) = variable_values[index] else {
             return Err(Error::Arithmetic {
                 operation: "locate validated variable column",
             });

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -145,12 +145,30 @@ pub enum RowWriteError {
         /// Provided byte length.
         actual: usize,
     },
+    /// A column's declared size is incompatible with its physical type.
+    InvalidColumnSize {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Column physical type.
+        physical_type: ColumnPhysicalType,
+        /// Rejected declared size.
+        size: u16,
+    },
     /// A column's storage class is incompatible with its physical type.
     InvalidStorage {
         /// Zero-based column ordinal.
         ordinal: u16,
         /// Column physical type.
         physical_type: ColumnPhysicalType,
+    },
+    /// A fixed column does not begin at the next derived offset.
+    InvalidFixedOffset {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Rejected fixed offset.
+        offset: u16,
+        /// Offset derived from preceding fixed columns.
+        expected: u16,
     },
     /// Variable indexes are not exactly `0..variable_count`.
     InvalidVariableIndex {
@@ -251,18 +269,15 @@ fn validate(
     budget
         .charge_items(columns.len() as u64)
         .map_err(RowWriteError::Resource)?;
-    let mut fixed_size = 0_usize;
+    let mut next_fixed_offset = 0_u16;
     let mut variable_count = 0_usize;
     let mut variable_bytes = 0_usize;
     let mut seen_indexes = [false; MAX_COLUMN_COUNT];
     for (ordinal, (column, value)) in (0_u16..).zip(columns.iter().zip(values)) {
+        validate_column_layout(ordinal, *column, &mut next_fixed_offset)?;
         let width = value_width(ordinal, *column, *value)?;
         match column.storage {
-            ColumnStorageClass::Fixed { offset } => {
-                if column.physical_type != ColumnPhysicalType::Boolean {
-                    fixed_size = fixed_size.max(usize::from(offset) + usize::from(column.size));
-                }
-            }
+            ColumnStorageClass::Fixed { .. } => {}
             ColumnStorageClass::Variable { index } => {
                 let slot = seen_indexes
                     .get_mut(usize::from(index))
@@ -280,6 +295,7 @@ fn validate(
             }
         }
     }
+    let fixed_size = usize::from(next_fixed_offset);
     // Indexes are unique, so any index at or beyond the count leaves a hole.
     for (ordinal, column) in (0_u16..).zip(columns) {
         if let ColumnStorageClass::Variable { index } = column.storage
@@ -322,6 +338,76 @@ fn validate(
         wide,
         length,
     })
+}
+
+/// Validates the schema invariants established for column definitions.
+fn validate_column_layout(
+    ordinal: u16,
+    column: RowColumnLayout,
+    next_fixed_offset: &mut u16,
+) -> Result<(), RowWriteError> {
+    let valid_size = match column.physical_type {
+        ColumnPhysicalType::Boolean | ColumnPhysicalType::Byte => column.size == 1,
+        ColumnPhysicalType::Integer => column.size == 2,
+        ColumnPhysicalType::Long | ColumnPhysicalType::Single => column.size == 4,
+        ColumnPhysicalType::Currency
+        | ColumnPhysicalType::Double
+        | ColumnPhysicalType::DateTime => column.size == 8,
+        ColumnPhysicalType::Guid => column.size == 16,
+        ColumnPhysicalType::Binary | ColumnPhysicalType::Text => (1..=255).contains(&column.size),
+        ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo => column.size == 0,
+    };
+    if !valid_size {
+        return Err(RowWriteError::InvalidColumnSize {
+            ordinal,
+            physical_type: column.physical_type,
+            size: column.size,
+        });
+    }
+
+    let storage_error = || RowWriteError::InvalidStorage {
+        ordinal,
+        physical_type: column.physical_type,
+    };
+    match column.storage {
+        ColumnStorageClass::Fixed { offset } => {
+            if matches!(
+                column.physical_type,
+                ColumnPhysicalType::Binary
+                    | ColumnPhysicalType::LongBinary
+                    | ColumnPhysicalType::Memo
+            ) {
+                return Err(storage_error());
+            }
+            if offset != *next_fixed_offset {
+                return Err(RowWriteError::InvalidFixedOffset {
+                    ordinal,
+                    offset,
+                    expected: *next_fixed_offset,
+                });
+            }
+            if column.physical_type != ColumnPhysicalType::Boolean {
+                *next_fixed_offset =
+                    next_fixed_offset
+                        .checked_add(column.size)
+                        .ok_or(RowWriteError::Resource(Error::Arithmetic {
+                            operation: "advance encoded-row fixed offset",
+                        }))?;
+            }
+        }
+        ColumnStorageClass::Variable { .. } => {
+            if !matches!(
+                column.physical_type,
+                ColumnPhysicalType::Binary
+                    | ColumnPhysicalType::Text
+                    | ColumnPhysicalType::LongBinary
+                    | ColumnPhysicalType::Memo
+            ) {
+                return Err(storage_error());
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Checks the value against the column and returns its physical byte width.

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -1,0 +1,524 @@
+//! Checked encoder for one logical Jet 3 data row, the inverse of the layout
+//! validated by `row.rs` (`EXP-0060`) with the scalar encodings of `EXP-0061`.
+//!
+//! Memo and OLE values are supplied as already-encoded long-value bytes
+//! (12-byte header plus any inline payload); writing external LVAL pages is a
+//! separate concern.
+
+use std::fmt;
+
+use crate::{
+    BinaryWriter, ByteCount, ByteOffset, ColumnDefinition, ColumnPhysicalType, ColumnStorageClass,
+    Error, ResourceBudget,
+};
+
+/// `EXP-0060`: one-byte column count, so at most 255 columns.
+const MAX_COLUMN_COUNT: usize = u8::MAX as usize;
+/// `EXP-0060`: rows longer than 255 bytes use one jump byte for boundary
+/// high bits; only single-variable-column wide rows were isolated.
+const MAX_NARROW_ROW_LEN: usize = u8::MAX as usize;
+/// `EXP-0060`: a jump bit adds 256 to a boundary, so boundaries stay below 512.
+const MAX_WIDE_BOUNDARY: usize = 2 * (u8::MAX as usize + 1) - 1;
+/// `EXP-0061`: every long field begins with a 12-byte header.
+const LONG_VALUE_HEADER_LEN: usize = 12;
+const NULL_MAP_MAX_LEN: usize = MAX_COLUMN_COUNT.div_ceil(8);
+
+/// Row placement of one column, independent of how the schema was obtained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowColumnLayout {
+    physical_type: ColumnPhysicalType,
+    storage: ColumnStorageClass,
+    size: u16,
+}
+
+impl RowColumnLayout {
+    /// Describes a column by type, resolved storage, and declared size.
+    #[must_use]
+    pub const fn new(
+        physical_type: ColumnPhysicalType,
+        storage: ColumnStorageClass,
+        size: u16,
+    ) -> Self {
+        Self {
+            physical_type,
+            storage,
+            size,
+        }
+    }
+
+    /// Returns the physical type.
+    #[must_use]
+    pub const fn physical_type(self) -> ColumnPhysicalType {
+        self.physical_type
+    }
+
+    /// Returns the resolved storage class.
+    #[must_use]
+    pub const fn storage(self) -> ColumnStorageClass {
+        self.storage
+    }
+
+    /// Returns the declared fixed or maximum size.
+    #[must_use]
+    pub const fn size(self) -> u16 {
+        self.size
+    }
+}
+
+impl From<&ColumnDefinition> for RowColumnLayout {
+    fn from(column: &ColumnDefinition) -> Self {
+        Self::new(column.physical_type(), column.storage(), column.size())
+    }
+}
+
+/// One value to encode, in the physical shapes established by `EXP-0061`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum RowValue<'a> {
+    /// Absent value; for Boolean columns equivalent to `false`.
+    Null,
+    /// Boolean stored as the presence bit.
+    Boolean(bool),
+    /// Unsigned eight-bit integer.
+    Byte(u8),
+    /// Signed 16-bit integer.
+    Integer(i16),
+    /// Signed 32-bit integer.
+    Long(i32),
+    /// Currency as its integer scaled by 10,000.
+    Currency {
+        /// Stored integer before applying the four-place scale.
+        scaled: i64,
+    },
+    /// IEEE-754 single-precision value.
+    Single(f32),
+    /// IEEE-754 double-precision value.
+    Double(f64),
+    /// OLE Automation day count.
+    DateTime {
+        /// Day count as stored.
+        days: f64,
+    },
+    /// Short binary bytes.
+    Binary(&'a [u8]),
+    /// Text already encoded in the database code page.
+    Text(&'a [u8]),
+    /// Replication ID in conventional display-byte order.
+    Guid([u8; 16]),
+    /// Already-encoded Memo/OLE header plus inline payload.
+    LongValue(&'a [u8]),
+}
+
+/// Structured failure while validating or encoding a row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RowWriteError {
+    /// More columns than the one-byte row count can hold.
+    TooManyColumns {
+        /// Requested column count.
+        count: usize,
+        /// Maximum encodable count.
+        maximum: usize,
+    },
+    /// The value slice length differs from the column count.
+    ValueCountMismatch {
+        /// Column count.
+        expected: usize,
+        /// Value count.
+        actual: usize,
+    },
+    /// A value variant does not match the column's physical type.
+    TypeMismatch {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Column physical type.
+        physical_type: ColumnPhysicalType,
+    },
+    /// A value's byte length is incompatible with the column.
+    InvalidWidth {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Column physical type.
+        physical_type: ColumnPhysicalType,
+        /// Required or maximum byte length.
+        expected: usize,
+        /// Provided byte length.
+        actual: usize,
+    },
+    /// A column's storage class is incompatible with its physical type.
+    InvalidStorage {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Column physical type.
+        physical_type: ColumnPhysicalType,
+    },
+    /// Variable indexes are not exactly `0..variable_count`.
+    InvalidVariableIndex {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Requested variable index.
+        index: u16,
+        /// Variable column count.
+        variable_count: usize,
+    },
+    /// The row needs the unobserved multi-column wide offset encoding.
+    UnsupportedWideVariableOffsets {
+        /// Variable column count.
+        variable_count: usize,
+        /// Complete row length.
+        row_length: usize,
+    },
+    /// A variable boundary exceeds what the jump byte can represent.
+    BoundaryTooLarge {
+        /// Zero-based variable index whose end boundary overflowed.
+        index: u16,
+        /// Requested boundary.
+        boundary: usize,
+        /// Maximum boundary.
+        maximum: usize,
+    },
+    /// The output slice cannot hold the complete row.
+    OutputTooSmall {
+        /// Required length.
+        needed: usize,
+        /// Provided length.
+        available: usize,
+    },
+    /// Resource policy or checked arithmetic rejected the encoding.
+    Resource(Error),
+}
+
+impl fmt::Display for RowWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "row encoding failed: {self:?}")
+    }
+}
+
+impl std::error::Error for RowWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Resource(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RowShape {
+    fixed_size: usize,
+    variable_count: usize,
+    null_len: usize,
+    wide: bool,
+    length: usize,
+}
+
+/// Encodes one row into `output`, returning the encoded length.
+pub fn encode_row(
+    columns: &[RowColumnLayout],
+    values: &[RowValue<'_>],
+    output: &mut [u8],
+    budget: &mut ResourceBudget,
+) -> Result<ByteCount, RowWriteError> {
+    let shape = validate(columns, values, budget)?;
+    if output.len() < shape.length {
+        return Err(RowWriteError::OutputTooSmall {
+            needed: shape.length,
+            available: output.len(),
+        });
+    }
+    let mut writer = BinaryWriter::new(output, budget).map_err(RowWriteError::Resource)?;
+    write_row(&mut writer, columns, values, shape).map_err(RowWriteError::Resource)?;
+    Ok(ByteCount::new(writer.position().get()))
+}
+
+fn validate(
+    columns: &[RowColumnLayout],
+    values: &[RowValue<'_>],
+    budget: &mut ResourceBudget,
+) -> Result<RowShape, RowWriteError> {
+    if columns.len() > MAX_COLUMN_COUNT {
+        return Err(RowWriteError::TooManyColumns {
+            count: columns.len(),
+            maximum: MAX_COLUMN_COUNT,
+        });
+    }
+    if values.len() != columns.len() {
+        return Err(RowWriteError::ValueCountMismatch {
+            expected: columns.len(),
+            actual: values.len(),
+        });
+    }
+    budget
+        .charge_items(columns.len() as u64)
+        .map_err(RowWriteError::Resource)?;
+    let mut fixed_size = 0_usize;
+    let mut variable_count = 0_usize;
+    let mut variable_bytes = 0_usize;
+    let mut seen_indexes = [false; MAX_COLUMN_COUNT];
+    for (ordinal, (column, value)) in (0_u16..).zip(columns.iter().zip(values)) {
+        let width = value_width(ordinal, *column, *value)?;
+        match column.storage {
+            ColumnStorageClass::Fixed { offset } => {
+                if column.physical_type != ColumnPhysicalType::Boolean {
+                    fixed_size = fixed_size.max(usize::from(offset) + usize::from(column.size));
+                }
+            }
+            ColumnStorageClass::Variable { index } => {
+                let slot = seen_indexes
+                    .get_mut(usize::from(index))
+                    .filter(|seen| !**seen);
+                let Some(slot) = slot else {
+                    return Err(RowWriteError::InvalidVariableIndex {
+                        ordinal,
+                        index,
+                        variable_count: columns.len(),
+                    });
+                };
+                *slot = true;
+                variable_count += 1;
+                variable_bytes += width;
+            }
+        }
+    }
+    // Indexes are unique, so any index at or beyond the count leaves a hole.
+    for (ordinal, column) in (0_u16..).zip(columns) {
+        if let ColumnStorageClass::Variable { index } = column.storage
+            && usize::from(index) >= variable_count
+        {
+            return Err(RowWriteError::InvalidVariableIndex {
+                ordinal,
+                index,
+                variable_count,
+            });
+        }
+    }
+    let null_len = columns.len().div_ceil(8);
+    let mut length = 1 + fixed_size + variable_bytes + null_len;
+    if variable_count > 0 {
+        length += variable_count + 1 + 1;
+    }
+    let wide = length > MAX_NARROW_ROW_LEN && variable_count > 0;
+    if wide {
+        if variable_count != 1 {
+            return Err(RowWriteError::UnsupportedWideVariableOffsets {
+                variable_count,
+                row_length: length,
+            });
+        }
+        length += 1;
+        let last_boundary = 1 + fixed_size + variable_bytes;
+        if last_boundary > MAX_WIDE_BOUNDARY {
+            return Err(RowWriteError::BoundaryTooLarge {
+                index: 0,
+                boundary: last_boundary,
+                maximum: MAX_WIDE_BOUNDARY,
+            });
+        }
+    }
+    Ok(RowShape {
+        fixed_size,
+        variable_count,
+        null_len,
+        wide,
+        length,
+    })
+}
+
+/// Checks the value against the column and returns its physical byte width.
+fn value_width(
+    ordinal: u16,
+    column: RowColumnLayout,
+    value: RowValue<'_>,
+) -> Result<usize, RowWriteError> {
+    let physical_type = column.physical_type;
+    let fixed = matches!(column.storage, ColumnStorageClass::Fixed { .. });
+    let storage_error = RowWriteError::InvalidStorage {
+        ordinal,
+        physical_type,
+    };
+    let mismatch = RowWriteError::TypeMismatch {
+        ordinal,
+        physical_type,
+    };
+    let width = |actual: usize, expected: usize, exact: bool| {
+        if (exact && actual != expected) || (!exact && actual > expected) {
+            Err(RowWriteError::InvalidWidth {
+                ordinal,
+                physical_type,
+                expected,
+                actual,
+            })
+        } else {
+            Ok(actual)
+        }
+    };
+    let size = usize::from(column.size);
+    match physical_type {
+        ColumnPhysicalType::Boolean => match (fixed, value) {
+            (true, RowValue::Null | RowValue::Boolean(_)) => Ok(0),
+            (false, _) => Err(storage_error),
+            _ => Err(mismatch),
+        },
+        ColumnPhysicalType::Byte
+        | ColumnPhysicalType::Integer
+        | ColumnPhysicalType::Long
+        | ColumnPhysicalType::Currency
+        | ColumnPhysicalType::Single
+        | ColumnPhysicalType::Double
+        | ColumnPhysicalType::DateTime
+        | ColumnPhysicalType::Guid => {
+            if !fixed {
+                return Err(storage_error);
+            }
+            let matches = match value {
+                RowValue::Null => true,
+                RowValue::Byte(_) => physical_type == ColumnPhysicalType::Byte,
+                RowValue::Integer(_) => physical_type == ColumnPhysicalType::Integer,
+                RowValue::Long(_) => physical_type == ColumnPhysicalType::Long,
+                RowValue::Currency { .. } => physical_type == ColumnPhysicalType::Currency,
+                RowValue::Single(_) => physical_type == ColumnPhysicalType::Single,
+                RowValue::Double(_) => physical_type == ColumnPhysicalType::Double,
+                RowValue::DateTime { .. } => physical_type == ColumnPhysicalType::DateTime,
+                RowValue::Guid(_) => physical_type == ColumnPhysicalType::Guid,
+                _ => false,
+            };
+            if matches { Ok(size) } else { Err(mismatch) }
+        }
+        ColumnPhysicalType::Text => match value {
+            RowValue::Null => Ok(0),
+            RowValue::Text(bytes) => width(bytes.len(), size, fixed),
+            _ => Err(mismatch),
+        },
+        ColumnPhysicalType::Binary => match (fixed, value) {
+            (true, _) => Err(storage_error),
+            (false, RowValue::Null) => Ok(0),
+            (false, RowValue::Binary(bytes)) => width(bytes.len(), size, false),
+            _ => Err(mismatch),
+        },
+        ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo => match (fixed, value) {
+            (true, _) => Err(storage_error),
+            (false, RowValue::Null) => Ok(0),
+            (false, RowValue::LongValue(bytes)) => {
+                if bytes.len() < LONG_VALUE_HEADER_LEN {
+                    return Err(RowWriteError::InvalidWidth {
+                        ordinal,
+                        physical_type,
+                        expected: LONG_VALUE_HEADER_LEN,
+                        actual: bytes.len(),
+                    });
+                }
+                Ok(bytes.len())
+            }
+            _ => Err(mismatch),
+        },
+    }
+}
+
+fn write_row(
+    writer: &mut BinaryWriter<'_, '_>,
+    columns: &[RowColumnLayout],
+    values: &[RowValue<'_>],
+    shape: RowShape,
+) -> Result<(), Error> {
+    let count = u8::try_from(columns.len()).map_err(|_| Error::IntegerConversion {
+        value: columns.len() as u128,
+        target: "u8",
+    })?;
+    writer.write_u8(count)?;
+    // EXP-0060: bytes reserved for null fixed fields are not interpreted.
+    write_zeros(writer, shape.fixed_size)?;
+    let fixed_end = writer.position();
+    let mut null_map = [0_u8; NULL_MAP_MAX_LEN];
+    for (ordinal, (column, value)) in columns.iter().zip(values).enumerate() {
+        let present = match (column.physical_type, value) {
+            (ColumnPhysicalType::Boolean, RowValue::Boolean(bit)) => *bit,
+            (_, RowValue::Null) => false,
+            (ColumnPhysicalType::Boolean, _) => false,
+            _ => true,
+        };
+        if present {
+            null_map[ordinal / 8] |= 1 << (ordinal % 8);
+        }
+        if let (ColumnStorageClass::Fixed { offset }, true) = (column.storage, present) {
+            if column.physical_type == ColumnPhysicalType::Boolean {
+                continue;
+            }
+            let position = ByteOffset::new(1).checked_add(ByteCount::new(u64::from(offset)))?;
+            writer.seek(position)?;
+            write_scalar(writer, *value)?;
+        }
+    }
+    writer.seek(fixed_end)?;
+    let mut boundaries = [0_usize; MAX_COLUMN_COUNT + 1];
+    boundaries[0] = fixed_end.to_usize()?;
+    for index in 0..shape.variable_count {
+        let Some((_, value)) = columns.iter().zip(values).find(|(column, _)| {
+            column.storage
+                == ColumnStorageClass::Variable {
+                    index: index as u16,
+                }
+        }) else {
+            return Err(Error::Arithmetic {
+                operation: "locate validated variable column",
+            });
+        };
+        match value {
+            RowValue::Text(bytes) | RowValue::Binary(bytes) | RowValue::LongValue(bytes) => {
+                writer.write_exact(bytes)?;
+            }
+            _ => {}
+        }
+        boundaries[index + 1] = writer.position().to_usize()?;
+    }
+    if shape.variable_count > 0 {
+        // EXP-0060: boundaries in reverse order, low byte each.
+        let mut jump = 0_u8;
+        for ordinal in (0..=shape.variable_count).rev() {
+            let boundary = boundaries[ordinal];
+            writer.write_u8((boundary & 0xff) as u8)?;
+            let reversed = shape.variable_count - ordinal;
+            if shape.wide && boundary & 0x100 != 0 {
+                jump |= 1 << reversed;
+            }
+        }
+        if shape.wide {
+            writer.write_u8(jump)?;
+        }
+        writer.write_u8(shape.variable_count as u8)?;
+    }
+    writer.write_exact(&null_map[..shape.null_len])
+}
+
+fn write_scalar(writer: &mut BinaryWriter<'_, '_>, value: RowValue<'_>) -> Result<(), Error> {
+    match value {
+        RowValue::Byte(raw) => writer.write_u8(raw),
+        RowValue::Integer(raw) => writer.write_i16_le(raw),
+        RowValue::Long(raw) => writer.write_i32_le(raw),
+        RowValue::Currency { scaled } => writer.write_i64_le(scaled),
+        RowValue::Single(raw) => writer.write_f32_le(raw),
+        RowValue::Double(raw) | RowValue::DateTime { days: raw } => writer.write_f64_le(raw),
+        RowValue::Text(bytes) => writer.write_exact(bytes),
+        // EXP-0061: first three groups little-endian, last eight bytes in display order.
+        RowValue::Guid(d) => writer.write_exact(&[
+            d[3], d[2], d[1], d[0], d[5], d[4], d[7], d[6], d[8], d[9], d[10], d[11], d[12], d[13],
+            d[14], d[15],
+        ]),
+        RowValue::Null | RowValue::Boolean(_) | RowValue::Binary(_) | RowValue::LongValue(_) => {
+            Ok(())
+        }
+    }
+}
+
+fn write_zeros(writer: &mut BinaryWriter<'_, '_>, mut count: usize) -> Result<(), Error> {
+    const ZEROS: [u8; 64] = [0; 64];
+    while count > 0 {
+        let chunk = count.min(ZEROS.len());
+        writer.write_exact(&ZEROS[..chunk])?;
+        count -= chunk;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "row_writer_tests.rs"]
+mod tests;

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -1,0 +1,418 @@
+use super::{RowColumnLayout, RowValue, RowWriteError, encode_row};
+use crate::{
+    ByteCount, ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageClass,
+    ColumnStorageKind, DatabaseReader, Error, JET3_PAGE_SIZE, MapRowLocator, PageNumber,
+    ReadLimits, ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource,
+    TableDefinitionSpec, TextCodePage, ValueKind, encode_table_definition,
+};
+
+const PAGE_BYTES: usize = JET3_PAGE_SIZE.get() as usize;
+const ROOT: usize = 1;
+const MAP_PAGE: usize = 2;
+const DATA_PAGE: usize = 3;
+
+fn all_type_columns() -> Vec<ColumnSpec<'static>> {
+    use ColumnPhysicalType as T;
+    use ColumnStorageKind::{Fixed, Variable};
+    vec![
+        ColumnSpec::new(b"Id", T::Long, Fixed, 4),
+        ColumnSpec::new(b"Flag", T::Boolean, Fixed, 1),
+        ColumnSpec::new(b"Small", T::Byte, Fixed, 1),
+        ColumnSpec::new(b"Short", T::Integer, Fixed, 2),
+        ColumnSpec::new(b"Money", T::Currency, Fixed, 8),
+        ColumnSpec::new(b"Ratio", T::Single, Fixed, 4),
+        ColumnSpec::new(b"Precise", T::Double, Fixed, 8),
+        ColumnSpec::new(b"When", T::DateTime, Fixed, 8),
+        ColumnSpec::new(b"Blob", T::Binary, Variable, 16),
+        ColumnSpec::new(b"Name", T::Text, Variable, 50),
+        ColumnSpec::new(b"Code", T::Text, Fixed, 3),
+        ColumnSpec::new(b"Ole", T::LongBinary, Variable, 0),
+        ColumnSpec::new(b"Notes", T::Memo, Variable, 0),
+        ColumnSpec::new(b"Rid", T::Guid, Fixed, 16),
+    ]
+}
+
+fn write_rows(page: &mut [u8], owner: u32, rows: &[&[u8]]) {
+    page[0] = 1;
+    page[4..8].copy_from_slice(&owner.to_le_bytes());
+    page[8..10].copy_from_slice(&(rows.len() as u16).to_le_bytes());
+    let mut start = PAGE_BYTES;
+    for (index, row) in rows.iter().enumerate() {
+        start -= row.len();
+        page[10 + 2 * index..12 + 2 * index].copy_from_slice(&(start as u16).to_le_bytes());
+        page[start..start + row.len()].copy_from_slice(row);
+    }
+}
+
+/// Builds a one-table database whose data page holds the given rows.
+fn database_bytes(
+    columns: &[ColumnSpec<'_>],
+    rows: &[&[u8]],
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut bytes = vec![0_u8; 4 * PAGE_BYTES];
+    bytes[4..19].copy_from_slice(b"Standard Jet DB");
+    bytes[0x41] = 0x4e;
+    bytes[0x42..0x50].copy_from_slice(&[
+        0x86, 0xfb, 0xec, 0x37, 0x5d, 0x44, 0x9c, 0xfa, 0xc6, 0x5e, 0x28, 0xe6, 0x13, 0xb6,
+    ]);
+    let spec = TableDefinitionSpec {
+        columns,
+        physical_indexes: &[],
+        indexes: &[],
+        owned_map: MapRowLocator::new(PageNumber::new(MAP_PAGE as u64), 0),
+        available_map: MapRowLocator::new(PageNumber::new(MAP_PAGE as u64), 1),
+        raw_suffix: &[],
+    };
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    encode_table_definition(
+        &spec,
+        &mut bytes[ROOT * PAGE_BYTES..(ROOT + 1) * PAGE_BYTES],
+        &mut budget,
+    )?;
+    let owned = [0, 0, 0, 0, 0, 1 << DATA_PAGE];
+    let available = [0, 0, 0, 0, 0];
+    write_rows(
+        &mut bytes[MAP_PAGE * PAGE_BYTES..(MAP_PAGE + 1) * PAGE_BYTES],
+        0,
+        &[&owned, &available],
+    );
+    write_rows(
+        &mut bytes[DATA_PAGE * PAGE_BYTES..(DATA_PAGE + 1) * PAGE_BYTES],
+        ROOT as u32,
+        rows,
+    );
+    Ok(bytes)
+}
+
+fn layouts(columns: &[ColumnSpec<'_>]) -> Result<Vec<RowColumnLayout>, Box<dyn std::error::Error>> {
+    let bytes = database_bytes(columns, &[])?;
+    let definition = open_definition(&bytes)?;
+    Ok(definition
+        .columns()
+        .iter()
+        .map(RowColumnLayout::from)
+        .collect())
+}
+
+fn open_definition(bytes: &[u8]) -> Result<crate::TableDefinition, Box<dyn std::error::Error>> {
+    let mut budget = budget_for(bytes);
+    let source = SliceSource::new(bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    Ok(database.table_definition(PageNumber::new(ROOT as u64), &mut budget)?)
+}
+
+fn budget_for(bytes: &[u8]) -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::new(ReadLimits::new(
+        ByteCount::new(bytes.len() as u64),
+        JET3_PAGE_SIZE,
+        ByteCount::new(u64::MAX),
+    )))
+}
+
+fn encode(layout: &[RowColumnLayout], values: &[RowValue<'_>]) -> Result<Vec<u8>, RowWriteError> {
+    let mut output = vec![0xa5_u8; PAGE_BYTES];
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let length = encode_row(layout, values, &mut output, &mut budget)?;
+    output.truncate(length.get() as usize);
+    Ok(output)
+}
+
+#[test]
+fn round_trips_every_type_and_nulls_through_the_row_decoder()
+-> Result<(), Box<dyn std::error::Error>> {
+    let columns = all_type_columns();
+    let layout = layouts(&columns)?;
+    let guid = [
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc,
+        0xfe,
+    ];
+    let mut memo = 0x8000_0005_u32.to_le_bytes().to_vec();
+    memo.extend_from_slice(&[0; 8]);
+    memo.extend_from_slice(b"hello");
+    let full = [
+        RowValue::Long(-7),
+        RowValue::Boolean(true),
+        RowValue::Byte(200),
+        RowValue::Integer(-2),
+        RowValue::Currency { scaled: 12_345 },
+        RowValue::Single(1.5),
+        RowValue::Double(-2.25),
+        RowValue::DateTime { days: 36_526.5 },
+        RowValue::Binary(&[1, 2, 3]),
+        RowValue::Text(b"Caf\xe9 \x80"),
+        RowValue::Text(b"ABC"),
+        RowValue::LongValue(&memo),
+        RowValue::LongValue(&memo),
+        RowValue::Guid(guid),
+    ];
+    let sparse = [
+        RowValue::Long(1),
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Integer(9),
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Text(b""),
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Null,
+        RowValue::Null,
+    ];
+    let full_row = encode(&layout, &full)?;
+    let sparse_row = encode(&layout, &sparse)?;
+    let bytes = database_bytes(&columns, &[&full_row, &sparse_row])?;
+    let definition = open_definition(&bytes)?;
+    let mut budget = budget_for(&bytes);
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let mut rows = database.rows(&definition, &mut budget)?;
+
+    let kind = |row: &mut crate::RowView<'_, '_>,
+                ordinal: u16|
+     -> Result<String, Box<dyn std::error::Error>> {
+        let value = row
+            .value(ColumnOrdinal::new(ordinal), TextCodePage::Windows1252)?
+            .ok_or("missing column")?;
+        Ok(format!("{:?}", value.kind()))
+    };
+    {
+        let mut row = rows.next_row()?.ok_or("missing full row")?;
+        assert_eq!(row.raw_bytes()[0], 14);
+        assert_eq!(kind(&mut row, 0)?, format!("{:?}", ValueKind::Long(-7)));
+        assert_eq!(
+            kind(&mut row, 1)?,
+            format!("{:?}", ValueKind::Boolean(true))
+        );
+        assert_eq!(kind(&mut row, 2)?, format!("{:?}", ValueKind::Byte(200)));
+        assert_eq!(kind(&mut row, 3)?, format!("{:?}", ValueKind::Integer(-2)));
+        assert!(kind(&mut row, 4)?.contains("scaled: 12345"));
+        assert_eq!(kind(&mut row, 5)?, format!("{:?}", ValueKind::Single(1.5)));
+        assert_eq!(
+            kind(&mut row, 6)?,
+            format!("{:?}", ValueKind::Double(-2.25))
+        );
+        assert!(kind(&mut row, 7)?.contains("days: 36526.5"));
+        assert_eq!(
+            kind(&mut row, 8)?,
+            format!("{:?}", ValueKind::Binary(&[1, 2, 3]))
+        );
+        let text = row
+            .value(ColumnOrdinal::new(9), TextCodePage::Windows1252)?
+            .ok_or("missing text")?;
+        let ValueKind::Text(text) = text.kind() else {
+            return Err("expected text".into());
+        };
+        assert_eq!(text.as_str(), "Café €");
+        let fixed_text = row
+            .value(ColumnOrdinal::new(10), TextCodePage::Windows1252)?
+            .ok_or("missing fixed text")?;
+        assert_eq!(fixed_text.raw_bytes(), Some(&b"ABC"[..]));
+        assert_eq!(
+            row.field(ColumnOrdinal::new(11))
+                .and_then(|f| f.raw_bytes()),
+            Some(&memo[..])
+        );
+        let ole = row
+            .value(ColumnOrdinal::new(12), TextCodePage::Windows1252)?
+            .ok_or("missing memo")?;
+        assert!(format!("{:?}", ole.kind()).contains("hello"));
+        let rid = row
+            .value(ColumnOrdinal::new(13), TextCodePage::Windows1252)?
+            .ok_or("missing guid")?;
+        let ValueKind::Guid(rid) = rid.kind() else {
+            return Err("expected guid".into());
+        };
+        assert_eq!(rid.display_bytes(), guid);
+    }
+    {
+        let mut row = rows.next_row()?.ok_or("missing sparse row")?;
+        assert_eq!(kind(&mut row, 0)?, format!("{:?}", ValueKind::Long(1)));
+        assert_eq!(
+            kind(&mut row, 1)?,
+            format!("{:?}", ValueKind::Boolean(false))
+        );
+        assert_eq!(kind(&mut row, 2)?, format!("{:?}", ValueKind::Null));
+        assert_eq!(kind(&mut row, 3)?, format!("{:?}", ValueKind::Integer(9)));
+        assert_eq!(kind(&mut row, 8)?, format!("{:?}", ValueKind::Null));
+        assert_eq!(
+            row.field(ColumnOrdinal::new(9)).and_then(|f| f.raw_bytes()),
+            Some(&b""[..])
+        );
+        assert_eq!(kind(&mut row, 12)?, format!("{:?}", ValueKind::Null));
+        assert_eq!(kind(&mut row, 13)?, format!("{:?}", ValueKind::Null));
+    }
+    assert!(rows.next_row()?.is_none());
+    Ok(())
+}
+
+#[test]
+fn reproduces_exp_0060_controls_and_wide_single_variable_rows()
+-> Result<(), Box<dyn std::error::Error>> {
+    // EXP-0060 variable-only control: `02 41 42 43 44 45 06 02 01 02 03`.
+    let variable_only = [
+        RowColumnLayout::new(
+            ColumnPhysicalType::Text,
+            ColumnStorageClass::Variable { index: 0 },
+            50,
+        ),
+        RowColumnLayout::new(
+            ColumnPhysicalType::Text,
+            ColumnStorageClass::Variable { index: 1 },
+            50,
+        ),
+    ];
+    assert_eq!(
+        encode(
+            &variable_only,
+            &[RowValue::Text(b"ABCDE"), RowValue::Text(b"")]
+        )?,
+        [
+            0x02, 0x41, 0x42, 0x43, 0x44, 0x45, 0x06, 0x06, 0x01, 0x02, 0x03
+        ]
+    );
+    // EXP-0060 mixed control: `03 40 30 20 10 2a 6d 69 78 65 64 0b 06 01 07`.
+    let mixed = [
+        RowColumnLayout::new(
+            ColumnPhysicalType::Long,
+            ColumnStorageClass::Fixed { offset: 0 },
+            4,
+        ),
+        RowColumnLayout::new(
+            ColumnPhysicalType::Byte,
+            ColumnStorageClass::Fixed { offset: 4 },
+            1,
+        ),
+        RowColumnLayout::new(
+            ColumnPhysicalType::Text,
+            ColumnStorageClass::Variable { index: 0 },
+            50,
+        ),
+    ];
+    assert_eq!(
+        encode(
+            &mixed,
+            &[
+                RowValue::Long(0x1020_3040),
+                RowValue::Byte(0x2a),
+                RowValue::Text(b"mixed")
+            ]
+        )?,
+        [
+            0x03, 0x40, 0x30, 0x20, 0x10, 0x2a, 0x6d, 0x69, 0x78, 0x65, 0x64, 0x0b, 0x06, 0x01,
+            0x07
+        ]
+    );
+    // EXP-0060 265-byte overflow target: low bytes `04 05`, jump `01`, count, presence `03`.
+    let wide = [
+        RowColumnLayout::new(
+            ColumnPhysicalType::Long,
+            ColumnStorageClass::Fixed { offset: 0 },
+            4,
+        ),
+        RowColumnLayout::new(
+            ColumnPhysicalType::Text,
+            ColumnStorageClass::Variable { index: 0 },
+            255,
+        ),
+    ];
+    let row = encode(&wide, &[RowValue::Long(5), RowValue::Text(&[b'O'; 255])])?;
+    assert_eq!(row.len(), 265);
+    assert_eq!(&row[260..], &[0x04, 0x05, 0x01, 0x01, 0x03]);
+    Ok(())
+}
+
+#[test]
+fn rejects_mismatches_unsupported_shapes_small_output_and_exhausted_budget() {
+    let long = RowColumnLayout::new(
+        ColumnPhysicalType::Long,
+        ColumnStorageClass::Fixed { offset: 0 },
+        4,
+    );
+    let text = |index| {
+        RowColumnLayout::new(
+            ColumnPhysicalType::Text,
+            ColumnStorageClass::Variable { index },
+            255,
+        )
+    };
+    assert_eq!(
+        encode(&[long], &[RowValue::Byte(1)]),
+        Err(RowWriteError::TypeMismatch {
+            ordinal: 0,
+            physical_type: ColumnPhysicalType::Long,
+        })
+    );
+    assert_eq!(
+        encode(&[long], &[]),
+        Err(RowWriteError::ValueCountMismatch {
+            expected: 1,
+            actual: 0,
+        })
+    );
+    assert_eq!(
+        encode(&[text(0)], &[RowValue::Text(&[0; 256])]),
+        Err(RowWriteError::InvalidWidth {
+            ordinal: 0,
+            physical_type: ColumnPhysicalType::Text,
+            expected: 255,
+            actual: 256,
+        })
+    );
+    assert_eq!(
+        encode(&[text(1)], &[RowValue::Text(b"")]),
+        Err(RowWriteError::InvalidVariableIndex {
+            ordinal: 0,
+            index: 1,
+            variable_count: 1,
+        })
+    );
+    assert_eq!(
+        encode(
+            &[text(0), text(1)],
+            &[RowValue::Text(&[0; 200]), RowValue::Text(&[0; 100])]
+        ),
+        Err(RowWriteError::UnsupportedWideVariableOffsets {
+            variable_count: 2,
+            row_length: 306,
+        })
+    );
+    let many = vec![long; 256];
+    assert_eq!(
+        encode(&many, &vec![RowValue::Null; 256]),
+        Err(RowWriteError::TooManyColumns {
+            count: 256,
+            maximum: 255,
+        })
+    );
+    let mut small = [0_u8; 5];
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    assert_eq!(
+        encode_row(&[long], &[RowValue::Long(1)], &mut small, &mut budget),
+        Err(RowWriteError::OutputTooSmall {
+            needed: 6,
+            available: 5,
+        })
+    );
+    let mut output = [0_u8; 16];
+    let mut exhausted =
+        ResourceBudget::new(ResourceLimits::default().with_max_encoded_bytes(ByteCount::new(2)));
+    assert_eq!(
+        encode_row(&[long], &[RowValue::Long(1)], &mut output, &mut exhausted),
+        Err(RowWriteError::Resource(Error::ResourceLimitExceeded {
+            kind: ResourceLimitKind::EncodedBytes,
+            requested: 5,
+            maximum: 2,
+        }))
+    );
+    assert!(
+        RowWriteError::TooManyColumns {
+            count: 0,
+            maximum: 0
+        }
+        .to_string()
+        .contains("row encoding failed")
+    );
+}

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -352,6 +352,34 @@ fn rejects_mismatches_unsupported_shapes_small_output_and_exhausted_budget() {
             actual: 0,
         })
     );
+    let invalid_size = RowColumnLayout::new(
+        ColumnPhysicalType::Long,
+        ColumnStorageClass::Fixed { offset: 0 },
+        1,
+    );
+    let mut untouched = [0xa5_u8; 16];
+    assert_eq!(
+        encode_row(
+            &[invalid_size],
+            &[RowValue::Long(0x4433_2211)],
+            &mut untouched,
+            &mut ResourceBudget::new(ResourceLimits::default())
+        ),
+        Err(RowWriteError::InvalidColumnSize {
+            ordinal: 0,
+            physical_type: ColumnPhysicalType::Long,
+            size: 1,
+        })
+    );
+    assert_eq!(untouched, [0xa5; 16]);
+    assert_eq!(
+        encode(&[long, long], &[RowValue::Long(1), RowValue::Long(2)]),
+        Err(RowWriteError::InvalidFixedOffset {
+            ordinal: 1,
+            offset: 0,
+            expected: 4,
+        })
+    );
     assert_eq!(
         encode(&[text(0)], &[RowValue::Text(&[0; 256])]),
         Err(RowWriteError::InvalidWidth {

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -325,6 +325,33 @@ fn reproduces_exp_0060_controls_and_wide_single_variable_rows()
 }
 
 #[test]
+fn accepts_the_absolute_maximum_single_page_row() -> Result<(), RowWriteError> {
+    let full = [0x5a_u8; 255];
+    let tail = [0xa5_u8; 249];
+    let mut layout: Vec<_> = (0_u16..7)
+        .map(|index| {
+            RowColumnLayout::new(
+                ColumnPhysicalType::Text,
+                ColumnStorageClass::Fixed {
+                    offset: index * 255,
+                },
+                255,
+            )
+        })
+        .collect();
+    layout.push(RowColumnLayout::new(
+        ColumnPhysicalType::Text,
+        ColumnStorageClass::Fixed { offset: 7 * 255 },
+        249,
+    ));
+    let mut values = vec![RowValue::Text(&full); 7];
+    values.push(RowValue::Text(&tail));
+
+    assert_eq!(encode(&layout, &values)?.len(), PAGE_BYTES - 12);
+    Ok(())
+}
+
+#[test]
 fn rejects_mismatches_unsupported_shapes_small_output_and_exhausted_budget() {
     let long = RowColumnLayout::new(
         ColumnPhysicalType::Long,
@@ -405,6 +432,28 @@ fn rejects_mismatches_unsupported_shapes_small_output_and_exhausted_budget() {
         Err(RowWriteError::UnsupportedWideVariableOffsets {
             variable_count: 2,
             row_length: 306,
+        })
+    );
+    let fixed_text = [0_u8; 255];
+    let oversized_layout: Vec<_> = (0..9)
+        .map(|index| {
+            RowColumnLayout::new(
+                ColumnPhysicalType::Text,
+                ColumnStorageClass::Fixed {
+                    offset: index * 255,
+                },
+                255,
+            )
+        })
+        .collect();
+    assert_eq!(
+        encode(
+            &oversized_layout,
+            &vec![RowValue::Text(&fixed_text); oversized_layout.len()]
+        ),
+        Err(RowWriteError::RowTooLong {
+            length: 2_298,
+            maximum: PAGE_BYTES - 12,
         })
     );
     let many = vec![long; 256];

--- a/crates/jet3/src/table_definition_writer.rs
+++ b/crates/jet3/src/table_definition_writer.rs
@@ -1,0 +1,496 @@
+//! Checked encoder for the logical bytes of a Jet 3 table definition, the
+//! inverse of `table_definition.rs` (`EXP-0059`).
+//!
+//! The output is the contiguous logical definition that `EXP-0059` describes:
+//! root bytes `[0,2048)` plus continuation payloads. Splitting a definition
+//! longer than one page across continuation pages, and filling the
+//! next-page reference at `[4,8)`, is left to the page assembler.
+
+use std::fmt;
+
+use crate::column_definition_writer::{
+    COLUMN_RECORD_LEN, ColumnSpec, ColumnStorageKind, LOGICAL_RECORD_LEN, LogicalIndexKindSpec,
+    LogicalIndexSpec, MAX_NAME_LEN, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, PhysicalIndexSpec,
+    physical_flags, resolve_column, validate_physical_index, write_column_record,
+    write_logical_record, write_name, write_physical_record,
+};
+use crate::{
+    BinaryWriter, ByteCount, ColumnPhysicalType, Error, MapRowLocator, PageNumber, ResourceBudget,
+};
+
+/// `EXP-0059`: four-byte definition page prefix.
+const DEFINITION_PREFIX: [u8; 4] = [0x02, 0x01, 0x56, 0x43];
+/// `EXP-0059`: fixed header before the physical-index prefixes.
+const DEFINITION_HEADER_LEN: usize = 43;
+/// `EXP-0059`: byte 20 marker.
+const HEADER_MARKER: u8 = 0x4e;
+/// `EXP-0059`: the logical definition ends in `ff ff`.
+const TERMINATOR: [u8; 2] = [0xff, 0xff];
+/// `EXP-0060`: a row stores its column count in one byte.
+const MAX_COLUMN_COUNT: usize = u8::MAX as usize;
+/// `EXP-0059`: primary logical indexes map to physical flags `0x09`.
+const PRIMARY_FLAGS: u8 = 0x09;
+
+/// Complete description of one table definition to encode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TableDefinitionSpec<'a> {
+    /// Columns in ordinal order; at most 255 (`EXP-0060`).
+    pub columns: &'a [ColumnSpec<'a>],
+    /// Physical indexes in creation order.
+    pub physical_indexes: &'a [PhysicalIndexSpec<'a>],
+    /// Logical indexes in stored order; every physical index must be referenced.
+    pub indexes: &'a [LogicalIndexSpec<'a>],
+    /// Row holding the table's owned-page map.
+    pub owned_map: MapRowLocator,
+    /// Row holding the table's available-page map.
+    pub available_map: MapRowLocator,
+    /// Uninterpreted bytes stored before the terminator (`EXP-0059`).
+    pub raw_suffix: &'a [u8],
+}
+
+/// Structured failure while validating or encoding a table definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TableDefinitionWriteError {
+    /// More columns than a row can count.
+    TooManyColumns {
+        /// Requested column count.
+        count: usize,
+        /// Maximum encodable count.
+        maximum: usize,
+    },
+    /// More indexes than a 16-bit count can hold.
+    TooManyIndexes {
+        /// `"physical"` or `"logical"`.
+        role: &'static str,
+        /// Requested count.
+        count: usize,
+    },
+    /// A column or logical index name is empty.
+    EmptyName {
+        /// `"column"` or `"logical index"`.
+        role: &'static str,
+        /// Zero-based ordinal.
+        ordinal: u16,
+    },
+    /// A name exceeds its one-byte length prefix.
+    NameTooLong {
+        /// `"column"` or `"logical index"`.
+        role: &'static str,
+        /// Zero-based ordinal.
+        ordinal: u16,
+        /// Requested length.
+        length: usize,
+        /// Maximum length.
+        maximum: usize,
+    },
+    /// A name repeats an earlier name of the same role.
+    DuplicateName {
+        /// `"column"` or `"logical index"`.
+        role: &'static str,
+        /// Zero-based ordinal of the repeated name.
+        ordinal: u16,
+    },
+    /// A column size is incompatible with its physical type.
+    UnsupportedColumnSize {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Physical type.
+        physical_type: ColumnPhysicalType,
+        /// Requested size.
+        size: u16,
+    },
+    /// A storage kind or auto-increment flag is incompatible with the type.
+    UnsupportedColumnClass {
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Physical type.
+        physical_type: ColumnPhysicalType,
+        /// Requested storage kind.
+        storage: ColumnStorageKind,
+    },
+    /// Fixed offsets overflowed the 16-bit offset field.
+    FixedAreaTooLarge {
+        /// Column whose offset could not be represented.
+        ordinal: u16,
+    },
+    /// A physical index has no key fields.
+    EmptyPhysicalIndex {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+    },
+    /// A physical index has more key fields than slots.
+    TooManyKeyFields {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+        /// Requested field count.
+        count: usize,
+        /// Slot count.
+        maximum: usize,
+    },
+    /// A key field names a column outside the table.
+    InvalidKeyColumn {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+        /// Requested column ordinal.
+        ordinal: u16,
+        /// Table column count.
+        column_count: u16,
+    },
+    /// A key repeats a column.
+    DuplicateKeyColumn {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+        /// Repeated column ordinal.
+        ordinal: u16,
+    },
+    /// A physical page reference is zero or too large for its field.
+    InvalidPhysicalReference {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+        /// Semantic role of the reference.
+        role: &'static str,
+        /// Rejected page.
+        page: PageNumber,
+    },
+    /// A logical index references no physical index.
+    InvalidPhysicalIndexOrdinal {
+        /// Zero-based logical-index ordinal.
+        logical_index: u16,
+        /// Requested physical ordinal.
+        ordinal: u16,
+        /// Physical-index count.
+        physical_count: u16,
+    },
+    /// More than one primary logical index was requested.
+    DuplicatePrimaryIndex,
+    /// A primary logical index references a physical index that is not
+    /// unique and required.
+    InvalidPrimaryFlags {
+        /// Zero-based logical-index ordinal.
+        logical_index: u16,
+        /// Flags of the referenced physical index.
+        raw: u8,
+    },
+    /// A relationship references page zero or a page beyond 32 bits.
+    InvalidRelationshipReference {
+        /// Zero-based logical-index ordinal.
+        logical_index: u16,
+        /// Rejected page.
+        page: PageNumber,
+    },
+    /// A physical index is not referenced by any logical index.
+    UnreferencedPhysicalIndex {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+    },
+    /// The logical definition exceeds the 32-bit length field.
+    DefinitionTooLong {
+        /// Requested length.
+        length: usize,
+    },
+    /// The output slice cannot hold the complete definition.
+    OutputTooSmall {
+        /// Required length.
+        needed: usize,
+        /// Provided length.
+        available: usize,
+    },
+    /// Resource policy or checked arithmetic rejected the encoding.
+    Resource(Error),
+}
+
+impl fmt::Display for TableDefinitionWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "table definition encoding failed: {self:?}")
+    }
+}
+
+impl std::error::Error for TableDefinitionWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Resource(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Returns the exact logical length of the encoded definition.
+pub fn table_definition_len(
+    spec: &TableDefinitionSpec<'_>,
+) -> Result<usize, TableDefinitionWriteError> {
+    let mut total = DEFINITION_HEADER_LEN;
+    let mut add = |amount: usize| -> Result<(), TableDefinitionWriteError> {
+        total = total
+            .checked_add(amount)
+            .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
+        Ok(())
+    };
+    add(spec.physical_indexes.len() * (PHYSICAL_PREFIX_LEN + PHYSICAL_RECORD_LEN))?;
+    add(spec.columns.len() * COLUMN_RECORD_LEN)?;
+    for column in spec.columns {
+        add(1)?;
+        add(column.name().len())?;
+    }
+    add(spec.indexes.len() * LOGICAL_RECORD_LEN)?;
+    for index in spec.indexes {
+        add(1)?;
+        add(index.name.len())?;
+    }
+    add(spec.raw_suffix.len())?;
+    add(TERMINATOR.len())?;
+    if u32::try_from(total).is_err() {
+        return Err(TableDefinitionWriteError::DefinitionTooLong { length: total });
+    }
+    Ok(total)
+}
+
+/// Encodes the logical definition into `output`, returning the encoded length.
+///
+/// Bytes `[4,8)` (next definition page) are written as zero for the page
+/// assembler to fill; bytes with no `EXP-0059` meaning are written as zero.
+pub fn encode_table_definition(
+    spec: &TableDefinitionSpec<'_>,
+    output: &mut [u8],
+    budget: &mut ResourceBudget,
+) -> Result<ByteCount, TableDefinitionWriteError> {
+    let counts = validate(spec, budget)?;
+    let length = table_definition_len(spec)?;
+    if output.len() < length {
+        return Err(TableDefinitionWriteError::OutputTooSmall {
+            needed: length,
+            available: output.len(),
+        });
+    }
+    let logical_length = u32::try_from(length)
+        .map_err(|_| TableDefinitionWriteError::DefinitionTooLong { length })?;
+    let mut writer =
+        BinaryWriter::new(output, budget).map_err(TableDefinitionWriteError::Resource)?;
+    write_header(&mut writer, spec, counts, logical_length)
+        .map_err(TableDefinitionWriteError::Resource)?;
+    for _ in spec.physical_indexes {
+        writer
+            .write_exact(&[0; PHYSICAL_PREFIX_LEN])
+            .map_err(TableDefinitionWriteError::Resource)?;
+    }
+    let mut next_fixed_offset = 0_u16;
+    let mut variables_seen = 0_u16;
+    for (ordinal, column) in (0_u16..).zip(spec.columns) {
+        let resolved =
+            resolve_column(ordinal, column, &mut next_fixed_offset, &mut variables_seen)?;
+        write_column_record(&mut writer, ordinal, column, resolved)
+            .map_err(TableDefinitionWriteError::Resource)?;
+    }
+    for column in spec.columns {
+        write_name(&mut writer, column.name())?;
+    }
+    for index in spec.physical_indexes {
+        write_physical_record(&mut writer, index).map_err(TableDefinitionWriteError::Resource)?;
+    }
+    for index in spec.indexes {
+        write_logical_record(&mut writer, index).map_err(TableDefinitionWriteError::Resource)?;
+    }
+    for index in spec.indexes {
+        write_name(&mut writer, index.name)?;
+    }
+    writer
+        .write_exact(spec.raw_suffix)
+        .and_then(|()| writer.write_exact(&TERMINATOR))
+        .map_err(TableDefinitionWriteError::Resource)?;
+    Ok(ByteCount::new(writer.position().get()))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Counts {
+    columns: u16,
+    variables: u16,
+    physical: u16,
+    logical: u16,
+}
+
+fn validate(
+    spec: &TableDefinitionSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<Counts, TableDefinitionWriteError> {
+    if spec.columns.len() > MAX_COLUMN_COUNT {
+        return Err(TableDefinitionWriteError::TooManyColumns {
+            count: spec.columns.len(),
+            maximum: MAX_COLUMN_COUNT,
+        });
+    }
+    let columns = u16::try_from(spec.columns.len()).map_err(|_| {
+        TableDefinitionWriteError::TooManyColumns {
+            count: spec.columns.len(),
+            maximum: MAX_COLUMN_COUNT,
+        }
+    })?;
+    let physical = u16::try_from(spec.physical_indexes.len()).map_err(|_| {
+        TableDefinitionWriteError::TooManyIndexes {
+            role: "physical",
+            count: spec.physical_indexes.len(),
+        }
+    })?;
+    let logical = u16::try_from(spec.indexes.len()).map_err(|_| {
+        TableDefinitionWriteError::TooManyIndexes {
+            role: "logical",
+            count: spec.indexes.len(),
+        }
+    })?;
+    // Name uniqueness is quadratic in the (bounded) count; charge it as items.
+    let name_work = u64::from(columns)
+        .saturating_mul(u64::from(columns))
+        .saturating_add(u64::from(logical).saturating_mul(u64::from(logical)))
+        .saturating_add(u64::from(physical));
+    budget
+        .charge_items(name_work)
+        .map_err(TableDefinitionWriteError::Resource)?;
+
+    let mut next_fixed_offset = 0_u16;
+    let mut variables = 0_u16;
+    for (ordinal, column) in (0_u16..).zip(spec.columns) {
+        validate_name(
+            "column",
+            ordinal,
+            column.name(),
+            spec.columns[..usize::from(ordinal)]
+                .iter()
+                .map(ColumnSpec::name),
+        )?;
+        resolve_column(ordinal, column, &mut next_fixed_offset, &mut variables)?;
+    }
+    for (ordinal, index) in (0_u16..).zip(spec.physical_indexes) {
+        validate_physical_index(ordinal, index, columns)?;
+    }
+    budget
+        .charge_allocation(ByteCount::new(u64::from(physical)))
+        .map_err(TableDefinitionWriteError::Resource)?;
+    let mut referenced = Vec::new();
+    referenced
+        .try_reserve_exact(usize::from(physical))
+        .map_err(|_| {
+            TableDefinitionWriteError::Resource(Error::Io {
+                operation: "reserve physical index references",
+                kind: std::io::ErrorKind::OutOfMemory,
+            })
+        })?;
+    referenced.resize(usize::from(physical), false);
+    let mut primary_seen = false;
+    for (logical_index, index) in (0_u16..).zip(spec.indexes) {
+        validate_name(
+            "logical index",
+            logical_index,
+            index.name,
+            spec.indexes[..usize::from(logical_index)]
+                .iter()
+                .map(|earlier| earlier.name),
+        )?;
+        let Some(physical_spec) = spec.physical_indexes.get(usize::from(index.physical_index))
+        else {
+            return Err(TableDefinitionWriteError::InvalidPhysicalIndexOrdinal {
+                logical_index,
+                ordinal: index.physical_index,
+                physical_count: physical,
+            });
+        };
+        referenced[usize::from(index.physical_index)] = true;
+        match index.kind {
+            LogicalIndexKindSpec::Ordinary => {}
+            LogicalIndexKindSpec::Primary => {
+                if primary_seen {
+                    return Err(TableDefinitionWriteError::DuplicatePrimaryIndex);
+                }
+                primary_seen = true;
+                let raw = physical_flags(physical_spec);
+                if raw != PRIMARY_FLAGS {
+                    return Err(TableDefinitionWriteError::InvalidPrimaryFlags {
+                        logical_index,
+                        raw,
+                    });
+                }
+            }
+            LogicalIndexKindSpec::Relationship { related_table, .. } => {
+                if related_table.get() == 0 || related_table.get() > u64::from(u32::MAX) {
+                    return Err(TableDefinitionWriteError::InvalidRelationshipReference {
+                        logical_index,
+                        page: related_table,
+                    });
+                }
+            }
+        }
+    }
+    if let Some(physical_index) = (0..physical).find(|ordinal| !referenced[usize::from(*ordinal)]) {
+        return Err(TableDefinitionWriteError::UnreferencedPhysicalIndex { physical_index });
+    }
+    Ok(Counts {
+        columns,
+        variables,
+        physical,
+        logical,
+    })
+}
+
+fn validate_name<'a>(
+    role: &'static str,
+    ordinal: u16,
+    name: &[u8],
+    earlier: impl Iterator<Item = &'a [u8]>,
+) -> Result<(), TableDefinitionWriteError> {
+    if name.is_empty() {
+        return Err(TableDefinitionWriteError::EmptyName { role, ordinal });
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(TableDefinitionWriteError::NameTooLong {
+            role,
+            ordinal,
+            length: name.len(),
+            maximum: MAX_NAME_LEN,
+        });
+    }
+    let mut earlier = earlier;
+    if earlier.any(|other| other == name) {
+        return Err(TableDefinitionWriteError::DuplicateName { role, ordinal });
+    }
+    Ok(())
+}
+
+fn write_header(
+    writer: &mut BinaryWriter<'_, '_>,
+    spec: &TableDefinitionSpec<'_>,
+    counts: Counts,
+    logical_length: u32,
+) -> Result<(), Error> {
+    writer.write_exact(&DEFINITION_PREFIX)?;
+    writer.write_u32_le(0)?;
+    writer.write_u32_le(logical_length)?;
+    writer.write_exact(&[0; 8])?;
+    writer.write_u8(HEADER_MARKER)?;
+    writer.write_u16_le(counts.columns)?;
+    writer.write_u16_le(counts.variables)?;
+    writer.write_u16_le(counts.columns)?;
+    writer.write_u16_le(counts.logical)?;
+    writer.write_u16_le(0)?;
+    writer.write_u16_le(counts.physical)?;
+    writer.write_exact(&[0; 2])?;
+    write_map_locator(writer, spec.owned_map)?;
+    write_map_locator(writer, spec.available_map)
+}
+
+/// `EXP-0059` via `EXP-0057`: one row byte then a three-byte little-endian page.
+fn write_map_locator(
+    writer: &mut BinaryWriter<'_, '_>,
+    locator: MapRowLocator,
+) -> Result<(), Error> {
+    let page = u32::try_from(locator.page().get())
+        .ok()
+        .filter(|page| *page <= 0x00ff_ffff)
+        .ok_or(Error::IntegerConversion {
+            value: u128::from(locator.page().get()),
+            target: "u24",
+        })?;
+    writer.write_u8(locator.row())?;
+    writer.write_exact(&page.to_le_bytes()[..3])
+}
+
+#[cfg(test)]
+#[path = "table_definition_writer_tests.rs"]
+mod tests;

--- a/crates/jet3/src/table_definition_writer.rs
+++ b/crates/jet3/src/table_definition_writer.rs
@@ -14,6 +14,7 @@ use crate::column_definition_writer::{
     physical_flags, resolve_column, validate_physical_index, write_column_record,
     write_logical_record, write_name, write_physical_record,
 };
+use crate::data_page_directory::MAX_STORED_ROW_LEN;
 use crate::{
     BinaryWriter, ByteCount, ColumnPhysicalType, Error, MapRowLocator, PageNumber, ResourceBudget,
 };
@@ -114,6 +115,13 @@ pub enum TableDefinitionWriteError {
         /// Column whose offset could not be represented.
         ordinal: u16,
     },
+    /// Even an all-null row cannot fit in one data-page row slot.
+    RowLayoutTooLarge {
+        /// Minimum encoded row length for the schema.
+        minimum: usize,
+        /// Maximum length after the page header and one directory entry.
+        maximum: usize,
+    },
     /// A physical index has no key fields.
     EmptyPhysicalIndex {
         /// Zero-based physical-index ordinal.
@@ -152,6 +160,22 @@ pub enum TableDefinitionWriteError {
         role: &'static str,
         /// Rejected page.
         page: PageNumber,
+    },
+    /// A required table usage-map page is zero or too large for its field.
+    InvalidMapReference {
+        /// `"owned"` or `"available"`.
+        role: &'static str,
+        /// Rejected page.
+        page: PageNumber,
+    },
+    /// A physical index targets a column type that DAO does not index.
+    UnsupportedKeyColumn {
+        /// Zero-based physical-index ordinal.
+        physical_index: u16,
+        /// Zero-based column ordinal.
+        ordinal: u16,
+        /// Rejected column type.
+        physical_type: ColumnPhysicalType,
     },
     /// A logical index references no physical index.
     InvalidPhysicalIndexOrdinal {
@@ -219,6 +243,20 @@ impl std::error::Error for TableDefinitionWriteError {
 pub fn table_definition_len(
     spec: &TableDefinitionSpec<'_>,
 ) -> Result<usize, TableDefinitionWriteError> {
+    if spec.columns.len() > MAX_COLUMN_COUNT {
+        return Err(TableDefinitionWriteError::TooManyColumns {
+            count: spec.columns.len(),
+            maximum: MAX_COLUMN_COUNT,
+        });
+    }
+    for (role, count) in [
+        ("physical", spec.physical_indexes.len()),
+        ("logical", spec.indexes.len()),
+    ] {
+        if u16::try_from(count).is_err() {
+            return Err(TableDefinitionWriteError::TooManyIndexes { role, count });
+        }
+    }
     let mut total = DEFINITION_HEADER_LEN;
     let mut add = |amount: usize| -> Result<(), TableDefinitionWriteError> {
         total = total
@@ -226,13 +264,28 @@ pub fn table_definition_len(
             .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
         Ok(())
     };
-    add(spec.physical_indexes.len() * (PHYSICAL_PREFIX_LEN + PHYSICAL_RECORD_LEN))?;
-    add(spec.columns.len() * COLUMN_RECORD_LEN)?;
+    let physical_bytes = spec
+        .physical_indexes
+        .len()
+        .checked_mul(PHYSICAL_PREFIX_LEN + PHYSICAL_RECORD_LEN)
+        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
+    add(physical_bytes)?;
+    let column_bytes = spec
+        .columns
+        .len()
+        .checked_mul(COLUMN_RECORD_LEN)
+        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
+    add(column_bytes)?;
     for column in spec.columns {
         add(1)?;
         add(column.name().len())?;
     }
-    add(spec.indexes.len() * LOGICAL_RECORD_LEN)?;
+    let logical_bytes = spec
+        .indexes
+        .len()
+        .checked_mul(LOGICAL_RECORD_LEN)
+        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
+    add(logical_bytes)?;
     for index in spec.indexes {
         add(1)?;
         add(index.name.len())?;
@@ -336,6 +389,12 @@ fn validate(
             count: spec.indexes.len(),
         }
     })?;
+    for (role, locator) in [("owned", spec.owned_map), ("available", spec.available_map)] {
+        let page = locator.page();
+        if page.get() == 0 || page.get() > 0x00ff_ffff {
+            return Err(TableDefinitionWriteError::InvalidMapReference { role, page });
+        }
+    }
     // Name uniqueness is quadratic in the (bounded) count; charge it as items.
     let name_work = u64::from(columns)
         .saturating_mul(u64::from(columns))
@@ -358,8 +417,38 @@ fn validate(
         )?;
         resolve_column(ordinal, column, &mut next_fixed_offset, &mut variables)?;
     }
+    let variable_trailer = if variables == 0 {
+        0
+    } else {
+        usize::from(variables)
+            .checked_add(2)
+            .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+                operation: "size minimum encoded-row variable trailer",
+            }))?
+    };
+    let mut minimum_row_len = 1_usize
+        .checked_add(usize::from(next_fixed_offset))
+        .and_then(|value| value.checked_add(spec.columns.len().div_ceil(8)))
+        .and_then(|value| value.checked_add(variable_trailer))
+        .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+            operation: "size minimum encoded row",
+        }))?;
+    if variables > 0 && minimum_row_len > u8::MAX as usize {
+        minimum_row_len =
+            minimum_row_len
+                .checked_add(1)
+                .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+                    operation: "size minimum encoded-row jump table",
+                }))?;
+    }
+    if minimum_row_len > MAX_STORED_ROW_LEN {
+        return Err(TableDefinitionWriteError::RowLayoutTooLarge {
+            minimum: minimum_row_len,
+            maximum: MAX_STORED_ROW_LEN,
+        });
+    }
     for (ordinal, index) in (0_u16..).zip(spec.physical_indexes) {
-        validate_physical_index(ordinal, index, columns)?;
+        validate_physical_index(ordinal, index, spec.columns)?;
     }
     budget
         .charge_allocation(ByteCount::new(u64::from(physical)))

--- a/crates/jet3/src/table_definition_writer_tests.rs
+++ b/crates/jet3/src/table_definition_writer_tests.rs
@@ -1,0 +1,345 @@
+use super::{
+    TableDefinitionSpec, TableDefinitionWriteError, encode_table_definition, table_definition_len,
+};
+use crate::{
+    ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind,
+    DatabaseReader, Error, IndexDefinitionKind, IndexDirection, IndexFieldSpec, JET3_PAGE_SIZE,
+    LogicalIndexKindSpec, LogicalIndexSpec, MapRowLocator, PageNumber, PhysicalIndexSpec,
+    ReadLimits, RelationshipSide, ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource,
+    TableDefinition,
+};
+
+const PAGE_BYTES: usize = JET3_PAGE_SIZE.get() as usize;
+const ROOT: u64 = 1;
+const MAP_PAGE: u64 = 2;
+const INDEX_ROOT: u64 = 3;
+const RELATED_ROOT: u64 = 5;
+
+fn all_type_columns() -> Vec<ColumnSpec<'static>> {
+    use ColumnPhysicalType as T;
+    use ColumnStorageKind::{Fixed, Variable};
+    vec![
+        ColumnSpec::new(b"Id", T::Long, Fixed, 4).with_auto_increment(),
+        ColumnSpec::new(b"Flag", T::Boolean, Fixed, 1),
+        ColumnSpec::new(b"Small", T::Byte, Fixed, 1),
+        ColumnSpec::new(b"Short", T::Integer, Fixed, 2),
+        ColumnSpec::new(b"Money", T::Currency, Fixed, 8),
+        ColumnSpec::new(b"Ratio", T::Single, Fixed, 4),
+        ColumnSpec::new(b"Precise", T::Double, Fixed, 8),
+        ColumnSpec::new(b"When", T::DateTime, Fixed, 8),
+        ColumnSpec::new(b"Blob", T::Binary, Variable, 16),
+        ColumnSpec::new(b"Caf\xe9", T::Text, Variable, 50),
+        ColumnSpec::new(b"Code", T::Text, Fixed, 3),
+        ColumnSpec::new(b"Ole", T::LongBinary, Variable, 0),
+        ColumnSpec::new(b"Notes", T::Memo, Variable, 0),
+        ColumnSpec::new(b"Rid", T::Guid, Fixed, 16),
+    ]
+}
+
+fn physical(fields: &[IndexFieldSpec], unique: bool, required: bool) -> PhysicalIndexSpec<'_> {
+    PhysicalIndexSpec {
+        fields,
+        usage_map_page: PageNumber::new(MAP_PAGE),
+        usage_map_row: 2,
+        root: PageNumber::new(INDEX_ROOT),
+        unique,
+        required,
+    }
+}
+
+fn spec<'a>(
+    columns: &'a [ColumnSpec<'a>],
+    physical_indexes: &'a [PhysicalIndexSpec<'a>],
+    indexes: &'a [LogicalIndexSpec<'a>],
+) -> TableDefinitionSpec<'a> {
+    TableDefinitionSpec {
+        columns,
+        physical_indexes,
+        indexes,
+        owned_map: MapRowLocator::new(PageNumber::new(MAP_PAGE), 0),
+        available_map: MapRowLocator::new(PageNumber::new(MAP_PAGE), 1),
+        raw_suffix: &[7, 7],
+    }
+}
+
+fn decode(logical: &[u8]) -> Result<TableDefinition, Box<dyn std::error::Error>> {
+    let mut bytes = vec![0_u8; 6 * PAGE_BYTES];
+    bytes[4..19].copy_from_slice(b"Standard Jet DB");
+    bytes[0x41] = 0x4e;
+    bytes[0x42..0x50].copy_from_slice(&[
+        0x86, 0xfb, 0xec, 0x37, 0x5d, 0x44, 0x9c, 0xfa, 0xc6, 0x5e, 0x28, 0xe6, 0x13, 0xb6,
+    ]);
+    let root = ROOT as usize * PAGE_BYTES;
+    bytes[root..root + logical.len()].copy_from_slice(logical);
+    bytes[MAP_PAGE as usize * PAGE_BYTES] = 1;
+    bytes[INDEX_ROOT as usize * PAGE_BYTES] = 4;
+    bytes[RELATED_ROOT as usize * PAGE_BYTES] = 2;
+    let mut budget = ResourceBudget::new(ResourceLimits::new(ReadLimits::new(
+        ByteCount::new(bytes.len() as u64),
+        JET3_PAGE_SIZE,
+        ByteCount::new(u64::MAX),
+    )));
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    Ok(database.table_definition(PageNumber::new(ROOT), &mut budget)?)
+}
+
+#[test]
+fn round_trips_every_column_type_and_index_kind() -> Result<(), Box<dyn std::error::Error>> {
+    let columns = all_type_columns();
+    let primary_fields = [IndexFieldSpec {
+        column: 0,
+        direction: IndexDirection::Ascending,
+    }];
+    let composite_fields = [
+        IndexFieldSpec {
+            column: 10,
+            direction: IndexDirection::Descending,
+        },
+        IndexFieldSpec {
+            column: 3,
+            direction: IndexDirection::Ascending,
+        },
+    ];
+    let physical_indexes = [
+        physical(&primary_fields, true, true),
+        physical(&composite_fields, false, false),
+    ];
+    let indexes = [
+        LogicalIndexSpec {
+            name: b"CodeSeq",
+            physical_index: 1,
+            kind: LogicalIndexKindSpec::Ordinary,
+        },
+        LogicalIndexSpec {
+            name: b"PrimaryKey",
+            physical_index: 0,
+            kind: LogicalIndexKindSpec::Primary,
+        },
+        LogicalIndexSpec {
+            name: b".rB",
+            physical_index: 0,
+            kind: LogicalIndexKindSpec::Relationship {
+                side: RelationshipSide::PrimaryTable,
+                related_table: PageNumber::new(RELATED_ROOT),
+                raw_selector: 1,
+                relation_ordinal: 0,
+                cascade_updates: true,
+                cascade_deletes: false,
+            },
+        },
+    ];
+    let spec = spec(&columns, &physical_indexes, &indexes);
+    let mut output = vec![0xa5_u8; PAGE_BYTES];
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let length = encode_table_definition(&spec, &mut output, &mut budget)?;
+    assert_eq!(length.get() as usize, table_definition_len(&spec)?);
+    let decoded = decode(&output[..length.get() as usize])?;
+
+    assert_eq!(decoded.logical_length(), length.get() as u32);
+    assert_eq!(decoded.maps().owned().page(), PageNumber::new(MAP_PAGE));
+    assert_eq!(decoded.maps().available().row(), 1);
+    assert_eq!(decoded.raw_suffix(), &[7, 7]);
+    assert_eq!(decoded.columns().len(), columns.len());
+    for (column, expected) in decoded.columns().iter().zip(&columns) {
+        assert_eq!(column.name().raw_bytes(), expected.name());
+        assert_eq!(column.physical_type(), expected.physical_type());
+        assert_eq!(column.size(), expected.size());
+        assert_eq!(
+            matches!(column.storage(), ColumnStorageClass::Fixed { .. }),
+            expected.storage() == ColumnStorageKind::Fixed
+        );
+    }
+    assert!(decoded.columns()[0].auto_increment());
+    assert_eq!(
+        decoded.columns()[1].storage(),
+        ColumnStorageClass::Fixed { offset: 4 }
+    );
+    assert_eq!(
+        decoded.columns()[2].storage(),
+        ColumnStorageClass::Fixed { offset: 4 }
+    );
+    assert_eq!(
+        decoded.columns()[13].storage(),
+        ColumnStorageClass::Fixed { offset: 38 }
+    );
+    assert_eq!(
+        decoded.columns()[12].storage(),
+        ColumnStorageClass::Variable { index: 3 }
+    );
+
+    let composite = &decoded.physical_indexes()[1];
+    assert_eq!(composite.fields().len(), 2);
+    assert_eq!(composite.fields()[0].column().get(), 10);
+    assert_eq!(
+        composite.fields()[0].direction(),
+        IndexDirection::Descending
+    );
+    assert_eq!(composite.fields()[1].direction(), IndexDirection::Ascending);
+    assert!(!composite.unique());
+    assert_eq!(composite.usage_map().row(), 2);
+    assert_eq!(composite.root(), PageNumber::new(INDEX_ROOT));
+    assert_eq!(decoded.physical_indexes()[0].raw_flags(), 0x09);
+
+    assert_eq!(decoded.indexes()[0].kind(), IndexDefinitionKind::Ordinary);
+    assert_eq!(decoded.indexes()[0].physical_index(), 1);
+    assert_eq!(decoded.indexes()[1].kind(), IndexDefinitionKind::Primary);
+    assert_eq!(decoded.indexes()[1].name().raw_bytes(), b"PrimaryKey");
+    let IndexDefinitionKind::Relationship(relation) = decoded.indexes()[2].kind() else {
+        return Err("expected relationship".into());
+    };
+    assert_eq!(relation.side(), RelationshipSide::PrimaryTable);
+    assert_eq!(relation.related_table(), PageNumber::new(RELATED_ROOT));
+    assert_eq!(relation.raw_selector(), 1);
+    assert!(relation.cascade_updates());
+    assert!(!relation.cascade_deletes());
+    Ok(())
+}
+
+#[test]
+fn rejects_structural_errors_before_writing() {
+    let mut output = vec![0_u8; PAGE_BYTES];
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let long_name = [b'x'; 256];
+    let cases: Vec<(Vec<ColumnSpec<'_>>, TableDefinitionWriteError)> = vec![
+        (
+            vec![ColumnSpec::new(b"A", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4); 256],
+            TableDefinitionWriteError::TooManyColumns {
+                count: 256,
+                maximum: 255,
+            },
+        ),
+        (
+            vec![ColumnSpec::new(
+                &long_name,
+                ColumnPhysicalType::Long,
+                ColumnStorageKind::Fixed,
+                4,
+            )],
+            TableDefinitionWriteError::NameTooLong {
+                role: "column",
+                ordinal: 0,
+                length: 256,
+                maximum: 255,
+            },
+        ),
+        (
+            vec![
+                ColumnSpec::new(b"A", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
+                ColumnSpec::new(b"A", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
+            ],
+            TableDefinitionWriteError::DuplicateName {
+                role: "column",
+                ordinal: 1,
+            },
+        ),
+        (
+            vec![ColumnSpec::new(
+                b"A",
+                ColumnPhysicalType::Memo,
+                ColumnStorageKind::Fixed,
+                0,
+            )],
+            TableDefinitionWriteError::UnsupportedColumnClass {
+                ordinal: 0,
+                physical_type: ColumnPhysicalType::Memo,
+                storage: ColumnStorageKind::Fixed,
+            },
+        ),
+        (
+            vec![ColumnSpec::new(
+                b"A",
+                ColumnPhysicalType::Guid,
+                ColumnStorageKind::Fixed,
+                8,
+            )],
+            TableDefinitionWriteError::UnsupportedColumnSize {
+                ordinal: 0,
+                physical_type: ColumnPhysicalType::Guid,
+                size: 8,
+            },
+        ),
+    ];
+    for (columns, expected) in cases {
+        assert_eq!(
+            encode_table_definition(&spec(&columns, &[], &[]), &mut output, &mut budget),
+            Err(expected)
+        );
+    }
+    assert!(output.iter().all(|byte| *byte == 0));
+
+    let columns = [ColumnSpec::new(
+        b"Id",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    let fields = [IndexFieldSpec {
+        column: 0,
+        direction: IndexDirection::Ascending,
+    }];
+    let physical_indexes = [physical(&fields, false, false)];
+    let unreferenced = spec(&columns, &physical_indexes, &[]);
+    assert_eq!(
+        encode_table_definition(&unreferenced, &mut output, &mut budget),
+        Err(TableDefinitionWriteError::UnreferencedPhysicalIndex { physical_index: 0 })
+    );
+    let primary = [LogicalIndexSpec {
+        name: b"PK",
+        physical_index: 0,
+        kind: LogicalIndexKindSpec::Primary,
+    }];
+    assert_eq!(
+        encode_table_definition(
+            &spec(&columns, &physical_indexes, &primary),
+            &mut output,
+            &mut budget
+        ),
+        Err(TableDefinitionWriteError::InvalidPrimaryFlags {
+            logical_index: 0,
+            raw: 0,
+        })
+    );
+}
+
+#[test]
+fn rejects_small_output_and_exhausted_budget() -> Result<(), Box<dyn std::error::Error>> {
+    let columns = [ColumnSpec::new(
+        b"Id",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    let spec = spec(&columns, &[], &[]);
+    let needed = table_definition_len(&spec)?;
+    let mut output = vec![0_u8; needed];
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    assert_eq!(
+        encode_table_definition(&spec, &mut output[..needed - 1], &mut budget),
+        Err(TableDefinitionWriteError::OutputTooSmall {
+            needed,
+            available: needed - 1,
+        })
+    );
+    let mut exhausted =
+        ResourceBudget::new(ResourceLimits::default().with_max_encoded_bytes(ByteCount::new(3)));
+    assert_eq!(
+        encode_table_definition(&spec, &mut output, &mut exhausted),
+        Err(TableDefinitionWriteError::Resource(
+            Error::ResourceLimitExceeded {
+                kind: ResourceLimitKind::EncodedBytes,
+                requested: 4,
+                maximum: 3,
+            }
+        ))
+    );
+    let error = TableDefinitionWriteError::DuplicatePrimaryIndex;
+    assert!(
+        error
+            .to_string()
+            .contains("table definition encoding failed")
+    );
+    assert!(encode_table_definition(&spec, &mut output, &mut budget).is_ok());
+    assert!(decode(&output).is_ok());
+    Ok(())
+}

--- a/crates/jet3/src/table_definition_writer_tests.rs
+++ b/crates/jet3/src/table_definition_writer_tests.rs
@@ -261,11 +261,89 @@ fn rejects_structural_errors_before_writing() {
         ),
     ];
     for (columns, expected) in cases {
+        if matches!(&expected, TableDefinitionWriteError::TooManyColumns { .. }) {
+            assert_eq!(
+                table_definition_len(&spec(&columns, &[], &[])),
+                Err(expected.clone())
+            );
+        }
         assert_eq!(
             encode_table_definition(&spec(&columns, &[], &[]), &mut output, &mut budget),
             Err(expected)
         );
     }
+
+    let names: [&[u8]; 9] = [b"A", b"B", b"C", b"D", b"E", b"F", b"G", b"H", b"I"];
+    let oversized_columns: Vec<_> = names
+        .into_iter()
+        .map(|name| {
+            ColumnSpec::new(
+                name,
+                ColumnPhysicalType::Text,
+                ColumnStorageKind::Fixed,
+                255,
+            )
+        })
+        .collect();
+    assert_eq!(
+        encode_table_definition(
+            &spec(&oversized_columns, &[], &[]),
+            &mut output,
+            &mut budget
+        ),
+        Err(TableDefinitionWriteError::RowLayoutTooLarge {
+            minimum: 2_298,
+            maximum: PAGE_BYTES - 12,
+        })
+    );
+
+    let columns = [ColumnSpec::new(
+        b"Notes",
+        ColumnPhysicalType::Memo,
+        ColumnStorageKind::Variable,
+        0,
+    )];
+    let fields = [IndexFieldSpec {
+        column: 0,
+        direction: IndexDirection::Ascending,
+    }];
+    let physical_indexes = [physical(&fields, false, false)];
+    assert_eq!(
+        encode_table_definition(
+            &spec(&columns, &physical_indexes, &[]),
+            &mut output,
+            &mut budget
+        ),
+        Err(TableDefinitionWriteError::UnsupportedKeyColumn {
+            physical_index: 0,
+            ordinal: 0,
+            physical_type: ColumnPhysicalType::Memo,
+        })
+    );
+
+    let columns = [ColumnSpec::new(
+        b"Id",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    let mut invalid_map = spec(&columns, &[], &[]);
+    invalid_map.owned_map = MapRowLocator::new(PageNumber::new(0), 0);
+    assert_eq!(
+        encode_table_definition(&invalid_map, &mut output, &mut budget),
+        Err(TableDefinitionWriteError::InvalidMapReference {
+            role: "owned",
+            page: PageNumber::new(0),
+        })
+    );
+    invalid_map.owned_map = MapRowLocator::new(PageNumber::new(0x0100_0000), 0);
+    assert_eq!(
+        encode_table_definition(&invalid_map, &mut output, &mut budget),
+        Err(TableDefinitionWriteError::InvalidMapReference {
+            role: "owned",
+            page: PageNumber::new(0x0100_0000),
+        })
+    );
     assert!(output.iter().all(|byte| *byte == 0));
 
     let columns = [ColumnSpec::new(


### PR DESCRIPTION
Second write-side building block for #100. To create a database the writer must emit table definitions, `MSysObjects` catalog rows, and data rows — the crate could only read them.

Adds `encode_table_definition` (all 13 column types, fixed/variable layout derived automatically, physical and logical index definitions incl. primary, composite, descending, and relationship records — `EXP-0059`/`EXP-0062`), `encode_catalog_record` (`EXP-0058`), and `encode_row` (null mask, fixed and variable areas — `EXP-0060`/`EXP-0061`). Each writes into a caller slice via `BinaryWriter` and is round-tripped through the real decoders, including the CP1252 `Café_Euro€` name and the byte-exact `EXP-0060` row controls.

Left unimplemented with structured errors rather than guessed, because no provenance entry establishes them: wide rows with more than one variable column, padding of short fixed-width Text, and Unicode→code-page text encoding (values take pre-encoded bytes). LVAL chains and index key encoding are separate follow-ups.

Checks: `just ready` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)