### PR TITLE
feat(writer): aggregate whole-file page plans

### DIFF
--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -46,6 +46,7 @@ pub mod text;
 pub mod usage_map;
 pub mod usage_map_writer;
 pub mod value;
+mod whole_file_plan;
 
 pub use allocation::{
     AllocationMap, AllocationMapError, ExtendedAllocationBits, IndirectAllocationMap,

--- a/crates/jet3/src/whole_file_plan.rs
+++ b/crates/jet3/src/whole_file_plan.rs
@@ -1,0 +1,152 @@
+//! Crate-private aggregation of complete page plans in physical file order.
+//!
+//! This module combines the existing-slot and append planners without
+//! assigning meaning to any page image. The caller supplies all 20 existing
+//! images and every appended image already complete. The resulting sequence
+//! does not establish that its bytes form a DAO-openable bootstrap image.
+
+#![allow(
+    dead_code,
+    reason = "staged for the future crate-private writer composition layer"
+)]
+
+use std::fmt;
+
+use crate::page_append_plan::{
+    AppendPageError, AppendPagePlan, EMPTY_DATABASE_PAGE_COUNT, ExistingPageError, PlannedPage,
+    plan_existing_page,
+};
+use crate::{InlineUsageMapEncoder, PageImage, PageNumber};
+
+const EXISTING_PAGE_COUNT: usize = EMPTY_DATABASE_PAGE_COUNT as usize;
+
+/// Structured failure while aggregating a whole-file page plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WholeFilePlanError {
+    /// Storage for the requested number of complete page plans was unavailable.
+    PageStorageUnavailable {
+        /// Total page count the plan attempted to retain.
+        requested_page_count: u64,
+    },
+    /// An existing image could not be paired with its physical slot.
+    Existing(ExistingPageError),
+    /// A fresh image could not be appended.
+    Append(AppendPageError),
+}
+
+impl fmt::Display for WholeFilePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PageStorageUnavailable {
+                requested_page_count,
+            } => write!(
+                formatter,
+                "storage unavailable for {requested_page_count} planned pages"
+            ),
+            Self::Existing(source) => write!(formatter, "existing page plan failed: {source}"),
+            Self::Append(source) => write!(formatter, "page append plan failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for WholeFilePlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Existing(source) => Some(source),
+            Self::Append(source) => Some(source),
+            Self::PageStorageUnavailable { .. } => None,
+        }
+    }
+}
+
+impl From<ExistingPageError> for WholeFilePlanError {
+    fn from(source: ExistingPageError) -> Self {
+        Self::Existing(source)
+    }
+}
+
+impl From<AppendPageError> for WholeFilePlanError {
+    fn from(source: AppendPageError) -> Self {
+        Self::Append(source)
+    }
+}
+
+/// Complete page images ordered by their planned physical file slots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WholeFileImagePlan {
+    pages: Vec<PlannedPage>,
+    append_plan: AppendPagePlan,
+}
+
+impl WholeFileImagePlan {
+    /// Pairs 20 caller-complete images with existing slots 0 through 19.
+    ///
+    /// `EXP-0065` Q1 establishes only the fixed page count and slot range.
+    /// This constructor neither inspects page bytes nor assigns bootstrap
+    /// roles, references, or sufficiency to them.
+    pub(crate) fn from_existing_pages(
+        images: [PageImage; EXISTING_PAGE_COUNT],
+    ) -> Result<Self, WholeFilePlanError> {
+        let mut pages = Vec::new();
+        pages.try_reserve_exact(EXISTING_PAGE_COUNT).map_err(|_| {
+            WholeFilePlanError::PageStorageUnavailable {
+                requested_page_count: EMPTY_DATABASE_PAGE_COUNT,
+            }
+        })?;
+
+        for (number, image) in (0_u64..).zip(images) {
+            pages.push(plan_existing_page(PageNumber::new(number), image)?);
+        }
+
+        Ok(Self {
+            pages,
+            append_plan: AppendPagePlan::after_empty_database(),
+        })
+    }
+
+    /// Returns all retained page plans in increasing physical-page order.
+    pub(crate) fn pages(&self) -> &[PlannedPage] {
+        &self.pages
+    }
+
+    /// Returns the page count after all successful appends.
+    pub(crate) const fn page_count(&self) -> u64 {
+        self.append_plan.page_count()
+    }
+
+    /// Plans and retains one fresh page after the existing sequence.
+    ///
+    /// Storage is reserved before the append planner changes the page count or
+    /// global free map. On any error, the retained sequence, count, and map are
+    /// logically unchanged.
+    pub(crate) fn append(
+        &mut self,
+        image: PageImage,
+        global_free_map: &mut InlineUsageMapEncoder,
+    ) -> Result<PageNumber, WholeFilePlanError> {
+        let requested_page_count = self.page_count().checked_add(1).ok_or_else(|| {
+            WholeFilePlanError::Append(AppendPageError::PageCountOverflow {
+                page_count: self.page_count(),
+            })
+        })?;
+        self.pages
+            .try_reserve(1)
+            .map_err(|_| WholeFilePlanError::PageStorageUnavailable {
+                requested_page_count,
+            })?;
+
+        let planned = self.append_plan.append(image, global_free_map)?;
+        let number = planned.number();
+        self.pages.push(planned);
+        Ok(number)
+    }
+
+    /// Consumes the aggregate and returns its ordered page plans.
+    pub(crate) fn into_pages(self) -> Vec<PlannedPage> {
+        self.pages
+    }
+}
+
+#[cfg(test)]
+#[path = "whole_file_plan_tests.rs"]
+mod tests;

