### PR TITLE
feat(jet3): decode system definitions and long-value maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,3 @@ fixtures/work/
 # Local evidence/handoff output and OS noise; never committed.
 /artifacts/
 .DS_Store
-
-# Agent scratch worktrees.
-/.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ fixtures/work/
 # Local evidence/handoff output and OS noise; never committed.
 /artifacts/
 .DS_Store
+
+# Agent scratch worktrees.
+/.claude/

--- a/crates/jet3-cli/src/inspect.rs
+++ b/crates/jet3-cli/src/inspect.rs
@@ -273,8 +273,20 @@ fn definition_json(definition: &TableDefinition) -> Value {
             })
         })
         .collect();
+    let long_value_maps: Vec<Value> = definition
+        .long_value_maps()
+        .iter()
+        .map(|map| {
+            json!({
+                "column": map.column().get(),
+                "owned": {"page": map.owned().page().get(), "row": map.owned().row()},
+                "available": {"page": map.available().page().get(), "row": map.available().row()},
+            })
+        })
+        .collect();
     json!({
         "root": definition.root().get(),
+        "kind": format!("{:?}", definition.kind()),
         "logical_length": definition.logical_length(),
         "raw_header": hex_string(definition.raw_header()),
         "maps": {
@@ -284,6 +296,7 @@ fn definition_json(definition: &TableDefinition) -> Value {
         "columns": columns,
         "physical_indexes": physical_indexes,
         "indexes": indexes,
+        "long_value_maps": long_value_maps,
         "raw_suffix": hex_string(definition.raw_suffix()),
     })
 }

--- a/crates/jet3/src/column_definition.rs
+++ b/crates/jet3/src/column_definition.rs
@@ -1,18 +1,28 @@
 //! Lossless Jet 3 column definitions and database-code-page names.
 //!
-//! `SRC-0023` supplies the checked DAO candidate inventory and `EXP-0059`
-//! supplies the physical type, size, class, ordinal, and name observations.
+//! `SRC-0023` supplies the checked DAO candidate inventory, `EXP-0059`
+//! supplies the user-table physical type, size, class, ordinal, and name
+//! observations, and `EXP-0073` supplies the system-table relaxations.
 
 use std::mem::size_of;
 
 use crate::definition_name::{DefinitionName, contains_name};
-use crate::table_definition::TableDefinitionError;
+use crate::table_definition::{TableDefinitionError, TableDefinitionKind};
 use crate::{ByteCount, Error, ResourceBudget};
 
 pub(crate) const COLUMN_RECORD_LEN: usize = 18;
+/// `EXP-0059` user classes; `EXP-0073` system classes carry the same low
+/// three bits (the pinned `system_catalog.py` analyzer's storage mask) under
+/// retained high bits.
+const STORAGE_CLASS_MASK: u8 = 0x07;
 const VARIABLE_CLASS: u8 = 2;
 const FIXED_CLASS: u8 = 3;
 const AUTO_INCREMENT_CLASS: u8 = 7;
+const USER_CLASSES: [u8; 3] = [VARIABLE_CLASS, FIXED_CLASS, AUTO_INCREMENT_CLASS];
+const SYSTEM_CLASSES: [u8; 3] = [0x12, 0x13, 0x32];
+/// `EXP-0059`: sourced value 1 at `[7,9)`; `EXP-0073`: zero in system tables.
+const USER_COLUMN_CONSTANT: u16 = 1;
+const SYSTEM_COLUMN_CONSTANT: u16 = 0;
 
 /// A zero-based table-column ordinal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -175,10 +185,16 @@ impl ColumnDefinition {
 pub(crate) fn decode_columns(
     bytes: &[u8],
     offset: &mut usize,
+    kind: TableDefinitionKind,
     column_count: u16,
     variable_count: u16,
     budget: &mut ResourceBudget,
 ) -> Result<Vec<ColumnDefinition>, TableDefinitionError> {
+    // EXP-0073: system records repeat zero instead of the ordinal.
+    let (expected_constant, admitted_classes, repeats_ordinal) = match kind {
+        TableDefinitionKind::User => (USER_COLUMN_CONSTANT, USER_CLASSES, true),
+        TableDefinitionKind::System => (SYSTEM_COLUMN_CONSTANT, SYSTEM_CLASSES, false),
+    };
     budget
         .charge_items(u64::from(column_count).saturating_mul(2))
         .map_err(TableDefinitionError::Resource)?;
@@ -195,7 +211,8 @@ pub(crate) fn decode_columns(
         let first_ordinal = u16_at(&raw_record, 1);
         let variable_counter = u16_at(&raw_record, 3);
         let repeated_ordinal = u16_at(&raw_record, 5);
-        if first_ordinal != record_ordinal || repeated_ordinal != record_ordinal {
+        let expected_repeat = if repeats_ordinal { record_ordinal } else { 0 };
+        if first_ordinal != record_ordinal || repeated_ordinal != expected_repeat {
             return Err(TableDefinitionError::InvalidColumnOrdinal {
                 record: record_ordinal,
                 first: first_ordinal,
@@ -210,7 +227,7 @@ pub(crate) fn decode_columns(
             });
         }
         let sourced_constant = u16_at(&raw_record, 7);
-        if sourced_constant != 1 {
+        if sourced_constant != expected_constant {
             return Err(TableDefinitionError::InvalidColumnConstant {
                 ordinal: record_ordinal,
                 raw: sourced_constant,
@@ -227,7 +244,14 @@ pub(crate) fn decode_columns(
         let size = u16_at(&raw_record, 16);
         validate_size(record_ordinal, physical_type, size)?;
         let raw_class = raw_record[13];
-        let storage = match raw_class {
+        if !admitted_classes.contains(&raw_class) {
+            return Err(TableDefinitionError::UnsupportedColumnClass {
+                ordinal: record_ordinal,
+                physical_type,
+                raw: raw_class,
+            });
+        }
+        let storage = match raw_class & STORAGE_CLASS_MASK {
             VARIABLE_CLASS => {
                 if !matches!(
                     physical_type,
@@ -253,6 +277,7 @@ pub(crate) fn decode_columns(
             }
             FIXED_CLASS | AUTO_INCREMENT_CLASS => {
                 if raw_class == AUTO_INCREMENT_CLASS && physical_type != ColumnPhysicalType::Long {
+                    // AUTO_INCREMENT_CLASS is admitted for user tables only.
                     return Err(TableDefinitionError::UnsupportedColumnClass {
                         ordinal: record_ordinal,
                         physical_type,

--- a/crates/jet3/src/index_definition.rs
+++ b/crates/jet3/src/index_definition.rs
@@ -12,7 +12,7 @@ pub use crate::physical_index_definition::{
     IndexDirection, IndexField, IndexUsageMapReference, PhysicalIndexDefinition,
 };
 use crate::physical_index_definition::{
-    KEY_SLOT_COUNT, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, UNIQUE_FLAG, decode_physical,
+    KEY_SLOT_COUNT, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, decode_physical,
 };
 use crate::{ByteCount, Error, PageGeometry, PageNumber, ResourceBudget};
 
@@ -304,7 +304,8 @@ pub(crate) struct IndexDecodeContext<'a> {
     pub(crate) column_count: u16,
     pub(crate) logical_count: u16,
     pub(crate) physical_count: u16,
-    pub(crate) supported_physical_flags: u8,
+    pub(crate) supported_physical_flags: &'static [u8],
+    pub(crate) primary_flags: u8,
     pub(crate) table_root: PageNumber,
     pub(crate) geometry: PageGeometry,
 }
@@ -451,10 +452,8 @@ pub(crate) fn decode_indexes(
                         return Err(IndexDefinitionError::DuplicatePrimaryIndex);
                     }
                     primary_seen = true;
-                    // EXP-0059 primaries carry 0x09; EXP-0073 system
-                    // primaries carry 0x01. Both are unique.
                     let flags = physical[usize::from(physical_ordinal)].raw_flags();
-                    if flags & UNIQUE_FLAG == 0 {
+                    if flags != context.primary_flags {
                         return Err(IndexDefinitionError::InvalidPrimaryFlags {
                             logical_index,
                             raw: flags,

--- a/crates/jet3/src/index_definition.rs
+++ b/crates/jet3/src/index_definition.rs
@@ -12,7 +12,7 @@ pub use crate::physical_index_definition::{
     IndexDirection, IndexField, IndexUsageMapReference, PhysicalIndexDefinition,
 };
 use crate::physical_index_definition::{
-    KEY_SLOT_COUNT, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, SUPPORTED_FLAGS, decode_physical,
+    KEY_SLOT_COUNT, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, UNIQUE_FLAG, decode_physical,
 };
 use crate::{ByteCount, Error, PageGeometry, PageNumber, ResourceBudget};
 
@@ -304,6 +304,7 @@ pub(crate) struct IndexDecodeContext<'a> {
     pub(crate) column_count: u16,
     pub(crate) logical_count: u16,
     pub(crate) physical_count: u16,
+    pub(crate) supported_physical_flags: u8,
     pub(crate) table_root: PageNumber,
     pub(crate) geometry: PageGeometry,
 }
@@ -343,6 +344,7 @@ pub(crate) fn decode_indexes(
             sourced_prefix,
             raw_record,
             context.column_count,
+            context.supported_physical_flags,
             context.geometry,
             budget,
         )?);
@@ -449,8 +451,10 @@ pub(crate) fn decode_indexes(
                         return Err(IndexDefinitionError::DuplicatePrimaryIndex);
                     }
                     primary_seen = true;
+                    // EXP-0059 primaries carry 0x09; EXP-0073 system
+                    // primaries carry 0x01. Both are unique.
                     let flags = physical[usize::from(physical_ordinal)].raw_flags();
-                    if flags != SUPPORTED_FLAGS {
+                    if flags & UNIQUE_FLAG == 0 {
                         return Err(IndexDefinitionError::InvalidPrimaryFlags {
                             logical_index,
                             raw: flags,

--- a/crates/jet3/src/index_tree_key_inventory_tests.rs
+++ b/crates/jet3/src/index_tree_key_inventory_tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+#[test]
+fn key_inventory_is_typed_only_for_observed_encodings_and_other_bytes_are_lossless()
+-> Result<(), Box<dyn std::error::Error>> {
+    let cases: &[(u8, u8, u16, &[u8], IndexKeyEncoding)] = &[
+        (1, 3, 1, &[0x7f, 0xff], IndexKeyEncoding::Boolean),
+        (2, 3, 1, &[0x7f, 0x7f], IndexKeyEncoding::Byte),
+        (3, 3, 2, &[0x7f, 0x80, 0], IndexKeyEncoding::Integer),
+        (4, 3, 4, &[0x7f, 0x80, 0, 0, 0], IndexKeyEncoding::Long),
+        (
+            5,
+            3,
+            8,
+            &[0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0],
+            IndexKeyEncoding::Currency,
+        ),
+        (6, 3, 4, &[0x7f, 0x80, 0, 0, 0], IndexKeyEncoding::Single),
+        (
+            7,
+            3,
+            8,
+            &[0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0],
+            IndexKeyEncoding::Double,
+        ),
+        (
+            8,
+            3,
+            8,
+            &[0x7f, 0xc0, 0, 0, 0, 0, 0, 0, 0],
+            IndexKeyEncoding::DateTime,
+        ),
+        (9, 2, 3, &[0x7f, 1, 2, 3, 3], IndexKeyEncoding::Binary),
+        (10, 2, 20, &[0x7f, 0x60, 0], IndexKeyEncoding::TextCollation),
+        (4, 3, 4, &[0], IndexKeyEncoding::Null),
+        (11, 2, 0, &[0xde, 0xad], IndexKeyEncoding::Unsupported),
+        (12, 2, 0, &[0xbe, 0xef], IndexKeyEncoding::Unsupported),
+        (15, 3, 16, &[0xca, 0xfe], IndexKeyEncoding::Unsupported),
+    ];
+    for (physical_type, class, size, raw_key, expected) in cases {
+        let mut bytes = database_bytes(*physical_type, *class, *size);
+        let entry = leaf_entry(raw_key, 0);
+        write_node(
+            &mut bytes,
+            NodeSpec {
+                page: INDEX_ROOT,
+                tag: 4,
+                previous: 0,
+                next: 0,
+                tail_child: 0,
+                prefix: &[],
+                entries: &[&entry],
+            },
+        );
+        let (tree, _) = traverse_with_limits(&bytes, limits(&bytes))?;
+        assert_eq!(tree.entries()[0].key().encoding(), *expected);
+        assert_eq!(tree.entries()[0].key().raw_bytes(), *raw_key);
+    }
+    Ok(())
+}

--- a/crates/jet3/src/index_tree_tests.rs
+++ b/crates/jet3/src/index_tree_tests.rs
@@ -78,7 +78,15 @@ fn definition_with(columns: &[ColumnSpec], keys: &[(u16, bool)]) -> Vec<u8> {
     logical[9..13].copy_from_slice(&u32::MAX.to_le_bytes());
     logical[17..19].copy_from_slice(&[4, 4]);
     bytes.extend_from_slice(&logical);
-    bytes.extend_from_slice(&[3, b'I', b'd', b'x', 0xff, 0xff]);
+    bytes.extend_from_slice(&[3, b'I', b'd', b'x']);
+    for column in columns
+        .iter()
+        .filter(|column| matches!(column.physical_type, 11 | 12))
+    {
+        let [low, high] = column.ordinal.to_le_bytes();
+        bytes.extend_from_slice(&[low, high, 0, MAP_PAGE as u8, 0, 0, 1, MAP_PAGE as u8, 0, 0]);
+    }
+    bytes.extend_from_slice(&[0xff, 0xff]);
     let length = bytes.len() as u32;
     bytes[8..12].copy_from_slice(&length.to_le_bytes());
     bytes
@@ -128,7 +136,11 @@ fn database_with_definition(definition: &[u8]) -> Vec<u8> {
         0x86, 0xfb, 0xec, 0x37, 0x5d, 0x44, 0x9c, 0xfa, 0xc6, 0x5e, 0x28, 0xe6, 0x13, 0xb6,
     ]);
     bytes[ROOT * PAGE_BYTES..ROOT * PAGE_BYTES + definition.len()].copy_from_slice(definition);
-    bytes[MAP_PAGE * PAGE_BYTES] = 1;
+    let map = &mut bytes[MAP_PAGE * PAGE_BYTES..(MAP_PAGE + 1) * PAGE_BYTES];
+    map[0] = 1;
+    map[8..10].copy_from_slice(&2_u16.to_le_bytes());
+    map[10..12].copy_from_slice(&((PAGE_BYTES - 1) as u16).to_le_bytes());
+    map[12..14].copy_from_slice(&((PAGE_BYTES - 2) as u16).to_le_bytes());
     write_row_page(&mut bytes, ROW_PAGE, 4);
     bytes
 }
@@ -322,65 +334,6 @@ fn exact_depth_succeeds_and_one_over_is_resource_rejected() -> Result<(), Box<dy
             maximum: 1,
         })
     ));
-    Ok(())
-}
-
-#[test]
-fn key_inventory_is_typed_only_for_observed_encodings_and_other_bytes_are_lossless()
--> Result<(), Box<dyn std::error::Error>> {
-    let cases: &[(u8, u8, u16, &[u8], IndexKeyEncoding)] = &[
-        (1, 3, 1, &[0x7f, 0xff], IndexKeyEncoding::Boolean),
-        (2, 3, 1, &[0x7f, 0x7f], IndexKeyEncoding::Byte),
-        (3, 3, 2, &[0x7f, 0x80, 0], IndexKeyEncoding::Integer),
-        (4, 3, 4, &[0x7f, 0x80, 0, 0, 0], IndexKeyEncoding::Long),
-        (
-            5,
-            3,
-            8,
-            &[0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0],
-            IndexKeyEncoding::Currency,
-        ),
-        (6, 3, 4, &[0x7f, 0x80, 0, 0, 0], IndexKeyEncoding::Single),
-        (
-            7,
-            3,
-            8,
-            &[0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0],
-            IndexKeyEncoding::Double,
-        ),
-        (
-            8,
-            3,
-            8,
-            &[0x7f, 0xc0, 0, 0, 0, 0, 0, 0, 0],
-            IndexKeyEncoding::DateTime,
-        ),
-        (9, 2, 3, &[0x7f, 1, 2, 3, 3], IndexKeyEncoding::Binary),
-        (10, 2, 20, &[0x7f, 0x60, 0], IndexKeyEncoding::TextCollation),
-        (4, 3, 4, &[0], IndexKeyEncoding::Null),
-        (11, 2, 0, &[0xde, 0xad], IndexKeyEncoding::Unsupported),
-        (12, 2, 0, &[0xbe, 0xef], IndexKeyEncoding::Unsupported),
-        (15, 3, 16, &[0xca, 0xfe], IndexKeyEncoding::Unsupported),
-    ];
-    for (physical_type, class, size, raw_key, expected) in cases {
-        let mut bytes = database_bytes(*physical_type, *class, *size);
-        let entry = leaf_entry(raw_key, 0);
-        write_node(
-            &mut bytes,
-            NodeSpec {
-                page: INDEX_ROOT,
-                tag: 4,
-                previous: 0,
-                next: 0,
-                tail_child: 0,
-                prefix: &[],
-                entries: &[&entry],
-            },
-        );
-        let (tree, _) = traverse_with_limits(&bytes, limits(&bytes))?;
-        assert_eq!(tree.entries()[0].key().encoding(), *expected);
-        assert_eq!(tree.entries()[0].key().raw_bytes(), *raw_key);
-    }
     Ok(())
 }
 
@@ -796,3 +749,6 @@ fn invalid_row_reference_and_error_sources_remain_structured()
     assert!(plain.source().is_none());
     Ok(())
 }
+
+#[path = "index_tree_key_inventory_tests.rs"]
+mod key_inventory;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -26,6 +26,7 @@ mod index_tree_rows;
 pub mod jet3_page;
 pub mod limits;
 pub mod long_value;
+pub mod long_value_map;
 pub mod map_location;
 pub mod offset;
 pub mod page;
@@ -104,6 +105,7 @@ pub use long_value::{
     ExternalLongValueStorage, InlineLongValue, LongValue, LongValueChunk, LongValueChunkValue,
     LongValueCursor, LongValueError, LongValueKind, LongValueReference,
 };
+pub use long_value_map::{LONG_VALUE_MAP_GROUP_LEN, LongValueMapDefinition, LongValueMapError};
 pub use map_location::{MapLocationError, MapRowLocator, TableMapLocations, locate_table_maps};
 pub use offset::{ByteCount, ByteOffset};
 pub use page::{PageGeometry, PageNumber, PageOffset};
@@ -116,7 +118,7 @@ pub use row::{RawField, RowCursor, RowError, RowView};
 pub use row_directory::{RowDirectoryError, RowLocator};
 pub use row_writer::{RowColumnLayout, RowValue, RowWriteError, encode_row};
 pub use source::{FileSource, ReadAt, SliceSource};
-pub use table_definition::{TableDefinition, TableDefinitionError};
+pub use table_definition::{TableDefinition, TableDefinitionError, TableDefinitionKind};
 pub use table_definition_writer::{
     TableDefinitionSpec, TableDefinitionWriteError, encode_table_definition, table_definition_len,
 };

--- a/crates/jet3/src/long_value_map.rs
+++ b/crates/jet3/src/long_value_map.rs
@@ -1,0 +1,264 @@
+//! Per-column long-value map locators decoded from the table-definition
+//! suffix.
+//!
+//! `EXP-0074` fixes the group shape: one 10-byte group per Memo or LongBinary
+//! column holding a little-endian column ordinal followed by owned and
+//! available map locators in the `EXP-0057` row-byte-plus-24-bit-page form.
+//! `EXP-0077` accepts that grammar with order-insensitive coverage and
+//! correlates the owned map with newly appearing long-value pages.
+
+use std::fmt;
+use std::mem::size_of;
+
+use crate::column_definition::{ColumnDefinition, ColumnOrdinal, ColumnPhysicalType};
+use crate::{ByteCount, Error, MapRowLocator, PageGeometry, PageNumber, ResourceBudget};
+
+/// Length of one sourced long-value map group.
+pub const LONG_VALUE_MAP_GROUP_LEN: usize = 10;
+
+/// One column's owned and available long-value map locators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LongValueMapDefinition {
+    column: ColumnOrdinal,
+    owned: MapRowLocator,
+    available: MapRowLocator,
+    raw_group: [u8; LONG_VALUE_MAP_GROUP_LEN],
+}
+
+impl LongValueMapDefinition {
+    /// Returns the Memo or LongBinary column the maps belong to.
+    #[must_use]
+    pub const fn column(&self) -> ColumnOrdinal {
+        self.column
+    }
+
+    /// Returns the row tracking the column's owned long-value pages.
+    #[must_use]
+    pub const fn owned(&self) -> MapRowLocator {
+        self.owned
+    }
+
+    /// Returns the second locator, named by analogy with the table maps.
+    #[must_use]
+    pub const fn available(&self) -> MapRowLocator {
+        self.available
+    }
+
+    /// Returns the complete sourced group.
+    #[must_use]
+    pub const fn raw_group(&self) -> &[u8; LONG_VALUE_MAP_GROUP_LEN] {
+        &self.raw_group
+    }
+}
+
+/// Structured failure while decoding the long-value map suffix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LongValueMapError {
+    /// The suffix is not a whole number of groups.
+    InvalidSuffixLength {
+        /// Sourced suffix length.
+        length: usize,
+    },
+    /// A group names a column ordinal outside the definition.
+    InvalidColumnOrdinal {
+        /// Zero-based group index.
+        group: usize,
+        /// Sourced column ordinal.
+        ordinal: u16,
+        /// Number of columns in the definition.
+        column_count: usize,
+    },
+    /// A group names a column that is not Memo or LongBinary.
+    NotLongValueColumn {
+        /// Sourced column ordinal.
+        ordinal: u16,
+        /// Decoded physical type of that column.
+        physical_type: ColumnPhysicalType,
+    },
+    /// Two groups name the same column.
+    DuplicateColumn {
+        /// Repeated column ordinal.
+        ordinal: u16,
+    },
+    /// A Memo or LongBinary column has no group.
+    MissingColumn {
+        /// Column ordinal lacking a group.
+        ordinal: u16,
+    },
+    /// A locator names a page outside the captured input.
+    InvalidReference {
+        /// Column ordinal whose group holds the locator.
+        ordinal: u16,
+        /// Whether the owned or available locator failed.
+        role: &'static str,
+        /// Decoded locator.
+        locator: MapRowLocator,
+        /// Geometry failure, absent for a zero page.
+        source: Option<Error>,
+    },
+    /// A locator does not name an existing data-page row.
+    InvalidMapRow {
+        /// Column ordinal whose group holds the locator.
+        ordinal: u16,
+        /// Whether the owned or available locator failed.
+        role: &'static str,
+        /// Decoded locator.
+        locator: MapRowLocator,
+        /// Row lookup failure.
+        source: crate::UsageMapError,
+    },
+    /// Resource policy rejected decoding work or owned storage.
+    Resource(Error),
+}
+
+impl fmt::Display for LongValueMapError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "long-value map suffix failed: {self:?}")
+    }
+}
+
+impl std::error::Error for LongValueMapError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidReference {
+                source: Some(source),
+                ..
+            }
+            | Self::Resource(source) => Some(source),
+            Self::InvalidMapRow { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn decode_long_value_maps(
+    suffix: &[u8],
+    columns: &[ColumnDefinition],
+    geometry: PageGeometry,
+    budget: &mut ResourceBudget,
+) -> Result<Vec<LongValueMapDefinition>, LongValueMapError> {
+    if !suffix.len().is_multiple_of(LONG_VALUE_MAP_GROUP_LEN) {
+        return Err(LongValueMapError::InvalidSuffixLength {
+            length: suffix.len(),
+        });
+    }
+    let group_count = suffix.len() / LONG_VALUE_MAP_GROUP_LEN;
+    let item_work = group_count
+        .checked_add(columns.len())
+        .ok_or(LongValueMapError::Resource(Error::Arithmetic {
+            operation: "count long-value map work",
+        }))?;
+    budget
+        .charge_items(item_work as u64)
+        .map_err(LongValueMapError::Resource)?;
+    let bytes = (size_of::<LongValueMapDefinition>() as u64)
+        .checked_mul(group_count as u64)
+        .ok_or(LongValueMapError::Resource(Error::Arithmetic {
+            operation: "size long-value map vector",
+        }))?;
+    budget
+        .charge_allocation(ByteCount::new(bytes))
+        .map_err(LongValueMapError::Resource)?;
+    let mut maps = Vec::new();
+    maps.try_reserve_exact(group_count).map_err(|_| {
+        LongValueMapError::Resource(Error::Io {
+            operation: "reserve long-value map definitions",
+            kind: std::io::ErrorKind::OutOfMemory,
+        })
+    })?;
+    budget
+        .charge_allocation(ByteCount::new(columns.len() as u64))
+        .map_err(LongValueMapError::Resource)?;
+    let mut seen = Vec::new();
+    seen.try_reserve_exact(columns.len()).map_err(|_| {
+        LongValueMapError::Resource(Error::Io {
+            operation: "reserve long-value map coverage",
+            kind: std::io::ErrorKind::OutOfMemory,
+        })
+    })?;
+    seen.resize(columns.len(), false);
+    for (group, raw) in suffix.chunks_exact(LONG_VALUE_MAP_GROUP_LEN).enumerate() {
+        let raw_group: [u8; LONG_VALUE_MAP_GROUP_LEN] = raw.try_into().map_err(|_| {
+            LongValueMapError::Resource(Error::Arithmetic {
+                operation: "slice long-value map group",
+            })
+        })?;
+        let ordinal = u16::from_le_bytes([raw_group[0], raw_group[1]]);
+        let column =
+            columns
+                .get(usize::from(ordinal))
+                .ok_or(LongValueMapError::InvalidColumnOrdinal {
+                    group,
+                    ordinal,
+                    column_count: columns.len(),
+                })?;
+        if !is_long_value(column) {
+            return Err(LongValueMapError::NotLongValueColumn {
+                ordinal,
+                physical_type: column.physical_type(),
+            });
+        }
+        if seen[usize::from(ordinal)] {
+            return Err(LongValueMapError::DuplicateColumn { ordinal });
+        }
+        let owned = decode_locator(&raw_group[2..6]);
+        let available = decode_locator(&raw_group[6..10]);
+        for (role, locator) in [("owned", owned), ("available", available)] {
+            validate_locator(ordinal, role, locator, geometry)?;
+        }
+        maps.push(LongValueMapDefinition {
+            column: ColumnOrdinal::new(ordinal),
+            owned,
+            available,
+            raw_group,
+        });
+        seen[usize::from(ordinal)] = true;
+    }
+    if let Some(missing) = columns
+        .iter()
+        .filter(|column| is_long_value(column))
+        .find(|column| !seen[usize::from(column.ordinal().get())])
+    {
+        return Err(LongValueMapError::MissingColumn {
+            ordinal: missing.ordinal().get(),
+        });
+    }
+    Ok(maps)
+}
+
+fn is_long_value(column: &ColumnDefinition) -> bool {
+    matches!(
+        column.physical_type(),
+        ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
+    )
+}
+
+fn decode_locator(raw: &[u8]) -> MapRowLocator {
+    let page = u32::from_le_bytes([raw[1], raw[2], raw[3], 0]);
+    MapRowLocator::new(PageNumber::new(u64::from(page)), raw[0])
+}
+
+fn validate_locator(
+    ordinal: u16,
+    role: &'static str,
+    locator: MapRowLocator,
+    geometry: PageGeometry,
+) -> Result<(), LongValueMapError> {
+    if locator.page().get() == 0 {
+        return Err(LongValueMapError::InvalidReference {
+            ordinal,
+            role,
+            locator,
+            source: None,
+        });
+    }
+    geometry
+        .validate_reference(locator.page())
+        .map_err(|source| LongValueMapError::InvalidReference {
+            ordinal,
+            role,
+            locator,
+            source: Some(source),
+        })
+}

--- a/crates/jet3/src/physical_index_definition.rs
+++ b/crates/jet3/src/physical_index_definition.rs
@@ -11,9 +11,13 @@ pub(crate) const PHYSICAL_RECORD_LEN: usize = 39;
 pub(crate) const KEY_SLOT_COUNT: usize = 10;
 const KEY_SLOT_LEN: usize = 3;
 const NULL_COLUMN_ORDINAL: u16 = u16::MAX;
-const UNIQUE_FLAG: u8 = 0x01;
+pub(crate) const UNIQUE_FLAG: u8 = 0x01;
 const REQUIRED_FLAG: u8 = 0x08;
-pub(crate) const SUPPORTED_FLAGS: u8 = UNIQUE_FLAG | REQUIRED_FLAG;
+/// `EXP-0073`: set on every `MSysRelationships` index; retained without an
+/// assigned meaning.
+const UNINTERPRETED_FLAG: u8 = 0x02;
+pub(crate) const USER_SUPPORTED_FLAGS: u8 = UNIQUE_FLAG | REQUIRED_FLAG;
+pub(crate) const SYSTEM_SUPPORTED_FLAGS: u8 = USER_SUPPORTED_FLAGS | UNINTERPRETED_FLAG;
 
 /// Direction of one sourced index key field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -134,6 +138,7 @@ pub(crate) fn decode_physical(
     sourced_prefix: [u8; PHYSICAL_PREFIX_LEN],
     raw_record: [u8; PHYSICAL_RECORD_LEN],
     column_count: u16,
+    supported_flags: u8,
     geometry: PageGeometry,
     budget: &mut ResourceBudget,
 ) -> Result<PhysicalIndexDefinition, IndexDefinitionError> {
@@ -219,7 +224,7 @@ pub(crate) fn decode_physical(
         })?;
     }
     let raw_flags = raw_record[38];
-    if raw_flags & !SUPPORTED_FLAGS != 0 {
+    if raw_flags & !supported_flags != 0 {
         return Err(IndexDefinitionError::UnsupportedPhysicalFlags {
             physical_index,
             raw: raw_flags,

--- a/crates/jet3/src/physical_index_definition.rs
+++ b/crates/jet3/src/physical_index_definition.rs
@@ -16,8 +16,12 @@ const REQUIRED_FLAG: u8 = 0x08;
 /// `EXP-0073`: set on every `MSysRelationships` index; retained without an
 /// assigned meaning.
 const UNINTERPRETED_FLAG: u8 = 0x02;
-pub(crate) const USER_SUPPORTED_FLAGS: u8 = UNIQUE_FLAG | REQUIRED_FLAG;
-pub(crate) const SYSTEM_SUPPORTED_FLAGS: u8 = USER_SUPPORTED_FLAGS | UNINTERPRETED_FLAG;
+pub(crate) const USER_PRIMARY_FLAGS: u8 = UNIQUE_FLAG | REQUIRED_FLAG;
+pub(crate) const SYSTEM_PRIMARY_FLAGS: u8 = UNIQUE_FLAG;
+pub(crate) const USER_SUPPORTED_FLAGS: &[u8] = &[0, UNIQUE_FLAG, REQUIRED_FLAG, USER_PRIMARY_FLAGS];
+/// `EXP-0073` observed these three complete system-index flag values. The
+/// uninterpreted `0x02` value is not assumed to compose with the others.
+pub(crate) const SYSTEM_SUPPORTED_FLAGS: &[u8] = &[UNIQUE_FLAG, UNINTERPRETED_FLAG, REQUIRED_FLAG];
 
 /// Direction of one sourced index key field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -138,7 +142,7 @@ pub(crate) fn decode_physical(
     sourced_prefix: [u8; PHYSICAL_PREFIX_LEN],
     raw_record: [u8; PHYSICAL_RECORD_LEN],
     column_count: u16,
-    supported_flags: u8,
+    supported_flags: &[u8],
     geometry: PageGeometry,
     budget: &mut ResourceBudget,
 ) -> Result<PhysicalIndexDefinition, IndexDefinitionError> {
@@ -224,7 +228,7 @@ pub(crate) fn decode_physical(
         })?;
     }
     let raw_flags = raw_record[38];
-    if raw_flags & !supported_flags != 0 {
+    if !supported_flags.contains(&raw_flags) {
         return Err(IndexDefinitionError::UnsupportedPhysicalFlags {
             physical_index,
             raw: raw_flags,

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -55,13 +55,29 @@ fn database_bytes(
     bytes[0x42..0x50].copy_from_slice(&[
         0x86, 0xfb, 0xec, 0x37, 0x5d, 0x44, 0x9c, 0xfa, 0xc6, 0x5e, 0x28, 0xe6, 0x13, 0xb6,
     ]);
+    // One long-value map group per Memo or LongBinary column, reusing the
+    // two table map rows.
+    let raw_suffix: Vec<u8> = columns
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| {
+            matches!(
+                column.physical_type(),
+                ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
+            )
+        })
+        .flat_map(|(ordinal, _)| {
+            let [low, high] = (ordinal as u16).to_le_bytes();
+            [low, high, 0, MAP_PAGE as u8, 0, 0, 1, MAP_PAGE as u8, 0, 0]
+        })
+        .collect();
     let spec = TableDefinitionSpec {
         columns,
         physical_indexes: &[],
         indexes: &[],
         owned_map: MapRowLocator::new(PageNumber::new(MAP_PAGE as u64), 0),
         available_map: MapRowLocator::new(PageNumber::new(MAP_PAGE as u64), 1),
-        raw_suffix: &[],
+        raw_suffix: &raw_suffix,
     };
     let mut budget = ResourceBudget::new(ResourceLimits::default());
     encode_table_definition(

--- a/crates/jet3/src/table_definition.rs
+++ b/crates/jet3/src/table_definition.rs
@@ -14,7 +14,9 @@ use crate::index_definition::{
     PhysicalIndexDefinition, decode_indexes,
 };
 use crate::long_value_map::{LongValueMapDefinition, LongValueMapError, decode_long_value_maps};
-use crate::physical_index_definition::{SYSTEM_SUPPORTED_FLAGS, USER_SUPPORTED_FLAGS};
+use crate::physical_index_definition::{
+    SYSTEM_PRIMARY_FLAGS, SYSTEM_SUPPORTED_FLAGS, USER_PRIMARY_FLAGS, USER_SUPPORTED_FLAGS,
+};
 use crate::{
     AllocationTraversalError, ByteCount, DatabasePageError, DatabaseReader, Error, JET3_PAGE_SIZE,
     MapLocationError, PageChainWalker, PageKind, PageNumber, ReadAt, ResourceBudget,
@@ -484,6 +486,10 @@ fn decode_definition(
             supported_physical_flags: match kind {
                 TableDefinitionKind::User => USER_SUPPORTED_FLAGS,
                 TableDefinitionKind::System => SYSTEM_SUPPORTED_FLAGS,
+            },
+            primary_flags: match kind {
+                TableDefinitionKind::User => USER_PRIMARY_FLAGS,
+                TableDefinitionKind::System => SYSTEM_PRIMARY_FLAGS,
             },
             table_root: root,
             geometry,

--- a/crates/jet3/src/table_definition.rs
+++ b/crates/jet3/src/table_definition.rs
@@ -1,5 +1,7 @@
 //! Bounded immutable Jet 3 table definitions from `EXP-0059`, composed with
-//! the table allocation-map locators from `EXP-0057`.
+//! the table allocation-map locators from `EXP-0057`, the system-definition
+//! relaxations from `EXP-0073`, and the long-value map suffix from
+//! `EXP-0077`.
 //!
 //! Definitions retain sourced bytes and typed references. Callers can pass a
 //! decoded definition to [`crate::DatabaseReader::index_tree`] separately.
@@ -11,10 +13,12 @@ use crate::index_definition::{
     DecodedIndexes, IndexDecodeContext, IndexDefinition, IndexDefinitionError, IndexDefinitionKind,
     PhysicalIndexDefinition, decode_indexes,
 };
+use crate::long_value_map::{LongValueMapDefinition, LongValueMapError, decode_long_value_maps};
+use crate::physical_index_definition::{SYSTEM_SUPPORTED_FLAGS, USER_SUPPORTED_FLAGS};
 use crate::{
     AllocationTraversalError, ByteCount, DatabasePageError, DatabaseReader, Error, JET3_PAGE_SIZE,
     MapLocationError, PageChainWalker, PageKind, PageNumber, ReadAt, ResourceBudget,
-    TableMapLocations, locate_table_maps,
+    TableMapLocations, locate_table_maps, locate_usage_map,
 };
 
 const PAGE_BYTES: usize = JET3_PAGE_SIZE.get() as usize;
@@ -23,17 +27,35 @@ const DEFINITION_HEADER_LEN: usize = 43;
 const PHYSICAL_PREFIX_LEN: usize = 8;
 const TERMINATOR_LEN: usize = 2;
 const DEFINITION_PREFIX: [u8; 4] = [0x02, 0x01, 0x56, 0x43];
-const HEADER_MARKER: u8 = 0x4e;
+/// `EXP-0059`: byte 20 of every user table definition.
+const USER_HEADER_MARKER: u8 = 0x4e;
+/// `EXP-0073`: byte 20 of every system table definition.
+const SYSTEM_HEADER_MARKER: u8 = 0x53;
+
+/// Header-marker class of a table definition.
+///
+/// The class selects which sourced column-record constants are admitted:
+/// `EXP-0059` values for user tables and the `EXP-0073` relaxations for
+/// system tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TableDefinitionKind {
+    /// Marker `0x4e`, created for user tables.
+    User,
+    /// Marker `0x53`, created for the `MSys*` system tables.
+    System,
+}
 
 /// One complete immutable table definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableDefinition {
     root: PageNumber,
+    kind: TableDefinitionKind,
     logical_length: u32,
     maps: TableMapLocations,
     columns: Vec<ColumnDefinition>,
     physical_indexes: Vec<PhysicalIndexDefinition>,
     indexes: Vec<IndexDefinition>,
+    long_value_maps: Vec<LongValueMapDefinition>,
     raw_header: [u8; DEFINITION_HEADER_LEN],
     raw_suffix: Vec<u8>,
 }
@@ -43,6 +65,19 @@ impl TableDefinition {
     /// Returns the table-definition root page.
     pub const fn root(&self) -> PageNumber {
         self.root
+    }
+
+    #[must_use]
+    /// Returns the header-marker class of the definition.
+    pub const fn kind(&self) -> TableDefinitionKind {
+        self.kind
+    }
+
+    #[must_use]
+    /// Returns one long-value map group per Memo or LongBinary column, in
+    /// stored order.
+    pub fn long_value_maps(&self) -> &[LongValueMapDefinition] {
+        &self.long_value_maps
     }
 
     #[must_use]
@@ -81,7 +116,7 @@ impl TableDefinition {
         &self.raw_header
     }
 
-    /// Returns still-uninterpreted sourced bytes before the final `ff ff`.
+    /// Returns the sourced suffix bytes before the final `ff ff`.
     #[must_use]
     pub fn raw_suffix(&self) -> &[u8] {
         &self.raw_suffix
@@ -100,6 +135,8 @@ pub enum TableDefinitionError {
     Page(DatabasePageError),
     /// Physical or logical index decoding failed.
     Index(IndexDefinitionError),
+    /// Long-value map suffix decoding failed.
+    LongValueMap(LongValueMapError),
     /// The root page lacks the observed table-definition prefix.
     InvalidPrefix {
         /// Root page being decoded.
@@ -269,6 +306,7 @@ impl std::error::Error for TableDefinitionError {
             Self::MapLocation(source) => Some(source),
             Self::Page(source) => Some(source),
             Self::Index(source) => Some(source),
+            Self::LongValueMap(source) => Some(source),
             Self::Resource(source) => Some(source),
             _ => None,
         }
@@ -285,7 +323,7 @@ impl<S: ReadAt> DatabaseReader<S> {
         let geometry = self.geometry();
         let (bytes, maps) = read_definition_chain(self, root, budget)?;
         let mut definition = decode_definition(&bytes, root, maps, geometry, budget)?;
-        validate_index_references(self, &definition, budget)?;
+        validate_references(self, &definition, budget)?;
         definition.logical_length = u32::try_from(bytes.len()).map_err(|_| {
             TableDefinitionError::Resource(Error::IntegerConversion {
                 value: bytes.len() as u128,
@@ -392,11 +430,11 @@ fn decode_definition(
     budget: &mut ResourceBudget,
 ) -> Result<TableDefinition, TableDefinitionError> {
     let raw_header = array_at::<DEFINITION_HEADER_LEN>(bytes, 0)?;
-    if raw_header[20] != HEADER_MARKER {
-        return Err(TableDefinitionError::InvalidHeaderMarker {
-            raw: raw_header[20],
-        });
-    }
+    let kind = match raw_header[20] {
+        USER_HEADER_MARKER => TableDefinitionKind::User,
+        SYSTEM_HEADER_MARKER => TableDefinitionKind::System,
+        raw => return Err(TableDefinitionError::InvalidHeaderMarker { raw }),
+    };
     let column_count = u16_at(bytes, 21);
     let variable_count = u16_at(bytes, 23);
     let repeated_column_count = u16_at(bytes, 25);
@@ -427,7 +465,14 @@ fn decode_definition(
                 operation: "locate column records",
             }))?;
     checked_slice(bytes, prefix_offset, prefix_bytes)?;
-    let columns = decode_columns(bytes, &mut offset, column_count, variable_count, budget)?;
+    let columns = decode_columns(
+        bytes,
+        &mut offset,
+        kind,
+        column_count,
+        variable_count,
+        budget,
+    )?;
     let DecodedIndexes { physical, logical } = decode_indexes(
         IndexDecodeContext {
             bytes,
@@ -436,6 +481,10 @@ fn decode_definition(
             column_count,
             logical_count,
             physical_count,
+            supported_physical_flags: match kind {
+                TableDefinitionKind::User => USER_SUPPORTED_FLAGS,
+                TableDefinitionKind::System => SYSTEM_SUPPORTED_FLAGS,
+            },
             table_root: root,
             geometry,
         },
@@ -464,24 +513,43 @@ fn decode_definition(
         });
     }
     let raw_suffix = copy_owned(&bytes[offset..suffix_end], budget)?;
+    let long_value_maps = decode_long_value_maps(&raw_suffix, &columns, geometry, budget)
+        .map_err(TableDefinitionError::LongValueMap)?;
     Ok(TableDefinition {
         root,
+        kind,
         logical_length: 0,
         maps,
         columns,
         physical_indexes: physical,
         indexes: logical,
+        long_value_maps,
         raw_header,
         raw_suffix,
     })
 }
 
-fn validate_index_references<S: ReadAt>(
+fn validate_references<S: ReadAt>(
     database: &mut DatabaseReader<S>,
     definition: &TableDefinition,
     budget: &mut ResourceBudget,
 ) -> Result<(), TableDefinitionError> {
     let mut page = [0_u8; PAGE_BYTES];
+    for map in &definition.long_value_maps {
+        for (role, locator) in [("owned", map.owned()), ("available", map.available())] {
+            let classified = database
+                .read_classified_page(locator.page(), &mut page, budget)
+                .map_err(TableDefinitionError::Page)?;
+            locate_usage_map(classified, locator, budget).map_err(|source| {
+                TableDefinitionError::LongValueMap(LongValueMapError::InvalidMapRow {
+                    ordinal: map.column().get(),
+                    role,
+                    locator,
+                    source,
+                })
+            })?;
+        }
+    }
     for physical in &definition.physical_indexes {
         validate_reference_kind(
             database,

--- a/crates/jet3/src/table_definition_system_tests.rs
+++ b/crates/jet3/src/table_definition_system_tests.rs
@@ -1,0 +1,289 @@
+use super::*;
+use crate::{LongValueMapError, UsageMapError};
+
+fn long_value_columns() -> Vec<ColumnSpec> {
+    vec![
+        (4, 3, 0, 4, b"Id".to_vec()),
+        (12, 2, 0, 0, b"Note".to_vec()),
+        (11, 2, 0, 0, b"Ole".to_vec()),
+    ]
+}
+
+fn long_value_definition(suffix: &[u8]) -> Vec<u8> {
+    build_definition(USER_MARKER, &long_value_columns(), &[], &[], suffix)
+}
+
+fn ordinary_logical(physical_index: u32, class: u8) -> [u8; 20] {
+    let mut logical = [0_u8; 20];
+    logical[..4].copy_from_slice(&physical_index.to_le_bytes());
+    logical[4..8].copy_from_slice(&physical_index.to_le_bytes());
+    logical[9..13].copy_from_slice(&u32::MAX.to_le_bytes());
+    logical[17..19].copy_from_slice(&[4, 4]);
+    logical[19] = class;
+    logical
+}
+
+/// An `MSysACEs`-shaped system definition plus one Memo column, with the
+/// `EXP-0073` primary over unique-only flags and one `0x02`-flagged index.
+fn system_definition() -> Vec<u8> {
+    let columns: Vec<ColumnSpec> = vec![
+        (4, 0x13, 0, 4, b"ObjectId".to_vec()),
+        (9, 0x32, 0, 255, b"SID".to_vec()),
+        (12, 0x12, 0, 0, b"Lv".to_vec()),
+        (1, 0x13, 0, 1, b"FInheritable".to_vec()),
+    ];
+    let mut relationship_like = physical_index(2);
+    relationship_like[..2].copy_from_slice(&1_u16.to_le_bytes());
+    build_definition(
+        SYSTEM_MARKER,
+        &columns,
+        &[physical_index(1), relationship_like],
+        &[
+            (ordinary_logical(0, 1), b"ObjectId"),
+            (ordinary_logical(1, 0), b"SID"),
+        ],
+        &group(2, 2, 3, MAP_PAGE as u8),
+    )
+}
+
+#[test]
+fn definition_errors_expose_display_and_nested_sources() {
+    let plain = TableDefinitionError::InvalidHeaderMarker { raw: 0 };
+    assert!(plain.to_string().contains("table definition failed"));
+    assert!(plain.source().is_none());
+
+    let resource = TableDefinitionError::Resource(Error::Arithmetic {
+        operation: "test table definition source",
+    });
+    assert!(resource.source().is_some());
+
+    let index = IndexDefinitionError::Truncated {
+        offset: 1,
+        needed: 2,
+        length: 1,
+    };
+    assert!(index.to_string().contains("invalid table index definition"));
+    assert!(index.source().is_none());
+    assert!(TableDefinitionError::Index(index).source().is_some());
+
+    let index_resource = IndexDefinitionError::Resource(Error::Arithmetic {
+        operation: "test index definition source",
+    });
+    assert!(index_resource.source().is_some());
+
+    let map = LongValueMapError::MissingColumn { ordinal: 1 };
+    assert!(map.to_string().contains("long-value map suffix failed"));
+    assert!(map.source().is_none());
+    let map_row = LongValueMapError::InvalidMapRow {
+        ordinal: 1,
+        role: "owned",
+        locator: crate::MapRowLocator::new(PageNumber::new(2), 9),
+        source: UsageMapError::RowOutOfBounds {
+            row: 9,
+            row_count: 4,
+        },
+    };
+    assert!(map_row.source().is_some());
+    assert!(
+        TableDefinitionError::LongValueMap(map_row)
+            .source()
+            .is_some()
+    );
+}
+
+#[test]
+fn decodes_system_definition_under_exp_0073_relaxations() -> Result<(), Box<dyn std::error::Error>>
+{
+    let definition = decode(&database_bytes(&system_definition(), None))?;
+    assert_eq!(definition.kind(), TableDefinitionKind::System);
+    assert_eq!(definition.raw_header()[20], SYSTEM_MARKER);
+    let columns = definition.columns();
+    assert_eq!(columns.len(), 4);
+    assert_eq!(
+        columns[0].storage(),
+        ColumnStorageClass::Fixed { offset: 0 }
+    );
+    assert_eq!(columns[0].raw_class_flags(), 0x13);
+    assert_eq!(columns[0].sourced_constant(), 0);
+    assert_eq!(columns[0].raw_record()[5..7], [0, 0]);
+    assert_eq!(
+        columns[1].storage(),
+        ColumnStorageClass::Variable { index: 0 }
+    );
+    assert_eq!(columns[1].raw_class_flags(), 0x32);
+    assert_eq!(
+        columns[2].storage(),
+        ColumnStorageClass::Variable { index: 1 }
+    );
+    assert_eq!(columns[3].physical_type(), ColumnPhysicalType::Boolean);
+    assert!(!columns[0].auto_increment());
+
+    assert_eq!(definition.indexes()[0].kind(), IndexDefinitionKind::Primary);
+    assert_eq!(definition.physical_indexes()[0].raw_flags(), 1);
+    assert_eq!(definition.physical_indexes()[1].raw_flags(), 2);
+    assert!(!definition.physical_indexes()[1].unique());
+    assert!(!definition.physical_indexes()[1].required());
+
+    let mut user_flags = primary_definition();
+    user_flags[PHYSICAL_OFFSET + 38] = 2;
+    assert!(matches!(
+        decode(&database_bytes(&user_flags, None)),
+        Err(TableDefinitionError::Index(
+            IndexDefinitionError::UnsupportedPhysicalFlags { raw: 2, .. }
+        ))
+    ));
+
+    let maps = definition.long_value_maps();
+    assert_eq!(maps.len(), 1);
+    assert_eq!(maps[0].column().get(), 2);
+    assert_eq!(maps[0].owned().page(), PageNumber::new(MAP_PAGE as u64));
+    assert_eq!(maps[0].owned().row(), 2);
+    assert_eq!(maps[0].available().row(), 3);
+    assert_eq!(maps[0].raw_group(), &group(2, 2, 3, MAP_PAGE as u8));
+    assert_eq!(definition.raw_suffix(), &group(2, 2, 3, MAP_PAGE as u8));
+    Ok(())
+}
+
+#[test]
+fn rejects_column_constants_of_the_other_definition_kind() {
+    let system = system_definition();
+    let system_column = |ordinal: usize| COLUMN_ONLY_OFFSET + 16 + ordinal * 18;
+
+    let mut constant = system.clone();
+    constant[system_column(0) + 7] = 1;
+    assert!(matches!(
+        decode(&database_bytes(&constant, None)),
+        Err(TableDefinitionError::InvalidColumnConstant { ordinal: 0, raw: 1 })
+    ));
+
+    let mut repeat = system.clone();
+    repeat[system_column(1) + 5] = 1;
+    assert!(matches!(
+        decode(&database_bytes(&repeat, None)),
+        Err(TableDefinitionError::InvalidColumnOrdinal {
+            record: 1,
+            repeated: 1,
+            ..
+        })
+    ));
+
+    for class in [3, 7, 0x17, 0x33] {
+        let mut user_class = system.clone();
+        user_class[system_column(0) + 13] = class;
+        assert!(matches!(
+            decode(&database_bytes(&user_class, None)),
+            Err(TableDefinitionError::UnsupportedColumnClass { ordinal: 0, .. })
+        ));
+    }
+
+    let mut user = column_only_definition();
+    user[COLUMN_ONLY_OFFSET + 13] = 0x13;
+    assert!(matches!(
+        decode(&database_bytes(&user, None)),
+        Err(TableDefinitionError::UnsupportedColumnClass {
+            ordinal: 0,
+            raw: 0x13,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn decodes_long_value_maps_in_stored_order_and_rejects_corruption()
+-> Result<(), Box<dyn std::error::Error>> {
+    let page = MAP_PAGE as u8;
+    let mut suffix = Vec::new();
+    suffix.extend_from_slice(&group(2, 0, 1, page));
+    suffix.extend_from_slice(&group(1, 2, 3, page));
+    let definition = decode(&database_bytes(&long_value_definition(&suffix), None))?;
+    let maps = definition.long_value_maps();
+    assert_eq!(maps.len(), 2);
+    assert_eq!(maps[0].column().get(), 2);
+    assert_eq!(maps[1].column().get(), 1);
+    assert_eq!(maps[1].owned().row(), 2);
+    assert_eq!(maps[1].available().row(), 3);
+
+    let decode_suffix =
+        |suffix: &[u8]| decode(&database_bytes(&long_value_definition(suffix), None));
+    let map_error = |suffix: &[u8]| match decode_suffix(suffix) {
+        Err(TableDefinitionError::LongValueMap(error)) => Some(error),
+        _ => None,
+    };
+    assert!(matches!(
+        map_error(&suffix[..19]),
+        Some(LongValueMapError::InvalidSuffixLength { length: 19 })
+    ));
+    assert!(matches!(
+        map_error(&group(1, 0, 1, page)),
+        Some(LongValueMapError::MissingColumn { ordinal: 2 })
+    ));
+    let mut both = Vec::new();
+    both.extend_from_slice(&group(1, 0, 1, page));
+    both.extend_from_slice(&group(1, 0, 1, page));
+    assert!(matches!(
+        map_error(&both),
+        Some(LongValueMapError::DuplicateColumn { ordinal: 1 })
+    ));
+    let mut out_of_range = suffix.clone();
+    out_of_range[..2].copy_from_slice(&5_u16.to_le_bytes());
+    assert!(matches!(
+        map_error(&out_of_range),
+        Some(LongValueMapError::InvalidColumnOrdinal {
+            group: 0,
+            ordinal: 5,
+            column_count: 3,
+        })
+    ));
+    let mut scalar = suffix.clone();
+    scalar[..2].copy_from_slice(&0_u16.to_le_bytes());
+    assert!(matches!(
+        map_error(&scalar),
+        Some(LongValueMapError::NotLongValueColumn {
+            ordinal: 0,
+            physical_type: ColumnPhysicalType::Long,
+        })
+    ));
+    let mut zero_page = suffix.clone();
+    zero_page[3] = 0;
+    assert!(matches!(
+        map_error(&zero_page),
+        Some(LongValueMapError::InvalidReference {
+            role: "owned",
+            source: None,
+            ..
+        })
+    ));
+    let mut beyond = suffix.clone();
+    beyond[7] = 99;
+    assert!(matches!(
+        map_error(&beyond),
+        Some(LongValueMapError::InvalidReference {
+            role: "available",
+            source: Some(_),
+            ..
+        })
+    ));
+    let mut wrong_kind = suffix.clone();
+    wrong_kind[3] = INDEX_ROOT as u8;
+    assert!(matches!(
+        map_error(&wrong_kind),
+        Some(LongValueMapError::InvalidMapRow {
+            ordinal: 2,
+            role: "owned",
+            source: UsageMapError::ExpectedDataPage { .. },
+            ..
+        })
+    ));
+    let mut missing_row = suffix;
+    missing_row[16] = 9;
+    assert!(matches!(
+        map_error(&missing_row),
+        Some(LongValueMapError::InvalidMapRow {
+            ordinal: 1,
+            role: "available",
+            source: UsageMapError::RowOutOfBounds { row: 9, .. },
+            ..
+        })
+    ));
+    Ok(())
+}

--- a/crates/jet3/src/table_definition_system_tests.rs
+++ b/crates/jet3/src/table_definition_system_tests.rs
@@ -26,6 +26,10 @@ fn ordinary_logical(physical_index: u32, class: u8) -> [u8; 20] {
 /// An `MSysACEs`-shaped system definition plus one Memo column, with the
 /// `EXP-0073` primary over unique-only flags and one `0x02`-flagged index.
 fn system_definition() -> Vec<u8> {
+    system_definition_with_first_flags(1)
+}
+
+fn system_definition_with_first_flags(first_flags: u8) -> Vec<u8> {
     let columns: Vec<ColumnSpec> = vec![
         (4, 0x13, 0, 4, b"ObjectId".to_vec()),
         (9, 0x32, 0, 255, b"SID".to_vec()),
@@ -37,7 +41,7 @@ fn system_definition() -> Vec<u8> {
     build_definition(
         SYSTEM_MARKER,
         &columns,
-        &[physical_index(1), relationship_like],
+        &[physical_index(first_flags), relationship_like],
         &[
             (ordinary_logical(0, 1), b"ObjectId"),
             (ordinary_logical(1, 0), b"SID"),
@@ -123,6 +127,16 @@ fn decodes_system_definition_under_exp_0073_relaxations() -> Result<(), Box<dyn 
     assert_eq!(definition.physical_indexes()[1].raw_flags(), 2);
     assert!(!definition.physical_indexes()[1].unique());
     assert!(!definition.physical_indexes()[1].required());
+
+    assert!(matches!(
+        decode(&database_bytes(
+            &system_definition_with_first_flags(3),
+            None
+        )),
+        Err(TableDefinitionError::Index(
+            IndexDefinitionError::UnsupportedPhysicalFlags { raw: 3, .. }
+        ))
+    ));
 
     let mut user_flags = primary_definition();
     user_flags[PHYSICAL_OFFSET + 38] = 2;

--- a/crates/jet3/src/table_definition_tests.rs
+++ b/crates/jet3/src/table_definition_tests.rs
@@ -563,9 +563,12 @@ fn rejects_each_logical_index_class_invariant() -> Result<(), Box<dyn std::error
 
     let mut unique_only = primary;
     unique_only[PHYSICAL_OFFSET + 38] = 1;
-    let definition = decode(&database_bytes(&unique_only, None))?;
-    assert_eq!(definition.indexes()[0].kind(), IndexDefinitionKind::Primary);
-    assert!(!definition.physical_indexes()[0].required());
+    assert!(matches!(
+        decode(&database_bytes(&unique_only, None)),
+        Err(TableDefinitionError::Index(
+            IndexDefinitionError::InvalidPrimaryFlags { raw: 1, .. }
+        ))
+    ));
 
     let relationship = relationship_definition();
     for (offset, value) in [

--- a/crates/jet3/src/table_definition_tests.rs
+++ b/crates/jet3/src/table_definition_tests.rs
@@ -1,14 +1,16 @@
-use super::TableDefinitionError;
+use super::{TableDefinitionError, TableDefinitionKind};
 use crate::{
     AllocationTraversalError, ByteCount, ColumnPhysicalType, ColumnStorageClass, DatabaseReader,
-    Error, IndexDefinitionError, IndexDefinitionKind, IndexDirection, JET3_PAGE_SIZE, PageNumber,
-    ReadLimits, RelationshipSide, ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource,
+    Error, IndexDefinitionError, IndexDefinitionKind, IndexDirection, JET3_PAGE_SIZE,
+    LongValueMapError, PageNumber, ReadLimits, RelationshipSide, ResourceBudget, ResourceLimitKind,
+    ResourceLimits, SliceSource,
 };
 use std::error::Error as _;
 
 const PAGE_BYTES: usize = JET3_PAGE_SIZE.get() as usize;
 const ROOT: usize = 1;
 const MAP_PAGE: usize = 2;
+const MAP_ROWS: u16 = 4;
 const INDEX_ROOT: usize = 3;
 const CONTINUATION: usize = 4;
 const RELATED_ROOT: usize = 5;
@@ -16,6 +18,80 @@ const COLUMN_ONLY_OFFSET: usize = 43;
 const COLUMN_OFFSET: usize = 51;
 const PHYSICAL_OFFSET: usize = COLUMN_OFFSET + 18 + 3;
 const LOGICAL_OFFSET: usize = PHYSICAL_OFFSET + 39;
+const USER_MARKER: u8 = 0x4e;
+const SYSTEM_MARKER: u8 = 0x53;
+
+/// One column for [`build_definition`]: type, class, fixed offset, size, name.
+type ColumnSpec = (u8, u8, u16, u16, Vec<u8>);
+
+/// Builds a complete logical definition under either marker, deriving the
+/// variable counters, the marker-specific constant and ordinal repeat, and
+/// the header counts from the supplied records.
+fn build_definition(
+    marker: u8,
+    columns: &[ColumnSpec],
+    physical: &[[u8; 39]],
+    logical: &[([u8; 20], &[u8])],
+    suffix: &[u8],
+) -> Vec<u8> {
+    let mut bytes = definition_header(logical.len() as u16, physical.len() as u16);
+    bytes[20] = marker;
+    let variable_count = columns.iter().filter(|column| column.1 & 7 == 2).count() as u16;
+    bytes[21..23].copy_from_slice(&(columns.len() as u16).to_le_bytes());
+    bytes[23..25].copy_from_slice(&variable_count.to_le_bytes());
+    bytes[25..27].copy_from_slice(&(columns.len() as u16).to_le_bytes());
+    bytes.extend(std::iter::repeat_n(0, physical.len() * 8));
+    let mut variables_seen = 0_u16;
+    for (ordinal, (physical_type, class, fixed_offset, size, _)) in columns.iter().enumerate() {
+        let ordinal = ordinal as u16;
+        let mut record = column_record(*physical_type, *class, *fixed_offset, *size);
+        record[1..3].copy_from_slice(&ordinal.to_le_bytes());
+        if marker == SYSTEM_MARKER {
+            record[5..7].fill(0);
+            record[7..9].fill(0);
+        } else {
+            record[5..7].copy_from_slice(&ordinal.to_le_bytes());
+        }
+        record[3..5].copy_from_slice(&variables_seen.to_le_bytes());
+        if class & 7 == 2 {
+            variables_seen += 1;
+        }
+        bytes.extend_from_slice(&record);
+    }
+    for (_, _, _, _, name) in columns {
+        bytes.push(name.len() as u8);
+        bytes.extend_from_slice(name);
+    }
+    for record in physical {
+        bytes.extend_from_slice(record);
+    }
+    for (record, _) in logical {
+        bytes.extend_from_slice(record);
+    }
+    for (_, name) in logical {
+        bytes.push(name.len() as u8);
+        bytes.extend_from_slice(name);
+    }
+    bytes.extend_from_slice(suffix);
+    finish(bytes)
+}
+
+fn group(ordinal: u16, owned_row: u8, available_row: u8, page: u8) -> [u8; 10] {
+    let [low, high] = ordinal.to_le_bytes();
+    [low, high, owned_row, page, 0, 0, available_row, page, 0, 0]
+}
+
+/// A definition whose column records and suffix span two pages.
+fn many_memo_definition() -> Vec<u8> {
+    let columns: Vec<ColumnSpec> = (0..120_u16)
+        .map(|ordinal| (12, 2, 0, 0, format!("M{ordinal}").into_bytes()))
+        .collect();
+    let suffix: Vec<u8> = (0..120_u16)
+        .rev()
+        .flat_map(|ordinal| group(ordinal, 0, 1, MAP_PAGE as u8))
+        .collect();
+    build_definition(USER_MARKER, &columns, &[], &[], &suffix)
+}
 
 fn column_record(physical_type: u8, class: u8, fixed_offset: u16, size: u16) -> [u8; 18] {
     let mut record = [0_u8; 18];
@@ -53,10 +129,14 @@ fn column_only_definition() -> Vec<u8> {
 }
 
 fn custom_column_definition(record: [u8; 18], variable_count: u16) -> Vec<u8> {
+    let physical_type = record[0];
     let mut bytes = definition_header(0, 0);
     bytes[23..25].copy_from_slice(&variable_count.to_le_bytes());
     bytes.extend_from_slice(&record);
     bytes.extend_from_slice(&[2, b'I', b'd']);
+    if matches!(physical_type, 11 | 12) {
+        bytes.extend_from_slice(&group(0, 0, 1, MAP_PAGE as u8));
+    }
     finish(bytes)
 }
 
@@ -148,7 +228,13 @@ fn database_bytes(logical: &[u8], next: Option<usize>) -> Vec<u8> {
             .unwrap_or_default()
             .to_le_bytes(),
     );
-    bytes[MAP_PAGE * PAGE_BYTES] = 1;
+    let map = &mut bytes[MAP_PAGE * PAGE_BYTES..(MAP_PAGE + 1) * PAGE_BYTES];
+    map[0] = 1;
+    map[8..10].copy_from_slice(&MAP_ROWS.to_le_bytes());
+    for row in 0..usize::from(MAP_ROWS) {
+        let start = (PAGE_BYTES - 8 * (row + 1)) as u16;
+        map[10 + 2 * row..12 + 2 * row].copy_from_slice(&start.to_le_bytes());
+    }
     bytes[INDEX_ROOT * PAGE_BYTES] = 4;
     bytes[RELATED_ROOT * PAGE_BYTES] = 2;
     if logical.len() > PAGE_BYTES {
@@ -198,6 +284,8 @@ fn decodes_fixed_column_and_primary_index_losslessly() -> Result<(), Box<dyn std
     );
     assert_eq!(definition.maps().available().row(), 1);
     assert_eq!(definition.raw_header()[20], 0x4e);
+    assert_eq!(definition.kind(), TableDefinitionKind::User);
+    assert!(definition.long_value_maps().is_empty());
     assert_eq!(definition.columns().len(), 1);
     let column = &definition.columns()[0];
     assert_eq!(column.name().decoded_ascii(), Some("Id"));
@@ -306,14 +394,15 @@ fn preserves_primary_relationship_side() -> Result<(), Box<dyn std::error::Error
 #[test]
 fn follows_exact_multi_page_chain_and_rejects_chain_corruption()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut logical = column_only_definition();
-    logical.splice(logical.len() - 2..logical.len() - 2, vec![0x5a; PAGE_BYTES]);
+    let logical = many_memo_definition();
+    assert!(logical.len() > PAGE_BYTES);
     let length = u32::try_from(logical.len())?;
-    logical[8..12].copy_from_slice(&length.to_le_bytes());
     let bytes = database_bytes(&logical, Some(CONTINUATION));
     let definition = decode(&bytes)?;
     assert_eq!(definition.logical_length(), length);
-    assert_eq!(definition.raw_suffix().len(), PAGE_BYTES);
+    assert_eq!(definition.raw_suffix().len(), 1200);
+    assert_eq!(definition.long_value_maps().len(), 120);
+    assert_eq!(definition.long_value_maps()[0].column().get(), 119);
 
     let truncated = database_bytes(&logical, None);
     assert!(matches!(
@@ -452,7 +541,7 @@ fn rejects_each_logical_index_class_invariant() -> Result<(), Box<dyn std::error
         (LOGICAL_OFFSET + 8, 1),
         (LOGICAL_OFFSET, 1),
         (LOGICAL_OFFSET + 9, 0),
-        (PHYSICAL_OFFSET + 38, 1),
+        (PHYSICAL_OFFSET + 38, 8),
         (LOGICAL_OFFSET + 19, 3),
     ];
     for &(offset, value) in cases {
@@ -464,13 +553,19 @@ fn rejects_each_logical_index_class_invariant() -> Result<(), Box<dyn std::error
         ));
     }
 
-    let mut ordinary = primary;
+    let mut ordinary = primary.clone();
     ordinary[LOGICAL_OFFSET + 19] = 0;
     let definition = decode(&database_bytes(&ordinary, None))?;
     assert_eq!(
         definition.indexes()[0].kind(),
         IndexDefinitionKind::Ordinary
     );
+
+    let mut unique_only = primary;
+    unique_only[PHYSICAL_OFFSET + 38] = 1;
+    let definition = decode(&database_bytes(&unique_only, None))?;
+    assert_eq!(definition.indexes()[0].kind(), IndexDefinitionKind::Primary);
+    assert!(!definition.physical_indexes()[0].required());
 
     let relationship = relationship_definition();
     for (offset, value) in [
@@ -567,32 +662,6 @@ fn boolean_fixed_offset_does_not_advance_byte_backed_columns()
 }
 
 #[test]
-fn definition_errors_expose_display_and_nested_sources() {
-    let plain = TableDefinitionError::InvalidHeaderMarker { raw: 0 };
-    assert!(plain.to_string().contains("table definition failed"));
-    assert!(plain.source().is_none());
-
-    let resource = TableDefinitionError::Resource(Error::Arithmetic {
-        operation: "test table definition source",
-    });
-    assert!(resource.source().is_some());
-
-    let index = IndexDefinitionError::Truncated {
-        offset: 1,
-        needed: 2,
-        length: 1,
-    };
-    assert!(index.to_string().contains("invalid table index definition"));
-    assert!(index.source().is_none());
-    assert!(TableDefinitionError::Index(index).source().is_some());
-
-    let index_resource = IndexDefinitionError::Resource(Error::Arithmetic {
-        operation: "test index definition source",
-    });
-    assert!(index_resource.source().is_some());
-}
-
-#[test]
 fn rejects_truncated_counts_duplicate_keys_and_out_of_range_references() {
     let mut logical = column_only_definition();
     logical[21..23].copy_from_slice(&2_u16.to_le_bytes());
@@ -641,6 +710,11 @@ fn exact_allocation_item_and_chain_budgets_reject_one_over()
                 kind: ResourceLimitKind::AllocationBytes,
                 ..
             }
+        )) | Err(TableDefinitionError::LongValueMap(
+            LongValueMapError::Resource(Error::ResourceLimitExceeded {
+                kind: ResourceLimitKind::AllocationBytes,
+                ..
+            })
         )) | Err(TableDefinitionError::Chain(
             AllocationTraversalError::Resource(Error::ResourceLimitExceeded {
                 kind: ResourceLimitKind::AllocationBytes,
@@ -657,6 +731,11 @@ fn exact_allocation_item_and_chain_budgets_reject_one_over()
                 kind: ResourceLimitKind::ItemWork,
                 ..
             }
+        )) | Err(TableDefinitionError::LongValueMap(
+            LongValueMapError::Resource(Error::ResourceLimitExceeded {
+                kind: ResourceLimitKind::ItemWork,
+                ..
+            })
         )) | Err(TableDefinitionError::Index(IndexDefinitionError::Resource(
             Error::ResourceLimitExceeded {
                 kind: ResourceLimitKind::ItemWork,
@@ -665,11 +744,7 @@ fn exact_allocation_item_and_chain_budgets_reject_one_over()
         )))
     ));
 
-    let mut logical = column_only_definition();
-    logical.splice(logical.len() - 2..logical.len() - 2, vec![0; PAGE_BYTES]);
-    let length = u32::try_from(logical.len())?;
-    logical[8..12].copy_from_slice(&length.to_le_bytes());
-    let chained = database_bytes(&logical, Some(CONTINUATION));
+    let chained = database_bytes(&many_memo_definition(), Some(CONTINUATION));
     decode_with_limits(&chained, limits(&chained).with_max_chain_depth(2))?;
     assert!(matches!(
         decode_with_limits(&chained, limits(&chained).with_max_chain_depth(1)),
@@ -682,3 +757,6 @@ fn exact_allocation_item_and_chain_budgets_reject_one_over()
     ));
     Ok(())
 }
+
+#[path = "table_definition_system_tests.rs"]
+mod system;

--- a/crates/jet3/src/table_definition_writer_tests.rs
+++ b/crates/jet3/src/table_definition_writer_tests.rs
@@ -52,15 +52,49 @@ fn spec<'a>(
     physical_indexes: &'a [PhysicalIndexSpec<'a>],
     indexes: &'a [LogicalIndexSpec<'a>],
 ) -> TableDefinitionSpec<'a> {
+    let raw_suffix = if columns.iter().any(|column| {
+        matches!(
+            column.physical_type(),
+            ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
+        )
+    }) {
+        &LONG_VALUE_SUFFIX[..]
+    } else {
+        &[]
+    };
     TableDefinitionSpec {
         columns,
         physical_indexes,
         indexes,
         owned_map: MapRowLocator::new(PageNumber::new(MAP_PAGE), 0),
         available_map: MapRowLocator::new(PageNumber::new(MAP_PAGE), 1),
-        raw_suffix: &[7, 7],
+        raw_suffix,
     }
 }
+
+/// One long-value map group each for `Ole` (ordinal 11) and `Notes` (12).
+const LONG_VALUE_SUFFIX: [u8; 20] = [
+    11,
+    0,
+    2,
+    MAP_PAGE as u8,
+    0,
+    0,
+    3,
+    MAP_PAGE as u8,
+    0,
+    0,
+    12,
+    0,
+    2,
+    MAP_PAGE as u8,
+    0,
+    0,
+    3,
+    MAP_PAGE as u8,
+    0,
+    0,
+];
 
 fn decode(logical: &[u8]) -> Result<TableDefinition, Box<dyn std::error::Error>> {
     let mut bytes = vec![0_u8; 6 * PAGE_BYTES];
@@ -71,7 +105,13 @@ fn decode(logical: &[u8]) -> Result<TableDefinition, Box<dyn std::error::Error>>
     ]);
     let root = ROOT as usize * PAGE_BYTES;
     bytes[root..root + logical.len()].copy_from_slice(logical);
-    bytes[MAP_PAGE as usize * PAGE_BYTES] = 1;
+    let map = &mut bytes[MAP_PAGE as usize * PAGE_BYTES..(MAP_PAGE as usize + 1) * PAGE_BYTES];
+    map[0] = 1;
+    map[8..10].copy_from_slice(&4_u16.to_le_bytes());
+    for row in 0..4 {
+        let start = (PAGE_BYTES - 8 * (row + 1)) as u16;
+        map[10 + 2 * row..12 + 2 * row].copy_from_slice(&start.to_le_bytes());
+    }
     bytes[INDEX_ROOT as usize * PAGE_BYTES] = 4;
     bytes[RELATED_ROOT as usize * PAGE_BYTES] = 2;
     let mut budget = ResourceBudget::new(ResourceLimits::new(ReadLimits::new(
@@ -139,7 +179,8 @@ fn round_trips_every_column_type_and_index_kind() -> Result<(), Box<dyn std::err
     assert_eq!(decoded.logical_length(), length.get() as u32);
     assert_eq!(decoded.maps().owned().page(), PageNumber::new(MAP_PAGE));
     assert_eq!(decoded.maps().available().row(), 1);
-    assert_eq!(decoded.raw_suffix(), &[7, 7]);
+    assert_eq!(decoded.raw_suffix(), &LONG_VALUE_SUFFIX);
+    assert_eq!(decoded.long_value_maps().len(), 2);
     assert_eq!(decoded.columns().len(), columns.len());
     for (column, expected) in decoded.columns().iter().zip(&columns) {
         assert_eq!(column.name().raw_bytes(), expected.name());

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -43,13 +43,12 @@ delivered in this order:
 
 ## Current next step
 
-Continue #100 from the accepted EXP-0073 system-catalog result. It supplies
-the system table definitions, a page-role map for the empty image (page 7
-excepted), the system row encodings, and full attribution of the create,
-index, query, and relationship transitions. The next writer step is the
-crate-private bootstrap composer that generates the empty image and the
-create transition from those semantics, validated later by DAO endpoints
-under a fresh preregistration. The raw definition suffix and page 7 remain
-uninterpreted and are the first candidates for a follow-up experiment.
-#102 is the separate hosted write differential after database creation is
-complete.
+Continue #100 with the crate-private bootstrap composer. The reader now
+accepts the EXP-0073 system definitions and decodes and validates the
+per-column long-value maps accepted by EXP-0077, including the map that
+assigns empty-image page 7. The composer is the next writer step: generate
+the empty image and create transition from those accepted semantics, adding
+typed system-marker and suffix encoding where the composition needs it.
+Validate the resulting writer behavior later through DAO endpoints under a
+fresh preregistration. #102 remains the separate hosted write differential
+after database creation is complete.

--- a/fuzz/fuzz_targets/table_definition_parsing.rs
+++ b/fuzz/fuzz_targets/table_definition_parsing.rs
@@ -1,7 +1,8 @@
 #![no_main]
 
 // Every database byte is project-authored synthetic input. Physical assertions
-// are limited to SRC-0020, EXP-0057, and development-only EXP-0059.
+// are limited to SRC-0020, EXP-0057, and development-only EXP-0059, EXP-0073,
+// and EXP-0077.
 
 use std::hint::black_box;
 
@@ -19,14 +20,10 @@ const CONTROL_BYTES: usize = 6;
 fuzz_target!(|data: &[u8]| {
     let mut bytes = [0_u8; DATABASE_BYTES];
     supported_header(&mut bytes);
-    relationship_definition(&mut bytes);
+    relationship_definition(&mut bytes, selector(data.get(5).copied()) & 1 != 0);
     let payload = data.get(CONTROL_BYTES..).unwrap_or_default();
     if !payload.starts_with(b"valid-definition") && !payload.starts_with(b"tight-resources") {
-        mutate_selected_region(
-            &mut bytes,
-            selector(data.get(5).copied()) % 5,
-            payload,
-        );
+        mutate_selected_region(&mut bytes, selector(data.get(5).copied()) % 6, payload);
     }
 
     let limits = ResourceLimits::new(ReadLimits::default())
@@ -49,7 +46,14 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
     black_box(definition.logical_length());
+    black_box(definition.kind());
     black_box(definition.raw_suffix());
+    for map in definition.long_value_maps() {
+        black_box(map.column());
+        black_box(map.owned());
+        black_box(map.available());
+        black_box(map.raw_group());
+    }
     for column in definition.columns() {
         black_box(column.name().raw_bytes());
         black_box(column.physical_type().raw());
@@ -77,27 +81,50 @@ fn supported_header(bytes: &mut [u8; DATABASE_BYTES]) {
     ]);
 }
 
-fn relationship_definition(bytes: &mut [u8; DATABASE_BYTES]) {
-    let mut logical = [0x5a_u8; PAGE_BYTES + 34];
-    logical[..43].fill(0);
+/// A two-page user or system definition with one Memo column, one long-value
+/// map group, and one relationship index.
+fn relationship_definition(bytes: &mut [u8; DATABASE_BYTES], system: bool) {
+    const COLUMN_COUNT: u16 = 100;
+    const MEMO_ORDINAL: u16 = COLUMN_COUNT - 1;
+    let mut logical = Vec::with_capacity(PAGE_BYTES + 512);
+    logical.extend_from_slice(&[0_u8; 43]);
     logical[..4].copy_from_slice(&[0x02, 0x01, 0x56, 0x43]);
     logical[4..8].copy_from_slice(&4_u32.to_le_bytes());
-    logical[20] = 0x4e;
-    logical[21..23].copy_from_slice(&1_u16.to_le_bytes());
-    logical[25..27].copy_from_slice(&1_u16.to_le_bytes());
+    logical[20] = if system { 0x53 } else { 0x4e };
+    logical[21..23].copy_from_slice(&COLUMN_COUNT.to_le_bytes());
+    logical[23..25].copy_from_slice(&1_u16.to_le_bytes());
+    logical[25..27].copy_from_slice(&COLUMN_COUNT.to_le_bytes());
     logical[27..29].copy_from_slice(&1_u16.to_le_bytes());
     logical[31..33].copy_from_slice(&1_u16.to_le_bytes());
     logical[35..39].copy_from_slice(&[0, 2, 0, 0]);
     logical[39..43].copy_from_slice(&[1, 2, 0, 0]);
-    logical[43..51].fill(0);
-    let mut column = [0_u8; 18];
-    column[0] = 4;
-    column[7..9].copy_from_slice(&1_u16.to_le_bytes());
-    column[9..13].copy_from_slice(&[0x09, 0x04, 0xe4, 0x04]);
-    column[13] = 3;
-    column[16..18].copy_from_slice(&4_u16.to_le_bytes());
-    logical[51..69].copy_from_slice(&column);
-    logical[69..72].copy_from_slice(&[2, b'I', b'd']);
+    logical.extend_from_slice(&[0_u8; 8]);
+    for ordinal in 0..COLUMN_COUNT {
+        let mut column = [0_u8; 18];
+        column[0] = if ordinal == MEMO_ORDINAL { 12 } else { 4 };
+        column[1..3].copy_from_slice(&ordinal.to_le_bytes());
+        if !system {
+            column[5..7].copy_from_slice(&ordinal.to_le_bytes());
+            column[7..9].copy_from_slice(&1_u16.to_le_bytes());
+        }
+        column[9..13].copy_from_slice(&[0x09, 0x04, 0xe4, 0x04]);
+        column[13] = match (system, ordinal == MEMO_ORDINAL) {
+            (false, false) => 3,
+            (false, true) => 2,
+            (true, false) => 0x13,
+            (true, true) => 0x12,
+        };
+        if ordinal != MEMO_ORDINAL {
+            column[14..16].copy_from_slice(&(ordinal * 4).to_le_bytes());
+            column[16..18].copy_from_slice(&4_u16.to_le_bytes());
+        }
+        logical.extend_from_slice(&column);
+    }
+    for ordinal in 0..COLUMN_COUNT {
+        let name = format!("C{ordinal}");
+        logical.push(name.len() as u8);
+        logical.extend_from_slice(name.as_bytes());
+    }
     let mut physical = [0_u8; 39];
     for slot in 0..10 {
         physical[slot * 3..slot * 3 + 2].copy_from_slice(&u16::MAX.to_le_bytes());
@@ -106,21 +133,31 @@ fn relationship_definition(bytes: &mut [u8; DATABASE_BYTES]) {
     physical[2] = 1;
     physical[31..34].copy_from_slice(&[2, 0, 0]);
     physical[34..38].copy_from_slice(&3_u32.to_le_bytes());
-    logical[72..111].copy_from_slice(&physical);
+    physical[38] = if system { 2 } else { 0 };
+    logical.extend_from_slice(&physical);
     let mut index = [0_u8; 20];
     index[8] = 2;
     index[9..13].copy_from_slice(&1_u32.to_le_bytes());
     index[13..17].copy_from_slice(&5_u32.to_le_bytes());
     index[17..19].copy_from_slice(&[1, 1]);
     index[19] = 2;
-    logical[111..131].copy_from_slice(&index);
-    logical[131..135].copy_from_slice(&[3, b'R', b'e', b'l']);
-    logical[PAGE_BYTES + 32..].copy_from_slice(&[0xff, 0xff]);
+    logical.extend_from_slice(&index);
+    logical.extend_from_slice(&[3, b'R', b'e', b'l']);
+    let [low, high] = MEMO_ORDINAL.to_le_bytes();
+    logical.extend_from_slice(&[low, high, 2, 2, 0, 0, 3, 2, 0, 0, 0xff, 0xff]);
     let logical_length = logical.len() as u32;
     logical[8..12].copy_from_slice(&logical_length.to_le_bytes());
+    assert!(logical.len() > PAGE_BYTES);
+    assert!(logical.len() - PAGE_BYTES <= PAGE_BYTES - 8);
 
     bytes[PAGE_BYTES..2 * PAGE_BYTES].copy_from_slice(&logical[..PAGE_BYTES]);
-    bytes[2 * PAGE_BYTES] = 1;
+    let map = &mut bytes[2 * PAGE_BYTES..3 * PAGE_BYTES];
+    map[0] = 1;
+    map[8..10].copy_from_slice(&4_u16.to_le_bytes());
+    for row in 0..4 {
+        let start = (PAGE_BYTES - 8 * (row + 1)) as u16;
+        map[10 + 2 * row..12 + 2 * row].copy_from_slice(&start.to_le_bytes());
+    }
     bytes[3 * PAGE_BYTES] = 4;
     let continuation = &mut bytes[4 * PAGE_BYTES..5 * PAGE_BYTES];
     continuation[..4].copy_from_slice(&[0x02, 0x01, 0x56, 0x43]);
@@ -137,7 +174,8 @@ fn mutate_selected_region(bytes: &mut [u8; DATABASE_BYTES], mode: u8, payload: &
         1 => (4 * PAGE_BYTES, PAGE_BYTES),
         2 => (2 * PAGE_BYTES, PAGE_BYTES),
         3 => (3 * PAGE_BYTES, PAGE_BYTES),
-        _ => (5 * PAGE_BYTES, PAGE_BYTES),
+        4 => (5 * PAGE_BYTES, PAGE_BYTES),
+        _ => (0, PAGE_BYTES),
     };
     let length = payload.len().min(maximum);
     bytes[start..start + length].copy_from_slice(&payload[..length]);


### PR DESCRIPTION
The reader still rejected the system table definitions and treated their per-column long-value maps as opaque, even though EXP-0073 and EXP-0077 established the bounded grammar needed by the bootstrap work. That also kept the inspect tool from decoding the four system tables.

This change gates the observed system relaxations on the system marker while keeping user definitions strict. It decodes the 10-byte Memo/LongBinary map groups with exact column coverage, bounded linear work, checked locators, and active map-row validation. Index-flag handling retains the EXP-0073 system-only bit without assigning semantics, and inspect now reports definition kinds and typed long-value maps. Synthetic fixtures, corruption/resource boundaries, writer round trips, and the fuzz target cover both user and system shapes.

Validation:
- just ready
- cargo +nightly-2026-07-20 fuzz run table_definition_parsing fuzz/corpus/table_definition_parsing --fuzz-dir fuzz -- -runs=3
- retained EXP-0073 relationship checkpoint decoded locally: four system and two user definitions

The retained-artifact check is development evidence only; this PR makes no compatibility, support, or support-matrix claim.

Refs #100