### PR TITLE
feat(oracle): preregister writer bootstrap layout

### DIFF
--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -37,6 +37,7 @@ just windows-dev-table-definition
 just windows-dev-row
 just windows-dev-value
 just windows-dev-index
+just windows-dev-bootstrap-layout
 ```
 
 `provider-probe` records the Windows, x86 PowerShell, locale, and registered
@@ -87,6 +88,15 @@ It closes DAO before publishing the fixed 11 MDB filenames, never compacts,
 and keeps every database below 16 MiB. Populated GUID keys remain outside the
 observed inventory because this local provider rejected their first indexed
 insertion.
+
+`bootstrap-layout` is the SHA-256-pinned, development-only writer-bootstrap
+experiment for issue #100. It creates three fresh databases containing one
+empty Long-column table, performs the single preregistered rename used to
+separate candidate timestamps, and evaluates a finite set of read-only DAO
+ablation controls once each. Its analyzer may establish necessity, never
+sufficiency. Honest `no_outcome` results are retained without retry. The job
+does not test user rows, user indexes, relationships, publication by Rust, or
+DAO interoperability.
 
 Outputs under the external `shared/outbox/` directory are marked
 `development_only`. They are disposable diagnostics, not release evidence, and

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6094,6 +6094,49 @@ Use `not applicable` explicitly rather than omitting a field.
   byte-for-byte evaluator recomputation checked; focused A9 contract tests must
   pass
 
+### EXP-0066 — Preregistered local writer-bootstrap layout experiment
+
+- Recorded: 2026-08-30, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration; no provider
+  acquisition or format observation has occurred
+- Question: For one empty table containing one Long column, which candidate
+  page-0 byte, catalog timestamp fields, structural LvProp reference, and
+  bounded existing/appended page mutation groups can be identified, and which
+  preregistered groups are necessary for DAO read-only open and enumeration?
+- Origin: project-authored clean-room experiment design using only the DAO
+  operations documented by the retained public-source inventory and the exact
+  bounded facts recorded by `EXP-0058`, `EXP-0059`, `EXP-0061`, and
+  `EXP-0065`; no third-party MDB implementation or donated MDB is an input
+- Protocol: execute three independent fresh `dbVersion30` replicas once in the
+  private local Windows development VM. Capture empty, created, and renamed
+  checkpoints with DAO closed; use the one clock-separated rename only to
+  distinguish candidate timestamps; run created-state page ablations and
+  renamed-state timestamp ablations once through four read-only DAO endpoints;
+  verify exact clone reconstruction and unchanged post-open hashes. LvProp is
+  correlation-only because no valid empty replacement encoding is established.
+  Failures and ambiguous correlations yield an honest `no_outcome` and are not
+  retried.
+- Preregistration artifact:
+  `oracle/windows-dao/acquisition/bootstrap-layout.plan.json`, SHA-256
+  `73e402a255795eb6bd08bffa5e3611ceef219f6e810e99f9715f0e69b4aef8fc`.
+  The plan pins the host client, provider probe, guest runner, dispatcher,
+  publisher, producer, and host analyzer. The host and guest both reject input
+  digest mismatches before the first DAO mutation.
+- Observation: `preregistration.acquisition_started` is `false`. No new MDB,
+  provider output, canonical report, or scientific result exists.
+- Interpretation: this entry fixes the bounded experiment and its
+  necessity-only decision rules. It establishes no format fact, sufficiency,
+  Rust correctness, compatibility, or support result. Post-hoc inspection of
+  retained A9 or catalog MDBs remains design input only.
+- Usage: `file:oracle/windows-dao/acquisition/bootstrap-layout.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/bootstrap_layout.py`;
+  `file:docs/LOCAL_WINDOWS_VM.md`
+- Rights: future project-generated MDBs and provider outputs remain outside the
+  repository and are neither committed nor redistributed
+- Review: pending independent plan, producer, analyzer, and negative-control
+  review before local acquisition
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/justfile
+++ b/justfile
@@ -63,3 +63,7 @@ windows-dev-value:
 # Discover index-tree pages, key encodings, and relationship metadata.
 windows-dev-index:
     "{{PYTHON}}" scripts/windows-dao-dev.py index --timeout 600
+
+# Run the preregistered writer-bootstrap layout experiment in the local VM.
+windows-dev-bootstrap-layout:
+    "{{PYTHON}}" scripts/windows-dao-dev.py bootstrap-layout --timeout 900

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -18,6 +18,10 @@ The retained tooling has three purposes:
   its plan, evaluates its artifact, and runs the synthetic dry run.
   `.github/workflows/windows-dao-allocation-a9.yml` hosts it under the same
   gating as the read differential.
+- `acquisition/bootstrap-layout.plan.json`,
+  `scripts/dev/BootstrapLayout.DevJob.ps1`, and
+  `scripts/bootstrap_layout.py` define the development-only local-VM
+  preregistration that blocks the next narrow creation slice in #100.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.
@@ -35,6 +39,7 @@ python3 -B oracle/windows-dao/scripts/dao_allocation_a9.py plan \
   oracle/windows-dao/acquisition/a9-allocation.plan.json .
 python3 -B oracle/windows-dao/scripts/dao_allocation_a9.py synthetic-dry-run \
   /tmp/jet3-dao-a9-dry-run.json
+python3 -B -m unittest oracle/windows-dao/tests/test_bootstrap_layout.py -v
 python3 -B -m unittest discover -s oracle/windows-dao/tests -v
 ```
 
@@ -81,7 +86,10 @@ rejects a tampered one.
 
 ## Experiment discipline
 
-Preregister each hosted experiment as one SHA-256-pinned plan before acquiring
-data. Record the validated outcome once as an additive `EXP-` entry. A failure
-after the first DAO mutation is a scientific result and must not be retried
-without a human decision.
+Preregister each experiment as one SHA-256-pinned plan before acquiring data.
+For `bootstrap-layout`, the local client verifies every pinned input before
+staging, the guest rechecks the plan and staged producer inputs before probing
+DAO, and the host analyzer writes the canonical report after publication.
+Record the validated outcome once as an additive `EXP-` entry. A failure after
+the first DAO mutation is a scientific result and must not be retried without
+a human decision.

--- a/oracle/windows-dao/acquisition/bootstrap-layout.plan.json
+++ b/oracle/windows-dao/acquisition/bootstrap-layout.plan.json
@@ -1,0 +1,97 @@
+{
+  "document_type": "dao_bootstrap_layout_plan",
+  "issue": 100,
+  "development_only": true,
+  "purpose": "Resolve only the remaining semantic and necessity questions that block composition of one empty Long-column Jet 3 table from the accepted writer primitives.",
+  "preregistration": {
+    "acquisition_started": false,
+    "amendment_rule": "After the first DAO mutation, any failure or no_outcome is recorded once and the run is not retried without a new human decision. Before acquisition, corrections replace this plan rather than stacking revision files."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "029c871b9fbeef228f015e5561f7b8a9980645f605c398157cc75bf35c623715",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "e7e07d560484ea6399275a963591a115c9c7ac3ec069a4ca80432d8f5a403759",
+    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "e04cecec6a3678b76bd1b54bd2d77fc52b94316c1e38e584bc373654e59a4a88",
+    "oracle/windows-dao/scripts/bootstrap_layout.py": "f78e4986f00e4e303e26038bb4ee012fb2352dbe7f443fa3a5e0337f7b868d06"
+  },
+  "basis": {
+    "EXP-0058": "Dynamic catalog-root discovery, catalog-owned page 18 in the observed controls, table record identifier to table-definition correlation, and the bounded catalog row fields recorded there.",
+    "EXP-0059": "Table-definition chain and owned/free map locator meanings.",
+    "EXP-0061": "External long-value pointer, LVAL owner, and bounded row-directory structure only.",
+    "EXP-0065": "Only its preregistered Q1/Q2 facts: empty page count and tags, page append sequence, global-map transitions, and changed byte ranges. No post-hoc semantic page-role inference is admitted."
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "scenario": "For each independent replica, create one fresh dbVersion30 CP1252 database, create one empty table named BootstrapLayout with one Long field named Id, wait exactly two seconds, and rename the table to BootstrapRenamed.",
+    "checkpoints": [
+      "empty",
+      "created",
+      "renamed"
+    ],
+    "bounds": {
+      "maximum_pages_per_database": 64,
+      "maximum_table_definitions": 128,
+      "maximum_variants_per_replica": 64,
+      "maximum_replicas": 3,
+      "maximum_clock_separation_seconds": 2
+    },
+    "capture": "Close and release every DAO object before each MDB copy or hash. Retain the three closed checkpoints, bounded semantic metadata, and only the preregistered ablation clones. MDBs remain external."
+  },
+  "questions": {
+    "Q1": {
+      "title": "Candidate page-0 byte",
+      "question": "Does page-0 byte range [1538,1539) satisfy the candidate-counter hypothesis across the fixed create and rename sequence, and is its post-create value necessary for the read-only DAO endpoints?",
+      "measurement": "Record the byte value at empty, created, and renamed plus every page-0 changed range for empty-to-created and created-to-renamed. Any additional page-0 change makes this question no_outcome rather than being assigned a meaning.",
+      "ablation": "From the created checkpoint, make one clone per replica and replace exactly [1538,1539) with the empty-checkpoint byte. Test for BootstrapLayout; the rename is not part of this necessity result."
+    },
+    "Q2": {
+      "title": "Candidate catalog timestamp fields and LvProp structure",
+      "question": "Can DAO DateCreated and LastUpdated be correlated to unique eight-byte OLE Date values after the single clock-separated rename, and can the DAO-visible LvProp bytes be correlated structurally through one exact EXP-0061 external pointer/header? Which correlated timestamp values are necessary for the read-only DAO endpoints?",
+      "ablation": "If and only if a timestamp correlation is unique in the renamed checkpoint, replace that timestamp separately with valid OLE Date zero and test for BootstrapRenamed. A failed or ambiguous timestamp correlation is no_outcome and creates no variant. LvProp is correlation-only: EXP-0061 does not establish an empty replacement encoding, so this plan performs no LvProp ablation and makes no LvProp necessity claim."
+    },
+    "Q3": {
+      "title": "Required existing and appended page mutation groups",
+      "question": "Which bounded page mutation groups from empty to created are necessary for DAO to open the database, enumerate the BootstrapLayout TableDef and its Id field, and open the empty table?",
+      "ablation": "Starting from the created checkpoint, for each changed pre-existing page other than page 0 create one clone that restores the entire page from the empty checkpoint. For each appended page, create one clone that replaces the entire page with zeros. The rename transition is excluded."
+    }
+  },
+  "ablation_contract": {
+    "endpoints": [
+      "OpenDatabase read-only",
+      "TableDefs enumeration finds the base checkpoint's table: BootstrapLayout for created-state page controls or BootstrapRenamed for renamed-state timestamp controls",
+      "field enumeration finds exactly Id as Long",
+      "open that base checkpoint's table as an empty snapshot"
+    ],
+    "execution": "Run every predefined clone through the endpoints once. Hash immediately before and after DAO access; a changed hash yields no_outcome for that variant because DAO may have repaired it.",
+    "interpretation": "A failed endpoint with an unchanged post-access hash may establish necessity of that mutation group. A passing endpoint set reports not_observed_necessary. Leave-one-out results never establish sufficiency or a minimal complete mutation set."
+  },
+  "decision_rule": {
+    "accepted": "The plan and every staged input match their SHA-256 pins; the provider is ready; all three replicas and predefined variants run once; files, hashes, bounds, and result shape validate; and the analyzer emits a deterministic accepted or no_outcome report.",
+    "no_outcome": "Timestamp or LvProp ambiguity, replica disagreement, a baseline endpoint failure, a post-access hash change, or an otherwise intact but non-decisive observation is reported honestly as no_outcome.",
+    "rejected": "A plan/input digest mismatch, malformed or missing checkpoint, bound violation, unexpected variant, file digest mismatch, or result-shape failure rejects validation.",
+    "retry": "No automatic retry after the first DAO mutation."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "user rows",
+    "user indexes",
+    "relationships",
+    "free-page reuse",
+    "extended allocation maps",
+    "general long-value allocation or thresholds",
+    "public Rust API expansion",
+    "Rust publication or I/O",
+    "hosted write differential #102",
+    "compatibility or support claims"
+  ]
+}

