### PR TITLE
feat(oracle): close the empty-image page gap with pinned long-value maps

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6816,7 +6816,7 @@ Use `not applicable` explicitly rather than omitting a field.
   external long-value page to Note's owned map.
 - Preregistration artifact:
   `oracle/windows-dao/acquisition/long-value-maps.plan.json`, SHA-256
-  `defacc3bee5e48e3865088998e69d71159bee94c1826df8bfaf1b34ec6eb6b69`.
+  `5b2fc593ddfaaa303c37e885d68ab1964e99779593f307ea3bfb702a4c0621d9`.
   The plan pins the host client, provider probe, guest runner, dispatcher,
   publisher, producer, and analyzer. Host and guest reject any plan or staged
   input mismatch before the first DAO mutation.
@@ -6825,8 +6825,9 @@ Use `not applicable` explicitly rather than omitting a field.
   explicit human authorization is required for one local-VM run.
 - Decision rule: H5 is `answered` only if all three replicas complete all
   three checkpoints once, their decoded suffixes and page roles agree, every
-  empty page is assigned, `Gamma.Note` has the predicted single group, and
-  its owned-map transition identifies an external long-value page. Replica
+  Memo or LongBinary column has exactly one group, every empty page is
+  assigned, `Gamma.Note` has the predicted single group, and its newly added
+  owned-map pages equal Gamma's newly appearing long-value pages. Replica
   failure, disagreement, decode failure, or a missing prediction is an honest
   `no_outcome`; digest, bound, result-shape, or checkpoint defects reject
   validation. There is no automatic retry after the first DAO mutation.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6789,6 +6789,61 @@ Use `not applicable` explicitly rather than omitting a field.
   three-replica agreement, checkpoint identities, and zero unattributed
   ranges checked
 
+### EXP-0074 — Preregistered local long-value column-map experiment
+
+- Recorded: 2026-09-01, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration; no provider
+  acquisition or format observation has occurred under this plan
+- Question: Across three fresh replicas, does the table-definition suffix
+  decode as one 10-byte group per Memo or LongBinary column, does that grammar
+  assign every page of the empty image, and does a user Memo column's owned
+  map add the page that receives one external long value?
+- Origin: project-authored clean-room experiment using only `EXP-0051`,
+  `EXP-0057`, `EXP-0059`, `EXP-0060`, `EXP-0061`, and `EXP-0073` as recorded
+  above. Interactive decoding of the externally retained `EXP-0073`
+  checkpoints suggested H5 but is design input only, not an experiment input
+  or result.
+- Protocol: create three independent fresh `dbVersion30` CP1252 replicas
+  once. Per replica capture the closed checkpoints `empty`; `table` after
+  creating `Gamma` with Long `Id` and Memo `Note`; and `row` after inserting
+  exactly one row whose 4,101-character Memo forces external storage. Close
+  and release DAO before every copy or hash; retain all nine MDBs externally.
+- Hypothesis H5: the definition suffix consists of 10-byte groups containing
+  a little-endian column ordinal followed by owned and available map locators,
+  each in row-byte-plus-24-bit-little-endian-page form. In the empty image the
+  decoded locators assign page 7 through `MSysObjects.LvExtra`; `Gamma.Note`
+  has exactly one group of the same shape; and inserting the row adds its
+  external long-value page to Note's owned map.
+- Preregistration artifact:
+  `oracle/windows-dao/acquisition/long-value-maps.plan.json`, SHA-256
+  `defacc3bee5e48e3865088998e69d71159bee94c1826df8bfaf1b34ec6eb6b69`.
+  The plan pins the host client, provider probe, guest runner, dispatcher,
+  publisher, producer, and analyzer. Host and guest reject any plan or staged
+  input mismatch before the first DAO mutation.
+- Observation: `preregistration.acquisition_started` is `false`. Committing
+  this plan does not authorize acquisition. After review and merge, one
+  explicit human authorization is required for one local-VM run.
+- Decision rule: H5 is `answered` only if all three replicas complete all
+  three checkpoints once, their decoded suffixes and page roles agree, every
+  empty page is assigned, `Gamma.Note` has the predicted single group, and
+  its owned-map transition identifies an external long-value page. Replica
+  failure, disagreement, decode failure, or a missing prediction is an honest
+  `no_outcome`; digest, bound, result-shape, or checkpoint defects reject
+  validation. There is no automatic retry after the first DAO mutation.
+- Interpretation: this entry fixes an acquisition and analysis contract only.
+  It establishes no new format fact, Rust writer correctness, compatibility,
+  support result, or support-matrix movement. The optional property-blob
+  question is explicitly excluded.
+- Usage: future `EXP-0075`; issue `#100`;
+  `file:oracle/windows-dao/acquisition/long-value-maps.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/system_catalog.py`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: pending independent evidence-boundary, hypothesis, plan-pin,
+  producer, analyzer, and no-retry review before merge and local acquisition
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/justfile
+++ b/justfile
@@ -72,6 +72,10 @@ windows-dev-bootstrap-layout:
 windows-dev-system-catalog:
     "{{PYTHON}}" scripts/windows-dao-dev.py system-catalog --timeout 900
 
+# Run the preregistered long-value column-map experiment in the local VM.
+windows-dev-long-value-maps:
+    "{{PYTHON}}" scripts/windows-dao-dev.py long-value-maps --timeout 900
+
 # Run one ad-hoc PowerShell script under x86 DAO in the local VM (discovery only).
 windows-dev-ps script *args:
     "{{PYTHON}}" scripts/windows-dao-ps.py {{script}} {{args}}

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -30,6 +30,9 @@ The retained tooling has three purposes:
   system-catalog semantics experiment for #100: five closed checkpoints per
   replica with DAO-visible catalog metadata, analyzed against pinned
   system-table hypotheses.
+- `acquisition/long-value-maps.plan.json` reuses that bounded producer and
+  analyzer for the three-checkpoint EXP-0074 successor that tests per-column
+  long-value map locators and assigns the final empty-image page role.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.

