### PR TITLE
feat(oracle): preregister bootstrap sufficiency

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6351,6 +6351,73 @@ Use `not applicable` explicitly rather than omitting a field.
   identities, exact mutation reconstruction, and deterministic canonical
   report checked; focused bootstrap analyzer and pin-contract tests must pass
 
+### EXP-0070 — Preregistered local bootstrap-correlation and sufficiency successor
+
+- Recorded: 2026-08-31, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration; no provider
+  acquisition or format observation has occurred under this plan
+- Question: For three fresh replicas, can the unresolved `EXP-0069`
+  DateCreated and LvProp correlations be resolved under bounded, independently
+  checked rules, and is a candidate assembled from the complete observed
+  empty-to-created mutation groups sufficient for the four bounded read-only
+  DAO endpoints?
+- Origin: project-authored clean-room successor using the exact basis admitted
+  by `EXP-0068` plus only the validated, additive `EXP-0069` result recorded
+  above. No prior MDB, producer JSON, unrecorded endpoint pattern, corrected
+  projection, or post-hoc byte inspection is an experiment input, and
+  `EXP-0069` is not treated as composition or sufficiency evidence.
+- Protocol: create three independent fresh `dbVersion30` replicas once. For
+  DateCreated, admit either one exact whole-image OLE Date match or exactly one
+  match in the fixed plus-or-minus-64-byte window around one exact LastUpdated
+  match. After the property-free empty, created, and renamed checkpoints, add
+  one deterministic 768-character custom DAO Memo property and capture a
+  separate `property-set` checkpoint; read `MSysObjects` through one temporary
+  `WITH OWNERACCESS OPTION` QueryDef and require one exact `EXP-0061`
+  single-page LvProp row/header correlation. The downstream property checkpoint
+  cannot contribute bytes to the created-state sufficiency candidate.
+- Sufficiency protocol: allocate a new created-length byte array, copy only the
+  empty checkpoint into its prefix, and apply every exact page-0 and existing-
+  page empty-to-created changed range plus every complete appended page. The
+  producer does not copy the created file as the candidate. The pinned analyzer
+  independently repeats the application and uses byte equality with the
+  created checkpoint solely as a completeness and integrity check, then
+  validates the candidate's once-only DAO endpoint result and unchanged hash.
+  The `EXP-0068` leave-one-out variants are repeated only as execution-integrity
+  controls and cannot broaden the necessity claims already recorded by
+  `EXP-0069`.
+- Preregistration artifact:
+  `oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json`,
+  SHA-256
+  `0fc3e3447fb60b14fa6fca3ec89152ccc364165f9f74933b509d534da3d2d00b`.
+  The plan pins the host client, provider probe, guest runner, dispatcher,
+  publisher, producer, and host analyzer. The host and guest reject plan or
+  staged-input digest mismatches before the first DAO mutation.
+- Observation: `preregistration.acquisition_started` is `false`. Committing the
+  plan does not authorize acquisition. After review and merge, one explicit
+  human authorization is required for one local-VM run. No new MDB, provider
+  output, canonical report, or scientific result exists.
+- Decision rule: a validated, replica-consistent, unchanged-hash endpoint pass
+  reports `observed_sufficient` only for this complete-group scenario. A
+  consistent unchanged-hash endpoint failure reports
+  `not_observed_sufficient`. Unresolved correlation, repair, baseline failure,
+  replica disagreement, or an otherwise intact non-decisive result is an
+  honest `no_outcome`; integrity and shape defects reject validation. There is
+  no automatic retry after the first DAO mutation.
+- Interpretation: this entry fixes a bounded acquisition and analysis contract
+  only. It establishes no format fact, minimal mutation set, general timestamp
+  or LvProp encoding, Rust writer correctness, compatibility, support result,
+  or support-matrix movement.
+- Usage:
+  `file:oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/bootstrap_layout.py`;
+  `file:docs/LOCAL_WINDOWS_VM.md`; issue `#100`
+- Rights: future project-generated MDBs and provider outputs remain outside the
+  repository and are neither committed nor redistributed
+- Review: pending independent evidence-boundary, checkpoint-isolation,
+  plan-pin, producer, analyzer, sufficiency-negative-control, and no-retry
+  review before merge and local acquisition
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6367,9 +6367,11 @@ Use `not applicable` explicitly rather than omitting a field.
   projection, or post-hoc byte inspection is an experiment input, and
   `EXP-0069` is not treated as composition or sufficiency evidence.
 - Protocol: create three independent fresh `dbVersion30` replicas once. For
-  DateCreated, admit either one exact whole-image OLE Date match or exactly one
-  match in the fixed plus-or-minus-64-byte window around one exact LastUpdated
-  match. After the property-free empty, created, and renamed checkpoints, add
+  DateCreated, admit `unique_exact` for one exact whole-image OLE Date match or
+  `last_updated_anchor` for exactly one match in the fixed plus-or-minus-64-byte
+  window around one exact LastUpdated match. LastUpdated admits only
+  `unique_exact`; DateCreated can never serve as its reverse anchor. After the
+  property-free empty, created, and renamed checkpoints, add
   one deterministic 768-character custom DAO Memo property and capture a
   separate `property-set` checkpoint; read `MSysObjects` through one temporary
   `WITH OWNERACCESS OPTION` QueryDef and require one exact `EXP-0061`
@@ -6381,14 +6383,18 @@ Use `not applicable` explicitly rather than omitting a field.
   producer does not copy the created file as the candidate. The pinned analyzer
   independently repeats the application and uses byte equality with the
   created checkpoint solely as a completeness and integrity check, then
-  validates the candidate's once-only DAO endpoint result and unchanged hash.
+  validates the candidate's once-only DAO endpoint result. Baseline,
+  sufficiency, and ablation artifacts all report the same bounded before/after
+  size and SHA-256 snapshot contract. A bounded size or hash change is retained
+  as a repair and produces `no_outcome`; malformed or out-of-bound snapshots
+  reject.
   The `EXP-0068` leave-one-out variants are repeated only as execution-integrity
   controls and cannot broaden the necessity claims already recorded by
   `EXP-0069`.
 - Preregistration artifact:
   `oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json`,
   SHA-256
-  `0ee0212d7cd102a6518051c2a7e2025d58157771bd9aed552b88a4c870d7d82e`.
+  `28943c5f1efc62c89036fce4d997ab717321d152de3918f06d3bb1b9585ee5aa`.
   The plan pins the host client, provider probe, guest runner, dispatcher,
   publisher, producer, and host analyzer. The host and guest reject plan or
   staged-input digest mismatches before the first DAO mutation.
@@ -6397,14 +6403,17 @@ Use `not applicable` explicitly rather than omitting a field.
   human authorization is required for one local-VM run. No new MDB, provider
   output, canonical report, or scientific result exists.
 - Decision rule: validated correlations require identical canonical methods
-  and byte targets across replicas. A validated, identical, unchanged-hash DAO
-  endpoint map reports `observed_sufficient` or `not_observed_sufficient` only
-  for this complete-group scenario. Unresolved correlation, baseline failure
-  or repair, composed-image repair, correlation-target or endpoint-frontier
-  disagreement, or an otherwise intact non-decisive result is an honest
-  `no_outcome`; a failed or repaired created baseline also forces the
-  sufficiency claim false. Integrity and shape defects reject validation.
-  There is no automatic retry after the first DAO mutation.
+  and byte targets across replicas. Endpoint evidence must be one reachable
+  sequential frontier: `FFFF`, `TFFF`, `TTFF`, `TTTF`, or `TTTT`; any
+  true-after-false pattern rejects. A validated, identical, unchanged-size and
+  unchanged-hash DAO endpoint map reports `observed_sufficient` or
+  `not_observed_sufficient` only for this complete-group scenario. Unresolved
+  correlation, baseline failure or bounded repair, composed-image bounded
+  repair, correlation-target or endpoint-frontier disagreement, or an
+  otherwise intact non-decisive result is an honest `no_outcome`; a failed or
+  repaired created baseline also forces the sufficiency claim false. Integrity,
+  bound, and shape defects reject validation. There is no automatic retry
+  after the first DAO mutation.
 - Interpretation: this entry fixes a bounded acquisition and analysis contract
   only. It establishes no format fact, minimal mutation set, general timestamp
   or LvProp encoding, Rust writer correctness, compatibility, support result,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6388,7 +6388,7 @@ Use `not applicable` explicitly rather than omitting a field.
 - Preregistration artifact:
   `oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json`,
   SHA-256
-  `0fc3e3447fb60b14fa6fca3ec89152ccc364165f9f74933b509d534da3d2d00b`.
+  `0ee0212d7cd102a6518051c2a7e2025d58157771bd9aed552b88a4c870d7d82e`.
   The plan pins the host client, provider probe, guest runner, dispatcher,
   publisher, producer, and host analyzer. The host and guest reject plan or
   staged-input digest mismatches before the first DAO mutation.
@@ -6396,13 +6396,15 @@ Use `not applicable` explicitly rather than omitting a field.
   plan does not authorize acquisition. After review and merge, one explicit
   human authorization is required for one local-VM run. No new MDB, provider
   output, canonical report, or scientific result exists.
-- Decision rule: a validated, replica-consistent, unchanged-hash endpoint pass
-  reports `observed_sufficient` only for this complete-group scenario. A
-  consistent unchanged-hash endpoint failure reports
-  `not_observed_sufficient`. Unresolved correlation, repair, baseline failure,
-  replica disagreement, or an otherwise intact non-decisive result is an
-  honest `no_outcome`; integrity and shape defects reject validation. There is
-  no automatic retry after the first DAO mutation.
+- Decision rule: validated correlations require identical canonical methods
+  and byte targets across replicas. A validated, identical, unchanged-hash DAO
+  endpoint map reports `observed_sufficient` or `not_observed_sufficient` only
+  for this complete-group scenario. Unresolved correlation, baseline failure
+  or repair, composed-image repair, correlation-target or endpoint-frontier
+  disagreement, or an otherwise intact non-decisive result is an honest
+  `no_outcome`; a failed or repaired created baseline also forces the
+  sufficiency claim false. Integrity and shape defects reject validation.
+  There is no automatic retry after the first DAO mutation.
 - Interpretation: this entry fixes a bounded acquisition and analysis contract
   only. It establishes no format fact, minimal mutation set, general timestamp
   or LvProp encoding, Rust writer correctness, compatibility, support result,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6394,7 +6394,7 @@ Use `not applicable` explicitly rather than omitting a field.
 - Preregistration artifact:
   `oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json`,
   SHA-256
-  `28943c5f1efc62c89036fce4d997ab717321d152de3918f06d3bb1b9585ee5aa`.
+  `da56d399dd4608a6d938deac3dde4ce0d6125a15a56dc8204be1ebe9338b6994`.
   The plan pins the host client, provider probe, guest runner, dispatcher,
   publisher, producer, and host analyzer. The host and guest reject plan or
   staged-input digest mismatches before the first DAO mutation.

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -20,10 +20,11 @@ The retained tooling has three purposes:
   gating as the read differential.
 - `acquisition/bootstrap-layout.plan.json` retains the consumed acquisition
   rejected by `EXP-0067`; `acquisition/bootstrap-layout-floor.plan.json`,
-  `scripts/dev/BootstrapLayout.DevJob.ps1`, and
-  `scripts/bootstrap_layout.py` define the development-only local-VM
-  floor-corrected preregistration that blocks the next narrow creation slice
-  in #100.
+  consumed by `EXP-0069`, also remains immutable.
+  `acquisition/bootstrap-layout-sufficiency.plan.json`,
+  `scripts/dev/BootstrapLayout.DevJob.ps1`, and `scripts/bootstrap_layout.py`
+  define the active development-only local-VM successor for the unresolved
+  correlations and bounded all-groups sufficiency question in #100.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.

--- a/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
+++ b/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
@@ -1,0 +1,113 @@
+{
+  "document_type": "dao_bootstrap_layout_sufficiency_plan",
+  "experiment_id": "bootstrap_layout_sufficiency",
+  "issue": 100,
+  "development_only": true,
+  "purpose": "Resolve the two EXP-0069 catalog-correlation no_outcomes and test whether one complete empty-to-created mutation-group reconstruction is sufficient for DAO's bounded read-only endpoints.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_preregistration": "EXP-0068",
+    "prior_result": "EXP-0069",
+    "authorization": "No acquisition is authorized by committing this plan. After review and merge, the human operator may explicitly authorize one local-VM acquisition.",
+    "amendment_rule": "This is a distinct successor experiment, not a revision or retroactive repair. After its first DAO mutation, any failure or no_outcome is recorded once and it is not redispatched without another human decision."
+  },
+  "evidence_boundary": {
+    "admitted_prior_result": "EXP-0069 only as recorded in docs/PROVENANCE.md: DateCreated and LvProp correlations were no_outcome, LastUpdated was resolved, and the page groups were necessity-only. No prior MDB, producer JSON, unrecorded endpoint pattern, or post-hoc byte inspection is an experiment input.",
+    "not_composition_evidence": "EXP-0069 is not treated as sufficiency or composition evidence. The new composed candidate and its DAO observation are generated only under this plan from fresh checkpoints.",
+    "claims": "A successful result may establish only bounded sufficiency of the complete observed empty-to-created group reconstruction for this scenario and these read-only endpoints. It cannot establish a minimal group set, general encoding, Rust writer correctness, compatibility, support, or support-matrix movement."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "d089975e2680382d79dbb578270e0d094a88bfc292146e452e2391c962c04c58",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "70ae2742df55835069eb9c52e4e20bea219a7a6752b65d88d46addc9e40a72c9",
+    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "e6fd1f4ed9c6e0585b5080401f1343403396106b44840c42e2cf347fc9594806",
+    "oracle/windows-dao/scripts/bootstrap_layout.py": "201bfb20a8cca779a69c866a27d871d5931a8e9180624c46578ea242a83cfc12"
+  },
+  "basis": {
+    "EXP-0058": "Dynamic catalog-root discovery, catalog-owned page 18 in the observed controls, table record identifier to table-definition correlation, and the bounded catalog row fields recorded there.",
+    "EXP-0059": "Table-definition chain and owned/free map locator meanings.",
+    "EXP-0061": "OLE Date encoding and external long-value header, LVAL owner, and bounded row-directory structure only.",
+    "EXP-0065": "Only its preregistered Q1/Q2 facts: empty page count and tags, page append sequence, global-map transitions, and changed byte ranges.",
+    "EXP-0069": "Only its validated, additive result as described by evidence_boundary; its necessity results are controls and are not admitted as composition evidence."
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "scenario": "For each independent replica, create one fresh dbVersion30 CP1252 database, capture it closed, create one empty table named BootstrapLayout with one Long field named Id, capture it closed, wait exactly two seconds, rename it to BootstrapRenamed, and capture it closed. Only after that renamed checkpoint, add one DAO-visible custom Memo property named Jet3BootstrapProbe whose value is a deterministic replica-specific 768-character CP1252 marker, then capture the separate property-set checkpoint.",
+    "checkpoints": [
+      "empty",
+      "created",
+      "renamed",
+      "property-set"
+    ],
+    "isolation": "The property-set checkpoint is downstream of renamed. Its custom property and all resulting bytes are excluded from the empty-to-created mutation groups, the composed candidate, and the sufficiency leg.",
+    "bounds": {
+      "maximum_pages_per_database": 64,
+      "maximum_table_definitions": 128,
+      "maximum_catalog_rows": 512,
+      "maximum_lvprop_bytes": 65536,
+      "maximum_variants_per_replica": 64,
+      "maximum_replicas": 3,
+      "maximum_clock_separation_seconds": 2,
+      "timestamp_anchor_window_bytes": 64,
+      "lvprop_marker_characters": 768
+    },
+    "capture": "Close and release every DAO object before each MDB copy or hash. Retain four closed checkpoints, bounded semantic metadata, the existing preregistered control ablations, and one composed candidate per replica. MDBs remain external."
+  },
+  "questions": {
+    "Q1": {
+      "title": "DateCreated and LvProp correlations",
+      "date_created": "Scan the renamed image for exact little-endian OLE Date bytes returned by DAO. Accept a unique whole-image match, or, when the DateCreated bytes repeat, accept exactly one match within plus or minus 64 absolute file bytes of exactly one LastUpdated match. Any other candidate count, equal DAO timestamps, replica disagreement, or out-of-window attribution is no_outcome.",
+      "timestamp_ablation": "If and only if a timestamp correlation resolves, retain the EXP-0068 valid-OLE-Date-zero ablation and bounded read-only endpoints. These controls do not broaden the EXP-0069 necessity claim.",
+      "lvprop": "Read Name and LvProp through one temporary, non-persisted DAO QueryDef using WITH OWNERACCESS OPTION after the property-set checkpoint. Correlate the exact bounded DAO-visible LvProp payload to one complete EXP-0061 single-page LVAL row and one derived external header. Missing permission, null/empty payload, non-single-page storage, ambiguity, or replica disagreement is no_outcome.",
+      "separation": "LvProp evidence comes only from property-set. No property-set byte participates in Q2."
+    },
+    "Q2": {
+      "title": "Complete-group composed-image sufficiency",
+      "composition": "Allocate a new byte array at the created-checkpoint length; copy only the empty checkpoint bytes into its prefix; then apply source bytes for every exact page-0 empty-to-created range, every exact changed range on pre-existing pages 1 through empty_page_count-1, and every complete appended page. Do not copy the created file as the candidate.",
+      "independent_check": "The pinned analyzer independently repeats the range application and requires the reconstruction to equal the created checkpoint byte for byte. Equality is only a completeness/integrity check on the preregistered construction, not an input or a compatibility claim.",
+      "dao_observation": "Run the composed candidate once through OpenDatabase read-only, TableDefs enumeration for BootstrapLayout, exact Id/Long field enumeration, and an empty snapshot open. Hash immediately before and after DAO access.",
+      "answer": "All endpoints passing with an unchanged hash in all replicas is observed_sufficient for this bounded complete-group reconstruction. A consistent endpoint failure with unchanged hashes is not_observed_sufficient. Any repair, replica disagreement, baseline failure, or incomplete reconstruction is no_outcome or validation rejection according to the decision rule."
+    }
+  },
+  "controls": {
+    "baseline": "An exact created-checkpoint clone must pass the same endpoints with an unchanged hash in every replica.",
+    "necessity_repetition": "Retain the EXP-0068 page-0 and per-existing/appended-page leave-one-out controls as execution-integrity controls. They remain necessity-only and cannot establish sufficiency or a minimal set.",
+    "endpoint_contract": [
+      "OpenDatabase read-only",
+      "TableDefs enumeration finds exactly the checkpoint's target table",
+      "field enumeration finds exactly Id as Long",
+      "open the target table as an empty snapshot"
+    ]
+  },
+  "decision_rule": {
+    "accepted": "The plan and every staged input match their SHA-256 pins; the provider is ready; all three fresh replicas, controls, and composed candidates run once; files, hashes, bounds, checkpoint separation, page/range containment, independent reconstruction, and result shape validate; and the analyzer emits one deterministic accepted report. An accepted report may contain either observed_sufficient or not_observed_sufficient.",
+    "no_outcome": "Unresolved DateCreated or LvProp correlation, replica disagreement, a baseline endpoint failure, a post-access hash change, a partial producer failure after acquisition starts, or an otherwise intact but non-decisive observation is reported honestly as no_outcome.",
+    "rejected": "A plan/input digest mismatch, malformed or missing checkpoint, bound violation, property contamination of the created candidate, page/range mismatch, incomplete reconstruction, unexpected variant, file digest mismatch, or result-shape failure rejects validation.",
+    "retry": "This plan authorizes no run by itself. A later explicit human authorization permits one acquisition only; there is no automatic retry after the first DAO mutation."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "minimal mutation-set claims",
+    "general timestamp or LvProp encoding beyond the bounded controls",
+    "user rows",
+    "user indexes",
+    "relationships",
+    "free-page reuse",
+    "extended allocation maps",
+    "general long-value allocation or thresholds",
+    "public Rust API expansion",
+    "Rust publication or I/O",
+    "hosted write differential #102",
+    "compatibility or support claims"
+  ]
+}

