### PR TITLE
docs(oracle): record accepted read differential

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -5944,6 +5944,66 @@ Use `not applicable` explicitly rather than omitting a field.
   or provider binary is committed or redistributed
 - Review: pending independent review
 
+### EXP-0064 — Accepted hosted protocol-1.2 read differential
+
+- Recorded: 2026-08-30, OpenAI Codex
+- Kind: accepted exact-commit hosted DAO-versus-Rust read differential
+- Question: Does the bounded Rust reader produce the same canonical semantic
+  results as DAO for every scenario in the preregistered protocol-1.2 read
+  inventory?
+- Origin: GitHub Actions run `33338088215`, attempt 1, job `99328555970`,
+  dispatched from exact clean pushed commit
+  `e6a7b2c24afa2ef386031a2e70cdedb120180a3e` under the approved
+  `read-v1_2.plan.json` SHA-256
+  `b4a05fc381efdaf56011205063c07232a77d23f99837e021242ee199cda48570`.
+  The project-authored producer created the scenario databases and DAO
+  snapshots; the project-authored evaluator generated the result report.
+- Environment: `windows-2022` image `20260824.284.2`, Windows Server 2022
+  build 20348, x86 Windows PowerShell 5.1, culture `en-US`, ANSI code page
+  1252, and UTC. The untouched image supplied x86 `DAO.DBEngine.36` version
+  3.6 from `dao360.dll` version `03.60.9765.0`, SHA-256
+  `4cc28a5be8dc7425a4c4c1ef275ca392f18be35d70232e777dce6d9f3b4d79ac`;
+  its `dbVersion30` creation probe passed, so no runtime was installed.
+- Protocol: the approved plan permitted one attempt over exactly 98 scenarios.
+  Plan verification, provider probing, the locked release build, acquisition,
+  canonical validation, Rust coverage checks, and evaluation all completed.
+  A fresh download of the retained artifact was evaluated again from the same
+  source revision with `dao_read_diff.py`; the recomputed report was
+  byte-for-byte identical to the hosted report.
+- Artifacts: access-controlled GitHub artifact
+  `windows-dao-read-e6a7b2c24afa2ef386031a2e70cdedb120180a3e-1` (id
+  `9739871270`) contains the generated MDBs, DAO snapshots, manifest,
+  comparisons, provider diagnostics, and report. `report.json` SHA-256 is
+  `d5593d9a66962b478e68bf8e764cb606911db6d8b04e41390e81b0f46cc6eea4`;
+  `dao-manifest.raw.json` SHA-256 is
+  `c66b1a1d3d29da7a0735fc96dd2c15dddae17fdf880838f26727911048acd20a`.
+- Observation: the canonical report records `all_matched=true`, 98 distinct
+  scenario results, and inventory SHA-256
+  `b1f4a2e7d4b657e35467a43196008916df86d5426a367b0aeb8d8423cda9b97f`.
+  All 95 successful-open DAO/Rust comparison projections matched, and all
+  three declared opening-error scenarios produced their expected matched
+  outcomes.
+- Interpretation: this accepted result establishes `dao_differential`
+  verification at the exact source revision only for the capability IDs
+  explicitly attached to its scenarios: `database.open`,
+  `format.header_and_version`, `format.pages_allocation_usage`,
+  `schema.catalog_and_table_definitions`, `rows.streaming_read`,
+  `values.all_dao_jet3_table_types`, `values.null_fixed_variable`,
+  `values.code_pages_lossless_raw`,
+  `values.date_currency_binary_guid_replication`,
+  `values.memo_ole_multi_page`, `indexes.primary_unique_non_unique`, and
+  `indexes.composite_ascending_descending`. Partial implementation states
+  remain partial. The result does not verify capabilities absent from the
+  inventory and makes no writer, malformed-input, Jet 4, encryption, or
+  password-support claim.
+- Usage: `file:docs/validation/support-matrix.json`;
+  `file:oracle/windows-dao/acquisition/read-v1_2.plan.json`
+- Rights: the generated MDBs, snapshots, report, and provider diagnostics
+  remain access-controlled and uncommitted; no MDB bytes or provider binaries
+  are redistributed
+- Review: report integrity independently reproduced; entry and matrix review
+  pending
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/validation/support-matrix.json
+++ b/docs/validation/support-matrix.json
@@ -4,8 +4,9 @@
     {
       "id": "database.open",
       "implementation": "partial",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/database.rs",
         "crates/jet3/src/database_tests.rs"
       ]
