### PR TITLE
docs: close out the acceptance-gate reduction that #111 already did

### DIFF
--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -30,9 +30,8 @@ delivered in this order:
   commit.
 - Every format constant in `crates/jet3` cites a provenance entry.
 
-`scripts/acceptance.sh full` and the G0–G8 gate set in
-`docs/validation/ACCEPTANCE.md` are to be reduced to the three gates above
-(tracked as an issue).
+`docs/validation/ACCEPTANCE.md` describes these gates and the
+`scripts/acceptance.sh` checks that cover them.
 
 ## Explicitly out of v1
 


### PR DESCRIPTION
The scope doc still said the G0–G8 gate set and `scripts/acceptance.sh full` were to be reduced to the three v1 release gates "tracked as an issue", which is why #134 was filed. Checking the tree, #111 already did that: `docs/validation/ACCEPTANCE.md` lists exactly the three gates, and `scripts/acceptance.sh` only runs the checks that cover them. This removes the stale promise so the scope doc matches reality.

Checks: `git diff --check`. Docs only.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaSCZwjDrcTJJYvLeGK9k8