### PR TITLE
fix(oracle): floor bootstrap timestamp page metadata

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6186,6 +6186,51 @@ Use `not applicable` explicitly rather than omitting a field.
   rejection path were independently rechecked; no scientific outcome exists
   to review
 
+### EXP-0068 — Preregistered local writer-bootstrap page-floor experiment
+
+- Recorded: 2026-08-30, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration for one new
+  human-authorized acquisition; no acquisition or format observation has
+  occurred under this plan
+- Question: For three fresh replicas of the `EXP-0066` scenario, can the same
+  bounded Q1--Q3 questions produce a canonical report after timestamp page
+  metadata is derived with floor division?
+- Origin: project-authored clean-room experiment design using only the exact
+  basis admitted by `EXP-0066`. `EXP-0067` contributes only the identity of the
+  rejected run and its project-producer rounding defect; none of that run's
+  MDB bytes, endpoint patterns, corrected projections, or Q1--Q3 observations
+  are inputs.
+- Protocol: create three new independent `dbVersion30` replicas and execute
+  the unchanged `EXP-0066` scenario, checkpoints, ablations, bounds, read-only
+  endpoints, decision rules, and exclusions once. The only producer correction
+  derives timestamp page metadata as `floor(offset / 2048)` and rejects a
+  timestamp range that crosses that page. The exact rejected offset 38,381 is
+  fixed as a regression mapping to zero-based page 18. This is a distinct next
+  experiment, not a revision or retroactive repair of `EXP-0066`.
+- Preregistration artifact:
+  `oracle/windows-dao/acquisition/bootstrap-layout-floor.plan.json`, SHA-256
+  `c0161be2ba1189249d743c9198bcd004dd9d927edcc7d753cffe79c421677773`.
+  The plan pins the host client, provider probe, guest runner, dispatcher,
+  publisher, corrected producer, and unchanged host analyzer. The host and
+  guest reject digest mismatches before the first DAO mutation.
+- Observation: `preregistration.acquisition_started` is `false`. The explicit
+  post-`EXP-0067` authorization permits one new acquisition only. No new MDB,
+  provider output, canonical report, or scientific result exists.
+- Interpretation: this entry fixes only the timestamp page-metadata defect and
+  preserves the original experiment's questions and lane boundaries. It
+  establishes no format or necessity fact, sufficiency, writer implementation
+  fact, Rust correctness, compatibility, support result, or support-matrix
+  movement.
+- Usage:
+  `file:oracle/windows-dao/acquisition/bootstrap-layout-floor.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/bootstrap_layout.py`;
+  `file:docs/LOCAL_WINDOWS_VM.md`; issue `#100`
+- Rights: future project-generated MDBs and provider outputs remain outside the
+  repository and are neither committed nor redistributed
+- Review: pending independent correction-boundary, plan-pin, producer,
+  analyzer, and negative-control review before local acquisition
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -18,10 +18,12 @@ The retained tooling has three purposes:
   its plan, evaluates its artifact, and runs the synthetic dry run.
   `.github/workflows/windows-dao-allocation-a9.yml` hosts it under the same
   gating as the read differential.
-- `acquisition/bootstrap-layout.plan.json`,
+- `acquisition/bootstrap-layout.plan.json` retains the consumed acquisition
+  rejected by `EXP-0067`; `acquisition/bootstrap-layout-floor.plan.json`,
   `scripts/dev/BootstrapLayout.DevJob.ps1`, and
   `scripts/bootstrap_layout.py` define the development-only local-VM
-  preregistration that blocks the next narrow creation slice in #100.
+  floor-corrected preregistration that blocks the next narrow creation slice
+  in #100.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.