--- a/oracle/windows-dao/scripts/bootstrap_layout.py
+++ b/oracle/windows-dao/scripts/bootstrap_layout.py
@@ -1,0 +1,1269 @@
+#!/usr/bin/env python3
+"""Validate and summarize one bounded local bootstrap-layout experiment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import struct
+import sys
+from typing import Any
+
+
+PAGE_BYTES = 2048
+REPLICA_COUNT = 3
+MAX_PAGES = 64
+MAX_ITEMS = 64
+MAX_JSON_BYTES = 1024 * 1024
+CHECKPOINT_NAMES = ("empty", "created", "renamed")
+CORRELATION_NAMES = ("date_created", "date_updated", "lvprop")
+ENDPOINT_NAMES = (
+    "open_database",
+    "table_enumerated",
+    "field_enumerated",
+    "table_opened",
+)
+VARIANT_KINDS = {
+    "candidate_page0",
+    "candidate_date_created",
+    "candidate_date_updated",
+    "revert_existing_page",
+    "zero_appended_page",
+}
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+SAFE_NAME = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,127}$")
+SAFE_MDB = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,119}[.]mdb$", re.IGNORECASE)
+HEX_BYTES = re.compile(r"^(?:[0-9a-f]{2})+$")
+
+
+class AnalysisError(ValueError):
+    """The producer result is malformed or fails an integrity check."""
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical_bytes(document: Any) -> bytes:
+    return (
+        json.dumps(
+            document,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AnalysisError(f"duplicate JSON field {key!r}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise AnalysisError("job result must be a regular file")
+    if path.stat().st_size > MAX_JSON_BYTES:
+        raise AnalysisError("job result exceeds the one-MiB bound")
+    try:
+        document = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_object_without_duplicates,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise AnalysisError(f"cannot load job result: {error}") from error
+    if not isinstance(document, dict):
+        raise AnalysisError("job result must be an object")
+    return document
+
+
+def _expect_keys(
+    value: Any,
+    required: set[str],
+    optional: set[str],
+    location: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AnalysisError(f"{location} must be an object")
+    missing = required - set(value)
+    unexpected = set(value) - required - optional
+    if missing:
+        raise AnalysisError(f"{location} is missing fields: {', '.join(sorted(missing))}")
+    if unexpected:
+        raise AnalysisError(
+            f"{location} has unexpected fields: {', '.join(sorted(unexpected))}"
+        )
+    return value
+
+
+def _integer(value: Any, location: str, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise AnalysisError(
+            f"{location} must be an integer between {minimum} and {maximum}"
+        )
+    return value
+
+
+def _detail(value: Any, location: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 512:
+        raise AnalysisError(f"{location} must be a nonempty string of at most 512 characters")
+    return value
+
+
+def _digest(value: Any, location: str) -> str:
+    if not isinstance(value, str) or not HEX_64.fullmatch(value):
+        raise AnalysisError(f"{location} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _name(value: Any, location: str) -> str:
+    if not isinstance(value, str) or not SAFE_NAME.fullmatch(value):
+        raise AnalysisError(f"{location} is malformed")
+    return value
+
+
+def _database(value: Any, location: str) -> str:
+    if not isinstance(value, str) or not SAFE_MDB.fullmatch(value):
+        raise AnalysisError(f"{location} must be an MDB basename")
+    if Path(value).name != value or "/" in value or "\\" in value:
+        raise AnalysisError(f"{location} must not contain a path")
+    return value
+
+
+def _size(value: Any, location: str) -> int:
+    size = _integer(value, location, PAGE_BYTES, MAX_PAGES * PAGE_BYTES)
+    if size % PAGE_BYTES:
+        raise AnalysisError(f"{location} is not an exact sequence of 2-KiB pages")
+    return size
+
+
+def _ranges(
+    value: Any,
+    location: str,
+    *,
+    maximum: int,
+    page: int | None,
+    allow_empty: bool = False,
+) -> list[dict[str, int]]:
+    minimum = 0 if allow_empty else 1
+    if not isinstance(value, list) or not minimum <= len(value) <= MAX_ITEMS:
+        raise AnalysisError(
+            f"{location} must contain between {minimum} and {MAX_ITEMS} ranges"
+        )
+    result: list[dict[str, int]] = []
+    previous_end = -1
+    page_start = page * PAGE_BYTES if page is not None else 0
+    page_end = page_start + PAGE_BYTES if page is not None else maximum
+    for index, raw in enumerate(value):
+        item = _expect_keys(raw, {"start", "end"}, set(), f"{location}[{index}]")
+        start = _integer(item["start"], f"{location}[{index}].start", 0, maximum)
+        end = _integer(item["end"], f"{location}[{index}].end", 0, maximum)
+        if start >= end:
+            raise AnalysisError(f"{location}[{index}] must be a nonempty half-open range")
+        if start < previous_end:
+            raise AnalysisError(f"{location} must be sorted and nonoverlapping")
+        if page is not None and not (page_start <= start < end <= page_end):
+            raise AnalysisError(f"{location}[{index}] is outside page {page}")
+        result.append({"start": start, "end": end})
+        previous_end = end
+    return result
+
+
+def _endpoints(value: dict[str, Any], location: str) -> dict[str, bool]:
+    result: dict[str, bool] = {}
+    for name in ENDPOINT_NAMES:
+        if name not in value or type(value[name]) is not bool:
+            raise AnalysisError(f"{location}.{name} must be boolean")
+        result[name] = value[name]
+    return result
+
+
+def _read_file(root: Path, database: str, size: int, digest: str, location: str) -> bytes:
+    path = root / database
+    if not path.is_file() or path.is_symlink():
+        raise AnalysisError(f"{location}.database is not an adjacent regular file")
+    data = path.read_bytes()
+    if len(data) != size:
+        raise AnalysisError(f"{location}.database size differs from metadata")
+    if sha256(data) != digest:
+        raise AnalysisError(f"{location}.database digest differs from metadata")
+    return data
+
+
+def _dao(value: Any, checkpoint: str, location: str) -> dict[str, Any]:
+    if checkpoint == "empty":
+        item = _expect_keys(value, {"table_definition_count"}, set(), location)
+        _integer(item["table_definition_count"], f"{location}.table_definition_count", 0, 128)
+        return item
+    item = _expect_keys(
+        value,
+        {
+            "table_name",
+            "date_created_oadate",
+            "last_updated_oadate",
+            "fields",
+            "lvprop",
+        },
+        set(),
+        location,
+    )
+    if not isinstance(item["table_name"], str) or not item["table_name"]:
+        raise AnalysisError(f"{location}.table_name must be nonempty")
+    for field in ("date_created_oadate", "last_updated_oadate"):
+        number = item[field]
+        if isinstance(number, bool) or not isinstance(number, (int, float)) or not math.isfinite(number):
+            raise AnalysisError(f"{location}.{field} must be a finite number")
+    fields = item["fields"]
+    if not isinstance(fields, list) or len(fields) > 128:
+        raise AnalysisError(f"{location}.fields must contain at most 128 entries")
+    for index, raw in enumerate(fields):
+        entry = _expect_keys(raw, {"name", "type"}, set(), f"{location}.fields[{index}]")
+        if not isinstance(entry["name"], str) or not entry["name"]:
+            raise AnalysisError(f"{location}.fields[{index}].name must be nonempty")
+        _integer(entry["type"], f"{location}.fields[{index}].type", -32768, 32767)
+    lvprop = _expect_keys(
+        item["lvprop"], {"status", "detail"}, {"length", "bytes_hex"}, f"{location}.lvprop"
+    )
+    _detail(lvprop["detail"], f"{location}.lvprop.detail")
+    if lvprop["status"] not in ("captured", "no_outcome"):
+        raise AnalysisError(f"{location}.lvprop.status must be captured or no_outcome")
+    if lvprop["status"] == "captured":
+        if set(lvprop) != {"status", "detail", "length", "bytes_hex"}:
+            raise AnalysisError(f"{location}.lvprop captured evidence is incomplete")
+        length = _integer(lvprop["length"], f"{location}.lvprop.length", 1, 65536)
+        encoded = lvprop["bytes_hex"]
+        if not isinstance(encoded, str) or not HEX_BYTES.fullmatch(encoded):
+            raise AnalysisError(f"{location}.lvprop.bytes_hex must be lowercase hex")
+        if len(encoded) != length * 2:
+            raise AnalysisError(f"{location}.lvprop.length differs from bytes_hex")
+    elif set(lvprop) != {"status", "detail"}:
+        raise AnalysisError(f"{location}.lvprop no_outcome must not carry captured bytes")
+    return item
+
+
+def _checkpoint(value: Any, location: str, root: Path) -> tuple[dict[str, Any], bytes]:
+    item = _expect_keys(
+        value,
+        {"name", "database", "size", "page_count", "sha256"},
+        {"dao"},
+        location,
+    )
+    if item["name"] not in CHECKPOINT_NAMES:
+        raise AnalysisError(f"{location}.name is not preregistered")
+    database = _database(item["database"], f"{location}.database")
+    size = _size(item["size"], f"{location}.size")
+    page_count = _integer(item["page_count"], f"{location}.page_count", 1, MAX_PAGES)
+    if page_count != size // PAGE_BYTES:
+        raise AnalysisError(f"{location}.page_count differs from size")
+    digest = _digest(item["sha256"], f"{location}.sha256")
+    dao = _dao(item["dao"], item["name"], f"{location}.dao") if "dao" in item else None
+    data = _read_file(root, database, size, digest, location)
+    return {
+        "database": database,
+        "dao": dao,
+        "name": item["name"],
+        "page_count": page_count,
+        "sha256": digest,
+        "size": size,
+    }, data
+
+
+def _difference_ranges(before: bytes, after: bytes, page: int) -> list[dict[str, int]]:
+    start = page * PAGE_BYTES
+    result: list[dict[str, int]] = []
+    for offset in range(start, start + PAGE_BYTES):
+        if before[offset] == after[offset]:
+            continue
+        if result and result[-1]["end"] == offset:
+            result[-1]["end"] = offset + 1
+        else:
+            result.append({"start": offset, "end": offset + 1})
+    return result
+
+
+def _offsets(ranges: list[dict[str, int]]) -> set[int]:
+    return {offset for item in ranges for offset in range(item["start"], item["end"])}
+
+
+def _find_all(data: bytes, needle: bytes) -> list[int]:
+    result: list[int] = []
+    start = 0
+    while True:
+        found = data.find(needle, start)
+        if found < 0:
+            return result
+        result.append(found)
+        start = found + 1
+
+
+def _reported_date_correlation(
+    value: Any,
+    location: str,
+    renamed: bytes,
+    oadate: float | None,
+    other: float | None,
+) -> dict[str, Any]:
+    item = _expect_keys(value, {"status", "detail"}, {"offsets"}, location)
+    _detail(item["detail"], f"{location}.detail")
+    matches = [] if oadate is None else _find_all(renamed, struct.pack("<d", oadate))
+    resolved = oadate is not None and other is not None and oadate != other and len(matches) == 1
+    if resolved:
+        if item["status"] != "resolved" or item.get("offsets") != matches:
+            raise AnalysisError(f"{location} differs from independently scanned OADate bytes")
+        return {"offsets": matches, "status": "resolved"}
+    if item["status"] != "no_outcome" or "offsets" in item:
+        raise AnalysisError(f"{location} must be no_outcome for ambiguous OADate bytes")
+    return {"status": "no_outcome"}
+
+
+def _lvprop_locator(data: bytes, payload: bytes) -> tuple[int, int, int] | None:
+    locators: list[tuple[int, int]] = []
+    for page in range(len(data) // PAGE_BYTES):
+        start = page * PAGE_BYTES
+        image = data[start : start + PAGE_BYTES]
+        if image[0] != 1 or image[4:8] != b"LVAL":
+            continue
+        rows = int.from_bytes(image[8:10], "little")
+        directory_end = 10 + 2 * rows
+        if rows > 256 or directory_end > PAGE_BYTES:
+            continue
+        prior = PAGE_BYTES
+        for row in range(rows):
+            raw = int.from_bytes(image[10 + 2 * row : 12 + 2 * row], "little")
+            offset = raw & 0x1FFF
+            if raw & 0xE000 or offset < directory_end or offset >= prior:
+                break
+            if image[offset:prior] == payload:
+                locators.append((page, row))
+            prior = offset
+    if len(locators) != 1:
+        return None
+    page, row = locators[0]
+    header = struct.pack("<I", len(payload) | 0x40000000)
+    header += bytes([row]) + page.to_bytes(3, "little") + bytes(4)
+    offsets = _find_all(data, header)
+    return (offsets[0], page, row) if len(offsets) == 1 else None
+
+
+def _reported_lvprop_correlation(
+    value: Any,
+    location: str,
+    renamed: bytes,
+    dao: dict[str, Any] | None,
+) -> dict[str, Any]:
+    item = _expect_keys(
+        value,
+        {"status", "detail"},
+        {"header_offset", "payload_page", "payload_row"},
+        location,
+    )
+    _detail(item["detail"], f"{location}.detail")
+    payload = None
+    if dao is not None and dao["lvprop"]["status"] == "captured":
+        payload = bytes.fromhex(dao["lvprop"]["bytes_hex"])
+    locator = None if payload is None else _lvprop_locator(renamed, payload)
+    if locator is None:
+        evidence = [item.get(name) for name in ("header_offset", "payload_page", "payload_row")]
+        if item["status"] != "no_outcome" or any(part is not None for part in evidence):
+            raise AnalysisError(f"{location} must be no_outcome without unique LvProp evidence")
+        return {"status": "no_outcome"}
+    expected = {
+        "header_offset": locator[0],
+        "payload_page": locator[1],
+        "payload_row": locator[2],
+    }
+    if item["status"] != "resolved" or any(item.get(name) != found for name, found in expected.items()):
+        raise AnalysisError(f"{location} differs from independently reconstructed LvProp evidence")
+    return {"status": "resolved", **expected}
+
+
+def _baseline(
+    value: Any,
+    location: str,
+    root: Path,
+    created: dict[str, Any],
+    created_bytes: bytes,
+) -> dict[str, Any]:
+    item = _expect_keys(
+        value,
+        {"database", "sha256_before_open", "sha256_after_open", *ENDPOINT_NAMES},
+        {"detail"},
+        location,
+    )
+    database = _database(item["database"], f"{location}.database")
+    before = _digest(item["sha256_before_open"], f"{location}.sha256_before_open")
+    after = _digest(item["sha256_after_open"], f"{location}.sha256_after_open")
+    if "detail" in item:
+        _detail(item["detail"], f"{location}.detail")
+    endpoints = _endpoints(item, location)
+    current = _read_file(root, database, created["size"], after, location)
+    if before != created["sha256"]:
+        raise AnalysisError(f"{location} pre-open hash differs from the created checkpoint")
+    repaired = before != after
+    if not repaired and current != created_bytes:
+        raise AnalysisError(f"{location} is not an exact created-checkpoint clone")
+    return {"endpoints": endpoints, "repaired": repaired}
+
+
+def _groups(
+    value: Any,
+    location: str,
+    maximum: int,
+    page_count: int,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or len(value) > MAX_ITEMS:
+        raise AnalysisError(f"{location} must be an array of at most {MAX_ITEMS} groups")
+    result = []
+    for index, raw in enumerate(value):
+        here = f"{location}[{index}]"
+        item = _expect_keys(raw, {"name", "page", "ranges"}, set(), here)
+        page = _integer(item["page"], f"{here}.page", 0, page_count - 1)
+        result.append(
+            {
+                "name": _name(item["name"], f"{here}.name"),
+                "page": page,
+                "ranges": _ranges(
+                    item["ranges"], f"{here}.ranges", maximum=maximum, page=page
+                ),
+            }
+        )
+    return result
+
+
+def _page0(
+    values_raw: Any,
+    ranges_raw: Any,
+    images: dict[str, bytes],
+    location: str,
+) -> tuple[dict[str, int], dict[str, list[dict[str, int]]], bool]:
+    values_item = _expect_keys(
+        values_raw, set(CHECKPOINT_NAMES), set(), f"{location}.page0_values"
+    )
+    values = {
+        name: _integer(values_item[name], f"{location}.page0_values.{name}", 0, 255)
+        for name in CHECKPOINT_NAMES
+    }
+    for name in CHECKPOINT_NAMES:
+        if images[name][1538] != values[name]:
+            raise AnalysisError(f"{location}.page0_values.{name} differs from checkpoint")
+    ranges_item = _expect_keys(
+        ranges_raw,
+        {"empty_to_created", "created_to_renamed"},
+        set(),
+        f"{location}.page0_changed_ranges",
+    )
+    transitions = {
+        name: _ranges(
+            ranges_item[name],
+            f"{location}.page0_changed_ranges.{name}",
+            maximum=PAGE_BYTES,
+            page=0,
+            allow_empty=True,
+        )
+        for name in ("empty_to_created", "created_to_renamed")
+    }
+    actual = {
+        "empty_to_created": _difference_ranges(images["empty"], images["created"], 0),
+        "created_to_renamed": _difference_ranges(images["created"], images["renamed"], 0),
+    }
+    if transitions != actual:
+        raise AnalysisError(f"{location}.page0_changed_ranges differ from checkpoints")
+    observed = _offsets(transitions["empty_to_created"])
+    if 1538 not in observed:
+        raise AnalysisError(f"{location}.page0 transition omits byte 1538")
+    renamed_observed = _offsets(transitions["created_to_renamed"])
+    isolated = observed == {1538} and renamed_observed <= {1538}
+    return values, transitions, isolated
+
+
+def _parse_variant(
+    value: Any,
+    location: str,
+    root: Path,
+    maximum: int,
+    page_count: int,
+) -> tuple[dict[str, Any], bytes]:
+    required = {
+        "name",
+        "kind",
+        "database",
+        "size",
+        "base_checkpoint",
+        "ranges",
+        "sha256_before_open",
+        "sha256_after_open",
+        "endpoints",
+    }
+    item = _expect_keys(value, required, {"page", "detail"}, location)
+    if item["kind"] not in VARIANT_KINDS:
+        raise AnalysisError(f"{location}.kind is not preregistered")
+    if item["base_checkpoint"] not in ("created", "renamed"):
+        raise AnalysisError(f"{location}.base_checkpoint must be created or renamed")
+    database = _database(item["database"], f"{location}.database")
+    size = _size(item["size"], f"{location}.size")
+    if size != maximum:
+        raise AnalysisError(f"{location}.size differs from its checkpoint size")
+    before = _digest(item["sha256_before_open"], f"{location}.sha256_before_open")
+    after = _digest(item["sha256_after_open"], f"{location}.sha256_after_open")
+    page = None
+    if "page" in item:
+        page = _integer(item["page"], f"{location}.page", 0, page_count - 1)
+    ranges = _ranges(item["ranges"], f"{location}.ranges", maximum=maximum, page=page)
+    endpoints_item = _expect_keys(
+        item["endpoints"], set(ENDPOINT_NAMES), {"detail"}, f"{location}.endpoints"
+    )
+    endpoints = _endpoints(endpoints_item, f"{location}.endpoints")
+    if "detail" in endpoints_item:
+        _detail(endpoints_item["detail"], f"{location}.endpoints.detail")
+    if "detail" in item:
+        _detail(item["detail"], f"{location}.detail")
+    data = _read_file(root, database, size, after, location)
+    return {
+        "base_checkpoint": item["base_checkpoint"],
+        "database": database,
+        "endpoints": endpoints,
+        "kind": item["kind"],
+        "name": _name(item["name"], f"{location}.name"),
+        "page": page,
+        "ranges": ranges,
+        "repaired": before != after,
+        "sha256": before,
+    }, data
+
+
+def _apply_source(base: bytes, source: bytes | None, ranges: list[dict[str, int]]) -> bytes:
+    result = bytearray(base)
+    for item in ranges:
+        start, end = item["start"], item["end"]
+        result[start:end] = bytes(end - start) if source is None else source[start:end]
+    return bytes(result)
+
+
+def _variant_outcome(variant: dict[str, Any]) -> str:
+    if variant["repaired"]:
+        return "no_outcome"
+    return "not_observed_necessary" if all(variant["endpoints"].values()) else "necessary"
+
+
+def _validate_complete_replica(
+    item: dict[str, Any], root: Path, location: str
+) -> dict[str, Any]:
+    raw_checkpoints = item["checkpoints"]
+    if not isinstance(raw_checkpoints, list) or len(raw_checkpoints) != 3:
+        raise AnalysisError(f"{location}.checkpoints must contain exactly three entries")
+    checkpoints: dict[str, dict[str, Any]] = {}
+    images: dict[str, bytes] = {}
+    databases: set[str] = set()
+    for index, raw in enumerate(raw_checkpoints):
+        checkpoint, data = _checkpoint(raw, f"{location}.checkpoints[{index}]", root)
+        if checkpoint["name"] in checkpoints or checkpoint["database"] in databases:
+            raise AnalysisError(f"{location}.checkpoints contains a duplicate")
+        checkpoints[checkpoint["name"]] = checkpoint
+        images[checkpoint["name"]] = data
+        databases.add(checkpoint["database"])
+    if set(checkpoints) != set(CHECKPOINT_NAMES):
+        raise AnalysisError(f"{location}.checkpoints do not match the required names")
+    if checkpoints["created"]["page_count"] < checkpoints["empty"]["page_count"]:
+        raise AnalysisError(f"{location}.created is shorter than empty")
+    if checkpoints["renamed"]["size"] != checkpoints["created"]["size"]:
+        raise AnalysisError(f"{location}.renamed size differs from created")
+    baseline = _baseline(
+        item["baseline"], f"{location}.baseline", root, checkpoints["created"], images["created"]
+    )
+
+    renamed_dao = checkpoints["renamed"]["dao"]
+    created_size = checkpoints["created"]["size"]
+    page_count = checkpoints["created"]["page_count"]
+    correlations_item = _expect_keys(
+        item["correlations"], set(CORRELATION_NAMES), set(), f"{location}.correlations"
+    )
+    created_date = None if renamed_dao is None else float(renamed_dao["date_created_oadate"])
+    updated_date = None if renamed_dao is None else float(renamed_dao["last_updated_oadate"])
+    correlations = {
+        "date_created": _reported_date_correlation(
+            correlations_item["date_created"],
+            f"{location}.correlations.date_created",
+            images["renamed"],
+            created_date,
+            updated_date,
+        ),
+        "date_updated": _reported_date_correlation(
+            correlations_item["date_updated"],
+            f"{location}.correlations.date_updated",
+            images["renamed"],
+            updated_date,
+            created_date,
+        ),
+        "lvprop": _reported_lvprop_correlation(
+            correlations_item["lvprop"],
+            f"{location}.correlations.lvprop",
+            images["renamed"],
+            renamed_dao,
+        ),
+    }
+    page0_values, page0_ranges, page0_isolated = _page0(
+        item["page0_values"], item["page0_changed_ranges"], images, location
+    )
+
+    changed = _groups(
+        item["changed_page_groups"], f"{location}.changed_page_groups", created_size, page_count
+    )
+    appended = _groups(
+        item["appended_page_groups"], f"{location}.appended_page_groups", created_size, page_count
+    )
+    if len(changed) + len(appended) > MAX_ITEMS:
+        raise AnalysisError(f"{location} lists too many mutation groups")
+    group_names = [group["name"] for group in changed + appended]
+    if len(group_names) != len(set(group_names)):
+        raise AnalysisError(f"{location} repeats a mutation-group name")
+    empty_pages = checkpoints["empty"]["page_count"]
+    if any(group["page"] == 0 or group["page"] >= empty_pages for group in changed):
+        raise AnalysisError(f"{location}.changed_page_groups must name existing non-page0 pages")
+    if any(group["page"] < empty_pages for group in appended):
+        raise AnalysisError(f"{location}.appended_page_groups names an existing page")
+    actual_changed = {
+        page: _difference_ranges(images["empty"], images["created"], page)
+        for page in range(1, empty_pages)
+        if images["empty"][page * PAGE_BYTES : (page + 1) * PAGE_BYTES]
+        != images["created"][page * PAGE_BYTES : (page + 1) * PAGE_BYTES]
+    }
+    listed: dict[int, list[dict[str, int]]] = {}
+    for group in changed:
+        listed.setdefault(group["page"], []).extend(group["ranges"])
+    if set(listed) != set(actual_changed):
+        raise AnalysisError(f"{location}.changed_page_groups omit or add changed pages")
+    for page, ranges in listed.items():
+        if _offsets(ranges) != _offsets(actual_changed[page]):
+            raise AnalysisError(f"{location}.changed_page_groups differ from page {page} bytes")
+        if sum(part["end"] - part["start"] for part in ranges) != len(_offsets(ranges)):
+            raise AnalysisError(f"{location}.changed_page_groups overlap on page {page}")
+    expected_appended = set(range(empty_pages, page_count))
+    appended_pages = [group["page"] for group in appended]
+    if len(appended_pages) != len(set(appended_pages)) or set(appended_pages) != expected_appended:
+        raise AnalysisError(f"{location}.appended_page_groups must name each appended page once")
+    for group in appended:
+        page = group["page"]
+        expected = [{"start": page * PAGE_BYTES, "end": (page + 1) * PAGE_BYTES}]
+        if group["ranges"] != expected:
+            raise AnalysisError(f"{location}.appended_page_groups must cover complete pages")
+
+    raw_variants = item["variants"]
+    if not isinstance(raw_variants, list) or not 1 <= len(raw_variants) <= MAX_ITEMS:
+        raise AnalysisError(f"{location}.variants must contain 1 through {MAX_ITEMS} entries")
+    variants_with_data = [
+        _parse_variant(raw, f"{location}.variants[{index}]", root, created_size, page_count)
+        for index, raw in enumerate(raw_variants)
+    ]
+    variants = [pair[0] for pair in variants_with_data]
+    if len({variant["name"] for variant in variants}) != len(variants):
+        raise AnalysisError(f"{location}.variants repeats a name")
+    by_kind = {
+        kind: [variant for variant in variants if variant["kind"] == kind]
+        for kind in VARIANT_KINDS
+    }
+    page0 = by_kind["candidate_page0"]
+    if (
+        len(page0) != 1
+        or page0[0]["name"] != "page0-byte-1538"
+        or page0[0]["page"] != 0
+        or page0[0]["ranges"] != [{"start": 1538, "end": 1539}]
+    ):
+        raise AnalysisError(f"{location} lacks the fixed candidate-page0 ablation")
+    date_kinds = {
+        "date_created": "candidate_date_created",
+        "date_updated": "candidate_date_updated",
+    }
+    for field, kind in date_kinds.items():
+        candidates = by_kind[kind]
+        resolved = correlations[field]["status"] == "resolved"
+        if len(candidates) != (1 if resolved else 0):
+            raise AnalysisError(f"{location} has the wrong number of {kind} variants")
+        if resolved:
+            expected_name = "date-created-zero" if field == "date_created" else "date-updated-zero"
+            if candidates[0]["name"] != expected_name:
+                raise AnalysisError(f"{location}.{kind} has an unexpected name")
+            expected = [
+                {"start": offset, "end": offset + 8}
+                for offset in correlations[field]["offsets"]
+            ]
+            if candidates[0]["ranges"] != expected:
+                raise AnalysisError(f"{location}.{kind} ranges differ from correlation offsets")
+
+    group_by_name = {group["name"]: ("revert_existing_page", group) for group in changed}
+    group_by_name.update({group["name"]: ("zero_appended_page", group) for group in appended})
+    group_variants = [
+        variant
+        for variant in variants
+        if variant["kind"] in ("revert_existing_page", "zero_appended_page")
+    ]
+    if {variant["name"] for variant in group_variants} != set(group_by_name):
+        raise AnalysisError(f"{location} lacks exactly one variant per mutation group")
+    for variant in group_variants:
+        expected_kind, group = group_by_name[variant["name"]]
+        if (
+            variant["kind"] != expected_kind
+            or variant["page"] != group["page"]
+            or variant["ranges"] != group["ranges"]
+        ):
+            raise AnalysisError(f"{location}.{variant['name']} differs from its mutation group")
+
+    data_by_name = {variant["name"]: data for variant, data in variants_with_data}
+    for variant in variants:
+        kind = variant["kind"]
+        expected_base = "renamed" if kind.startswith("candidate_date_") else "created"
+        if variant["base_checkpoint"] != expected_base:
+            raise AnalysisError(f"{location}.{variant['name']} has the wrong base checkpoint")
+        source = images["empty"] if kind in ("candidate_page0", "revert_existing_page") else None
+        expected = _apply_source(images[expected_base], source, variant["ranges"])
+        if sha256(expected) != variant["sha256"]:
+            raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
+        if not variant["repaired"] and data_by_name[variant["name"]] != expected:
+            raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
+        if variant["sha256"] == checkpoints[expected_base]["sha256"]:
+            raise AnalysisError(f"{location}.{variant['name']} did not mutate its base checkpoint")
+
+    summarized = [
+        {
+            "base_checkpoint": variant["base_checkpoint"],
+            "kind": variant["kind"],
+            "name": variant["name"],
+            "outcome": _variant_outcome(variant),
+            "page": variant["page"],
+            "ranges": variant["ranges"],
+        }
+        for variant in sorted(variants, key=lambda entry: entry["name"])
+    ]
+    return {
+        "baseline": baseline,
+        "checkpoints": checkpoints,
+        "complete": True,
+        "correlations": correlations,
+        "groups": {
+            group["name"]: {"kind": kind, "page": group["page"], "ranges": group["ranges"]}
+            for kind, groups in (
+                ("revert_existing_page", changed),
+                ("zero_appended_page", appended),
+            )
+            for group in groups
+        },
+        "page0_changed_ranges": page0_ranges,
+        "page0_isolated": page0_isolated,
+        "page0_values": page0_values,
+        "replica": item["replica"],
+        "status": "pass",
+        "variants": summarized,
+    }
+
+
+def _validate_partial_replica(
+    item: dict[str, Any], root: Path, location: str
+) -> dict[str, Any]:
+    raw = item.get("checkpoints", [])
+    if not isinstance(raw, list) or len(raw) > 3:
+        raise AnalysisError(f"{location}.checkpoints must contain at most three entries")
+    checkpoints: dict[str, dict[str, Any]] = {}
+    images: dict[str, bytes] = {}
+    databases: set[str] = set()
+    for index, value in enumerate(raw):
+        checkpoint, data = _checkpoint(value, f"{location}.checkpoints[{index}]", root)
+        if checkpoint["name"] in checkpoints or checkpoint["database"] in databases:
+            raise AnalysisError(f"{location}.checkpoints contains a duplicate")
+        checkpoints[checkpoint["name"]] = checkpoint
+        images[checkpoint["name"]] = data
+        databases.add(checkpoint["database"])
+
+    if "baseline" in item:
+        baseline = _expect_keys(
+            item["baseline"],
+            {"database", "sha256_before_open", "sha256_after_open", *ENDPOINT_NAMES},
+            {"detail"},
+            f"{location}.baseline",
+        )
+        _endpoints(baseline, f"{location}.baseline")
+        if "detail" in baseline:
+            _detail(baseline["detail"], f"{location}.baseline.detail")
+        identity = [
+            baseline["database"],
+            baseline["sha256_before_open"],
+            baseline["sha256_after_open"],
+        ]
+        if all(value is None for value in identity):
+            pass
+        elif any(value is None for value in identity):
+            raise AnalysisError(f"{location}.baseline has incomplete file identity")
+        else:
+            if "created" not in checkpoints:
+                raise AnalysisError(f"{location}.baseline lacks its created checkpoint")
+            _baseline(
+                item["baseline"],
+                f"{location}.baseline",
+                root,
+                checkpoints["created"],
+                images["created"],
+            )
+    has_page0 = "page0_values" in item or "page0_changed_ranges" in item
+    if has_page0:
+        values = item.get("page0_values")
+        ranges = item.get("page0_changed_ranges")
+        if values is None and ranges is None:
+            pass
+        elif values is None or ranges is None:
+            raise AnalysisError(f"{location}.page0 evidence is incomplete")
+        else:
+            if not {"empty", "created", "renamed"} <= set(checkpoints):
+                raise AnalysisError(f"{location}.page0 evidence lacks all checkpoints")
+            _page0(values, ranges, images, location)
+
+    correlations: dict[str, dict[str, Any]] | None = None
+    if "correlations" in item:
+        raw_correlations = _expect_keys(
+            item["correlations"], set(CORRELATION_NAMES), set(), f"{location}.correlations"
+        )
+        if "renamed" in checkpoints:
+            dao = checkpoints["renamed"]["dao"]
+            created_date = None if dao is None else float(dao["date_created_oadate"])
+            updated_date = None if dao is None else float(dao["last_updated_oadate"])
+            correlations = {
+                "date_created": _reported_date_correlation(
+                    raw_correlations["date_created"],
+                    f"{location}.correlations.date_created",
+                    images["renamed"],
+                    created_date,
+                    updated_date,
+                ),
+                "date_updated": _reported_date_correlation(
+                    raw_correlations["date_updated"],
+                    f"{location}.correlations.date_updated",
+                    images["renamed"],
+                    updated_date,
+                    created_date,
+                ),
+                "lvprop": _reported_lvprop_correlation(
+                    raw_correlations["lvprop"],
+                    f"{location}.correlations.lvprop",
+                    images["renamed"],
+                    dao,
+                ),
+            }
+        else:
+            correlations = {}
+            for name in ("date_created", "date_updated"):
+                correlation = _expect_keys(
+                    raw_correlations[name],
+                    {"status", "detail"},
+                    {"offsets"},
+                    f"{location}.correlations.{name}",
+                )
+                _detail(correlation["detail"], f"{location}.correlations.{name}.detail")
+                if correlation["status"] != "no_outcome" or "offsets" in correlation:
+                    raise AnalysisError(
+                        f"{location}.correlations.{name} needs a renamed checkpoint"
+                    )
+                correlations[name] = {"status": "no_outcome"}
+            lvprop = _expect_keys(
+                raw_correlations["lvprop"],
+                {"status", "detail"},
+                {"header_offset", "payload_page", "payload_row"},
+                f"{location}.correlations.lvprop",
+            )
+            _detail(lvprop["detail"], f"{location}.correlations.lvprop.detail")
+            evidence = [
+                lvprop.get(field)
+                for field in ("header_offset", "payload_page", "payload_row")
+            ]
+            if lvprop["status"] != "no_outcome" or any(value is not None for value in evidence):
+                raise AnalysisError(f"{location}.correlations.lvprop needs a renamed checkpoint")
+            correlations["lvprop"] = {"status": "no_outcome"}
+
+    changed: list[dict[str, Any]] = []
+    appended: list[dict[str, Any]] = []
+    for field in ("changed_page_groups", "appended_page_groups"):
+        if field not in item:
+            continue
+        if "created" not in checkpoints:
+            if item[field] != []:
+                raise AnalysisError(f"{location}.{field} lacks the created checkpoint")
+            continue
+        parsed = _groups(
+            item[field],
+            f"{location}.{field}",
+            checkpoints["created"]["size"],
+            checkpoints["created"]["page_count"],
+        )
+        if field == "changed_page_groups":
+            changed = parsed
+        else:
+            appended = parsed
+    group_names = [group["name"] for group in changed + appended]
+    if len(group_names) != len(set(group_names)):
+        raise AnalysisError(f"{location} repeats a mutation-group name")
+    if "empty" in checkpoints and "created" in checkpoints:
+        empty_pages = checkpoints["empty"]["page_count"]
+        if any(group["page"] == 0 or group["page"] >= empty_pages for group in changed):
+            raise AnalysisError(f"{location}.changed_page_groups has an invalid page")
+        if any(group["page"] < empty_pages for group in appended):
+            raise AnalysisError(f"{location}.appended_page_groups has an invalid page")
+        changed_pages = [group["page"] for group in changed]
+        appended_pages = [group["page"] for group in appended]
+        if len(changed_pages) != len(set(changed_pages)) or len(appended_pages) != len(
+            set(appended_pages)
+        ):
+            raise AnalysisError(f"{location} repeats a mutation-group page")
+        for group in changed:
+            actual = _difference_ranges(images["empty"], images["created"], group["page"])
+            if group["ranges"] != actual:
+                raise AnalysisError(f"{location}.{group['name']} differs from checkpoint bytes")
+        for group in appended:
+            page = group["page"]
+            if group["ranges"] != [
+                {"start": page * PAGE_BYTES, "end": (page + 1) * PAGE_BYTES}
+            ]:
+                raise AnalysisError(f"{location}.{group['name']} does not cover its full page")
+
+    if "variants" in item:
+        raw_variants = item["variants"]
+        if not isinstance(raw_variants, list) or len(raw_variants) > MAX_ITEMS:
+            raise AnalysisError(f"{location}.variants must be a bounded array")
+        if raw_variants and "created" not in checkpoints:
+            raise AnalysisError(f"{location}.variants lack the created checkpoint")
+        maximum = checkpoints["created"]["size"] if "created" in checkpoints else PAGE_BYTES
+        page_count = (
+            checkpoints["created"]["page_count"] if "created" in checkpoints else 1
+        )
+        parsed = [
+            _parse_variant(raw_variant, f"{location}.variants[{index}]", root, maximum, page_count)
+            for index, raw_variant in enumerate(raw_variants)
+        ]
+        variants = [pair[0] for pair in parsed]
+        if len({variant["name"] for variant in variants}) != len(variants):
+            raise AnalysisError(f"{location}.variants repeats a name")
+        groups = {
+            group["name"]: (kind, group)
+            for kind, entries in (
+                ("revert_existing_page", changed),
+                ("zero_appended_page", appended),
+            )
+            for group in entries
+        }
+        for variant, current in parsed:
+            kind = variant["kind"]
+            base = "renamed" if kind.startswith("candidate_date_") else "created"
+            if variant["base_checkpoint"] != base or base not in images:
+                raise AnalysisError(f"{location}.{variant['name']} has an invalid base checkpoint")
+            if kind == "candidate_page0":
+                if (
+                    variant["name"] != "page0-byte-1538"
+                    or variant["page"] != 0
+                    or variant["ranges"] != [{"start": 1538, "end": 1539}]
+                ):
+                    raise AnalysisError(f"{location}.{variant['name']} has an invalid page0 range")
+                source = images.get("empty")
+                if source is None:
+                    raise AnalysisError(f"{location}.{variant['name']} lacks the empty checkpoint")
+            elif kind.startswith("candidate_date_"):
+                field = "date_created" if kind.endswith("created") else "date_updated"
+                if correlations is None or correlations[field]["status"] != "resolved":
+                    raise AnalysisError(f"{location}.{variant['name']} lacks a resolved correlation")
+                expected_ranges = [
+                    {"start": offset, "end": offset + 8}
+                    for offset in correlations[field]["offsets"]
+                ]
+                if variant["ranges"] != expected_ranges:
+                    raise AnalysisError(f"{location}.{variant['name']} has invalid timestamp ranges")
+                expected_name = (
+                    "date-created-zero" if field == "date_created" else "date-updated-zero"
+                )
+                if variant["name"] != expected_name:
+                    raise AnalysisError(f"{location}.{variant['name']} has an invalid name")
+                source = None
+            else:
+                expected = groups.get(variant["name"])
+                if expected is None or expected[0] != kind or expected[1]["page"] != variant["page"] or expected[1]["ranges"] != variant["ranges"]:
+                    raise AnalysisError(f"{location}.{variant['name']} is not a declared mutation group")
+                source = images.get("empty") if kind == "revert_existing_page" else None
+                if kind == "revert_existing_page" and source is None:
+                    raise AnalysisError(f"{location}.{variant['name']} lacks the empty checkpoint")
+            expected_bytes = _apply_source(images[base], source, variant["ranges"])
+            if sha256(expected_bytes) != variant["sha256"]:
+                raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
+            if not variant["repaired"] and current != expected_bytes:
+                raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
+            if variant["sha256"] == checkpoints[base]["sha256"]:
+                raise AnalysisError(f"{location}.{variant['name']} did not mutate its base checkpoint")
+    return {
+        "checkpoint_sha256": {
+            name: checkpoint["sha256"] for name, checkpoint in sorted(checkpoints.items())
+        },
+        "complete": False,
+        "detail": item["detail"],
+        "replica": item["replica"],
+        "status": "no_outcome",
+    }
+
+
+def _validate_replica(value: Any, root: Path, location: str) -> dict[str, Any]:
+    inventory = {
+        "checkpoints",
+        "page0_values",
+        "page0_changed_ranges",
+        "baseline",
+        "correlations",
+        "changed_page_groups",
+        "appended_page_groups",
+        "variants",
+    }
+    item = _expect_keys(value, {"replica", "status", "detail"}, inventory, location)
+    item["replica"] = _integer(item["replica"], f"{location}.replica", 1, 3)
+    _detail(item["detail"], f"{location}.detail")
+    if item["status"] not in ("pass", "fail"):
+        raise AnalysisError(f"{location}.status must be pass or fail")
+    if item["status"] == "fail":
+        return _validate_partial_replica(item, root, location)
+    missing = inventory - set(item)
+    if missing:
+        raise AnalysisError(
+            f"{location} is missing completed inventories: {', '.join(sorted(missing))}"
+        )
+    return _validate_complete_replica(item, root, location)
+
+
+def _aggregate(values: list[str], label: str) -> dict[str, Any]:
+    if "no_outcome" in values:
+        return {
+            "reason": f"at least one {label} observation changed during DAO open",
+            "status": "no_outcome",
+        }
+    if len(set(values)) == 1:
+        return {"outcome": values[0], "status": "answered"}
+    return {"reason": f"replicas disagree for {label}", "status": "no_outcome"}
+
+
+def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> dict[str, Any]:
+    complete = all(replica["complete"] for replica in replicas)
+    if not complete:
+        reason = "at least one replica recorded a partial no_outcome"
+        questions = {
+            name: {"reason": reason, "status": "no_outcome"}
+            for name in (
+                "candidate_page0",
+                "candidate_catalog_fields",
+                "required_mutation_groups",
+            )
+        }
+    else:
+        page0 = (
+            _aggregate(
+                [
+                    next(
+                        variant["outcome"]
+                        for variant in replica["variants"]
+                        if variant["kind"] == "candidate_page0"
+                    )
+                    for replica in replicas
+                ],
+                "candidate_page0",
+            )
+            if all(replica["page0_isolated"] for replica in replicas)
+            else {
+                "reason": "create-and-rename page0 changes were not isolated to byte 1538",
+                "status": "no_outcome",
+            }
+        )
+        fields: dict[str, dict[str, Any]] = {}
+        for field, kind in (
+            ("date_created", "candidate_date_created"),
+            ("date_updated", "candidate_date_updated"),
+        ):
+            if any(replica["correlations"][field]["status"] == "no_outcome" for replica in replicas):
+                fields[field] = {
+                    "reason": "at least one replica did not resolve the correlation",
+                    "status": "no_outcome",
+                }
+            else:
+                fields[field] = _aggregate(
+                    [
+                        next(
+                            variant["outcome"]
+                            for variant in replica["variants"]
+                            if variant["kind"] == kind
+                        )
+                        for replica in replicas
+                    ],
+                    field,
+                )
+        fields["lvprop"] = (
+            {"outcome": "resolved", "status": "answered"}
+            if all(replica["correlations"]["lvprop"]["status"] == "resolved" for replica in replicas)
+            else {
+                "reason": "at least one replica did not resolve the structural correlation",
+                "status": "no_outcome",
+            }
+        )
+        catalog = {
+            "fields": fields,
+            "status": (
+                "answered"
+                if all(field["status"] == "answered" for field in fields.values())
+                else "no_outcome"
+            ),
+        }
+        group_names = [set(replica["groups"]) for replica in replicas]
+        groups: dict[str, dict[str, Any]] = {}
+        groups_status = "answered"
+        groups_reason = ""
+        if any(names != group_names[0] for names in group_names[1:]):
+            groups_status = "no_outcome"
+            groups_reason = "replicas disagree on mutation-group names"
+        else:
+            for name in sorted(group_names[0]):
+                definitions = [replica["groups"][name] for replica in replicas]
+                if any(definition != definitions[0] for definition in definitions[1:]):
+                    groups[name] = {
+                        "reason": "replicas disagree on the mutation-group definition",
+                        "status": "no_outcome",
+                    }
+                    groups_status = "no_outcome"
+                    continue
+                outcomes = [
+                    next(
+                        variant["outcome"]
+                        for variant in replica["variants"]
+                        if variant["name"] == name
+                    )
+                    for replica in replicas
+                ]
+                aggregate = _aggregate(outcomes, name)
+                groups[name] = {**definitions[0], **aggregate}
+                if aggregate["status"] == "no_outcome":
+                    groups_status = "no_outcome"
+        mutation_groups: dict[str, Any] = {"groups": groups, "status": groups_status}
+        if groups_reason:
+            mutation_groups["reason"] = groups_reason
+        questions = {
+            "candidate_catalog_fields": catalog,
+            "candidate_page0": page0,
+            "required_mutation_groups": mutation_groups,
+        }
+
+    summaries = []
+    for replica in replicas:
+        if not replica["complete"]:
+            summaries.append(
+                {
+                    "checkpoint_sha256": replica["checkpoint_sha256"],
+                    "detail": replica["detail"],
+                    "replica": replica["replica"],
+                    "status": "no_outcome",
+                }
+            )
+            continue
+        summaries.append(
+            {
+                "baseline_passed": (
+                    not replica["baseline"]["repaired"]
+                    and all(replica["baseline"]["endpoints"].values())
+                ),
+                "checkpoint_sha256": {
+                    name: replica["checkpoints"][name]["sha256"] for name in CHECKPOINT_NAMES
+                },
+                "correlations": {
+                    name: replica["correlations"][name]["status"]
+                    for name in CORRELATION_NAMES
+                },
+                "mutation_group_count": len(replica["groups"]),
+                "page0_changed_ranges": replica["page0_changed_ranges"],
+                "page0_values": replica["page0_values"],
+                "replica": replica["replica"],
+                "status": "pass",
+                "variants": replica["variants"],
+            }
+        )
+    status = "accepted"
+    if (
+        document["status"] != "pass"
+        or not complete
+        or any(
+            replica["baseline"]["repaired"]
+            or not all(replica["baseline"]["endpoints"].values())
+            for replica in replicas
+            if replica["complete"]
+        )
+        or any(question["status"] == "no_outcome" for question in questions.values())
+    ):
+        status = "no_outcome"
+    return {
+        "compatibility_claim": False,
+        "development_only": True,
+        "document_type": "bootstrap_layout_report",
+        "plan_sha256": document["plan_sha256"],
+        "questions": questions,
+        "replicas": summaries,
+        "status": status,
+        "sufficiency_claim": False,
+        "support_movement": False,
+    }
+
+
+def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[str, Any]:
+    expected = _digest(expected_plan_sha256, "--expected-plan-sha256")
+    document = load_json(job_result)
+    item = _expect_keys(
+        document,
+        {"development_only", "status", "detail", "plan_sha256", "replicas"},
+        set(),
+        "$",
+    )
+    if item["development_only"] is not True:
+        raise AnalysisError("$.development_only must be true")
+    if item["status"] not in ("pass", "fail"):
+        raise AnalysisError("$.status must be pass or fail")
+    _detail(item["detail"], "$.detail")
+    if _digest(item["plan_sha256"], "$.plan_sha256") != expected:
+        raise AnalysisError("job result plan digest differs from the approved plan")
+    raw_replicas = item["replicas"]
+    if not isinstance(raw_replicas, list) or len(raw_replicas) != REPLICA_COUNT:
+        raise AnalysisError("$.replicas must contain exactly three replicas")
+    replicas = [
+        _validate_replica(raw, job_result.parent, f"$.replicas[{index}]")
+        for index, raw in enumerate(raw_replicas)
+    ]
+    indexes = [replica["replica"] for replica in replicas]
+    if sorted(indexes) != [1, 2, 3] or len(indexes) != len(set(indexes)):
+        raise AnalysisError("$.replicas must be indexed exactly 1 through 3")
+    replicas.sort(key=lambda replica: replica["replica"])
+    report = build_report(item, replicas)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_bytes(report))
+    return report
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("job_result", type=Path)
+    result.add_argument("--expected-plan-sha256", required=True)
+    result.add_argument("--output", required=True, type=Path)
+    return result
+
+
+def main(arguments: list[str] | None = None) -> int:
+    args = parser().parse_args(arguments)
+    try:
+        evaluate(args.job_result, args.expected_plan_sha256, args.output)
+    except (AnalysisError, OSError) as error:
+        print(f"bootstrap-layout analysis failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
@@ -1,0 +1,1002 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RunRoot,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-f]{64}$')]
+    [string]$PlanSha256
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+if ($PlanSha256 -cnotmatch '^[0-9a-f]{64}$') {
+    throw "PlanSha256 must be a lowercase 64-hex digest."
+}
+
+$DbVersion30 = 32
+$DbLong = 4
+$DbOpenSnapshot = 4
+$DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
+$CreatedTableName = "BootstrapLayout"
+$RenamedTableName = "BootstrapRenamed"
+$PageSize = 2048
+$MaximumPages = 64
+$MaximumTableDefs = 128
+$MaximumCatalogRows = 512
+$MaximumLvPropBytes = 65536
+$MaximumVariants = 64
+
+function Write-JsonDocument {
+    param([string]$Path, [object]$Document)
+
+    $encoding = New-Object Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText(
+        [IO.Path]::GetFullPath($Path),
+        (($Document | ConvertTo-Json -Depth 20) + "`n"),
+        $encoding
+    )
+}
+
+function Release-ComObject {
+    param([object]$Value)
+
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function ConvertTo-Hex {
+    param([byte[]]$Bytes)
+
+    return [BitConverter]::ToString($Bytes).Replace("-", "").ToLowerInvariant()
+}
+
+function Get-BoundedFileFacts {
+    param([string]$Path)
+
+    $item = Get-Item -LiteralPath $Path
+    if (($item.Length % $PageSize) -ne 0) {
+        throw "Database is not an exact sequence of 2 KiB pages: $Path"
+    }
+    $pageCount = [long]($item.Length / $PageSize)
+    if ($pageCount -gt $MaximumPages) {
+        throw "Database exceeds the 64-page development bound: $Path"
+    }
+    return [ordered]@{
+        size = [long]$item.Length
+        page_count = $pageCount
+        sha256 = Get-Sha256 -Path $Path
+    }
+}
+
+function Invoke-WithDatabase {
+    param(
+        [string]$Path,
+        [switch]$ReadOnly,
+        [scriptblock]$Action
+    )
+
+    $engine = $null
+    $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $database = $engine.OpenDatabase($Path, $false, [bool]$ReadOnly)
+        & $Action $database
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) {
+            try { $database.Close() } catch { }
+        }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+function New-Jet3Database {
+    param([string]$Path)
+
+    $engine = $null
+    $workspace = $null
+    $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $workspace = $engine.Workspaces.Item(0)
+        $database = $workspace.CreateDatabase($Path, $DatabaseLocale, $DbVersion30)
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) {
+            try { $database.Close() } catch { }
+        }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $workspace
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+function New-BootstrapTable {
+    param([string]$Path)
+
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $table = $null
+        $field = $null
+        try {
+            $table = $database.CreateTableDef($CreatedTableName)
+            $field = $table.CreateField("Id", $DbLong)
+            $table.Fields.Append($field)
+            $database.TableDefs.Append($table)
+        }
+        finally {
+            Release-ComObject -Value $field
+            Release-ComObject -Value $table
+        }
+    }
+}
+
+function Rename-BootstrapTable {
+    param([string]$Path)
+
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $table = $null
+        $definitions = $null
+        try {
+            $definitions = $database.TableDefs
+            $table = $definitions.Item($CreatedTableName)
+            $table.Name = $RenamedTableName
+        }
+        finally {
+            Release-ComObject -Value $table
+            Release-ComObject -Value $definitions
+        }
+    }
+}
+
+function Get-LvPropSnapshot {
+    param(
+        [object]$Database,
+        [string]$TableName
+    )
+
+    $recordset = $null
+    $nameField = $null
+    $lvPropField = $null
+    try {
+        $recordset = $Database.OpenRecordset("MSysObjects", $DbOpenSnapshot, 0)
+        $rowCount = 0
+        $matches = New-Object Collections.ArrayList
+        while (-not [bool]$recordset.EOF) {
+            $rowCount++
+            if ($rowCount -gt $MaximumCatalogRows) {
+                throw "MSysObjects exceeds the 512-row development bound."
+            }
+            try {
+                $nameField = $recordset.Fields.Item("Name")
+                $name = [string]$nameField.Value
+            }
+            finally {
+                Release-ComObject -Value $nameField
+                $nameField = $null
+            }
+            if ($name -ceq $TableName) {
+                try {
+                    $lvPropField = $recordset.Fields.Item("LvProp")
+                    $value = $lvPropField.Value
+                    if ($null -eq $value) {
+                        [void]$matches.Add($null)
+                    }
+                    else {
+                        [byte[]]$bytes = $value
+                        if ($bytes.Length -gt $MaximumLvPropBytes) {
+                            throw "MSysObjects LvProp exceeds the 65536-byte development bound."
+                        }
+                        [void]$matches.Add($bytes)
+                    }
+                }
+                finally {
+                    Release-ComObject -Value $lvPropField
+                    $lvPropField = $null
+                }
+            }
+            $recordset.MoveNext()
+        }
+        if ($matches.Count -ne 1) {
+            return [pscustomobject]@{
+                report = [ordered]@{
+                    status = "no_outcome"
+                    detail = "Expected one bounded MSysObjects row for $TableName; found $($matches.Count)."
+                }
+                bytes = $null
+            }
+        }
+        if ($null -eq $matches[0] -or ([byte[]]$matches[0]).Length -eq 0) {
+            return [pscustomobject]@{
+                report = [ordered]@{
+                    status = "no_outcome"
+                    detail = "MSysObjects LvProp was null or empty."
+                }
+                bytes = $null
+            }
+        }
+        [byte[]]$captured = $matches[0]
+        return [pscustomobject]@{
+            report = [ordered]@{
+                status = "captured"
+                detail = "Captured the bounded DAO MSysObjects LvProp value."
+                length = [int]$captured.Length
+                bytes_hex = ConvertTo-Hex -Bytes $captured
+            }
+            bytes = $captured
+        }
+    }
+    catch {
+        return [pscustomobject]@{
+            report = [ordered]@{
+                status = "no_outcome"
+                detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+            }
+            bytes = $null
+        }
+    }
+    finally {
+        if ($null -ne $recordset) {
+            try { $recordset.Close() } catch { }
+        }
+        Release-ComObject -Value $lvPropField
+        Release-ComObject -Value $nameField
+        Release-ComObject -Value $recordset
+    }
+}
+
+function Get-DaoSnapshot {
+    param(
+        [string]$Path,
+        [AllowNull()][string]$TargetName
+    )
+
+    $holder = [pscustomobject]@{
+        report = $null
+        lvprop_bytes = $null
+    }
+    Invoke-WithDatabase -Path $Path -ReadOnly -Action {
+        param($database)
+        $definitions = $null
+        try {
+            $definitions = $database.TableDefs
+            $count = [int]$definitions.Count
+            if ($count -gt $MaximumTableDefs) {
+                throw "DAO returned more than 128 table definitions."
+            }
+            if ([string]::IsNullOrEmpty($TargetName)) {
+                $holder.report = [ordered]@{ table_definition_count = $count }
+                return
+            }
+
+            $matches = New-Object Collections.ArrayList
+            for ($index = 0; $index -lt $count; $index++) {
+                $table = $null
+                try {
+                    $table = $definitions.Item($index)
+                    if ([string]$table.Name -ceq $TargetName) {
+                        [void]$matches.Add($index)
+                    }
+                }
+                finally {
+                    Release-ComObject -Value $table
+                }
+            }
+            if ($matches.Count -ne 1) {
+                throw "Expected exactly one DAO TableDef named $TargetName; found $($matches.Count)."
+            }
+
+            $target = $null
+            $fields = $null
+            try {
+                $target = $definitions.Item([int]$matches[0])
+                $fieldRows = New-Object Collections.ArrayList
+                $fields = $target.Fields
+                $fieldCount = [int]$fields.Count
+                if ($fieldCount -gt 128) {
+                    throw "DAO returned more than 128 fields."
+                }
+                for ($fieldIndex = 0; $fieldIndex -lt $fieldCount; $fieldIndex++) {
+                    $field = $null
+                    try {
+                        $field = $fields.Item($fieldIndex)
+                        [void]$fieldRows.Add([ordered]@{
+                            name = [string]$field.Name
+                            type = [int]$field.Type
+                        })
+                    }
+                    finally {
+                        Release-ComObject -Value $field
+                    }
+                }
+                $lvProp = Get-LvPropSnapshot -Database $database -TableName $TargetName
+                $holder.lvprop_bytes = $lvProp.bytes
+                $holder.report = [ordered]@{
+                    table_name = [string]$target.Name
+                    date_created_oadate = [double]([datetime]$target.DateCreated).ToOADate()
+                    last_updated_oadate = [double]([datetime]$target.LastUpdated).ToOADate()
+                    fields = @($fieldRows)
+                    lvprop = $lvProp.report
+                }
+            }
+            finally {
+                Release-ComObject -Value $fields
+                Release-ComObject -Value $target
+            }
+        }
+        finally {
+            Release-ComObject -Value $definitions
+        }
+    }
+    return [pscustomobject]@{
+        report = $holder.report
+        lvprop_bytes = $holder.lvprop_bytes
+    }
+}
+
+function Save-Checkpoint {
+    param(
+        [string]$Source,
+        [int]$Replica,
+        [ValidateSet("empty", "created", "renamed")]
+        [string]$Name,
+        [AllowNull()][string]$TargetName
+    )
+
+    # DAO is closed and released by Get-DaoSnapshot before the copy and hash.
+    $dao = Get-DaoSnapshot -Path $Source -TargetName $TargetName
+    $fileName = "bootstrap-layout-r$Replica-$Name.mdb"
+    $destination = Join-Path $RunRoot $fileName
+    if ([IO.Path]::GetFullPath($Source) -ne [IO.Path]::GetFullPath($destination)) {
+        Copy-Item -LiteralPath $Source -Destination $destination
+    }
+    $facts = Get-BoundedFileFacts -Path $destination
+    return [pscustomobject]@{
+        report = [ordered]@{
+            name = $Name
+            database = $fileName
+            size = $facts.size
+            page_count = $facts.page_count
+            sha256 = $facts.sha256
+            dao = $dao.report
+        }
+        path = $destination
+        bytes = [IO.File]::ReadAllBytes($destination)
+        dao = $dao.report
+        lvprop_bytes = $dao.lvprop_bytes
+    }
+}
+
+function Find-ByteSequence {
+    param(
+        [byte[]]$Haystack,
+        [byte[]]$Needle
+    )
+
+    $matches = New-Object Collections.ArrayList
+    if ($Needle.Length -eq 0 -or $Needle.Length -gt $Haystack.Length) {
+        return @()
+    }
+    $last = $Haystack.Length - $Needle.Length
+    for ($start = 0; $start -le $last; $start++) {
+        $same = $true
+        for ($index = 0; $index -lt $Needle.Length; $index++) {
+            if ($Haystack[$start + $index] -ne $Needle[$index]) {
+                $same = $false
+                break
+            }
+        }
+        if ($same) {
+            [void]$matches.Add([long]$start)
+        }
+    }
+    return @($matches)
+}
+
+function Get-TimestampCorrelation {
+    param(
+        [double]$OaDate,
+        [double]$OtherOaDate,
+        [byte[]]$RenamedBytes
+    )
+
+    $needle = [BitConverter]::GetBytes($OaDate)
+    if ($OaDate -eq $OtherOaDate) {
+        return [pscustomobject]@{
+            report = [ordered]@{
+                status = "no_outcome"
+                detail = "DAO timestamps were equal and could not be attributed independently."
+            }
+            offsets = @()
+        }
+    }
+    $offsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle $needle)
+    if ($offsets.Count -ne 1) {
+        return [pscustomobject]@{
+            report = [ordered]@{
+                status = "no_outcome"
+                detail = "The exact DAO OLE Date byte sequence occurred $($offsets.Count) times in the renamed MDB."
+            }
+            offsets = @()
+        }
+    }
+    return [pscustomobject]@{
+        report = [ordered]@{
+            status = "resolved"
+            detail = "The exact DAO OLE Date byte sequence occurred once in the renamed MDB."
+            offsets = @($offsets)
+        }
+        offsets = @($offsets)
+    }
+}
+
+function Test-ByteRangeEqual {
+    param(
+        [byte[]]$Left,
+        [int]$LeftStart,
+        [byte[]]$Right,
+        [int]$RightStart,
+        [int]$Length
+    )
+
+    for ($index = 0; $index -lt $Length; $index++) {
+        if ($Left[$LeftStart + $index] -ne $Right[$RightStart + $index]) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Get-LvPropCorrelation {
+    param(
+        [AllowNull()][byte[]]$LvPropBytes,
+        [byte[]]$RenamedBytes
+    )
+
+    $noOutcome = {
+        param([string]$Detail)
+        return [pscustomobject]@{
+            report = [ordered]@{
+                status = "no_outcome"
+                detail = $Detail
+                header_offset = $null
+                payload_page = $null
+                payload_row = $null
+            }
+            header_offset = $null
+        }
+    }
+    if ($null -eq $LvPropBytes -or $LvPropBytes.Length -eq 0) {
+        return (& $noOutcome "DAO did not expose one bounded non-empty LvProp payload.")
+    }
+    if ($LvPropBytes.Length -gt 0x00ffffff) {
+        return (& $noOutcome "The LvProp payload exceeds the observed 24-bit external length.")
+    }
+
+    $payloadLocators = New-Object Collections.ArrayList
+    $pageCount = [int]($RenamedBytes.Length / $PageSize)
+    for ($page = 0; $page -lt $pageCount; $page++) {
+        $pageStart = $page * $PageSize
+        if ($RenamedBytes[$pageStart] -ne 1) { continue }
+        if (-not (Test-ByteRangeEqual -Left $RenamedBytes -LeftStart ($pageStart + 4) -Right ([Text.Encoding]::ASCII.GetBytes("LVAL")) -RightStart 0 -Length 4)) {
+            continue
+        }
+        $rowCount = [int][BitConverter]::ToUInt16($RenamedBytes, $pageStart + 8)
+        if ($rowCount -gt 256 -or (10 + (2 * $rowCount)) -gt $PageSize) { continue }
+        $prior = $PageSize
+        $directoryEnd = 10 + (2 * $rowCount)
+        for ($row = 0; $row -lt $rowCount; $row++) {
+            $raw = [int][BitConverter]::ToUInt16($RenamedBytes, $pageStart + 10 + (2 * $row))
+            if (($raw -band 0xe000) -ne 0) {
+                $prior = -1
+                break
+            }
+            $start = $raw -band 0x1fff
+            if ($start -lt $directoryEnd -or $start -ge $prior) {
+                $prior = -1
+                break
+            }
+            $length = $prior - $start
+            if ($length -eq $LvPropBytes.Length -and
+                (Test-ByteRangeEqual -Left $RenamedBytes -LeftStart ($pageStart + $start) -Right $LvPropBytes -RightStart 0 -Length $length)) {
+                [void]$payloadLocators.Add([ordered]@{ page = $page; row = $row })
+            }
+            $prior = $start
+        }
+    }
+    if ($payloadLocators.Count -ne 1) {
+        return (& $noOutcome "The exact DAO LvProp payload occupied $($payloadLocators.Count) complete tag-01 LVAL rows.")
+    }
+
+    $locator = $payloadLocators[0]
+    $header = New-Object byte[] 12
+    $lengthAndFlag = [uint32]$LvPropBytes.Length -bor [uint32]0x40000000
+    [BitConverter]::GetBytes($lengthAndFlag).CopyTo($header, 0)
+    $header[4] = [byte]$locator.row
+    $pageBytes = [BitConverter]::GetBytes([uint32]$locator.page)
+    $header[5] = $pageBytes[0]
+    $header[6] = $pageBytes[1]
+    $header[7] = $pageBytes[2]
+    $headerOffsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle $header)
+    if ($headerOffsets.Count -ne 1) {
+        return (& $noOutcome "The derived 12-byte single-page external LvProp header occurred $($headerOffsets.Count) times.")
+    }
+    return [pscustomobject]@{
+        report = [ordered]@{
+            status = "resolved"
+            detail = "The exact DAO payload occupied one LVAL row and its derived external header occurred once."
+            header_offset = [long]$headerOffsets[0]
+            payload_page = [int]$locator.page
+            payload_row = [int]$locator.row
+        }
+        header_offset = [long]$headerOffsets[0]
+    }
+}
+
+function Get-DifferenceRanges {
+    param(
+        [byte[]]$EmptyBytes,
+        [byte[]]$RenamedBytes,
+        [int]$Page
+    )
+
+    $ranges = New-Object Collections.ArrayList
+    $pageStart = $Page * $PageSize
+    $runStart = -1
+    for ($offset = 0; $offset -lt $PageSize; $offset++) {
+        $different = $EmptyBytes[$pageStart + $offset] -ne $RenamedBytes[$pageStart + $offset]
+        if ($different -and $runStart -lt 0) {
+            $runStart = $pageStart + $offset
+        }
+        elseif (-not $different -and $runStart -ge 0) {
+            [void]$ranges.Add([ordered]@{ start = [long]$runStart; end = [long]($pageStart + $offset) })
+            $runStart = -1
+        }
+    }
+    if ($runStart -ge 0) {
+        [void]$ranges.Add([ordered]@{ start = [long]$runStart; end = [long]($pageStart + $PageSize) })
+    }
+    return @($ranges)
+}
+
+function Test-BaselineEndpoints {
+    param(
+        [string]$Path,
+        [string]$TableName
+    )
+
+    $endpoints = [ordered]@{
+        open_database = $false
+        table_enumerated = $false
+        field_enumerated = $false
+        table_opened = $false
+        detail = $null
+    }
+    $engine = $null
+    $database = $null
+    $definitions = $null
+    $target = $null
+    $fields = $null
+    $recordset = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $database = $engine.OpenDatabase($Path, $false, $true)
+        $endpoints.open_database = $true
+        $definitions = $database.TableDefs
+        $count = [int]$definitions.Count
+        if ($count -gt $MaximumTableDefs) {
+            throw "DAO returned more than 128 table definitions."
+        }
+        $matches = New-Object Collections.ArrayList
+        for ($index = 0; $index -lt $count; $index++) {
+            $table = $null
+            try {
+                $table = $definitions.Item($index)
+                if ([string]$table.Name -ceq $TableName) {
+                    [void]$matches.Add($index)
+                }
+            }
+            finally {
+                Release-ComObject -Value $table
+            }
+        }
+        if ($matches.Count -ne 1) {
+            throw "Expected exactly one TableDef named $TableName; found $($matches.Count)."
+        }
+        $endpoints.table_enumerated = $true
+
+        $target = $definitions.Item([int]$matches[0])
+        $fields = $target.Fields
+        if ([int]$fields.Count -ne 1) {
+            throw "Expected exactly one field on $TableName."
+        }
+        $field = $null
+        try {
+            $field = $fields.Item(0)
+            if ([string]$field.Name -cne "Id" -or [int]$field.Type -ne $DbLong) {
+                throw "Expected exactly the Id Long field."
+            }
+        }
+        finally {
+            Release-ComObject -Value $field
+        }
+        $endpoints.field_enumerated = $true
+
+        $recordset = $database.OpenRecordset($TableName, $DbOpenSnapshot, 0)
+        if (-not ([bool]$recordset.BOF -and [bool]$recordset.EOF)) {
+            throw "Expected the target table snapshot to be empty."
+        }
+        $endpoints.table_opened = $true
+        $endpoints.detail = "All bounded read-only endpoints passed."
+    }
+    catch {
+        $endpoints.detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+    }
+    finally {
+        if ($null -ne $recordset) {
+            try { $recordset.Close() } catch { }
+        }
+        Release-ComObject -Value $recordset
+        Release-ComObject -Value $fields
+        Release-ComObject -Value $target
+        Release-ComObject -Value $definitions
+        if ($null -ne $database) {
+            try { $database.Close() } catch { }
+        }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+    return $endpoints
+}
+
+function Add-VariantSpec {
+    param(
+        [Collections.ArrayList]$Specs,
+        [string]$Name,
+        [string]$Kind,
+        [ValidateSet("created", "renamed")]
+        [string]$BaseCheckpoint,
+        [AllowNull()][object]$Page,
+        [object[]]$Ranges,
+        [ValidateSet("copy_byte", "zero_date", "revert_page", "zero_page")]
+        [string]$Mutation,
+        [int]$MutationOffset
+    )
+
+    [void]$Specs.Add([pscustomobject]@{
+        name = $Name
+        kind = $Kind
+        base_checkpoint = $BaseCheckpoint
+        page = $Page
+        ranges = @($Ranges)
+        mutation = $Mutation
+        mutation_offset = $MutationOffset
+    })
+}
+
+function Invoke-ReplicaCore {
+    param(
+        [int]$Replica,
+        [object]$State
+    )
+
+    $workingPath = Join-Path $RunRoot "working-r$Replica.mdb"
+    New-Jet3Database -Path $workingPath
+
+    $empty = Save-Checkpoint -Source $workingPath -Replica $Replica -Name "empty" -TargetName $null
+    [void]$State.checkpoints.Add($empty.report)
+    New-BootstrapTable -Path $workingPath
+    $created = Save-Checkpoint -Source $workingPath -Replica $Replica -Name "created" -TargetName $CreatedTableName
+    [void]$State.checkpoints.Add($created.report)
+    Start-Sleep -Seconds 2
+    Rename-BootstrapTable -Path $workingPath
+    $renamed = Save-Checkpoint -Source $workingPath -Replica $Replica -Name "renamed" -TargetName $RenamedTableName
+    [void]$State.checkpoints.Add($renamed.report)
+
+    $State.page0_values = [ordered]@{
+        empty = [int]$empty.bytes[1538]
+        created = [int]$created.bytes[1538]
+        renamed = [int]$renamed.bytes[1538]
+    }
+    $State.page0_changed_ranges = [ordered]@{
+        empty_to_created = @(Get-DifferenceRanges -EmptyBytes $empty.bytes -RenamedBytes $created.bytes -Page 0)
+        created_to_renamed = @(Get-DifferenceRanges -EmptyBytes $created.bytes -RenamedBytes $renamed.bytes -Page 0)
+    }
+
+    $dateCreated = Get-TimestampCorrelation `
+        -OaDate ([double]$renamed.dao.date_created_oadate) `
+        -OtherOaDate ([double]$renamed.dao.last_updated_oadate) `
+        -RenamedBytes $renamed.bytes
+    $dateUpdated = Get-TimestampCorrelation `
+        -OaDate ([double]$renamed.dao.last_updated_oadate) `
+        -OtherOaDate ([double]$renamed.dao.date_created_oadate) `
+        -RenamedBytes $renamed.bytes
+    $lvProp = Get-LvPropCorrelation -LvPropBytes $renamed.lvprop_bytes -RenamedBytes $renamed.bytes
+    $State.correlations = [ordered]@{
+        date_created = $dateCreated.report
+        date_updated = $dateUpdated.report
+        lvprop = $lvProp.report
+    }
+
+    $emptyPageCount = [int]$empty.report.page_count
+    $createdPageCount = [int]$created.report.page_count
+    if ($createdPageCount -lt $emptyPageCount) {
+        throw "The created database has fewer pages than the fresh database."
+    }
+    $changedPageGroups = New-Object Collections.ArrayList
+    for ($page = 1; $page -lt $emptyPageCount; $page++) {
+        $ranges = @(Get-DifferenceRanges -EmptyBytes $empty.bytes -RenamedBytes $created.bytes -Page $page)
+        if ($ranges.Count -gt 0) {
+            [void]$changedPageGroups.Add([ordered]@{
+                name = "existing-page-$page"
+                page = $page
+                ranges = @($ranges)
+            })
+        }
+    }
+    $appendedPageGroups = New-Object Collections.ArrayList
+    for ($page = $emptyPageCount; $page -lt $createdPageCount; $page++) {
+        $start = [long]($page * $PageSize)
+        [void]$appendedPageGroups.Add([ordered]@{
+            name = "appended-page-$page"
+            page = $page
+            ranges = @([ordered]@{ start = $start; end = [long]($start + $PageSize) })
+        })
+    }
+    $State.changed_page_groups = $changedPageGroups
+    $State.appended_page_groups = $appendedPageGroups
+
+    $specs = New-Object Collections.ArrayList
+    $pageZeroStart = 1538
+    Add-VariantSpec -Specs $specs -Name "page0-byte-1538" -Kind "candidate_page0" -BaseCheckpoint "created" -Page 0 `
+        -Ranges @([ordered]@{ start = [long]$pageZeroStart; end = [long]($pageZeroStart + 1) }) `
+        -Mutation "copy_byte" -MutationOffset $pageZeroStart
+    if ($dateCreated.report.status -eq "resolved") {
+        $offset = [int]$dateCreated.offsets[0]
+        Add-VariantSpec -Specs $specs -Name "date-created-zero" -Kind "candidate_date_created" -BaseCheckpoint "renamed" -Page ([int]($offset / $PageSize)) `
+            -Ranges @([ordered]@{ start = [long]$offset; end = [long]($offset + 8) }) `
+            -Mutation "zero_date" -MutationOffset $offset
+    }
+    if ($dateUpdated.report.status -eq "resolved") {
+        $offset = [int]$dateUpdated.offsets[0]
+        Add-VariantSpec -Specs $specs -Name "date-updated-zero" -Kind "candidate_date_updated" -BaseCheckpoint "renamed" -Page ([int]($offset / $PageSize)) `
+            -Ranges @([ordered]@{ start = [long]$offset; end = [long]($offset + 8) }) `
+            -Mutation "zero_date" -MutationOffset $offset
+    }
+    foreach ($group in $changedPageGroups) {
+        $page = [int]$group.page
+        Add-VariantSpec -Specs $specs -Name ([string]$group.name) -Kind "revert_existing_page" -BaseCheckpoint "created" -Page $page `
+            -Ranges @($group.ranges) -Mutation "revert_page" -MutationOffset ($page * $PageSize)
+    }
+    foreach ($group in $appendedPageGroups) {
+        $page = [int]$group.page
+        Add-VariantSpec -Specs $specs -Name ([string]$group.name) -Kind "zero_appended_page" -BaseCheckpoint "created" -Page $page `
+            -Ranges @($group.ranges) -Mutation "zero_page" -MutationOffset ($page * $PageSize)
+    }
+    if ($specs.Count -gt $MaximumVariants) {
+        throw "Replica $Replica requires more than 64 ablation variants."
+    }
+
+    $baselineName = "bootstrap-layout-r$Replica-variant-baseline-created.mdb"
+    $baselinePath = Join-Path $RunRoot $baselineName
+    try {
+        Copy-Item -LiteralPath $created.path -Destination $baselinePath
+        $baselineFactsBefore = Get-BoundedFileFacts -Path $baselinePath
+        $baselineHashBefore = [string]$baselineFactsBefore.sha256
+    }
+    catch {
+        if (Test-Path -LiteralPath $baselinePath -PathType Leaf) {
+            Remove-Item -LiteralPath $baselinePath -Force
+        }
+        throw
+    }
+    $State.baseline = [ordered]@{
+        database = $baselineName
+        sha256_before_open = $baselineHashBefore
+        sha256_after_open = $baselineHashBefore
+        open_database = $false
+        table_enumerated = $false
+        field_enumerated = $false
+        table_opened = $false
+        detail = "Baseline endpoints were not reached."
+    }
+    $baselineEndpoints = Test-BaselineEndpoints -Path $baselinePath -TableName $CreatedTableName
+    $State.baseline.open_database = [bool]$baselineEndpoints.open_database
+    $State.baseline.table_enumerated = [bool]$baselineEndpoints.table_enumerated
+    $State.baseline.field_enumerated = [bool]$baselineEndpoints.field_enumerated
+    $State.baseline.table_opened = [bool]$baselineEndpoints.table_opened
+    $State.baseline.detail = [string]$baselineEndpoints.detail
+    $baselineFactsAfter = Get-BoundedFileFacts -Path $baselinePath
+    $baselineHashAfter = [string]$baselineFactsAfter.sha256
+    $State.baseline.sha256_after_open = $baselineHashAfter
+    if ($baselineFactsAfter.size -ne $baselineFactsBefore.size) {
+        throw "DAO changed the created baseline clone size during read-only endpoint checks."
+    }
+    if ($baselineHashBefore -ne $baselineHashAfter) {
+        $State.baseline.detail = "DAO changed the created baseline clone during read-only endpoint checks."
+    }
+
+    foreach ($spec in $specs) {
+        if ($spec.name -notmatch '^[a-z0-9-]+$') {
+            throw "Variant name is not filename-safe: $($spec.name)"
+        }
+        $fileName = "bootstrap-layout-r$Replica-variant-$($spec.name).mdb"
+        $path = Join-Path $RunRoot $fileName
+        $basePath = if ($spec.base_checkpoint -eq "created") { $created.path } else { $renamed.path }
+        try {
+            Copy-Item -LiteralPath $basePath -Destination $path
+            [byte[]]$bytes = [IO.File]::ReadAllBytes($path)
+            switch ($spec.mutation) {
+                "copy_byte" {
+                    $bytes[$spec.mutation_offset] = $empty.bytes[$spec.mutation_offset]
+                }
+                "zero_date" {
+                    [Array]::Clear($bytes, $spec.mutation_offset, 8)
+                }
+                "revert_page" {
+                    [Array]::Copy(
+                        $empty.bytes,
+                        $spec.mutation_offset,
+                        $bytes,
+                        $spec.mutation_offset,
+                        $PageSize
+                    )
+                }
+                "zero_page" {
+                    [Array]::Clear($bytes, $spec.mutation_offset, $PageSize)
+                }
+            }
+            [IO.File]::WriteAllBytes($path, $bytes)
+            $variantFacts = Get-BoundedFileFacts -Path $path
+            $before = [string]$variantFacts.sha256
+        }
+        catch {
+            if (Test-Path -LiteralPath $path -PathType Leaf) {
+                Remove-Item -LiteralPath $path -Force
+            }
+            throw
+        }
+        $variant = [ordered]@{
+            name = $spec.name
+            kind = $spec.kind
+            database = $fileName
+            size = $variantFacts.size
+            base_checkpoint = $spec.base_checkpoint
+            ranges = @($spec.ranges)
+            sha256_before_open = $before
+            sha256_after_open = $before
+            endpoints = [ordered]@{
+                open_database = $false
+                table_enumerated = $false
+                field_enumerated = $false
+                table_opened = $false
+                detail = "DAO endpoints were not reached."
+            }
+            detail = "DAO endpoints were not reached."
+        }
+        if ($null -ne $spec.page) {
+            $variant.page = [int]$spec.page
+        }
+        [void]$State.variants.Add($variant)
+
+        $targetName = if ($spec.base_checkpoint -eq "created") { $CreatedTableName } else { $RenamedTableName }
+        $endpoints = Test-BaselineEndpoints -Path $path -TableName $targetName
+        $variant.endpoints = $endpoints
+        $variant.detail = [string]$endpoints.detail
+        $afterFacts = Get-BoundedFileFacts -Path $path
+        $after = [string]$afterFacts.sha256
+        $variant.sha256_after_open = $after
+        if ($afterFacts.size -ne $variant.size) {
+            throw "DAO changed a variant clone size during read-only endpoint checks."
+        }
+        $detail = [string]$endpoints.detail
+        if ($before -ne $after) {
+            $detail += " DAO changed the clone during the read-only open."
+        }
+        $variant.detail = $detail
+    }
+}
+
+function Invoke-Replica {
+    param([int]$Replica)
+
+    $state = [ordered]@{
+        replica = $Replica
+        status = "fail"
+        detail = "Replica did not start."
+        checkpoints = New-Object Collections.ArrayList
+        page0_values = $null
+        page0_changed_ranges = $null
+        baseline = [ordered]@{
+            database = $null
+            sha256_before_open = $null
+            sha256_after_open = $null
+            open_database = $false
+            table_enumerated = $false
+            field_enumerated = $false
+            table_opened = $false
+            detail = "Baseline endpoints were not reached."
+        }
+        correlations = [ordered]@{
+            date_created = [ordered]@{ status = "no_outcome"; detail = "Correlation was not reached." }
+            date_updated = [ordered]@{ status = "no_outcome"; detail = "Correlation was not reached." }
+            lvprop = [ordered]@{ status = "no_outcome"; detail = "Correlation was not reached." }
+        }
+        changed_page_groups = New-Object Collections.ArrayList
+        appended_page_groups = New-Object Collections.ArrayList
+        variants = New-Object Collections.ArrayList
+    }
+    try {
+        Invoke-ReplicaCore -Replica $Replica -State $state
+        $state.status = "pass"
+        $state.detail = "Completed the preregistered replica once without retry."
+    }
+    catch {
+        $state.status = "fail"
+        $state.detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+    }
+    finally {
+        $workingPath = Join-Path $RunRoot "working-r$Replica.mdb"
+        try {
+            if (Test-Path -LiteralPath $workingPath -PathType Leaf) {
+                Remove-Item -LiteralPath $workingPath -Force
+            }
+        }
+        catch {
+            $state.status = "fail"
+            $state.detail += " Working-file cleanup failed: " + $_.Exception.Message
+        }
+    }
+    return $state
+}
+
+[void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($RunRoot))
+$resultPath = Join-Path $RunRoot "bootstrap-layout-job-result.json"
+$replicas = New-Object Collections.ArrayList
+try {
+    foreach ($replica in 1..3) {
+        [void]$replicas.Add((Invoke-Replica -Replica $replica))
+    }
+    $result = [ordered]@{
+        development_only = $true
+        status = "pass"
+        detail = "Attempted each of the three bounded bootstrap-layout replicas once; per-replica status records partial outcomes."
+        plan_sha256 = $PlanSha256
+        replicas = @($replicas)
+    }
+    Write-JsonDocument -Path $resultPath -Document $result
+    exit 0
+}
+catch {
+    $result = [ordered]@{
+        development_only = $true
+        status = "fail"
+        detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        plan_sha256 = $PlanSha256
+        replicas = @($replicas)
+    }
+    Write-JsonDocument -Path $resultPath -Document $result
+    exit 1
+}

--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("catalog", "table-definition", "row", "value", "index")]
+    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$RunRoot,
@@ -16,7 +16,10 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$ValueJobPath,
     [Parameter(Mandatory = $true)]
-    [string]$IndexJobPath
+    [string]$IndexJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$BootstrapLayoutJobPath,
+    [string]$PlanSha256 = ""
 )
 
 Set-StrictMode -Version Latest
@@ -39,6 +42,7 @@ $scriptPath = switch ($Job) {
     "row" { $RowJobPath }
     "value" { $ValueJobPath }
     "index" { $IndexJobPath }
+    "bootstrap-layout" { $BootstrapLayoutJobPath }
 }
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
     [Console]::Error.WriteLine("INVALID: selected staged job does not exist.")
@@ -57,6 +61,9 @@ $arguments = @(
 if ($Job -ceq "table-definition") {
     $arguments += @("-TypeInputPath", $TableDefinitionTypeInputPath)
 }
+elseif ($Job -ceq "bootstrap-layout") {
+    $arguments += @("-PlanSha256", $PlanSha256)
+}
 & (Join-Path $PSHOME "powershell.exe") @arguments
 $jobExitCode = [int]$LASTEXITCODE
 $resultName = switch ($Job) {
@@ -65,6 +72,7 @@ $resultName = switch ($Job) {
     "row" { "row-job-result.json" }
     "value" { "value-job-result.json" }
     "index" { "index-job-result.json" }
+    "bootstrap-layout" { "bootstrap-layout-job-result.json" }
 }
 $resultPath = Join-Path $RunRoot $resultName
 if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
@@ -79,6 +87,7 @@ if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
         row_scenarios = @()
         value_scenarios = @()
         index_scenarios = @()
+        bootstrap_layout_replicas = @()
     }
     Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result
     exit 1
@@ -91,6 +100,7 @@ $tableDefinitionTypeResults = @()
 $rowScenarios = @()
 $valueScenarios = @()
 $indexScenarios = @()
+$bootstrapLayoutReplicas = @()
 if ($Job -ceq "catalog") { $catalogCheckpoints = @($jobResult.checkpoints) }
 elseif ($Job -ceq "table-definition") {
     $tableDefinitionCheckpoints = @($jobResult.checkpoints)
@@ -99,6 +109,9 @@ elseif ($Job -ceq "table-definition") {
 elseif ($Job -ceq "row") { $rowScenarios = @($jobResult.scenarios) }
 elseif ($Job -ceq "value") { $valueScenarios = @($jobResult.scenarios) }
 elseif ($Job -ceq "index") { $indexScenarios = @($jobResult.scenarios) }
+elseif ($Job -ceq "bootstrap-layout") {
+    $bootstrapLayoutReplicas = @($jobResult.replicas)
+}
 $result = [ordered]@{
     development_only = $true
     job = $Job
@@ -110,6 +123,7 @@ $result = [ordered]@{
     row_scenarios = @($rowScenarios)
     value_scenarios = @($valueScenarios)
     index_scenarios = @($indexScenarios)
+    bootstrap_layout_replicas = @($bootstrapLayoutReplicas)
 }
 Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result
 exit $jobExitCode

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
@@ -26,6 +26,10 @@ param(
     [string]$ValueJobPath,
     [Parameter(Mandatory = $true)]
     [string]$IndexJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$BootstrapLayoutJobPath,
+    [string]$PlanSha256 = "",
+    [string]$PlanPath = "",
     [string]$GuestOutputRoot = (Join-Path $env:LOCALAPPDATA "jet3-rs-dev")
 )
 
@@ -365,10 +369,48 @@ if ($Job -ceq "table-definition" -and
     [Console]::Error.WriteLine("INVALID: table-definition job inputs do not exist.")
     exit 2
 }
-foreach ($requiredHelper in @($DispatchPath, $PublicationPath, $RowJobPath, $ValueJobPath, $IndexJobPath)) {
+foreach ($requiredHelper in @(
+    $DispatchPath, $PublicationPath, $RowJobPath, $ValueJobPath, $IndexJobPath,
+    $BootstrapLayoutJobPath
+)) {
     if (-not (Test-Path -LiteralPath $requiredHelper -PathType Leaf)) {
         [Console]::Error.WriteLine("INVALID: staged development helper does not exist.")
         exit 2
+    }
+}
+if ($Job -ceq "bootstrap-layout" -and $PlanSha256 -cnotmatch "^[0-9a-f]{64}$") {
+    [Console]::Error.WriteLine("INVALID: bootstrap-layout plan digest is malformed.")
+    exit 2
+}
+if ($Job -ceq "bootstrap-layout") {
+    if (-not (Test-Path -LiteralPath $PlanPath -PathType Leaf)) {
+        [Console]::Error.WriteLine("INVALID: bootstrap-layout plan is missing.")
+        exit 2
+    }
+    $actualPlanSha256 = (Get-FileHash -LiteralPath $PlanPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualPlanSha256 -cne $PlanSha256) {
+        [Console]::Error.WriteLine("INVALID: bootstrap-layout plan digest differs after staging.")
+        exit 2
+    }
+    $plan = Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-Json
+    $guestInputs = [ordered]@{
+        "oracle/windows-dao/scripts/probe-provider.ps1" = $ProviderProbePath
+        "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1" = $PSCommandPath
+        "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1" = $DispatchPath
+        "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1" = $PublicationPath
+        "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1" = $BootstrapLayoutJobPath
+    }
+    foreach ($entry in $guestInputs.GetEnumerator()) {
+        $pin = $plan.inputs.PSObject.Properties[$entry.Key]
+        if ($null -eq $pin) {
+            [Console]::Error.WriteLine("INVALID: bootstrap-layout plan omits a staged input.")
+            exit 2
+        }
+        $actual = (Get-FileHash -LiteralPath $entry.Value -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actual -cne [string]$pin.Value) {
+            [Console]::Error.WriteLine("INVALID: bootstrap-layout staged input differs from its plan.")
+            exit 2
+        }
     }
 }
 
@@ -401,6 +443,7 @@ $tableDefinitionTypeResults = @()
 $rowScenarios = @()
 $valueScenarios = @()
 $indexScenarios = @()
+$bootstrapLayoutReplicas = @()
 
 if ($Job -ceq "provider-probe") {
     if ($probeExitCode -eq 0) {
@@ -626,7 +669,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
         }
     }
 }
-elseif ($Job -in @("catalog", "table-definition", "row", "value", "index") -and $probeExitCode -eq 0) {
+elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout") -and $probeExitCode -eq 0) {
     $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
@@ -636,7 +679,8 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index") -and 
             -ExecutionPolicy Bypass -File $DispatchPath -Job $Job -RunRoot $runRoot `
             -CatalogJobPath $CatalogJobPath -TableDefinitionJobPath $TableDefinitionJobPath `
             -TableDefinitionTypeInputPath $TableDefinitionTypeInputPath -RowJobPath $RowJobPath `
-            -ValueJobPath $ValueJobPath -IndexJobPath $IndexJobPath
+            -ValueJobPath $ValueJobPath -IndexJobPath $IndexJobPath `
+            -BootstrapLayoutJobPath $BootstrapLayoutJobPath -PlanSha256 $PlanSha256
         $dispatchExitCode = [int]$LASTEXITCODE
         $dispatchResultPath = Join-Path $runRoot "dispatch-result.json"
         if (-not (Test-Path -LiteralPath $dispatchResultPath -PathType Leaf)) {
@@ -653,6 +697,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index") -and 
             $rowScenarios = @($dispatchResult.row_scenarios)
             $valueScenarios = @($dispatchResult.value_scenarios)
             $indexScenarios = @($dispatchResult.index_scenarios)
+            $bootstrapLayoutReplicas = @($dispatchResult.bootstrap_layout_replicas)
             $status = [string]$dispatchResult.status
             $detail = [string]$dispatchResult.detail
             $exitCode = $dispatchExitCode
@@ -681,6 +726,8 @@ $result = [ordered]@{
     row_scenarios = @($rowScenarios)
     value_scenarios = @($valueScenarios)
     index_scenarios = @($indexScenarios)
+    plan_sha256 = $PlanSha256
+    bootstrap_layout_replicas = @($bootstrapLayoutReplicas)
     completed_at_utc = [DateTimeOffset]::UtcNow.ToString("o")
 }
 Write-JsonDocument -Path (Join-Path $runRoot "result.json") -Document $result

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$Source,
@@ -81,6 +81,45 @@ switch ($Job) {
             "relationship-created", "relationship-update", "relationship-delete",
             "relationship-cascade", "relationship-deleted"
         )) { [void]$names.Add("index-$name.mdb") }
+    }
+    "bootstrap-layout" {
+        [void]$names.Add("bootstrap-layout-job-result.json")
+        $jobResultPath = Join-Path $Source "bootstrap-layout-job-result.json"
+        if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
+            throw "Bootstrap-layout result is missing."
+        }
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $referenced = New-Object Collections.ArrayList
+        foreach ($replica in @($jobResult.replicas)) {
+            foreach ($checkpoint in @($replica.checkpoints)) {
+                [void]$referenced.Add([string]$checkpoint.database)
+            }
+            if (-not [string]::IsNullOrEmpty([string]$replica.baseline.database)) {
+                [void]$referenced.Add([string]$replica.baseline.database)
+            }
+            foreach ($variant in @($replica.variants)) {
+                [void]$referenced.Add([string]$variant.database)
+            }
+        }
+        if ($referenced.Count -gt 204) {
+            throw "Bootstrap-layout output exceeds the 204-database bound."
+        }
+        if (@($referenced | Select-Object -Unique).Count -ne $referenced.Count) {
+            throw "Bootstrap-layout result contains duplicate database names."
+        }
+        foreach ($name in $referenced) {
+            if ($name -cnotmatch '^bootstrap-layout-r[1-3]-(empty|created|renamed|variant-[a-z0-9-]+)\.mdb$') {
+                throw "Bootstrap-layout output contains an unexpected database name."
+            }
+            [void]$names.Add($name)
+        }
+        $actual = @(Get-ChildItem -LiteralPath $Source -File |
+            Where-Object { $_.Name -clike "bootstrap-layout-*.mdb" } |
+            ForEach-Object { $_.Name } | Sort-Object)
+        $expected = @($referenced | Sort-Object)
+        if (($actual -join "`n") -cne ($expected -join "`n")) {
+            throw "Bootstrap-layout MDB inventory differs from its result."
+        }
     }
 }
 

--- a/oracle/windows-dao/tests/test_bootstrap_layout.py
+++ b/oracle/windows-dao/tests/test_bootstrap_layout.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+import struct
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import bootstrap_layout as bootstrap  # noqa: E402
+
+
+PLAN_SHA256 = "a" * 64
+CREATED_DATE = 45000.25
+UPDATED_DATE = 45001.5
+PAYLOAD = b"props!"
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def endpoints(value: bool) -> dict[str, bool]:
+    return {name: value for name in bootstrap.ENDPOINT_NAMES}
+
+
+def table_dao(name: str) -> dict:
+    return {
+        "table_name": name,
+        "date_created_oadate": CREATED_DATE,
+        "last_updated_oadate": UPDATED_DATE,
+        "fields": [{"name": "Id", "type": 4}],
+        "lvprop": {
+            "status": "captured",
+            "detail": "captured once",
+            "length": len(PAYLOAD),
+            "bytes_hex": PAYLOAD.hex(),
+        },
+    }
+
+
+def write_checkpoint(
+    root: Path, replica: int, name: str, pages: list[bytearray], dao: dict
+) -> dict:
+    data = b"".join(bytes(page) for page in pages)
+    database = f"r{replica}-{name}.mdb"
+    (root / database).write_bytes(data)
+    return {
+        "name": name,
+        "database": database,
+        "size": len(data),
+        "page_count": len(pages),
+        "sha256": digest(data),
+        "dao": dao,
+    }
+
+
+def synthetic_document(root: Path) -> dict:
+    replicas = []
+    date_created_offset = 18 * bootstrap.PAGE_BYTES + 100
+    date_updated_offset = date_created_offset + 8
+    header_offset = 18 * bootstrap.PAGE_BYTES + 200
+    payload_page = 22
+    payload_row = 0
+    for replica in range(1, 4):
+        empty = [bytearray(bootstrap.PAGE_BYTES) for _ in range(20)]
+        for page, image in enumerate(empty):
+            image[0] = page % 6
+            image[20] = replica
+        created = copy.deepcopy(empty)
+        created[0][1538] = 7
+        created[1][1922] = 0x0F
+        created.extend(bytearray(bootstrap.PAGE_BYTES) for _ in range(3))
+        created[20][0] = 2
+        created[21][0] = 1
+        created[22][0] = 1
+        created[22][4:8] = b"LVAL"
+        created[22][8:10] = (1).to_bytes(2, "little")
+        payload_start = bootstrap.PAGE_BYTES - len(PAYLOAD)
+        created[22][10:12] = payload_start.to_bytes(2, "little")
+        created[22][payload_start:] = PAYLOAD
+        header = struct.pack("<I", len(PAYLOAD) | 0x40000000)
+        header += bytes([payload_row]) + payload_page.to_bytes(3, "little") + bytes(4)
+        created[18][200:212] = header
+        renamed = copy.deepcopy(created)
+        renamed[18][100:108] = struct.pack("<d", CREATED_DATE)
+        renamed[18][108:116] = struct.pack("<d", UPDATED_DATE)
+        checkpoints = [
+            write_checkpoint(root, replica, "empty", empty, {"table_definition_count": 4}),
+            write_checkpoint(root, replica, "created", created, table_dao("BootstrapLayout")),
+            write_checkpoint(root, replica, "renamed", renamed, table_dao("BootstrapRenamed")),
+        ]
+        created_bytes = b"".join(bytes(page) for page in created)
+        renamed_bytes = b"".join(bytes(page) for page in renamed)
+        empty_bytes = b"".join(bytes(page) for page in empty)
+        changed_groups = [
+            {"name": "existing-page-1", "page": 1, "ranges": [{"start": 3970, "end": 3971}]},
+            {
+                "name": "existing-page-18",
+                "page": 18,
+                "ranges": bootstrap._difference_ranges(empty_bytes, created_bytes, 18),
+            },
+        ]
+        appended_groups = [
+            {
+                "name": f"appended-page-{page}",
+                "page": page,
+                "ranges": [
+                    {
+                        "start": page * bootstrap.PAGE_BYTES,
+                        "end": (page + 1) * bootstrap.PAGE_BYTES,
+                    }
+                ],
+            }
+            for page in range(20, 23)
+        ]
+
+        def make_variant(
+            name: str,
+            kind: str,
+            base_checkpoint: str,
+            ranges: list[dict[str, int]],
+            source: bytes | None,
+            passes: bool,
+            page: int | None = None,
+        ) -> dict:
+            base = renamed_bytes if base_checkpoint == "renamed" else created_bytes
+            mutated = bytearray(base)
+            for item in ranges:
+                start, end = item["start"], item["end"]
+                mutated[start:end] = bytes(end - start) if source is None else source[start:end]
+            database = f"r{replica}-variant-{name}.mdb"
+            data = bytes(mutated)
+            (root / database).write_bytes(data)
+            result = {
+                "name": name,
+                "kind": kind,
+                "database": database,
+                "size": len(data),
+                "base_checkpoint": base_checkpoint,
+                "ranges": ranges,
+                "sha256_before_open": digest(data),
+                "sha256_after_open": digest(data),
+                "endpoints": endpoints(passes),
+                "detail": "single read-only observation",
+            }
+            if page is not None:
+                result["page"] = page
+            return result
+
+        variants = [
+            make_variant(
+                "page0-byte-1538",
+                "candidate_page0",
+                "created",
+                [{"start": 1538, "end": 1539}],
+                empty_bytes,
+                False,
+                0,
+            ),
+            make_variant(
+                "date-created-zero",
+                "candidate_date_created",
+                "renamed",
+                [{"start": date_created_offset, "end": date_created_offset + 8}],
+                None,
+                True,
+                18,
+            ),
+            make_variant(
+                "date-updated-zero",
+                "candidate_date_updated",
+                "renamed",
+                [{"start": date_updated_offset, "end": date_updated_offset + 8}],
+                None,
+                False,
+                18,
+            ),
+        ]
+        for group in changed_groups:
+            variants.append(
+                make_variant(
+                    group["name"],
+                    "revert_existing_page",
+                    "created",
+                    group["ranges"],
+                    empty_bytes,
+                    group["page"] == 1,
+                    group["page"],
+                )
+            )
+        for group in appended_groups:
+            variants.append(
+                make_variant(
+                    group["name"],
+                    "zero_appended_page",
+                    "created",
+                    group["ranges"],
+                    None,
+                    False,
+                    group["page"],
+                )
+            )
+        created_sha = checkpoints[1]["sha256"]
+        baseline_database = f"r{replica}-variant-baseline-created.mdb"
+        (root / baseline_database).write_bytes(created_bytes)
+        replicas.append(
+            {
+                "replica": replica,
+                "status": "pass",
+                "detail": "completed once",
+                "checkpoints": checkpoints,
+                "page0_values": {"empty": 0, "created": 7, "renamed": 7},
+                "page0_changed_ranges": {
+                    "empty_to_created": [{"start": 1538, "end": 1539}],
+                    "created_to_renamed": [],
+                },
+                "baseline": {
+                    "database": baseline_database,
+                    "sha256_before_open": created_sha,
+                    "sha256_after_open": created_sha,
+                    **endpoints(True),
+                    "detail": "all endpoints passed",
+                },
+                "correlations": {
+                    "date_created": {
+                        "status": "resolved",
+                        "detail": "unique",
+                        "offsets": [date_created_offset],
+                    },
+                    "date_updated": {
+                        "status": "resolved",
+                        "detail": "unique",
+                        "offsets": [date_updated_offset],
+                    },
+                    "lvprop": {
+                        "status": "resolved",
+                        "detail": "unique row and header",
+                        "header_offset": header_offset,
+                        "payload_page": payload_page,
+                        "payload_row": payload_row,
+                    },
+                },
+                "changed_page_groups": changed_groups,
+                "appended_page_groups": appended_groups,
+                "variants": variants,
+            }
+        )
+    return {
+        "development_only": True,
+        "status": "pass",
+        "detail": "attempted three replicas once",
+        "plan_sha256": PLAN_SHA256,
+        "replicas": replicas,
+    }
+
+
+def write_job(root: Path, document: dict) -> Path:
+    path = root / "bootstrap-layout-job-result.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+class BootstrapLayoutTests(unittest.TestCase):
+    def test_accepts_and_emits_deterministic_canonical_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            job = write_job(root, document)
+            first = root / "first.json"
+            second = root / "second.json"
+            report = bootstrap.evaluate(job, PLAN_SHA256, first)
+            bootstrap.evaluate(job, PLAN_SHA256, second)
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            self.assertEqual(first.read_bytes(), bootstrap.canonical_bytes(report))
+        self.assertEqual(report["status"], "accepted")
+        self.assertFalse(report["compatibility_claim"])
+        self.assertFalse(report["support_movement"])
+        self.assertFalse(report["sufficiency_claim"])
+        self.assertEqual(report["questions"]["candidate_page0"]["outcome"], "necessary")
+        self.assertEqual(
+            report["questions"]["candidate_catalog_fields"]["fields"]["lvprop"]["outcome"],
+            "resolved",
+        )
+
+    def test_partial_failed_replica_is_canonical_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            failed = document["replicas"][1]
+            document["replicas"][1] = {
+                "replica": 2,
+                "status": "fail",
+                "detail": "one-run acquisition stopped",
+                "checkpoints": failed["checkpoints"][:1],
+                "changed_page_groups": [],
+                "appended_page_groups": [],
+                "variants": [],
+            }
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(report["replicas"][1]["status"], "no_outcome")
+
+    def test_producer_shaped_early_failure_is_canonical_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            checkpoint = document["replicas"][0]["checkpoints"][0]
+            document["replicas"][0] = {
+                "replica": 1,
+                "status": "fail",
+                "detail": "failed after the empty checkpoint",
+                "checkpoints": [checkpoint],
+                "page0_values": None,
+                "page0_changed_ranges": None,
+                "baseline": {
+                    "database": None,
+                    "sha256_before_open": None,
+                    "sha256_after_open": None,
+                    **endpoints(False),
+                    "detail": "baseline was not reached",
+                },
+                "correlations": {
+                    name: {"status": "no_outcome", "detail": "not reached"}
+                    for name in bootstrap.CORRELATION_NAMES
+                },
+                "changed_page_groups": [],
+                "appended_page_groups": [],
+                "variants": [],
+            }
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(report["replicas"][0]["status"], "no_outcome")
+
+    def test_extra_created_to_renamed_page0_range_makes_q1_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            replica = document["replicas"][0]
+            renamed = replica["checkpoints"][2]
+            renamed_path = root / renamed["database"]
+            renamed_bytes = bytearray(renamed_path.read_bytes())
+            renamed_bytes[1500] = 9
+            renamed_path.write_bytes(renamed_bytes)
+            renamed["sha256"] = digest(bytes(renamed_bytes))
+            replica["page0_changed_ranges"]["created_to_renamed"] = [
+                {"start": 1500, "end": 1501}
+            ]
+            for variant in replica["variants"]:
+                if not variant["kind"].startswith("candidate_date_"):
+                    continue
+                path = root / variant["database"]
+                data = bytearray(path.read_bytes())
+                data[1500] = 9
+                path.write_bytes(data)
+                variant["sha256_before_open"] = digest(bytes(data))
+                variant["sha256_after_open"] = digest(bytes(data))
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(report["questions"]["candidate_page0"]["status"], "no_outcome")
+        self.assertEqual(
+            report["questions"]["candidate_page0"]["reason"],
+            "create-and-rename page0 changes were not isolated to byte 1538",
+        )
+
+    def test_ambiguous_timestamp_is_honest_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            for replica in document["replicas"]:
+                replica["checkpoints"][2]["dao"]["last_updated_oadate"] = CREATED_DATE
+                replica["correlations"]["date_created"] = {
+                    "status": "no_outcome",
+                    "detail": "timestamps equal",
+                }
+                replica["correlations"]["date_updated"] = {
+                    "status": "no_outcome",
+                    "detail": "timestamps equal",
+                }
+                replica["variants"] = [
+                    variant
+                    for variant in replica["variants"]
+                    if not variant["kind"].startswith("candidate_date_")
+                ]
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(report["status"], "no_outcome")
+
+    def test_repair_is_no_outcome_and_wrong_reconstruction_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            variant = document["replicas"][0]["variants"][0]
+            path = root / variant["database"]
+            repaired = bytearray(path.read_bytes())
+            repaired[500] ^= 1
+            path.write_bytes(repaired)
+            variant["sha256_after_open"] = digest(bytes(repaired))
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "a.json"
+            )
+            self.assertEqual(report["status"], "no_outcome")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            baseline = document["replicas"][0]["baseline"]
+            path = root / baseline["database"]
+            repaired = bytearray(path.read_bytes())
+            repaired[501] ^= 1
+            path.write_bytes(repaired)
+            baseline["sha256_after_open"] = digest(bytes(repaired))
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "baseline.json"
+            )
+            self.assertEqual(report["status"], "no_outcome")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            variant = document["replicas"][0]["variants"][0]
+            path = root / variant["database"]
+            data = bytearray(path.read_bytes())
+            data[500] ^= 1
+            path.write_bytes(data)
+            changed = digest(bytes(data))
+            variant["sha256_before_open"] = changed
+            variant["sha256_after_open"] = changed
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "declared mutation"):
+                bootstrap.evaluate(write_job(root, document), PLAN_SHA256, root / "b.json")
+
+    def test_rejects_garbage_variant_in_partial_failed_replica(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            original = document["replicas"][0]
+            garbage = copy.deepcopy(original["variants"][0])
+            garbage["kind"] = "unregistered_garbage"
+            document["replicas"][0] = {
+                "replica": 1,
+                "status": "fail",
+                "detail": "stopped after one invalidly reported variant",
+                "checkpoints": original["checkpoints"],
+                "variants": [garbage],
+            }
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "not preregistered"):
+                bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "report.json"
+                )
+
+    def test_rejects_missing_variant_wrong_replica_and_checkpoint_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][0]["variants"] = document["replicas"][0]["variants"][1:]
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "candidate-page0"):
+                bootstrap.evaluate(write_job(root, document), PLAN_SHA256, root / "a.json")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][2]["replica"] = 2
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "indexed exactly"):
+                bootstrap.evaluate(write_job(root, document), PLAN_SHA256, root / "b.json")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][0]["checkpoints"][0]["sha256"] = "c" * 64
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "digest differs"):
+                bootstrap.evaluate(write_job(root, document), PLAN_SHA256, root / "c.json")
+
+    def test_cli_rejects_malformed_plan_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["plan_sha256"] = "A" * 64
+            code = bootstrap.main(
+                [
+                    str(write_job(root, document)),
+                    "--expected-plan-sha256",
+                    PLAN_SHA256,
+                    "--output",
+                    str(root / "report.json"),
+                ]
+            )
+        self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import importlib.util
 import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -57,6 +59,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 "row",
                 "value",
                 "index",
+                "bootstrap-layout",
             ),
         )
         self.assertNotIn("command", {action.dest for action in parser._actions})
@@ -96,6 +99,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                     CLIENT.ROW_JOB.name,
                     CLIENT.VALUE_JOB.name,
                     CLIENT.INDEX_JOB.name,
+                    CLIENT.BOOTSTRAP_LAYOUT_JOB.name,
                 },
             )
 
@@ -129,6 +133,43 @@ class WindowsDaoDevClientTests(unittest.TestCase):
             with self.assertRaises(CLIENT.DevClientError):
                 CLIENT.validate_args(args)
 
+    def test_bootstrap_layout_binds_and_verifies_the_committed_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            identity = root / "identity"
+            identity.write_text("private", encoding="utf-8")
+            args = self.args(root, identity)
+            args.job = "bootstrap-layout"
+            CLIENT.validate_args(args)
+            self.assertEqual(
+                args.plan_sha256,
+                hashlib.sha256(CLIENT.BOOTSTRAP_LAYOUT_PLAN.read_bytes()).hexdigest(),
+            )
+            invocation = CLIENT.invocation_script(args)
+            self.assertIn("-PlanSha256 ([string]$c.plan_sha256)", invocation)
+            self.assertIn("-PlanPath ([string]$c.plan)", invocation)
+            staged = CLIENT.stage_job(args)
+            self.assertTrue((staged / CLIENT.BOOTSTRAP_LAYOUT_PLAN.name).is_file())
+            self.assertTrue((staged / CLIENT.BOOTSTRAP_LAYOUT_ANALYZER.name).is_file())
+
+            altered_plan = root / "altered.plan.json"
+            altered_plan.write_text(
+                json.dumps(
+                    {
+                        "document_type": "dao_bootstrap_layout_plan",
+                        "issue": 100,
+                        "development_only": True,
+                        "inputs": {"scripts/windows-dao-dev.py": "0" * 64},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(CLIENT, "BOOTSTRAP_LAYOUT_PLAN", altered_plan):
+                with self.assertRaisesRegex(
+                    CLIENT.DevClientError, "differs from its plan"
+                ):
+                    CLIENT.verified_bootstrap_plan_sha256()
+
 
 class WindowsDaoDevRemoteContractTests(unittest.TestCase):
     @classmethod
@@ -139,7 +180,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_remote_is_exploratory_and_allowlisted(self) -> None:
         self.assertIn(
-            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index")]',
+            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]',
             self.remote,
         )
         self.assertIn("development_only = $true", self.remote)
@@ -234,8 +275,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]', self.dispatch)
         self.assertIn("$MaximumRows = 64", row)
         self.assertIn("foreach ($replica in 1..3)", row)
         for scenario in (
@@ -255,8 +296,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_value_job_is_repeated_bounded_and_never_compacts(self) -> None:
         value = CLIENT.VALUE_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]', self.dispatch)
         self.assertIn("$MaximumDatabaseBytes = 4MB", value)
         self.assertIn("foreach ($replica in 1..3)", value)
         self.assertIn("$LongLengths = @(32, 512, 2048, 4096)", value)
@@ -267,8 +308,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_index_job_is_staged_bounded_and_never_compacts(self) -> None:
         index = CLIENT.INDEX_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout")]', self.dispatch)
         self.assertIn("$MaximumRows = 4096", index)
         self.assertIn("$MaximumDatabaseBytes = 16MB", index)
         for scenario in (
@@ -287,6 +328,24 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             self.assertIn(f'"{scenario}"', index)
             self.assertIn(f'"{scenario}"', self.publication)
         self.assertNotIn("CompactDatabase", index)
+
+    def test_bootstrap_layout_is_plan_bound_bounded_and_development_only(self) -> None:
+        job = CLIENT.BOOTSTRAP_LAYOUT_JOB.read_text(encoding="utf-8")
+        plan = json.loads(CLIENT.BOOTSTRAP_LAYOUT_PLAN.read_text(encoding="utf-8"))
+        self.assertIn('$Job -ceq "bootstrap-layout"', self.remote)
+        self.assertIn("BootstrapLayoutJobPath", self.remote)
+        self.assertIn("PlanSha256", self.remote)
+        self.assertIn("foreach ($replica in 1..3)", job)
+        self.assertIn("development_only = $true", job)
+        self.assertIn("$MaximumPages = 64", job)
+        self.assertIn("$MaximumVariants = 64", job)
+        self.assertNotIn("CompactDatabase", job)
+        self.assertIn("204-database bound", self.publication)
+        self.assertTrue(plan["development_only"])
+        self.assertEqual(plan["issue"], 100)
+        for relative, expected in plan["inputs"].items():
+            actual = hashlib.sha256((ROOT / relative).read_bytes()).hexdigest()
+            self.assertEqual(actual, expected, relative)
 
 
 if __name__ == "__main__":

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import hashlib
 import json
 import ntpath
 import os
@@ -45,6 +46,28 @@ STAGED_PUBLICATION = (
 ROW_JOB = ROOT / "oracle" / "windows-dao" / "scripts" / "dev" / "Row.DevJob.ps1"
 VALUE_JOB = ROOT / "oracle" / "windows-dao" / "scripts" / "dev" / "Value.DevJob.ps1"
 INDEX_JOB = ROOT / "oracle" / "windows-dao" / "scripts" / "dev" / "Index.DevJob.ps1"
+BOOTSTRAP_LAYOUT_JOB = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "scripts"
+    / "dev"
+    / "BootstrapLayout.DevJob.ps1"
+)
+BOOTSTRAP_LAYOUT_PLAN = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "acquisition"
+    / "bootstrap-layout.plan.json"
+)
+BOOTSTRAP_LAYOUT_ANALYZER = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "scripts"
+    / "bootstrap_layout.py"
+)
 SAFE_HOST = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$")
 SAFE_USER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 SAFE_RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")
@@ -58,11 +81,43 @@ ALLOWED_JOBS = (
     "row",
     "value",
     "index",
+    "bootstrap-layout",
 )
 
 
 class DevClientError(RuntimeError):
     """A local request or returned development result is invalid."""
+
+
+def verified_bootstrap_plan_sha256() -> str:
+    try:
+        plan_bytes = BOOTSTRAP_LAYOUT_PLAN.read_bytes()
+        plan = json.loads(plan_bytes)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DevClientError("bootstrap-layout plan is unreadable") from error
+    if (
+        not isinstance(plan, dict)
+        or plan.get("document_type") != "dao_bootstrap_layout_plan"
+        or plan.get("issue") != 100
+        or plan.get("development_only") is not True
+    ):
+        raise DevClientError("bootstrap-layout plan is malformed")
+    inputs = plan.get("inputs")
+    if not isinstance(inputs, dict) or not inputs:
+        raise DevClientError("bootstrap-layout plan has no pinned inputs")
+    for relative, expected in inputs.items():
+        if (
+            not isinstance(relative, str)
+            or not isinstance(expected, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", expected)
+        ):
+            raise DevClientError("bootstrap-layout input pin is malformed")
+        path = (ROOT / relative).resolve()
+        if not path.is_relative_to(ROOT) or not path.is_file():
+            raise DevClientError("bootstrap-layout input is missing or outside the repository")
+        if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+            raise DevClientError(f"bootstrap-layout input differs from its plan: {relative}")
+    return hashlib.sha256(plan_bytes).hexdigest()
 
 
 def powershell_encoded(script: str) -> str:
@@ -111,6 +166,9 @@ def validate_args(args: argparse.Namespace) -> None:
     args.remote_shared_root = canonical_windows_path(
         args.remote_shared_root, label="remote shared root"
     )
+    args.plan_sha256 = (
+        verified_bootstrap_plan_sha256() if args.job == "bootstrap-layout" else ""
+    )
 
 
 def stage_job(args: argparse.Namespace) -> Path:
@@ -134,6 +192,25 @@ def stage_job(args: argparse.Namespace) -> Path:
         shutil.copyfile(ROW_JOB, staging / ROW_JOB.name)
         shutil.copyfile(VALUE_JOB, staging / VALUE_JOB.name)
         shutil.copyfile(INDEX_JOB, staging / INDEX_JOB.name)
+        shutil.copyfile(BOOTSTRAP_LAYOUT_JOB, staging / BOOTSTRAP_LAYOUT_JOB.name)
+        if args.job == "bootstrap-layout":
+            shutil.copyfile(
+                BOOTSTRAP_LAYOUT_ANALYZER, staging / BOOTSTRAP_LAYOUT_ANALYZER.name
+            )
+            shutil.copyfile(
+                BOOTSTRAP_LAYOUT_PLAN, staging / BOOTSTRAP_LAYOUT_PLAN.name
+            )
+            if verified_bootstrap_plan_sha256() != args.plan_sha256:
+                raise DevClientError("bootstrap-layout plan changed during staging")
+            plan = json.loads(BOOTSTRAP_LAYOUT_PLAN.read_bytes())
+            for relative, expected in plan["inputs"].items():
+                staged_input = staging / Path(relative).name
+                if staged_input.is_file() and (
+                    hashlib.sha256(staged_input.read_bytes()).hexdigest() != expected
+                ):
+                    raise DevClientError(
+                        f"staged bootstrap-layout input differs from its plan: {relative}"
+                    )
         staging.rename(final)
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
@@ -156,6 +233,9 @@ def invocation_script(args: argparse.Namespace) -> str:
         "row_job": ntpath.join(remote_input, ROW_JOB.name),
         "value_job": ntpath.join(remote_input, VALUE_JOB.name),
         "index_job": ntpath.join(remote_input, INDEX_JOB.name),
+        "bootstrap_layout_job": ntpath.join(remote_input, BOOTSTRAP_LAYOUT_JOB.name),
+        "plan_sha256": args.plan_sha256,
+        "plan": ntpath.join(remote_input, BOOTSTRAP_LAYOUT_PLAN.name),
         "output": ntpath.join(args.remote_shared_root, "outbox", args.run_id),
     }
     encoded = base64.b64encode(
@@ -178,7 +258,9 @@ def invocation_script(args: argparse.Namespace) -> str:
         "-PublicationPath ([string]$c.publication) "
         "-RowJobPath ([string]$c.row_job) "
         "-ValueJobPath ([string]$c.value_job) "
-        "-IndexJobPath ([string]$c.index_job);"
+        "-IndexJobPath ([string]$c.index_job) "
+        "-BootstrapLayoutJobPath ([string]$c.bootstrap_layout_job) "
+        "-PlanSha256 ([string]$c.plan_sha256) -PlanPath ([string]$c.plan);"
         "exit $LASTEXITCODE"
     )
 
@@ -224,6 +306,45 @@ def run_remote(args: argparse.Namespace) -> int:
         raise DevClientError(f"remote job exceeded {args.timeout} seconds") from error
 
 
+def analyze_bootstrap_output(args: argparse.Namespace) -> Path:
+    if verified_bootstrap_plan_sha256() != args.plan_sha256:
+        raise DevClientError("bootstrap-layout plan or input changed during acquisition")
+    staged_analyzer = (
+        args.shared_root / "inbox" / args.run_id / BOOTSTRAP_LAYOUT_ANALYZER.name
+    )
+    plan = json.loads(BOOTSTRAP_LAYOUT_PLAN.read_bytes())
+    expected_analyzer = plan["inputs"][
+        "oracle/windows-dao/scripts/bootstrap_layout.py"
+    ]
+    if (
+        not staged_analyzer.is_file()
+        or hashlib.sha256(staged_analyzer.read_bytes()).hexdigest()
+        != expected_analyzer
+    ):
+        raise DevClientError("staged bootstrap-layout analyzer differs from its plan")
+    output = args.shared_root / "outbox" / args.run_id
+    job_result = output / "bootstrap-layout-job-result.json"
+    report = output / "bootstrap-layout-report.json"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            str(staged_analyzer),
+            str(job_result),
+            "--expected-plan-sha256",
+            args.plan_sha256,
+            "--output",
+            str(report),
+        ],
+        cwd=ROOT,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0 or not report.is_file():
+        raise DevClientError("bootstrap-layout analyzer rejected the published result")
+    return report
+
+
 def validated_result(args: argparse.Namespace, exit_code: int) -> dict[str, object]:
     result_path = args.shared_root / "outbox" / args.run_id / "result.json"
     if not result_path.is_file() or result_path.is_symlink():
@@ -238,6 +359,8 @@ def validated_result(args: argparse.Namespace, exit_code: int) -> dict[str, obje
         "run_id": args.run_id,
         "status": {0: "pass", 1: "fail", 3: "blocked"}.get(exit_code),
     }
+    if args.job == "bootstrap-layout":
+        expected["plan_sha256"] = args.plan_sha256
     if not isinstance(document, dict) or any(
         document.get(key) != value for key, value in expected.items()
     ):
@@ -252,6 +375,9 @@ def run(args: argparse.Namespace) -> int:
     if exit_code not in (0, 1, 3):
         raise DevClientError(f"remote job returned unexpected exit code {exit_code}")
     result = validated_result(args, exit_code)
+    report = None
+    if args.job == "bootstrap-layout" and exit_code in (0, 1):
+        report = analyze_bootstrap_output(args)
     print(
         json.dumps(
             {
@@ -260,6 +386,7 @@ def run(args: argparse.Namespace) -> int:
                 "job": args.job,
                 "output": str(args.shared_root / "outbox" / args.run_id),
                 "status": result["status"],
+                "report": str(report) if report is not None else None,
             },
             sort_keys=True,
         )


### PR DESCRIPTION
The writer bootstrap is blocked on a few unresolved physical-layout facts. The previous DAO action did not establish them, and another acquisition must be preregistered and independently validated before it can inform parser code.

This change adds a development-only, SHA-pinned local VM experiment for three fresh Jet 3 replicas. It captures empty/create/rename checkpoints, performs bounded page-0 and timestamp ablations, treats LvProp as correlation-only, publishes an exact artifact inventory, and independently reconstructs and validates every mutation. Partial or ambiguous evidence becomes an honest no_outcome.

Scope stays limited to bootstrap-layout discovery and its local VM plumbing. It does not publish compatibility, change the support matrix, implement writer behavior, or expand issue #102.

Checks:
- python3 -B -m unittest discover -s oracle/windows-dao/tests (71 passed)
- just ready
- two final narrow review passes clean

Plan SHA-256: 73e402a255795eb6bd08bffa5e3611ceef219f6e810e99f9715f0e69b4aef8fc

Related: #100