### PR TITLE
feat(oracle): preregister A9 writer-allocation experiment

### DIFF
--- a/.github/workflows/windows-dao-allocation-a9.yml
+++ b/.github/workflows/windows-dao-allocation-a9.yml
@@ -1,0 +1,349 @@
+name: Windows DAO allocation A9
+
+on:
+  workflow_dispatch:
+    inputs:
+      accept_microsoft_access_runtime_license:
+        description: Accept Microsoft's Access Runtime license for this run
+        required: true
+        type: boolean
+        default: false
+      run_acquisition:
+        description: Run the preregistered A9 allocation acquisition (issue 99)
+        required: true
+        type: boolean
+        default: false
+      approve_acquisition:
+        description: Approve the single preregistered DAO acquisition
+        required: true
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the reviewed acquisition plan
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-dao-allocation-a9-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  provider-probe:
+    name: Probe x86 DAO and optionally acquire
+    runs-on: windows-2022
+    timeout-minutes: 240
+    env:
+      ODT_URL: https://download.microsoft.com/download/6c1eeb25-cf8b-41d9-8d0d-cc1dbc032140/officedeploymenttool_20228-20124.exe
+      ODT_SHA256: 92a3cbd56191533e36bde1c6e4640883c900c00d1b5d43a974c870893681e0d4
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify preregistration and human approval
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          APPROVED: ${{ inputs.approve_acquisition }}
+          EXPECTED_PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:APPROVED -cne "true") {
+            throw "The DAO acquisition requires explicit human approval."
+          }
+          if ($env:EXPECTED_PLAN_SHA256 -cnotmatch "^[0-9a-f]{64}$") {
+            throw "The reviewed plan SHA-256 is required."
+          }
+          $plan = "oracle/windows-dao/acquisition/a9-allocation.plan.json"
+          $actual = (Get-FileHash -LiteralPath $plan -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -cne $env:EXPECTED_PLAN_SHA256) {
+            throw "The checked-in acquisition plan does not match the approved digest."
+          }
+          python oracle/windows-dao/scripts/dao_allocation_a9.py plan $plan .
+          if ($LASTEXITCODE -ne 0) {
+            throw "The acquisition plan inputs do not match their pinned digests."
+          }
+
+      - name: Record runner identity
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $artifactRoot = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-hosted-probe"
+          New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
+          [ordered]@{
+            document_type = "jet3_windows_hosted_runner"
+            github_sha = $env:GITHUB_SHA
+            github_run_id = $env:GITHUB_RUN_ID
+            github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+            requested_image = "windows-2022"
+            image_os = $env:ImageOS
+            image_version = $env:ImageVersion
+            windows_version = [Environment]::OSVersion.VersionString
+            process_architecture = $env:PROCESSOR_ARCHITECTURE
+          } | ConvertTo-Json -Depth 4 | Set-Content `
+            -LiteralPath (Join-Path $artifactRoot "runner.json") `
+            -Encoding UTF8
+
+      - name: Probe the untouched runner image
+        id: stock
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $artifactRoot = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-hosted-probe"
+          $output = Join-Path $artifactRoot "environment-stock.json"
+          $stdout = Join-Path $artifactRoot "probe-stock.stdout.log"
+          $stderr = Join-Path $artifactRoot "probe-stock.stderr.log"
+          $x86PowerShell = Join-Path $env:WINDIR `
+            "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+          if (-not (Test-Path -LiteralPath $x86PowerShell -PathType Leaf)) {
+            throw "x86 Windows PowerShell is unavailable."
+          }
+          . "oracle/windows-dao/scripts/remote/Remote.Process.ps1"
+          $probe = Invoke-Jet3BootstrapProcess `
+            -Executable $x86PowerShell `
+            -Arguments @(
+              "-NoLogo", "-NoProfile", "-NonInteractive",
+              "-ExecutionPolicy", "Bypass",
+              "-File", "oracle/windows-dao/scripts/probe-provider.ps1",
+              "-ProtocolVersion", "1.2.0", "-OutputPath", $output
+            ) `
+            -Label "Stock DAO provider probe" `
+            -TimeoutSeconds 120 -MaximumOutputBytes 1MB
+          [IO.File]::WriteAllText($stdout, $probe.stdout)
+          [IO.File]::WriteAllText($stderr, $probe.stderr)
+          $probeExit = $probe.exit_code
+          "exit_code=$probeExit" | Out-File -FilePath $env:GITHUB_OUTPUT `
+            -Encoding utf8 -Append
+          if ($probeExit -notin @(0, 3)) {
+            throw "Stock provider probe returned unexpected exit $probeExit."
+          }
+          exit 0
+
+      - name: Install the Microsoft 365 Access Runtime (x86)
+        id: install
+        if: >-
+          steps.stock.outputs.exit_code == '3' &&
+          inputs.accept_microsoft_access_runtime_license
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
+          . "oracle/windows-dao/scripts/remote/Remote.Process.ps1"
+
+          function Invoke-ProcessWithTimeout {
+            param(
+              [Parameter(Mandatory = $true)][string]$FilePath,
+              [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+              [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+            )
+            $process = Start-Process -FilePath $FilePath -PassThru `
+              -ArgumentList $ArgumentList
+            if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+              Stop-Jet3BootstrapProcessTree -Process $process `
+                -Label "Microsoft runtime installation"
+              throw "Timed out while running $([IO.Path]::GetFileName($FilePath))."
+            }
+            return $process.ExitCode
+          }
+
+          $artifactRoot = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-hosted-probe"
+          $odtRoot = Join-Path $env:RUNNER_TEMP "jet3-odt"
+          New-Item -ItemType Directory -Force -Path $artifactRoot, $odtRoot |
+            Out-Null
+          $installRecord = Join-Path $artifactRoot "runtime-install.json"
+          [ordered]@{
+            document_type = "jet3_windows_hosted_runtime_install"
+            status = "started"
+            github_sha = $env:GITHUB_SHA
+            odt_download_url = $env:ODT_URL
+            odt_expected_sha256 = $env:ODT_SHA256
+            office_client_edition = "32"
+            product_id = "AccessRuntimeRetail"
+          } | ConvertTo-Json -Depth 4 | Set-Content `
+            -LiteralPath $installRecord -Encoding UTF8
+
+          $odtPackage = Join-Path $odtRoot "officedeploymenttool.exe"
+          Invoke-WebRequest -UseBasicParsing -Uri $env:ODT_URL `
+            -OutFile $odtPackage
+          $packageInfo = Get-Item -LiteralPath $odtPackage
+          if ($packageInfo.Length -lt 1MB -or $packageInfo.Length -gt 16MB) {
+            throw "The ODT package size is outside the reviewed bounds."
+          }
+          $packageHash = (
+            Get-FileHash -LiteralPath $odtPackage -Algorithm SHA256
+          ).Hash.ToLowerInvariant()
+          if ($packageHash -cne $env:ODT_SHA256) {
+            throw "The ODT package does not match its pinned SHA-256."
+          }
+          $signature = Get-AuthenticodeSignature -LiteralPath $odtPackage
+          if (
+            $signature.Status -ne [Management.Automation.SignatureStatus]::Valid -or
+            $null -eq $signature.SignerCertificate -or
+            $signature.SignerCertificate.Subject -notmatch '(^|, )O=Microsoft Corporation(,|$)'
+          ) {
+            throw "The ODT package does not have a valid Microsoft signature."
+          }
+
+          $extractRoot = Join-Path $odtRoot "extracted"
+          New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
+          $extractExit = Invoke-ProcessWithTimeout -FilePath $odtPackage `
+            -ArgumentList @("/quiet", "/extract:$extractRoot") `
+            -TimeoutSeconds 120
+          if ($extractExit -ne 0) {
+            throw "The Office Deployment Tool could not be extracted."
+          }
+          $setup = Join-Path $extractRoot "setup.exe"
+          if (-not (Test-Path -LiteralPath $setup -PathType Leaf)) {
+            throw "The extracted Office Deployment Tool is incomplete."
+          }
+
+          $configuration = Join-Path $odtRoot "access-runtime-x86.xml"
+          @'
+          <Configuration>
+            <Add OfficeClientEdition="32" Channel="Current">
+              <Product ID="AccessRuntimeRetail">
+                <Language ID="en-us" />
+              </Product>
+            </Add>
+            <Display Level="None" AcceptEULA="TRUE" />
+            <Updates Enabled="FALSE" />
+          </Configuration>
+          '@ | Set-Content -LiteralPath $configuration -Encoding UTF8
+          $installExit = Invoke-ProcessWithTimeout -FilePath $setup `
+            -ArgumentList @("/configure", $configuration) `
+            -TimeoutSeconds 1200
+          if ($installExit -ne 0) {
+            throw "Access Runtime installation failed with exit $installExit."
+          }
+
+          [ordered]@{
+            document_type = "jet3_windows_hosted_runtime_install"
+            status = "installed"
+            github_sha = $env:GITHUB_SHA
+            odt_download_url = $env:ODT_URL
+            odt_sha256 = $packageHash
+            odt_signer_subject = $signature.SignerCertificate.Subject
+            office_client_edition = "32"
+            product_id = "AccessRuntimeRetail"
+            install_exit_code = $installExit
+          } | ConvertTo-Json -Depth 4 | Set-Content `
+            -LiteralPath $installRecord -Encoding UTF8
+
+      - name: Probe after Access Runtime installation
+        id: hosted
+        if: >-
+          always() && steps.stock.outputs.exit_code == '3' &&
+          steps.install.outcome == 'success'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $artifactRoot = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-hosted-probe"
+          $output = Join-Path $artifactRoot "environment.json"
+          $stdout = Join-Path $artifactRoot "probe-installed.stdout.log"
+          $stderr = Join-Path $artifactRoot "probe-installed.stderr.log"
+          $x86PowerShell = Join-Path $env:WINDIR `
+            "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+          . "oracle/windows-dao/scripts/remote/Remote.Process.ps1"
+          $probe = Invoke-Jet3BootstrapProcess `
+            -Executable $x86PowerShell `
+            -Arguments @(
+              "-NoLogo", "-NoProfile", "-NonInteractive",
+              "-ExecutionPolicy", "Bypass",
+              "-File", "oracle/windows-dao/scripts/probe-provider.ps1",
+              "-ProtocolVersion", "1.2.0", "-OutputPath", $output
+            ) `
+            -Label "Installed DAO provider probe" `
+            -TimeoutSeconds 120 -MaximumOutputBytes 1MB
+          [IO.File]::WriteAllText($stdout, $probe.stdout)
+          [IO.File]::WriteAllText($stderr, $probe.stderr)
+          $probeExit = $probe.exit_code
+          "exit_code=$probeExit" | Out-File -FilePath $env:GITHUB_OUTPUT `
+            -Encoding utf8 -Append
+          if ($probeExit -notin @(0, 3)) {
+            throw "Installed provider probe returned unexpected exit $probeExit."
+          }
+          exit 0
+
+      - name: Select the stock provider record
+        if: steps.stock.outputs.exit_code == '0'
+        shell: powershell
+        run: >-
+          Copy-Item -LiteralPath
+          "artifacts/dao-hosted-probe/environment-stock.json"
+          -Destination "artifacts/dao-hosted-probe/environment.json"
+
+      - name: Acquire the A9 allocation page images
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $x86PowerShell = Join-Path $env:WINDIR `
+            "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
+          $output = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-allocation-a9"
+          & $x86PowerShell -NoLogo -NoProfile -NonInteractive `
+            -ExecutionPolicy Bypass `
+            -File "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1" `
+            -EnvironmentPath "artifacts/dao-hosted-probe/environment.json" `
+            -OutputRoot $output `
+            -SourceRevision $env:GITHUB_SHA `
+            -TimeoutMinutes 120
+          if ($LASTEXITCODE -ne 0) {
+            throw "The A9 generator failed with exit $LASTEXITCODE."
+          }
+
+      - name: Evaluate the A9 artifact
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_allocation_a9.py evaluate `
+            artifacts/dao-allocation-a9/manifest.raw.json `
+            artifacts/dao-allocation-a9 `
+            artifacts/dao-allocation-a9/report.json
+
+      - name: Summarize the provider result
+        if: always()
+        shell: powershell
+        env:
+          PROBE_EXIT_CODE: ${{ steps.hosted.outputs.exit_code || steps.stock.outputs.exit_code }}
+        run: |
+          $summary = @(
+            "## Windows DAO allocation A9",
+            "",
+            "- Image: ``windows-2022`` / ``$env:ImageVersion``",
+            "- Commit: ``$env:GITHUB_SHA``",
+            "- Probe exit: ``$env:PROBE_EXIT_CODE``"
+          )
+          $environmentPath = "artifacts/dao-hosted-probe/environment.json"
+          if (Test-Path -LiteralPath $environmentPath -PathType Leaf) {
+            $record = Get-Content -LiteralPath $environmentPath -Raw |
+              ConvertFrom-Json
+            $summary += "- Status: ``$($record.status)``"
+            if ($null -ne $record.accepted_provider) {
+              $summary += "- Provider: ``$($record.accepted_provider.prog_id)``"
+            }
+          }
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY `
+            -Encoding utf8 -Append
+
+      - name: Upload provider diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-allocation-a9-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Require a dbVersion30-capable provider
+        if: always()
+        shell: powershell
+        env:
+          PROBE_EXIT_CODE: ${{ steps.hosted.outputs.exit_code || steps.stock.outputs.exit_code }}
+        run: |
+          if ($env:PROBE_EXIT_CODE -ne "0") {
+            throw "The hosted runner did not provide a usable DAO environment."
+          }

--- a/.github/workflows/windows-dao-allocation-a9.yml
+++ b/.github/workflows/windows-dao-allocation-a9.yml
@@ -52,6 +52,9 @@ jobs:
           EXPECTED_PLAN_SHA256: ${{ inputs.plan_sha256 }}
         run: |
           $ErrorActionPreference = "Stop"
+          if ($env:GITHUB_RUN_ATTEMPT -cne "1") {
+            throw "The preregistered acquisition permits only the first workflow attempt."
+          }
           if ($env:APPROVED -cne "true") {
             throw "The DAO acquisition requires explicit human approval."
           }
@@ -281,28 +284,50 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
+          . "oracle/windows-dao/scripts/remote/Remote.Process.ps1"
           $x86PowerShell = Join-Path $env:WINDIR `
             "SysWOW64\WindowsPowerShell\v1.0\powershell.exe"
           $output = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-allocation-a9"
-          & $x86PowerShell -NoLogo -NoProfile -NonInteractive `
-            -ExecutionPolicy Bypass `
-            -File "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1" `
-            -EnvironmentPath "artifacts/dao-hosted-probe/environment.json" `
-            -OutputRoot $output `
-            -SourceRevision $env:GITHUB_SHA `
-            -TimeoutMinutes 120
-          if ($LASTEXITCODE -ne 0) {
-            throw "The A9 generator failed with exit $LASTEXITCODE."
+          $artifactRoot = Join-Path $env:GITHUB_WORKSPACE "artifacts\dao-hosted-probe"
+          $stdout = Join-Path $artifactRoot "a9-generator.stdout.log"
+          $stderr = Join-Path $artifactRoot "a9-generator.stderr.log"
+          $arguments = @(
+              "-NoLogo", "-NoProfile", "-NonInteractive",
+              "-ExecutionPolicy", "Bypass",
+              "-File", "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1",
+              "-EnvironmentPath", "artifacts/dao-hosted-probe/environment.json",
+              "-OutputRoot", $output,
+              "-SourceRevision", $env:GITHUB_SHA,
+              "-PlanSha256", "${{ inputs.plan_sha256 }}",
+              "-TimeoutMinutes", "120"
+            ) | ForEach-Object { ConvertTo-Jet3ProcessArgument -Value $_ }
+          $generator = Start-Process -FilePath $x86PowerShell -PassThru `
+            -ArgumentList ($arguments -join " ") `
+            -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+          try {
+            if (-not $generator.WaitForExit(7200 * 1000)) {
+              Stop-Jet3BootstrapProcessTree -Process $generator `
+                -Label "A9 allocation generator"
+              throw "The A9 generator exceeded its 120-minute wall-clock ceiling."
+            }
+            if ($generator.ExitCode -ne 0) {
+              throw "The A9 generator failed with exit $($generator.ExitCode)."
+            }
+          }
+          finally {
+            $generator.Dispose()
           }
 
       - name: Evaluate the A9 artifact