--- a/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
+++ b/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
@@ -22,8 +22,8 @@
     "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
     "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "12249f3d7e82193bb47391760c1a92b816438ce726b89bd80e89dcab39fee781",
-    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "e6fd1f4ed9c6e0585b5080401f1343403396106b44840c42e2cf347fc9594806",
-    "oracle/windows-dao/scripts/bootstrap_layout.py": "2bb4439217f772c42b1e696d325bfcd37365da77b75b5cf73f312e0d5365b1e1"
+    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "8fad1a0ba81f516dd9fd66dd7c484ff54454847c6d3f0569dd76f69d8be22ccb",
+    "oracle/windows-dao/scripts/bootstrap_layout.py": "b29983ba258aad95031031e8b8adbe41a53f98d1b1a9c492c66f75128559e8f8"
   },
   "basis": {
     "EXP-0058": "Dynamic catalog-root discovery, catalog-owned page 18 in the observed controls, table record identifier to table-definition correlation, and the bounded catalog row fields recorded there.",
@@ -56,12 +56,13 @@
       "lvprop_marker_characters": 768,
       "maximum_published_databases": 210
     },
-    "capture": "Close and release every DAO object before each MDB copy or hash. Retain four closed checkpoints, bounded semantic metadata, the existing preregistered control ablations, and one composed candidate per replica. MDBs remain external."
+    "capture": "Close and release every DAO object before each MDB copy or hash. Retain four closed checkpoints, bounded semantic metadata, the existing preregistered control ablations, and one composed candidate per replica. Every baseline, composed-candidate, and ablation observation uses the same artifact contract: database, size_before, size_after, sha256_before, sha256_after, the four-endpoint frontier, and bounded detail. MDBs remain external."
   },
   "questions": {
     "Q1": {
       "title": "DateCreated and LvProp correlations",
-      "date_created": "Scan the renamed image for exact little-endian OLE Date bytes returned by DAO. Accept a unique whole-image match, or, when the DateCreated bytes repeat, accept exactly one match within plus or minus 64 absolute file bytes of exactly one LastUpdated match. Any other candidate count, equal DAO timestamps, replica disagreement, or out-of-window attribution is no_outcome.",
+      "date_created": "Scan the renamed image for exact little-endian OLE Date bytes returned by DAO. Accept method unique_exact for a unique whole-image DateCreated match, or method last_updated_anchor when repeated DateCreated bytes leave exactly one match within plus or minus 64 absolute file bytes of exactly one LastUpdated match. Any other candidate count, equal DAO timestamps, replica disagreement, or out-of-window attribution is no_outcome.",
+      "last_updated": "Accept LastUpdated only by method unique_exact: exactly one whole-image match for the DAO value, distinct from DateCreated. DateCreated is never an anchor for LastUpdated; multiple or missing LastUpdated matches are no_outcome.",
       "timestamp_ablation": "If and only if a timestamp correlation resolves, retain the EXP-0068 valid-OLE-Date-zero ablation and bounded read-only endpoints. These controls do not broaden the EXP-0069 necessity claim.",
       "lvprop": "Read Name and LvProp through one temporary, non-persisted DAO QueryDef using WITH OWNERACCESS OPTION after the property-set checkpoint. Correlate the exact bounded DAO-visible LvProp payload to one complete EXP-0061 single-page LVAL row and one derived external header. Missing permission, null/empty payload, non-single-page storage, ambiguity, or replica disagreement is no_outcome.",
       "replica_consistency": "All three replicas must report exactly the same canonical timestamp method and offset list and exactly the same LvProp header offset, payload page, and payload row. The canonical report retains these resolved targets; any disagreement is no_outcome.",
@@ -71,12 +72,12 @@
       "title": "Complete-group composed-image sufficiency",
       "composition": "Allocate a new byte array at the created-checkpoint length; copy only the empty checkpoint bytes into its prefix; then apply source bytes for every exact page-0 empty-to-created range, every exact changed range on pre-existing pages 1 through empty_page_count-1, and every complete appended page. Do not copy the created file as the candidate.",
       "independent_check": "The pinned analyzer independently repeats the range application and requires the reconstruction to equal the created checkpoint byte for byte. Equality is only a completeness/integrity check on the preregistered construction, not an input or a compatibility claim.",
-      "dao_observation": "Run the composed candidate once through OpenDatabase read-only, TableDefs enumeration for BootstrapLayout, exact Id/Long field enumeration, and an empty snapshot open. Hash immediately before and after DAO access.",
-      "answer": "All endpoints passing with an unchanged hash in all replicas is observed_sufficient for this bounded complete-group reconstruction. One exact, replica-consistent endpoint-failure map with unchanged hashes is not_observed_sufficient. The canonical report retains the agreed endpoint map. Any endpoint-frontier disagreement, repair, created-baseline failure or repair, unresolved correlation, or incomplete reconstruction is no_outcome or validation rejection according to the decision rule."
+      "dao_observation": "Run the composed candidate once through OpenDatabase read-only, TableDefs enumeration for BootstrapLayout, exact Id/Long field enumeration, and an empty snapshot open. Record bounded size and SHA-256 immediately before and after DAO access.",
+      "answer": "All endpoints passing with unchanged size and hash in all replicas is observed_sufficient for this bounded complete-group reconstruction. One exact, replica-consistent reachable endpoint frontier with unchanged sizes and hashes is not_observed_sufficient. The only reachable frontiers are FFFF, TFFF, TTFF, TTTF, and TTTT in endpoint_contract order; true-after-false evidence rejects as malformed. The canonical report retains the agreed endpoint map. Any endpoint-frontier disagreement, bounded repair, created-baseline failure or repair, unresolved correlation, or incomplete reconstruction is no_outcome or validation rejection according to the decision rule."
     }
   },
   "controls": {
-    "baseline": "An exact created-checkpoint clone must pass the same endpoints with an unchanged hash in every replica.",
+    "baseline": "An exact created-checkpoint clone must pass the same endpoints with unchanged bounded size and hash in every replica.",
     "necessity_repetition": "Retain the EXP-0068 page-0 and per-existing/appended-page leave-one-out controls as execution-integrity controls. They remain necessity-only and cannot establish sufficiency or a minimal set.",
     "endpoint_contract": [
       "OpenDatabase read-only",
@@ -87,8 +88,8 @@
   },
   "decision_rule": {
     "accepted": "The plan and every staged input match their SHA-256 pins; the provider is ready; all three fresh replicas, controls, and composed candidates run once; files, hashes, bounds, checkpoint separation, page/range containment, independent reconstruction, and result shape validate; and the analyzer emits one deterministic accepted report. An accepted report may contain either observed_sufficient or not_observed_sufficient.",
-    "no_outcome": "Unresolved DateCreated or LvProp correlation, disagreement in a canonical correlation target or exact DAO endpoint map, a created-baseline endpoint failure or repair, a post-access hash change, a partial producer failure after acquisition starts, or an otherwise intact but non-decisive observation is reported honestly as no_outcome. A failed or repaired created baseline forces Q2 to no_outcome and sufficiency_claim false regardless of the composed candidate observation.",
-    "rejected": "A plan/input digest mismatch, malformed or missing checkpoint, bound violation, property contamination of the created candidate, page/range mismatch, incomplete reconstruction, unexpected variant, file digest mismatch, or result-shape failure rejects validation.",
+    "no_outcome": "Unresolved DateCreated or LvProp correlation, disagreement in a canonical correlation target or exact reachable DAO endpoint frontier, a created-baseline endpoint failure or repair, any bounded post-access size or hash change, a partial producer failure after acquisition starts, or an otherwise intact but non-decisive observation is reported honestly as no_outcome. A failed or repaired created baseline forces Q2 to no_outcome and sufficiency_claim false regardless of the composed candidate observation.",
+    "rejected": "A plan/input digest mismatch, malformed or missing checkpoint, bound violation, malformed or out-of-bound before/after artifact snapshot, impossible true-after-false endpoint evidence, property contamination of the created candidate, page/range mismatch, incomplete reconstruction, unexpected variant, file digest mismatch, or result-shape failure rejects validation. A bounded, well-formed post-access size or hash change is a repair/no_outcome, not rejection.",
     "retry": "This plan authorizes no run by itself. A later explicit human authorization permits one acquisition only; there is no automatic retry after the first DAO mutation."
   },
   "publication": {

--- a/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
+++ b/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
@@ -22,7 +22,7 @@
     "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
     "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "12249f3d7e82193bb47391760c1a92b816438ce726b89bd80e89dcab39fee781",
-    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "8fad1a0ba81f516dd9fd66dd7c484ff54454847c6d3f0569dd76f69d8be22ccb",
+    "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "583d77a60d8fe915983ca7366ea48198f27c226caaf7c58f43b65866af5d17d7",
     "oracle/windows-dao/scripts/bootstrap_layout.py": "b29983ba258aad95031031e8b8adbe41a53f98d1b1a9c492c66f75128559e8f8"
   },
   "basis": {

--- a/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
+++ b/oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json
@@ -21,9 +21,9 @@
     "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
     "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "f5ed1b5d04f632ef20483aa6526e51693a7ea9a0170821f869ea93faf0534381",
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "42ead0007ff899b7f586cdc897b2e037a8d155931f8ec48988c46c16701b26c3",
-    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "70ae2742df55835069eb9c52e4e20bea219a7a6752b65d88d46addc9e40a72c9",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "12249f3d7e82193bb47391760c1a92b816438ce726b89bd80e89dcab39fee781",
     "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1": "e6fd1f4ed9c6e0585b5080401f1343403396106b44840c42e2cf347fc9594806",
-    "oracle/windows-dao/scripts/bootstrap_layout.py": "201bfb20a8cca779a69c866a27d871d5931a8e9180624c46578ea242a83cfc12"
+    "oracle/windows-dao/scripts/bootstrap_layout.py": "2bb4439217f772c42b1e696d325bfcd37365da77b75b5cf73f312e0d5365b1e1"
   },
   "basis": {
     "EXP-0058": "Dynamic catalog-root discovery, catalog-owned page 18 in the observed controls, table record identifier to table-definition correlation, and the bounded catalog row fields recorded there.",
@@ -53,7 +53,8 @@
       "maximum_replicas": 3,
       "maximum_clock_separation_seconds": 2,
       "timestamp_anchor_window_bytes": 64,
-      "lvprop_marker_characters": 768
+      "lvprop_marker_characters": 768,
+      "maximum_published_databases": 210
     },
     "capture": "Close and release every DAO object before each MDB copy or hash. Retain four closed checkpoints, bounded semantic metadata, the existing preregistered control ablations, and one composed candidate per replica. MDBs remain external."
   },
@@ -63,6 +64,7 @@
       "date_created": "Scan the renamed image for exact little-endian OLE Date bytes returned by DAO. Accept a unique whole-image match, or, when the DateCreated bytes repeat, accept exactly one match within plus or minus 64 absolute file bytes of exactly one LastUpdated match. Any other candidate count, equal DAO timestamps, replica disagreement, or out-of-window attribution is no_outcome.",
       "timestamp_ablation": "If and only if a timestamp correlation resolves, retain the EXP-0068 valid-OLE-Date-zero ablation and bounded read-only endpoints. These controls do not broaden the EXP-0069 necessity claim.",
       "lvprop": "Read Name and LvProp through one temporary, non-persisted DAO QueryDef using WITH OWNERACCESS OPTION after the property-set checkpoint. Correlate the exact bounded DAO-visible LvProp payload to one complete EXP-0061 single-page LVAL row and one derived external header. Missing permission, null/empty payload, non-single-page storage, ambiguity, or replica disagreement is no_outcome.",
+      "replica_consistency": "All three replicas must report exactly the same canonical timestamp method and offset list and exactly the same LvProp header offset, payload page, and payload row. The canonical report retains these resolved targets; any disagreement is no_outcome.",
       "separation": "LvProp evidence comes only from property-set. No property-set byte participates in Q2."
     },
     "Q2": {
@@ -70,7 +72,7 @@
       "composition": "Allocate a new byte array at the created-checkpoint length; copy only the empty checkpoint bytes into its prefix; then apply source bytes for every exact page-0 empty-to-created range, every exact changed range on pre-existing pages 1 through empty_page_count-1, and every complete appended page. Do not copy the created file as the candidate.",
       "independent_check": "The pinned analyzer independently repeats the range application and requires the reconstruction to equal the created checkpoint byte for byte. Equality is only a completeness/integrity check on the preregistered construction, not an input or a compatibility claim.",
       "dao_observation": "Run the composed candidate once through OpenDatabase read-only, TableDefs enumeration for BootstrapLayout, exact Id/Long field enumeration, and an empty snapshot open. Hash immediately before and after DAO access.",
-      "answer": "All endpoints passing with an unchanged hash in all replicas is observed_sufficient for this bounded complete-group reconstruction. A consistent endpoint failure with unchanged hashes is not_observed_sufficient. Any repair, replica disagreement, baseline failure, or incomplete reconstruction is no_outcome or validation rejection according to the decision rule."
+      "answer": "All endpoints passing with an unchanged hash in all replicas is observed_sufficient for this bounded complete-group reconstruction. One exact, replica-consistent endpoint-failure map with unchanged hashes is not_observed_sufficient. The canonical report retains the agreed endpoint map. Any endpoint-frontier disagreement, repair, created-baseline failure or repair, unresolved correlation, or incomplete reconstruction is no_outcome or validation rejection according to the decision rule."
     }
   },
   "controls": {
@@ -85,7 +87,7 @@
   },
   "decision_rule": {
     "accepted": "The plan and every staged input match their SHA-256 pins; the provider is ready; all three fresh replicas, controls, and composed candidates run once; files, hashes, bounds, checkpoint separation, page/range containment, independent reconstruction, and result shape validate; and the analyzer emits one deterministic accepted report. An accepted report may contain either observed_sufficient or not_observed_sufficient.",
-    "no_outcome": "Unresolved DateCreated or LvProp correlation, replica disagreement, a baseline endpoint failure, a post-access hash change, a partial producer failure after acquisition starts, or an otherwise intact but non-decisive observation is reported honestly as no_outcome.",
+    "no_outcome": "Unresolved DateCreated or LvProp correlation, disagreement in a canonical correlation target or exact DAO endpoint map, a created-baseline endpoint failure or repair, a post-access hash change, a partial producer failure after acquisition starts, or an otherwise intact but non-decisive observation is reported honestly as no_outcome. A failed or repaired created baseline forces Q2 to no_outcome and sufficiency_claim false regardless of the composed candidate observation.",
     "rejected": "A plan/input digest mismatch, malformed or missing checkpoint, bound violation, property contamination of the created candidate, page/range mismatch, incomplete reconstruction, unexpected variant, file digest mismatch, or result-shape failure rejects validation.",
     "retry": "This plan authorizes no run by itself. A later explicit human authorization permits one acquisition only; there is no automatic retry after the first DAO mutation."
   },

--- a/oracle/windows-dao/scripts/bootstrap_layout.py
+++ b/oracle/windows-dao/scripts/bootstrap_layout.py
@@ -29,6 +29,18 @@ ENDPOINT_NAMES = (
     "field_enumerated",
     "table_opened",
 )
