### PR TITLE
feat(oracle): correct the long-value map experiment after EXP-0075

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6947,7 +6947,7 @@ Use `not applicable` explicitly rather than omitting a field.
   each capture; retain the nine MDBs externally and commit none.
 - Preregistration artifact:
   `oracle/windows-dao/acquisition/long-value-maps-followup.plan.json`, SHA-256
-  `c9b46d888fe2d168b612f56dfbf7a47571a7eaebfad1cd535988998c29740fa4`.
+  `1052458ff87814bf8ac2d5dd09da740eb61565c0aaf27654228c9352c85dd46c`.
   It pins the host client, provider probe, guest runner, dispatcher, publisher,
   producer, and analyzer; host and guest reject mismatches before mutation.
 - Observation: `preregistration.acquisition_started` is `false`. Committing

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -6922,6 +6922,56 @@ Use `not applicable` explicitly rather than omitting a field.
   reproducibility, all question fields, replica completion, and false claim
   flags checked
 
+### EXP-0076 — Preregistered corrected long-value column-map experiment
+
+- Recorded: 2026-09-01, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration; no provider
+  acquisition or format observation has occurred under this plan
+- Question: Across three new fresh replicas, does exact order-insensitive
+  suffix coverage assign every empty-image page, and do `Gamma.Note`'s
+  owned-map additions exactly equal the newly appearing globally identified
+  long-value pages?
+- Origin: project-authored clean-room follow-up using only `EXP-0051`,
+  `EXP-0057`, `EXP-0059`, `EXP-0060`, `EXP-0061`, `EXP-0073`, and the
+  validated `EXP-0075` no-outcome as recorded above. This is a distinct
+  experiment, not a reinterpretation or redispatch of `EXP-0074`.
+- Correction boundary: `EXP-0075` recorded two failed comparisons. Its system
+  suffix groups were not stored in ordinal order, despite each expected
+  column appearing once, so H6 uses exact set equality. Its Gamma column pages
+  carried the global `long_value` role but were absent from Gamma's table-owned
+  map, so H6 compares Note's owned additions with newly appearing pages having
+  the `EXP-0061` global LVAL signature. No other hypothesis changes.
+- Protocol: repeat the bounded three-replica `empty`, `table`, and `row`
+  scenario fixed by `EXP-0074`, using new fresh databases and one
+  4,101-character `Gamma.Note` value per replica. Close and release DAO before
+  each capture; retain the nine MDBs externally and commit none.
+- Preregistration artifact:
+  `oracle/windows-dao/acquisition/long-value-maps-followup.plan.json`, SHA-256
+  `c9b46d888fe2d168b612f56dfbf7a47571a7eaebfad1cd535988998c29740fa4`.
+  It pins the host client, provider probe, guest runner, dispatcher, publisher,
+  producer, and analyzer; host and guest reject mismatches before mutation.
+- Observation: `preregistration.acquisition_started` is `false`. Committing
+  the plan does not itself authorize acquisition. After independent review and
+  merge, one explicit human authorization permits one local-VM run.
+- Decision rule: H6 is answered only when all replicas agree, every Memo or
+  LongBinary column appears exactly once regardless of group order, every
+  empty page is assigned, `Gamma.Note` has one stable group, and the nonempty
+  pages added to its owned map exactly equal newly appearing global
+  `long_value` pages. Any missing predicate is an honest `no_outcome`; input,
+  digest, bound, shape, or checkpoint defects reject validation. There is no
+  automatic retry after the first DAO mutation.
+- Interpretation: this entry fixes only a corrected acquisition and analysis
+  contract. It establishes no new format fact, Rust writer correctness,
+  compatibility, support result, or support-matrix movement.
+- Usage: future `EXP-0077`; issue `#100`;
+  `file:oracle/windows-dao/acquisition/long-value-maps-followup.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/system_catalog.py`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: pending repeated independent evidence-boundary, plan-pin, producer,
+  analyzer, decision-rule, and no-retry review before merge and acquisition
+
 
 ## Fixtures and black-box results
 

--- a/justfile
+++ b/justfile
@@ -76,6 +76,10 @@ windows-dev-system-catalog:
 windows-dev-long-value-maps:
     "{{PYTHON}}" scripts/windows-dao-dev.py long-value-maps --timeout 900
 
