### PR TITLE
feat(jet3): plan fresh page appends

### DIFF
--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -29,6 +29,7 @@ pub mod long_value;
 pub mod map_location;
 pub mod offset;
 pub mod page;
+mod page_append_plan;
 pub mod page_image;
 pub mod page_kind;
 mod physical_index_definition;

--- a/crates/jet3/src/page_append_plan.rs
+++ b/crates/jet3/src/page_append_plan.rs
@@ -1,0 +1,142 @@
+//! Crate-private composition of complete page images with fresh append slots.
+//!
+//! This module does not build pages or perform I/O. It assigns the next
+//! physical page number to an already-complete [`PageImage`] and applies the
+//! matching global-map transition observed in `EXP-0065`.
+
+#![allow(
+    dead_code,
+    reason = "staged for the next crate-private writer composition layer"
+)]
+
+use std::fmt;
+
+use crate::{InlineUsageMapEncoder, PageImage, PageNumber, UsageMapWriteError};
+
+// EXP-0065 Q1: every empty Jet 3 database in the accepted A9 acquisition had
+// 20 pages.
+pub(crate) const EMPTY_DATABASE_PAGE_COUNT: u64 = 20;
+
+/// A complete page image paired with its planned physical page number.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedPage {
+    number: PageNumber,
+    image: PageImage,
+}
+
+impl PlannedPage {
+    /// Returns the planned physical page number.
+    pub(crate) const fn number(&self) -> PageNumber {
+        self.number
+    }
+
+    /// Returns the complete page image without interpreting its contents.
+    pub(crate) const fn image(&self) -> &PageImage {
+        &self.image
+    }
+
+    /// Splits the planned page into its number and complete image.
+    pub(crate) fn into_parts(self) -> (PageNumber, PageImage) {
+        (self.number, self.image)
+    }
+}
+
+/// Structured failure while planning one fresh page append.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AppendPageError {
+    /// The current page count cannot advance after another append.
+    PageCountOverflow {
+        /// Page count that could not be incremented.
+        page_count: u64,
+    },
+    /// The global free map already marks the append slot as in use.
+    PageAlreadyInUse {
+        /// Rejected append slot.
+        page: PageNumber,
+    },
+    /// The supplied inline map cannot represent or update the append slot.
+    GlobalMap(UsageMapWriteError),
+}
+
+impl fmt::Display for AppendPageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PageCountOverflow { page_count } => {
+                write!(formatter, "page count {page_count} cannot advance")
+            }
+            Self::PageAlreadyInUse { page } => {
+                write!(formatter, "append page {} is already in use", page.get())
+            }
+            Self::GlobalMap(source) => {
+                write!(formatter, "global usage map rejected append: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AppendPageError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::GlobalMap(source) => Some(source),
+            Self::PageCountOverflow { .. } | Self::PageAlreadyInUse { .. } => None,
+        }
+    }
+}
+
+impl From<UsageMapWriteError> for AppendPageError {
+    fn from(source: UsageMapWriteError) -> Self {
+        Self::GlobalMap(source)
+    }
+}
+
+/// Tracks append-only page numbering for a fresh database image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AppendPagePlan {
+    page_count: u64,
+}
+
+impl AppendPagePlan {
+    /// Starts immediately after the 20-page empty-database image from A9 Q1.
+    pub(crate) const fn after_empty_database() -> Self {
+        Self {
+            page_count: EMPTY_DATABASE_PAGE_COUNT,
+        }
+    }
+
+    /// Returns the page count after all successfully planned appends.
+    pub(crate) const fn page_count(self) -> u64 {
+        self.page_count
+    }
+
+    /// Assigns the next page number and marks that global-map page in use.
+    ///
+    /// `image` is moved through unchanged. The map and page count remain
+    /// unchanged if the next slot is not free, is outside the map, or the page
+    /// count cannot advance.
+    pub(crate) fn append(
+        &mut self,
+        image: PageImage,
+        global_free_map: &mut InlineUsageMapEncoder,
+    ) -> Result<PlannedPage, AppendPageError> {
+        let next_count =
+            self.page_count
+                .checked_add(1)
+                .ok_or(AppendPageError::PageCountOverflow {
+                    page_count: self.page_count,
+                })?;
+        let number = PageNumber::new(self.page_count);
+        if !global_free_map.is_set(number)? {
+            return Err(AppendPageError::PageAlreadyInUse { page: number });
+        }
+
+        // EXP-0051 and EXP-0065 Q2: a set global-map bit means free, and each
+        // newly appended page transitions to in use.
+        global_free_map.clear_page(number)?;
+        self.page_count = next_count;
+        Ok(PlannedPage { number, image })
+    }
+}
+
+#[cfg(test)]
+#[path = "page_append_plan_tests.rs"]
+mod tests;