--- a/oracle/windows-dao/acquisition/long-value-maps.plan.json
+++ b/oracle/windows-dao/acquisition/long-value-maps.plan.json
@@ -1,0 +1,78 @@
+{
+  "document_type": "dao_long_value_maps_plan",
+  "experiment_id": "long_value_column_maps",
+  "issue": 100,
+  "development_only": true,
+  "purpose": "Close the remaining empty-image page-role gap by testing the 10-byte per-long-value-column definition suffix grammar and observing the map transition caused by one external Memo value.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_result": "EXP-0073",
+    "authorization": "No acquisition is authorized by committing this plan. After review and merge, the human operator may explicitly authorize one local-VM acquisition.",
+    "amendment_rule": "This is one immutable experiment. After its first DAO mutation, any failure or no_outcome is recorded once and it is not redispatched without another human decision."
+  },
+  "evidence_boundary": {
+    "admitted_prior_results": "EXP-0051, EXP-0057, EXP-0059, EXP-0060, EXP-0061, and EXP-0073 as recorded in docs/PROVENANCE.md.",
+    "design_input": "Interactive decoding of the externally retained EXP-0073 checkpoints suggested H5. Those bytes are design input only and are not an experiment input or result.",
+    "dao_limits": "The local provider has no workgroup information file. DAO system-table reads and permission operations are excluded; correlation is limited to DAO-visible table names, attributes, and timestamps.",
+    "claims": "A successful result establishes only the bounded H5 observations below. It cannot establish Rust writer correctness, compatibility, support, or support-matrix movement."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "06dfb002dc7821293e0ae285103e39cfbc89e719979fc4375d81b3cb1a8949d4",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "b0cb6346183ad6b5d8923e4dc377c23599605d4568121816c7a5f340424b3c9e",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "48a5967e9b92d37742af805462c68b062b649a2cac42544f2791e7b9b1542030",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "e858eac6424a4a7f271dc16f4d726e997e9066502d008021f4997ad190c502a8",
+    "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1": "673445d0987e47e92512fb7cf2ad1bc485910193a5a9f9f8555ef87b6d4e99a1",
+    "oracle/windows-dao/scripts/system_catalog.py": "28c8adf7847919f9e7e5a2b5f949a3b3850a80c041bfcb76da458be67bf50505"
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "scenario": [
+      "Create one fresh dbVersion30 CP1252 database and capture it closed as empty.",
+      "Create table Gamma with Long Id and Memo Note and capture it closed as table.",
+      "Insert exactly one row with Id 1 and a 4101-character Memo Note, long enough to require external storage, and capture it closed as row."
+    ],
+    "checkpoints": ["empty", "table", "row"],
+    "capture": "Close and release every DAO object before each copy or hash. Retain all nine MDB checkpoints externally with sizes and SHA-256 digests; commit none.",
+    "bounds": {
+      "maximum_pages_per_database": 64,
+      "maximum_checkpoints": 3,
+      "maximum_replicas": 3,
+      "maximum_tables": 16,
+      "maximum_columns_per_table": 64,
+      "maximum_rows_per_page": 64,
+      "maximum_property_value_characters": 256,
+      "maximum_json_bytes": 4194304
+    }
+  },
+  "hypotheses": {
+    "H5_long_value_column_maps": "The definition suffix is a sequence of 10-byte groups, one for each Memo or LongBinary column: a little-endian two-byte column ordinal, then an owned-map locator and an available-map locator, each encoded as one row byte followed by a little-endian 24-bit page. In the empty image this assigns every page, including page 7 through MSysObjects.LvExtra. Gamma.Note carries exactly one group of the same shape. After inserting the external Memo, Note's per-column owned map adds the page that holds that external long value."
+  },
+  "questions": {
+    "H5": "Across all three replicas, does the suffix decode under H5, does it assign every empty-image page, does Gamma.Note use the same one-group shape, and does its owned map add an external long-value page after the row insertion?"
+  },
+  "decision_rule": {
+    "accepted": "The plan and staged inputs match their SHA-256 pins; the provider is ready; all three replicas complete all three checkpoints once; bounds and file digests validate; and the analyzer emits one deterministic report with H5 answered.",
+    "answered": "H5 is answered only if the decoded observations and page roles are identical across all three replicas and every preregistered prediction is observed.",
+    "no_outcome": "A replica failure or disagreement, decode failure, unassigned empty page, missing or malformed Gamma.Note suffix group, or absence of the predicted owned-map transition is recorded as no_outcome.",
+    "rejected": "A plan or input digest mismatch, malformed result, bound violation, file digest mismatch, or checkpoint-order defect rejects validation.",
+    "retry": "One explicit human authorization permits one acquisition only; there is no automatic retry after the first DAO mutation."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "long-value content interpretation",
+    "the optional property-blob question",
+    "workgroup security semantics",
+    "Rust writer changes",
+    "public API expansion",
+    "compatibility or support claims"
+  ]
+}

--- a/oracle/windows-dao/acquisition/long-value-maps.plan.json
+++ b/oracle/windows-dao/acquisition/long-value-maps.plan.json
@@ -23,7 +23,7 @@
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "48a5967e9b92d37742af805462c68b062b649a2cac42544f2791e7b9b1542030",
     "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "e858eac6424a4a7f271dc16f4d726e997e9066502d008021f4997ad190c502a8",
     "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1": "673445d0987e47e92512fb7cf2ad1bc485910193a5a9f9f8555ef87b6d4e99a1",
-    "oracle/windows-dao/scripts/system_catalog.py": "28c8adf7847919f9e7e5a2b5f949a3b3850a80c041bfcb76da458be67bf50505"
+    "oracle/windows-dao/scripts/system_catalog.py": "99413dc51472ed6eb09520f9996c32505574b9681e0f5cb582c2b0c711e4a4f4"
   },
   "execution": {
     "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
@@ -55,8 +55,8 @@
   },
   "decision_rule": {
     "accepted": "The plan and staged inputs match their SHA-256 pins; the provider is ready; all three replicas complete all three checkpoints once; bounds and file digests validate; and the analyzer emits one deterministic report with H5 answered.",
-    "answered": "H5 is answered only if the decoded observations and page roles are identical across all three replicas and every preregistered prediction is observed.",
-    "no_outcome": "A replica failure or disagreement, decode failure, unassigned empty page, missing or malformed Gamma.Note suffix group, or absence of the predicted owned-map transition is recorded as no_outcome.",
+    "answered": "H5 is answered only if the decoded observations and page roles are identical across all three replicas, every Memo or LongBinary column has exactly one suffix group at every checkpoint, and the pages newly added to Gamma.Note's owned map equal the Gamma long-value pages newly appearing after insertion.",
+    "no_outcome": "A replica failure or disagreement, decode failure, unassigned empty page, missing or extra long-value-column suffix group, malformed Gamma.Note group, or mismatch between the owned-map additions and newly appearing Gamma long-value pages is recorded as no_outcome.",
     "rejected": "A plan or input digest mismatch, malformed result, bound violation, file digest mismatch, or checkpoint-order defect rejects validation.",
     "retry": "One explicit human authorization permits one acquisition only; there is no automatic retry after the first DAO mutation."
   },

--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]
+    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$RunRoot,
@@ -47,6 +47,7 @@ $scriptPath = switch ($Job) {
     "index" { $IndexJobPath }
     "bootstrap-layout" { $BootstrapLayoutJobPath }
     "system-catalog" { $SystemCatalogJobPath }
+    "long-value-maps" { $SystemCatalogJobPath }
 }
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
     [Console]::Error.WriteLine("INVALID: selected staged job does not exist.")
@@ -68,8 +69,8 @@ if ($Job -ceq "table-definition") {
 elseif ($Job -ceq "bootstrap-layout") {
     $arguments += @("-PlanSha256", $PlanSha256)
 }
-elseif ($Job -ceq "system-catalog") {
-    $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId)
+elseif ($Job -in @("system-catalog", "long-value-maps")) {
+    $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId, "-Experiment", $Job)
 }
 & (Join-Path $PSHOME "powershell.exe") @arguments
 $jobExitCode = [int]$LASTEXITCODE
@@ -81,6 +82,7 @@ $resultName = switch ($Job) {
     "index" { "index-job-result.json" }
     "bootstrap-layout" { "bootstrap-layout-job-result.json" }
     "system-catalog" { "system-catalog-job-result.json" }
+    "long-value-maps" { "long-value-maps-job-result.json" }
 }
 $resultPath = Join-Path $RunRoot $resultName
 if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
