### PR TITLE
fix(writer): budget whole-file plan storage

### DIFF
--- a/crates/jet3/src/page_append_plan.rs
+++ b/crates/jet3/src/page_append_plan.rs
@@ -81,6 +81,23 @@ pub(crate) fn plan_existing_page(
     Ok(PlannedPage { number, image })
 }
 
+/// Pairs exactly 20 complete images with existing slots 0 through 19.
+///
+/// The fixed-size input makes every slot valid by construction. As with
+/// [`plan_existing_page`], the images are moved through without inspection or
+/// any assignment of bootstrap semantics.
+pub(crate) fn plan_existing_pages(
+    images: [PageImage; EMPTY_DATABASE_PAGE_COUNT as usize],
+) -> impl ExactSizeIterator<Item = PlannedPage> {
+    images
+        .into_iter()
+        .enumerate()
+        .map(|(number, image)| PlannedPage {
+            number: PageNumber::new(number as u64),
+            image,
+        })
+}
+
 /// Structured failure while planning one fresh page append.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AppendPageError {

--- a/crates/jet3/src/page_append_plan_tests.rs
+++ b/crates/jet3/src/page_append_plan_tests.rs
@@ -1,4 +1,6 @@
-use super::{AppendPageError, AppendPagePlan, ExistingPageError, plan_existing_page};
+use super::{
+    AppendPageError, AppendPagePlan, ExistingPageError, plan_existing_page, plan_existing_pages,
+};
 use crate::limits::ReadLimits;
 use crate::{
     ByteCount, InlineUsageMapEncoder, PageImage, PageKind, PageNumber, ResourceBudget,
@@ -57,6 +59,22 @@ fn existing_page_rejects_the_first_append_slot() {
             page: PageNumber::new(20),
         })
     );
+}
+
+#[test]
+fn exact_existing_batch_pairs_all_slots_without_a_failure_state() {
+    let images: [PageImage; 20] = std::array::from_fn(|index| {
+        let mut bytes = [0x5a; crate::PAGE_BYTES];
+        bytes[11] = index as u8;
+        PageImage::from_bytes(bytes)
+    });
+
+    let planned = plan_existing_pages(images.clone());
+    assert_eq!(planned.len(), 20);
+    for (index, (page, image)) in planned.zip(images).enumerate() {
+        assert_eq!(page.number(), PageNumber::new(index as u64));
+        assert_eq!(page.image(), &image);
+    }
 }
 
 #[test]

--- a/crates/jet3/src/whole_file_plan.rs
+++ b/crates/jet3/src/whole_file_plan.rs
@@ -10,26 +10,20 @@
     reason = "staged for the future crate-private writer composition layer"
 )]
 
-use std::fmt;
+use std::{fmt, mem::size_of};
 
 use crate::page_append_plan::{
-    AppendPageError, AppendPagePlan, EMPTY_DATABASE_PAGE_COUNT, ExistingPageError, PlannedPage,
-    plan_existing_page,
+    AppendPageError, AppendPagePlan, EMPTY_DATABASE_PAGE_COUNT, PlannedPage, plan_existing_pages,
 };
-use crate::{InlineUsageMapEncoder, PageImage, PageNumber};
+use crate::{ByteCount, Error, InlineUsageMapEncoder, PageImage, PageNumber, ResourceBudget};
 
 const EXISTING_PAGE_COUNT: usize = EMPTY_DATABASE_PAGE_COUNT as usize;
 
 /// Structured failure while aggregating a whole-file page plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WholeFilePlanError {
-    /// Storage for the requested number of complete page plans was unavailable.
-    PageStorageUnavailable {
-        /// Total page count the plan attempted to retain.
-        requested_page_count: u64,
-    },
-    /// An existing image could not be paired with its physical slot.
-    Existing(ExistingPageError),
+    /// Resource accounting or allocation failed while retaining page plans.
+    Resource(Error),
     /// A fresh image could not be appended.
     Append(AppendPageError),
 }
@@ -37,13 +31,9 @@ pub(crate) enum WholeFilePlanError {
 impl fmt::Display for WholeFilePlanError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::PageStorageUnavailable {
-                requested_page_count,
-            } => write!(
-                formatter,
-                "storage unavailable for {requested_page_count} planned pages"
-            ),
-            Self::Existing(source) => write!(formatter, "existing page plan failed: {source}"),
+            Self::Resource(source) => {
+                write!(formatter, "whole-file plan resource failure: {source}")
+            }
             Self::Append(source) => write!(formatter, "page append plan failed: {source}"),
         }
     }