+# Run the preregistered corrected long-value column-map experiment.
+windows-dev-long-value-maps-followup:
+    "{{PYTHON}}" scripts/windows-dao-dev.py long-value-maps-followup --timeout 900
+
 # Run one ad-hoc PowerShell script under x86 DAO in the local VM (discovery only).
 windows-dev-ps script *args:
     "{{PYTHON}}" scripts/windows-dao-ps.py {{script}} {{args}}

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -33,6 +33,9 @@ The retained tooling has three purposes:
 - `acquisition/long-value-maps.plan.json` reuses that bounded producer and
   analyzer for the three-checkpoint EXP-0074 successor that tests per-column
   long-value map locators and assigns the final empty-image page role.
+- `acquisition/long-value-maps-followup.plan.json` pins the corrected H6
+  successor after EXP-0075: exact order-insensitive suffix coverage and the
+  per-column owned-page transition against global LVAL page roles.
 
 Concluded A1-A4 and M3-M5 experiment machinery was removed after its results
 were recorded in `docs/PROVENANCE.md`. Git history is the archive.

--- a/oracle/windows-dao/acquisition/long-value-maps-followup.plan.json
+++ b/oracle/windows-dao/acquisition/long-value-maps-followup.plan.json
@@ -1,0 +1,78 @@
+{
+  "document_type": "dao_long_value_maps_followup_plan",
+  "experiment_id": "long_value_column_maps_followup",
+  "issue": 100,
+  "development_only": true,
+  "purpose": "Resolve the two predicates that made EXP-0075 a no_outcome by testing exact order-insensitive suffix coverage and correlating Gamma.Note's owned-map additions with newly appearing globally identified long-value pages.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_result": "EXP-0075",
+    "authorization": "No acquisition is authorized by committing this plan. After review and merge, one explicit human authorization permits one local-VM acquisition.",
+    "amendment_rule": "This is a distinct immutable experiment, not a retry of EXP-0074. After its first DAO mutation, any failure or no_outcome is recorded once and it is not redispatched without another human decision."
+  },
+  "evidence_boundary": {
+    "admitted_prior_results": "EXP-0051, EXP-0057, EXP-0059, EXP-0060, EXP-0061, EXP-0073, and the validated no_outcome EXP-0075 as recorded in docs/PROVENANCE.md.",
+    "correction_boundary": "EXP-0075 showed that MSysObjects suffix groups are not stored in ordinal order and that Gamma.Note owned pages are globally classified as long_value even though Gamma's table-owned map does not name them. H6 changes only those two failed comparisons: coverage becomes exact set equality, and the transition compares Note's owned additions with globally identified newly appearing long-value pages.",
+    "dao_limits": "The local provider has no workgroup information file. DAO system-table reads and permission operations are excluded; correlation is limited to DAO-visible table names, attributes, timestamps, and the effects of the experiment's own write.",
+    "claims": "A successful result establishes only the bounded H6 observations below. It cannot establish Rust writer correctness, compatibility, support, or support-matrix movement."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "d9e6e1b193ad49820a0420a5859431a3bd80dff3d9edfc0a4bb852aa06d8f3df",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "1467f1ff42223f78590501e831d66085a342ab79b0a5b2c4ba16eecf759511f2",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "7396a4e1c98c08e1baf3746d0fbf57c604fe5922e266552ecced27a035740734",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "13631649156db024dcf2c58fa420f4b8a0ddfef834dd530f7e92933680bc1418",
+    "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1": "297303d201af577c219411c77e2714671f1f14435c9ba84c473836c20e83fd82",
+    "oracle/windows-dao/scripts/system_catalog.py": "2614378d00a6ee6724282cd87112b08b12437140348cbaac019e22415257f733"
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "scenario": [
+      "Create one fresh dbVersion30 CP1252 database and capture it closed as empty.",
+      "Create table Gamma with Long Id and Memo Note and capture it closed as table.",
+      "Insert exactly one row with Id 1 and a 4101-character Memo Note, long enough to require external storage, and capture it closed as row."
+    ],
+    "checkpoints": ["empty", "table", "row"],
+    "capture": "Close and release every DAO object before each copy or hash. Retain all nine MDB checkpoints externally with sizes and SHA-256 digests; commit none.",
+    "bounds": {
+      "maximum_pages_per_database": 64,
+      "maximum_checkpoints": 3,
+      "maximum_replicas": 3,
+      "maximum_tables": 16,
+      "maximum_columns_per_table": 64,
+      "maximum_rows_per_page": 64,
+      "maximum_property_value_characters": 256,
+      "maximum_json_bytes": 4194304
+    }
+  },
+  "hypotheses": {
+    "H6_corrected_long_value_maps": "Definition suffix groups form an exact order-insensitive one-to-one mapping with every Memo or LongBinary column. The locators assign every empty-image page. Gamma.Note carries exactly one group. Between table and row, the nonempty set of pages added to Note's owned map equals the set of globally identified long_value pages that newly appears, where the global role uses the EXP-0061 LVAL page signature and does not require Gamma's table-owned map to name those pages."
+  },
+  "questions": {
+    "H6": "Across all three replicas, does exact order-insensitive suffix coverage hold, does it assign every empty-image page, and do Gamma.Note's owned-map additions equal the newly appearing globally identified long-value pages?"
+  },
+  "decision_rule": {
+    "accepted": "The plan and staged inputs match their SHA-256 pins; the provider is ready; all three replicas complete all three checkpoints once; bounds and file digests validate; and the analyzer emits one deterministic report with H6 answered.",
+    "answered": "H6 is answered only if observations and page roles agree across all replicas, every Memo or LongBinary column appears exactly once regardless of group order, every empty page is assigned, Gamma.Note has one stable group, and its nonempty owned-map additions exactly equal newly appearing global long_value pages.",
+    "no_outcome": "A replica failure or disagreement, decode failure, unassigned empty page, missing or extra long-value-column group, malformed Gamma.Note group, empty transition, or mismatch between Note's owned additions and newly appearing global long_value pages is recorded as no_outcome.",
+    "rejected": "A plan or input digest mismatch, malformed result, bound violation, file digest mismatch, or checkpoint-order defect rejects validation.",
+    "retry": "One explicit human authorization permits one acquisition only; there is no automatic retry after the first DAO mutation."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "long-value content interpretation",
+    "property-blob decoding",
+    "workgroup security semantics",
+    "Rust writer changes",
+    "public API expansion",
+    "compatibility or support claims"
+  ]
+}