+VALID_ENDPOINT_FRONTIERS = {
+    tuple(index < reached for index in range(len(ENDPOINT_NAMES)))
+    for reached in range(len(ENDPOINT_NAMES) + 1)
+}
+ARTIFACT_OBSERVATION_FIELDS = {
+    "database",
+    "size_before",
+    "size_after",
+    "sha256_before",
+    "sha256_after",
+    "endpoints",
+}
 VARIANT_KINDS = {
     "candidate_page0",
     "candidate_date_created",
@@ -181,12 +193,16 @@ def _ranges(
     return result
 
 
-def _endpoints(value: dict[str, Any], location: str) -> dict[str, bool]:
+def _endpoint_frontier(value: Any, location: str) -> dict[str, bool]:
+    if not isinstance(value, dict):
+        raise AnalysisError(f"{location} must be an object")
     result: dict[str, bool] = {}
     for name in ENDPOINT_NAMES:
         if name not in value or type(value[name]) is not bool:
             raise AnalysisError(f"{location}.{name} must be boolean")
         result[name] = value[name]
+    if tuple(result.values()) not in VALID_ENDPOINT_FRONTIERS:
+        raise AnalysisError(f"{location} is not a reachable DAO endpoint frontier")
     return result
 
 
@@ -200,6 +216,85 @@ def _read_file(root: Path, database: str, size: int, digest: str, location: str)
     if sha256(data) != digest:
         raise AnalysisError(f"{location}.database digest differs from metadata")
     return data
+
+
+def _artifact_observation_contract(
+    value: Any,
+    location: str,
+    *,
+    required: set[str] | None = None,
+    optional: set[str] | None = None,
+) -> tuple[dict[str, Any], dict[str, bool]]:
+    item = _expect_keys(
+        value,
+        ARTIFACT_OBSERVATION_FIELDS | (required or set()),
+        {"detail"} | (optional or set()),
+        location,
+    )
+    endpoint_item = _expect_keys(
+        item["endpoints"], set(ENDPOINT_NAMES), {"detail"}, f"{location}.endpoints"
+    )
+    endpoints = _endpoint_frontier(endpoint_item, f"{location}.endpoints")
+    if "detail" in endpoint_item:
+        _detail(endpoint_item["detail"], f"{location}.endpoints.detail")
+    if "detail" in item:
+        _detail(item["detail"], f"{location}.detail")
+    return item, endpoints
+
+
+def _artifact_observation(
+    value: Any,
+    location: str,
+    root: Path,
+    *,
+    expected_before: bytes,
+    required: set[str] | None = None,
+    optional: set[str] | None = None,
+) -> dict[str, Any]:
+    item, endpoints = _artifact_observation_contract(
+        value, location, required=required, optional=optional
+    )
+    database = _database(item["database"], f"{location}.database")
+    size_before = _size(item["size_before"], f"{location}.size_before")
+    size_after = _size(item["size_after"], f"{location}.size_after")
+    before = _digest(item["sha256_before"], f"{location}.sha256_before")
+    after = _digest(item["sha256_after"], f"{location}.sha256_after")
+    if size_before != len(expected_before) or before != sha256(expected_before):
+        raise AnalysisError(f"{location} pre-open snapshot differs from its expected image")
+    current = _read_file(root, database, size_after, after, location)
+    repaired = size_before != size_after or before != after
+    if not repaired and current != expected_before:
+        raise AnalysisError(f"{location} unchanged snapshot differs from its expected image")
+    return {
+        "endpoints": endpoints,
+        "repaired": repaired,
+        "sha256": before,
+    }
+
+
+def _partial_artifact_observation(
+    value: Any,
+    location: str,
+    root: Path,
+    *,
+    expected_before: bytes | None,
+) -> dict[str, Any] | None:
+    item, _ = _artifact_observation_contract(value, location)
+    identity = [
+        item[name]
+        for name in (
+            "database",
+            "size_before",
+            "size_after",
+            "sha256_before",
+            "sha256_after",
+        )
+    ]
+    if all(part is None for part in identity):
+        return None
+    if any(part is None for part in identity) or expected_before is None:
+        raise AnalysisError(f"{location} has incomplete artifact snapshots")
+    return _artifact_observation(item, location, root, expected_before=expected_before)
 
 
 def _dao(value: Any, checkpoint: str, location: str) -> dict[str, Any]:
@@ -313,26 +408,40 @@ def _reported_date_correlation(
     location: str,
     renamed: bytes,
     oadate: float | None,
-    other: float | None,
+    *,
+    distinct_from: float | None,
+    last_updated_anchor: float | None,
+    allow_last_updated_anchor: bool,
 ) -> dict[str, Any]:
+    if allow_last_updated_anchor != (last_updated_anchor is not None):
+        raise AnalysisError(f"{location} has an invalid timestamp-correlation policy")
     item = _expect_keys(value, {"status", "detail"}, {"method", "offsets"}, location)
     _detail(item["detail"], f"{location}.detail")
     matches = [] if oadate is None else _find_all(renamed, struct.pack("<d", oadate))
     resolved_matches = matches
     method = "unique_exact"
-    if oadate is not None and other is not None and oadate != other and len(matches) != 1:
-        anchors = _find_all(renamed, struct.pack("<d", other))
+    distinct_anchor = (
+        oadate is not None
+        and distinct_from is not None
+        and oadate != distinct_from
+    )
+    usable_anchor = (
+        distinct_anchor
+        and last_updated_anchor is not None
+        and oadate != last_updated_anchor
+    )
+    if allow_last_updated_anchor and usable_anchor and len(matches) != 1:
+        anchors = _find_all(renamed, struct.pack("<d", last_updated_anchor))
         if len(anchors) == 1:
             resolved_matches = [
                 offset
                 for offset in matches
                 if abs(offset - anchors[0]) <= TIMESTAMP_ANCHOR_WINDOW_BYTES
             ]
-            method = "other_timestamp_anchor"
+            method = "last_updated_anchor"
     resolved = (
         oadate is not None
-        and other is not None
-        and oadate != other
+        and distinct_anchor
         and len(resolved_matches) == 1
     )
     if resolved:
@@ -413,28 +522,9 @@ def _baseline(
     value: Any,
     location: str,
     root: Path,
-    created: dict[str, Any],
     created_bytes: bytes,
 ) -> dict[str, Any]:
-    item = _expect_keys(
-        value,
-        {"database", "sha256_before_open", "sha256_after_open", *ENDPOINT_NAMES},
-        {"detail"},
-        location,
-    )
-    database = _database(item["database"], f"{location}.database")
-    before = _digest(item["sha256_before_open"], f"{location}.sha256_before_open")
-    after = _digest(item["sha256_after_open"], f"{location}.sha256_after_open")
-    if "detail" in item:
-        _detail(item["detail"], f"{location}.detail")
-    endpoints = _endpoints(item, location)
-    current = _read_file(root, database, created["size"], after, location)
-    if before != created["sha256"]:
-        raise AnalysisError(f"{location} pre-open hash differs from the created checkpoint")
-    repaired = before != after
-    if not repaired and current != created_bytes:
-        raise AnalysisError(f"{location} is not an exact created-checkpoint clone")
-    return {"endpoints": endpoints, "repaired": repaired}
+    return _artifact_observation(value, location, root, expected_before=created_bytes)
 
 
 def _sufficiency(
@@ -447,33 +537,6 @@ def _sufficiency(
     page0_ranges: list[dict[str, int]],
     groups: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    item = _expect_keys(
-        value,
-        {
-            "database",
-            "size",
-            "sha256_before_open",
-            "sha256_after_open",
-            "endpoints",
-        },
-        {"detail"},
-        location,
-    )
-    database = _database(item["database"], f"{location}.database")
-    size = _size(item["size"], f"{location}.size")
-    if size != created["size"]:
-        raise AnalysisError(f"{location}.size differs from the created checkpoint")
-    before = _digest(item["sha256_before_open"], f"{location}.sha256_before_open")
-    after = _digest(item["sha256_after_open"], f"{location}.sha256_after_open")
-    endpoint_item = _expect_keys(
-        item["endpoints"], set(ENDPOINT_NAMES), {"detail"}, f"{location}.endpoints"
-    )
-    endpoints = _endpoints(endpoint_item, f"{location}.endpoints")
-    if "detail" in endpoint_item:
-        _detail(endpoint_item["detail"], f"{location}.endpoints.detail")
-    if "detail" in item:
-        _detail(item["detail"], f"{location}.detail")
-
     expected = bytearray(created["size"])
     expected[: len(empty_bytes)] = empty_bytes
     for group in [{"ranges": page0_ranges}, *groups]:
@@ -483,13 +546,7 @@ def _sufficiency(
     expected_bytes = bytes(expected)
     if expected_bytes != created_bytes:
         raise AnalysisError(f"{location} mutation groups do not reconstruct the created checkpoint")
-    if before != sha256(expected_bytes):
-        raise AnalysisError(f"{location} pre-open digest differs from independent reconstruction")
-    current = _read_file(root, database, size, after, location)
-    repaired = before != after
-    if not repaired and current != expected_bytes:
-        raise AnalysisError(f"{location} differs from independent reconstruction")
-    return {"endpoints": endpoints, "repaired": repaired}
+    return _artifact_observation(value, location, root, expected_before=expected_bytes)
 
 
 def _groups(
@@ -566,56 +623,38 @@ def _page0(
 def _parse_variant(
     value: Any,
     location: str,
-    root: Path,
     maximum: int,
     page_count: int,
-) -> tuple[dict[str, Any], bytes]:
-    required = {
+) -> dict[str, Any]:
+    variant_fields = {
         "name",
         "kind",
-        "database",
-        "size",
         "base_checkpoint",
         "ranges",
-        "sha256_before_open",
-        "sha256_after_open",
-        "endpoints",
     }
-    item = _expect_keys(value, required, {"page", "detail"}, location)
+    item = _expect_keys(
+        value,
+        variant_fields | ARTIFACT_OBSERVATION_FIELDS,
+        {"page", "detail"},
+        location,
+    )
     if item["kind"] not in VARIANT_KINDS:
         raise AnalysisError(f"{location}.kind is not preregistered")
     if item["base_checkpoint"] not in ("created", "renamed"):
         raise AnalysisError(f"{location}.base_checkpoint must be created or renamed")
-    database = _database(item["database"], f"{location}.database")
-    size = _size(item["size"], f"{location}.size")
-    if size != maximum:
-        raise AnalysisError(f"{location}.size differs from its checkpoint size")
-    before = _digest(item["sha256_before_open"], f"{location}.sha256_before_open")
-    after = _digest(item["sha256_after_open"], f"{location}.sha256_after_open")
     page = None
     if "page" in item:
         page = _integer(item["page"], f"{location}.page", 0, page_count - 1)
     ranges = _ranges(item["ranges"], f"{location}.ranges", maximum=maximum, page=page)
-    endpoints_item = _expect_keys(
-        item["endpoints"], set(ENDPOINT_NAMES), {"detail"}, f"{location}.endpoints"
-    )
-    endpoints = _endpoints(endpoints_item, f"{location}.endpoints")
-    if "detail" in endpoints_item:
-        _detail(endpoints_item["detail"], f"{location}.endpoints.detail")
-    if "detail" in item:
-        _detail(item["detail"], f"{location}.detail")
-    data = _read_file(root, database, size, after, location)
     return {
         "base_checkpoint": item["base_checkpoint"],
-        "database": database,
-        "endpoints": endpoints,
+        "database": item["database"],
         "kind": item["kind"],
         "name": _name(item["name"], f"{location}.name"),
         "page": page,
         "ranges": ranges,
-        "repaired": before != after,
-        "sha256": before,
-    }, data
+        "raw": item,
+    }
 
 
 def _apply_source(base: bytes, source: bytes | None, ranges: list[dict[str, int]]) -> bytes:
@@ -657,7 +696,7 @@ def _validate_complete_replica(
     if checkpoints["property-set"]["size"] < checkpoints["renamed"]["size"]:
         raise AnalysisError(f"{location}.property-set is shorter than renamed")
     baseline = _baseline(
-        item["baseline"], f"{location}.baseline", root, checkpoints["created"], images["created"]
+        item["baseline"], f"{location}.baseline", root, images["created"]
     )
 
     renamed_dao = checkpoints["renamed"]["dao"]
@@ -675,14 +714,18 @@ def _validate_complete_replica(
             f"{location}.correlations.date_created",
             images["renamed"],
             created_date,
-            updated_date,
+            distinct_from=updated_date,
+            last_updated_anchor=updated_date,
+            allow_last_updated_anchor=True,
         ),
         "date_updated": _reported_date_correlation(
             correlations_item["date_updated"],
             f"{location}.correlations.date_updated",
             images["renamed"],
             updated_date,
-            created_date,
+            distinct_from=created_date,
+            last_updated_anchor=None,
+            allow_last_updated_anchor=False,
         ),
         "lvprop": _reported_lvprop_correlation(
             correlations_item["lvprop"],
@@ -751,11 +794,10 @@ def _validate_complete_replica(
     raw_variants = item["variants"]
     if not isinstance(raw_variants, list) or not 1 <= len(raw_variants) <= MAX_ITEMS:
         raise AnalysisError(f"{location}.variants must contain 1 through {MAX_ITEMS} entries")
-    variants_with_data = [
-        _parse_variant(raw, f"{location}.variants[{index}]", root, created_size, page_count)
+    variants = [
+        _parse_variant(raw, f"{location}.variants[{index}]", created_size, page_count)
         for index, raw in enumerate(raw_variants)
     ]
-    variants = [pair[0] for pair in variants_with_data]
     if len({variant["name"] for variant in variants}) != len(variants):
         raise AnalysisError(f"{location}.variants repeats a name")
     by_kind = {
@@ -808,18 +850,22 @@ def _validate_complete_replica(
         ):
             raise AnalysisError(f"{location}.{variant['name']} differs from its mutation group")
 
-    data_by_name = {variant["name"]: data for variant, data in variants_with_data}
-    for variant in variants:
+    for index, variant in enumerate(variants):
         kind = variant["kind"]
         expected_base = "renamed" if kind.startswith("candidate_date_") else "created"
         if variant["base_checkpoint"] != expected_base:
             raise AnalysisError(f"{location}.{variant['name']} has the wrong base checkpoint")
         source = images["empty"] if kind in ("candidate_page0", "revert_existing_page") else None
         expected = _apply_source(images[expected_base], source, variant["ranges"])
-        if sha256(expected) != variant["sha256"]:
-            raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
-        if not variant["repaired"] and data_by_name[variant["name"]] != expected:
-            raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
+        observation = _artifact_observation(
+            variant["raw"],
+            f"{location}.variants[{index}]",
+            root,
+            expected_before=expected,
+            required={"name", "kind", "base_checkpoint", "ranges"},
+            optional={"page"},
+        )
+        variant.update(observation)
         if variant["sha256"] == checkpoints[expected_base]["sha256"]:
             raise AnalysisError(f"{location}.{variant['name']} did not mutate its base checkpoint")
 
@@ -876,34 +922,12 @@ def _validate_partial_replica(
         databases.add(checkpoint["database"])
 
     if "baseline" in item:
-        baseline = _expect_keys(
+        _partial_artifact_observation(
             item["baseline"],
-            {"database", "sha256_before_open", "sha256_after_open", *ENDPOINT_NAMES},
-            {"detail"},
             f"{location}.baseline",
+            root,
+            expected_before=images.get("created"),
         )
-        _endpoints(baseline, f"{location}.baseline")
-        if "detail" in baseline:
-            _detail(baseline["detail"], f"{location}.baseline.detail")
-        identity = [
-            baseline["database"],
-            baseline["sha256_before_open"],
-            baseline["sha256_after_open"],
-        ]
-        if all(value is None for value in identity):
-            pass
-        elif any(value is None for value in identity):
-            raise AnalysisError(f"{location}.baseline has incomplete file identity")
-        else:
-            if "created" not in checkpoints:
-                raise AnalysisError(f"{location}.baseline lacks its created checkpoint")
-            _baseline(
-                item["baseline"],
-                f"{location}.baseline",
-                root,
-                checkpoints["created"],
-                images["created"],
-            )
     page0_ranges: dict[str, list[dict[str, int]]] | None = None
     has_page0 = "page0_values" in item or "page0_changed_ranges" in item
     if has_page0:
@@ -933,14 +957,18 @@ def _validate_partial_replica(
                     f"{location}.correlations.date_created",
                     images["renamed"],
                     created_date,
-                    updated_date,
+                    distinct_from=updated_date,
+                    last_updated_anchor=updated_date,
+                    allow_last_updated_anchor=True,
                 ),
                 "date_updated": _reported_date_correlation(
                     raw_correlations["date_updated"],
                     f"{location}.correlations.date_updated",
                     images["renamed"],
                     updated_date,
-                    created_date,
+                    distinct_from=created_date,
+                    last_updated_anchor=None,
+                    allow_last_updated_anchor=False,
                 ),
                 "lvprop": _reported_lvprop_correlation(
                     raw_correlations["lvprop"],
@@ -1029,55 +1057,30 @@ def _validate_partial_replica(
                 raise AnalysisError(f"{location}.{group['name']} does not cover its full page")
 
     if "sufficiency" in item:
-        sufficiency = _expect_keys(
-            item["sufficiency"],
-            {
-                "database",
-                "size",
-                "sha256_before_open",
-                "sha256_after_open",
-                "endpoints",
-            },
-            {"detail"},
-            f"{location}.sufficiency",
-        )
-        endpoint_item = _expect_keys(
-            sufficiency["endpoints"],
-            set(ENDPOINT_NAMES),
-            {"detail"},
-            f"{location}.sufficiency.endpoints",
-        )
-        _endpoints(endpoint_item, f"{location}.sufficiency.endpoints")
-        if "detail" in endpoint_item:
-            _detail(
-                endpoint_item["detail"], f"{location}.sufficiency.endpoints.detail"
-            )
-        if "detail" in sufficiency:
-            _detail(sufficiency["detail"], f"{location}.sufficiency.detail")
-        identity = [
-            sufficiency["database"],
-            sufficiency["sha256_before_open"],
-            sufficiency["sha256_after_open"],
-        ]
-        if all(value is None for value in identity):
-            if sufficiency["size"] != 0:
-                raise AnalysisError(f"{location}.sufficiency empty identity has nonzero size")
-        elif any(value is None for value in identity):
-            raise AnalysisError(f"{location}.sufficiency has incomplete file identity")
-        else:
-            if not {"empty", "created"} <= set(checkpoints) or page0_ranges is None:
-                raise AnalysisError(
-                    f"{location}.sufficiency lacks its reconstruction checkpoints"
-                )
-            _sufficiency(
-                sufficiency,
+        if not {"empty", "created"} <= set(checkpoints) or page0_ranges is None:
+            _partial_artifact_observation(
+                item["sufficiency"],
                 f"{location}.sufficiency",
                 root,
-                images["empty"],
-                checkpoints["created"],
-                images["created"],
-                page0_ranges["empty_to_created"],
-                changed + appended,
+                expected_before=None,
+            )
+        else:
+            expected = bytearray(checkpoints["created"]["size"])
+            expected[: len(images["empty"])] = images["empty"]
+            for group in [{"ranges": page0_ranges["empty_to_created"]}, *changed, *appended]:
+                for part in group["ranges"]:
+                    start, end = part["start"], part["end"]
+                    expected[start:end] = images["created"][start:end]
+            if bytes(expected) != images["created"]:
+                raise AnalysisError(
+                    f"{location}.sufficiency mutation groups do not reconstruct "
+                    "the created checkpoint"
+                )
+            _partial_artifact_observation(
+                item["sufficiency"],
+                f"{location}.sufficiency",
+                root,
+                expected_before=bytes(expected),
             )
 
     if "variants" in item:
@@ -1090,11 +1093,10 @@ def _validate_partial_replica(
         page_count = (
             checkpoints["created"]["page_count"] if "created" in checkpoints else 1
         )
-        parsed = [
-            _parse_variant(raw_variant, f"{location}.variants[{index}]", root, maximum, page_count)
+        variants = [
+            _parse_variant(raw_variant, f"{location}.variants[{index}]", maximum, page_count)
             for index, raw_variant in enumerate(raw_variants)
         ]
-        variants = [pair[0] for pair in parsed]
         if len({variant["name"] for variant in variants}) != len(variants):
             raise AnalysisError(f"{location}.variants repeats a name")
         groups = {
@@ -1105,7 +1107,7 @@ def _validate_partial_replica(
             )
             for group in entries
         }
-        for variant, current in parsed:
+        for index, variant in enumerate(variants):
             kind = variant["kind"]
             base = "renamed" if kind.startswith("candidate_date_") else "created"
             if variant["base_checkpoint"] != base or base not in images:
@@ -1144,11 +1146,15 @@ def _validate_partial_replica(
                 if kind == "revert_existing_page" and source is None:
                     raise AnalysisError(f"{location}.{variant['name']} lacks the empty checkpoint")
             expected_bytes = _apply_source(images[base], source, variant["ranges"])
-            if sha256(expected_bytes) != variant["sha256"]:
-                raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
-            if not variant["repaired"] and current != expected_bytes:
-                raise AnalysisError(f"{location}.{variant['name']} differs outside its declared mutation")
-            if variant["sha256"] == checkpoints[base]["sha256"]:
+            observation = _artifact_observation(
+                variant["raw"],
+                f"{location}.variants[{index}]",
+                root,
+                expected_before=expected_bytes,
+                required={"name", "kind", "base_checkpoint", "ranges"},
+                optional={"page"},
+            )
+            if observation["sha256"] == checkpoints[base]["sha256"]:
                 raise AnalysisError(f"{location}.{variant['name']} did not mutate its base checkpoint")
     return {
         "checkpoint_sha256": {

--- a/oracle/windows-dao/scripts/bootstrap_layout.py
+++ b/oracle/windows-dao/scripts/bootstrap_layout.py
@@ -826,6 +826,7 @@ def _validate_complete_replica(
     summarized = [
         {
             "base_checkpoint": variant["base_checkpoint"],
+            "endpoints": variant["endpoints"],
             "kind": variant["kind"],
             "name": variant["name"],
             "outcome": _variant_outcome(variant),
@@ -1198,6 +1199,35 @@ def _aggregate(values: list[str], label: str) -> dict[str, Any]:
     return {"reason": f"replicas disagree for {label}", "status": "no_outcome"}
 
 
+def _aggregate_variant_observations(
+    observations: list[dict[str, Any]], label: str
+) -> dict[str, Any]:
+    endpoint_maps = [observation["endpoints"] for observation in observations]
+    if any(endpoints != endpoint_maps[0] for endpoints in endpoint_maps[1:]):
+        return {
+            "reason": f"replicas disagree on the DAO endpoint map for {label}",
+            "status": "no_outcome",
+        }
+    aggregate = _aggregate(
+        [observation["outcome"] for observation in observations], label
+    )
+    return {**aggregate, "endpoints": endpoint_maps[0]}
+
+
+def _resolved_correlation(
+    replicas: list[dict[str, Any]], field: str, unresolved_reason: str
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    correlations = [replica["correlations"][field] for replica in replicas]
+    if any(correlation["status"] != "resolved" for correlation in correlations):
+        return None, {"reason": unresolved_reason, "status": "no_outcome"}
+    if any(correlation != correlations[0] for correlation in correlations[1:]):
+        return None, {
+            "reason": f"replicas disagree on the {field} correlation evidence",
+            "status": "no_outcome",
+        }
+    return correlations[0], None
+
+
 def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> dict[str, Any]:
     complete = all(replica["complete"] for replica in replicas)
     if not complete:
@@ -1213,10 +1243,10 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
         }
     else:
         page0 = (
-            _aggregate(
+            _aggregate_variant_observations(
                 [
                     next(
-                        variant["outcome"]
+                        variant
                         for variant in replica["variants"]
                         if variant["kind"] == "candidate_page0"
                     )
@@ -1235,29 +1265,38 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
             ("date_created", "candidate_date_created"),
             ("date_updated", "candidate_date_updated"),
         ):
-            if any(replica["correlations"][field]["status"] == "no_outcome" for replica in replicas):
-                fields[field] = {
-                    "reason": "at least one replica did not resolve the correlation",
-                    "status": "no_outcome",
-                }
+            correlation, no_outcome = _resolved_correlation(
+                replicas,
+                field,
+                "at least one replica did not resolve the correlation",
+            )
+            if no_outcome is not None:
+                fields[field] = no_outcome
             else:
-                fields[field] = _aggregate(
-                    [
-                        next(
-                            variant["outcome"]
-                            for variant in replica["variants"]
-                            if variant["kind"] == kind
-                        )
-                        for replica in replicas
-                    ],
-                    field,
-                )
+                observations = [
+                    next(
+                        variant
+                        for variant in replica["variants"]
+                        if variant["kind"] == kind
+                    )
+                    for replica in replicas
+                ]
+                fields[field] = {
+                    **_aggregate_variant_observations(observations, field),
+                    "evidence": correlation,
+                }
+        lvprop_correlation, lvprop_no_outcome = _resolved_correlation(
+            replicas,
+            "lvprop",
+            "at least one replica did not resolve the structural correlation",
+        )
         fields["lvprop"] = (
-            {"outcome": "resolved", "status": "answered"}
-            if all(replica["correlations"]["lvprop"]["status"] == "resolved" for replica in replicas)
+            lvprop_no_outcome
+            if lvprop_no_outcome is not None
             else {
-                "reason": "at least one replica did not resolve the structural correlation",
-                "status": "no_outcome",
+                "evidence": lvprop_correlation,
+                "outcome": "resolved",
+                "status": "answered",
             }
         )
         catalog = {
@@ -1285,34 +1324,54 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
                     }
                     groups_status = "no_outcome"
                     continue
-                outcomes = [
+                observations = [
                     next(
-                        variant["outcome"]
+                        variant
                         for variant in replica["variants"]
                         if variant["name"] == name
                     )
                     for replica in replicas
                 ]
-                aggregate = _aggregate(outcomes, name)
+                aggregate = _aggregate_variant_observations(observations, name)
                 groups[name] = {**definitions[0], **aggregate}
                 if aggregate["status"] == "no_outcome":
                     groups_status = "no_outcome"
         mutation_groups: dict[str, Any] = {"groups": groups, "status": groups_status}
         if groups_reason:
             mutation_groups["reason"] = groups_reason
-        sufficiency = _aggregate(
-            [
-                "no_outcome"
-                if replica["sufficiency"]["repaired"]
-                else (
-                    "observed_sufficient"
-                    if all(replica["sufficiency"]["endpoints"].values())
-                    else "not_observed_sufficient"
-                )
-                for replica in replicas
-            ],
-            "composed_image_sufficiency",
+        baseline_failed = any(
+            replica["baseline"]["repaired"]
+            or not all(replica["baseline"]["endpoints"].values())
+            for replica in replicas
         )
+        endpoint_maps = [replica["sufficiency"]["endpoints"] for replica in replicas]
+        if baseline_failed:
+            sufficiency = {
+                "reason": "at least one created baseline failed or changed during DAO open",
+                "status": "no_outcome",
+            }
+        elif any(endpoints != endpoint_maps[0] for endpoints in endpoint_maps[1:]):
+            sufficiency = {
+                "reason": "replicas disagree on the composed-image DAO endpoint map",
+                "status": "no_outcome",
+            }
+        else:
+            sufficiency = {
+                **_aggregate(
+                    [
+                        "no_outcome"
+                        if replica["sufficiency"]["repaired"]
+                        else (
+                            "observed_sufficient"
+                            if all(replica["sufficiency"]["endpoints"].values())
+                            else "not_observed_sufficient"
+                        )
+                        for replica in replicas
+                    ],
+                    "composed_image_sufficiency",
+                ),
+                "endpoints": endpoint_maps[0],
+            }
         questions = {
             "candidate_catalog_fields": catalog,
             "candidate_page0": page0,
@@ -1371,7 +1430,8 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
     ):
         status = "no_outcome"
     bounded_sufficiency = (
-        questions["composed_image_sufficiency"].get("outcome")
+        status == "accepted"
+        and questions["composed_image_sufficiency"].get("outcome")
         == "observed_sufficient"
     )
     return {

--- a/oracle/windows-dao/scripts/bootstrap_layout.py
+++ b/oracle/windows-dao/scripts/bootstrap_layout.py
@@ -19,7 +19,9 @@ REPLICA_COUNT = 3
 MAX_PAGES = 64
 MAX_ITEMS = 64
 MAX_JSON_BYTES = 1024 * 1024
-CHECKPOINT_NAMES = ("empty", "created", "renamed")
+TIMESTAMP_ANCHOR_WINDOW_BYTES = 64
+BASE_CHECKPOINT_NAMES = ("empty", "created", "renamed")
+CHECKPOINT_NAMES = (*BASE_CHECKPOINT_NAMES, "property-set")
 CORRELATION_NAMES = ("date_created", "date_updated", "lvprop")
 ENDPOINT_NAMES = (
     "open_database",
@@ -313,15 +315,35 @@ def _reported_date_correlation(
     oadate: float | None,
     other: float | None,
 ) -> dict[str, Any]:
-    item = _expect_keys(value, {"status", "detail"}, {"offsets"}, location)
+    item = _expect_keys(value, {"status", "detail"}, {"method", "offsets"}, location)
     _detail(item["detail"], f"{location}.detail")
     matches = [] if oadate is None else _find_all(renamed, struct.pack("<d", oadate))
-    resolved = oadate is not None and other is not None and oadate != other and len(matches) == 1
+    resolved_matches = matches
+    method = "unique_exact"
+    if oadate is not None and other is not None and oadate != other and len(matches) != 1:
+        anchors = _find_all(renamed, struct.pack("<d", other))
+        if len(anchors) == 1:
+            resolved_matches = [
+                offset
+                for offset in matches
+                if abs(offset - anchors[0]) <= TIMESTAMP_ANCHOR_WINDOW_BYTES
+            ]
+            method = "other_timestamp_anchor"
+    resolved = (
+        oadate is not None
+        and other is not None
+        and oadate != other
+        and len(resolved_matches) == 1
+    )
     if resolved:
-        if item["status"] != "resolved" or item.get("offsets") != matches:
+        if (
+            item["status"] != "resolved"
+            or item.get("method") != method
+            or item.get("offsets") != resolved_matches
+        ):
             raise AnalysisError(f"{location} differs from independently scanned OADate bytes")
-        return {"offsets": matches, "status": "resolved"}
-    if item["status"] != "no_outcome" or "offsets" in item:
+        return {"method": method, "offsets": resolved_matches, "status": "resolved"}
+    if item["status"] != "no_outcome" or "offsets" in item or "method" in item:
         raise AnalysisError(f"{location} must be no_outcome for ambiguous OADate bytes")
     return {"status": "no_outcome"}
 
@@ -415,6 +437,61 @@ def _baseline(
     return {"endpoints": endpoints, "repaired": repaired}
 
 
+def _sufficiency(
+    value: Any,
+    location: str,
+    root: Path,
+    empty_bytes: bytes,
+    created: dict[str, Any],
+    created_bytes: bytes,
+    page0_ranges: list[dict[str, int]],
+    groups: list[dict[str, Any]],
+) -> dict[str, Any]:
+    item = _expect_keys(
+        value,
+        {
+            "database",
+            "size",
+            "sha256_before_open",
+            "sha256_after_open",
+            "endpoints",
+        },
+        {"detail"},
+        location,
+    )
+    database = _database(item["database"], f"{location}.database")
+    size = _size(item["size"], f"{location}.size")
+    if size != created["size"]:
+        raise AnalysisError(f"{location}.size differs from the created checkpoint")
+    before = _digest(item["sha256_before_open"], f"{location}.sha256_before_open")
+    after = _digest(item["sha256_after_open"], f"{location}.sha256_after_open")
+    endpoint_item = _expect_keys(
+        item["endpoints"], set(ENDPOINT_NAMES), {"detail"}, f"{location}.endpoints"
+    )
+    endpoints = _endpoints(endpoint_item, f"{location}.endpoints")
+    if "detail" in endpoint_item:
+        _detail(endpoint_item["detail"], f"{location}.endpoints.detail")
+    if "detail" in item:
+        _detail(item["detail"], f"{location}.detail")
+
+    expected = bytearray(created["size"])
+    expected[: len(empty_bytes)] = empty_bytes
+    for group in [{"ranges": page0_ranges}, *groups]:
+        for part in group["ranges"]:
+            start, end = part["start"], part["end"]
+            expected[start:end] = created_bytes[start:end]
+    expected_bytes = bytes(expected)
+    if expected_bytes != created_bytes:
+        raise AnalysisError(f"{location} mutation groups do not reconstruct the created checkpoint")
+    if before != sha256(expected_bytes):
+        raise AnalysisError(f"{location} pre-open digest differs from independent reconstruction")
+    current = _read_file(root, database, size, after, location)
+    repaired = before != after
+    if not repaired and current != expected_bytes:
+        raise AnalysisError(f"{location} differs from independent reconstruction")
+    return {"endpoints": endpoints, "repaired": repaired}
+
+
 def _groups(
     value: Any,
     location: str,
@@ -447,13 +524,13 @@ def _page0(
     location: str,
 ) -> tuple[dict[str, int], dict[str, list[dict[str, int]]], bool]:
     values_item = _expect_keys(
-        values_raw, set(CHECKPOINT_NAMES), set(), f"{location}.page0_values"
+        values_raw, set(BASE_CHECKPOINT_NAMES), set(), f"{location}.page0_values"
     )
     values = {
         name: _integer(values_item[name], f"{location}.page0_values.{name}", 0, 255)
-        for name in CHECKPOINT_NAMES
+        for name in BASE_CHECKPOINT_NAMES
     }
-    for name in CHECKPOINT_NAMES:
+    for name in BASE_CHECKPOINT_NAMES:
         if images[name][1538] != values[name]:
             raise AnalysisError(f"{location}.page0_values.{name} differs from checkpoint")
     ranges_item = _expect_keys(
@@ -559,8 +636,8 @@ def _validate_complete_replica(
     item: dict[str, Any], root: Path, location: str
 ) -> dict[str, Any]:
     raw_checkpoints = item["checkpoints"]
-    if not isinstance(raw_checkpoints, list) or len(raw_checkpoints) != 3:
-        raise AnalysisError(f"{location}.checkpoints must contain exactly three entries")
+    if not isinstance(raw_checkpoints, list) or len(raw_checkpoints) != 4:
+        raise AnalysisError(f"{location}.checkpoints must contain exactly four entries")
     checkpoints: dict[str, dict[str, Any]] = {}
     images: dict[str, bytes] = {}
     databases: set[str] = set()
@@ -577,11 +654,14 @@ def _validate_complete_replica(
         raise AnalysisError(f"{location}.created is shorter than empty")
     if checkpoints["renamed"]["size"] != checkpoints["created"]["size"]:
         raise AnalysisError(f"{location}.renamed size differs from created")
+    if checkpoints["property-set"]["size"] < checkpoints["renamed"]["size"]:
+        raise AnalysisError(f"{location}.property-set is shorter than renamed")
     baseline = _baseline(
         item["baseline"], f"{location}.baseline", root, checkpoints["created"], images["created"]
     )
 
     renamed_dao = checkpoints["renamed"]["dao"]
+    property_dao = checkpoints["property-set"]["dao"]
     created_size = checkpoints["created"]["size"]
     page_count = checkpoints["created"]["page_count"]
     correlations_item = _expect_keys(
@@ -607,8 +687,8 @@ def _validate_complete_replica(
         "lvprop": _reported_lvprop_correlation(
             correlations_item["lvprop"],
             f"{location}.correlations.lvprop",
-            images["renamed"],
-            renamed_dao,
+            images["property-set"],
+            property_dao,
         ),
     }
     page0_values, page0_ranges, page0_isolated = _page0(
@@ -656,6 +736,17 @@ def _validate_complete_replica(
         expected = [{"start": page * PAGE_BYTES, "end": (page + 1) * PAGE_BYTES}]
         if group["ranges"] != expected:
             raise AnalysisError(f"{location}.appended_page_groups must cover complete pages")
+
+    sufficiency = _sufficiency(
+        item["sufficiency"],
+        f"{location}.sufficiency",
+        root,
+        images["empty"],
+        checkpoints["created"],
+        images["created"],
+        page0_ranges["empty_to_created"],
+        changed + appended,
+    )
 
     raw_variants = item["variants"]
     if not isinstance(raw_variants, list) or not 1 <= len(raw_variants) <= MAX_ITEMS:
@@ -761,6 +852,7 @@ def _validate_complete_replica(
         "page0_values": page0_values,
         "replica": item["replica"],
         "status": "pass",
+        "sufficiency": sufficiency,
         "variants": summarized,
     }
 
@@ -769,8 +861,8 @@ def _validate_partial_replica(
     item: dict[str, Any], root: Path, location: str
 ) -> dict[str, Any]:
     raw = item.get("checkpoints", [])
-    if not isinstance(raw, list) or len(raw) > 3:
-        raise AnalysisError(f"{location}.checkpoints must contain at most three entries")
+    if not isinstance(raw, list) or len(raw) > 4:
+        raise AnalysisError(f"{location}.checkpoints must contain at most four entries")
     checkpoints: dict[str, dict[str, Any]] = {}
     images: dict[str, bytes] = {}
     databases: set[str] = set()
@@ -811,6 +903,7 @@ def _validate_partial_replica(
                 checkpoints["created"],
                 images["created"],
             )
+    page0_ranges: dict[str, list[dict[str, int]]] | None = None
     has_page0 = "page0_values" in item or "page0_changed_ranges" in item
     if has_page0:
         values = item.get("page0_values")
@@ -822,7 +915,7 @@ def _validate_partial_replica(
         else:
             if not {"empty", "created", "renamed"} <= set(checkpoints):
                 raise AnalysisError(f"{location}.page0 evidence lacks all checkpoints")
-            _page0(values, ranges, images, location)
+            _, page0_ranges, _ = _page0(values, ranges, images, location)
 
     correlations: dict[str, dict[str, Any]] | None = None
     if "correlations" in item:
@@ -851,8 +944,8 @@ def _validate_partial_replica(
                 "lvprop": _reported_lvprop_correlation(
                     raw_correlations["lvprop"],
                     f"{location}.correlations.lvprop",
-                    images["renamed"],
-                    dao,
+                    images.get("property-set", b""),
+                    checkpoints.get("property-set", {}).get("dao"),
                 ),
             }
         else:
@@ -861,11 +954,15 @@ def _validate_partial_replica(
                 correlation = _expect_keys(
                     raw_correlations[name],
                     {"status", "detail"},
-                    {"offsets"},
+                    {"method", "offsets"},
                     f"{location}.correlations.{name}",
                 )
                 _detail(correlation["detail"], f"{location}.correlations.{name}.detail")
-                if correlation["status"] != "no_outcome" or "offsets" in correlation:
+                if (
+                    correlation["status"] != "no_outcome"
+                    or "offsets" in correlation
+                    or "method" in correlation
+                ):
                     raise AnalysisError(
                         f"{location}.correlations.{name} needs a renamed checkpoint"
                     )
@@ -929,6 +1026,58 @@ def _validate_partial_replica(
                 {"start": page * PAGE_BYTES, "end": (page + 1) * PAGE_BYTES}
             ]:
                 raise AnalysisError(f"{location}.{group['name']} does not cover its full page")
+
+    if "sufficiency" in item:
+        sufficiency = _expect_keys(
+            item["sufficiency"],
+            {
+                "database",
+                "size",
+                "sha256_before_open",
+                "sha256_after_open",
+                "endpoints",
+            },
+            {"detail"},
+            f"{location}.sufficiency",
+        )
+        endpoint_item = _expect_keys(
+            sufficiency["endpoints"],
+            set(ENDPOINT_NAMES),
+            {"detail"},
+            f"{location}.sufficiency.endpoints",
+        )
+        _endpoints(endpoint_item, f"{location}.sufficiency.endpoints")
+        if "detail" in endpoint_item:
+            _detail(
+                endpoint_item["detail"], f"{location}.sufficiency.endpoints.detail"
+            )
+        if "detail" in sufficiency:
+            _detail(sufficiency["detail"], f"{location}.sufficiency.detail")
+        identity = [
+            sufficiency["database"],
+            sufficiency["sha256_before_open"],
+            sufficiency["sha256_after_open"],
+        ]
+        if all(value is None for value in identity):
+            if sufficiency["size"] != 0:
+                raise AnalysisError(f"{location}.sufficiency empty identity has nonzero size")
+        elif any(value is None for value in identity):
+            raise AnalysisError(f"{location}.sufficiency has incomplete file identity")
+        else:
+            if not {"empty", "created"} <= set(checkpoints) or page0_ranges is None:
+                raise AnalysisError(
+                    f"{location}.sufficiency lacks its reconstruction checkpoints"
+                )
+            _sufficiency(
+                sufficiency,
+                f"{location}.sufficiency",
+                root,
+                images["empty"],
+                checkpoints["created"],
+                images["created"],
+                page0_ranges["empty_to_created"],
+                changed + appended,
+            )
 
     if "variants" in item:
         raw_variants = item["variants"]
@@ -1020,6 +1169,7 @@ def _validate_replica(value: Any, root: Path, location: str) -> dict[str, Any]:
         "correlations",
         "changed_page_groups",
         "appended_page_groups",
+        "sufficiency",
         "variants",
     }
     item = _expect_keys(value, {"replica", "status", "detail"}, inventory, location)
@@ -1057,6 +1207,7 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
             for name in (
                 "candidate_page0",
                 "candidate_catalog_fields",
+                "composed_image_sufficiency",
                 "required_mutation_groups",
             )
         }
@@ -1149,9 +1300,23 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
         mutation_groups: dict[str, Any] = {"groups": groups, "status": groups_status}
         if groups_reason:
             mutation_groups["reason"] = groups_reason
+        sufficiency = _aggregate(
+            [
+                "no_outcome"
+                if replica["sufficiency"]["repaired"]
+                else (
+                    "observed_sufficient"
+                    if all(replica["sufficiency"]["endpoints"].values())
+                    else "not_observed_sufficient"
+                )
+                for replica in replicas
+            ],
+            "composed_image_sufficiency",
+        )
         questions = {
             "candidate_catalog_fields": catalog,
             "candidate_page0": page0,
+            "composed_image_sufficiency": sufficiency,
             "required_mutation_groups": mutation_groups,
         }
 
@@ -1185,6 +1350,10 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
                 "page0_values": replica["page0_values"],
                 "replica": replica["replica"],
                 "status": "pass",
+                "sufficiency": {
+                    "endpoints": replica["sufficiency"]["endpoints"],
+                    "repaired": replica["sufficiency"]["repaired"],
+                },
                 "variants": replica["variants"],
             }
         )
@@ -1201,6 +1370,10 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
         or any(question["status"] == "no_outcome" for question in questions.values())
     ):
         status = "no_outcome"
+    bounded_sufficiency = (
+        questions["composed_image_sufficiency"].get("outcome")
+        == "observed_sufficient"
+    )
     return {
         "compatibility_claim": False,
         "development_only": True,
@@ -1209,7 +1382,7 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
         "questions": questions,
         "replicas": summaries,
         "status": status,
-        "sufficiency_claim": False,
+        "sufficiency_claim": bounded_sufficiency,
         "support_movement": False,
     }
 

--- a/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
@@ -78,6 +78,57 @@ function Get-BoundedFileFacts {
     }
 }
 
+function New-ArtifactObservation {
+    param(
+        [AllowNull()][object]$Database,
+        [AllowNull()][object]$BeforeFacts,
+        [string]$Detail
+    )
+
+    $databaseValue = $null
+    $sizeBefore = $null
+    $sha256Before = $null
+    if ($null -ne $Database) {
+        $databaseValue = [string]$Database
+    }
+    if ($null -ne $BeforeFacts) {
+        $sizeBefore = [long]$BeforeFacts.size
+        $sha256Before = [string]$BeforeFacts.sha256
+    }
+    return [ordered]@{
+        database = $databaseValue
+        size_before = $sizeBefore
+        size_after = $null
+        sha256_before = $sha256Before
+        sha256_after = $null
+        endpoints = [ordered]@{
+            open_database = $false
+            table_enumerated = $false
+            field_enumerated = $false
+            table_opened = $false
+            detail = $Detail
+        }
+        detail = $Detail
+    }
+}
+
+function Complete-ArtifactObservation {
+    param(
+        [object]$Observation,
+        [object]$AfterFacts,
+        [object]$Endpoints
+    )
+
+    $Observation.size_after = [long]$AfterFacts.size
+    $Observation.sha256_after = [string]$AfterFacts.sha256
+    $Observation.endpoints = $Endpoints
+    $Observation.detail = [string]$Endpoints.detail
+    if ($Observation.size_before -ne $Observation.size_after -or
+        $Observation.sha256_before -cne $Observation.sha256_after) {
+        $Observation.detail += " DAO changed the artifact during read-only endpoint checks."
+    }
+}
+
 function Invoke-WithDatabase {
     param(
         [string]$Path,
@@ -451,12 +502,20 @@ function Find-ByteSequence {
 function Get-TimestampCorrelation {
     param(
         [double]$OaDate,
-        [double]$OtherOaDate,
+        [double]$DistinctFromOaDate,
+        [AllowNull()][object]$LastUpdatedAnchor,
+        [switch]$AllowLastUpdatedAnchor,
         [byte[]]$RenamedBytes
     )
 
+    if ($AllowLastUpdatedAnchor -and $null -eq $LastUpdatedAnchor) {
+        throw "The last-updated-anchor policy requires a LastUpdated value."
+    }
+    if (-not $AllowLastUpdatedAnchor -and $null -ne $LastUpdatedAnchor) {
+        throw "The unique-exact-only policy does not admit an anchor."
+    }
     $needle = [BitConverter]::GetBytes($OaDate)
-    if ($OaDate -eq $OtherOaDate) {
+    if ($OaDate -eq $DistinctFromOaDate) {
         return [pscustomobject]@{
             report = [ordered]@{
                 status = "no_outcome"
@@ -468,14 +527,14 @@ function Get-TimestampCorrelation {
     $offsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle $needle)
     $resolvedOffsets = @($offsets)
     $method = "unique_exact"
-    if ($offsets.Count -ne 1) {
-        $anchorOffsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle ([BitConverter]::GetBytes($OtherOaDate)))
+    if ($AllowLastUpdatedAnchor -and $offsets.Count -ne 1) {
+        $anchorOffsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle ([BitConverter]::GetBytes([double]$LastUpdatedAnchor)))
         if ($anchorOffsets.Count -eq 1) {
             $anchor = [long]$anchorOffsets[0]
             $resolvedOffsets = @($offsets | Where-Object {
                 [Math]::Abs(([long]$_) - $anchor) -le $TimestampAnchorWindowBytes
             })
-            $method = "other_timestamp_anchor"
+            $method = "last_updated_anchor"
         }
     }
     if ($resolvedOffsets.Count -ne 1) {
@@ -795,11 +854,14 @@ function Invoke-ReplicaCore {
 
     $dateCreated = Get-TimestampCorrelation `
         -OaDate ([double]$renamed.dao.date_created_oadate) `
-        -OtherOaDate ([double]$renamed.dao.last_updated_oadate) `
+        -DistinctFromOaDate ([double]$renamed.dao.last_updated_oadate) `
+        -LastUpdatedAnchor ([double]$renamed.dao.last_updated_oadate) `
+        -AllowLastUpdatedAnchor `
         -RenamedBytes $renamed.bytes
     $dateUpdated = Get-TimestampCorrelation `
         -OaDate ([double]$renamed.dao.last_updated_oadate) `
-        -OtherOaDate ([double]$renamed.dao.date_created_oadate) `
+        -DistinctFromOaDate ([double]$renamed.dao.date_created_oadate) `
+        -LastUpdatedAnchor $null `
         -RenamedBytes $renamed.bytes
     $lvProp = Get-LvPropCorrelation -LvPropBytes $propertySet.lvprop_bytes -RenamedBytes $propertySet.bytes
     $State.correlations = [ordered]@{
@@ -872,7 +934,6 @@ function Invoke-ReplicaCore {
     try {
         Copy-Item -LiteralPath $created.path -Destination $baselinePath
         $baselineFactsBefore = Get-BoundedFileFacts -Path $baselinePath
-        $baselineHashBefore = [string]$baselineFactsBefore.sha256
     }
     catch {
         if (Test-Path -LiteralPath $baselinePath -PathType Leaf) {
@@ -880,31 +941,16 @@ function Invoke-ReplicaCore {
         }
         throw
     }
-    $State.baseline = [ordered]@{
-        database = $baselineName
-        sha256_before_open = $baselineHashBefore
-        sha256_after_open = $baselineHashBefore
-        open_database = $false
-        table_enumerated = $false
-        field_enumerated = $false
-        table_opened = $false
-        detail = "Baseline endpoints were not reached."
-    }
+    $State.baseline = New-ArtifactObservation `
+        -Database $baselineName `
+        -BeforeFacts $baselineFactsBefore `
+        -Detail "Baseline endpoints were not reached."
     $baselineEndpoints = Test-BaselineEndpoints -Path $baselinePath -TableName $CreatedTableName
-    $State.baseline.open_database = [bool]$baselineEndpoints.open_database
-    $State.baseline.table_enumerated = [bool]$baselineEndpoints.table_enumerated
-    $State.baseline.field_enumerated = [bool]$baselineEndpoints.field_enumerated
-    $State.baseline.table_opened = [bool]$baselineEndpoints.table_opened
-    $State.baseline.detail = [string]$baselineEndpoints.detail
     $baselineFactsAfter = Get-BoundedFileFacts -Path $baselinePath
-    $baselineHashAfter = [string]$baselineFactsAfter.sha256
-    $State.baseline.sha256_after_open = $baselineHashAfter
-    if ($baselineFactsAfter.size -ne $baselineFactsBefore.size) {
-        throw "DAO changed the created baseline clone size during read-only endpoint checks."
-    }
-    if ($baselineHashBefore -ne $baselineHashAfter) {
-        $State.baseline.detail = "DAO changed the created baseline clone during read-only endpoint checks."
-    }
+    Complete-ArtifactObservation `
+        -Observation $State.baseline `
+        -AfterFacts $baselineFactsAfter `
+        -Endpoints $baselineEndpoints
 
     $composedName = "bootstrap-layout-r$Replica-variant-composed.mdb"
     $composedPath = Join-Path $RunRoot $composedName
@@ -922,31 +968,16 @@ function Invoke-ReplicaCore {
     }
     [IO.File]::WriteAllBytes($composedPath, $composedBytes)
     $composedFactsBefore = Get-BoundedFileFacts -Path $composedPath
-    $State.sufficiency = [ordered]@{
-        database = $composedName
-        size = $composedFactsBefore.size
-        sha256_before_open = [string]$composedFactsBefore.sha256
-        sha256_after_open = [string]$composedFactsBefore.sha256
-        endpoints = [ordered]@{
-            open_database = $false
-            table_enumerated = $false
-            field_enumerated = $false
-            table_opened = $false
-            detail = "Composed-image endpoints were not reached."
-        }
-        detail = "Composed-image endpoints were not reached."
-    }
+    $State.sufficiency = New-ArtifactObservation `
+        -Database $composedName `
+        -BeforeFacts $composedFactsBefore `
+        -Detail "Composed-image endpoints were not reached."
     $composedEndpoints = Test-BaselineEndpoints -Path $composedPath -TableName $CreatedTableName
-    $State.sufficiency.endpoints = $composedEndpoints
-    $State.sufficiency.detail = [string]$composedEndpoints.detail
     $composedFactsAfter = Get-BoundedFileFacts -Path $composedPath
-    $State.sufficiency.sha256_after_open = [string]$composedFactsAfter.sha256
-    if ($composedFactsAfter.size -ne $composedFactsBefore.size) {
-        throw "DAO changed the composed candidate size during read-only endpoint checks."
-    }
-    if ($composedFactsBefore.sha256 -ne $composedFactsAfter.sha256) {
-        $State.sufficiency.detail += " DAO changed the composed candidate during read-only access."
-    }
+    Complete-ArtifactObservation `
+        -Observation $State.sufficiency `
+        -AfterFacts $composedFactsAfter `
+        -Endpoints $composedEndpoints
 
     foreach ($spec in $specs) {
         if ($spec.name -notmatch '^[a-z0-9-]+$') {
@@ -980,7 +1011,6 @@ function Invoke-ReplicaCore {
             }
             [IO.File]::WriteAllBytes($path, $bytes)
             $variantFacts = Get-BoundedFileFacts -Path $path
-            $before = [string]$variantFacts.sha256
         }
         catch {
             if (Test-Path -LiteralPath $path -PathType Leaf) {
@@ -988,50 +1018,40 @@ function Invoke-ReplicaCore {
             }
             throw
         }
-        $variant = [ordered]@{
-            name = $spec.name
-            kind = $spec.kind
-            database = $fileName
-            size = $variantFacts.size
-            base_checkpoint = $spec.base_checkpoint
-            ranges = @($spec.ranges)
-            sha256_before_open = $before
-            sha256_after_open = $before
-            endpoints = [ordered]@{
-                open_database = $false
-                table_enumerated = $false
-                field_enumerated = $false
-                table_opened = $false
-                detail = "DAO endpoints were not reached."
-            }
-            detail = "DAO endpoints were not reached."
-        }
+        $variant = New-ArtifactObservation `
+            -Database $fileName `
+            -BeforeFacts $variantFacts `
+            -Detail "DAO endpoints were not reached."
+        [void]$variant.Add("name", [string]$spec.name)
+        [void]$variant.Add("kind", [string]$spec.kind)
+        [void]$variant.Add("base_checkpoint", [string]$spec.base_checkpoint)
+        [void]$variant.Add("ranges", @($spec.ranges))
         if ($null -ne $spec.page) {
-            $variant.page = [int]$spec.page
+            [void]$variant.Add("page", [int]$spec.page)
         }
         [void]$State.variants.Add($variant)
 
         $targetName = if ($spec.base_checkpoint -eq "created") { $CreatedTableName } else { $RenamedTableName }
         $endpoints = Test-BaselineEndpoints -Path $path -TableName $targetName
-        $variant.endpoints = $endpoints
-        $variant.detail = [string]$endpoints.detail
         $afterFacts = Get-BoundedFileFacts -Path $path
-        $after = [string]$afterFacts.sha256
-        $variant.sha256_after_open = $after
-        if ($afterFacts.size -ne $variant.size) {
-            throw "DAO changed a variant clone size during read-only endpoint checks."
-        }
-        $detail = [string]$endpoints.detail
-        if ($before -ne $after) {
-            $detail += " DAO changed the clone during the read-only open."
-        }
-        $variant.detail = $detail
+        Complete-ArtifactObservation `
+            -Observation $variant `
+            -AfterFacts $afterFacts `
+            -Endpoints $endpoints
     }
 }
 
 function Invoke-Replica {
     param([int]$Replica)
 
+    $emptyBaseline = New-ArtifactObservation `
+        -Database $null `
+        -BeforeFacts $null `
+        -Detail "Baseline endpoints were not reached."
+    $emptySufficiency = New-ArtifactObservation `
+        -Database $null `
+        -BeforeFacts $null `
+        -Detail "Composed-image endpoints were not reached."
     $state = [ordered]@{
         replica = $Replica
         status = "fail"
@@ -1039,16 +1059,7 @@ function Invoke-Replica {
         checkpoints = New-Object Collections.ArrayList
         page0_values = $null
         page0_changed_ranges = $null
-        baseline = [ordered]@{
-            database = $null
-            sha256_before_open = $null
-            sha256_after_open = $null
-            open_database = $false
-            table_enumerated = $false
-            field_enumerated = $false
-            table_opened = $false
-            detail = "Baseline endpoints were not reached."
-        }
+        baseline = $emptyBaseline
         correlations = [ordered]@{
             date_created = [ordered]@{ status = "no_outcome"; detail = "Correlation was not reached." }
             date_updated = [ordered]@{ status = "no_outcome"; detail = "Correlation was not reached." }
@@ -1056,20 +1067,7 @@ function Invoke-Replica {
         }
         changed_page_groups = New-Object Collections.ArrayList
         appended_page_groups = New-Object Collections.ArrayList
-        sufficiency = [ordered]@{
-            database = $null
-            size = 0
-            sha256_before_open = $null
-            sha256_after_open = $null
-            endpoints = [ordered]@{
-                open_database = $false
-                table_enumerated = $false
-                field_enumerated = $false
-                table_opened = $false
-                detail = "Composed-image endpoints were not reached."
-            }
-            detail = "Composed-image endpoints were not reached."
-        }
+        sufficiency = $emptySufficiency
         variants = New-Object Collections.ArrayList
     }
     try {

--- a/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
@@ -28,6 +28,7 @@ $MaximumCatalogRows = 512
 $MaximumLvPropBytes = 65536
 $MaximumVariants = 64
 $TimestampAnchorWindowBytes = 64
+$MaximumDetailCharacters = 512
 
 function Write-JsonDocument {
     param([string]$Path, [object]$Document)
@@ -78,6 +79,43 @@ function Get-BoundedFileFacts {
     }
 }
 
+function ConvertTo-BoundedDetail {
+    param(
+        [AllowNull()][object]$Detail,
+        [AllowNull()][object]$Suffix = $null
+    )
+
+    $text = ([string]$Detail -replace '\s+', ' ').Trim()
+    if ([string]::IsNullOrEmpty($text)) {
+        $text = "No additional detail was reported."
+    }
+    $suffixText = ([string]$Suffix -replace '\s+', ' ').Trim()
+    if (-not [string]::IsNullOrEmpty($suffixText)) {
+        $suffixText = " " + $suffixText
+    }
+    if (($text.Length + $suffixText.Length) -le $MaximumDetailCharacters) {
+        return $text + $suffixText
+    }
+
+    $ellipsis = "..."
+    if ([string]::IsNullOrEmpty($suffixText)) {
+        return $text.Substring(0, $MaximumDetailCharacters - $ellipsis.Length) + $ellipsis
+    }
+
+    $maximumSuffixCharacters = 192
+    if ($suffixText.Length -gt $maximumSuffixCharacters) {
+        $suffixText = $suffixText.Substring(
+            0,
+            $maximumSuffixCharacters - $ellipsis.Length
+        ) + $ellipsis
+    }
+    $prefixCharacters = $MaximumDetailCharacters - $suffixText.Length - $ellipsis.Length
+    if ($text.Length -gt $prefixCharacters) {
+        $text = $text.Substring(0, $prefixCharacters) + $ellipsis
+    }
+    return $text + $suffixText
+}
+
 function New-ArtifactObservation {
     param(
         [AllowNull()][object]$Database,
@@ -95,6 +133,7 @@ function New-ArtifactObservation {
         $sizeBefore = [long]$BeforeFacts.size
         $sha256Before = [string]$BeforeFacts.sha256
     }
+    $boundedDetail = ConvertTo-BoundedDetail -Detail $Detail
     return [ordered]@{
         database = $databaseValue
         size_before = $sizeBefore
@@ -106,9 +145,9 @@ function New-ArtifactObservation {
             table_enumerated = $false
             field_enumerated = $false
             table_opened = $false
-            detail = $Detail
+            detail = $boundedDetail
         }
-        detail = $Detail
+        detail = $boundedDetail
     }
 }
 
@@ -121,12 +160,17 @@ function Complete-ArtifactObservation {
 
     $Observation.size_after = [long]$AfterFacts.size
     $Observation.sha256_after = [string]$AfterFacts.sha256
+    $endpointDetail = ConvertTo-BoundedDetail -Detail $Endpoints.detail
+    $Endpoints.detail = $endpointDetail
     $Observation.endpoints = $Endpoints
-    $Observation.detail = [string]$Endpoints.detail
+    $repairSuffix = $null
     if ($Observation.size_before -ne $Observation.size_after -or
         $Observation.sha256_before -cne $Observation.sha256_after) {
-        $Observation.detail += " DAO changed the artifact during read-only endpoint checks."
+        $repairSuffix = "DAO changed the artifact during read-only endpoint checks."
     }
+    $Observation.detail = ConvertTo-BoundedDetail `
+        -Detail $endpointDetail `
+        -Suffix $repairSuffix
 }
 
 function Invoke-WithDatabase {
@@ -335,7 +379,9 @@ function Get-LvPropSnapshot {
         return [pscustomobject]@{
             report = [ordered]@{
                 status = "no_outcome"
-                detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+                detail = ConvertTo-BoundedDetail -Detail (
+                    $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+                )
             }
             bytes = $null
         }
@@ -754,10 +800,13 @@ function Test-BaselineEndpoints {
             throw "Expected the target table snapshot to be empty."
         }
         $endpoints.table_opened = $true
-        $endpoints.detail = "All bounded read-only endpoints passed."
+        $endpoints.detail = ConvertTo-BoundedDetail `
+            -Detail "All bounded read-only endpoints passed."
     }
     catch {
-        $endpoints.detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        $endpoints.detail = ConvertTo-BoundedDetail -Detail (
+            $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        )
     }
     finally {
         if ($null -ne $recordset) {
@@ -1055,7 +1104,7 @@ function Invoke-Replica {
     $state = [ordered]@{
         replica = $Replica
         status = "fail"
-        detail = "Replica did not start."
+        detail = ConvertTo-BoundedDetail -Detail "Replica did not start."
         checkpoints = New-Object Collections.ArrayList
         page0_values = $null
         page0_changed_ranges = $null
@@ -1073,11 +1122,14 @@ function Invoke-Replica {
     try {
         Invoke-ReplicaCore -Replica $Replica -State $state
         $state.status = "pass"
-        $state.detail = "Completed the preregistered replica once without retry."
+        $state.detail = ConvertTo-BoundedDetail `
+            -Detail "Completed the preregistered replica once without retry."
     }
     catch {
         $state.status = "fail"
-        $state.detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        $state.detail = ConvertTo-BoundedDetail -Detail (
+            $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        )
     }
     finally {
         $workingPath = Join-Path $RunRoot "working-r$Replica.mdb"
@@ -1088,7 +1140,9 @@ function Invoke-Replica {
         }
         catch {
             $state.status = "fail"
-            $state.detail += " Working-file cleanup failed: " + $_.Exception.Message
+            $state.detail = ConvertTo-BoundedDetail `
+                -Detail $state.detail `
+                -Suffix ("Working-file cleanup failed: " + $_.Exception.Message)
         }
     }
     return $state
@@ -1104,7 +1158,10 @@ try {
     $result = [ordered]@{
         development_only = $true
         status = "pass"
-        detail = "Attempted each of the three bounded bootstrap-layout replicas once; per-replica status records partial outcomes."
+        detail = ConvertTo-BoundedDetail -Detail (
+            "Attempted each of the three bounded bootstrap-layout replicas once; " +
+            "per-replica status records partial outcomes."
+        )
         plan_sha256 = $PlanSha256
         replicas = @($replicas)
     }
@@ -1115,7 +1172,9 @@ catch {
     $result = [ordered]@{
         development_only = $true
         status = "fail"
-        detail = $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        detail = ConvertTo-BoundedDetail -Detail (
+            $_.Exception.GetType().FullName + ": " + $_.Exception.Message
+        )
         plan_sha256 = $PlanSha256
         replicas = @($replicas)
     }

--- a/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1
@@ -16,6 +16,7 @@ if ($PlanSha256 -cnotmatch '^[0-9a-f]{64}$') {
 
 $DbVersion30 = 32
 $DbLong = 4
+$DbMemo = 12
 $DbOpenSnapshot = 4
 $DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
 $CreatedTableName = "BootstrapLayout"
@@ -26,6 +27,7 @@ $MaximumTableDefs = 128
 $MaximumCatalogRows = 512
 $MaximumLvPropBytes = 65536
 $MaximumVariants = 64
+$TimestampAnchorWindowBytes = 64
 
 function Write-JsonDocument {
     param([string]$Path, [object]$Document)
@@ -150,6 +152,33 @@ function New-BootstrapTable {
     }
 }
 
+function Add-LvPropProbe {
+    param(
+        [string]$Path,
+        [int]$Replica
+    )
+
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $definitions = $null
+        $table = $null
+        $property = $null
+        try {
+            $definitions = $database.TableDefs
+            $table = $definitions.Item($RenamedTableName)
+            $marker = "jet3-bootstrap-lvprop-r{0:d2}-" -f $Replica
+            $marker += ("x" * (768 - $marker.Length))
+            $property = $table.CreateProperty("Jet3BootstrapProbe", $DbMemo, $marker)
+            $table.Properties.Append($property)
+        }
+        finally {
+            Release-ComObject -Value $property
+            Release-ComObject -Value $table
+            Release-ComObject -Value $definitions
+        }
+    }
+}
+
 function Rename-BootstrapTable {
     param([string]$Path)
 
@@ -175,11 +204,16 @@ function Get-LvPropSnapshot {
         [string]$TableName
     )
 
+    $query = $null
     $recordset = $null
     $nameField = $null
     $lvPropField = $null
     try {
-        $recordset = $Database.OpenRecordset("MSysObjects", $DbOpenSnapshot, 0)
+        $query = $Database.CreateQueryDef(
+            "",
+            "SELECT Name, LvProp FROM MSysObjects WITH OWNERACCESS OPTION;"
+        )
+        $recordset = $query.OpenRecordset($DbOpenSnapshot, 0)
         $rowCount = 0
         $matches = New-Object Collections.ArrayList
         while (-not [bool]$recordset.EOF) {
@@ -262,6 +296,7 @@ function Get-LvPropSnapshot {
         Release-ComObject -Value $lvPropField
         Release-ComObject -Value $nameField
         Release-ComObject -Value $recordset
+        Release-ComObject -Value $query
     }
 }
 
@@ -358,7 +393,7 @@ function Save-Checkpoint {
     param(
         [string]$Source,
         [int]$Replica,
-        [ValidateSet("empty", "created", "renamed")]
+        [ValidateSet("empty", "created", "renamed", "property-set")]
         [string]$Name,
         [AllowNull()][string]$TargetName
     )
@@ -431,11 +466,23 @@ function Get-TimestampCorrelation {
         }
     }
     $offsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle $needle)
+    $resolvedOffsets = @($offsets)
+    $method = "unique_exact"
     if ($offsets.Count -ne 1) {
+        $anchorOffsets = @(Find-ByteSequence -Haystack $RenamedBytes -Needle ([BitConverter]::GetBytes($OtherOaDate)))
+        if ($anchorOffsets.Count -eq 1) {
+            $anchor = [long]$anchorOffsets[0]
+            $resolvedOffsets = @($offsets | Where-Object {
+                [Math]::Abs(([long]$_) - $anchor) -le $TimestampAnchorWindowBytes
+            })
+            $method = "other_timestamp_anchor"
+        }
+    }
+    if ($resolvedOffsets.Count -ne 1) {
         return [pscustomobject]@{
             report = [ordered]@{
                 status = "no_outcome"
-                detail = "The exact DAO OLE Date byte sequence occurred $($offsets.Count) times in the renamed MDB."
+                detail = "The exact DAO OLE Date byte sequence left $($resolvedOffsets.Count) candidates after the bounded correlation rule."
             }
             offsets = @()
         }
@@ -443,10 +490,11 @@ function Get-TimestampCorrelation {
     return [pscustomobject]@{
         report = [ordered]@{
             status = "resolved"
-            detail = "The exact DAO OLE Date byte sequence occurred once in the renamed MDB."
-            offsets = @($offsets)
+            detail = "One exact DAO OLE Date candidate survived the bounded correlation rule."
+            method = $method
+            offsets = @($resolvedOffsets)
         }
-        offsets = @($offsets)
+        offsets = @($resolvedOffsets)
     }
 }
 
@@ -731,6 +779,9 @@ function Invoke-ReplicaCore {
     Rename-BootstrapTable -Path $workingPath
     $renamed = Save-Checkpoint -Source $workingPath -Replica $Replica -Name "renamed" -TargetName $RenamedTableName
     [void]$State.checkpoints.Add($renamed.report)
+    Add-LvPropProbe -Path $workingPath -Replica $Replica
+    $propertySet = Save-Checkpoint -Source $workingPath -Replica $Replica -Name "property-set" -TargetName $RenamedTableName
+    [void]$State.checkpoints.Add($propertySet.report)
 
     $State.page0_values = [ordered]@{
         empty = [int]$empty.bytes[1538]
@@ -750,7 +801,7 @@ function Invoke-ReplicaCore {
         -OaDate ([double]$renamed.dao.last_updated_oadate) `
         -OtherOaDate ([double]$renamed.dao.date_created_oadate) `
         -RenamedBytes $renamed.bytes
-    $lvProp = Get-LvPropCorrelation -LvPropBytes $renamed.lvprop_bytes -RenamedBytes $renamed.bytes
+    $lvProp = Get-LvPropCorrelation -LvPropBytes $propertySet.lvprop_bytes -RenamedBytes $propertySet.bytes
     $State.correlations = [ordered]@{
         date_created = $dateCreated.report
         date_updated = $dateUpdated.report
@@ -853,6 +904,48 @@ function Invoke-ReplicaCore {
     }
     if ($baselineHashBefore -ne $baselineHashAfter) {
         $State.baseline.detail = "DAO changed the created baseline clone during read-only endpoint checks."
+    }
+
+    $composedName = "bootstrap-layout-r$Replica-variant-composed.mdb"
+    $composedPath = Join-Path $RunRoot $composedName
+    [byte[]]$composedBytes = New-Object byte[] $created.bytes.Length
+    [Array]::Copy($empty.bytes, 0, $composedBytes, 0, $empty.bytes.Length)
+    foreach ($range in @($State.page0_changed_ranges.empty_to_created)) {
+        $length = [int]($range.end - $range.start)
+        [Array]::Copy($created.bytes, [int]$range.start, $composedBytes, [int]$range.start, $length)
+    }
+    foreach ($group in @($changedPageGroups) + @($appendedPageGroups)) {
+        foreach ($range in @($group.ranges)) {
+            $length = [int]($range.end - $range.start)
+            [Array]::Copy($created.bytes, [int]$range.start, $composedBytes, [int]$range.start, $length)
+        }
+    }
+    [IO.File]::WriteAllBytes($composedPath, $composedBytes)
+    $composedFactsBefore = Get-BoundedFileFacts -Path $composedPath
+    $State.sufficiency = [ordered]@{
+        database = $composedName
+        size = $composedFactsBefore.size
+        sha256_before_open = [string]$composedFactsBefore.sha256
+        sha256_after_open = [string]$composedFactsBefore.sha256
+        endpoints = [ordered]@{
+            open_database = $false
+            table_enumerated = $false
+            field_enumerated = $false
+            table_opened = $false
+            detail = "Composed-image endpoints were not reached."
+        }
+        detail = "Composed-image endpoints were not reached."
+    }
+    $composedEndpoints = Test-BaselineEndpoints -Path $composedPath -TableName $CreatedTableName
+    $State.sufficiency.endpoints = $composedEndpoints
+    $State.sufficiency.detail = [string]$composedEndpoints.detail
+    $composedFactsAfter = Get-BoundedFileFacts -Path $composedPath
+    $State.sufficiency.sha256_after_open = [string]$composedFactsAfter.sha256
+    if ($composedFactsAfter.size -ne $composedFactsBefore.size) {
+        throw "DAO changed the composed candidate size during read-only endpoint checks."
+    }
+    if ($composedFactsBefore.sha256 -ne $composedFactsAfter.sha256) {
+        $State.sufficiency.detail += " DAO changed the composed candidate during read-only access."
     }
 
     foreach ($spec in $specs) {
@@ -963,6 +1056,20 @@ function Invoke-Replica {
         }
         changed_page_groups = New-Object Collections.ArrayList
         appended_page_groups = New-Object Collections.ArrayList
+        sufficiency = [ordered]@{
+            database = $null
+            size = 0
+            sha256_before_open = $null
+            sha256_after_open = $null
+            endpoints = [ordered]@{
+                open_database = $false
+                table_enumerated = $false
+                field_enumerated = $false
+                table_opened = $false
+                detail = "Composed-image endpoints were not reached."
+            }
+            detail = "Composed-image endpoints were not reached."
+        }
         variants = New-Object Collections.ArrayList
     }
     try {

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -97,6 +97,9 @@ switch ($Job) {
             if (-not [string]::IsNullOrEmpty([string]$replica.baseline.database)) {
                 [void]$referenced.Add([string]$replica.baseline.database)
             }
+            if (-not [string]::IsNullOrEmpty([string]$replica.sufficiency.database)) {
+                [void]$referenced.Add([string]$replica.sufficiency.database)
+            }
             foreach ($variant in @($replica.variants)) {
                 [void]$referenced.Add([string]$variant.database)
             }
@@ -108,7 +111,7 @@ switch ($Job) {
             throw "Bootstrap-layout result contains duplicate database names."
         }
         foreach ($name in $referenced) {
-            if ($name -cnotmatch '^bootstrap-layout-r[1-3]-(empty|created|renamed|variant-[a-z0-9-]+)\.mdb$') {
+            if ($name -cnotmatch '^bootstrap-layout-r[1-3]-(empty|created|renamed|property-set|variant-[a-z0-9-]+)\.mdb$') {
                 throw "Bootstrap-layout output contains an unexpected database name."
             }
             [void]$names.Add($name)

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -104,8 +104,8 @@ switch ($Job) {
                 [void]$referenced.Add([string]$variant.database)
             }
         }
-        if ($referenced.Count -gt 204) {
-            throw "Bootstrap-layout output exceeds the 204-database bound."
+        if ($referenced.Count -gt 210) {
+            throw "Bootstrap-layout output exceeds the 210-database bound."
         }
         if (@($referenced | Select-Object -Unique).Count -ne $referenced.Count) {
             throw "Bootstrap-layout result contains duplicate database names."

--- a/oracle/windows-dao/tests/test_bootstrap_layout.py
+++ b/oracle/windows-dao/tests/test_bootstrap_layout.py
@@ -321,6 +321,22 @@ class BootstrapLayoutTests(unittest.TestCase):
             report["questions"]["candidate_catalog_fields"]["fields"]["lvprop"]["outcome"],
             "resolved",
         )
+        self.assertEqual(
+            report["questions"]["candidate_catalog_fields"]["fields"]["date_created"][
+                "evidence"
+            ]["method"],
+            "other_timestamp_anchor",
+        )
+        self.assertEqual(
+            report["questions"]["candidate_catalog_fields"]["fields"]["lvprop"][
+                "evidence"
+            ]["header_offset"],
+            18 * bootstrap.PAGE_BYTES + 200,
+        )
+        self.assertEqual(
+            report["questions"]["composed_image_sufficiency"]["endpoints"],
+            endpoints(True),
+        )
 
     def test_partial_failed_replica_is_canonical_no_outcome(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -481,6 +497,126 @@ class BootstrapLayoutTests(unittest.TestCase):
         self.assertEqual(report["status"], "no_outcome")
         self.assertFalse(report["sufficiency_claim"])
 
+    def test_failed_created_baseline_blocks_sufficiency(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][0]["baseline"]["table_opened"] = False
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(
+            report["questions"]["composed_image_sufficiency"],
+            {
+                "reason": "at least one created baseline failed or changed during DAO open",
+                "status": "no_outcome",
+            },
+        )
+        self.assertFalse(report["sufficiency_claim"])
+
+    def test_correlation_evidence_disagreement_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            replica = document["replicas"][1]
+            duplicate_start = 22 * bootstrap.PAGE_BYTES + 100
+            duplicate_end = duplicate_start + 16
+
+            renamed = replica["checkpoints"][2]
+            renamed_path = root / renamed["database"]
+            renamed_bytes = bytearray(renamed_path.read_bytes())
+            renamed_bytes[duplicate_start:duplicate_end] = bytes(16)
+            renamed_path.write_bytes(renamed_bytes)
+            renamed["sha256"] = digest(bytes(renamed_bytes))
+            replica["correlations"]["date_created"]["method"] = "unique_exact"
+
+            for variant in replica["variants"]:
+                if not variant["kind"].startswith("candidate_date_"):
+                    continue
+                path = root / variant["database"]
+                data = bytearray(path.read_bytes())
+                data[duplicate_start:duplicate_end] = bytes(16)
+                path.write_bytes(data)
+                variant["sha256_before_open"] = digest(bytes(data))
+                variant["sha256_after_open"] = digest(bytes(data))
+
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(
+            report["questions"]["candidate_catalog_fields"]["fields"][
+                "date_created"
+            ],
+            {
+                "reason": "replicas disagree on the date_created correlation evidence",
+                "status": "no_outcome",
+            },
+        )
+        self.assertFalse(report["sufficiency_claim"])
+
+    def test_lvprop_locator_disagreement_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            replica = document["replicas"][1]
+            old_offset = 18 * bootstrap.PAGE_BYTES + 200
+            new_offset = old_offset + 20
+            property_set = replica["checkpoints"][3]
+            path = root / property_set["database"]
+            data = bytearray(path.read_bytes())
+            header = bytes(data[old_offset : old_offset + 12])
+            data[old_offset : old_offset + 12] = bytes(12)
+            data[new_offset : new_offset + 12] = header
+            path.write_bytes(data)
+            property_set["sha256"] = digest(bytes(data))
+            replica["correlations"]["lvprop"]["header_offset"] = new_offset
+
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(
+            report["questions"]["candidate_catalog_fields"]["fields"]["lvprop"],
+            {
+                "reason": "replicas disagree on the lvprop correlation evidence",
+                "status": "no_outcome",
+            },
+        )
+        self.assertFalse(report["sufficiency_claim"])
+
+    def test_composed_endpoint_frontier_disagreement_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            first_frontier = {
+                "open_database": True,
+                "table_enumerated": False,
+                "field_enumerated": False,
+                "table_opened": False,
+            }
+            second_frontier = {
+                "open_database": True,
+                "table_enumerated": True,
+                "field_enumerated": False,
+                "table_opened": False,
+            }
+            for replica, frontier in zip(
+                document["replicas"],
+                (first_frontier, second_frontier, first_frontier),
+                strict=True,
+            ):
+                replica["sufficiency"]["endpoints"].update(frontier)
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(
+            report["questions"]["composed_image_sufficiency"],
+            {
+                "reason": "replicas disagree on the composed-image DAO endpoint map",
+                "status": "no_outcome",
+            },
+        )
+        self.assertFalse(report["sufficiency_claim"])
+
     def test_repair_is_no_outcome_and_wrong_reconstruction_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -508,6 +644,11 @@ class BootstrapLayoutTests(unittest.TestCase):
                 write_job(root, document), PLAN_SHA256, root / "baseline.json"
             )
             self.assertEqual(report["status"], "no_outcome")
+            self.assertEqual(
+                report["questions"]["composed_image_sufficiency"]["status"],
+                "no_outcome",
+            )
+            self.assertFalse(report["sufficiency_claim"])
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             document = synthetic_document(root)

--- a/oracle/windows-dao/tests/test_bootstrap_layout.py
+++ b/oracle/windows-dao/tests/test_bootstrap_layout.py
@@ -433,6 +433,49 @@ class BootstrapLayoutTests(unittest.TestCase):
         self.assertEqual(report["status"], "no_outcome")
         self.assertEqual(report["replicas"][0]["status"], "no_outcome")
 
+    def test_accepts_producer_bounded_failure_and_repair_details(self) -> None:
+        repair = "DAO changed the artifact during read-only endpoint checks."
+        endpoint_detail = "System.Exception: " + "e" * 600
+        endpoint_detail = endpoint_detail[:509] + "..."
+        artifact_prefix_length = 512 - len(" " + repair) - len("...")
+        artifact_detail = (
+            endpoint_detail[:artifact_prefix_length] + "... " + repair
+        )
+        replica_detail = "System.Exception: " + "r" * 600
+        replica_detail = replica_detail[:509] + "..."
+        self.assertEqual(len(endpoint_detail), 512)
+        self.assertEqual(len(artifact_detail), 512)
+        self.assertEqual(len(replica_detail), 512)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            failed = document["replicas"][1]
+            failed["status"] = "fail"
+            failed["detail"] = replica_detail
+            baseline = failed["baseline"]
+            baseline_path = root / baseline["database"]
+            repaired = bytearray(baseline_path.read_bytes())
+            repaired[500] ^= 1
+            baseline_path.write_bytes(repaired)
+            baseline["sha256_after"] = digest(bytes(repaired))
+            baseline["endpoints"]["detail"] = endpoint_detail
+            baseline["detail"] = artifact_detail
+
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "bounded.json"
+            )
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertEqual(report["replicas"][1]["detail"], replica_detail)
+
+            failed["detail"] += "x"
+            with self.assertRaisesRegex(
+                bootstrap.AnalysisError, "at most 512 characters"
+            ):
+                bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "too-long.json"
+                )
+
     def test_extra_created_to_renamed_page0_range_makes_q1_no_outcome(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/oracle/windows-dao/tests/test_bootstrap_layout.py
+++ b/oracle/windows-dao/tests/test_bootstrap_layout.py
@@ -31,18 +31,23 @@ def endpoints(value: bool) -> dict[str, bool]:
     return {name: value for name in bootstrap.ENDPOINT_NAMES}
 
 
-def table_dao(name: str) -> dict:
+def table_dao(name: str, *, with_lvprop: bool = False) -> dict:
+    lvprop = (
+        {
+            "status": "captured",
+            "detail": "captured once",
+            "length": len(PAYLOAD),
+            "bytes_hex": PAYLOAD.hex(),
+        }
+        if with_lvprop
+        else {"status": "no_outcome", "detail": "property not set"}
+    )
     return {
         "table_name": name,
         "date_created_oadate": CREATED_DATE,
         "last_updated_oadate": UPDATED_DATE,
         "fields": [{"name": "Id", "type": 4}],
-        "lvprop": {
-            "status": "captured",
-            "detail": "captured once",
-            "length": len(PAYLOAD),
-            "bytes_hex": PAYLOAD.hex(),
-        },
+        "lvprop": lvprop,
     }
 
 
@@ -78,24 +83,35 @@ def synthetic_document(root: Path) -> dict:
         created[0][1538] = 7
         created[1][1922] = 0x0F
         created.extend(bytearray(bootstrap.PAGE_BYTES) for _ in range(3))
+        created[18][10] = replica
         created[20][0] = 2
         created[21][0] = 1
         created[22][0] = 1
-        created[22][4:8] = b"LVAL"
-        created[22][8:10] = (1).to_bytes(2, "little")
-        payload_start = bootstrap.PAGE_BYTES - len(PAYLOAD)
-        created[22][10:12] = payload_start.to_bytes(2, "little")
-        created[22][payload_start:] = PAYLOAD
-        header = struct.pack("<I", len(PAYLOAD) | 0x40000000)
-        header += bytes([payload_row]) + payload_page.to_bytes(3, "little") + bytes(4)
-        created[18][200:212] = header
         renamed = copy.deepcopy(created)
         renamed[18][100:108] = struct.pack("<d", CREATED_DATE)
         renamed[18][108:116] = struct.pack("<d", UPDATED_DATE)
+        renamed[22][100:108] = struct.pack("<d", CREATED_DATE)
+        renamed[22][108:116] = struct.pack("<d", CREATED_DATE)
+        property_set = copy.deepcopy(renamed)
+        property_set[22][4:8] = b"LVAL"
+        property_set[22][8:10] = (1).to_bytes(2, "little")
+        payload_start = bootstrap.PAGE_BYTES - len(PAYLOAD)
+        property_set[22][10:12] = payload_start.to_bytes(2, "little")
+        property_set[22][payload_start:] = PAYLOAD
+        header = struct.pack("<I", len(PAYLOAD) | 0x40000000)
+        header += bytes([payload_row]) + payload_page.to_bytes(3, "little") + bytes(4)
+        property_set[18][200:212] = header
         checkpoints = [
             write_checkpoint(root, replica, "empty", empty, {"table_definition_count": 4}),
             write_checkpoint(root, replica, "created", created, table_dao("BootstrapLayout")),
             write_checkpoint(root, replica, "renamed", renamed, table_dao("BootstrapRenamed")),
+            write_checkpoint(
+                root,
+                replica,
+                "property-set",
+                property_set,
+                table_dao("BootstrapRenamed", with_lvprop=True),
+            ),
         ]
         created_bytes = b"".join(bytes(page) for page in created)
         renamed_bytes = b"".join(bytes(page) for page in renamed)
@@ -211,6 +227,8 @@ def synthetic_document(root: Path) -> dict:
         created_sha = checkpoints[1]["sha256"]
         baseline_database = f"r{replica}-variant-baseline-created.mdb"
         (root / baseline_database).write_bytes(created_bytes)
+        sufficiency_database = f"r{replica}-variant-composed.mdb"
+        (root / sufficiency_database).write_bytes(created_bytes)
         replicas.append(
             {
                 "replica": replica,
@@ -233,11 +251,13 @@ def synthetic_document(root: Path) -> dict:
                     "date_created": {
                         "status": "resolved",
                         "detail": "unique",
+                        "method": "other_timestamp_anchor",
                         "offsets": [date_created_offset],
                     },
                     "date_updated": {
                         "status": "resolved",
                         "detail": "unique",
+                        "method": "unique_exact",
                         "offsets": [date_updated_offset],
                     },
                     "lvprop": {
@@ -250,6 +270,14 @@ def synthetic_document(root: Path) -> dict:
                 },
                 "changed_page_groups": changed_groups,
                 "appended_page_groups": appended_groups,
+                "sufficiency": {
+                    "database": sufficiency_database,
+                    "size": len(created_bytes),
+                    "sha256_before_open": created_sha,
+                    "sha256_after_open": created_sha,
+                    "endpoints": {**endpoints(True), "detail": "all endpoints passed"},
+                    "detail": "all endpoints passed",
+                },
                 "variants": variants,
             }
         )
@@ -283,7 +311,11 @@ class BootstrapLayoutTests(unittest.TestCase):
         self.assertEqual(report["status"], "accepted")
         self.assertFalse(report["compatibility_claim"])
         self.assertFalse(report["support_movement"])
-        self.assertFalse(report["sufficiency_claim"])
+        self.assertTrue(report["sufficiency_claim"])
+        self.assertEqual(
+            report["questions"]["composed_image_sufficiency"]["outcome"],
+            "observed_sufficient",
+        )
         self.assertEqual(report["questions"]["candidate_page0"]["outcome"], "necessary")
         self.assertEqual(
             report["questions"]["candidate_catalog_fields"]["fields"]["lvprop"]["outcome"],
@@ -399,6 +431,55 @@ class BootstrapLayoutTests(unittest.TestCase):
                 write_job(root, document), PLAN_SHA256, root / "report.json"
             )
         self.assertEqual(report["status"], "no_outcome")
+
+    def test_rejects_timestamp_outside_the_preregistered_anchor_rule(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][0]["correlations"]["date_created"]["method"] = (
+                "unique_exact"
+            )
+            with self.assertRaisesRegex(
+                bootstrap.AnalysisError, "independently scanned OADate bytes"
+            ):
+                bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "report.json"
+                )
+
+    def test_composed_image_is_independently_reconstructed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            sufficiency = document["replicas"][0]["sufficiency"]
+            path = root / sufficiency["database"]
+            data = bytearray(path.read_bytes())
+            data[500] ^= 1
+            path.write_bytes(data)
+            changed = digest(bytes(data))
+            sufficiency["sha256_before_open"] = changed
+            sufficiency["sha256_after_open"] = changed
+            with self.assertRaisesRegex(
+                bootstrap.AnalysisError, "independent reconstruction"
+            ):
+                bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "report.json"
+                )
+
+    def test_composed_image_repair_is_honest_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            sufficiency = document["replicas"][0]["sufficiency"]
+            path = root / sufficiency["database"]
+            repaired = bytearray(path.read_bytes())
+            repaired[500] ^= 1
+            path.write_bytes(repaired)
+            sufficiency["sha256_after_open"] = digest(bytes(repaired))
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertFalse(report["sufficiency_claim"])
 
     def test_repair_is_no_outcome_and_wrong_reconstruction_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/oracle/windows-dao/tests/test_bootstrap_layout.py
+++ b/oracle/windows-dao/tests/test_bootstrap_layout.py
@@ -31,6 +31,24 @@ def endpoints(value: bool) -> dict[str, bool]:
     return {name: value for name in bootstrap.ENDPOINT_NAMES}
 
 
+def artifact_observation(
+    database: str,
+    data: bytes,
+    *,
+    passes: bool,
+    detail: str,
+) -> dict:
+    return {
+        "database": database,
+        "size_before": len(data),
+        "size_after": len(data),
+        "sha256_before": digest(data),
+        "sha256_after": digest(data),
+        "endpoints": {**endpoints(passes), "detail": detail},
+        "detail": detail,
+    }
+
+
 def table_dao(name: str, *, with_lvprop: bool = False) -> dict:
     lvprop = (
         {
@@ -156,16 +174,16 @@ def synthetic_document(root: Path) -> dict:
             data = bytes(mutated)
             (root / database).write_bytes(data)
             result = {
+                **artifact_observation(
+                    database,
+                    data,
+                    passes=passes,
+                    detail="single read-only observation",
+                ),
                 "name": name,
                 "kind": kind,
-                "database": database,
-                "size": len(data),
                 "base_checkpoint": base_checkpoint,
                 "ranges": ranges,
-                "sha256_before_open": digest(data),
-                "sha256_after_open": digest(data),
-                "endpoints": endpoints(passes),
-                "detail": "single read-only observation",
             }
             if page is not None:
                 result["page"] = page
@@ -224,7 +242,6 @@ def synthetic_document(root: Path) -> dict:
                     group["page"],
                 )
             )
-        created_sha = checkpoints[1]["sha256"]
         baseline_database = f"r{replica}-variant-baseline-created.mdb"
         (root / baseline_database).write_bytes(created_bytes)
         sufficiency_database = f"r{replica}-variant-composed.mdb"
@@ -241,17 +258,18 @@ def synthetic_document(root: Path) -> dict:
                     "created_to_renamed": [],
                 },
                 "baseline": {
-                    "database": baseline_database,
-                    "sha256_before_open": created_sha,
-                    "sha256_after_open": created_sha,
-                    **endpoints(True),
-                    "detail": "all endpoints passed",
+                    **artifact_observation(
+                        baseline_database,
+                        created_bytes,
+                        passes=True,
+                        detail="all endpoints passed",
+                    ),
                 },
                 "correlations": {
                     "date_created": {
                         "status": "resolved",
                         "detail": "unique",
-                        "method": "other_timestamp_anchor",
+                        "method": "last_updated_anchor",
                         "offsets": [date_created_offset],
                     },
                     "date_updated": {
@@ -271,12 +289,12 @@ def synthetic_document(root: Path) -> dict:
                 "changed_page_groups": changed_groups,
                 "appended_page_groups": appended_groups,
                 "sufficiency": {
-                    "database": sufficiency_database,
-                    "size": len(created_bytes),
-                    "sha256_before_open": created_sha,
-                    "sha256_after_open": created_sha,
-                    "endpoints": {**endpoints(True), "detail": "all endpoints passed"},
-                    "detail": "all endpoints passed",
+                    **artifact_observation(
+                        sufficiency_database,
+                        created_bytes,
+                        passes=True,
+                        detail="all endpoints passed",
+                    ),
                 },
                 "variants": variants,
             }
@@ -297,6 +315,25 @@ def write_job(root: Path, document: dict) -> Path:
 
 
 class BootstrapLayoutTests(unittest.TestCase):
+    def test_endpoint_frontier_model_accepts_only_sequential_states(self) -> None:
+        for bits in range(1 << len(bootstrap.ENDPOINT_NAMES)):
+            frontier = {
+                name: bool(bits & (1 << index))
+                for index, name in enumerate(bootstrap.ENDPOINT_NAMES)
+            }
+            expected = tuple(frontier.values()) in bootstrap.VALID_ENDPOINT_FRONTIERS
+            with self.subTest(frontier=tuple(frontier.values())):
+                if expected:
+                    self.assertEqual(
+                        bootstrap._endpoint_frontier(frontier, "$.endpoints"),
+                        frontier,
+                    )
+                else:
+                    with self.assertRaisesRegex(
+                        bootstrap.AnalysisError, "reachable DAO endpoint frontier"
+                    ):
+                        bootstrap._endpoint_frontier(frontier, "$.endpoints")
+
     def test_accepts_and_emits_deterministic_canonical_report(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -325,7 +362,7 @@ class BootstrapLayoutTests(unittest.TestCase):
             report["questions"]["candidate_catalog_fields"]["fields"]["date_created"][
                 "evidence"
             ]["method"],
-            "other_timestamp_anchor",
+            "last_updated_anchor",
         )
         self.assertEqual(
             report["questions"]["candidate_catalog_fields"]["fields"]["lvprop"][
@@ -372,9 +409,14 @@ class BootstrapLayoutTests(unittest.TestCase):
                 "page0_changed_ranges": None,
                 "baseline": {
                     "database": None,
-                    "sha256_before_open": None,
-                    "sha256_after_open": None,
-                    **endpoints(False),
+                    "size_before": None,
+                    "size_after": None,
+                    "sha256_before": None,
+                    "sha256_after": None,
+                    "endpoints": {
+                        **endpoints(False),
+                        "detail": "baseline was not reached",
+                    },
                     "detail": "baseline was not reached",
                 },
                 "correlations": {
@@ -412,8 +454,8 @@ class BootstrapLayoutTests(unittest.TestCase):
                 data = bytearray(path.read_bytes())
                 data[1500] = 9
                 path.write_bytes(data)
-                variant["sha256_before_open"] = digest(bytes(data))
-                variant["sha256_after_open"] = digest(bytes(data))
+                variant["sha256_before"] = digest(bytes(data))
+                variant["sha256_after"] = digest(bytes(data))
             report = bootstrap.evaluate(
                 write_job(root, document), PLAN_SHA256, root / "report.json"
             )
@@ -462,6 +504,122 @@ class BootstrapLayoutTests(unittest.TestCase):
                     write_job(root, document), PLAN_SHA256, root / "report.json"
                 )
 
+    def test_last_updated_cannot_reverse_fallback_to_date_created(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            duplicate_offset = 22 * bootstrap.PAGE_BYTES + 300
+            duplicate_created = slice(
+                22 * bootstrap.PAGE_BYTES + 100,
+                22 * bootstrap.PAGE_BYTES + 116,
+            )
+            for replica in document["replicas"]:
+                renamed = replica["checkpoints"][2]
+                path = root / renamed["database"]
+                data = bytearray(path.read_bytes())
+                data[duplicate_created] = bytes(16)
+                data[duplicate_offset : duplicate_offset + 8] = struct.pack(
+                    "<d", UPDATED_DATE
+                )
+                path.write_bytes(data)
+                renamed["sha256"] = digest(bytes(data))
+                replica["correlations"]["date_created"]["method"] = "unique_exact"
+                replica["correlations"]["date_updated"] = {
+                    "status": "no_outcome",
+                    "detail": "LastUpdated is not uniquely exact",
+                }
+                updated_variants = []
+                for variant in replica["variants"]:
+                    if variant["kind"] == "candidate_date_updated":
+                        continue
+                    if variant["kind"] == "candidate_date_created":
+                        variant_path = root / variant["database"]
+                        variant_data = bytearray(variant_path.read_bytes())
+                        variant_data[duplicate_created] = bytes(16)
+                        variant_data[duplicate_offset : duplicate_offset + 8] = struct.pack(
+                            "<d", UPDATED_DATE
+                        )
+                        variant_path.write_bytes(variant_data)
+                        variant["sha256_before"] = digest(bytes(variant_data))
+                        variant["sha256_after"] = digest(bytes(variant_data))
+                    updated_variants.append(variant)
+                replica["variants"] = updated_variants
+
+            report = bootstrap.evaluate(
+                write_job(root, document), PLAN_SHA256, root / "report.json"
+            )
+        self.assertEqual(
+            report["questions"]["candidate_catalog_fields"]["fields"]["date_updated"][
+                "status"
+            ],
+            "no_outcome",
+        )
+
+    def test_rejects_true_after_false_endpoint_evidence_on_every_surface(self) -> None:
+        for surface in ("baseline", "sufficiency", "variant"):
+            with self.subTest(surface=surface), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                document = synthetic_document(root)
+                observation = (
+                    document["replicas"][0]["variants"][0]
+                    if surface == "variant"
+                    else document["replicas"][0][surface]
+                )
+                observation["endpoints"].update(
+                    {
+                        "open_database": False,
+                        "table_enumerated": True,
+                        "field_enumerated": False,
+                        "table_opened": False,
+                    }
+                )
+                with self.assertRaisesRegex(
+                    bootstrap.AnalysisError, "reachable DAO endpoint frontier"
+                ):
+                    bootstrap.evaluate(
+                        write_job(root, document), PLAN_SHA256, root / "report.json"
+                    )
+
+    def test_bounded_size_change_is_repair_on_every_surface(self) -> None:
+        for surface in ("baseline", "sufficiency", "variant"):
+            with self.subTest(surface=surface), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                document = synthetic_document(root)
+                observation = (
+                    document["replicas"][0]["variants"][0]
+                    if surface == "variant"
+                    else document["replicas"][0][surface]
+                )
+                path = root / observation["database"]
+                repaired = path.read_bytes() + bytes(bootstrap.PAGE_BYTES)
+                path.write_bytes(repaired)
+                observation["size_after"] = len(repaired)
+                observation["sha256_after"] = digest(repaired)
+                report = bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "report.json"
+                )
+                self.assertEqual(report["status"], "no_outcome")
+
+    def test_rejects_malformed_or_out_of_bound_artifact_snapshots(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][0]["baseline"]["sha256_after"] = None
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "lowercase SHA-256"):
+                bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "malformed.json"
+                )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = synthetic_document(root)
+            document["replicas"][0]["sufficiency"]["size_after"] = (
+                bootstrap.MAX_PAGES + 1
+            ) * bootstrap.PAGE_BYTES
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "between"):
+                bootstrap.evaluate(
+                    write_job(root, document), PLAN_SHA256, root / "unbounded.json"
+                )
+
     def test_composed_image_is_independently_reconstructed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -472,10 +630,10 @@ class BootstrapLayoutTests(unittest.TestCase):
             data[500] ^= 1
             path.write_bytes(data)
             changed = digest(bytes(data))
-            sufficiency["sha256_before_open"] = changed
-            sufficiency["sha256_after_open"] = changed
+            sufficiency["sha256_before"] = changed
+            sufficiency["sha256_after"] = changed
             with self.assertRaisesRegex(
-                bootstrap.AnalysisError, "independent reconstruction"
+                bootstrap.AnalysisError, "expected image"
             ):
                 bootstrap.evaluate(
                     write_job(root, document), PLAN_SHA256, root / "report.json"
@@ -490,7 +648,7 @@ class BootstrapLayoutTests(unittest.TestCase):
             repaired = bytearray(path.read_bytes())
             repaired[500] ^= 1
             path.write_bytes(repaired)
-            sufficiency["sha256_after_open"] = digest(bytes(repaired))
+            sufficiency["sha256_after"] = digest(bytes(repaired))
             report = bootstrap.evaluate(
                 write_job(root, document), PLAN_SHA256, root / "report.json"
             )
@@ -501,7 +659,7 @@ class BootstrapLayoutTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             document = synthetic_document(root)
-            document["replicas"][0]["baseline"]["table_opened"] = False
+            document["replicas"][0]["baseline"]["endpoints"]["table_opened"] = False
             report = bootstrap.evaluate(
                 write_job(root, document), PLAN_SHA256, root / "report.json"
             )
@@ -537,8 +695,8 @@ class BootstrapLayoutTests(unittest.TestCase):
                 data = bytearray(path.read_bytes())
                 data[duplicate_start:duplicate_end] = bytes(16)
                 path.write_bytes(data)
-                variant["sha256_before_open"] = digest(bytes(data))
-                variant["sha256_after_open"] = digest(bytes(data))
+                variant["sha256_before"] = digest(bytes(data))
+                variant["sha256_after"] = digest(bytes(data))
 
             report = bootstrap.evaluate(
                 write_job(root, document), PLAN_SHA256, root / "report.json"
@@ -626,7 +784,7 @@ class BootstrapLayoutTests(unittest.TestCase):
             repaired = bytearray(path.read_bytes())
             repaired[500] ^= 1
             path.write_bytes(repaired)
-            variant["sha256_after_open"] = digest(bytes(repaired))
+            variant["sha256_after"] = digest(bytes(repaired))
             report = bootstrap.evaluate(
                 write_job(root, document), PLAN_SHA256, root / "a.json"
             )
@@ -639,7 +797,7 @@ class BootstrapLayoutTests(unittest.TestCase):
             repaired = bytearray(path.read_bytes())
             repaired[501] ^= 1
             path.write_bytes(repaired)
-            baseline["sha256_after_open"] = digest(bytes(repaired))
+            baseline["sha256_after"] = digest(bytes(repaired))
             report = bootstrap.evaluate(
                 write_job(root, document), PLAN_SHA256, root / "baseline.json"
             )
@@ -658,9 +816,9 @@ class BootstrapLayoutTests(unittest.TestCase):
             data[500] ^= 1
             path.write_bytes(data)
             changed = digest(bytes(data))
-            variant["sha256_before_open"] = changed
-            variant["sha256_after_open"] = changed
-            with self.assertRaisesRegex(bootstrap.AnalysisError, "declared mutation"):
+            variant["sha256_before"] = changed
+            variant["sha256_after"] = changed
+            with self.assertRaisesRegex(bootstrap.AnalysisError, "expected image"):
                 bootstrap.evaluate(write_job(root, document), PLAN_SHA256, root / "b.json")
 
     def test_rejects_garbage_variant_in_partial_failed_replica(self) -> None:

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -407,6 +407,37 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             actual = hashlib.sha256((ROOT / relative).read_bytes()).hexdigest()
             self.assertEqual(actual, expected, relative)
 
+    def test_bootstrap_detail_normalization_covers_failure_and_repair_surfaces(self) -> None:
+        job = CLIENT.BOOTSTRAP_LAYOUT_JOB.read_text(encoding="utf-8")
+        helper_start = job.index("function ConvertTo-BoundedDetail")
+        helper_end = job.index("function New-ArtifactObservation")
+        helper = job[helper_start:helper_end]
+
+        self.assertIn("$MaximumDetailCharacters = 512", job)
+        self.assertIn("No additional detail was reported.", helper)
+        self.assertIn("$maximumSuffixCharacters = 192", helper)
+        self.assertIn(
+            "$text.Substring(0, $MaximumDetailCharacters - $ellipsis.Length)",
+            helper,
+        )
+        self.assertIn("$suffixText = $suffixText.Substring(", helper)
+        self.assertIn("-Suffix $repairSuffix", job)
+        self.assertIn(
+            '-Suffix ("Working-file cleanup failed: " + $_.Exception.Message)',
+            job,
+        )
+        self.assertNotIn("$Observation.detail +=", job)
+
+        exception_detail = '$_.Exception.GetType().FullName + ": " + $_.Exception.Message'
+        self.assertEqual(job.count(exception_detail), 4)
+        offset = 0
+        while (position := job.find(exception_detail, offset)) >= 0:
+            self.assertIn(
+                "ConvertTo-BoundedDetail",
+                job[max(0, position - 120) : position],
+            )
+            offset = position + len(exception_detail)
+
     def test_bootstrap_timestamp_pages_use_floor_division(self) -> None:
         job = CLIENT.BOOTSTRAP_LAYOUT_JOB.read_text(encoding="utf-8")
 

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -25,6 +25,13 @@ PUBLICATION_PATH = REMOTE_PATH.with_name("Publish.DevJob.ps1")
 CONSUMED_BOOTSTRAP_PLAN = (
     ROOT / "oracle" / "windows-dao" / "acquisition" / "bootstrap-layout.plan.json"
 )
+CONSUMED_BOOTSTRAP_FLOOR_PLAN = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "acquisition"
+    / "bootstrap-layout-floor.plan.json"
+)
 SPEC = importlib.util.spec_from_file_location("windows_dao_dev", CLIENT_PATH)
 assert SPEC is not None and SPEC.loader is not None
 CLIENT = importlib.util.module_from_spec(SPEC)
@@ -154,6 +161,17 @@ class WindowsDaoDevClientTests(unittest.TestCase):
         )
         self.assertEqual(document["inputs"], expected_inputs)
 
+    def test_consumed_bootstrap_floor_plan_remains_immutable(self) -> None:
+        document = json.loads(
+            CONSUMED_BOOTSTRAP_FLOOR_PLAN.read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(
+            hashlib.sha256(CONSUMED_BOOTSTRAP_FLOOR_PLAN.read_bytes()).hexdigest(),
+            "c0161be2ba1189249d743c9198bcd004dd9d927edcc7d753cffe79c421677773",
+        )
+        self.assertEqual(document["document_type"], "dao_bootstrap_layout_floor_plan")
+
     def test_bootstrap_layout_binds_and_verifies_the_active_plan(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -177,7 +195,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
             altered_plan.write_text(
                 json.dumps(
                     {
-                        "document_type": "dao_bootstrap_layout_floor_plan",
+                        "document_type": "dao_bootstrap_layout_sufficiency_plan",
                         "issue": 100,
                         "development_only": True,
                         "inputs": {"scripts/windows-dao-dev.py": "0" * 64},
@@ -362,6 +380,11 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertIn("$MaximumVariants = 64", job)
         self.assertNotIn("CompactDatabase", job)
         self.assertIn("204-database bound", self.publication)
+        self.assertIn("WITH OWNERACCESS OPTION", job)
+        self.assertIn("$TimestampAnchorWindowBytes = 64", job)
+        self.assertIn('Name "property-set"', job)
+        self.assertIn("$State.sufficiency", job)
+        self.assertIn("replica.sufficiency.database", self.publication)
         self.assertTrue(plan["development_only"])
         self.assertEqual(plan["issue"], 100)
         for relative, expected in plan["inputs"].items():

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -383,8 +383,19 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertIn("210-database bound", self.publication)
         self.assertIn("WITH OWNERACCESS OPTION", job)
         self.assertIn("$TimestampAnchorWindowBytes = 64", job)
+        self.assertIn("-AllowLastUpdatedAnchor", job)
+        self.assertIn("-LastUpdatedAnchor $null", job)
         self.assertIn('Name "property-set"', job)
         self.assertIn("$State.sufficiency", job)
+        for field in (
+            "size_before",
+            "size_after",
+            "sha256_before",
+            "sha256_after",
+        ):
+            self.assertIn(field, job)
+        self.assertNotIn("sha256_before_open", job)
+        self.assertNotIn("sha256_after_open", job)
         self.assertIn("replica.sufficiency.database", self.publication)
         self.assertTrue(plan["development_only"])
         self.assertEqual(plan["issue"], 100)

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -379,7 +379,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertIn("$MaximumPages = 64", job)
         self.assertIn("$MaximumVariants = 64", job)
         self.assertNotIn("CompactDatabase", job)
-        self.assertIn("204-database bound", self.publication)
+        self.assertIn("$referenced.Count -gt 210", self.publication)
+        self.assertIn("210-database bound", self.publication)
         self.assertIn("WITH OWNERACCESS OPTION", job)
         self.assertIn("$TimestampAnchorWindowBytes = 64", job)
         self.assertIn('Name "property-set"', job)
@@ -387,6 +388,10 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertIn("replica.sufficiency.database", self.publication)
         self.assertTrue(plan["development_only"])
         self.assertEqual(plan["issue"], 100)
+        self.assertEqual(
+            plan["execution"]["bounds"]["maximum_published_databases"],
+            3 * (4 + 1 + 1 + 64),
+        )
         for relative, expected in plan["inputs"].items():
             actual = hashlib.sha256((ROOT / relative).read_bytes()).hexdigest()
             self.assertEqual(actual, expected, relative)

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -59,7 +59,7 @@ BOOTSTRAP_LAYOUT_PLAN = (
     / "oracle"
     / "windows-dao"
     / "acquisition"
-    / "bootstrap-layout-floor.plan.json"
+    / "bootstrap-layout-sufficiency.plan.json"
 )
 BOOTSTRAP_LAYOUT_ANALYZER = (
     ROOT
@@ -97,7 +97,7 @@ def verified_bootstrap_plan_sha256() -> str:
         raise DevClientError("bootstrap-layout plan is unreadable") from error
     if (
         not isinstance(plan, dict)
-        or plan.get("document_type") != "dao_bootstrap_layout_floor_plan"
+        or plan.get("document_type") != "dao_bootstrap_layout_sufficiency_plan"
         or plan.get("issue") != 100
         or plan.get("development_only") is not True
     ):


### PR DESCRIPTION
EXP-0069 left DateCreated and LvProp correlations unresolved and established only leave-one-out necessity, so the bootstrap composer still lacks the evidence needed to proceed. This successor preregisters one bounded local-VM acquisition that targets those correlations and separately tests whether all recorded create-transition mutation groups are sufficient for DAO to open the reconstructed image.

The property-free created checkpoint is kept isolated from a later deterministic LvProp control. Each sufficiency candidate is reconstructed from the empty checkpoint plus the complete preregistered transition groups; byte equality with the DAO-created checkpoint is an independent completeness check, not the construction method. The candidate then runs the four read-only DAO endpoints once with before/after hashing. DateCreated uses a bounded window around the uniquely correlated LastUpdated value, and LvProp uses the later property-set checkpoint only.

The immutable successor plan is `oracle/windows-dao/acquisition/bootstrap-layout-sufficiency.plan.json`, SHA-256 `da56d399dd4608a6d938deac3dde4ce0d6125a15a56dc8204be1ebe9338b6994`, recorded additively as EXP-0070. It preserves one attempt, no automatic retry after the first DAO mutation, and honest `no_outcome` terminals. No acquisition has run.

Checks:
- 41 focused bootstrap/analyzer/client contract tests
- all seven plan input SHA-256 pins
- JSON parsing and Python compilation
- `git diff --check`
- `just ready`

PowerShell is unavailable locally, so the guest script was not parsed by PowerShell here. Acquisition remains blocked until this preregistration is reviewed and merged and the user explicitly authorizes the single local-VM run.

Refs #100
