### PR TITLE
docs: advance v1 roadmap to writer bootstrap

### DIFF
--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -44,6 +44,9 @@ delivered in this order:
 
 ## Current next step
 
-Review and approve the SHA-256-pinned #98 acquisition plan, then run the DAO
-read differential once. The producer, evaluator, hosted workflow, and
-non-evidentiary synthetic dry run are ready.
+Continue #100 from the accepted A9 allocation result. The next writer layer
+needs a narrow local-VM bootstrap-layout observation before implementation:
+the semantic roles and references connecting the empty 20-page image, the
+first table-definition pages, its map rows, and the catalog update. This
+discovery remains development-only; #102 is the separate hosted write
+differential after database creation is complete.


### PR DESCRIPTION
The roadmap still directed contributors to approve and run #98 even though the read differential, A9 acquisition, and first bounded writer-allocation slice are merged.

This advances the current step to #100’s actual evidence boundary: a development-only local bootstrap-layout observation before the next writer layer. It keeps #102 as the separate hosted write differential and adds no implementation or support claim.

## Validation

- independent scope/evidence review
- `just ready`