--- a/oracle/windows-dao/acquisition/long-value-maps-followup.plan.json
+++ b/oracle/windows-dao/acquisition/long-value-maps-followup.plan.json
@@ -23,7 +23,7 @@
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "7396a4e1c98c08e1baf3746d0fbf57c604fe5922e266552ecced27a035740734",
     "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "13631649156db024dcf2c58fa420f4b8a0ddfef834dd530f7e92933680bc1418",
     "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1": "297303d201af577c219411c77e2714671f1f14435c9ba84c473836c20e83fd82",
-    "oracle/windows-dao/scripts/system_catalog.py": "2614378d00a6ee6724282cd87112b08b12437140348cbaac019e22415257f733"
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9"
   },
   "execution": {
     "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",

--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]
+    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$RunRoot,
@@ -48,6 +48,7 @@ $scriptPath = switch ($Job) {
     "bootstrap-layout" { $BootstrapLayoutJobPath }
     "system-catalog" { $SystemCatalogJobPath }
     "long-value-maps" { $SystemCatalogJobPath }
+    "long-value-maps-followup" { $SystemCatalogJobPath }
 }
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
     [Console]::Error.WriteLine("INVALID: selected staged job does not exist.")
@@ -69,7 +70,7 @@ if ($Job -ceq "table-definition") {
 elseif ($Job -ceq "bootstrap-layout") {
     $arguments += @("-PlanSha256", $PlanSha256)
 }
-elseif ($Job -in @("system-catalog", "long-value-maps")) {
+elseif ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId, "-Experiment", $Job)
 }
 & (Join-Path $PSHOME "powershell.exe") @arguments
@@ -83,6 +84,7 @@ $resultName = switch ($Job) {
     "bootstrap-layout" { "bootstrap-layout-job-result.json" }
     "system-catalog" { "system-catalog-job-result.json" }
     "long-value-maps" { "long-value-maps-job-result.json" }
+    "long-value-maps-followup" { "long-value-maps-followup-job-result.json" }
 }
 $resultPath = Join-Path $RunRoot $resultName
 if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
@@ -114,7 +116,7 @@ $indexScenarios = @()
 $bootstrapLayoutReplicas = @()
 $systemCatalogReplicas = @()
 # The system-catalog result carries no detail field; derive one from its status.