@@ -25,8 +26,9 @@
     {
       "id": "format.header_and_version",
       "implementation": "partial",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/database_header.rs",
         "crates/jet3/src/database_header_tests.rs",
         "crates/jet3/src/header.rs",
@@ -40,8 +42,9 @@
     {
       "id": "format.pages_allocation_usage",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/jet3_page.rs",
         "crates/jet3/src/jet3_page_tests.rs",
         "crates/jet3/src/raw_page_stream.rs",
@@ -59,8 +62,9 @@
     {
       "id": "schema.catalog_and_table_definitions",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/catalog.rs",
         "crates/jet3/src/catalog_record.rs",
         "crates/jet3/src/column_definition.rs",
@@ -80,8 +84,9 @@
     {
       "id": "values.all_dao_jet3_table_types",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/value.rs",
         "crates/jet3/src/text.rs",
         "crates/jet3/src/long_value.rs",
@@ -93,8 +98,9 @@
     {
       "id": "values.null_fixed_variable",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/row.rs",
         "crates/jet3/src/value.rs",
         "crates/jet3/src/row_tests.rs",
@@ -104,8 +110,9 @@
     {
       "id": "values.code_pages_lossless_raw",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/text.rs",
         "crates/jet3/src/text_tests.rs"
       ]
@@ -113,8 +120,9 @@
     {
       "id": "values.date_currency_binary_guid_replication",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/value.rs",
         "crates/jet3/src/value_tests.rs"
       ]
@@ -122,8 +130,9 @@
     {
       "id": "values.memo_ole_multi_page",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/long_value.rs",
         "crates/jet3/src/long_value_tests.rs"
       ]
@@ -131,8 +140,9 @@
     {
       "id": "rows.streaming_read",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/row_directory.rs",
         "crates/jet3/src/row.rs",
         "crates/jet3/src/row_directory_tests.rs",
@@ -148,8 +158,9 @@
     {
       "id": "indexes.primary_unique_non_unique",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/index_definition.rs",
         "crates/jet3/src/physical_index_definition.rs",
         "crates/jet3/src/index_tree.rs",
@@ -162,8 +173,9 @@
     {
       "id": "indexes.composite_ascending_descending",
       "implementation": "implemented",
-      "verification": "internal_only",
+      "verification": "dao_differential",
       "evidence": [
+        "docs/PROVENANCE.md",
         "crates/jet3/src/index_definition.rs",
         "crates/jet3/src/physical_index_definition.rs",
         "crates/jet3/src/index_tree.rs",

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -29,8 +29,6 @@ python3 -B oracle/windows-dao/scripts/build_v1_2_inventory.py --check
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py schemas
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py inventory \
   oracle/windows-dao/protocol/v1_2/scenarios.json
-python3 -B oracle/windows-dao/scripts/dao_read_diff.py plan \
-  oracle/windows-dao/acquisition/read-v1_2.plan.json .
 python3 -B oracle/windows-dao/scripts/dao_read_diff.py synthetic-dry-run \
   /tmp/jet3-dao-read-dry-run.json
 python3 -B oracle/windows-dao/scripts/dao_allocation_a9.py plan \
@@ -47,16 +45,14 @@ match and rejects a controlled mismatch.
 
 ## Hosted acquisition
 
-`oracle/windows-dao/acquisition/read-v1_2.plan.json` pins the inventory,
-producer, evaluator, validator, workflow, and Rust dependency lock. The
-workflow rejects acquisition before its first DAO mutation unless all three
-manual inputs are supplied: `run_acquisition=true`,
-`approve_acquisition=true`, and the exact lowercase SHA-256 of that plan.
-
-One accepted run must cover all 98 scenarios. The evaluator checks every MDB
-digest, Rust coverage verdict, snapshot pair, and comparison projection before
-writing `report.json`. The artifact upload may contain MDB bytes for review,
-but those bytes and provider binaries are never committed.
+`oracle/windows-dao/acquisition/read-v1_2.plan.json` is the immutable consumed
+plan for the accepted run recorded by `EXP-0064`. Its approved SHA-256 is
+`b4a05fc381efdaf56011205063c07232a77d23f99837e021242ee199cda48570`.
+It pins the inventory, producer, evaluator, validator, workflow, Rust source,
+and dependency lock at the acquired revision; it is not re-pinned or validated
+against later working trees. The retained evaluator checks every MDB digest,
+Rust coverage verdict, snapshot pair, and comparison projection. Artifact MDB
+bytes remain access-controlled and are never committed.
 
 ### A9 allocation (#99)
 

--- a/oracle/windows-dao/protocol/v1_2/README.md
+++ b/oracle/windows-dao/protocol/v1_2/README.md
@@ -134,10 +134,11 @@ When the reader rejects the header (`unsupported_version`,
 python3 -B oracle/windows-dao/scripts/build_v1_2_inventory.py --check
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py schemas
 python3 -B oracle/windows-dao/scripts/validate_protocol_v1_2.py inventory oracle/windows-dao/protocol/v1_2/scenarios.json
-python3 -B oracle/windows-dao/scripts/dao_read_diff.py plan oracle/windows-dao/acquisition/read-v1_2.plan.json .
 python3 -B oracle/windows-dao/scripts/dao_read_diff.py synthetic-dry-run /tmp/jet3-dao-read-dry-run.json
 python3 -B -m unittest discover -s oracle/windows-dao/tests -p 'test_protocol_validation.py' -v
 ```
 
-These documents are experiment inputs. They record no observation and move no
-capability; matrix transitions happen only after an accepted DAO differential.
+The acquisition plan remains unchanged as the consumed input for the accepted
+result recorded by `EXP-0064`; it is not re-pinned or checked against later
+working trees. The protocol and synthetic documents do not independently move
+a capability.

--- a/oracle/windows-dao/tests/test_dao_read_acquisition.py
+++ b/oracle/windows-dao/tests/test_dao_read_acquisition.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import copy
+import hashlib
 import json
 from pathlib import Path
 import sys
@@ -13,7 +13,6 @@ SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import dao_read_diff  # noqa: E402
-from protocol_validation import ValidationError  # noqa: E402
 
 
 PLAN = ROOT / "oracle" / "windows-dao" / "acquisition" / "read-v1_2.plan.json"
@@ -21,6 +20,16 @@ SYNTHETIC = (
     ROOT / "oracle" / "windows-dao" / "acquisition" / "read-v1_2.synthetic.json"
 )
 PRODUCER = SCRIPTS / "Invoke-DaoReadV12.ps1"
+PROVENANCE = ROOT / "docs" / "PROVENANCE.md"
+INVENTORY = ROOT / "oracle" / "windows-dao" / "protocol" / "v1_2" / "scenarios.json"
+SUPPORT_MATRIX = ROOT / "docs" / "validation" / "support-matrix.json"
+APPROVED_PLAN_SHA256 = (
+    "b4a05fc381efdaf56011205063c07232a77d23f99837e021242ee199cda48570"
+)
+ACCEPTED_REPORT_SHA256 = (
+    "d5593d9a66962b478e68bf8e764cb606911db6d8b04e41390e81b0f46cc6eea4"
+)
+ACCEPTED_SOURCE_REVISION = "e6a7b2c24afa2ef386031a2e70cdedb120180a3e"
 EXPECTED_EXECUTION_INPUTS = {
     ".github/workflows/windows-dao-hosted.yml",
     "Cargo.lock",
@@ -46,27 +55,70 @@ EXPECTED_SOURCE_TREES = {
     "crates/jet3-cli",
     "crates/jet3-testkit",
 }
+EXPECTED_DAO_DIFFERENTIAL_CAPABILITIES = {
+    "database.open",
+    "format.header_and_version",
+    "format.pages_allocation_usage",
+    "indexes.composite_ascending_descending",
+    "indexes.primary_unique_non_unique",
+    "rows.streaming_read",
+    "schema.catalog_and_table_definitions",
+    "values.all_dao_jet3_table_types",
+    "values.code_pages_lossless_raw",
+    "values.date_currency_binary_guid_replication",
+    "values.memo_ole_multi_page",
+    "values.null_fixed_variable",
+}
 
 
 class DaoReadAcquisitionTests(unittest.TestCase):
-    def test_preregistered_plan_pins_every_execution_input(self) -> None:
-        dao_read_diff.validate_plan(PLAN, ROOT)
+    def test_consumed_plan_and_accepted_result_remain_bound(self) -> None:
+        self.assertEqual(
+            hashlib.sha256(PLAN.read_bytes()).hexdigest(), APPROVED_PLAN_SHA256
+        )
         plan = json.loads(PLAN.read_text(encoding="utf-8"))
+        self.assertEqual(plan["document_type"], "dao_read_acquisition_plan")
+        self.assertEqual(plan["protocol_version"], "1.2.0")
         self.assertEqual(set(plan["inputs"]), EXPECTED_EXECUTION_INPUTS)
         self.assertEqual(set(plan["source_trees"]), EXPECTED_SOURCE_TREES)
+        self.assertEqual(
+            plan["inputs"]["docs/validation/support-matrix.json"],
+            "3cfb49712acbe715fa87516c9861953d31ecd495530be1ab4dfc410e209f3715",
+        )
         self.assertEqual(plan["execution"]["attempts"], 1)
         self.assertEqual(plan["execution"]["scenario_count"], 98)
         self.assertFalse(plan["publication"]["mdb_bytes_committed"])
         self.assertFalse(plan["synthetic_dry_run"]["compatibility_claim"])
 
-        broken = copy.deepcopy(plan)
-        first = next(iter(broken["inputs"]))
-        broken["inputs"][first] = "0" * 64
-        with tempfile.TemporaryDirectory() as temporary:
-            path = Path(temporary) / "plan.json"
-            path.write_text(json.dumps(broken), encoding="utf-8")
-            with self.assertRaisesRegex(ValidationError, "digest differs"):
-                dao_read_diff.validate_plan(path, ROOT)
+        provenance = PROVENANCE.read_text(encoding="utf-8")
+        result_entry = provenance.split("### EXP-0064", maxsplit=1)[1].split(
+            "\n## ", maxsplit=1
+        )[0]
+        self.assertIn(APPROVED_PLAN_SHA256, result_entry)
+        self.assertIn(ACCEPTED_REPORT_SHA256, result_entry)
+        self.assertIn(ACCEPTED_SOURCE_REVISION, result_entry)
+
+        inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+        covered_capabilities = {
+            capability
+            for scenario in inventory["scenarios"]
+            for capability in scenario["capability_ids"]
+        }
+        self.assertEqual(
+            covered_capabilities, EXPECTED_DAO_DIFFERENTIAL_CAPABILITIES
+        )
+        matrix = json.loads(SUPPORT_MATRIX.read_text(encoding="utf-8"))
+        differential_capabilities = {
+            capability["id"]
+            for capability in matrix["capabilities"]
+            if capability["verification"] == "dao_differential"
+        }
+        self.assertLessEqual(
+            EXPECTED_DAO_DIFFERENTIAL_CAPABILITIES, differential_capabilities
+        )
+        for capability in matrix["capabilities"]:
+            if capability["id"] in EXPECTED_DAO_DIFFERENTIAL_CAPABILITIES:
+                self.assertIn("docs/PROVENANCE.md", capability["evidence"])
 
     def test_dao_producer_covers_the_closed_recipe_grammar(self) -> None:
         producer = PRODUCER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- record the accepted 98/98 hosted DAO read differential as EXP-0064
- advance exactly the 12 inventory-backed read capabilities to `dao_differential`
- preserve the consumed acquisition plan byte-for-byte and bind its historical result in focused tests/docs

## Validation

- independent evaluator replay reproduced the hosted report byte-for-byte
- independent review → fix → clean re-review
- `just ready`
- Windows DAO unit tests and support-matrix/protocol validation

Closes #98