-        if: inputs.run_acquisition
+        if: always() && inputs.run_acquisition
         shell: powershell
         run: |
           python oracle/windows-dao/scripts/dao_allocation_a9.py evaluate `
             artifacts/dao-allocation-a9/manifest.raw.json `
             artifacts/dao-allocation-a9 `
-            artifacts/dao-allocation-a9/report.json
+            artifacts/dao-allocation-a9/report.json `
+            --expected-source-revision $env:GITHUB_SHA `
+            --expected-plan-sha256 "${{ inputs.plan_sha256 }}"
 
       - name: Summarize the provider result
         if: always()

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -64,8 +64,14 @@ but those bytes and provider binaries are never committed.
 page-allocation questions (Q1 empty template, Q2 page append, Q3 free-page
 reuse, Q4 table-map extension, Q5 index/long-value ownership) that the future
 writer needs, and pins the generator, evaluator, probe, process helper, and
-workflow. `windows-dao-allocation-a9.yml` uses the same three manual inputs
-plus `plan_sha256` and refuses before any DAO mutation unless all match.
+workflow. `windows-dao-allocation-a9.yml` uses the same explicit acquisition
+approval and exact `plan_sha256` gate and refuses before any DAO mutation
+unless all match. Workflow reruns are rejected; a new dispatch is a new
+explicit human decision.
+
+The workflow terminates the generator process tree at the preregistered
+120-minute wall-clock ceiling. The evaluator requires the manifest to bind
+both the approved plan digest and the checked-out source revision.
 
 One job runs three independent replicas. Each checkpoint is a closed-file
 capture of raw 2 KiB page images (hex plus SHA-256 per page) written under

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -13,6 +13,11 @@ The retained tooling has three purposes:
 - `.github/workflows/windows-dao-hosted.yml` probes the x86 DAO environment
   and, only when explicitly approved against the pinned plan, runs the single
   protocol-v1.2 acquisition.
+- `scripts/Invoke-DaoAllocationA9.ps1` is the bounded page-image generator for
+  the A9 allocation experiment (#99); `scripts/dao_allocation_a9.py` checks
+  its plan, evaluates its artifact, and runs the synthetic dry run.
+  `.github/workflows/windows-dao-allocation-a9.yml` hosts it under the same
+  gating as the read differential.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.
@@ -28,6 +33,10 @@ python3 -B oracle/windows-dao/scripts/dao_read_diff.py plan \
   oracle/windows-dao/acquisition/read-v1_2.plan.json .
 python3 -B oracle/windows-dao/scripts/dao_read_diff.py synthetic-dry-run \
   /tmp/jet3-dao-read-dry-run.json
+python3 -B oracle/windows-dao/scripts/dao_allocation_a9.py plan \
+  oracle/windows-dao/acquisition/a9-allocation.plan.json .
+python3 -B oracle/windows-dao/scripts/dao_allocation_a9.py synthetic-dry-run \
+  /tmp/jet3-dao-a9-dry-run.json
 python3 -B -m unittest discover -s oracle/windows-dao/tests -v
 ```
 
@@ -48,6 +57,25 @@ One accepted run must cover all 98 scenarios. The evaluator checks every MDB
 digest, Rust coverage verdict, snapshot pair, and comparison projection before
 writing `report.json`. The artifact upload may contain MDB bytes for review,
 but those bytes and provider binaries are never committed.
+
+### A9 allocation (#99)
+
+`oracle/windows-dao/acquisition/a9-allocation.plan.json` preregisters the
+page-allocation questions (Q1 empty template, Q2 page append, Q3 free-page
+reuse, Q4 table-map extension, Q5 index/long-value ownership) that the future
+writer needs, and pins the generator, evaluator, probe, process helper, and
+workflow. `windows-dao-allocation-a9.yml` uses the same three manual inputs
+plus `plan_sha256` and refuses before any DAO mutation unless all match.
+
+One job runs three independent replicas. Each checkpoint is a closed-file
+capture of raw 2 KiB page images (hex plus SHA-256 per page) written under
+`artifacts/dao-allocation-a9/r<n>/Q<k>/`. The evaluator verifies every digest,
+decodes only the SRC-0020 / EXP-0051 / EXP-0057 primitives, requires the
+structural answers to agree across replicas, and writes `report.json` with
+`status` of `accepted` or `no_outcome`; an integrity failure exits non-zero
+without a report. The committed `acquisition/a9-allocation.synthetic.json`
+proves only that the evaluator accepts a consistent fabricated artifact and
+rejects a tampered one.
 
 ## Experiment discipline
 

--- a/oracle/windows-dao/acquisition/a9-allocation.plan.json
+++ b/oracle/windows-dao/acquisition/a9-allocation.plan.json
@@ -5,7 +5,7 @@
   "inputs": {
     ".github/workflows/windows-dao-allocation-a9.yml": "78fc369b33f47dd2e70418d3f21ef70b864069a658a78773361e01b460e9b3ac",
     "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1": "70dea1a06fe7bf14271d0bd45cb8ec7c5d2a282b9d89ea1cd85c54017163fea6",
-    "oracle/windows-dao/scripts/dao_allocation_a9.py": "29d7af10edcb0dfa7fae2ba95db11036c1c3f0003fcc9f96f213e93147dbad90",
+    "oracle/windows-dao/scripts/dao_allocation_a9.py": "4ed77d505c74fbc6e584def5fd5c252f3e3f4820947ef8f9221fdc5cab6d8967",
     "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
     "oracle/windows-dao/scripts/remote/Remote.Process.ps1": "8c130cc86060f4e2856a48421789450008fd98668ebe6849af3787d5977dda2d"
   },
@@ -83,7 +83,7 @@
       ],
       "capture": "selected",
       "procedure": "Create A9Lval(Id Long, Payload LongBinary); insert 1800-byte rows in batches of 64 keeping a copy before each batch; capture the copy and the result around the batch in which the number of tag-05 pages first increases, then again around the next increase (at most 32768 rows). The working MDB is deleted afterwards to bound the artifact.",