-$detail = if ($Job -in @("system-catalog", "long-value-maps")) {
+$detail = if ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup")) {
     if ([string]$jobResult.status -ceq "pass") {
         "Completed all three system-catalog replicas once without retry."
     }
@@ -134,7 +136,7 @@ elseif ($Job -ceq "index") { $indexScenarios = @($jobResult.scenarios) }
 elseif ($Job -ceq "bootstrap-layout") {
     $bootstrapLayoutReplicas = @($jobResult.replicas)
 }
-elseif ($Job -in @("system-catalog", "long-value-maps")) {
+elseif ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup")) {
     $systemCatalogReplicas = @($jobResult.replicas)
 }
 $result = [ordered]@{

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
@@ -386,6 +386,7 @@ $planBoundJobs = @{
     "bootstrap-layout" = "oracle/windows-dao/scripts/dev/BootstrapLayout.DevJob.ps1"
     "system-catalog" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"
     "long-value-maps" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"
+    "long-value-maps-followup" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"
 }
 if ($planBoundJobs.ContainsKey($Job)) {
     if ($PlanSha256 -cnotmatch "^[0-9a-f]{64}$") {
@@ -680,7 +681,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
         }
     }
 }
-elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps") -and $probeExitCode -eq 0) {
+elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup") -and $probeExitCode -eq 0) {
     $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$Source,
@@ -188,6 +188,39 @@ switch ($Job) {
         $expected = @($referenced | Sort-Object)
         if (($actual -join "`n") -cne ($expected -join "`n")) {
             throw "Long-value-maps MDB inventory differs from its result."
+        }
+    }
+    "long-value-maps-followup" {
+        [void]$names.Add("long-value-maps-followup-job-result.json")
+        $jobResultPath = Join-Path $Source "long-value-maps-followup-job-result.json"
+        if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
+            throw "Long-value-maps follow-up result is missing."
+        }
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $referenced = New-Object Collections.ArrayList
+        foreach ($replica in @($jobResult.replicas)) {
+            foreach ($checkpoint in @($replica.checkpoints)) {
+                [void]$referenced.Add([string]$checkpoint.database)
+            }
+        }
+        if ($referenced.Count -gt 9) {
+            throw "Long-value-maps follow-up output exceeds the 9-database bound."
+        }
+        if (@($referenced | Select-Object -Unique).Count -ne $referenced.Count) {
+            throw "Long-value-maps follow-up result contains duplicate database names."
+        }
+        foreach ($name in $referenced) {
+            if ($name -cnotmatch '^long-value-maps-followup-r[1-3]-(empty|table|row)\.mdb$') {
+                throw "Long-value-maps follow-up output contains an unexpected database name."
+            }
+            [void]$names.Add($name)
+        }
+        $actual = @(Get-ChildItem -LiteralPath $Source -File |
+            Where-Object { $_.Name -clike "long-value-maps-followup-*.mdb" } |
+            ForEach-Object { $_.Name } | Sort-Object)
+        $expected = @($referenced | Sort-Object)
+        if (($actual -join "`n") -cne ($expected -join "`n")) {
+            throw "Long-value-maps follow-up MDB inventory differs from its result."
         }
     }
 }

--- a/oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1
@@ -10,7 +10,7 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$RunId,
 
-    [ValidateSet("system-catalog", "long-value-maps")]
+    [ValidateSet("system-catalog", "long-value-maps", "long-value-maps-followup")]
     [string]$Experiment = "system-catalog"
 )
 