--- a/crates/jet3/src/page_append_plan_tests.rs
+++ b/crates/jet3/src/page_append_plan_tests.rs
@@ -1,0 +1,128 @@
+use super::{AppendPageError, AppendPagePlan};
+use crate::limits::ReadLimits;
+use crate::{
+    ByteCount, InlineUsageMapEncoder, PageImage, PageKind, PageNumber, ResourceBudget,
+    ResourceLimits, UsageMapWriteError,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::new(ReadLimits::default()))
+}
+
+fn global_map(bitmap_bytes: u64) -> Result<InlineUsageMapEncoder, UsageMapWriteError> {
+    InlineUsageMapEncoder::new(
+        PageNumber::new(0),
+        ByteCount::new(bitmap_bytes),
+        &mut budget(),
+    )
+}
+
+fn free_pages(
+    map: &mut InlineUsageMapEncoder,
+    pages: impl IntoIterator<Item = u64>,
+) -> Result<(), UsageMapWriteError> {
+    for page in pages {
+        map.set_page(PageNumber::new(page))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn q2_append_sequence_numbers_complete_images_and_marks_global_in_use() -> TestResult {
+    let mut plan = AppendPagePlan::after_empty_database();
+    let mut map = global_map(4)?;
+    free_pages(&mut map, 20..=23)?;
+
+    let kinds = [
+        PageKind::TableDefinition,
+        PageKind::Data,
+        PageKind::Data,
+        PageKind::Data,
+    ];
+    for (expected, kind) in (20..=23).zip(kinds) {
+        let image = PageImage::new(kind);
+        let planned = plan.append(image.clone(), &mut map)?;
+        assert_eq!(planned.number(), PageNumber::new(expected));
+        assert_eq!(planned.image(), &image);
+        assert_eq!(planned.image().tag(), image.tag());
+        assert!(!map.is_set(PageNumber::new(expected))?);
+    }
+    assert_eq!(plan.page_count(), 24);
+    Ok(())
+}
+
+#[test]
+fn append_preserves_arbitrary_complete_page_bytes() -> TestResult {
+    let mut plan = AppendPagePlan::after_empty_database();
+    let mut map = global_map(4)?;
+    free_pages(&mut map, [20])?;
+    let mut bytes = [0xab; crate::PAGE_BYTES];
+    bytes[0] = 0xfe;
+    bytes[crate::PAGE_BYTES - 1] = 0x11;
+    let image = PageImage::from_bytes(bytes);
+
+    let (number, planned_image) = plan.append(image.clone(), &mut map)?.into_parts();
+    assert_eq!(number, PageNumber::new(20));
+    assert_eq!(planned_image, image);
+    assert_eq!(planned_image.as_bytes(), &bytes);
+    Ok(())
+}
+
+#[test]
+fn already_in_use_rejection_is_atomic() -> TestResult {
+    let mut plan = AppendPagePlan::after_empty_database();
+    let mut map = global_map(4)?;
+    let map_before = map.clone();
+
+    assert_eq!(
+        plan.append(PageImage::new(PageKind::Data), &mut map),
+        Err(AppendPageError::PageAlreadyInUse {
+            page: PageNumber::new(20),
+        })
+    );
+    assert_eq!(plan.page_count(), 20);
+    assert_eq!(map, map_before);
+    Ok(())
+}
+
+#[test]
+fn out_of_map_rejection_is_atomic() -> TestResult {
+    let mut plan = AppendPagePlan::after_empty_database();
+    let mut map = global_map(2)?;
+    let map_before = map.clone();
+
+    assert_eq!(
+        plan.append(PageImage::new(PageKind::Data), &mut map),
+        Err(AppendPageError::GlobalMap(
+            UsageMapWriteError::PageOutOfMap {
+                page: PageNumber::new(20),
+                first: PageNumber::new(0),
+                page_count: 16,
+            }
+        ))
+    );
+    assert_eq!(plan.page_count(), 20);
+    assert_eq!(map, map_before);
+    Ok(())
+}
+
+#[test]
+fn page_count_overflow_is_atomic() -> TestResult {
+    let mut plan = AppendPagePlan {
+        page_count: u64::MAX,
+    };
+    let mut map = global_map(1)?;
+    let map_before = map.clone();
+
+    assert_eq!(
+        plan.append(PageImage::new(PageKind::Data), &mut map),
+        Err(AppendPageError::PageCountOverflow {
+            page_count: u64::MAX,
+        })
+    );
+    assert_eq!(plan.page_count(), u64::MAX);
+    assert_eq!(map, map_before);
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6082,6 +6082,7 @@ Use `not applicable` explicitly rather than omitting a field.
   preregistered questions, establish no Rust correctness or DAO differential,
   and do not justify capability, compatibility, or support-matrix movement.
 - Usage: future separately reviewed writer-allocation implementation;
+  `file:crates/jet3/src/page_append_plan.rs`;
   `file:oracle/windows-dao/acquisition/a9-allocation.plan.json`;
   `file:oracle/windows-dao/scripts/dao_allocation_a9.py`
 - Rights: project-generated through the licensed Microsoft DAO provider and


### PR DESCRIPTION
## Summary

- add a crate-private append planner starting after the evidence-backed 20-page empty template
- assign fresh page numbers while atomically transitioning the matching global-map bit from free to in use
- preserve caller-complete page images without choosing or interpreting page kinds

## Scope

- no public API, I/O, allocation retention, or database bootstrap
- no schema/row/index/long-value orchestration
- no free-page reuse, extended maps, publication, or support-matrix movement

## Validation

- focused Q2 sequence and failure-atomicity tests (5/5)
- independent review → fix → clean re-review
- `just ready`

Part of #100