-      "evaluator_reports": "for every checkpoint the user table-definition page, the owned-map and free-map record kinds (type-0 inline or type-1 indirect), start page or references, exact decoded mapped page sets, mapped page counts, and the tag-05 page list; the owned/free kinds and exact mapped page sets, plus tag-05 counts, must agree across replicas. Transition granularity is one 64-row batch."
+      "evaluator_reports": "for every checkpoint the user table-definition page, the owned-map and free-map record kinds (type-0 inline or type-1 indirect), start page or references, exact decoded mapped page sets, mapped page counts, and the tag-05 page list; each captured global tag-05 increase is classified as a primary owned-map extension or other tag-05 growth, and at least one must monotonically extend the primary owned-map references with a tag-05 page added by that same transition; the owned/free kinds and exact mapped page sets, plus tag-05 counts and transition classifications, must agree across replicas. Transition granularity is one 64-row batch."
     },
     "Q5": {
       "title": "Ownership of index-tree and long-value pages",

--- a/oracle/windows-dao/acquisition/a9-allocation.plan.json
+++ b/oracle/windows-dao/acquisition/a9-allocation.plan.json
@@ -1,0 +1,118 @@
+{
+  "document_type": "dao_allocation_a9_plan",
+  "issue": 99,
+  "purpose": "Acquire the Jet 3 page-allocation facts (empty template, page append, free-page reuse, table-map extension, index/long-value ownership) that the Rust writer needs, from three independent DAO replicas in one hosted job.",
+  "inputs": {
+    ".github/workflows/windows-dao-allocation-a9.yml": "76f89d99e73ccad61c66475efbffcc8fa4a99440e7ddb573294720f2561abf4e",
+    "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1": "f9e2bd22c10e255c2c423026db51eba0ef29164523960e688314c99cbdc531f0",
+    "oracle/windows-dao/scripts/dao_allocation_a9.py": "b0e07412710b1bb96e3886fae7ffb7131bb20ff626104bb262f6df532ef5a58a",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/remote/Remote.Process.ps1": "8c130cc86060f4e2856a48421789450008fd98668ebe6849af3787d5977dda2d"
+  },
+  "execution": {
+    "runner": "windows-2022",
+    "process_architecture": "x86",
+    "replicas": 3,
+    "attempts": 1,
+    "workflow_timeout_minutes": 240,
+    "generator_timeout_minutes": 120,
+    "bounds": {
+      "maximum_rows_per_table": 32768,
+      "maximum_pages_per_database": 40000,
+      "maximum_tag_02_and_05_pages_per_selected_capture": 64,
+      "long_binary_payload_bytes": 1800,
+      "long_binary_batch_rows": 64,
+      "memo_length": 4096
+    },
+    "capture": "Every checkpoint is taken with DAO closed and all COM objects released. 'full' captures retain every page; 'selected' captures (Q4 only) retain pages 0 and 1, every tag-02 and tag-05 page, and the pages named by the EXP-0057 locators at table-definition offsets 35 and 39. Each page image is 2048 bytes as lowercase hex with its SHA-256; each checkpoint file is listed in manifest.raw.json with its SHA-256."
+  },
+  "decoding_basis": {
+    "SRC-0020": "page tag at byte 0; data-page row directory (row count at 8-9, two-byte offsets from 10, 0x1fff mask, 0x40/0x80 flags); type-0 record = tag, 4-byte start page, low-bit-first bitmap; type-1 record = tag followed by 4-byte references to tag-05 pages whose bitmap follows a 4-byte header",
+    "EXP-0051": "global usage record on page 1 at [1915, 2048); a set bit means the page is not in use",
+    "EXP-0057": "owned-map and free-map locators at table-definition offsets 35 and 39 (row byte, three-byte little-endian page); extended absolute page = slot * 16352 + bit",
+    "EXP-0058": "an empty database has 20 pages; system table definitions are pages 2-5; any other tag-02 page is a user table definition",
+    "assumption_under_test": "The evaluator decodes the EXP-0051 record as a SRC-0020 type-0 record (tag 00, 4-byte start page, 128-byte bitmap). If its tag byte is not 00 the affected questions report no_outcome rather than guessing."
+  },
+  "questions": {
+    "Q1": {
+      "title": "Empty-database template",
+      "checkpoints": [
+        "00-empty"
+      ],
+      "capture": "full",
+      "procedure": "CreateDatabase(dbVersion30, ;LANGID=0x0409;CP=1252;COUNTRY=0), close.",
+      "evaluator_reports": "page count per replica, tag of every page, and per-page byte ranges that differ across the three replicas (constant pages are the writer's template)."
+    },
+    "Q2": {
+      "title": "Page append",
+      "checkpoints": [
+        "00-empty",
+        "01-table-created",
+        "02-before-data-page",
+        "03-after-data-page"
+      ],
+      "capture": "full",
+      "procedure": "Create table A9Rows(Id Long, Payload Text 255); then insert 200-character rows one at a time, closing between rows and keeping a copy of the prior file, until the page count first grows (at most 64 rows).",
+      "evaluator_reports": "appended page numbers, the first 16 bytes of each appended page, which global-map pages became in use or free, and which byte ranges of page 0 and page 1 changed, for the table-create and data-page transitions; must be identical across replicas."
+    },
+    "Q3": {
+      "title": "Free-page reuse",
+      "checkpoints": [
+        "00-first-table",
+        "01-second-table",
+        "02-populated",
+        "03-freed",
+        "04-reinsert-1",
+        "04-reinsert-2",
+        "04-reinsert-3",
+        "04-reinsert-4"
+      ],
+      "capture": "full",
+      "procedure": "Create A9Rows and A9Drop (8 rows); insert into A9Rows in batches of 8 until the page count has grown by 6 (at most 512 rows); delete the upper half of Ids and drop A9Drop; reinsert the deleted count in four equal steps with a capture after each.",
+      "evaluator_reports": "pages that became free at 03-freed (global map), the first table's owned and free maps after freeing, and per reinsert step the pages that became in use, which of them were previously freed, and which were appended; verdict reuse / append / mixed / none must agree across replicas."
+    },
+    "Q4": {
+      "title": "Table-map extension",
+      "checkpoints": [
+        "00-created",
+        "01-before-first-type05",
+        "02-after-first-type05",
+        "03-before-second-type05",
+        "04-after-second-type05"
+      ],
+      "capture": "selected",
+      "procedure": "Create A9Lval(Id Long, Payload LongBinary); insert 1800-byte rows in batches of 64 keeping a copy before each batch; capture the copy and the result around the batch in which the number of tag-05 pages first increases, then again around the next increase (at most 32768 rows). The working MDB is deleted afterwards to bound the artifact.",
+      "evaluator_reports": "for every checkpoint the user table-definition page, the owned-map and free-map record kinds (type-0 inline or type-1 indirect), start page or references, mapped page count, and the tag-05 page list; kinds and tag-05 counts must agree across replicas. Transition granularity is one 64-row batch."
+    },
+    "Q5": {
+      "title": "Ownership of index-tree and long-value pages",
+      "checkpoints": [
+        "00-created",
+        "01-populated"
+      ],
+      "capture": "full",
+      "procedure": "Create A9Keyed(Id Long primary key, Note Memo); insert 64 rows whose Memo is 4096 repetitions of 'L' (0x4c) so long-value pages carry a recognisable marker.",
+      "evaluator_reports": "every page that came into use, classified by tag (03 intermediate index, 04 leaf index, 01 with marker = long value, 01 otherwise = data), with membership in the table owned map, table free map, and global in-use set; the per-class all/some/none summary must agree across replicas."
+    }
+  },
+  "decision_rule": {
+    "accept": "The provider is ready, the generator completes all three replicas, every checkpoint and page digest validates, and every question Q1-Q5 is answered with replica-consistent structural results.",
+    "reject": "Any provider, plan-digest, checkpoint-integrity, page-digest, or manifest-shape failure rejects the acquisition (evaluator exit 1).",
+    "no_outcome": "An intact artifact whose generator did not complete, whose maps cannot be decoded under the stated basis, or whose replicas disagree structurally yields status no_outcome for the affected questions; no_outcome is recorded honestly, not retried.",
+    "retry": "A failure after the first DAO mutation is a scientific result and is not retried without a new human decision."
+  },
+  "publication": {
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "artifact_note": "The uploaded artifact contains page images and the small Q1/Q2/Q3/Q5 working MDBs for review; none of it is committed.",
+    "result_record": "One additive EXP entry derived from the validated report JSON.",
+    "support_matrix": "Unchanged; A9 is format discovery for the writer, not a compatibility result."
+  },
+  "synthetic_dry_run": {
+    "compatibility_claim": false,
+    "required_checks": [
+      "consistent_input_accepted",
+      "inconsistent_input_rejected"
+    ]
+  }
+}

--- a/oracle/windows-dao/acquisition/a9-allocation.plan.json
+++ b/oracle/windows-dao/acquisition/a9-allocation.plan.json
@@ -3,9 +3,9 @@
   "issue": 99,
   "purpose": "Acquire the Jet 3 page-allocation facts (empty template, page append, free-page reuse, table-map extension, index/long-value ownership) that the Rust writer needs, from three independent DAO replicas in one hosted job.",
   "inputs": {
-    ".github/workflows/windows-dao-allocation-a9.yml": "76f89d99e73ccad61c66475efbffcc8fa4a99440e7ddb573294720f2561abf4e",
-    "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1": "f9e2bd22c10e255c2c423026db51eba0ef29164523960e688314c99cbdc531f0",
-    "oracle/windows-dao/scripts/dao_allocation_a9.py": "103cbfaedda88de605cdce9573f3be9db8bc9cd78ae7a06e0bd28938645afa50",
+    ".github/workflows/windows-dao-allocation-a9.yml": "78fc369b33f47dd2e70418d3f21ef70b864069a658a78773361e01b460e9b3ac",
+    "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1": "70dea1a06fe7bf14271d0bd45cb8ec7c5d2a282b9d89ea1cd85c54017163fea6",
+    "oracle/windows-dao/scripts/dao_allocation_a9.py": "29d7af10edcb0dfa7fae2ba95db11036c1c3f0003fcc9f96f213e93147dbad90",
     "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
     "oracle/windows-dao/scripts/remote/Remote.Process.ps1": "8c130cc86060f4e2856a48421789450008fd98668ebe6849af3787d5977dda2d"
   },
@@ -16,6 +16,7 @@
     "attempts": 1,
     "workflow_timeout_minutes": 240,
     "generator_timeout_minutes": 120,
+    "generator_timeout_enforcement": "The workflow terminates the complete x86 generator process tree after 120 wall-clock minutes; the generator also checks the same cooperative deadline between DAO operations.",
     "bounds": {
       "maximum_rows_per_table": 32768,
       "maximum_pages_per_database": 40000,
@@ -82,7 +83,7 @@
       ],
       "capture": "selected",
       "procedure": "Create A9Lval(Id Long, Payload LongBinary); insert 1800-byte rows in batches of 64 keeping a copy before each batch; capture the copy and the result around the batch in which the number of tag-05 pages first increases, then again around the next increase (at most 32768 rows). The working MDB is deleted afterwards to bound the artifact.",
-      "evaluator_reports": "for every checkpoint the user table-definition page, the owned-map and free-map record kinds (type-0 inline or type-1 indirect), start page or references, mapped page count, and the tag-05 page list; kinds and tag-05 counts must agree across replicas. Transition granularity is one 64-row batch."
+      "evaluator_reports": "for every checkpoint the user table-definition page, the owned-map and free-map record kinds (type-0 inline or type-1 indirect), start page or references, exact decoded mapped page sets, mapped page counts, and the tag-05 page list; the owned/free kinds and exact mapped page sets, plus tag-05 counts, must agree across replicas. Transition granularity is one 64-row batch."
     },
     "Q5": {
       "title": "Ownership of index-tree and long-value pages",
@@ -96,7 +97,7 @@
     }
   },
   "decision_rule": {
-    "accept": "The provider is ready, the generator completes all three replicas, every checkpoint and page digest validates, and every question Q1-Q5 is answered with replica-consistent structural results.",
+    "accept": "The provider is ready, the generator completes all three replicas on workflow attempt 1, the manifest binds the approved plan and source revision, every checkpoint and page digest validates, and every question Q1-Q5 is answered with replica-consistent structural results.",
     "reject": "Any provider, plan-digest, checkpoint-integrity, page-digest, or manifest-shape failure rejects the acquisition (evaluator exit 1).",
     "no_outcome": "An intact artifact whose generator did not complete, whose maps cannot be decoded under the stated basis, or whose replicas disagree structurally yields status no_outcome for the affected questions; no_outcome is recorded honestly, not retried.",
     "retry": "A failure after the first DAO mutation is a scientific result and is not retried without a new human decision."

--- a/oracle/windows-dao/acquisition/a9-allocation.plan.json
+++ b/oracle/windows-dao/acquisition/a9-allocation.plan.json
@@ -5,7 +5,7 @@
   "inputs": {
     ".github/workflows/windows-dao-allocation-a9.yml": "76f89d99e73ccad61c66475efbffcc8fa4a99440e7ddb573294720f2561abf4e",
     "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1": "f9e2bd22c10e255c2c423026db51eba0ef29164523960e688314c99cbdc531f0",
-    "oracle/windows-dao/scripts/dao_allocation_a9.py": "b0e07412710b1bb96e3886fae7ffb7131bb20ff626104bb262f6df532ef5a58a",
+    "oracle/windows-dao/scripts/dao_allocation_a9.py": "103cbfaedda88de605cdce9573f3be9db8bc9cd78ae7a06e0bd28938645afa50",
     "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
     "oracle/windows-dao/scripts/remote/Remote.Process.ps1": "8c130cc86060f4e2856a48421789450008fd98668ebe6849af3787d5977dda2d"
   },

--- a/oracle/windows-dao/acquisition/a9-allocation.synthetic.json
+++ b/oracle/windows-dao/acquisition/a9-allocation.synthetic.json
@@ -1,0 +1,1 @@
+{"compatibility_claim":false,"consistent_input_accepted":true,"document_type":"dao_allocation_a9_synthetic_dry_run","inconsistent_input_rejected":true,"issue":99,"question_statuses":{"Q1":"answered","Q2":"answered","Q3":"answered","Q4":"answered","Q5":"answered"}}

--- a/oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1
+++ b/oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1
@@ -3,6 +3,7 @@ param(
     [Parameter(Mandatory = $true)][string]$EnvironmentPath,
     [Parameter(Mandatory = $true)][string]$OutputRoot,
     [Parameter(Mandatory = $true)][string]$SourceRevision,
+    [Parameter(Mandatory = $true)][string]$PlanSha256,
     [int]$TimeoutMinutes = 120
 )
 
@@ -231,6 +232,7 @@ function Get-PageTags {
 
 function Get-TaggedPageCount {
     param([string]$Path, [byte]$Tag)
+    [void](Get-PageCount -Path $Path)
     $tags = Get-PageTags -Bytes ([IO.File]::ReadAllBytes([IO.Path]::GetFullPath($Path)))
     return @($tags | Where-Object { $_ -eq $Tag }).Count
 }
@@ -261,8 +263,8 @@ function Get-SelectedPages {
 function Save-Checkpoint {
     param([string]$Path, [int]$Replica, [string]$Question, [string]$Name, [ValidateSet("full", "selected")][string]$Capture)
     Assert-Budget
-    $bytes = [IO.File]::ReadAllBytes([IO.Path]::GetFullPath($Path))
     $pageCount = Get-PageCount -Path $Path
+    $bytes = [IO.File]::ReadAllBytes([IO.Path]::GetFullPath($Path))
     $numbers = if ($Capture -ceq "full") { @(0..($pageCount - 1)) } else { Get-SelectedPages -Bytes $bytes }
     $pages = New-Object Collections.ArrayList
     foreach ($number in $numbers) {
@@ -355,26 +357,31 @@ function Invoke-Replica {
 
     # Q4: long-binary growth until the first and second tag-05 pages appear (EXP-0057).
     $q4 = Join-Path $work "q4.mdb"
-    New-Database -Path $q4
-    New-Table -Path $q4 -Name "A9Lval" -Kind "long_binary"
-    Save-Checkpoint -Path $q4 -Replica $Replica -Question "Q4" -Name "00-created" -Capture "selected"
-    $rows = 0
-    foreach ($ordinal in @("first", "second")) {
-        $observed = Get-TaggedPageCount -Path $q4 -Tag 5
-        $found = $false
-        while ($rows -lt $MaximumRows) {
-            Copy-Item -LiteralPath $q4 -Destination $previous -Force
-            Add-Rows -Path $q4 -Table "A9Lval" -FirstId ($rows + 1) -Count $LongBinaryBatch -Kind "long_binary"
-            $rows += $LongBinaryBatch
-            if ((Get-TaggedPageCount -Path $q4 -Tag 5) -gt $observed) { $found = $true; break }
+    try {
+        New-Database -Path $q4
+        New-Table -Path $q4 -Name "A9Lval" -Kind "long_binary"
+        Save-Checkpoint -Path $q4 -Replica $Replica -Question "Q4" -Name "00-created" -Capture "selected"
+        $rows = 0
+        foreach ($ordinal in @("first", "second")) {
+            $observed = Get-TaggedPageCount -Path $q4 -Tag 5
+            $found = $false
+            while ($rows -lt $MaximumRows) {
+                Copy-Item -LiteralPath $q4 -Destination $previous -Force
+                Add-Rows -Path $q4 -Table "A9Lval" -FirstId ($rows + 1) -Count $LongBinaryBatch -Kind "long_binary"
+                $rows += $LongBinaryBatch
+                if ((Get-TaggedPageCount -Path $q4 -Tag 5) -gt $observed) { $found = $true; break }
+            }
+            if (-not $found) { throw "Q4: the $ordinal type-05 page did not appear within $MaximumRows rows." }
+            $prefix = if ($ordinal -ceq "first") { "01" } else { "03" }
+            $suffix = if ($ordinal -ceq "first") { "02" } else { "04" }
+            Save-Checkpoint -Path $previous -Replica $Replica -Question "Q4" -Name "$prefix-before-$ordinal-type05" -Capture "selected"
+            Save-Checkpoint -Path $q4 -Replica $Replica -Question "Q4" -Name "$suffix-after-$ordinal-type05" -Capture "selected"
         }
-        if (-not $found) { throw "Q4: the $ordinal type-05 page did not appear within $MaximumRows rows." }
-        $prefix = if ($ordinal -ceq "first") { "01" } else { "03" }
-        $suffix = if ($ordinal -ceq "first") { "02" } else { "04" }
-        Save-Checkpoint -Path $previous -Replica $Replica -Question "Q4" -Name "$prefix-before-$ordinal-type05" -Capture "selected"
-        Save-Checkpoint -Path $q4 -Replica $Replica -Question "Q4" -Name "$suffix-after-$ordinal-type05" -Capture "selected"
     }
-    Remove-Item -LiteralPath $q4 -Force
+    finally {
+        Remove-Item -LiteralPath $q4 -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $previous -Force -ErrorAction SilentlyContinue
+    }
 
     # Q5: primary key plus memo; index-tree and long-value page ownership.
     $q5 = Join-Path $work "q5.mdb"
@@ -383,10 +390,11 @@ function Invoke-Replica {
     Save-Checkpoint -Path $q5 -Replica $Replica -Question "Q5" -Name "00-created" -Capture "full"
     Add-Rows -Path $q5 -Table "A9Keyed" -FirstId 1 -Count 64 -Kind "keyed_memo"
     Save-Checkpoint -Path $q5 -Replica $Replica -Question "Q5" -Name "01-populated" -Capture "full"
-    Remove-Item -LiteralPath $previous -Force -ErrorAction SilentlyContinue
 }
 
 if ([IntPtr]::Size -ne 4) { throw "The A9 generator must run in an x86 process." }
+if ($SourceRevision -cnotmatch "^[0-9a-f]{40}$") { throw "The source revision is invalid." }
+if ($PlanSha256 -cnotmatch "^[0-9a-f]{64}$") { throw "The acquisition plan digest is invalid." }
 $environment = Get-Content -LiteralPath $EnvironmentPath -Raw | ConvertFrom-Json
 if ([string]$environment.status -cne "ready" -or $null -eq $environment.accepted_provider) {
     throw "The provider environment is not ready."
@@ -414,6 +422,7 @@ finally {
         document_type = "dao_allocation_a9_manifest"
         issue = 99
         source_revision = $SourceRevision
+        plan_sha256 = $PlanSha256
         status = $status
         detail = $detail
         provider = [ordered]@{

--- a/oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1
+++ b/oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1
@@ -1,0 +1,430 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$EnvironmentPath,
+    [Parameter(Mandatory = $true)][string]$OutputRoot,
+    [Parameter(Mandatory = $true)][string]$SourceRevision,
+    [int]$TimeoutMinutes = 120
+)
+
+# A9 (issue #99) page-allocation generator. It drives DAO through the creation,
+# growth, deletion, and reinsertion sequences preregistered in
+# acquisition/a9-allocation.plan.json and retains raw 2 KiB page images at each
+# closed-file checkpoint. Page selection uses only byte zero (SRC-0020) and the
+# EXP-0057 table-map locators; nothing here interprets allocation semantics.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# DAO API constants (SRC-0002, SRC-0009, SRC-0014); adapter inputs only.
+$DbVersion30 = 32
+$DbLong = 4
+$DbText = 10
+$DbLongBinary = 11
+$DbMemo = 12
+$DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
+$PageSize = 2048
+$Replicas = 3
+$MaximumRows = 32768
+$MaximumPages = 40000
+$MaximumTaggedPages = 64
+$LongBinaryBytes = 1800
+$LongBinaryBatch = 64
+$MemoLength = 4096
+$MemoMarkerByte = 0x4c
+$Deadline = [DateTime]::UtcNow.AddMinutes($TimeoutMinutes)
+$Utf8 = New-Object Text.UTF8Encoding($false)
+$Checkpoints = New-Object Collections.ArrayList
+$Provider = $null
+
+function Assert-Budget {
+    if ([DateTime]::UtcNow -gt $Deadline) { throw "The A9 generator exceeded its time budget." }
+}
+
+function Release-ComObject {
+    param([object]$Value)
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+
+function Write-JsonDocument {
+    param([string]$Path, [object]$Document)
+    [IO.File]::WriteAllText(
+        [IO.Path]::GetFullPath($Path),
+        (($Document | ConvertTo-Json -Depth 8 -Compress) + "`n"),
+        $Utf8
+    )
+}
+
+function Get-FileSha256 {
+    param([string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Convert-ToLowerHex {
+    param([byte[]]$Bytes)
+    return ([BitConverter]::ToString($Bytes)).Replace("-", "").ToLowerInvariant()
+}
+
+function New-Engine {
+    $type = [Type]::GetTypeFromProgID([string]$Provider.prog_id, $false)
+    if ($null -eq $type) { throw "Accepted DAO provider is unavailable." }
+    $engine = [Activator]::CreateInstance($type)
+    if ([string]$engine.Version -cne [string]$Provider.provider_version) {
+        throw "The active DAO version differs from the probed provider."
+    }
+    return $engine
+}
+
+function Invoke-WithDatabase {
+    param([string]$Path, [switch]$Create, [scriptblock]$Action)
+    $engine = $null
+    $workspace = $null
+    $database = $null
+    try {
+        $engine = New-Engine
+        $workspace = $engine.Workspaces.Item(0)
+        if ($Create) {
+            $database = $workspace.CreateDatabase($Path, $DatabaseLocale, $DbVersion30)
+        }
+        else {
+            $database = $engine.OpenDatabase($Path)
+        }
+        if ($null -ne $Action) { & $Action $database }
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $workspace
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+    Assert-Budget
+}
+
+function New-Database {
+    param([string]$Path)
+    Invoke-WithDatabase -Path $Path -Create -Action $null
+}
+
+function New-Table {
+    param([string]$Path, [string]$Name, [ValidateSet("text", "long_binary", "keyed_memo")][string]$Kind)
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $table = $null
+        $id = $null
+        $payload = $null
+        $index = $null
+        $indexField = $null
+        try {
+            $table = $database.CreateTableDef($Name)
+            $id = $table.CreateField("Id", $DbLong)
+            $table.Fields.Append($id)
+            switch ($Kind) {
+                "text" { $payload = $table.CreateField("Payload", $DbText, 255) }
+                "long_binary" { $payload = $table.CreateField("Payload", $DbLongBinary) }
+                "keyed_memo" { $payload = $table.CreateField("Note", $DbMemo) }
+            }
+            $table.Fields.Append($payload)
+            if ($Kind -ceq "keyed_memo") {
+                $index = $table.CreateIndex("PrimaryKey")
+                $index.Primary = $true
+                $index.Unique = $true
+                $indexField = $index.CreateField("Id")
+                $index.Fields.Append($indexField)
+                $table.Indexes.Append($index)
+            }
+            $database.TableDefs.Append($table)
+        }
+        finally {
+            Release-ComObject -Value $indexField
+            Release-ComObject -Value $index
+            Release-ComObject -Value $payload
+            Release-ComObject -Value $id
+            Release-ComObject -Value $table
+        }
+    }
+}
+
+function Add-Rows {
+    param([string]$Path, [string]$Table, [int]$FirstId, [int]$Count, [string]$Kind)
+    if ($FirstId + $Count - 1 -gt $MaximumRows) { throw "The A9 row ceiling would be exceeded." }
+    $longBinary = New-Object byte[] $LongBinaryBytes
+    for ($index = 0; $index -lt $longBinary.Length; $index++) {
+        $longBinary[$index] = [byte](($index * 29 + 17) % 251)
+    }
+    $memo = [string]::new([char]$MemoMarkerByte, $MemoLength)
+    $text = [string]::new([char]0x78, 200)
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $recordset = $null
+        $id = $null
+        $payload = $null
+        try {
+            $recordset = $database.OpenRecordset($Table, 2, 0)
+            $id = $recordset.Fields.Item(0)
+            $payload = $recordset.Fields.Item(1)
+            for ($offset = 0; $offset -lt $Count; $offset++) {
+                $recordset.AddNew()
+                $id.Value = [int]($FirstId + $offset)
+                switch ($Kind) {
+                    "text" { $payload.Value = $text }
+                    "long_binary" { $payload.AppendChunk($longBinary) }
+                    "keyed_memo" { $payload.AppendChunk($memo) }
+                }
+                $recordset.Update()
+            }
+        }
+        finally {
+            Release-ComObject -Value $payload
+            Release-ComObject -Value $id
+            if ($null -ne $recordset) { try { $recordset.Close() } catch { } }
+            Release-ComObject -Value $recordset
+        }
+    }
+}
+
+function Remove-RowsFrom {
+    param([string]$Path, [string]$Table, [int]$FirstId)
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $recordset = $null
+        try {
+            $recordset = $database.OpenRecordset(
+                "SELECT Id FROM [$Table] WHERE Id >= $FirstId ORDER BY Id", 2, 0)
+            while (-not $recordset.EOF) {
+                $recordset.Delete()
+                $recordset.MoveNext()
+            }
+        }
+        finally {
+            if ($null -ne $recordset) { try { $recordset.Close() } catch { } }
+            Release-ComObject -Value $recordset
+        }
+    }
+}
+
+function Remove-Table {
+    param([string]$Path, [string]$Table)
+    Invoke-WithDatabase -Path $Path -Action { param($database) $database.TableDefs.Delete($Table) }
+}
+
+function Get-PageCount {
+    param([string]$Path)
+    $length = (Get-Item -LiteralPath $Path).Length
+    if (($length % $PageSize) -ne 0) { throw "The database is not an exact sequence of 2 KiB pages." }
+    $count = [int]($length / $PageSize)
+    if ($count -gt $MaximumPages) { throw "The database exceeded the A9 page ceiling." }
+    return $count
+}
+
+function Get-PageTags {
+    param([byte[]]$Bytes)
+    $tags = New-Object byte[] ([int]($Bytes.Length / $PageSize))
+    for ($page = 0; $page -lt $tags.Length; $page++) { $tags[$page] = $Bytes[$page * $PageSize] }
+    return ,$tags
+}
+
+function Get-TaggedPageCount {
+    param([string]$Path, [byte]$Tag)
+    $tags = Get-PageTags -Bytes ([IO.File]::ReadAllBytes([IO.Path]::GetFullPath($Path)))
+    return @($tags | Where-Object { $_ -eq $Tag }).Count
+}
+
+function Get-SelectedPages {
+    # Pages 0 and 1, every tag-02 and tag-05 page, and the pages named by the
+    # EXP-0057 locators at tabledef offsets 35 and 39 (three-byte page numbers).
+    param([byte[]]$Bytes)
+    $tags = Get-PageTags -Bytes $Bytes
+    $selected = New-Object Collections.Generic.SortedSet[int]
+    [void]$selected.Add(0)
+    [void]$selected.Add(1)
+    $tagged = 0
+    for ($page = 2; $page -lt $tags.Length; $page++) {
+        if ($tags[$page] -ne 2 -and $tags[$page] -ne 5) { continue }
+        if (++$tagged -gt $MaximumTaggedPages) { throw "Too many tag-02/05 pages to capture." }
+        [void]$selected.Add($page)
+        if ($tags[$page] -ne 2) { continue }
+        foreach ($offset in @(36, 40)) {
+            $base = $page * $PageSize + $offset
+            $reference = [int]$Bytes[$base] -bor ([int]$Bytes[$base + 1] -shl 8) -bor ([int]$Bytes[$base + 2] -shl 16)
+            if ($reference -gt 1 -and $reference -lt $tags.Length) { [void]$selected.Add($reference) }
+        }
+    }
+    return @($selected)
+}
+
+function Save-Checkpoint {
+    param([string]$Path, [int]$Replica, [string]$Question, [string]$Name, [ValidateSet("full", "selected")][string]$Capture)
+    Assert-Budget
+    $bytes = [IO.File]::ReadAllBytes([IO.Path]::GetFullPath($Path))
+    $pageCount = Get-PageCount -Path $Path
+    $numbers = if ($Capture -ceq "full") { @(0..($pageCount - 1)) } else { Get-SelectedPages -Bytes $bytes }
+    $pages = New-Object Collections.ArrayList
+    foreach ($number in $numbers) {
+        $image = New-Object byte[] $PageSize
+        [Array]::Copy($bytes, $number * $PageSize, $image, 0, $PageSize)
+        $digest = [Security.Cryptography.SHA256]::Create().ComputeHash($image)
+        [void]$pages.Add([ordered]@{
+            page = [int]$number
+            sha256 = Convert-ToLowerHex $digest
+            hex = Convert-ToLowerHex $image
+        })
+    }
+    $relative = "r$Replica/$Question/$Name.json"
+    $target = Join-Path $OutputRoot $relative
+    [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($target)) | Out-Null
+    Write-JsonDocument -Path $target -Document ([ordered]@{
+        document_type = "dao_allocation_a9_checkpoint"
+        replica = $Replica
+        question = $Question
+        name = $Name
+        capture = $Capture
+        page_count = $pageCount
+        pages = @($pages)
+    })
+    [void]$Checkpoints.Add([ordered]@{
+        replica = $Replica
+        question = $Question
+        name = $Name
+        capture = $Capture
+        page_count = $pageCount
+        path = $relative
+        sha256 = Get-FileSha256 -Path $target
+    })
+    Write-Host "checkpoint $relative ($pageCount pages)"
+}
+
+function Invoke-Replica {
+    param([int]$Replica)
+    $work = Join-Path $OutputRoot "work\r$Replica"
+    [IO.Directory]::CreateDirectory($work) | Out-Null
+    $previous = Join-Path $work "previous.mdb"
+
+    # Q1: fresh empty database (EXP-0058 expects 20 pages).
+    $q1 = Join-Path $work "q1.mdb"
+    New-Database -Path $q1
+    Save-Checkpoint -Path $q1 -Replica $Replica -Question "Q1" -Name "00-empty" -Capture "full"
+
+    # Q2: first table-definition append, then the first data-page append.
+    $q2 = Join-Path $work "q2.mdb"
+    New-Database -Path $q2
+    Save-Checkpoint -Path $q2 -Replica $Replica -Question "Q2" -Name "00-empty" -Capture "full"
+    New-Table -Path $q2 -Name "A9Rows" -Kind "text"
+    Save-Checkpoint -Path $q2 -Replica $Replica -Question "Q2" -Name "01-table-created" -Capture "full"
+    $baseline = Get-PageCount -Path $q2
+    $grew = $false
+    for ($row = 1; $row -le 64; $row++) {
+        Copy-Item -LiteralPath $q2 -Destination $previous -Force
+        Add-Rows -Path $q2 -Table "A9Rows" -FirstId $row -Count 1 -Kind "text"
+        if ((Get-PageCount -Path $q2) -gt $baseline) { $grew = $true; break }
+    }
+    if (-not $grew) { throw "Q2: no data page was appended within 64 rows." }
+    Save-Checkpoint -Path $previous -Replica $Replica -Question "Q2" -Name "02-before-data-page" -Capture "full"
+    Save-Checkpoint -Path $q2 -Replica $Replica -Question "Q2" -Name "03-after-data-page" -Capture "full"
+
+    # Q3: populate several data pages, free the tail and a second table, reinsert.
+    $q3 = Join-Path $work "q3.mdb"
+    New-Database -Path $q3
+    New-Table -Path $q3 -Name "A9Rows" -Kind "text"
+    Save-Checkpoint -Path $q3 -Replica $Replica -Question "Q3" -Name "00-first-table" -Capture "full"
+    New-Table -Path $q3 -Name "A9Drop" -Kind "text"
+    Add-Rows -Path $q3 -Table "A9Drop" -FirstId 1 -Count 8 -Kind "text"
+    Save-Checkpoint -Path $q3 -Replica $Replica -Question "Q3" -Name "01-second-table" -Capture "full"
+    $baseline = Get-PageCount -Path $q3
+    $rows = 0
+    while ((Get-PageCount -Path $q3) -lt $baseline + 6) {
+        if ($rows -ge 512) { throw "Q3: six data pages were not reached within 512 rows." }
+        Add-Rows -Path $q3 -Table "A9Rows" -FirstId ($rows + 1) -Count 8 -Kind "text"
+        $rows += 8
+    }
+    Save-Checkpoint -Path $q3 -Replica $Replica -Question "Q3" -Name "02-populated" -Capture "full"
+    $keep = [int]($rows / 2)
+    Remove-RowsFrom -Path $q3 -Table "A9Rows" -FirstId ($keep + 1)
+    Remove-Table -Path $q3 -Table "A9Drop"
+    Save-Checkpoint -Path $q3 -Replica $Replica -Question "Q3" -Name "03-freed" -Capture "full"
+    $step = [int](($rows - $keep) / 4)
+    for ($ordinal = 1; $ordinal -le 4; $ordinal++) {
+        Add-Rows -Path $q3 -Table "A9Rows" -FirstId ($keep + 1 + ($ordinal - 1) * $step) -Count $step -Kind "text"
+        Save-Checkpoint -Path $q3 -Replica $Replica -Question "Q3" -Name "04-reinsert-$ordinal" -Capture "full"
+    }
+
+    # Q4: long-binary growth until the first and second tag-05 pages appear (EXP-0057).
+    $q4 = Join-Path $work "q4.mdb"
+    New-Database -Path $q4
+    New-Table -Path $q4 -Name "A9Lval" -Kind "long_binary"
+    Save-Checkpoint -Path $q4 -Replica $Replica -Question "Q4" -Name "00-created" -Capture "selected"
+    $rows = 0
+    foreach ($ordinal in @("first", "second")) {
+        $observed = Get-TaggedPageCount -Path $q4 -Tag 5
+        $found = $false
+        while ($rows -lt $MaximumRows) {
+            Copy-Item -LiteralPath $q4 -Destination $previous -Force
+            Add-Rows -Path $q4 -Table "A9Lval" -FirstId ($rows + 1) -Count $LongBinaryBatch -Kind "long_binary"
+            $rows += $LongBinaryBatch
+            if ((Get-TaggedPageCount -Path $q4 -Tag 5) -gt $observed) { $found = $true; break }
+        }
+        if (-not $found) { throw "Q4: the $ordinal type-05 page did not appear within $MaximumRows rows." }
+        $prefix = if ($ordinal -ceq "first") { "01" } else { "03" }
+        $suffix = if ($ordinal -ceq "first") { "02" } else { "04" }
+        Save-Checkpoint -Path $previous -Replica $Replica -Question "Q4" -Name "$prefix-before-$ordinal-type05" -Capture "selected"
+        Save-Checkpoint -Path $q4 -Replica $Replica -Question "Q4" -Name "$suffix-after-$ordinal-type05" -Capture "selected"
+    }
+    Remove-Item -LiteralPath $q4 -Force
+
+    # Q5: primary key plus memo; index-tree and long-value page ownership.
+    $q5 = Join-Path $work "q5.mdb"
+    New-Database -Path $q5
+    New-Table -Path $q5 -Name "A9Keyed" -Kind "keyed_memo"
+    Save-Checkpoint -Path $q5 -Replica $Replica -Question "Q5" -Name "00-created" -Capture "full"
+    Add-Rows -Path $q5 -Table "A9Keyed" -FirstId 1 -Count 64 -Kind "keyed_memo"
+    Save-Checkpoint -Path $q5 -Replica $Replica -Question "Q5" -Name "01-populated" -Capture "full"
+    Remove-Item -LiteralPath $previous -Force -ErrorAction SilentlyContinue
+}
+
+if ([IntPtr]::Size -ne 4) { throw "The A9 generator must run in an x86 process." }
+$environment = Get-Content -LiteralPath $EnvironmentPath -Raw | ConvertFrom-Json
+if ([string]$environment.status -cne "ready" -or $null -eq $environment.accepted_provider) {
+    throw "The provider environment is not ready."
+}
+$Provider = $environment.accepted_provider
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw "The A9 output root already exists." }
+[IO.Directory]::CreateDirectory($OutputRoot) | Out-Null
+
+$status = "failed"
+$detail = ""
+$exitCode = 1
+try {
+    for ($replica = 1; $replica -le $Replicas; $replica++) { Invoke-Replica -Replica $replica }
+    $status = "complete"
+    $detail = "All replicas completed."
+    $exitCode = 0
+}
+catch {
+    $detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+    [Console]::Error.WriteLine("FAIL: " + $detail)
+}
+finally {
+    Write-JsonDocument -Path (Join-Path $OutputRoot "manifest.raw.json") -Document ([ordered]@{
+        document_type = "dao_allocation_a9_manifest"
+        issue = 99
+        source_revision = $SourceRevision
+        status = $status
+        detail = $detail
+        provider = [ordered]@{
+            prog_id = [string]$Provider.prog_id
+            provider_version = [string]$Provider.provider_version
+            server_file_version = [string]$Provider.server_file_version
+            server_sha256 = [string]$Provider.server_sha256
+        }
+        replica_count = $Replicas
+        memo_marker_hex = ("{0:x2}" -f $MemoMarkerByte) * 64
+        checkpoints = @($Checkpoints)
+    })
+}
+exit $exitCode

--- a/oracle/windows-dao/scripts/dao_allocation_a9.py
+++ b/oracle/windows-dao/scripts/dao_allocation_a9.py
@@ -187,14 +187,12 @@ def usage_record(record: bytes, pages: dict[int, bytes]) -> dict[str, Any]:
             for slot in range((len(record) - 1) // 4)
         ]
         mapped: set[int] = set()
-        missing: list[int] = []
         for slot, ref in enumerate(refs):
             if ref == 0:
                 continue
             image = pages.get(ref)
             if image is None:
-                missing.append(ref)
-                continue
+                raise NoOutcome(f"type-1 reference {ref} was not captured")
             if image[0] != 0x05:
                 raise NoOutcome(f"type-1 reference {ref} is not a type-05 page")
             mapped |= bitmap_pages(image[4:], slot * TYPE05_BITS)
@@ -202,7 +200,6 @@ def usage_record(record: bytes, pages: dict[int, bytes]) -> dict[str, Any]:
             "kind": "type1_indirect",
             "slot_count": len(refs),
             "references": [ref for ref in refs if ref],
-            "uncaptured_references": missing,
             "pages": sorted(mapped),
         }
     raise NoOutcome(f"unknown usage record tag 0x{record[0]:02x}")
@@ -416,6 +413,32 @@ class Evaluation:
                     "owned_page_count": len(maps["owned"]["pages"]),
                     "free": {key: value for key, value in maps["free"].items() if key != "pages"},
                 }
+            for ordinal, (before_name, after_name) in enumerate(
+                (
+                    ("01-before-first-type05", "02-after-first-type05"),
+                    ("03-before-second-type05", "04-after-second-type05"),
+                ),
+                start=1,
+            ):
+                before, after = states[before_name], states[after_name]
+                before_refs = (
+                    len(before["owned"]["references"])
+                    if before["owned"]["kind"] == "type1_indirect"
+                    else 0
+                )
+                after_refs = (
+                    len(after["owned"]["references"])
+                    if after["owned"]["kind"] == "type1_indirect"
+                    else 0
+                )
+                if after_refs <= before_refs:
+                    raise NoOutcome(
+                        f"r{replica}/Q4: transition {ordinal} did not extend the owned-map references"
+                    )
+                if len(after["type05_pages"]) <= len(before["type05_pages"]):
+                    raise NoOutcome(
+                        f"r{replica}/Q4: transition {ordinal} did not add a captured type-05 page"
+                    )
             per_replica.append(states)
         shape = require_same(
             [

--- a/oracle/windows-dao/scripts/dao_allocation_a9.py
+++ b/oracle/windows-dao/scripts/dao_allocation_a9.py
@@ -14,6 +14,7 @@ import argparse
 import copy
 import hashlib
 import json
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -34,9 +35,34 @@ TYPE05_BITS = 16352
 # EXP-0058: an empty database has 20 pages and system table definitions at 2-5.
 EMPTY_PAGE_COUNT = 20
 SYSTEM_TDEF_PAGES = frozenset((2, 3, 4, 5))
-MAX_PAGES = 65536
+MAX_PAGES = 40000
 MAX_CHECKPOINT_BYTES = 64 * 1024 * 1024
 QUESTIONS = ("Q1", "Q2", "Q3", "Q4", "Q5")
+MEMO_MARKER = b"L" * 64
+EXPECTED_CHECKPOINTS = {
+    "Q1": {"00-empty": "full"},
+    "Q2": {
+        "00-empty": "full",
+        "01-table-created": "full",
+        "02-before-data-page": "full",
+        "03-after-data-page": "full",
+    },
+    "Q3": {
+        "00-first-table": "full",
+        "01-second-table": "full",
+        "02-populated": "full",
+        "03-freed": "full",
+        **{f"04-reinsert-{step}": "full" for step in range(1, 5)},
+    },
+    "Q4": {
+        "00-created": "selected",
+        "01-before-first-type05": "selected",
+        "02-after-first-type05": "selected",
+        "03-before-second-type05": "selected",
+        "04-after-second-type05": "selected",
+    },
+    "Q5": {"00-created": "full", "01-populated": "full"},
+}
 
 
 class EvaluationError(Exception):
@@ -81,9 +107,13 @@ class Checkpoint:
         for item in document["pages"]:
             number = int(item["page"])
             image = bytes.fromhex(item["hex"])
-            if len(image) != PAGE_SIZE or number in self.pages or number >= self.page_count:
+            if (
+                len(image) != PAGE_SIZE
+                or number in self.pages
+                or not 0 <= number < self.page_count
+            ):
                 raise EvaluationError(f"{self.label}: malformed page image {number}")
-            if sha256(image) != item["sha256"]:
+            if not valid_digest(item.get("sha256")) or sha256(image) != item["sha256"]:
                 raise EvaluationError(f"{self.label}: page {number} digest differs")
             self.pages[number] = image
         if self.capture == "full" and sorted(self.pages) != list(range(self.page_count)):
@@ -112,7 +142,7 @@ def load_checkpoints(manifest: dict[str, Any], root: Path) -> dict[tuple[int, st
         raw = (root / relative).read_bytes()
         if len(raw) > MAX_CHECKPOINT_BYTES:
             raise EvaluationError(f"{entry['path']}: checkpoint exceeds the size bound")
-        if sha256(raw) != entry["sha256"]:
+        if not valid_digest(entry.get("sha256")) or sha256(raw) != entry["sha256"]:
             raise EvaluationError(f"{entry['path']}: checkpoint digest differs")
         document = json.loads(raw.decode("utf-8"))
         if document.get("document_type") != "dao_allocation_a9_checkpoint":
@@ -128,6 +158,10 @@ def load_checkpoints(manifest: dict[str, Any], root: Path) -> dict[tuple[int, st
             raise EvaluationError(f"{checkpoint.label}: duplicate checkpoint")
         result[key] = checkpoint
     return result
+
+
+def valid_digest(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
 
 
 # --- page primitives (SRC-0020, EXP-0051, EXP-0057) --------------------------
@@ -223,6 +257,23 @@ def table_maps(checkpoint: Checkpoint, tdef_page: int) -> dict[str, Any]:
         decoded = usage_record(record, checkpoint.pages)
         decoded["locator"] = {"row": row, "page": page}
         result[name] = decoded
+    for name in ("owned", "free"):
+        outside = [
+            page
+            for page in result[name]["pages"]
+            if not 0 <= page < checkpoint.page_count
+        ]
+        if outside:
+            raise NoOutcome(
+                f"{checkpoint.label}: {name} map contains pages outside the checkpoint: {outside}"
+            )
+    owned = set(result["owned"]["pages"])
+    free = set(result["free"]["pages"])
+    if not free <= owned:
+        raise NoOutcome(
+            f"{checkpoint.label}: free map contains pages not present in the owned map: "
+            f"{sorted(free - owned)}"
+        )
     return result
 
 
@@ -291,7 +342,7 @@ class Evaluation:
     def __init__(self, manifest: dict[str, Any], root: Path) -> None:
         self.manifest = manifest
         self.checkpoints = load_checkpoints(manifest, root)
-        self.marker = bytes.fromhex(str(manifest["memo_marker_hex"]))
+        self.marker = MEMO_MARKER
 
     def get(self, replica: int, question: str, name: str) -> Checkpoint:
         try:
@@ -309,6 +360,14 @@ class Evaluation:
         }
         return {
             "page_count": page_count,
+            "replicas": [
+                {
+                    "replica": item.replica,
+                    "page_count": item.page_count,
+                    "page_tags": [item.tag(page) for page in range(item.page_count)],
+                }
+                for item in replicas
+            ],
             "matches_exp_0058_page_count": page_count == EMPTY_PAGE_COUNT,
             "page_tags": [replicas[0].tag(page) for page in range(page_count)],
             "varying_byte_ranges": varying,
@@ -317,6 +376,8 @@ class Evaluation:
 
     def q2_append(self) -> dict[str, Any]:
         def transition(before: Checkpoint, after: Checkpoint) -> dict[str, Any]:
+            if after.page_count <= before.page_count:
+                raise NoOutcome(f"{before.label} to {after.label}: page count did not grow")
             appended = list(range(before.page_count, after.page_count))
             return {
                 "appended_pages": appended,
@@ -410,8 +471,11 @@ class Evaluation:
                     "tdef_page": tdefs[0],
                     "type05_pages": checkpoint.tagged(0x05),
                     "owned": {key: value for key, value in maps["owned"].items() if key != "pages"},
+                    "owned_pages": maps["owned"]["pages"],
                     "owned_page_count": len(maps["owned"]["pages"]),
                     "free": {key: value for key, value in maps["free"].items() if key != "pages"},
+                    "free_pages": maps["free"]["pages"],
+                    "free_page_count": len(maps["free"]["pages"]),
                 }
             for ordinal, (before_name, after_name) in enumerate(
                 (
@@ -442,12 +506,21 @@ class Evaluation:
             per_replica.append(states)
         shape = require_same(
             [
-                {name: (state["owned"]["kind"], len(state["type05_pages"])) for name, state in states.items()}
+                {
+                    name: {
+                        "owned_kind": state["owned"]["kind"],
+                        "owned_pages": state["owned_pages"],
+                        "free_kind": state["free"]["kind"],
+                        "free_pages": state["free_pages"],
+                        "type05_page_count": len(state["type05_pages"]),
+                    }
+                    for name, state in states.items()
+                }
                 for states in per_replica
             ],
-            "Q4 map kinds",
+            "Q4 map contents",
         )
-        return {"map_kind_and_type05_count": shape, "replicas": per_replica}
+        return {"map_shape": shape, "replicas": per_replica}
 
     def q5_ownership(self) -> dict[str, Any]:
         per_replica = []
@@ -460,10 +533,9 @@ class Evaluation:
             maps = table_maps(populated, tdefs[0])
             owned, free = set(maps["owned"]["pages"]), set(maps["free"]["pages"])
             in_use = global_map(populated)["in_use"]
-            new_pages = sorted(
-                (in_use - global_map(created)["in_use"])
-                | set(range(created.page_count, populated.page_count))
-            )
+            new_pages = sorted(in_use - global_map(created)["in_use"])
+            if not new_pages:
+                raise NoOutcome(f"r{replica}/Q5: population did not bring any page into use")
             pages = [
                 {
                     "page": page,
@@ -486,17 +558,74 @@ class Evaluation:
         return {"summary": summary, "replicas": per_replica}
 
 
-def evaluate(manifest_path: Path, root: Path, output: Path) -> dict[str, Any]:
+def evaluate(
+    manifest_path: Path,
+    root: Path,
+    output: Path,
+    *,
+    expected_source_revision: str | None = None,
+    expected_plan_sha256: str | None = None,
+) -> dict[str, Any]:
     manifest = load_json(manifest_path)
     if manifest.get("document_type") != "dao_allocation_a9_manifest" or manifest.get("issue") != ISSUE:
         raise EvaluationError("manifest has the wrong document type or issue")
     if manifest.get("replica_count") != REPLICAS:
         raise EvaluationError("manifest does not declare three replicas")
+    if manifest.get("status") not in ("complete", "failed"):
+        raise EvaluationError("manifest has an invalid generator status")
+    source_revision = manifest.get("source_revision")
+    if source_revision != "synthetic" and (
+        not isinstance(source_revision, str)
+        or re.fullmatch(r"[0-9a-f]{40}", source_revision) is None
+    ):
+        raise EvaluationError("manifest has an invalid source revision")
+    if expected_source_revision is not None and source_revision != expected_source_revision:
+        raise EvaluationError("manifest source revision differs from the workflow revision")
+    plan_sha256 = manifest.get("plan_sha256")
+    if not valid_digest(plan_sha256):
+        raise EvaluationError("manifest has an invalid acquisition plan digest")
+    if expected_plan_sha256 is not None and plan_sha256 != expected_plan_sha256:
+        raise EvaluationError("manifest plan digest differs from the approved plan")
+    provider = manifest.get("provider")
+    if source_revision != "synthetic" and (
+        not isinstance(provider, dict)
+        or not all(
+            isinstance(provider.get(field), str) and provider[field]
+            for field in ("prog_id", "provider_version", "server_file_version")
+        )
+        or not valid_digest(provider.get("server_sha256"))
+    ):
+        raise EvaluationError("manifest has invalid provider identity")
+    if manifest.get("memo_marker_hex") != MEMO_MARKER.hex():
+        raise EvaluationError("manifest memo marker differs from the preregistered marker")
+    checkpoints = manifest.get("checkpoints")
+    if not isinstance(checkpoints, list):
+        raise EvaluationError("manifest checkpoints must be an array")
+    actual = {
+        (entry.get("replica"), entry.get("question"), entry.get("name")): entry.get("capture")
+        for entry in checkpoints
+        if isinstance(entry, dict)
+    }
+    if len(actual) != len(checkpoints):
+        raise EvaluationError("manifest has duplicate or malformed checkpoint entries")
+    expected = {
+        (replica, question, name): capture
+        for replica in range(1, REPLICAS + 1)
+        for question, names in EXPECTED_CHECKPOINTS.items()
+        for name, capture in names.items()
+    }
+    if set(actual) - set(expected):
+        raise EvaluationError("manifest declares an unexpected checkpoint")
+    if any(actual[key] != expected[key] for key in actual):
+        raise EvaluationError("manifest declares an unexpected capture mode")
+    if manifest.get("status") == "complete" and actual != expected:
+        raise EvaluationError("complete manifest does not contain every preregistered checkpoint")
     report: dict[str, Any] = {
         "document_type": "dao_allocation_a9_report",
         "issue": ISSUE,
         "compatibility_claim": False,
         "source_revision": manifest.get("source_revision"),
+        "plan_sha256": manifest.get("plan_sha256"),
         "provider": manifest.get("provider"),
         "generator_status": manifest.get("status"),
         "checkpoint_count": len(manifest.get("checkpoints", [])),
@@ -679,11 +808,12 @@ def synthetic_checkpoints(replica: int) -> list[tuple[str, str, str, SyntheticDa
         db.page_count = page_count
         db.set_tdef(20, 21)
         if refs is None:
-            db.set_map_page(21, db.type0(20, {21, 22}), db.type0(20, {22}))
+            db.set_map_page(21, db.type0(20, {20, 21}), db.type0(20, set()))
         else:
-            db.set_map_page(21, db.type1(refs + [0] * (4 - len(refs))), db.type0(20, {22}))
+            db.set_map_page(21, db.type1(refs + [0] * (4 - len(refs))), db.type0(20, set()))
             for slot, ref in enumerate(refs):
-                db.set_type05(ref, slot, {slot * TYPE05_BITS + 21})
+                owned = 21 if slot == 0 else slot * TYPE05_BITS
+                db.set_type05(ref, slot, {owned})
         return db
 
     result += [
@@ -746,6 +876,7 @@ def write_synthetic_artifact(root: Path) -> Path:
             "document_type": "dao_allocation_a9_manifest",
             "issue": ISSUE,
             "source_revision": "synthetic",
+            "plan_sha256": "0" * 64,
             "status": "complete",
             "detail": "synthetic",
             "provider": None,
@@ -802,6 +933,8 @@ def parser() -> argparse.ArgumentParser:
     evaluate_command.add_argument("manifest", type=Path)
     evaluate_command.add_argument("artifact_root", type=Path)
     evaluate_command.add_argument("output", type=Path)
+    evaluate_command.add_argument("--expected-source-revision", required=True)
+    evaluate_command.add_argument("--expected-plan-sha256", required=True)
     dry_run = commands.add_parser("synthetic-dry-run")
     dry_run.add_argument("output", type=Path)
     return result
@@ -813,7 +946,13 @@ def main(arguments: list[str]) -> int:
         if args.command == "plan":
             validate_plan(args.plan, args.repository_root)
         elif args.command == "evaluate":
-            report = evaluate(args.manifest, args.artifact_root, args.output)
+            report = evaluate(
+                args.manifest,
+                args.artifact_root,
+                args.output,
+                expected_source_revision=args.expected_source_revision,
+                expected_plan_sha256=args.expected_plan_sha256,
+            )
             print(f"{report['status']}: {args.output}")
             if report["status"] != "accepted":
                 return 2

--- a/oracle/windows-dao/scripts/dao_allocation_a9.py
+++ b/oracle/windows-dao/scripts/dao_allocation_a9.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python3
+"""Plan check, evaluator, and synthetic dry run for the A9 allocation experiment.
+
+The evaluator decodes retained page images with only the primitives recorded in
+docs/PROVENANCE.md: the page grammar and usage-record shapes of SRC-0020, the
+global map record of EXP-0051, the table-map locators and extended-map base of
+EXP-0057, and the empty-database layout of EXP-0058. Every question answer is
+derived from page bytes; nothing here claims compatibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+PAGE_SIZE = 2048
+ISSUE = 99
+REPLICAS = 3
+# EXP-0051: global usage record on page 1 at [1915, 2048); set bit = not in use.
+GLOBAL_MAP_PAGE = 1
+GLOBAL_RECORD_START = 1915
+# EXP-0057: owned-map and free-map locators at table-definition offsets 35 and 39,
+# one row byte followed by a three-byte little-endian page number.
+OWNED_LOCATOR = 35
+FREE_LOCATOR = 39
+# SRC-0020 / EXP-0057: one complete type-05 page maps 16,352 pages.
+TYPE05_BITS = 16352
+# EXP-0058: an empty database has 20 pages and system table definitions at 2-5.
+EMPTY_PAGE_COUNT = 20
+SYSTEM_TDEF_PAGES = frozenset((2, 3, 4, 5))
+MAX_PAGES = 65536
+MAX_CHECKPOINT_BYTES = 64 * 1024 * 1024
+QUESTIONS = ("Q1", "Q2", "Q3", "Q4", "Q5")
+
+
+class EvaluationError(Exception):
+    """Artifact integrity or plan failure; the acquisition is rejected."""
+
+
+class NoOutcome(Exception):
+    """The artifact is intact but the question cannot be decided from it."""
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_bytes().decode("utf-8"))
+
+
+def canonical_bytes(document: Any) -> bytes:
+    return (
+        json.dumps(document, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        + "\n"
+    ).encode("utf-8")
+
+
+def write_canonical(path: Path, document: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_bytes(document))
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+# --- artifact loading -------------------------------------------------------
+
+
+class Checkpoint:
+    def __init__(self, entry: dict[str, Any], document: dict[str, Any]) -> None:
+        self.replica = int(entry["replica"])
+        self.question = str(entry["question"])
+        self.name = str(entry["name"])
+        self.capture = str(entry["capture"])
+        self.page_count = int(entry["page_count"])
+        self.pages: dict[int, bytes] = {}
+        for item in document["pages"]:
+            number = int(item["page"])
+            image = bytes.fromhex(item["hex"])
+            if len(image) != PAGE_SIZE or number in self.pages or number >= self.page_count:
+                raise EvaluationError(f"{self.label}: malformed page image {number}")
+            if sha256(image) != item["sha256"]:
+                raise EvaluationError(f"{self.label}: page {number} digest differs")
+            self.pages[number] = image
+        if self.capture == "full" and sorted(self.pages) != list(range(self.page_count)):
+            raise EvaluationError(f"{self.label}: full capture is incomplete")
+        for required in (0, GLOBAL_MAP_PAGE):
+            if required not in self.pages:
+                raise EvaluationError(f"{self.label}: page {required} was not captured")
+
+    @property
+    def label(self) -> str:
+        return f"r{self.replica}/{self.question}/{self.name}"
+
+    def tag(self, page: int) -> int:
+        return self.pages[page][0]
+
+    def tagged(self, tag: int) -> list[int]:
+        return sorted(page for page, image in self.pages.items() if image[0] == tag)
+
+
+def load_checkpoints(manifest: dict[str, Any], root: Path) -> dict[tuple[int, str, str], Checkpoint]:
+    result: dict[tuple[int, str, str], Checkpoint] = {}
+    for entry in manifest["checkpoints"]:
+        relative = Path(str(entry["path"]))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise EvaluationError(f"unsafe checkpoint path {entry['path']!r}")
+        raw = (root / relative).read_bytes()
+        if len(raw) > MAX_CHECKPOINT_BYTES:
+            raise EvaluationError(f"{entry['path']}: checkpoint exceeds the size bound")
+        if sha256(raw) != entry["sha256"]:
+            raise EvaluationError(f"{entry['path']}: checkpoint digest differs")
+        document = json.loads(raw.decode("utf-8"))
+        if document.get("document_type") != "dao_allocation_a9_checkpoint":
+            raise EvaluationError(f"{entry['path']}: wrong checkpoint document type")
+        for field in ("replica", "question", "name", "capture", "page_count"):
+            if document.get(field) != entry.get(field):
+                raise EvaluationError(f"{entry['path']}: {field} differs from manifest")
+        if not 1 <= int(entry["page_count"]) <= MAX_PAGES:
+            raise EvaluationError(f"{entry['path']}: page count out of bounds")
+        checkpoint = Checkpoint(entry, document)
+        key = (checkpoint.replica, checkpoint.question, checkpoint.name)
+        if key in result:
+            raise EvaluationError(f"{checkpoint.label}: duplicate checkpoint")
+        result[key] = checkpoint
+    return result
+
+
+# --- page primitives (SRC-0020, EXP-0051, EXP-0057) --------------------------
+
+
+def bitmap_pages(data: bytes, base: int) -> set[int]:
+    """Low-bit-first bitmap positions offset by base (SRC-0020)."""
+    return {
+        base + index * 8 + bit
+        for index, value in enumerate(data)
+        if value
+        for bit in range(8)
+        if value & (1 << bit)
+    }
+
+
+def row_bytes(page: bytes, row: int) -> bytes | None:
+    """One data-page row via the SRC-0020 row directory; None when malformed."""
+    if page[0] != 0x01:
+        return None
+    count = int.from_bytes(page[8:10], "little")
+    if row >= count or 10 + 2 * count > PAGE_SIZE:
+        return None
+    end = PAGE_SIZE
+    for ordinal in range(row + 1):
+        raw = int.from_bytes(page[10 + 2 * ordinal : 12 + 2 * ordinal], "little")
+        start = raw & 0x1FFF
+        if start >= end or start < 10 + 2 * count:
+            return None
+        if ordinal == row:
+            if raw & 0xC000:
+                return None
+            return page[start:end]
+        end = start
+    return None
+
+
+def usage_record(record: bytes, pages: dict[int, bytes]) -> dict[str, Any]:
+    """Decode a type-0 inline or type-1 indirect usage record (SRC-0020, EXP-0057)."""
+    if not record:
+        raise NoOutcome("empty usage record")
+    if record[0] == 0x00:
+        if len(record) < 5:
+            raise NoOutcome("type-0 usage record is truncated")
+        start = int.from_bytes(record[1:5], "little")
+        return {
+            "kind": "type0_inline",
+            "start_page": start,
+            "bitmap_bytes": len(record) - 5,
+            "pages": sorted(bitmap_pages(record[5:], start)),
+        }
+    if record[0] == 0x01:
+        if (len(record) - 1) % 4:
+            raise NoOutcome("type-1 usage record is not slot aligned")
+        refs = [
+            int.from_bytes(record[1 + 4 * slot : 5 + 4 * slot], "little")
+            for slot in range((len(record) - 1) // 4)
+        ]
+        mapped: set[int] = set()
+        missing: list[int] = []
+        for slot, ref in enumerate(refs):
+            if ref == 0:
+                continue
+            image = pages.get(ref)
+            if image is None:
+                missing.append(ref)
+                continue
+            if image[0] != 0x05:
+                raise NoOutcome(f"type-1 reference {ref} is not a type-05 page")
+            mapped |= bitmap_pages(image[4:], slot * TYPE05_BITS)
+        return {
+            "kind": "type1_indirect",
+            "slot_count": len(refs),
+            "references": [ref for ref in refs if ref],
+            "uncaptured_references": missing,
+            "pages": sorted(mapped),
+        }
+    raise NoOutcome(f"unknown usage record tag 0x{record[0]:02x}")
+
+
+def locator(tdef: bytes, offset: int) -> tuple[int, int]:
+    return tdef[offset], int.from_bytes(tdef[offset + 1 : offset + 4], "little")
+
+
+def table_maps(checkpoint: Checkpoint, tdef_page: int) -> dict[str, Any]:
+    tdef = checkpoint.pages[tdef_page]
+    result: dict[str, Any] = {"tdef_page": tdef_page}
+    for name, offset in (("owned", OWNED_LOCATOR), ("free", FREE_LOCATOR)):
+        row, page = locator(tdef, offset)
+        image = checkpoint.pages.get(page)
+        if image is None:
+            raise NoOutcome(f"{checkpoint.label}: {name}-map page {page} was not captured")
+        record = row_bytes(image, row)
+        if record is None:
+            raise NoOutcome(f"{checkpoint.label}: {name}-map row {page}/{row} is malformed")
+        decoded = usage_record(record, checkpoint.pages)
+        decoded["locator"] = {"row": row, "page": page}
+        result[name] = decoded
+    return result
+
+
+def global_map(checkpoint: Checkpoint) -> dict[str, Any]:
+    """EXP-0051 global record decoded as a SRC-0020 type-0 usage record."""
+    record = checkpoint.pages[GLOBAL_MAP_PAGE][GLOBAL_RECORD_START:]
+    decoded = usage_record(record, {})
+    if decoded["kind"] != "type0_inline":
+        raise NoOutcome(f"{checkpoint.label}: global record is not a type-0 record")
+    free = set(decoded["pages"])
+    start = decoded["start_page"]
+    coverage = range(start, start + decoded["bitmap_bytes"] * 8)
+    in_use = {page for page in coverage if page < checkpoint.page_count and page not in free}
+    return {"start_page": start, "coverage_end": coverage.stop, "free": free, "in_use": in_use}
+
+
+def user_tdef_pages(checkpoint: Checkpoint) -> list[int]:
+    return [page for page in checkpoint.tagged(0x02) if page not in SYSTEM_TDEF_PAGES]
+
+
+def differing_ranges(images: list[bytes]) -> list[list[int]]:
+    ranges: list[list[int]] = []
+    for offset in range(PAGE_SIZE):
+        if all(image[offset] == images[0][offset] for image in images):
+            continue
+        if ranges and ranges[-1][1] == offset:
+            ranges[-1][1] = offset + 1
+        else:
+            ranges.append([offset, offset + 1])
+    return ranges
+
+
+def global_transitions(before: Checkpoint, after: Checkpoint) -> dict[str, list[int]]:
+    prior, later = global_map(before), global_map(after)
+    return {
+        "became_in_use": sorted(later["in_use"] - prior["in_use"]),
+        "became_free": sorted(later["free"] - prior["free"]),
+    }
+
+
+def page_classes(checkpoint: Checkpoint, page: int, marker: bytes) -> str:
+    tag = checkpoint.tag(page)
+    if tag == 0x03:
+        return "index_intermediate"
+    if tag == 0x04:
+        return "index_leaf"
+    if tag == 0x05:
+        return "usage_bitmap"
+    if tag == 0x02:
+        return "table_definition"
+    if tag == 0x01:
+        return "long_value" if marker in checkpoint.pages[page] else "data"
+    return f"tag_{tag:02x}"
+
+
+def require_same(values: list[Any], what: str) -> Any:
+    if any(canonical_bytes(value) != canonical_bytes(values[0]) for value in values):
+        raise NoOutcome(f"{what}: replicas disagree")
+    return values[0]
+
+
+# --- questions --------------------------------------------------------------
+
+
+class Evaluation:
+    def __init__(self, manifest: dict[str, Any], root: Path) -> None:
+        self.manifest = manifest
+        self.checkpoints = load_checkpoints(manifest, root)
+        self.marker = bytes.fromhex(str(manifest["memo_marker_hex"]))
+
+    def get(self, replica: int, question: str, name: str) -> Checkpoint:
+        try:
+            return self.checkpoints[(replica, question, name)]
+        except KeyError as error:
+            raise NoOutcome(f"missing checkpoint r{replica}/{question}/{name}") from error
+
+    def q1_empty_template(self) -> dict[str, Any]:
+        replicas = [self.get(replica, "Q1", "00-empty") for replica in range(1, REPLICAS + 1)]
+        page_count = require_same([item.page_count for item in replicas], "Q1 page count")
+        varying = {
+            str(page): ranges
+            for page in range(page_count)
+            if (ranges := differing_ranges([item.pages[page] for item in replicas]))
+        }
+        return {
+            "page_count": page_count,
+            "matches_exp_0058_page_count": page_count == EMPTY_PAGE_COUNT,
+            "page_tags": [replicas[0].tag(page) for page in range(page_count)],
+            "varying_byte_ranges": varying,
+            "constant_pages": [page for page in range(page_count) if str(page) not in varying],
+        }
+
+    def q2_append(self) -> dict[str, Any]:
+        def transition(before: Checkpoint, after: Checkpoint) -> dict[str, Any]:
+            appended = list(range(before.page_count, after.page_count))
+            return {
+                "appended_pages": appended,
+                "appended_first_16_hex": {
+                    str(page): after.pages[page][:16].hex() for page in appended
+                },
+                "global_map": global_transitions(before, after),
+                "header_page_changed_ranges": differing_ranges([before.pages[0], after.pages[0]]),
+                "global_map_page_changed_ranges": differing_ranges(
+                    [before.pages[GLOBAL_MAP_PAGE], after.pages[GLOBAL_MAP_PAGE]]
+                ),
+            }
+
+        per_replica = [
+            {
+                "table_create": transition(
+                    self.get(replica, "Q2", "00-empty"), self.get(replica, "Q2", "01-table-created")
+                ),
+                "data_page_append": transition(
+                    self.get(replica, "Q2", "02-before-data-page"),
+                    self.get(replica, "Q2", "03-after-data-page"),
+                ),
+            }
+            for replica in range(1, REPLICAS + 1)
+        ]
+        return require_same(per_replica, "Q2 transitions")
+
+    def q3_reuse(self) -> dict[str, Any]:
+        per_replica = []
+        for replica in range(1, REPLICAS + 1):
+            populated = self.get(replica, "Q3", "02-populated")
+            freed = self.get(replica, "Q3", "03-freed")
+            first_tdef = require_same([user_tdef_pages(self.get(replica, "Q3", "00-first-table"))], "")
+            if len(first_tdef) != 1:
+                raise NoOutcome(f"r{replica}/Q3: first table definition is ambiguous")
+            freed_pages = set(global_transitions(populated, freed)["became_free"])
+            steps = []
+            previous = freed
+            for step in range(1, 5):
+                current = self.get(replica, "Q3", f"04-reinsert-{step}")
+                used = global_transitions(previous, current)["became_in_use"]
+                appended = list(range(previous.page_count, current.page_count))
+                steps.append(
+                    {
+                        "step": step,
+                        "newly_in_use": used,
+                        "reused_freed_pages": [page for page in used if page in freed_pages],
+                        "appended_pages": appended,
+                    }
+                )
+                previous = current
+            reused = any(step["reused_freed_pages"] for step in steps)
+            appended = any(step["appended_pages"] for step in steps)
+            per_replica.append(
+                {
+                    "freed_pages": sorted(freed_pages),
+                    "page_count_after_free": freed.page_count,
+                    "owned_map_after_free": table_maps(freed, first_tdef[0])["owned"]["pages"],
+                    "free_map_after_free": table_maps(freed, first_tdef[0])["free"]["pages"],
+                    "reinsert_steps": steps,
+                    "verdict": {
+                        (True, False): "reuse",
+                        (False, True): "append",
+                        (True, True): "mixed",
+                        (False, False): "none",
+                    }[(reused, appended)],
+                }
+            )
+        verdict = require_same([item["verdict"] for item in per_replica], "Q3 verdict")
+        return {"verdict": verdict, "replicas": per_replica}
+
+    def q4_table_map_extension(self) -> dict[str, Any]:
+        names = (
+            "00-created",
+            "01-before-first-type05",
+            "02-after-first-type05",
+            "03-before-second-type05",
+            "04-after-second-type05",
+        )
+        per_replica = []
+        for replica in range(1, REPLICAS + 1):
+            states = {}
+            for name in names:
+                checkpoint = self.get(replica, "Q4", name)
+                tdefs = user_tdef_pages(checkpoint)
+                if len(tdefs) != 1:
+                    raise NoOutcome(f"{checkpoint.label}: user table definition is ambiguous")
+                maps = table_maps(checkpoint, tdefs[0])
+                states[name] = {
+                    "page_count": checkpoint.page_count,
+                    "tdef_page": tdefs[0],
+                    "type05_pages": checkpoint.tagged(0x05),
+                    "owned": {key: value for key, value in maps["owned"].items() if key != "pages"},
+                    "owned_page_count": len(maps["owned"]["pages"]),
+                    "free": {key: value for key, value in maps["free"].items() if key != "pages"},
+                }
+            per_replica.append(states)
+        shape = require_same(
+            [
+                {name: (state["owned"]["kind"], len(state["type05_pages"])) for name, state in states.items()}
+                for states in per_replica
+            ],
+            "Q4 map kinds",
+        )
+        return {"map_kind_and_type05_count": shape, "replicas": per_replica}
+
+    def q5_ownership(self) -> dict[str, Any]:
+        per_replica = []
+        for replica in range(1, REPLICAS + 1):
+            created = self.get(replica, "Q5", "00-created")
+            populated = self.get(replica, "Q5", "01-populated")
+            tdefs = user_tdef_pages(populated)
+            if len(tdefs) != 1:
+                raise NoOutcome(f"{populated.label}: user table definition is ambiguous")
+            maps = table_maps(populated, tdefs[0])
+            owned, free = set(maps["owned"]["pages"]), set(maps["free"]["pages"])
+            in_use = global_map(populated)["in_use"]
+            new_pages = sorted(
+                (in_use - global_map(created)["in_use"])
+                | set(range(created.page_count, populated.page_count))
+            )
+            pages = [
+                {
+                    "page": page,
+                    "class": page_classes(populated, page, self.marker),
+                    "in_table_owned_map": page in owned,
+                    "in_table_free_map": page in free,
+                    "in_global_map_in_use": page in in_use,
+                }
+                for page in new_pages
+            ]
+            summary: dict[str, dict[str, str]] = {}
+            for cls in sorted({item["class"] for item in pages}):
+                members = [item for item in pages if item["class"] == cls]
+                summary[cls] = {
+                    key: {0: "none", len(members): "all"}.get(sum(item[key] for item in members), "some")
+                    for key in ("in_table_owned_map", "in_table_free_map", "in_global_map_in_use")
+                }
+            per_replica.append({"tdef_page": tdefs[0], "pages": pages, "summary": summary})
+        summary = require_same([item["summary"] for item in per_replica], "Q5 ownership")
+        return {"summary": summary, "replicas": per_replica}
+
+
+def evaluate(manifest_path: Path, root: Path, output: Path) -> dict[str, Any]:
+    manifest = load_json(manifest_path)
+    if manifest.get("document_type") != "dao_allocation_a9_manifest" or manifest.get("issue") != ISSUE:
+        raise EvaluationError("manifest has the wrong document type or issue")
+    if manifest.get("replica_count") != REPLICAS:
+        raise EvaluationError("manifest does not declare three replicas")
+    report: dict[str, Any] = {
+        "document_type": "dao_allocation_a9_report",
+        "issue": ISSUE,
+        "compatibility_claim": False,
+        "source_revision": manifest.get("source_revision"),
+        "provider": manifest.get("provider"),
+        "generator_status": manifest.get("status"),
+        "checkpoint_count": len(manifest.get("checkpoints", [])),
+        "questions": {},
+    }
+    evaluation = Evaluation(manifest, root)
+    answers = {
+        "Q1": evaluation.q1_empty_template,
+        "Q2": evaluation.q2_append,
+        "Q3": evaluation.q3_reuse,
+        "Q4": evaluation.q4_table_map_extension,
+        "Q5": evaluation.q5_ownership,
+    }
+    for question in QUESTIONS:
+        try:
+            report["questions"][question] = {"status": "answered", "answer": answers[question]()}
+        except NoOutcome as reason:
+            report["questions"][question] = {"status": "no_outcome", "reason": str(reason)}
+    all_answered = all(item["status"] == "answered" for item in report["questions"].values())
+    report["status"] = "accepted" if all_answered and manifest.get("status") == "complete" else "no_outcome"
+    if manifest.get("status") != "complete":
+        report["generator_detail"] = manifest.get("detail")
+    write_canonical(output, report)
+    return report
+
+
+# --- plan -------------------------------------------------------------------
+
+
+def validate_plan(plan_path: Path, repository_root: Path) -> None:
+    plan = load_json(plan_path)
+    if plan.get("document_type") != "dao_allocation_a9_plan" or plan.get("issue") != ISSUE:
+        raise EvaluationError("plan has the wrong document type or issue")
+    execution = plan.get("execution", {})
+    if execution.get("attempts") != 1 or execution.get("replicas") != REPLICAS:
+        raise EvaluationError("plan must permit one attempt of three replicas")
+    if set(plan.get("questions", {})) != set(QUESTIONS):
+        raise EvaluationError("plan must state exactly Q1-Q5")
+    inputs = plan.get("inputs")
+    if not isinstance(inputs, dict) or not inputs:
+        raise EvaluationError("plan has no pinned inputs")
+    for relative, expected in inputs.items():
+        path = Path(relative)
+        if path.is_absolute() or ".." in path.parts:
+            raise EvaluationError(f"unsafe plan input path {relative!r}")
+        if not isinstance(expected, str) or len(expected) != 64 or set(expected) - set("0123456789abcdef"):
+            raise EvaluationError(f"invalid plan input digest for {relative}")
+        if sha256((repository_root / path).read_bytes()) != expected:
+            raise EvaluationError(f"plan input digest differs for {relative}")
+
+
+# --- synthetic dry run ------------------------------------------------------
+
+
+class SyntheticDatabase:
+    """Pages fabricated to the decoding assumptions above; no DAO involved."""
+
+    MARKER = b"L" * 64
+
+    def __init__(self, page_count: int, header_variant: int = 0) -> None:
+        self.page_count = page_count
+        self.free: set[int] = set()
+        self.pages: dict[int, bytes] = {}
+        header = bytearray(PAGE_SIZE)
+        header[0:15] = b"\x00Standard Jet DB"[:15]
+        header[100] = header_variant
+        self.pages[0] = bytes(header)
+        for page in range(2, page_count):
+            self.pages[page] = self.page(0x02 if page in SYSTEM_TDEF_PAGES else 0x01)
+
+    @staticmethod
+    def page(tag: int, body: bytes = b"", at: int = 1) -> bytes:
+        image = bytearray(PAGE_SIZE)
+        image[0] = tag
+        image[at : at + len(body)] = body
+        return bytes(image)
+
+    def set_tdef(self, page: int, map_page: int) -> None:
+        body = bytearray(PAGE_SIZE)
+        body[0] = 0x02
+        body[OWNED_LOCATOR : OWNED_LOCATOR + 4] = bytes([0]) + map_page.to_bytes(3, "little")
+        body[FREE_LOCATOR : FREE_LOCATOR + 4] = bytes([1]) + map_page.to_bytes(3, "little")
+        self.pages[page] = bytes(body)
+
+    def set_map_page(self, page: int, owned: bytes, free: bytes) -> None:
+        image = bytearray(PAGE_SIZE)
+        image[0] = 0x01
+        image[8:10] = (2).to_bytes(2, "little")
+        start0 = PAGE_SIZE - len(owned)
+        start1 = start0 - len(free)
+        image[10:12] = start0.to_bytes(2, "little")
+        image[12:14] = start1.to_bytes(2, "little")
+        image[start0:] = owned
+        image[start1:start0] = free
+        self.pages[page] = bytes(image)
+
+    @staticmethod
+    def type0(start: int, pages: set[int], size: int = 16) -> bytes:
+        bitmap = bytearray(size)
+        for page in pages:
+            bitmap[(page - start) // 8] |= 1 << ((page - start) % 8)
+        return b"\x00" + start.to_bytes(4, "little") + bytes(bitmap)
+
+    @staticmethod
+    def type1(refs: list[int]) -> bytes:
+        return b"\x01" + b"".join(ref.to_bytes(4, "little") for ref in refs)
+
+    def set_type05(self, page: int, slot: int, pages: set[int]) -> None:
+        bitmap = bytearray(PAGE_SIZE - 4)
+        for owned in pages:
+            bit = owned - slot * TYPE05_BITS
+            bitmap[bit // 8] |= 1 << (bit % 8)
+        self.pages[page] = self.page(0x05, b"\x01\x00\x00" + bytes(bitmap))
+
+    def images(self, selected: bool = False) -> dict[int, bytes]:
+        free = set(self.free) | set(range(self.page_count, 1024))
+        record = self.type0(0, free, 128)
+        page1 = bytearray(self.page(0x01))
+        page1[GLOBAL_RECORD_START:] = record
+        self.pages[GLOBAL_MAP_PAGE] = bytes(page1)
+        if not selected:
+            return dict(self.pages)
+        keep = {0, 1} | {page for page, image in self.pages.items() if image[0] in (0x02, 0x05)}
+        for page in list(keep):
+            if self.pages[page][0] == 0x02:
+                keep.add(locator(self.pages[page], OWNED_LOCATOR)[1])
+        return {page: self.pages[page] for page in sorted(keep)}
+
+
+def synthetic_checkpoints(replica: int) -> list[tuple[str, str, str, SyntheticDatabase]]:
+    """A tiny consistent Q1-Q5 checkpoint sequence for one replica."""
+    result = []
+    empty = SyntheticDatabase(EMPTY_PAGE_COUNT, header_variant=replica)
+    result.append(("Q1", "00-empty", "full", empty))
+
+    def user_table(db: SyntheticDatabase, tdef: int, owned: set[int], free: set[int]) -> None:
+        db.set_tdef(tdef, tdef + 1)
+        db.set_map_page(tdef + 1, db.type0(tdef, owned), db.type0(tdef, free))
+
+    q2_empty = SyntheticDatabase(20, replica)
+    q2_created = SyntheticDatabase(22, replica)
+    user_table(q2_created, 20, {21}, set())
+    q2_after = SyntheticDatabase(23, replica)
+    user_table(q2_after, 20, {21, 22}, {22})
+    result += [
+        ("Q2", "00-empty", "full", q2_empty),
+        ("Q2", "01-table-created", "full", q2_created),
+        ("Q2", "02-before-data-page", "full", q2_created),
+        ("Q2", "03-after-data-page", "full", q2_after),
+    ]
+
+    q3_first = SyntheticDatabase(22, replica)
+    user_table(q3_first, 20, {21}, set())
+    q3_second = SyntheticDatabase(24, replica)
+    user_table(q3_second, 20, {21}, set())
+    user_table(q3_second, 22, {23}, set())
+    q3_populated = SyntheticDatabase(30, replica)
+    user_table(q3_populated, 20, {21, 24, 25, 26, 27, 28, 29}, {29})
+    user_table(q3_populated, 22, {23}, set())
+    q3_freed = SyntheticDatabase(30, replica)
+    user_table(q3_freed, 20, {21, 24, 25, 26}, {26})
+    q3_freed.pages[22] = q3_freed.page(0x01)
+    q3_freed.free = {22, 23, 27, 28, 29}
+    result += [
+        ("Q3", "00-first-table", "full", q3_first),
+        ("Q3", "01-second-table", "full", q3_second),
+        ("Q3", "02-populated", "full", q3_populated),
+        ("Q3", "03-freed", "full", q3_freed),
+    ]
+    remaining = {22, 23, 27, 28, 29}
+    for step, reused in enumerate((27, 28, 29, 22), start=1):
+        remaining.discard(reused)
+        db = SyntheticDatabase(30, replica)
+        user_table(db, 20, {21, 24, 25, 26} | ({27, 28, 29, 22} - remaining), {reused})
+        db.free = set(remaining)
+        result.append(("Q3", f"04-reinsert-{step}", "full", db))
+
+    def q4_state(page_count: int, refs: list[int] | None) -> SyntheticDatabase:
+        db = SyntheticDatabase(min(page_count, 32), replica)
+        db.page_count = page_count
+        db.set_tdef(20, 21)
+        if refs is None:
+            db.set_map_page(21, db.type0(20, {21, 22}), db.type0(20, {22}))
+        else:
+            db.set_map_page(21, db.type1(refs + [0] * (4 - len(refs))), db.type0(20, {22}))
+            for slot, ref in enumerate(refs):
+                db.set_type05(ref, slot, {slot * TYPE05_BITS + 21})
+        return db
+
+    result += [
+        ("Q4", "00-created", "selected", q4_state(22, None)),
+        ("Q4", "01-before-first-type05", "selected", q4_state(1000, None)),
+        ("Q4", "02-after-first-type05", "selected", q4_state(1002, [1001])),
+        ("Q4", "03-before-second-type05", "selected", q4_state(16352, [1001])),
+        ("Q4", "04-after-second-type05", "selected", q4_state(16354, [1001, 16353])),
+    ]
+
+    q5_created = SyntheticDatabase(23, replica)
+    user_table(q5_created, 20, {21, 22}, set())
+    q5_created.pages[22] = q5_created.page(0x04)
+    q5_populated = SyntheticDatabase(26, replica)
+    user_table(q5_populated, 20, {21, 22, 23, 24, 25}, {23})
+    q5_populated.pages[22] = q5_populated.page(0x03)
+    q5_populated.pages[23] = q5_populated.page(0x01)
+    q5_populated.pages[24] = q5_populated.page(0x01, SyntheticDatabase.MARKER, at=32)
+    q5_populated.pages[25] = q5_populated.page(0x04)
+    result += [("Q5", "00-created", "full", q5_created), ("Q5", "01-populated", "full", q5_populated)]
+    return result
+
+
+def write_synthetic_artifact(root: Path) -> Path:
+    entries = []
+    for replica in range(1, REPLICAS + 1):
+        for question, name, capture, db in synthetic_checkpoints(replica):
+            images = db.images(selected=capture == "selected")
+            document = {
+                "document_type": "dao_allocation_a9_checkpoint",
+                "replica": replica,
+                "question": question,
+                "name": name,
+                "capture": capture,
+                "page_count": db.page_count,
+                "pages": [
+                    {"page": page, "sha256": sha256(image), "hex": image.hex()}
+                    for page, image in sorted(images.items())
+                ],
+            }
+            relative = Path(f"r{replica}") / question / f"{name}.json"
+            raw = canonical_bytes(document)
+            (root / relative).parent.mkdir(parents=True, exist_ok=True)
+            (root / relative).write_bytes(raw)
+            entries.append(
+                {
+                    "replica": replica,
+                    "question": question,
+                    "name": name,
+                    "capture": capture,
+                    "page_count": db.page_count,
+                    "path": relative.as_posix(),
+                    "sha256": sha256(raw),
+                }
+            )
+    manifest_path = root / "manifest.raw.json"
+    write_canonical(
+        manifest_path,
+        {
+            "document_type": "dao_allocation_a9_manifest",
+            "issue": ISSUE,
+            "source_revision": "synthetic",
+            "status": "complete",
+            "detail": "synthetic",
+            "provider": None,
+            "replica_count": REPLICAS,
+            "memo_marker_hex": SyntheticDatabase.MARKER.hex(),
+            "checkpoints": entries,
+        },
+    )
+    return manifest_path
+
+
+def synthetic_dry_run(output: Path) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        manifest_path = write_synthetic_artifact(root)
+        report = evaluate(manifest_path, root, root / "report.json")
+        accepted = report["status"] == "accepted"
+        # Controlled inconsistency: one page image no longer matches its digest.
+        tampered = copy.deepcopy(load_json(manifest_path))
+        target = root / tampered["checkpoints"][0]["path"]
+        document = load_json(target)
+        document["pages"][0]["hex"] = "ff" + document["pages"][0]["hex"][2:]
+        raw = canonical_bytes(document)
+        target.write_bytes(raw)
+        tampered["checkpoints"][0]["sha256"] = sha256(raw)
+        write_canonical(manifest_path, tampered)
+        rejected = False
+        try:
+            evaluate(manifest_path, root, root / "report-tampered.json")
+        except EvaluationError:
+            rejected = True
+    if not accepted or not rejected:
+        raise EvaluationError("synthetic dry run did not behave as required")
+    write_canonical(
+        output,
+        {
+            "compatibility_claim": False,
+            "consistent_input_accepted": accepted,
+            "document_type": "dao_allocation_a9_synthetic_dry_run",
+            "inconsistent_input_rejected": rejected,
+            "issue": ISSUE,
+            "question_statuses": {q: report["questions"][q]["status"] for q in QUESTIONS},
+        },
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    commands = result.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan")
+    plan.add_argument("plan", type=Path)
+    plan.add_argument("repository_root", type=Path)
+    evaluate_command = commands.add_parser("evaluate")
+    evaluate_command.add_argument("manifest", type=Path)
+    evaluate_command.add_argument("artifact_root", type=Path)
+    evaluate_command.add_argument("output", type=Path)
+    dry_run = commands.add_parser("synthetic-dry-run")
+    dry_run.add_argument("output", type=Path)
+    return result
+
+
+def main(arguments: list[str]) -> int:
+    args = parser().parse_args(arguments)
+    try:
+        if args.command == "plan":
+            validate_plan(args.plan, args.repository_root)
+        elif args.command == "evaluate":
+            report = evaluate(args.manifest, args.artifact_root, args.output)
+            print(f"{report['status']}: {args.output}")
+            if report["status"] != "accepted":
+                return 2
+        else:
+            synthetic_dry_run(args.output)
+    except (OSError, ValueError, KeyError, TypeError, EvaluationError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/oracle/windows-dao/scripts/dao_allocation_a9.py
+++ b/oracle/windows-dao/scripts/dao_allocation_a9.py
@@ -477,6 +477,7 @@ class Evaluation:
                     "free_pages": maps["free"]["pages"],
                     "free_page_count": len(maps["free"]["pages"]),
                 }
+            transitions = []
             for ordinal, (before_name, after_name) in enumerate(
                 (
                     ("01-before-first-type05", "02-after-first-type05"),
@@ -485,25 +486,57 @@ class Evaluation:
                 start=1,
             ):
                 before, after = states[before_name], states[after_name]
-                before_refs = (
-                    len(before["owned"]["references"])
+                before_refs = set(
+                    before["owned"]["references"]
                     if before["owned"]["kind"] == "type1_indirect"
-                    else 0
+                    else []
                 )
-                after_refs = (
-                    len(after["owned"]["references"])
+                after_refs = set(
+                    after["owned"]["references"]
                     if after["owned"]["kind"] == "type1_indirect"
-                    else 0
+                    else []
                 )
-                if after_refs <= before_refs:
-                    raise NoOutcome(
-                        f"r{replica}/Q4: transition {ordinal} did not extend the owned-map references"
-                    )
+                new_type05_pages = sorted(
+                    set(after["type05_pages"]) - set(before["type05_pages"])
+                )
                 if len(after["type05_pages"]) <= len(before["type05_pages"]):
                     raise NoOutcome(
                         f"r{replica}/Q4: transition {ordinal} did not add a captured type-05 page"
                     )
-            per_replica.append(states)
+                new_owned_references = after_refs - before_refs
+                linked_new_references = new_owned_references & set(new_type05_pages)
+                primary_extension = (
+                    after["owned"]["kind"] == "type1_indirect"
+                    and before_refs < after_refs
+                    and bool(linked_new_references)
+                )
+                transitions.append(
+                    {
+                        "ordinal": ordinal,
+                        "before": before_name,
+                        "after": after_name,
+                        "classification": (
+                            "primary_owned_map_extension"
+                            if primary_extension
+                            else "other_type05_growth"
+                        ),
+                        "new_type05_pages": new_type05_pages,
+                        "owned_kind_before": before["owned"]["kind"],
+                        "owned_kind_after": after["owned"]["kind"],
+                        "owned_references_before": sorted(before_refs),
+                        "owned_references_after": sorted(after_refs),
+                        "new_owned_references": sorted(new_owned_references),
+                        "linked_new_references": sorted(linked_new_references),
+                    }
+                )
+            if not any(
+                item["classification"] == "primary_owned_map_extension"
+                for item in transitions
+            ):
+                raise NoOutcome(
+                    f"r{replica}/Q4: neither captured transition extended the primary owned map"
+                )
+            per_replica.append({"checkpoints": states, "transitions": transitions})
         shape = require_same(
             [
                 {
@@ -514,13 +547,24 @@ class Evaluation:
                         "free_pages": state["free_pages"],
                         "type05_page_count": len(state["type05_pages"]),
                     }
-                    for name, state in states.items()
+                    for name, state in replica["checkpoints"].items()
                 }
-                for states in per_replica
+                for replica in per_replica
             ],
             "Q4 map contents",
         )
-        return {"map_shape": shape, "replicas": per_replica}
+        transition_classifications = require_same(
+            [
+                [transition["classification"] for transition in replica["transitions"]]
+                for replica in per_replica
+            ],
+            "Q4 transition classifications",
+        )
+        return {
+            "map_shape": shape,
+            "transition_classifications": transition_classifications,
+            "replicas": per_replica,
+        }
 
     def q5_ownership(self) -> dict[str, Any]:
         per_replica = []
@@ -803,7 +847,11 @@ def synthetic_checkpoints(replica: int) -> list[tuple[str, str, str, SyntheticDa
         db.free = set(remaining)
         result.append(("Q3", f"04-reinsert-{step}", "full", db))
 
-    def q4_state(page_count: int, refs: list[int] | None) -> SyntheticDatabase:
+    def q4_state(
+        page_count: int,
+        refs: list[int] | None,
+        other_type05_pages: tuple[int, ...] = (),
+    ) -> SyntheticDatabase:
         db = SyntheticDatabase(min(page_count, 32), replica)
         db.page_count = page_count
         db.set_tdef(20, 21)
@@ -814,14 +862,31 @@ def synthetic_checkpoints(replica: int) -> list[tuple[str, str, str, SyntheticDa
             for slot, ref in enumerate(refs):
                 owned = 21 if slot == 0 else slot * TYPE05_BITS
                 db.set_type05(ref, slot, {owned})
+        for page in other_type05_pages:
+            db.set_type05(page, 0, set())
         return db
 
     result += [
         ("Q4", "00-created", "selected", q4_state(22, None)),
         ("Q4", "01-before-first-type05", "selected", q4_state(1000, None)),
-        ("Q4", "02-after-first-type05", "selected", q4_state(1002, [1001])),
-        ("Q4", "03-before-second-type05", "selected", q4_state(16352, [1001])),
-        ("Q4", "04-after-second-type05", "selected", q4_state(16354, [1001, 16353])),
+        (
+            "Q4",
+            "02-after-first-type05",
+            "selected",
+            q4_state(1002, None, (1001,)),
+        ),
+        (
+            "Q4",
+            "03-before-second-type05",
+            "selected",
+            q4_state(16352, None, (1001,)),
+        ),
+        (
+            "Q4",
+            "04-after-second-type05",
+            "selected",
+            q4_state(16354, [16353], (1001,)),
+        ),
     ]
 
     q5_created = SyntheticDatabase(23, replica)

--- a/oracle/windows-dao/tests/test_dao_allocation_a9.py
+++ b/oracle/windows-dao/tests/test_dao_allocation_a9.py
@@ -95,6 +95,45 @@ class A9EvaluatorTests(unittest.TestCase):
         self.assertEqual(report["questions"]["Q3"]["status"], "no_outcome")
         self.assertEqual(report["questions"]["Q1"]["status"], "answered")
 
+    def test_uncaptured_indirect_reference_is_no_outcome(self) -> None:
+        with self.assertRaisesRegex(a9.NoOutcome, "reference 1001 was not captured"):
+            a9.usage_record(a9.SyntheticDatabase.type1([1001]), {})
+
+    def test_q4_requires_owned_map_reference_growth(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            for replica in range(1, a9.REPLICAS + 1):
+                before_entry = next(
+                    item
+                    for item in manifest["checkpoints"]
+                    if item["replica"] == replica
+                    and item["question"] == "Q4"
+                    and item["name"] == "01-before-first-type05"
+                )
+                after_entry = next(
+                    item
+                    for item in manifest["checkpoints"]
+                    if item["replica"] == replica
+                    and item["question"] == "Q4"
+                    and item["name"] == "02-after-first-type05"
+                )
+                before = a9.load_json(root / before_entry["path"])
+                after = a9.load_json(root / after_entry["path"])
+                before_map = next(page for page in before["pages"] if page["page"] == 21)
+                after["pages"] = [
+                    before_map if page["page"] == 21 else page for page in after["pages"]
+                ]
+                raw = a9.canonical_bytes(after)
+                (root / after_entry["path"]).write_bytes(raw)
+                after_entry["sha256"] = a9.sha256(raw)
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(report["questions"]["Q4"]["status"], "no_outcome")
+        self.assertIn("did not extend", report["questions"]["Q4"]["reason"])
+
     def test_row_directory_rejects_deleted_and_overflow_rows(self) -> None:
         page = bytearray(a9.PAGE_SIZE)
         page[0] = 0x01

--- a/oracle/windows-dao/tests/test_dao_allocation_a9.py
+++ b/oracle/windows-dao/tests/test_dao_allocation_a9.py
@@ -183,7 +183,20 @@ class A9EvaluatorTests(unittest.TestCase):
         self.assertEqual(report["status"], "no_outcome")
         self.assertIn("page count did not grow", report["questions"]["Q2"]["reason"])
 
-    def test_q4_requires_owned_map_reference_growth(self) -> None:
+    def test_q4_classifies_global_and_primary_map_transitions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        transitions = report["questions"]["Q4"]["answer"]["replicas"][0]["transitions"]
+        self.assertEqual(
+            [transition["classification"] for transition in transitions],
+            ["other_type05_growth", "primary_owned_map_extension"],
+        )
+        self.assertEqual(transitions[0]["new_type05_pages"], [1001])
+        self.assertEqual(transitions[1]["new_type05_pages"], [16353])
+
+    def test_q4_requires_at_least_one_primary_owned_map_extension(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             manifest_path = a9.write_synthetic_artifact(root)
@@ -194,14 +207,14 @@ class A9EvaluatorTests(unittest.TestCase):
                     for item in manifest["checkpoints"]
                     if item["replica"] == replica
                     and item["question"] == "Q4"
-                    and item["name"] == "01-before-first-type05"
+                    and item["name"] == "03-before-second-type05"
                 )
                 after_entry = next(
                     item
                     for item in manifest["checkpoints"]
                     if item["replica"] == replica
                     and item["question"] == "Q4"
-                    and item["name"] == "02-after-first-type05"
+                    and item["name"] == "04-after-second-type05"
                 )
                 before = a9.load_json(root / before_entry["path"])
                 after = a9.load_json(root / after_entry["path"])
@@ -216,7 +229,38 @@ class A9EvaluatorTests(unittest.TestCase):
             report = a9.evaluate(manifest_path, root, root / "report.json")
         self.assertEqual(report["status"], "no_outcome")
         self.assertEqual(report["questions"]["Q4"]["status"], "no_outcome")
-        self.assertIn("did not extend", report["questions"]["Q4"]["reason"])
+        self.assertIn("neither captured transition", report["questions"]["Q4"]["reason"])
+
+    def test_q4_primary_extension_must_reference_the_new_type05_page(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            for replica in range(1, a9.REPLICAS + 1):
+                entry = next(
+                    item
+                    for item in manifest["checkpoints"]
+                    if item["replica"] == replica
+                    and item["question"] == "Q4"
+                    and item["name"] == "04-after-second-type05"
+                )
+                document = a9.load_json(root / entry["path"])
+                map_page = next(page for page in document["pages"] if page["page"] == 21)
+                image = bytearray.fromhex(map_page["hex"])
+                owned_start = int.from_bytes(image[10:12], "little") & 0x1FFF
+                self.assertEqual(image[owned_start], 0x01)
+                image[owned_start + 1 : owned_start + 5] = (1001).to_bytes(4, "little")
+                encoded = bytes(image)
+                map_page["hex"] = encoded.hex()
+                map_page["sha256"] = a9.sha256(encoded)
+                raw = a9.canonical_bytes(document)
+                (root / entry["path"]).write_bytes(raw)
+                entry["sha256"] = a9.sha256(raw)
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(report["questions"]["Q4"]["status"], "no_outcome")
+        self.assertIn("neither captured transition", report["questions"]["Q4"]["reason"])
 
     def test_q4_requires_replica_consistent_free_map_count(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/oracle/windows-dao/tests/test_dao_allocation_a9.py
+++ b/oracle/windows-dao/tests/test_dao_allocation_a9.py
@@ -23,6 +23,45 @@ GENERATOR = SCRIPTS / "Invoke-DaoAllocationA9.ps1"
 WORKFLOW = ROOT / ".github" / "workflows" / "windows-dao-allocation-a9.yml"
 
 
+def mutate_map_bit(
+    manifest: dict,
+    root: Path,
+    *,
+    replica: int,
+    checkpoint_name: str,
+    row: int,
+    page: int,
+    set_bit: bool,
+) -> None:
+    entry = next(
+        item
+        for item in manifest["checkpoints"]
+        if item["replica"] == replica
+        and item["question"] == "Q4"
+        and item["name"] == checkpoint_name
+    )
+    document = a9.load_json(root / entry["path"])
+    map_image = next(item for item in document["pages"] if item["page"] == 21)
+    image = bytearray.fromhex(map_image["hex"])
+    start = int.from_bytes(image[10 + 2 * row : 12 + 2 * row], "little") & 0x1FFF
+    base = int.from_bytes(image[start + 1 : start + 5], "little")
+    relative = page - base
+    if relative < 0:
+        raise AssertionError("test page precedes the type-0 map base")
+    byte = start + 5 + relative // 8
+    mask = 1 << (relative % 8)
+    if set_bit:
+        image[byte] |= mask
+    else:
+        image[byte] &= ~mask
+    encoded = bytes(image)
+    map_image["hex"] = encoded.hex()
+    map_image["sha256"] = a9.sha256(encoded)
+    raw = a9.canonical_bytes(document)
+    (root / entry["path"]).write_bytes(raw)
+    entry["sha256"] = a9.sha256(raw)
+
+
 class A9PlanTests(unittest.TestCase):
     def test_plan_pins_every_execution_input(self) -> None:
         a9.validate_plan(PLAN, ROOT)
@@ -99,6 +138,51 @@ class A9EvaluatorTests(unittest.TestCase):
         with self.assertRaisesRegex(a9.NoOutcome, "reference 1001 was not captured"):
             a9.usage_record(a9.SyntheticDatabase.type1([1001]), {})
 
+    def test_complete_manifest_requires_exact_preregistered_checkpoints(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            manifest["checkpoints"].pop()
+            a9.write_canonical(manifest_path, manifest)
+            with self.assertRaisesRegex(a9.EvaluationError, "every preregistered checkpoint"):
+                a9.evaluate(manifest_path, root, root / "report.json")
+
+    def test_manifest_cannot_select_the_q5_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            manifest["memo_marker_hex"] = ""
+            a9.write_canonical(manifest_path, manifest)
+            with self.assertRaisesRegex(a9.EvaluationError, "memo marker differs"):
+                a9.evaluate(manifest_path, root, root / "report.json")
+
+    def test_q2_requires_both_preregistered_page_growth_transitions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            for entry in manifest["checkpoints"]:
+                if entry["question"] == "Q2" and entry["name"] == "01-table-created":
+                    empty = next(
+                        item
+                        for item in manifest["checkpoints"]
+                        if item["replica"] == entry["replica"]
+                        and item["question"] == "Q2"
+                        and item["name"] == "00-empty"
+                    )
+                    document = a9.load_json(root / empty["path"])
+                    document["name"] = entry["name"]
+                    raw = a9.canonical_bytes(document)
+                    (root / entry["path"]).write_bytes(raw)
+                    entry["page_count"] = document["page_count"]
+                    entry["sha256"] = a9.sha256(raw)
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertIn("page count did not grow", report["questions"]["Q2"]["reason"])
+
     def test_q4_requires_owned_map_reference_growth(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -134,6 +218,110 @@ class A9EvaluatorTests(unittest.TestCase):
         self.assertEqual(report["questions"]["Q4"]["status"], "no_outcome")
         self.assertIn("did not extend", report["questions"]["Q4"]["reason"])
 
+    def test_q4_requires_replica_consistent_free_map_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            mutate_map_bit(
+                manifest,
+                root,
+                replica=3,
+                checkpoint_name="00-created",
+                row=1,
+                page=21,
+                set_bit=True,
+            )
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertIn("replicas disagree", report["questions"]["Q4"]["reason"])
+
+    def test_q4_requires_replica_consistent_free_map_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            for replica in range(1, a9.REPLICAS + 1):
+                mutate_map_bit(
+                    manifest,
+                    root,
+                    replica=replica,
+                    checkpoint_name="00-created",
+                    row=1,
+                    page=20,
+                    set_bit=True,
+                )
+            mutate_map_bit(
+                manifest,
+                root,
+                replica=3,
+                checkpoint_name="00-created",
+                row=1,
+                page=20,
+                set_bit=False,
+            )
+            mutate_map_bit(
+                manifest,
+                root,
+                replica=3,
+                checkpoint_name="00-created",
+                row=1,
+                page=21,
+                set_bit=True,
+            )
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertIn("replicas disagree", report["questions"]["Q4"]["reason"])
+
+    def test_q4_rejects_mapped_page_outside_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            mutate_map_bit(
+                manifest,
+                root,
+                replica=1,
+                checkpoint_name="00-created",
+                row=0,
+                page=22,
+                set_bit=True,
+            )
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertIn("outside the checkpoint", report["questions"]["Q4"]["reason"])
+
+    def test_q4_rejects_free_page_not_owned(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            manifest = a9.load_json(manifest_path)
+            mutate_map_bit(
+                manifest,
+                root,
+                replica=1,
+                checkpoint_name="00-created",
+                row=0,
+                page=20,
+                set_bit=False,
+            )
+            mutate_map_bit(
+                manifest,
+                root,
+                replica=1,
+                checkpoint_name="00-created",
+                row=1,
+                page=20,
+                set_bit=True,
+            )
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertIn("not present in the owned map", report["questions"]["Q4"]["reason"])
+
     def test_row_directory_rejects_deleted_and_overflow_rows(self) -> None:
         page = bytearray(a9.PAGE_SIZE)
         page[0] = 0x01
@@ -168,6 +356,10 @@ class A9WorkflowTests(unittest.TestCase):
             "Invoke-DaoAllocationA9.ps1",
             "dao_allocation_a9.py evaluate",
             "if-no-files-found: error",
+            'GITHUB_RUN_ATTEMPT -cne "1"',
+            "WaitForExit(7200 * 1000)",
+            "--expected-source-revision",
+            "--expected-plan-sha256",
         ):
             self.assertIn(token, self.workflow)
         self.assertLess(

--- a/oracle/windows-dao/tests/test_dao_allocation_a9.py
+++ b/oracle/windows-dao/tests/test_dao_allocation_a9.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import copy
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import dao_allocation_a9 as a9  # noqa: E402
+
+
+ACQUISITION = ROOT / "oracle" / "windows-dao" / "acquisition"
+PLAN = ACQUISITION / "a9-allocation.plan.json"
+SYNTHETIC = ACQUISITION / "a9-allocation.synthetic.json"
+GENERATOR = SCRIPTS / "Invoke-DaoAllocationA9.ps1"
+WORKFLOW = ROOT / ".github" / "workflows" / "windows-dao-allocation-a9.yml"
+
+
+class A9PlanTests(unittest.TestCase):
+    def test_plan_pins_every_execution_input(self) -> None:
+        a9.validate_plan(PLAN, ROOT)
+        plan = json.loads(PLAN.read_text(encoding="utf-8"))
+        self.assertEqual(plan["issue"], 99)
+        self.assertEqual(plan["execution"]["attempts"], 1)
+        self.assertEqual(plan["execution"]["replicas"], 3)
+        self.assertFalse(plan["publication"]["mdb_bytes_committed"])
+        for relative in (
+            ".github/workflows/windows-dao-allocation-a9.yml",
+            "oracle/windows-dao/scripts/Invoke-DaoAllocationA9.ps1",
+            "oracle/windows-dao/scripts/dao_allocation_a9.py",
+            "oracle/windows-dao/scripts/probe-provider.ps1",
+        ):
+            self.assertIn(relative, plan["inputs"])
+        broken = copy.deepcopy(plan)
+        broken["inputs"]["oracle/windows-dao/scripts/dao_allocation_a9.py"] = "0" * 64
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "plan.json"
+            path.write_text(json.dumps(broken), encoding="utf-8")
+            with self.assertRaisesRegex(a9.EvaluationError, "digest differs"):
+                a9.validate_plan(path, ROOT)
+
+    def test_generator_is_bounded_and_covers_every_question(self) -> None:
+        generator = GENERATOR.read_text(encoding="utf-8")
+        for name in ("$MaximumRows", "$MaximumPages", "$MaximumTaggedPages", "Assert-Budget"):
+            self.assertIn(name, generator)
+        for question in a9.QUESTIONS:
+            self.assertIn(f'-Question "{question}"', generator)
+        self.assertIn("dao_allocation_a9_manifest", generator)
+        self.assertNotIn("Invoke-Expression", generator)
+        self.assertNotIn("CompactDatabase", generator)
+
+
+class A9EvaluatorTests(unittest.TestCase):
+    def test_synthetic_report_is_reproducible_and_non_evidentiary(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            generated = Path(temporary) / "synthetic.json"
+            a9.synthetic_dry_run(generated)
+            self.assertEqual(generated.read_bytes(), SYNTHETIC.read_bytes())
+        report = json.loads(SYNTHETIC.read_text(encoding="utf-8"))
+        self.assertFalse(report["compatibility_claim"])
+        self.assertTrue(report["consistent_input_accepted"])
+        self.assertTrue(report["inconsistent_input_rejected"])
+
+    def test_replica_disagreement_is_no_outcome_not_acceptance(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = a9.write_synthetic_artifact(root)
+            entry = next(
+                item
+                for item in a9.load_json(manifest_path)["checkpoints"]
+                if item["replica"] == 3 and item["question"] == "Q3" and item["name"] == "04-reinsert-4"
+            )
+            document = a9.load_json(root / entry["path"])
+            # Replica 3 appends a page instead of reusing one: verdicts differ.
+            document["page_count"] += 1
+            document["pages"].append(
+                {"page": 30, "sha256": a9.sha256(bytes([1]) + bytes(2047)), "hex": (bytes([1]) + bytes(2047)).hex()}
+            )
+            raw = a9.canonical_bytes(document)
+            (root / entry["path"]).write_bytes(raw)
+            manifest = a9.load_json(manifest_path)
+            for item in manifest["checkpoints"]:
+                if item["path"] == entry["path"]:
+                    item["sha256"], item["page_count"] = a9.sha256(raw), document["page_count"]
+            a9.write_canonical(manifest_path, manifest)
+            report = a9.evaluate(manifest_path, root, root / "report.json")
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(report["questions"]["Q3"]["status"], "no_outcome")
+        self.assertEqual(report["questions"]["Q1"]["status"], "answered")
+
+    def test_row_directory_rejects_deleted_and_overflow_rows(self) -> None:
+        page = bytearray(a9.PAGE_SIZE)
+        page[0] = 0x01
+        page[8:10] = (1).to_bytes(2, "little")
+        page[10:12] = (0x8000 | 2040).to_bytes(2, "little")
+        self.assertIsNone(a9.row_bytes(bytes(page), 0))
+        page[10:12] = (2040).to_bytes(2, "little")
+        self.assertEqual(len(a9.row_bytes(bytes(page), 0)), 8)
+
+
+class A9WorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_is_manual_only_with_read_only_permissions(self) -> None:
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertNotIn("push:", self.workflow)
+        self.assertNotIn("pull_request:", self.workflow)
+        self.assertRegex(self.workflow, r"permissions:\n  contents: read\n")
+        self.assertIn("windows-2022", self.workflow)
+
+    def test_gating_matches_the_read_differential(self) -> None:
+        for token in (
+            "accept_microsoft_access_runtime_license:",
+            "run_acquisition:",
+            "approve_acquisition:",
+            "plan_sha256:",
+            "a9-allocation.plan.json",
+            "dao_allocation_a9.py plan",
+            "Get-AuthenticodeSignature",
+            "Invoke-DaoAllocationA9.ps1",
+            "dao_allocation_a9.py evaluate",
+            "if-no-files-found: error",
+        ):
+            self.assertIn(token, self.workflow)
+        self.assertLess(
+            self.workflow.index("Verify preregistration and human approval"),
+            self.workflow.index("Probe the untouched runner image"),
+        )
+        self.assertNotIn("cargo", self.workflow)
+        uses = re.findall(r"^\s*-?\s*uses:\s*([^\s#]+)", self.workflow, re.MULTILINE)
+        for action in uses:
+            self.assertRegex(action, r"^[^@]+@[0-9a-f]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The writer (#100) needs allocation facts the reader never had to know: what an empty database looks like byte-for-byte, what changes when a page is appended, whether freed pages are reused, how table maps extend to a second type-`05` page, and which maps own index and long-value pages. This preregisters the single hosted DAO experiment (#99) that acquires them.

- `acquisition/a9-allocation.plan.json` pins the workflow, generator, evaluator, and probe; states Q1–Q5, bounds, and accept / reject / `no_outcome` / no-retry rules. The one decoding assumption (the `EXP-0051` global record is a `SRC-0020` type-0 record) is declared as under test.
- `Invoke-DaoAllocationA9.ps1` runs three independent replicas, closes DAO before every capture, and retains 2 KiB page images with digests.
- `dao_allocation_a9.py` verifies digests, decodes maps under `SRC-0020`/`EXP-0057`, and answers Q1–Q5 only when replicas agree structurally.
- `windows-dao-allocation-a9.yml` reuses the #98 gating: nothing touches DAO unless `run_acquisition`, `approve_acquisition`, and the exact plan SHA-256 are supplied.

The generator was exercised once on the private local VM (discovery only, no evidence): all three replicas completed and the evaluator returned `accepted` with all five questions answered.

Plan SHA-256 for approval: `2298043c7aabeb6b9a665bf44110fca26b6afd9a25a453cfed065807bed3b484`

🤖 Generated with [Claude Code](https://claude.com/claude-code)