@@ -584,7 +584,7 @@ function Invoke-Replica {
     try {
         New-Jet3Database -Path $workingPath
         [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "empty"))
-        if ($Experiment -ceq "long-value-maps") {
+        if ($Experiment -in @("long-value-maps", "long-value-maps-followup")) {
             New-GammaTable -Path $workingPath
             [void]$checkpoints.Add((Save-Checkpoint -Source $workingPath -Replica $Replica -Name "table"))
             Add-GammaLongMemoRow -Path $workingPath
@@ -636,6 +636,9 @@ foreach ($entry in $replicas) {
 $result = [ordered]@{
     document_type = if ($Experiment -ceq "long-value-maps") {
         "dao_long_value_maps_job_result"
+    }
+    elseif ($Experiment -ceq "long-value-maps-followup") {
+        "dao_long_value_maps_followup_job_result"
     }
     else { "dao_system_catalog_job_result" }
     development_only = $true

--- a/oracle/windows-dao/scripts/system_catalog.py
+++ b/oracle/windows-dao/scripts/system_catalog.py
@@ -1544,7 +1544,10 @@ def build_long_value_report(
                     map_tracks_external,
                 )
             ):
-                reason = "one or more preregistered H5 predictions was not observed"
+                hypothesis = "H6" if followup else "H5"
+                reason = (
+                    f"one or more preregistered {hypothesis} predictions was not observed"
+                )
     elif reason is None:
         reason = "not every preregistered checkpoint is present"
     status = "answered" if reason is None else "no_outcome"

--- a/oracle/windows-dao/scripts/system_catalog.py
+++ b/oracle/windows-dao/scripts/system_catalog.py
@@ -27,6 +27,7 @@ MAX_TEXT = 512
 CHECKPOINT_NAMES = ("empty", "table1", "table2", "query", "relationship")
 DOCUMENT_TYPE = "dao_system_catalog_job_result"
 LONG_VALUE_DOCUMENT_TYPE = "dao_long_value_maps_job_result"
+LONG_VALUE_FOLLOWUP_DOCUMENT_TYPE = "dao_long_value_maps_followup_job_result"
 LONG_VALUE_CHECKPOINT_NAMES = ("empty", "table", "row")
 DEFINITION_PREFIX = b"\x02\x01\x56\x43"
 LONG_VALUE_OWNER = b"LVAL"
@@ -1374,6 +1375,22 @@ def _incomplete_reason(document: dict[str, Any], replicas: list[dict[str, Any]])
     return None
 
 
+def _same_long_value_columns(
+    expected: list[dict[str, Any]], mappings: list[dict[str, Any]], *, ordered: bool
+) -> bool:
+    expected_pairs = [
+        (column["column"], column["column_name"]) for column in expected
+    ]
+    mapping_pairs = [
+        (mapping["column"], mapping["column_name"]) for mapping in mappings
+    ]
+    return (
+        expected_pairs == mapping_pairs
+        if ordered
+        else sorted(expected_pairs) == sorted(mapping_pairs)
+    )
+
+
 def _long_value_observation(analysis: dict[str, Any]) -> dict[str, Any]:
     tables = []
     for root in sorted(analysis["tables"]):
@@ -1411,14 +1428,12 @@ def _long_value_observation(analysis: dict[str, Any]) -> dict[str, Any]:
                 "long_value_pages": table["long_value_pages"],
                 "name": table["name"],
                 "root": root,
-                "suffix_complete": expected_columns
-                == [
-                    {
-                        "column": mapping["column"],
-                        "column_name": mapping["column_name"],
-                    }
-                    for mapping in mappings
-                ],
+                "suffix_complete": _same_long_value_columns(
+                    expected_columns, mappings, ordered=True
+                ),
+                "suffix_set_complete": _same_long_value_columns(
+                    expected_columns, mappings, ordered=False
+                ),
             }
         )
     return {
@@ -1431,7 +1446,10 @@ def _long_value_observation(analysis: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_long_value_report(
-    document: dict[str, Any], replicas: list[dict[str, Any]]
+    document: dict[str, Any],
+    replicas: list[dict[str, Any]],
+    *,
+    followup: bool = False,
 ) -> dict[str, Any]:
     analyses: list[dict[str, Any]] = []
     observations: list[dict[str, Any]] = []
@@ -1487,12 +1505,25 @@ def build_long_value_report(
                 and table_maps[0]["available"] == row_maps[0]["available"]
             )
             added_owned = sorted(set(row_maps[0]["owned_pages"]) - set(table_maps[0]["owned_pages"])) if grammar else []
-            added_long_value_pages = sorted(
-                set(gamma_row["long_value_pages"])
-                - set(gamma_table["long_value_pages"])
-            )
+            if followup:
+                table_long_value_pages = {
+                    page["page"]
+                    for page in table["pages"]
+                    if page["role"] == "long_value"
+                }
+                added_long_value_pages = sorted(
+                    page["page"]
+                    for page in row["pages"]
+                    if page["role"] == "long_value"
+                    and page["page"] not in table_long_value_pages
+                )
+            else:
+                added_long_value_pages = sorted(
+                    set(gamma_row["long_value_pages"])
+                    - set(gamma_table["long_value_pages"])
+                )
             complete_suffixes = all(
-                entry["suffix_complete"]
+                entry["suffix_set_complete" if followup else "suffix_complete"]
                 for checkpoint in (empty, table, row)
                 for entry in checkpoint["tables"]
             )
@@ -1541,13 +1572,18 @@ def build_long_value_report(
         }
         for replica in replicas
     ]
+    question_name = "H6" if followup else "H5"
     return {
         "checkpoints_compared": common,
         "compatibility_claim": False,
         "development_only": True,
-        "document_type": "long_value_maps_report",
+        "document_type": (
+            "long_value_maps_followup_report"
+            if followup
+            else "long_value_maps_report"
+        ),
         "plan_sha256": document["plan_sha256"],
-        "questions": {"H5": question},
+        "questions": {question_name: question},
         "replicas": summaries,
         "status": "accepted" if status == "answered" else "no_outcome",
         "support_movement": False,
@@ -1639,9 +1675,13 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         set(),
         "$",
     )
-    if item["document_type"] not in (DOCUMENT_TYPE, LONG_VALUE_DOCUMENT_TYPE):
+    if item["document_type"] not in (
+        DOCUMENT_TYPE,
+        LONG_VALUE_DOCUMENT_TYPE,
+        LONG_VALUE_FOLLOWUP_DOCUMENT_TYPE,
+    ):
         raise AnalysisError(
-            f"$.document_type must be {DOCUMENT_TYPE} or {LONG_VALUE_DOCUMENT_TYPE}"
+            f"$.document_type must be {DOCUMENT_TYPE}, {LONG_VALUE_DOCUMENT_TYPE}, or {LONG_VALUE_FOLLOWUP_DOCUMENT_TYPE}"
         )
     if item["development_only"] is not True:
         raise AnalysisError("$.development_only must be true")
@@ -1651,7 +1691,10 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
     if _digest(item["plan_sha256"], "$.plan_sha256") != expected:
         raise AnalysisError("job result plan digest differs from the approved plan")
     old_checkpoint_names = CHECKPOINT_NAMES
-    if item["document_type"] == LONG_VALUE_DOCUMENT_TYPE:
+    if item["document_type"] in (
+        LONG_VALUE_DOCUMENT_TYPE,
+        LONG_VALUE_FOLLOWUP_DOCUMENT_TYPE,
+    ):
         CHECKPOINT_NAMES = LONG_VALUE_CHECKPOINT_NAMES
     try:
         raw_replicas = item["replicas"]
@@ -1663,11 +1706,12 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         ]
         if [replica["replica"] for replica in replicas] != list(range(1, len(replicas) + 1)):
             raise AnalysisError("$.replicas must be numbered 1 through n in order")
-        report = (
-            build_long_value_report(item, replicas)
-            if item["document_type"] == LONG_VALUE_DOCUMENT_TYPE
-            else build_report(item, replicas)
-        )
+        if item["document_type"] == LONG_VALUE_DOCUMENT_TYPE:
+            report = build_long_value_report(item, replicas)
+        elif item["document_type"] == LONG_VALUE_FOLLOWUP_DOCUMENT_TYPE:
+            report = build_long_value_report(item, replicas, followup=True)
+        else:
+            report = build_report(item, replicas)
     finally:
         CHECKPOINT_NAMES = old_checkpoint_names
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/oracle/windows-dao/tests/test_system_catalog.py
+++ b/oracle/windows-dao/tests/test_system_catalog.py
@@ -499,6 +499,7 @@ def synthetic_document(root: Path, *, markers: dict[int, int] | None = None, str
 def long_value_document(
     root: Path,
     *,
+    followup: bool = False,
     missing_gamma_suffix: bool = False,
     wrong_transition: bool = False,
 ) -> dict:
@@ -530,7 +531,11 @@ def long_value_document(
             }
         )
     return {
-        "document_type": catalog.LONG_VALUE_DOCUMENT_TYPE,
+        "document_type": (
+            catalog.LONG_VALUE_FOLLOWUP_DOCUMENT_TYPE
+            if followup
+            else catalog.LONG_VALUE_DOCUMENT_TYPE
+        ),
         "development_only": True,
         "plan_sha256": PLAN_SHA256,
         "run_id": "synthetic-long-value-maps",
@@ -657,6 +662,58 @@ class SystemCatalogTests(unittest.TestCase):
         self.assertEqual(predictions["gamma_new_long_value_pages"], [14])
         self.assertFalse(
             predictions["note_owned_map_tracks_external_long_value_page"]
+        )
+
+    def test_h6_accepts_unordered_coverage_and_global_long_value_pages(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = long_value_document(root, followup=True)
+            report = self.evaluate(root, document)
+        self.assertEqual(report["document_type"], "long_value_maps_followup_report")
+        self.assertEqual(report["status"], "accepted")
+        h6 = report["questions"]["H6"]
+        self.assertEqual(h6["status"], "answered")
+        self.assertEqual(h6["predictions"]["gamma_new_long_value_pages"], [14])
+        self.assertEqual(h6["predictions"]["note_owned_map_added_pages"], [14])
+        self.assertTrue(
+            h6["predictions"]["note_owned_map_tracks_external_long_value_page"]
+        )
+
+    def test_h6_wrong_column_page_transition_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            report = self.evaluate(
+                root,
+                long_value_document(root, followup=True, wrong_transition=True),
+            )
+        predictions = report["questions"]["H6"]["predictions"]
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(predictions["gamma_new_long_value_pages"], [14])
+        self.assertEqual(predictions["note_owned_map_added_pages"], [13])
+
+    def test_followup_coverage_is_order_insensitive_but_exact(self) -> None:
+        expected = [
+            {"column": 8, "column_name": "Database"},
+            {"column": 9, "column_name": "Connect"},
+        ]
+        reversed_mappings = [
+            {"column": 9, "column_name": "Connect"},
+            {"column": 8, "column_name": "Database"},
+        ]
+        self.assertFalse(
+            catalog._same_long_value_columns(
+                expected, reversed_mappings, ordered=True
+            )
+        )
+        self.assertTrue(
+            catalog._same_long_value_columns(
+                expected, reversed_mappings, ordered=False
+            )
+        )
+        self.assertFalse(
+            catalog._same_long_value_columns(
+                expected, reversed_mappings[:1], ordered=False
+            )
         )
 
     def test_q4_attributes_row_insertion_and_reports_stray_byte(self) -> None:

--- a/oracle/windows-dao/tests/test_system_catalog.py
+++ b/oracle/windows-dao/tests/test_system_catalog.py
@@ -688,6 +688,10 @@ class SystemCatalogTests(unittest.TestCase):
             )
         predictions = report["questions"]["H6"]["predictions"]
         self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(
+            report["questions"]["H6"]["reason"],
+            "one or more preregistered H6 predictions was not observed",
+        )
         self.assertEqual(predictions["gamma_new_long_value_pages"], [14])
         self.assertEqual(predictions["note_owned_map_added_pages"], [13])
 

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -526,7 +526,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             CLIENT.verified_plan_sha256(
                 CLIENT.plan_binding("long-value-maps-followup")
             ),
-            "c9b46d888fe2d168b612f56dfbf7a47571a7eaebfad1cd535988998c29740fa4",
+            "1052458ff87814bf8ac2d5dd09da740eb61565c0aaf27654228c9352c85dd46c",
         )
 
     def test_bootstrap_detail_normalization_covers_failure_and_repair_surfaces(self) -> None:

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -72,6 +72,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 "bootstrap-layout",
                 "system-catalog",
                 "long-value-maps",
+                "long-value-maps-followup",
             ),
         )
         self.assertNotIn("command", {action.dest for action in parser._actions})