--- a/oracle/windows-dao/acquisition/bootstrap-layout-floor.plan.json
+++ b/oracle/windows-dao/acquisition/bootstrap-layout-floor.plan.json
@@ -1,0 +1,108 @@
+{
+  "document_type": "dao_bootstrap_layout_floor_plan",
+  "experiment_id": "bootstrap_layout_floor",
+  "issue": 100,
+  "development_only": true,
+  "purpose": "Repeat only the writer-bootstrap questions from EXP-0066 on fresh replicas after correcting the timestamp page-metadata calculation rejected by EXP-0067.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_preregistration": "EXP-0066",
+    "prior_rejected_acquisition": "EXP-0067",
+    "prior_run_id": "20260831T003722Z-bootstrap",
+    "authorization": "The human operator explicitly authorized one corrected acquisition after reviewing the EXP-0067 rejection.",
+    "amendment_rule": "This is a distinct next experiment, not a revision or retroactive repair. After its first DAO mutation, any failure or no_outcome is recorded once and it is not redispatched without another human decision."
+  },
+  "correction_contract": {
+    "change": "Derive timestamp variant page metadata as floor(offset / 2048), and reject a timestamp mutation range that crosses its declared page.",
+    "regression": "Absolute timestamp offset 38381 maps to zero-based page 18, not page 19.",
+    "fresh_inputs": "Use three new databases and new variants. No MDB, result JSON, corrected projection, or derived answer from run 20260831T003722Z-bootstrap is an experiment input."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "f6ad311031e39cd5c19526b22b5c21ac7f8874949a82eec84b504be0b981ddc3",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "e7e07d560484ea6399275a963591a115c9c7ac3ec069a4ca80432d8f5a403759",
+    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "2aae85c0a9e3cfdfd7a2d1c04fe0505e008b615cc11d72e7f76d6033cd99c955",
+    "oracle/windows-dao/scripts/bootstrap_layout.py": "f78e4986f00e4e303e26038bb4ee012fb2352dbe7f443fa3a5e0337f7b868d06"
+  },
+  "basis": {
+    "EXP-0058": "Dynamic catalog-root discovery, catalog-owned page 18 in the observed controls, table record identifier to table-definition correlation, and the bounded catalog row fields recorded there.",
+    "EXP-0059": "Table-definition chain and owned/free map locator meanings.",
+    "EXP-0061": "External long-value pointer, LVAL owner, and bounded row-directory structure only.",
+    "EXP-0065": "Only its preregistered Q1/Q2 facts: empty page count and tags, page append sequence, global-map transitions, and changed byte ranges. No post-hoc semantic page-role inference is admitted.",
+    "EXP-0067": "Only the validation-rejection identity and the project producer's page-rounding defect. None of its raw endpoint patterns or Q1-Q3 observations are admitted."
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "scenario": "For each independent replica, create one fresh dbVersion30 CP1252 database, create one empty table named BootstrapLayout with one Long field named Id, wait exactly two seconds, and rename the table to BootstrapRenamed.",
+    "checkpoints": [
+      "empty",
+      "created",
+      "renamed"
+    ],
+    "bounds": {
+      "maximum_pages_per_database": 64,
+      "maximum_table_definitions": 128,
+      "maximum_variants_per_replica": 64,
+      "maximum_replicas": 3,
+      "maximum_clock_separation_seconds": 2
+    },
+    "capture": "Close and release every DAO object before each MDB copy or hash. Retain the three closed checkpoints, bounded semantic metadata, and only the preregistered ablation clones. MDBs remain external."
+  },
+  "questions": {
+    "Q1": {
+      "title": "Candidate page-0 byte",
+      "question": "Does page-0 byte range [1538,1539) satisfy the candidate-counter hypothesis across the fixed create and rename sequence, and is its post-create value necessary for the read-only DAO endpoints?",
+      "measurement": "Record the byte value at empty, created, and renamed plus every page-0 changed range for empty-to-created and created-to-renamed. Any additional page-0 change makes this question no_outcome rather than being assigned a meaning.",
+      "ablation": "From the created checkpoint, make one clone per replica and replace exactly [1538,1539) with the empty-checkpoint byte. Test for BootstrapLayout; the rename is not part of this necessity result."
+    },
+    "Q2": {
+      "title": "Candidate catalog timestamp fields and LvProp structure",
+      "question": "Can DAO DateCreated and LastUpdated be correlated to unique eight-byte OLE Date values after the single clock-separated rename, and can the DAO-visible LvProp bytes be correlated structurally through one exact EXP-0061 external pointer/header? Which correlated timestamp values are necessary for the read-only DAO endpoints?",
+      "ablation": "If and only if a timestamp correlation is unique in the renamed checkpoint, replace that timestamp separately with valid OLE Date zero and test for BootstrapRenamed. A failed or ambiguous timestamp correlation is no_outcome and creates no variant. LvProp is correlation-only: EXP-0061 does not establish an empty replacement encoding, so this plan performs no LvProp ablation and makes no LvProp necessity claim."
+    },
+    "Q3": {
+      "title": "Required existing and appended page mutation groups",
+      "question": "Which bounded page mutation groups from empty to created are necessary for DAO to open the database, enumerate the BootstrapLayout TableDef and its Id field, and open the empty table?",
+      "ablation": "Starting from the created checkpoint, for each changed pre-existing page other than page 0 create one clone that restores the entire page from the empty checkpoint. For each appended page, create one clone that replaces the entire page with zeros. The rename transition is excluded."
+    }
+  },
+  "ablation_contract": {
+    "endpoints": [
+      "OpenDatabase read-only",
+      "TableDefs enumeration finds the base checkpoint's table: BootstrapLayout for created-state page controls or BootstrapRenamed for renamed-state timestamp controls",
+      "field enumeration finds exactly Id as Long",
+      "open that base checkpoint's table as an empty snapshot"
+    ],
+    "execution": "Run every predefined clone through the endpoints once. Hash immediately before and after DAO access; a changed hash yields no_outcome for that variant because DAO may have repaired it.",
+    "interpretation": "A failed endpoint with an unchanged post-access hash may establish necessity of that mutation group. A passing endpoint set reports not_observed_necessary. Leave-one-out results never establish sufficiency or a minimal complete mutation set."
+  },
+  "decision_rule": {
+    "accepted": "The plan and every staged input match their SHA-256 pins; the provider is ready; all three fresh replicas and predefined variants run once; files, hashes, bounds, page/range containment, and result shape validate; and the analyzer emits a deterministic accepted or no_outcome report.",
+    "no_outcome": "Timestamp or LvProp ambiguity, replica disagreement, a baseline endpoint failure, a post-access hash change, or an otherwise intact but non-decisive observation is reported honestly as no_outcome.",
+    "rejected": "A plan/input digest mismatch, malformed or missing checkpoint, bound violation, page/range mismatch, unexpected variant, file digest mismatch, or result-shape failure rejects validation.",
+    "retry": "This authorization permits one new acquisition only. There is no automatic retry after the first DAO mutation."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "user rows",
+    "user indexes",
+    "relationships",
+    "free-page reuse",
+    "extended allocation maps",
+    "general long-value allocation or thresholds",
+    "public Rust API expansion",
+    "Rust publication or I/O",
+    "hosted write differential #102",
+    "compatibility or support claims"
+  ]
+}