@@ -112,7 +114,7 @@ $indexScenarios = @()
 $bootstrapLayoutReplicas = @()
 $systemCatalogReplicas = @()
 # The system-catalog result carries no detail field; derive one from its status.
-$detail = if ($Job -ceq "system-catalog") {
+$detail = if ($Job -in @("system-catalog", "long-value-maps")) {
     if ([string]$jobResult.status -ceq "pass") {
         "Completed all three system-catalog replicas once without retry."
     }
@@ -132,7 +134,7 @@ elseif ($Job -ceq "index") { $indexScenarios = @($jobResult.scenarios) }
 elseif ($Job -ceq "bootstrap-layout") {
     $bootstrapLayoutReplicas = @($jobResult.replicas)
 }
-elseif ($Job -ceq "system-catalog") {
+elseif ($Job -in @("system-catalog", "long-value-maps")) {
     $systemCatalogReplicas = @($jobResult.replicas)
 }
 $result = [ordered]@{

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
@@ -385,6 +385,7 @@ foreach ($requiredHelper in @(
 $planBoundJobs = @{
     "bootstrap-layout" = "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1"
     "system-catalog" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"
+    "long-value-maps" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"
 }
 if ($planBoundJobs.ContainsKey($Job)) {
     if ($PlanSha256 -cnotmatch "^[0-9a-f]{64}$") {
@@ -679,7 +680,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
         }
     }
 }
-elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog") -and $probeExitCode -eq 0) {
+elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps") -and $probeExitCode -eq 0) {
     $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$Source,
@@ -155,6 +155,39 @@ switch ($Job) {
         $expected = @($referenced | Sort-Object)
         if (($actual -join "`n") -cne ($expected -join "`n")) {
             throw "System-catalog MDB inventory differs from its result."
+        }
+    }
+    "long-value-maps" {
+        [void]$names.Add("long-value-maps-job-result.json")
+        $jobResultPath = Join-Path $Source "long-value-maps-job-result.json"
+        if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
+            throw "Long-value-maps result is missing."
+        }
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $referenced = New-Object Collections.ArrayList
+        foreach ($replica in @($jobResult.replicas)) {
+            foreach ($checkpoint in @($replica.checkpoints)) {
+                [void]$referenced.Add([string]$checkpoint.database)
+            }
+        }
+        if ($referenced.Count -gt 9) {
+            throw "Long-value-maps output exceeds the 9-database bound."
+        }
+        if (@($referenced | Select-Object -Unique).Count -ne $referenced.Count) {
+            throw "Long-value-maps result contains duplicate database names."
+        }
+        foreach ($name in $referenced) {
+            if ($name -cnotmatch '^long-value-maps-r[1-3]-(empty|table|row)\.mdb$') {
+                throw "Long-value-maps output contains an unexpected database name."
+            }
+            [void]$names.Add($name)
+        }
+        $actual = @(Get-ChildItem -LiteralPath $Source -File |
+            Where-Object { $_.Name -clike "long-value-maps-*.mdb" } |
+            ForEach-Object { $_.Name } | Sort-Object)
+        $expected = @($referenced | Sort-Object)
+        if (($actual -join "`n") -cne ($expected -join "`n")) {
+            throw "Long-value-maps MDB inventory differs from its result."
         }
     }
 }

--- a/oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1
@@ -8,7 +8,10 @@ param(
     [string]$PlanSha256,
 
     [Parameter(Mandatory = $true)]
-    [string]$RunId
+    [string]$RunId,
+
+    [ValidateSet("system-catalog", "long-value-maps")]
+    [string]$Experiment = "system-catalog"
 )
 
 Set-StrictMode -Version Latest
@@ -20,6 +23,7 @@ if ($PlanSha256 -cnotmatch '^[0-9a-f]{64}$') {
 $DbVersion30 = 32
 $DbLong = 4
 $DbText = 10
+$DbMemo = 12
 $DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
 $PageSize = 2048
 $MaximumPages = 64
@@ -135,6 +139,55 @@ function New-AlphaTable {
         finally {
             Release-ComObject -Value $field
             Release-ComObject -Value $table
+        }
+    }
+}
+
+function New-GammaTable {
+    param([string]$Path)
+
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $table = $null
+        $idField = $null
+        $noteField = $null
+        try {
+            $table = $database.CreateTableDef("Gamma")
+            $idField = $table.CreateField("Id", $DbLong)
+            $table.Fields.Append($idField)
+            $noteField = $table.CreateField("Note", $DbMemo)
+            $table.Fields.Append($noteField)
+            $database.TableDefs.Append($table)
+        }
+        finally {
+            Release-ComObject -Value $noteField
+            Release-ComObject -Value $idField
+            Release-ComObject -Value $table
+        }
+    }
+}
+
+function Add-GammaLongMemoRow {
+    param([string]$Path)
+
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $records = $null
+        try {
+            $records = $database.OpenRecordset("Gamma")
+            $records.AddNew()
+            $records.Fields.Item("Id").Value = 1
+            $records.Fields.Item("Note").Value = ("memo-" + ("x" * 4096))
+            $records.Update()
+            $records.Close()
+            Release-ComObject -Value $records
+            $records = $null
+        }
+        finally {
+            if ($null -ne $records) {
+                try { $records.Close() } catch { }
+            }
+            Release-ComObject -Value $records
         }
     }
 }
@@ -501,7 +554,7 @@ function Save-Checkpoint {
     )
 
     # DAO is closed and released by the preceding mutation before the copy.
-    $fileName = "system-catalog-r$Replica-$Name.mdb"
+    $fileName = "$Experiment-r$Replica-$Name.mdb"
     $destination = Join-Path $RunRoot $fileName
     Copy-Item -LiteralPath $Source -Destination $destination
     $size = Get-BoundedSize -Path $destination
@@ -531,14 +584,22 @@ function Invoke-Replica {
     try {
         New-Jet3Database -Path $workingPath
         [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "empty"))
-        New-AlphaTable -Path $workingPath
-        [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "table1"))
-        New-BetaTable -Path $workingPath
-        [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "table2"))
-        New-SavedQuery -Path $workingPath
-        [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "query"))
-        New-BetaAlphaRelation -Path $workingPath
-        [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "relationship"))
+        if ($Experiment -ceq "long-value-maps") {
+            New-GammaTable -Path $workingPath
+            [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "table"))
+            Add-GammaLongMemoRow -Path $workingPath
+            [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "row"))
+        }
+        else {
+            New-AlphaTable -Path $workingPath
+            [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "table1"))
+            New-BetaTable -Path $workingPath
+            [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "table2"))
+            New-SavedQuery -Path $workingPath
+            [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "query"))
+            New-BetaAlphaRelation -Path $workingPath
+            [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "relationship"))
+        }
         $state.status = "pass"
     }
     catch {
@@ -561,7 +622,7 @@ function Invoke-Replica {
 }
 
 [void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($RunRoot))
-$resultPath = Join-Path $RunRoot "system-catalog-job-result.json"
+$resultPath = Join-Path $RunRoot "$Experiment-job-result.json"
 $replicas = New-Object Collections.ArrayList
 foreach ($replica in 1..3) {
     [void]$replicas.Add((Invoke-Replica -Replica $replica))
@@ -573,7 +634,10 @@ foreach ($entry in $replicas) {
     }
 }
 $result = [ordered]@{
-    document_type = "dao_system_catalog_job_result"
+    document_type = if ($Experiment -ceq "long-value-maps") {
+        "dao_long_value_maps_job_result"
+    }
+    else { "dao_system_catalog_job_result" }
     development_only = $true
     plan_sha256 = $PlanSha256
     run_id = $RunId

--- a/oracle/windows-dao/scripts/system_catalog.py
+++ b/oracle/windows-dao/scripts/system_catalog.py
@@ -1378,6 +1378,11 @@ def _long_value_observation(analysis: dict[str, Any]) -> dict[str, Any]:
     tables = []
     for root in sorted(analysis["tables"]):
         table = analysis["tables"][root]
+        expected_columns = [
+            {"column": column["ordinal"], "column_name": column["name"]}
+            for column in table["definition"]["columns"]
+            if column["type"] in ("Memo", "LongBinary")
+        ]
         mappings = []
         for mapping in table["definition"]["long_value_maps"]:
             mappings.append(
@@ -1402,9 +1407,18 @@ def _long_value_observation(analysis: dict[str, Any]) -> dict[str, Any]:
         tables.append(
             {
                 "long_value_maps": mappings,
+                "long_value_columns": expected_columns,
                 "long_value_pages": table["long_value_pages"],
                 "name": table["name"],
                 "root": root,
+                "suffix_complete": expected_columns
+                == [
+                    {
+                        "column": mapping["column"],
+                        "column_name": mapping["column_name"],
+                    }
+                    for mapping in mappings
+                ],
             }
         )
     return {
@@ -1473,17 +1487,28 @@ def build_long_value_report(
                 and table_maps[0]["available"] == row_maps[0]["available"]
             )
             added_owned = sorted(set(row_maps[0]["owned_pages"]) - set(table_maps[0]["owned_pages"])) if grammar else []
-            external_pages = gamma_row["long_value_pages"]
-            map_tracks_external = bool(set(added_owned) & set(external_pages))
+            added_long_value_pages = sorted(
+                set(gamma_row["long_value_pages"])
+                - set(gamma_table["long_value_pages"])
+            )
+            complete_suffixes = all(
+                entry["suffix_complete"]
+                for checkpoint in (empty, table, row)
+                for entry in checkpoint["tables"]
+            )
+            map_tracks_external = bool(added_owned) and added_owned == added_long_value_pages
             predictions = {
                 "all_empty_pages_assigned": empty["unassigned_pages"] == [],
+                "all_long_value_columns_have_one_suffix_group": complete_suffixes,
                 "gamma_note_has_one_suffix_group": grammar,
+                "gamma_new_long_value_pages": added_long_value_pages,
                 "note_owned_map_added_pages": added_owned,
                 "note_owned_map_tracks_external_long_value_page": map_tracks_external,
             }
             if not all(
                 (
                     predictions["all_empty_pages_assigned"],
+                    complete_suffixes,
                     grammar,
                     map_tracks_external,
                 )

--- a/oracle/windows-dao/scripts/system_catalog.py
+++ b/oracle/windows-dao/scripts/system_catalog.py
@@ -26,6 +26,8 @@ MAX_ITEMS = 64
 MAX_TEXT = 512
 CHECKPOINT_NAMES = ("empty", "table1", "table2", "query", "relationship")
 DOCUMENT_TYPE = "dao_system_catalog_job_result"
+LONG_VALUE_DOCUMENT_TYPE = "dao_long_value_maps_job_result"
+LONG_VALUE_CHECKPOINT_NAMES = ("empty", "table", "row")
 DEFINITION_PREFIX = b"\x02\x01\x56\x43"
 LONG_VALUE_OWNER = b"LVAL"
 SYSTEM_FLAG = 0x80000000
@@ -568,11 +570,38 @@ def _definition(data: bytes, root: int) -> dict[str, Any]:
         entry["name"] = name
     if offset + 2 > total or body[total - 2 :] != b"\xff\xff":
         raise DecodeError(f"{what}: logical definition does not end in ff ff")
+    suffix = body[offset : total - 2]
+    if len(suffix) % 10:
+        raise DecodeError(f"{what}: long-value map suffix is not a sequence of 10-byte groups")
+    long_value_maps = []
+    seen_long_value_columns: set[int] = set()
+    for group_offset in range(0, len(suffix), 10):
+        raw = suffix[group_offset : group_offset + 10]
+        ordinal = _u16(raw, 0, what)
+        if ordinal >= column_count:
+            raise DecodeError(f"{what}: long-value map names column {ordinal}")
+        if ordinal in seen_long_value_columns:
+            raise DecodeError(f"{what}: long-value map repeats column {ordinal}")
+        column = columns[ordinal]
+        if column["type"] not in ("Memo", "LongBinary"):
+            raise DecodeError(
+                f"{what}: long-value map names non-long-value column {ordinal}"
+            )
+        seen_long_value_columns.add(ordinal)
+        long_value_maps.append(
+            {
+                "available": {"row": raw[6], "page": int.from_bytes(raw[7:10], "little")},
+                "column": ordinal,
+                "column_name": column["name"],
+                "owned": {"row": raw[2], "page": int.from_bytes(raw[3:6], "little")},
+            }
+        )
     return {
         "columns": columns,
         "header_unknown_hex": body[16:20].hex() + body[33:35].hex(),
         "logical_indexes": logical_indexes,
         "logical_length": total,
+        "long_value_maps": long_value_maps,
         "maps": maps,
         "marker": marker,
         "pages": pages,
@@ -580,7 +609,7 @@ def _definition(data: bytes, root: int) -> dict[str, Any]:
         "root": root,
         "row_count": _u32(body, 12, what),
         "row_count_offset": file_offset(12),
-        "suffix_hex": body[offset : total - 2].hex(),
+        "suffix_hex": suffix.hex(),
     }
 
 
@@ -836,6 +865,7 @@ def analyze_checkpoint(data: bytes) -> dict[str, Any]:
         if data_pages is None:
             data_pages, long_value_pages = _table_pages(data, definition)
         entry["data_pages"] = data_pages
+        entry["long_value_pages"] = long_value_pages
         for page in data_pages:
             _assign_role(roles, page, "data", label)
         for page in long_value_pages:
@@ -846,6 +876,28 @@ def analyze_checkpoint(data: bytes) -> dict[str, Any]:
             _assign_role(roles, locator["page"], "map_rows", label)
             map_rows[(locator["page"], locator["row"])] = f"{label} {kind} map"
             map_pages.add(locator["page"])
+        for long_value_map in definition["long_value_maps"]:
+            for kind in ("owned", "available"):
+                locator = long_value_map[kind]
+                _locator_row(
+                    data,
+                    locator,
+                    f"{label} column {long_value_map['column_name']} {kind} map",
+                )
+                if locator["page"] not in roles:
+                    _assign_role(roles, locator["page"], "long_value_map_rows", label)
+                elif roles[locator["page"]]["role"] not in (
+                    "map_rows",
+                    "long_value_map_rows",
+                ):
+                    raise DecodeError(
+                        f"page {locator['page']} is both {roles[locator['page']]['role']} and long_value_map_rows"
+                    )
+                roles[locator["page"]]["owners"].add(label)
+                map_rows[(locator["page"], locator["row"])] = (
+                    f"{label} column {long_value_map['column_name']} {kind} map"
+                )
+                map_pages.add(locator["page"])
         for index_entry in definition["physical_indexes"]:
             index_label = f"{label} index {index_entry['index']}"
             offset = index_entry["entry_count_offset"]
@@ -961,6 +1013,7 @@ def _definition_identity(entry: dict[str, Any]) -> dict[str, Any]:
         ],
         "root": definition["root"],
         "suffix_hex": definition["suffix_hex"],
+        "long_value_maps": definition["long_value_maps"],
     }
 
 
@@ -1321,6 +1374,161 @@ def _incomplete_reason(document: dict[str, Any], replicas: list[dict[str, Any]])
     return None
 
 
+def _long_value_observation(analysis: dict[str, Any]) -> dict[str, Any]:
+    tables = []
+    for root in sorted(analysis["tables"]):
+        table = analysis["tables"][root]
+        mappings = []
+        for mapping in table["definition"]["long_value_maps"]:
+            mappings.append(
+                {
+                    **mapping,
+                    "available_pages": sorted(
+                        _locator_pages(
+                            analysis["data"],
+                            mapping["available"],
+                            f"table {root} {table['name']} column {mapping['column_name']} available map",
+                        )
+                    ),
+                    "owned_pages": sorted(
+                        _locator_pages(
+                            analysis["data"],
+                            mapping["owned"],
+                            f"table {root} {table['name']} column {mapping['column_name']} owned map",
+                        )
+                    ),
+                }
+            )
+        tables.append(
+            {
+                "long_value_maps": mappings,
+                "long_value_pages": table["long_value_pages"],
+                "name": table["name"],
+                "root": root,
+            }
+        )
+    return {
+        "pages": analysis["pages"],
+        "tables": tables,
+        "unassigned_pages": [
+            page["page"] for page in analysis["pages"] if page["role"] == "unassigned"
+        ],
+    }
+
+
+def build_long_value_report(
+    document: dict[str, Any], replicas: list[dict[str, Any]]
+) -> dict[str, Any]:
+    analyses: list[dict[str, Any]] = []
+    observations: list[dict[str, Any]] = []
+    decode_error = None
+    for replica in replicas:
+        per_analysis = {}
+        per_observation = {}
+        for checkpoint in replica["checkpoints"]:
+            name = checkpoint["name"]
+            try:
+                analysis = analyze_checkpoint(replica["images"][name])
+                per_analysis[name] = analysis
+                per_observation[name] = _long_value_observation(analysis)
+            except DecodeError as error:
+                decode_error = f"replica {replica['replica']} checkpoint {name}: {error}"
+                break
+        analyses.append(per_analysis)
+        observations.append(per_observation)
+    reason = _incomplete_reason(document, replicas) or decode_error
+    common_count = min(len(replica["checkpoints"]) for replica in replicas)
+    common = list(LONG_VALUE_CHECKPOINT_NAMES[:common_count])
+    if reason is None:
+        for replica_index in range(1, len(observations)):
+            for checkpoint in common:
+                difference = _first_difference(
+                    observations[0][checkpoint],
+                    observations[replica_index][checkpoint],
+                    f"replica {replica_index + 1} checkpoint {checkpoint}",
+                )
+                if difference is not None:
+                    reason = difference
+                    break
+            if reason is not None:
+                break
+    predictions: dict[str, Any] = {}
+    if reason is None and tuple(common) == LONG_VALUE_CHECKPOINT_NAMES:
+        empty = observations[0]["empty"]
+        table = observations[0]["table"]
+        row = observations[0]["row"]
+        gamma_table = next((entry for entry in table["tables"] if entry["name"] == "Gamma"), None)
+        gamma_row = next((entry for entry in row["tables"] if entry["name"] == "Gamma"), None)
+        if gamma_table is None or gamma_row is None:
+            reason = "Gamma did not resolve to one catalog table at both post-create checkpoints"
+        else:
+            table_maps = gamma_table["long_value_maps"]
+            row_maps = gamma_row["long_value_maps"]
+            grammar = (
+                len(table_maps) == 1
+                and len(row_maps) == 1
+                and table_maps[0]["column"] == 1
+                and table_maps[0]["column_name"] == "Note"
+                and table_maps[0]["owned"] == row_maps[0]["owned"]
+                and table_maps[0]["available"] == row_maps[0]["available"]
+            )
+            added_owned = sorted(set(row_maps[0]["owned_pages"]) - set(table_maps[0]["owned_pages"])) if grammar else []
+            external_pages = gamma_row["long_value_pages"]
+            map_tracks_external = bool(set(added_owned) & set(external_pages))
+            predictions = {
+                "all_empty_pages_assigned": empty["unassigned_pages"] == [],
+                "gamma_note_has_one_suffix_group": grammar,
+                "note_owned_map_added_pages": added_owned,
+                "note_owned_map_tracks_external_long_value_page": map_tracks_external,
+            }
+            if not all(
+                (
+                    predictions["all_empty_pages_assigned"],
+                    grammar,
+                    map_tracks_external,
+                )
+            ):
+                reason = "one or more preregistered H5 predictions was not observed"
+    elif reason is None:
+        reason = "not every preregistered checkpoint is present"
+    status = "answered" if reason is None else "no_outcome"
+    question = {
+        "checkpoints": observations[0] if observations else {},
+        "predictions": predictions,
+        "status": status,
+    }
+    if reason is not None:
+        question["reason"] = reason
+    summaries = [
+        {
+            "checkpoints": [
+                {
+                    "database": checkpoint["database"],
+                    "name": checkpoint["name"],
+                    "sha256": checkpoint["sha256"],
+                    "size": checkpoint["size"],
+                }
+                for checkpoint in replica["checkpoints"]
+            ],
+            "error": replica["error"],
+            "replica": replica["replica"],
+            "status": replica["status"],
+        }
+        for replica in replicas
+    ]
+    return {
+        "checkpoints_compared": common,
+        "compatibility_claim": False,
+        "development_only": True,
+        "document_type": "long_value_maps_report",
+        "plan_sha256": document["plan_sha256"],
+        "questions": {"H5": question},
+        "replicas": summaries,
+        "status": "accepted" if status == "answered" else "no_outcome",
+        "support_movement": False,
+    }
+
+
 def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate validated replicas into the deterministic report."""
     analyses = []
@@ -1397,6 +1605,7 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
 
 
 def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[str, Any]:
+    global CHECKPOINT_NAMES
     expected = _digest(expected_plan_sha256, "--expected-plan-sha256")
     document = load_json(job_result)
     item = _expect_keys(
@@ -1405,8 +1614,10 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         set(),
         "$",
     )
-    if item["document_type"] != DOCUMENT_TYPE:
-        raise AnalysisError(f"$.document_type must be {DOCUMENT_TYPE}")
+    if item["document_type"] not in (DOCUMENT_TYPE, LONG_VALUE_DOCUMENT_TYPE):
+        raise AnalysisError(
+            f"$.document_type must be {DOCUMENT_TYPE} or {LONG_VALUE_DOCUMENT_TYPE}"
+        )
     if item["development_only"] is not True:
         raise AnalysisError("$.development_only must be true")
     _string(item["run_id"], "$.run_id", maximum=128)
@@ -1414,16 +1625,26 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         raise AnalysisError("$.status must be pass or fail")
     if _digest(item["plan_sha256"], "$.plan_sha256") != expected:
         raise AnalysisError("job result plan digest differs from the approved plan")
-    raw_replicas = item["replicas"]
-    if not isinstance(raw_replicas, list) or not 1 <= len(raw_replicas) <= MAX_REPLICAS:
-        raise AnalysisError(f"$.replicas must contain one through {MAX_REPLICAS} replicas")
-    replicas = [
-        _replica(raw, f"$.replicas[{index}]", job_result.parent)
-        for index, raw in enumerate(raw_replicas)
-    ]
-    if [replica["replica"] for replica in replicas] != list(range(1, len(replicas) + 1)):
-        raise AnalysisError("$.replicas must be numbered 1 through n in order")
-    report = build_report(item, replicas)
+    old_checkpoint_names = CHECKPOINT_NAMES
+    if item["document_type"] == LONG_VALUE_DOCUMENT_TYPE:
+        CHECKPOINT_NAMES = LONG_VALUE_CHECKPOINT_NAMES
+    try:
+        raw_replicas = item["replicas"]
+        if not isinstance(raw_replicas, list) or not 1 <= len(raw_replicas) <= MAX_REPLICAS:
+            raise AnalysisError(f"$.replicas must contain one through {MAX_REPLICAS} replicas")
+        replicas = [
+            _replica(raw, f"$.replicas[{index}]", job_result.parent)
+            for index, raw in enumerate(raw_replicas)
+        ]
+        if [replica["replica"] for replica in replicas] != list(range(1, len(replicas) + 1)):
+            raise AnalysisError("$.replicas must be numbered 1 through n in order")
+        report = (
+            build_long_value_report(item, replicas)
+            if item["document_type"] == LONG_VALUE_DOCUMENT_TYPE
+            else build_report(item, replicas)
+        )
+    finally:
+        CHECKPOINT_NAMES = old_checkpoint_names
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(canonical_bytes(report))
     return report

--- a/oracle/windows-dao/tests/test_system_catalog.py
+++ b/oracle/windows-dao/tests/test_system_catalog.py
@@ -163,6 +163,7 @@ def definition(
     marker: int = 0x53,
     constant: int = 0,
     indexes: list[dict] | None = None,
+    suffix: bytes = b"",
 ) -> bytearray:
     columns = layout(spec)
     indexes = indexes or []
@@ -218,6 +219,7 @@ def definition(
     for index in indexes:
         raw = index["name"].encode("cp1252")
         body += bytes([len(raw)]) + raw
+    body += suffix
     body += b"\xff\xff"
     body[8:12] = le32(len(body))
     image = bytearray(PAGE)
@@ -574,6 +576,43 @@ class SystemCatalogTests(unittest.TestCase):
         data = bytes(PAGE * 2) + bytes(image)
         with self.assertRaisesRegex(catalog.DecodeError, "hole in its key slots"):
             catalog._definition(data, 2)
+
+    def test_definition_decodes_long_value_column_map_suffix(self) -> None:
+        suffix = le16(1) + bytes([3]) + (12).to_bytes(3, "little") + bytes([4]) + (13).to_bytes(3, "little")
+        image = definition(
+            2,
+            [("Id", 4, 0x03, 4), ("Note", 12, 0x02, 0)],
+            owned=(6, 0),
+            available=(6, 1),
+            row_count=0,
+            marker=0x4E,
+            constant=1,
+            suffix=suffix,
+        )
+        decoded = catalog._definition(bytes(PAGE * 2) + bytes(image), 2)
+        self.assertEqual(
+            decoded["long_value_maps"],
+            [{
+                "available": {"page": 13, "row": 4},
+                "column": 1,
+                "column_name": "Note",
+                "owned": {"page": 12, "row": 3},
+            }],
+        )
+
+    def test_definition_rejects_long_value_map_for_scalar_column(self) -> None:
+        image = definition(
+            2,
+            [("Id", 4, 0x03, 4)],
+            owned=(6, 0),
+            available=(6, 1),
+            row_count=0,
+            marker=0x4E,
+            constant=1,
+            suffix=le16(0) + bytes(8),
+        )
+        with self.assertRaisesRegex(catalog.DecodeError, "non-long-value column"):
+            catalog._definition(bytes(PAGE * 2) + bytes(image), 2)
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_system_catalog.py
+++ b/oracle/windows-dao/tests/test_system_catalog.py
@@ -50,6 +50,7 @@ ACES_COLUMNS = [
 QUERIES_COLUMNS = [("ObjectId", 4, 0x13, 4), ("Name1", 10, 0x12, 255)]
 RELATIONSHIPS_COLUMNS = [("szRelationship", 10, 0x12, 255), ("grbit", 4, 0x13, 4)]
 ALPHA_COLUMNS = [("Id", 4, 0x03, 4)]
+GAMMA_COLUMNS = [("Id", 4, 0x03, 4), ("Note", 12, 0x02, 0)]
 
 
 def digest(data: bytes) -> str:
@@ -185,6 +186,7 @@ def definition(
         record[0] = column["type_code"]
         record[1:3] = le16(column["ordinal"])
         record[3:5] = le16(column["variable_index"])
+        record[5:7] = le16(column["ordinal"] if marker == 0x4E and constant == 1 else 0)
         record[7:9] = le16(constant)
         record[9:13] = CONTEXT
         record[13] = column["class"]
@@ -296,6 +298,145 @@ def build_image(replica: int, with_alpha: bool, *, marker: int = 0x53, stray: bo
     return b"".join(bytes(page) for page in pages)
 
 
+def build_long_value_image(
+    replica: int,
+    checkpoint: str,
+    *,
+    missing_gamma_suffix: bool = False,
+    wrong_transition: bool = False,
+) -> bytes:
+    with_gamma = checkpoint != "empty"
+    with_row = checkpoint == "row"
+    stamp = 46000.0 + replica / 1000
+    objects = [
+        (TABLES_ID, CONTAINERS_PARENT, "Tables", 3, SYSTEM),
+        (DATABASES_ID, CONTAINERS_PARENT, "Databases", 3, SYSTEM),
+        (RELATIONSHIPS_ID, CONTAINERS_PARENT, "Relationships", 3, SYSTEM),
+        (MSYSDB_ID, DATABASES_ID, "MSysDb", 2, SYSTEM),
+        (2, TABLES_ID, "MSysObjects", 1, SYSTEM),
+        (3, TABLES_ID, "MSysACEs", 1, SYSTEM),
+        (4, TABLES_ID, "MSysQueries", 1, SYSTEM),
+        (5, TABLES_ID, "MSysRelationships", 1, SYSTEM),
+    ]
+    if with_gamma:
+        objects.append((ALPHA_ROOT, TABLES_ID, "Gamma", 1, 0))
+    object_columns = layout(OBJECTS_COLUMNS)
+    object_rows = [
+        encode_row(
+            object_columns,
+            [
+                ident,
+                parent,
+                name,
+                kind,
+                stamp,
+                stamp,
+                b"\x03\x01",
+                flags,
+                b"\x2b" + bytes(11) if name == "Gamma" else None,
+            ],
+        )
+        for ident, parent, name, kind, flags in objects
+    ]
+    ace_columns = layout(ACES_COLUMNS)
+    ace_rows = [
+        encode_row(ace_columns, [ident, b"\x03\x01", 393216, ident == TABLES_ID])
+        for ident, *_ in objects
+    ]
+    count = len(objects)
+    pages = [bytearray(PAGE) for _ in range(11)]
+    pages[0][1538] = 1 if with_gamma else 0
+    pages[1] = data_page(1, [map_record(set()), bytes(20)])
+    objects_suffix = (
+        le16(8)
+        + bytes([0])
+        + (10).to_bytes(3, "little")
+        + bytes([1])
+        + (10).to_bytes(3, "little")
+    )
+    pages[2] = definition(
+        2,
+        OBJECTS_COLUMNS,
+        owned=(6, 0),
+        available=(6, 1),
+        row_count=count,
+        suffix=objects_suffix,
+        indexes=[
+            {
+                "keys": [(0, 1)],
+                "map": (6, 2),
+                "root": 7,
+                "flags": 1,
+                "entry_count": count,
+                "name": "Id",
+                "class": 1,
+            }
+        ],
+    )
+    pages[3] = definition(3, ACES_COLUMNS, owned=(6, 3), available=(6, 4), row_count=count)
+    pages[4] = definition(4, QUERIES_COLUMNS, owned=(6, 5), available=(6, 6), row_count=0)
+    pages[5] = definition(5, RELATIONSHIPS_COLUMNS, owned=(6, 7), available=(6, 8), row_count=0)
+    pages[6] = data_page(
+        0,
+        [
+            map_record({8}),
+            map_record({8}),
+            map_record({7}),
+            map_record({9}),
+            map_record({9}),
+            map_record(set()),
+            map_record(set()),
+            map_record(set()),
+            map_record(set()),
+        ],
+    )
+    pages[7][0] = 4
+    pages[7][4:8] = le32(2)
+    pages[8] = data_page(2, object_rows)
+    pages[9] = data_page(3, ace_rows)
+    pages[10] = data_page(0, [map_record(set()), map_record(set())])
+    if with_gamma:
+        gamma_suffix = b"" if missing_gamma_suffix else (
+            le16(1)
+            + bytes([2])
+            + (12).to_bytes(3, "little")
+            + bytes([3])
+            + (12).to_bytes(3, "little")
+        )
+        pages.append(
+            definition(
+                ALPHA_ROOT,
+                GAMMA_COLUMNS,
+                owned=(12, 0),
+                available=(12, 1),
+                row_count=1 if with_row else 0,
+                marker=0x4E,
+                constant=1,
+                suffix=gamma_suffix,
+            )
+        )
+        note_owned = {13 if wrong_transition else 14} if with_row else set()
+        pages.append(
+            data_page(
+                0,
+                [
+                    map_record({13, 14} if with_row else set()),
+                    map_record(set()),
+                    map_record(note_owned),
+                    map_record(set()),
+                ],
+            )
+        )
+    if with_row:
+        gamma_row = encode_row(
+            layout(GAMMA_COLUMNS),
+            [1, b"\x05\x10\x00\x80" + le32(14) + bytes(4)],
+        )
+        pages.append(data_page(ALPHA_ROOT, [gamma_row]))
+        pages.append(data_page(catalog.LONG_VALUE_OWNER, [bytes(43)]))
+    return b"".join(bytes(page) for page in pages)
+
+
 def dao_metadata(replica: int, with_alpha: bool, *, extra_table: str | None = None) -> dict:
     stamp = 46000.0 + replica / 1000
     system_names = ["MSysACEs", "MSysObjects", "MSysQueries", "MSysRelationships"]
@@ -355,6 +496,49 @@ def synthetic_document(root: Path, *, markers: dict[int, int] | None = None, str
     }
 
 
+def long_value_document(
+    root: Path,
+    *,
+    missing_gamma_suffix: bool = False,
+    wrong_transition: bool = False,
+) -> dict:
+    replicas = []
+    for replica in (1, 2, 3):
+        checkpoints = []
+        for name in catalog.LONG_VALUE_CHECKPOINT_NAMES:
+            image = build_long_value_image(
+                replica,
+                name,
+                missing_gamma_suffix=missing_gamma_suffix,
+                wrong_transition=wrong_transition,
+            )
+            checkpoints.append(
+                write_checkpoint(
+                    root,
+                    replica,
+                    name,
+                    image,
+                    dao_metadata(replica, name != "empty"),
+                )
+            )
+        replicas.append(
+            {
+                "replica": replica,
+                "status": "pass",
+                "error": None,
+                "checkpoints": checkpoints,
+            }
+        )
+    return {
+        "document_type": catalog.LONG_VALUE_DOCUMENT_TYPE,
+        "development_only": True,
+        "plan_sha256": PLAN_SHA256,
+        "run_id": "synthetic-long-value-maps",
+        "status": "pass",
+        "replicas": replicas,
+    }
+
+
 def write_job(root: Path, document: dict) -> Path:
     path = root / "system-catalog-job-result.json"
     path.write_text(json.dumps(document), encoding="utf-8")
@@ -409,6 +593,71 @@ class SystemCatalogTests(unittest.TestCase):
         self.assertEqual(rows["MSysACEs"]["rows"][0], {"ACM": 393216, "FInheritable": True, "ObjectId": TABLES_ID, "SID": "0301"})
         self.assertFalse(rows["MSysACEs"]["rows"][1]["FInheritable"])
         self.assertEqual(report["replicas"][0]["dao_errors"], ["refused"])
+
+    def test_h5_accepts_complete_suffixes_and_exact_new_page_transition(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = long_value_document(root)
+            job = write_job(root, document)
+            first = root / "h5-first.json"
+            second = root / "h5-second.json"
+            report = catalog.evaluate(job, PLAN_SHA256, first)
+            catalog.evaluate(job, PLAN_SHA256, second)
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+        self.assertEqual(report["status"], "accepted")
+        h5 = report["questions"]["H5"]
+        self.assertEqual(h5["status"], "answered")
+        self.assertEqual(
+            h5["predictions"],
+            {
+                "all_empty_pages_assigned": True,
+                "all_long_value_columns_have_one_suffix_group": True,
+                "gamma_new_long_value_pages": [14],
+                "gamma_note_has_one_suffix_group": True,
+                "note_owned_map_added_pages": [14],
+                "note_owned_map_tracks_external_long_value_page": True,
+            },
+        )
+        empty_roles = {
+            page["page"]: page["role"]
+            for page in h5["checkpoints"]["empty"]["pages"]
+        }
+        self.assertEqual(empty_roles[10], "long_value_map_rows")
+
+    def test_h5_missing_gamma_group_is_no_outcome_even_when_page_is_assigned(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            report = self.evaluate(
+                root,
+                long_value_document(root, missing_gamma_suffix=True),
+            )
+        h5 = report["questions"]["H5"]
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertFalse(
+            h5["predictions"]["all_long_value_columns_have_one_suffix_group"]
+        )
+        gamma = next(
+            table
+            for table in h5["checkpoints"]["table"]["tables"]
+            if table["name"] == "Gamma"
+        )
+        self.assertFalse(gamma["suffix_complete"])
+        self.assertEqual(h5["checkpoints"]["table"]["unassigned_pages"], [])
+
+    def test_h5_owned_map_must_match_exact_new_long_value_pages(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            report = self.evaluate(
+                root,
+                long_value_document(root, wrong_transition=True),
+            )
+        predictions = report["questions"]["H5"]["predictions"]
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(predictions["note_owned_map_added_pages"], [13])
+        self.assertEqual(predictions["gamma_new_long_value_pages"], [14])
+        self.assertFalse(
+            predictions["note_owned_map_tracks_external_long_value_page"]
+        )
 
     def test_q4_attributes_row_insertion_and_reports_stray_byte(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -71,6 +71,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 "index",
                 "bootstrap-layout",
                 "system-catalog",
+                "long-value-maps",
             ),
         )
         self.assertNotIn("command", {action.dest for action in parser._actions})
@@ -222,6 +223,9 @@ class WindowsDaoDevClientTests(unittest.TestCase):
     def test_system_catalog_binds_and_verifies_a_pinned_plan(self) -> None:
         self.assert_plan_bound_job("system-catalog", "SYSTEM_CATALOG_PLAN")
 
+    def test_long_value_maps_binds_and_verifies_a_pinned_plan(self) -> None:
+        self.assert_plan_bound_job("long-value-maps", "LONG_VALUE_MAPS_PLAN")
+
     def test_consumed_bootstrap_sufficiency_plan_refuses_to_run(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -242,7 +246,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_remote_is_exploratory_and_allowlisted(self) -> None:
         self.assertIn(
-            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]',
+            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]',
             self.remote,
         )
         self.assertIn("development_only = $true", self.remote)
@@ -337,8 +341,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]', self.dispatch)
         self.assertIn("$MaximumRows = 64", row)
         self.assertIn("foreach ($replica in 1..3)", row)
         for scenario in (
@@ -358,8 +362,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_value_job_is_repeated_bounded_and_never_compacts(self) -> None:
         value = CLIENT.VALUE_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]', self.dispatch)
         self.assertIn("$MaximumDatabaseBytes = 4MB", value)
         self.assertIn("foreach ($replica in 1..3)", value)
         self.assertIn("$LongLengths = @(32, 512, 2048, 4096)", value)
@@ -370,8 +374,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_index_job_is_staged_bounded_and_never_compacts(self) -> None:
         index = CLIENT.INDEX_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]', self.dispatch)
         self.assertIn("$MaximumRows = 4096", index)
         self.assertIn("$MaximumDatabaseBytes = 16MB", index)
         for scenario in (
@@ -442,7 +446,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertIn("15-database bound", self.publication)
         self.assertIn("foreach ($replica in 1..3)", job)
         self.assertIn("development_only = $true", job)
-        self.assertIn('document_type = "dao_system_catalog_job_result"', job)
+        self.assertIn('else { "dao_system_catalog_job_result" }', job)
         self.assertIn("$MaximumPages = 64", job)
         self.assertIn("$MaximumTables = 16", job)
         self.assertIn("$MaximumPropertyValueCharacters = 256", job)
@@ -473,6 +477,26 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
                 "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1",
                 "oracle/windows-dao/scripts/system_catalog.py",
             },
+        )
+
+    def test_long_value_maps_is_plan_bound_bounded_and_development_only(self) -> None:
+        job = CLIENT.SYSTEM_CATALOG_JOB.read_text(encoding="utf-8")
+        plan = json.loads(CLIENT.LONG_VALUE_MAPS_PLAN.read_text(encoding="utf-8"))
+        self.assertIn('"long-value-maps" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"', self.remote)
+        self.assertIn('"long-value-maps" { $SystemCatalogJobPath }', self.dispatch)
+        self.assertIn('"long-value-maps" {', self.publication)
+        self.assertIn('New-GammaTable -Path $workingPath', job)
+        self.assertIn('Add-GammaLongMemoRow -Path $workingPath', job)
+        self.assertIn('-Name "table"', job)
+        self.assertIn('-Name "row"', job)
+        self.assertIn('"memo-" + ("x" * 4096)', job)
+        self.assertEqual(plan["document_type"], "dao_long_value_maps_plan")
+        self.assertEqual(plan["execution"]["checkpoints"], ["empty", "table", "row"])
+        self.assertEqual(plan["execution"]["bounds"]["maximum_replicas"], 3)
+        self.assertEqual(plan["execution"]["bounds"]["maximum_checkpoints"], 3)
+        self.assertEqual(
+            CLIENT.verified_plan_sha256(CLIENT.plan_binding("long-value-maps")),
+            "defacc3bee5e48e3865088998e69d71159bee94c1826df8bfaf1b34ec6eb6b69",
         )
 
     def test_bootstrap_detail_normalization_covers_failure_and_repair_surfaces(self) -> None:

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -496,7 +496,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertEqual(plan["execution"]["bounds"]["maximum_checkpoints"], 3)
         self.assertEqual(
             CLIENT.verified_plan_sha256(CLIENT.plan_binding("long-value-maps")),
-            "defacc3bee5e48e3865088998e69d71159bee94c1826df8bfaf1b34ec6eb6b69",
+            "5b2fc593ddfaaa303c37e885d68ab1964e99779593f307ea3bfb702a4c0621d9",
         )
 
     def test_bootstrap_detail_normalization_covers_failure_and_repair_surfaces(self) -> None:

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -78,6 +78,9 @@ SYSTEM_CATALOG_PLAN = (
 SYSTEM_CATALOG_ANALYZER = (
     ROOT / "oracle" / "windows-dao" / "scripts" / "system_catalog.py"
 )
+LONG_VALUE_MAPS_PLAN = (
+    ROOT / "oracle" / "windows-dao" / "acquisition" / "long-value-maps.plan.json"
+)
 SAFE_HOST = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$")
 SAFE_USER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 SAFE_RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")
@@ -93,6 +96,7 @@ ALLOWED_JOBS = (
     "index",
     "bootstrap-layout",
     "system-catalog",
+    "long-value-maps",
 )
 
 
@@ -132,6 +136,10 @@ def plan_binding(job: str) -> PlanBinding | None:
     if job == "system-catalog":
         return PlanBinding(
             job, SYSTEM_CATALOG_PLAN, SYSTEM_CATALOG_ANALYZER, "dao_system_catalog_plan"
+        )
+    if job == "long-value-maps":
+        return PlanBinding(
+            job, LONG_VALUE_MAPS_PLAN, SYSTEM_CATALOG_ANALYZER, "dao_long_value_maps_plan"
         )
     return None
 


### PR DESCRIPTION
The bootstrap composer still has one unexplained empty-image page and no recorded grammar for per-column long-value allocation maps. That leaves the empty image incomplete and makes a semantic composer premature.

This preregisters one bounded local-DAO experiment that tests the 10-byte Memo/LongBinary suffix grammar across three fresh replicas. It extends the existing system-catalog producer and analyzer with the Gamma Memo scenario, assigns locator-only pages as long-value map rows, and validates the map transition caused by one external Memo value.

The retained EXP-0073 checkpoints replay as accepted with page 7 resolved and no unassigned empty pages. No DAO acquisition was performed under this PR; EXP-0074 remains unconsumed until this plan is merged and a human explicitly authorizes its single run.

Checks:
- 18 focused system-catalog analyzer tests
- 24 Windows DAO development contract tests
- retained EXP-0073 canonical replay
- JSON validation and git diff --check

Plan SHA-256: defacc3bee5e48e3865088998e69d71159bee94c1826df8bfaf1b34ec6eb6b69