### PR TITLE
feat(writer): plan existing page images

### DIFF
--- a/crates/jet3/src/page_append_plan.rs
+++ b/crates/jet3/src/page_append_plan.rs
@@ -1,8 +1,9 @@
-//! Crate-private composition of complete page images with fresh append slots.
+//! Crate-private composition of complete page images with physical page slots.
 //!
-//! This module does not build pages or perform I/O. It assigns the next
-//! physical page number to an already-complete [`PageImage`] and applies the
-//! matching global-map transition observed in `EXP-0065`.
+//! This module does not build pages or perform I/O. It pairs already-complete
+//! [`PageImage`] values with existing slots in the fixed empty-database image,
+//! or assigns fresh append slots and applies the matching global-map transition
+//! observed in `EXP-0065`.
 
 #![allow(
     dead_code,
@@ -39,6 +40,45 @@ impl PlannedPage {
     pub(crate) fn into_parts(self) -> (PageNumber, PageImage) {
         (self.number, self.image)
     }
+}
+
+/// Structured failure while planning one existing empty-database page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExistingPageError {
+    /// The requested page is not part of the observed 20-page empty image.
+    OutsideEmptyDatabase {
+        /// Rejected existing page.
+        page: PageNumber,
+    },
+}
+
+impl fmt::Display for ExistingPageError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutsideEmptyDatabase { page } => write!(
+                formatter,
+                "page {} is outside the {EMPTY_DATABASE_PAGE_COUNT}-page empty database",
+                page.get()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ExistingPageError {}
+
+/// Pairs a complete image with one existing page in the fixed empty database.
+///
+/// The image is moved through unchanged and is not inspected. `EXP-0065` Q1
+/// establishes only that the observed empty database has pages 0 through 19;
+/// this function assigns no semantic role to any page or byte.
+pub(crate) fn plan_existing_page(
+    number: PageNumber,
+    image: PageImage,
+) -> Result<PlannedPage, ExistingPageError> {
+    if number.get() >= EMPTY_DATABASE_PAGE_COUNT {
+        return Err(ExistingPageError::OutsideEmptyDatabase { page: number });
+    }
+    Ok(PlannedPage { number, image })
 }
 
 /// Structured failure while planning one fresh page append.

--- a/crates/jet3/src/page_append_plan_tests.rs
+++ b/crates/jet3/src/page_append_plan_tests.rs
@@ -1,4 +1,4 @@
-use super::{AppendPageError, AppendPagePlan};
+use super::{AppendPageError, AppendPagePlan, ExistingPageError, plan_existing_page};
 use crate::limits::ReadLimits;
 use crate::{
     ByteCount, InlineUsageMapEncoder, PageImage, PageKind, PageNumber, ResourceBudget,
@@ -27,6 +27,36 @@ fn free_pages(
         map.set_page(PageNumber::new(page))?;
     }
     Ok(())
+}
+
+#[test]
+fn existing_page_boundaries_preserve_complete_images() -> TestResult {
+    for page in [0, 19] {
+        let mut bytes = [0xab; crate::PAGE_BYTES];
+        bytes[0] = page as u8;
+        bytes[crate::PAGE_BYTES - 1] = 0x11;
+        let image = PageImage::from_bytes(bytes);
+
+        let (number, planned_image) =
+            plan_existing_page(PageNumber::new(page), image.clone())?.into_parts();
+        assert_eq!(number, PageNumber::new(page));
+        assert_eq!(planned_image, image);
+        assert_eq!(planned_image.as_bytes(), &bytes);
+    }
+    Ok(())
+}
+
+#[test]
+fn existing_page_rejects_the_first_append_slot() {
+    assert_eq!(
+        plan_existing_page(
+            PageNumber::new(20),
+            PageImage::new(PageKind::TableDefinition),
+        ),
+        Err(ExistingPageError::OutsideEmptyDatabase {
+            page: PageNumber::new(20),
+        })
+    );
 }
 
 #[test]


### PR DESCRIPTION
The writer already had a private planner for fresh pages 20 and above, but a future composer could not produce the same private PlannedPage type for the fixed pages in the observed empty database.

This adds a crate-private, semantics-neutral constructor for existing pages 0 through 19. It preserves each complete PageImage unchanged and returns a structured error at the first append slot. The boundary relies only on EXP-0065 Q1; it does not treat the partially unresolved EXP-0069 bootstrap observations as composition evidence. No public API, map mutation, page construction, or I/O is added.

Checks:
- cargo test -p jet3 page_append_plan --lib --locked (7 passed)
- cargo clippy -p jet3 --lib --tests --locked -- -D warnings
- just ready
- three independent scoped reviews: clean