@@ -226,6 +227,11 @@ class WindowsDaoDevClientTests(unittest.TestCase):
     def test_long_value_maps_binds_and_verifies_a_pinned_plan(self) -> None:
         self.assert_plan_bound_job("long-value-maps", "LONG_VALUE_MAPS_PLAN")
 
+    def test_long_value_maps_followup_binds_and_verifies_a_pinned_plan(self) -> None:
+        self.assert_plan_bound_job(
+            "long-value-maps-followup", "LONG_VALUE_MAPS_FOLLOWUP_PLAN"
+        )
+
     def test_consumed_bootstrap_sufficiency_plan_refuses_to_run(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -246,7 +252,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_remote_is_exploratory_and_allowlisted(self) -> None:
         self.assertIn(
-            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]',
+            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]',
             self.remote,
         )
         self.assertIn("development_only = $true", self.remote)
@@ -341,8 +347,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]', self.dispatch)
         self.assertIn("$MaximumRows = 64", row)
         self.assertIn("foreach ($replica in 1..3)", row)
         for scenario in (
@@ -362,8 +368,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_value_job_is_repeated_bounded_and_never_compacts(self) -> None:
         value = CLIENT.VALUE_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]', self.dispatch)
         self.assertIn("$MaximumDatabaseBytes = 4MB", value)
         self.assertIn("foreach ($replica in 1..3)", value)
         self.assertIn("$LongLengths = @(32, 512, 2048, 4096)", value)