--- a/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
@@ -671,6 +671,23 @@ function Test-BaselineEndpoints {
     return $endpoints
 }
 
+function Get-PageForRange {
+    param(
+        [long]$Start,
+        [long]$End
+    )
+
+    if ($Start -lt 0 -or $End -le $Start) {
+        throw "Variant range is empty or reversed."
+    }
+    $page = [int][Math]::Floor([double]$Start / [double]$PageSize)
+    $pageStart = [long]$page * $PageSize
+    if ($End -gt ($pageStart + $PageSize)) {
+        throw "Variant range crosses its declared page."
+    }
+    return $page
+}
+
 function Add-VariantSpec {
     param(
         [Collections.ArrayList]$Specs,
@@ -775,13 +792,13 @@ function Invoke-ReplicaCore {
         -Mutation "copy_byte" -MutationOffset $pageZeroStart
     if ($dateCreated.report.status -eq "resolved") {
         $offset = [int]$dateCreated.offsets[0]
-        Add-VariantSpec -Specs $specs -Name "date-created-zero" -Kind "candidate_date_created" -BaseCheckpoint "renamed" -Page ([int]($offset / $PageSize)) `
+        Add-VariantSpec -Specs $specs -Name "date-created-zero" -Kind "candidate_date_created" -BaseCheckpoint "renamed" -Page (Get-PageForRange -Start $offset -End ($offset + 8)) `
             -Ranges @([ordered]@{ start = [long]$offset; end = [long]($offset + 8) }) `
             -Mutation "zero_date" -MutationOffset $offset
     }
     if ($dateUpdated.report.status -eq "resolved") {
         $offset = [int]$dateUpdated.offsets[0]
-        Add-VariantSpec -Specs $specs -Name "date-updated-zero" -Kind "candidate_date_updated" -BaseCheckpoint "renamed" -Page ([int]($offset / $PageSize)) `
+        Add-VariantSpec -Specs $specs -Name "date-updated-zero" -Kind "candidate_date_updated" -BaseCheckpoint "renamed" -Page (Get-PageForRange -Start $offset -End ($offset + 8)) `
             -Ranges @([ordered]@{ start = [long]$offset; end = [long]($offset + 8) }) `
             -Mutation "zero_date" -MutationOffset $offset
     }

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -22,6 +22,9 @@ REMOTE_PATH = (
 )
 DISPATCH_PATH = REMOTE_PATH.with_name("Dispatch.DevJob.ps1")
 PUBLICATION_PATH = REMOTE_PATH.with_name("Publish.DevJob.ps1")
+CONSUMED_BOOTSTRAP_PLAN = (
+    ROOT / "oracle" / "windows-dao" / "acquisition" / "bootstrap-layout.plan.json"
+)
 SPEC = importlib.util.spec_from_file_location("windows_dao_dev", CLIENT_PATH)
 assert SPEC is not None and SPEC.loader is not None
 CLIENT = importlib.util.module_from_spec(SPEC)
@@ -133,7 +136,25 @@ class WindowsDaoDevClientTests(unittest.TestCase):
             with self.assertRaises(CLIENT.DevClientError):
                 CLIENT.validate_args(args)
 
-    def test_bootstrap_layout_binds_and_verifies_the_committed_plan(self) -> None:
+    def test_consumed_bootstrap_plan_remains_immutable(self) -> None:
+        expected_inputs = {
+            "scripts/windows-dao-dev.py": "029c871b9fbeef228f015e5561f7b8a9980645f605c398157cc75bf35c623715",
+            "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+            "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
+            "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
+            "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "e7e07d560484ea6399275a963591a115c9c7ac3ec069a4ca80432d8f5a403759",
+            "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "e04cecec6a3678b76bd1b54bd2d77fc52b94316c1e38e584bc373654e59a4a88",
+            "oracle/windows-dao/scripts/bootstrap_layout.py": "f78e4986f00e4e303e26038bb4ee012fb2352dbe7f443fa3a5e0337f7b868d06",
+        }
+        document = json.loads(CONSUMED_BOOTSTRAP_PLAN.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            hashlib.sha256(CONSUMED_BOOTSTRAP_PLAN.read_bytes()).hexdigest(),
+            "73e402a255795eb6bd08bffa5e3611ceef219f6e810e99f9715f0e69b4aef8fc",
+        )
+        self.assertEqual(document["inputs"], expected_inputs)
+
+    def test_bootstrap_layout_binds_and_verifies_the_active_plan(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             identity = root / "identity"
@@ -156,7 +177,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
             altered_plan.write_text(
                 json.dumps(
                     {
-                        "document_type": "dao_bootstrap_layout_plan",
+                        "document_type": "dao_bootstrap_layout_floor_plan",
                         "issue": 100,
                         "development_only": True,
                         "inputs": {"scripts/windows-dao-dev.py": "0" * 64},
@@ -346,6 +367,17 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         for relative, expected in plan["inputs"].items():
             actual = hashlib.sha256((ROOT / relative).read_bytes()).hexdigest()
             self.assertEqual(actual, expected, relative)
+
+    def test_bootstrap_timestamp_pages_use_floor_division(self) -> None:
+        job = CLIENT.BOOTSTRAP_LAYOUT_JOB.read_text(encoding="utf-8")
+
+        self.assertEqual(38381 // 2048, 18)
+        self.assertIn(
+            "[int][Math]::Floor([double]$Start / [double]$PageSize)", job
+        )
+        self.assertEqual(job.count("Get-PageForRange -Start $offset"), 2)
+        self.assertIn("Variant range crosses its declared page.", job)
+        self.assertNotIn("[int]($offset / $PageSize)", job)
 
 
 if __name__ == "__main__":

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -59,7 +59,7 @@ BOOTSTRAP_LAYOUT_PLAN = (
     / "oracle"
     / "windows-dao"
     / "acquisition"
-    / "bootstrap-layout.plan.json"
+    / "bootstrap-layout-floor.plan.json"
 )
 BOOTSTRAP_LAYOUT_ANALYZER = (
     ROOT
@@ -97,7 +97,7 @@ def verified_bootstrap_plan_sha256() -> str:
         raise DevClientError("bootstrap-layout plan is unreadable") from error
     if (
         not isinstance(plan, dict)
-        or plan.get("document_type") != "dao_bootstrap_layout_plan"
+        or plan.get("document_type") != "dao_bootstrap_layout_floor_plan"
         or plan.get("issue") != 100
         or plan.get("development_only") is not True
     ):


### PR DESCRIPTION
The first preregistered bootstrap acquisition completed its DAO work but could not produce a canonical report: PowerShell rounded timestamp offset 38,381 to page 19 instead of flooring it to page 18. That validation rejection is recorded by EXP-0067 and cannot be repaired retroactively.

This creates a distinct, human-authorized next experiment. Timestamp page metadata now uses floor division and rejects a crossing timestamp range; the exact 38,381-to-page-18 case is locked by a regression. The consumed plan remains byte-identical, while the active client selects a new SHA-pinned plan for three fresh replicas. Execution, Q1-Q3, ablations, publication, and exclusions are unchanged.

This PR performs no DAO acquisition and makes no format, necessity, writer, compatibility, or support claim. It does not enter #102 or any excluded writer lane.

Checks:
- 73 Oracle tests passed
- just ready
- three independent narrow reviews clean

Active plan SHA-256: c0161be2ba1189249d743c9198bcd004dd9d927edcc7d753cffe79c421677773

Related: #100
Follow-up to: #125 and #126