@@ -52,16 +42,15 @@ impl fmt::Display for WholeFilePlanError {
 impl std::error::Error for WholeFilePlanError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Existing(source) => Some(source),
+            Self::Resource(source) => Some(source),
             Self::Append(source) => Some(source),
-            Self::PageStorageUnavailable { .. } => None,
         }
     }
 }
 
-impl From<ExistingPageError> for WholeFilePlanError {
-    fn from(source: ExistingPageError) -> Self {
-        Self::Existing(source)
+impl From<Error> for WholeFilePlanError {
+    fn from(source: Error) -> Self {
+        Self::Resource(source)
     }
 }
 
@@ -72,7 +61,7 @@ impl From<AppendPageError> for WholeFilePlanError {
 }
 
 /// Complete page images ordered by their planned physical file slots.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct WholeFileImagePlan {
     pages: Vec<PlannedPage>,
     append_plan: AppendPagePlan,
@@ -83,20 +72,15 @@ impl WholeFileImagePlan {
     ///
     /// `EXP-0065` Q1 establishes only the fixed page count and slot range.
     /// This constructor neither inspects page bytes nor assigns bootstrap
-    /// roles, references, or sufficiency to them.
+    /// roles, references, or sufficiency to them. The logical storage for all
+    /// retained plans is charged to `budget` before reservation.
     pub(crate) fn from_existing_pages(
         images: [PageImage; EXISTING_PAGE_COUNT],
+        budget: &mut ResourceBudget,
     ) -> Result<Self, WholeFilePlanError> {
         let mut pages = Vec::new();
-        pages.try_reserve_exact(EXISTING_PAGE_COUNT).map_err(|_| {
-            WholeFilePlanError::PageStorageUnavailable {
-                requested_page_count: EMPTY_DATABASE_PAGE_COUNT,
-            }
-        })?;
-
-        for (number, image) in (0_u64..).zip(images) {
-            pages.push(plan_existing_page(PageNumber::new(number), image)?);
-        }
+        reserve_planned_pages(&mut pages, EXISTING_PAGE_COUNT, budget)?;
+        pages.extend(plan_existing_pages(images));
 
         Ok(Self {
             pages,
@@ -116,24 +100,21 @@ impl WholeFileImagePlan {
 
     /// Plans and retains one fresh page after the existing sequence.
     ///
-    /// Storage is reserved before the append planner changes the page count or
-    /// global free map. On any error, the retained sequence, count, and map are
-    /// logically unchanged.
+    /// Logical storage for the page plan is charged and reserved before the
+    /// append planner changes the page count or global free map. On any error,
+    /// the retained sequence, count, and map are logically unchanged.
     pub(crate) fn append(
         &mut self,
         image: PageImage,
         global_free_map: &mut InlineUsageMapEncoder,
+        budget: &mut ResourceBudget,
     ) -> Result<PageNumber, WholeFilePlanError> {
-        let requested_page_count = self.page_count().checked_add(1).ok_or_else(|| {
+        self.page_count().checked_add(1).ok_or_else(|| {
             WholeFilePlanError::Append(AppendPageError::PageCountOverflow {
                 page_count: self.page_count(),
             })
         })?;
-        self.pages
-            .try_reserve(1)
-            .map_err(|_| WholeFilePlanError::PageStorageUnavailable {
-                requested_page_count,
-            })?;
+        reserve_planned_pages(&mut self.pages, 1, budget)?;
 
         let planned = self.append_plan.append(image, global_free_map)?;
         let number = planned.number();
@@ -145,6 +126,26 @@ impl WholeFileImagePlan {
     pub(crate) fn into_pages(self) -> Vec<PlannedPage> {
         self.pages
     }
+}
+
+fn reserve_planned_pages(
+    pages: &mut Vec<PlannedPage>,
+    additional: usize,
+    budget: &mut ResourceBudget,
+) -> Result<(), WholeFilePlanError> {
+    let bytes = u64::try_from(additional)
+        .ok()
+        .and_then(|count| count.checked_mul(size_of::<PlannedPage>() as u64))
+        .ok_or(Error::Arithmetic {
+            operation: "size whole-file planned-page storage",
+        })?;
+    budget.charge_allocation(ByteCount::new(bytes))?;
+    pages.try_reserve_exact(additional).map_err(|_| {
+        WholeFilePlanError::Resource(Error::Io {
+            operation: "reserve whole-file planned-page storage",
+            kind: std::io::ErrorKind::OutOfMemory,
+        })
+    })
 }
 
 #[cfg(test)]

--- a/crates/jet3/src/whole_file_plan_tests.rs
+++ b/crates/jet3/src/whole_file_plan_tests.rs
@@ -1,15 +1,21 @@
-use super::{EXISTING_PAGE_COUNT, WholeFileImagePlan, WholeFilePlanError};
+use super::{
+    EMPTY_DATABASE_PAGE_COUNT, EXISTING_PAGE_COUNT, WholeFileImagePlan, WholeFilePlanError,
+};
 use crate::limits::ReadLimits;
-use crate::page_append_plan::AppendPageError;
+use crate::page_append_plan::{AppendPageError, PlannedPage};
 use crate::{
-    ByteCount, InlineUsageMapEncoder, PageImage, PageNumber, ResourceBudget, ResourceLimits,
-    UsageMapWriteError,
+    ByteCount, Error, InlineUsageMapEncoder, PageImage, PageNumber, ResourceBudget,
+    ResourceLimitKind, ResourceLimits, UsageMapWriteError,
 };
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn budget() -> ResourceBudget {
     ResourceBudget::new(ResourceLimits::new(ReadLimits::default()))
+}
+
+fn planned_page_storage(page_count: u64) -> u64 {
+    (std::mem::size_of::<PlannedPage>() as u64) * page_count
 }
 
 fn global_map(bitmap_bytes: u64) -> Result<InlineUsageMapEncoder, UsageMapWriteError> {
@@ -31,7 +37,8 @@ fn existing_images() -> [PageImage; EXISTING_PAGE_COUNT] {
 #[test]
 fn complete_plan_preserves_existing_and_appended_images_in_slot_order() -> TestResult {
     let existing = existing_images();
-    let mut plan = WholeFileImagePlan::from_existing_pages(existing.clone())?;
+    let mut plan_budget = budget();
+    let mut plan = WholeFileImagePlan::from_existing_pages(existing.clone(), &mut plan_budget)?;
     let mut map = global_map(3)?;
     map.set_page(PageNumber::new(20))?;
     map.set_page(PageNumber::new(21))?;
@@ -43,9 +50,19 @@ fn complete_plan_preserves_existing_and_appended_images_in_slot_order() -> TestR
     second_bytes[17] = 21;
     let second = PageImage::from_bytes(second_bytes);
 
-    assert_eq!(plan.append(first.clone(), &mut map)?, PageNumber::new(20));
-    assert_eq!(plan.append(second.clone(), &mut map)?, PageNumber::new(21));
+    assert_eq!(
+        plan.append(first.clone(), &mut map, &mut plan_budget)?,
+        PageNumber::new(20)
+    );
+    assert_eq!(
+        plan.append(second.clone(), &mut map, &mut plan_budget)?,
+        PageNumber::new(21)
+    );
     assert_eq!(plan.page_count(), 22);
+    assert_eq!(
+        plan_budget.allocation_bytes(),
+        ByteCount::new(planned_page_storage(22))
+    );
     assert!(!map.is_set(PageNumber::new(20))?);
     assert!(!map.is_set(PageNumber::new(21))?);
 
@@ -62,20 +79,90 @@ fn complete_plan_preserves_existing_and_appended_images_in_slot_order() -> TestR
 
 #[test]
 fn rejected_append_preserves_whole_file_plan_and_global_map() -> TestResult {
-    let mut plan = WholeFileImagePlan::from_existing_pages(existing_images())?;
-    let plan_before = plan.clone();
+    let existing = existing_images();
+    let mut plan_budget = budget();
+    let mut plan = WholeFileImagePlan::from_existing_pages(existing.clone(), &mut plan_budget)?;
     let mut map = global_map(3)?;
     let map_before = map.clone();
 
     assert_eq!(
-        plan.append(PageImage::from_bytes([0x33; crate::PAGE_BYTES]), &mut map),
+        plan.append(
+            PageImage::from_bytes([0x33; crate::PAGE_BYTES]),
+            &mut map,
+            &mut plan_budget,
+        ),
         Err(WholeFilePlanError::Append(
             AppendPageError::PageAlreadyInUse {
                 page: PageNumber::new(20),
             }
         ))
     );
-    assert_eq!(plan, plan_before);
+    assert_eq!(plan.page_count(), 20);
+    assert_eq!(plan.pages().len(), 20);
+    for (index, (planned, image)) in plan.pages().iter().zip(existing.iter()).enumerate() {
+        assert_eq!(planned.number(), PageNumber::new(index as u64));
+        assert_eq!(planned.image(), image);
+    }
+    assert_eq!(map, map_before);
+    Ok(())
+}
+
+#[test]
+fn constructor_budget_rejection_precedes_storage_reservation() {
+    let requested = planned_page_storage(EMPTY_DATABASE_PAGE_COUNT);
+    let maximum = requested - 1;
+    let mut plan_budget = ResourceBudget::new(
+        ResourceLimits::new(ReadLimits::default())
+            .with_max_allocation_bytes(ByteCount::new(maximum)),
+    );
+
+    assert_eq!(
+        WholeFileImagePlan::from_existing_pages(existing_images(), &mut plan_budget),
+        Err(WholeFilePlanError::Resource(Error::ResourceLimitExceeded {
+            kind: ResourceLimitKind::AllocationBytes,
+            requested,
+            maximum,
+        }))
+    );
+    assert_eq!(plan_budget.allocation_bytes(), ByteCount::new(0));
+}
+
+#[test]
+fn append_budget_rejection_preserves_plan_and_global_map() -> TestResult {
+    let existing = existing_images();
+    let initial_storage = planned_page_storage(EMPTY_DATABASE_PAGE_COUNT);
+    let appended_storage = planned_page_storage(1);
+    let mut plan_budget = ResourceBudget::new(
+        ResourceLimits::new(ReadLimits::default())
+            .with_max_allocation_bytes(ByteCount::new(initial_storage)),
+    );
+    let mut plan = WholeFileImagePlan::from_existing_pages(existing.clone(), &mut plan_budget)?;
+    let mut map = global_map(3)?;
+    map.set_page(PageNumber::new(20))?;
+    let map_before = map.clone();
+
+    assert_eq!(
+        plan.append(
+            PageImage::from_bytes([0x44; crate::PAGE_BYTES]),
+            &mut map,
+            &mut plan_budget,
+        ),
+        Err(WholeFilePlanError::Resource(Error::ResourceLimitExceeded {
+            kind: ResourceLimitKind::AllocationBytes,
+            requested: initial_storage + appended_storage,
+            maximum: initial_storage,
+        }))
+    );
+    assert_eq!(
+        plan_budget.allocation_bytes(),
+        ByteCount::new(initial_storage)
+    );
+    assert_eq!(plan.page_count(), EMPTY_DATABASE_PAGE_COUNT);
+    assert_eq!(plan.pages().len(), EXISTING_PAGE_COUNT);
+    for (index, (planned, image)) in plan.pages().iter().zip(existing.iter()).enumerate() {
+        assert_eq!(planned.number(), PageNumber::new(index as u64));
+        assert_eq!(planned.image(), image);
+    }
     assert_eq!(map, map_before);
     Ok(())
 }


### PR DESCRIPTION
The thermonuclear review of merged #130 found that retained page plans could grow outside the parser's operation-wide allocation budget, and that the aggregate exposed an impossible existing-page error state.

This threads `ResourceBudget` through whole-file construction and append, charges the logical retained `PlannedPage` bytes before allocation, and surfaces resource failures structurally. It removes the infallible `Clone` path, adds exact-limit and one-below tests for constructor/append rejection and logical map/plan atomicity, and moves exact 20-slot pairing into an infallible canonical page-planner batch operation so the unreachable error branch disappears.

The accounting deliberately charges logical retained elements (`count * size_of::<PlannedPage>()`) rather than allocator capacity/padding; rejected attempts remain precharged like existing writer allocation patterns, while the page sequence/count and global map remain logically unchanged.

Checks:
- `cargo test -p jet3 whole_file_plan --lib --locked` (4 passed)
- `cargo test -p jet3 page_append_plan --lib --locked` (8 passed)
- `cargo clippy -p jet3 --lib --tests --locked -- -D warnings`
- `just ready`

Follow-up to #130. Refs #100.