@@ -374,8 +380,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_index_job_is_staged_bounded_and_never_compacts(self) -> None:
         index = CLIENT.INDEX_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup")]', self.dispatch)
         self.assertIn("$MaximumRows = 4096", index)
         self.assertIn("$MaximumDatabaseBytes = 16MB", index)
         for scenario in (
@@ -494,9 +500,33 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertEqual(plan["execution"]["checkpoints"], ["empty", "table", "row"])
         self.assertEqual(plan["execution"]["bounds"]["maximum_replicas"], 3)
         self.assertEqual(plan["execution"]["bounds"]["maximum_checkpoints"], 3)
+        with self.assertRaisesRegex(CLIENT.DevClientError, "differs from its plan"):
+            CLIENT.verified_plan_sha256(CLIENT.plan_binding("long-value-maps"))
+
+    def test_long_value_maps_followup_is_pinned_and_bounded(self) -> None:
+        plan = json.loads(
+            CLIENT.LONG_VALUE_MAPS_FOLLOWUP_PLAN.read_text(encoding="utf-8")
+        )
+        self.assertIn(
+            '"long-value-maps-followup" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"',
+            self.remote,
+        )
+        self.assertIn(
+            '"long-value-maps-followup" { $SystemCatalogJobPath }',
+            self.dispatch,
+        )
+        self.assertIn('"long-value-maps-followup" {', self.publication)
         self.assertEqual(
-            CLIENT.verified_plan_sha256(CLIENT.plan_binding("long-value-maps")),
-            "5b2fc593ddfaaa303c37e885d68ab1964e99779593f307ea3bfb702a4c0621d9",
+            plan["document_type"], "dao_long_value_maps_followup_plan"
+        )
+        self.assertEqual(plan["execution"]["checkpoints"], ["empty", "table", "row"])
+        self.assertEqual(plan["execution"]["bounds"]["maximum_replicas"], 3)
+        self.assertEqual(plan["execution"]["bounds"]["maximum_checkpoints"], 3)
+        self.assertEqual(
+            CLIENT.verified_plan_sha256(
+                CLIENT.plan_binding("long-value-maps-followup")
+            ),
+            "c9b46d888fe2d168b612f56dfbf7a47571a7eaebfad1cd535988998c29740fa4",
         )
 
     def test_bootstrap_detail_normalization_covers_failure_and_repair_surfaces(self) -> None:

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -81,6 +81,13 @@ SYSTEM_CATALOG_ANALYZER = (
 LONG_VALUE_MAPS_PLAN = (
     ROOT / "oracle" / "windows-dao" / "acquisition" / "long-value-maps.plan.json"
 )
+LONG_VALUE_MAPS_FOLLOWUP_PLAN = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "acquisition"
+    / "long-value-maps-followup.plan.json"
+)
 SAFE_HOST = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$")
 SAFE_USER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 SAFE_RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")
@@ -97,6 +104,7 @@ ALLOWED_JOBS = (
     "bootstrap-layout",
     "system-catalog",
     "long-value-maps",
+    "long-value-maps-followup",
 )
 
 
@@ -140,6 +148,13 @@ def plan_binding(job: str) -> PlanBinding | None:
     if job == "long-value-maps":
         return PlanBinding(
             job, LONG_VALUE_MAPS_PLAN, SYSTEM_CATALOG_ANALYZER, "dao_long_value_maps_plan"
+        )
+    if job == "long-value-maps-followup":
+        return PlanBinding(
+            job,
+            LONG_VALUE_MAPS_FOLLOWUP_PLAN,
+            SYSTEM_CATALOG_ANALYZER,
+            "dao_long_value_maps_followup_plan",
         )
     return None
 


### PR DESCRIPTION
EXP-0075 was an honest no_outcome because its analyzer required suffix groups to be stored in ordinal order and looked for Gamma column pages through the table-owned map. The report showed both comparisons were too strict while preserving the underlying observations.

This preregisters a distinct fresh-replica H6 experiment. Coverage is exact but order-insensitive, and Gamma.Note owned-page additions are compared with newly appearing pages carrying the independently established global LVAL signature. The consumed EXP-0074 plan remains immutable and refuses to run.

Two independent review tracks completed two passes over the candidate: scientific/evidence discipline and executable producer/analyzer/tooling correctness. Their only blocker—H6 no_outcome text mislabeled as H5—was fixed, tested, repinned, and cleared on the second pass.

Checks:
- 24 focused analyzer tests
- 26 Windows DAO development contract tests
- all seven plan input hashes verified
- plan SHA-256 1052458ff87814bf8ac2d5dd09da740eb61565c0aaf27654228c9352c85dd46c
- git diff --check

No DAO acquisition has occurred under this plan, and no MDB bytes or provider binaries are committed.