--- a/crates/jet3/src/whole_file_plan_tests.rs
+++ b/crates/jet3/src/whole_file_plan_tests.rs
@@ -1,0 +1,81 @@
+use super::{EXISTING_PAGE_COUNT, WholeFileImagePlan, WholeFilePlanError};
+use crate::limits::ReadLimits;
+use crate::page_append_plan::AppendPageError;
+use crate::{
+    ByteCount, InlineUsageMapEncoder, PageImage, PageNumber, ResourceBudget, ResourceLimits,
+    UsageMapWriteError,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::new(ReadLimits::default()))
+}
+
+fn global_map(bitmap_bytes: u64) -> Result<InlineUsageMapEncoder, UsageMapWriteError> {
+    InlineUsageMapEncoder::new(
+        PageNumber::new(0),
+        ByteCount::new(bitmap_bytes),
+        &mut budget(),
+    )
+}
+
+fn existing_images() -> [PageImage; EXISTING_PAGE_COUNT] {
+    std::array::from_fn(|index| {
+        let mut bytes = [0xa5; crate::PAGE_BYTES];
+        bytes[17] = index as u8;
+        PageImage::from_bytes(bytes)
+    })
+}
+
+#[test]
+fn complete_plan_preserves_existing_and_appended_images_in_slot_order() -> TestResult {
+    let existing = existing_images();
+    let mut plan = WholeFileImagePlan::from_existing_pages(existing.clone())?;
+    let mut map = global_map(3)?;
+    map.set_page(PageNumber::new(20))?;
+    map.set_page(PageNumber::new(21))?;
+
+    let mut first_bytes = [0x11; crate::PAGE_BYTES];
+    first_bytes[17] = 20;
+    let first = PageImage::from_bytes(first_bytes);
+    let mut second_bytes = [0x22; crate::PAGE_BYTES];
+    second_bytes[17] = 21;
+    let second = PageImage::from_bytes(second_bytes);
+
+    assert_eq!(plan.append(first.clone(), &mut map)?, PageNumber::new(20));
+    assert_eq!(plan.append(second.clone(), &mut map)?, PageNumber::new(21));
+    assert_eq!(plan.page_count(), 22);
+    assert!(!map.is_set(PageNumber::new(20))?);
+    assert!(!map.is_set(PageNumber::new(21))?);
+
+    let pages = plan.into_pages();
+    assert_eq!(pages.len(), 22);
+    for (index, image) in existing.iter().enumerate() {
+        assert_eq!(pages[index].number(), PageNumber::new(index as u64));
+        assert_eq!(pages[index].image(), image);
+    }
+    assert_eq!(pages[20].image(), &first);
+    assert_eq!(pages[21].image(), &second);
+    Ok(())
+}
+
+#[test]
+fn rejected_append_preserves_whole_file_plan_and_global_map() -> TestResult {
+    let mut plan = WholeFileImagePlan::from_existing_pages(existing_images())?;
+    let plan_before = plan.clone();
+    let mut map = global_map(3)?;
+    let map_before = map.clone();
+
+    assert_eq!(
+        plan.append(PageImage::from_bytes([0x33; crate::PAGE_BYTES]), &mut map),
+        Err(WholeFilePlanError::Append(
+            AppendPageError::PageAlreadyInUse {
+                page: PageNumber::new(20),
+            }
+        ))
+    );
+    assert_eq!(plan, plan_before);
+    assert_eq!(map, map_before);
+    Ok(())
+}


### PR DESCRIPTION
The writer has separate private planners for the observed 20 existing slots and for fresh appended pages, but a future composition layer otherwise has to hand-assemble their outputs while preserving ordering and failure atomicity.

This adds a crate-private aggregate over caller-complete page images. It pairs exactly 20 existing images with slots 0–19, retains appended images in physical order, and reserves storage before the append planner can mutate page count or the caller's global map. It adds no I/O, public API, page construction, or semantic roles.

Evidence boundary: the aggregate cites only EXP-0065 Q1 for the observed 20-page base image. Append map semantics remain in the existing EXP-0051/EXP-0065-backed primitive. EXP-0069 is not used as composition evidence, and the result is explicitly not claimed to be a DAO-openable bootstrap image.

Checks:
- `cargo test -p jet3 whole_file_plan --lib --locked` (2 passed)
- `cargo test -p jet3 page_append_plan --lib --locked` (7 passed)
- `cargo clippy -p jet3 --lib --tests --locked -- -D warnings`
- `just ready`
- independent scoped review: clean

Refs #100