### PR TITLE
feat(jet3): compute catalog name index keys instead of storing them

### DIFF
--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -16,6 +16,7 @@
 
 use std::fmt;
 
+use crate::catalog_name_key::{CatalogNameKeyError, encode_catalog_name_key};
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 use crate::whole_file_plan::{WholeFileImagePlan, WholeFilePlanError};
 use crate::{
@@ -79,20 +80,6 @@ const DATABASE_HEADER_FIXED_OPAQUE: [u8; 126] = [
 const ALPHA_LVPROP_PAYLOAD: &[u8] =
     b"KKD\x00\x10\x00\x00\x00\x80\x00\x08\x00Required\x17\x00\x00\x00\x01\x00\x08\x00\x00\x00\x02\x00Id\x09\x00\x01\x01\x00\x00\x01\x00\x00";
 
-// EXP-0079 records complete lossless keys for only the fixed bootstrap rows.
-// Their component and text encodings remain uninterpreted.
-const PARENT_NAME_KEYS: [&[u8]; 9] = [
-    b"\x7f\x8f\x00\x00\x00\x7f\x77\x60\x61\x6d\x66\x76\x00",
-    b"\x7f\x8f\x00\x00\x00\x7f\x64\x60\x77\x60\x61\x60\x76\x66\x76\x00",
-    b"\x7f\x8f\x00\x00\x00\x7f\x75\x66\x6d\x60\x77\x6a\x72\x70\x76\x69\x6a\x73\x76\x00",
-    b"\x7f\x8f\x00\x00\x02\x7f\x6f\x76\x7d\x76\x64\x61\x00",
-    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x72\x61\x6b\x66\x62\x77\x76\x00",
-    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x60\x62\x66\x76\x00",
-    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x74\x78\x66\x75\x6a\x66\x76\x00",
-    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x75\x66\x6d\x60\x77\x6a\x72\x70\x76\x69\x6a\x73\x76\x00",
-    b"\x7f\x8f\x00\x00\x01\x7f\x60\x6d\x73\x69\x60\x00",
-];
-
 const TABLES_ID: i32 = 0x0f00_0001;
 const DATABASES_ID: i32 = 0x0f00_0002;
 const RELATIONSHIPS_ID: i32 = 0x0f00_0003;
@@ -109,7 +96,7 @@ pub(crate) enum BootstrapComposeError {
     WholeFile(WholeFilePlanError),
     Encoding(Error),
     IndexPageFull { needed: usize, available: usize },
-    IndexKeyTooLong { needed: usize, available: usize },
+    NameKey(CatalogNameKeyError),
 }
 
 impl fmt::Display for BootstrapComposeError {
@@ -127,7 +114,8 @@ impl std::error::Error for BootstrapComposeError {
             Self::Row(source) => Some(source),
             Self::WholeFile(source) => Some(source),
             Self::Encoding(source) => Some(source),
-            Self::IndexPageFull { .. } | Self::IndexKeyTooLong { .. } => None,
+            Self::NameKey(source) => Some(source),
+            Self::IndexPageFull { .. } => None,
         }
     }
 }
@@ -160,6 +148,11 @@ impl From<WholeFilePlanError> for BootstrapComposeError {
 impl From<Error> for BootstrapComposeError {
     fn from(source: Error) -> Self {
         Self::Encoding(source)
+    }
+}
+impl From<CatalogNameKeyError> for BootstrapComposeError {
+    fn from(source: CatalogNameKeyError) -> Self {
+        Self::NameKey(source)
     }
 }
 
@@ -461,29 +454,28 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
     },
 ];
 
+const ALPHA_SEED: CatalogSeed = CatalogSeed {
+    id: ALPHA_ROOT as i32,
+    parent: TABLES_ID,
+    name: b"Alpha",
+    kind: 1,
+    owner: CATALOG_OWNER_0301,
+};
+
+/// Returns the catalog rows the composed image holds, in stored row order.
+fn catalog_seeds(alpha: bool) -> impl Iterator<Item = CatalogSeed> {
+    CATALOG_SEEDS.into_iter().chain(alpha.then_some(ALPHA_SEED))
+}
+
 fn objects_data_page(
     alpha: bool,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
-    for seed in CATALOG_SEEDS {
-        let length = encode_catalog_row(seed, None, &mut row, budget)?;
-        builder.append_row(&row[..length], budget)?;
-    }
-    if alpha {
-        let length = encode_catalog_row(
-            CatalogSeed {
-                id: ALPHA_ROOT as i32,
-                parent: TABLES_ID,
-                name: b"Alpha",
-                kind: 1,
-                owner: CATALOG_OWNER_0301,
-            },
-            Some(alpha_long_value_header()),
-            &mut row,
-            budget,
-        )?;
+    for seed in catalog_seeds(alpha) {
+        let lvprop = (seed.id == ALPHA_ROOT as i32).then(alpha_long_value_header);
+        let length = encode_catalog_row(seed, lvprop, &mut row, budget)?;
         builder.append_row(&row[..length], budget)?;
     }
     finish_data_builder(builder, budget)
@@ -632,17 +624,9 @@ impl OwnedIndexEntry {
         entry.row = row;
         entry
     }
-    fn raw(key: &[u8], row: u8) -> Result<Self, BootstrapComposeError> {
-        let needed = key.len();
-        if needed > INDEX_KEY_CAPACITY {
-            return Err(BootstrapComposeError::IndexKeyTooLong {
-                needed,
-                available: INDEX_KEY_CAPACITY,
-            });
-        }
+    fn name(parent: i32, name: &[u8], row: u8) -> Result<Self, BootstrapComposeError> {
         let mut entry = Self::EMPTY;
-        entry.key[..needed].copy_from_slice(key);
-        entry.len = needed;
+        entry.len = encode_catalog_name_key(parent, name, &mut entry.key)?;
         entry.row = row;
         Ok(entry)
     }
@@ -653,10 +637,10 @@ fn objects_parent_name_index(
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 9];
-    for (row, key) in PARENT_NAME_KEYS.iter().enumerate() {
-        entries[row] = OwnedIndexEntry::raw(key, row as u8)?;
-    }
     let count = if alpha { 9 } else { 8 };
+    for (row, seed) in catalog_seeds(alpha).enumerate() {
+        entries[row] = OwnedIndexEntry::name(seed.parent, seed.name, row as u8)?;
+    }
     sort_index_entries(&mut entries[..count]);
     index_page(
         MSYS_OBJECTS_ROOT,
@@ -670,11 +654,10 @@ fn objects_id_index(
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 9];
-    for (row, seed) in CATALOG_SEEDS.iter().enumerate() {
+    let count = if alpha { 9 } else { 8 };
+    for (row, seed) in catalog_seeds(alpha).enumerate() {
         entries[row] = OwnedIndexEntry::long(seed.id, row as u8);
     }
-    entries[8] = OwnedIndexEntry::long(ALPHA_ROOT as i32, 8);
-    let count = if alpha { 9 } else { 8 };
     sort_index_entries(&mut entries[..count]);
     index_page(
         MSYS_OBJECTS_ROOT,

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -1,6 +1,5 @@
 use super::{
-    ALPHA_LVPROP_PAYLOAD, BootstrapComposeError, INDEX_KEY_CAPACITY, OwnedIndexEntry,
-    PARENT_NAME_KEYS, compose_alpha_database, compose_empty_database,
+    ALPHA_LVPROP_PAYLOAD, BootstrapComposeError, compose_alpha_database, compose_empty_database,
 };
 use crate::{
     ByteCount, CatalogObjectClass, ColumnOrdinal, DatabaseReader, JET3_PAGE_SIZE, LongValue,
@@ -38,8 +37,24 @@ fn bytes(alpha: bool) -> Result<Vec<u8>, BootstrapComposeError> {
     Ok(bytes)
 }
 
+// EXP-0079 recorded these complete `ParentId`/`Name` keys for the fixed
+// bootstrap rows. The composer now derives its keys from the EXP-0087 encoding
+// instead of holding them, so this inventory is the check that the derivation
+// still reproduces the recorded bytes.
+const RECORDED_PARENT_NAME_KEYS: [&[u8]; 9] = [
+    b"\x7f\x8f\x00\x00\x00\x7f\x77\x60\x61\x6d\x66\x76\x00",
+    b"\x7f\x8f\x00\x00\x00\x7f\x64\x60\x77\x60\x61\x60\x76\x66\x76\x00",
+    b"\x7f\x8f\x00\x00\x00\x7f\x75\x66\x6d\x60\x77\x6a\x72\x70\x76\x69\x6a\x73\x76\x00",
+    b"\x7f\x8f\x00\x00\x02\x7f\x6f\x76\x7d\x76\x64\x61\x00",
+    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x72\x61\x6b\x66\x62\x77\x76\x00",
+    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x60\x62\x66\x76\x00",
+    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x74\x78\x66\x75\x6a\x66\x76\x00",
+    b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x75\x66\x6d\x60\x77\x6a\x72\x70\x76\x69\x6a\x73\x76\x00",
+    b"\x7f\x8f\x00\x00\x01\x7f\x60\x6d\x73\x69\x60\x00",
+];
+
 fn expected_parent_entries(count: usize) -> Vec<(&'static [u8], PageNumber, u8)> {
-    let mut entries = PARENT_NAME_KEYS[..count]
+    let mut entries = RECORDED_PARENT_NAME_KEYS[..count]
         .iter()
         .enumerate()
         .map(|(row, key)| (*key, PageNumber::new(18), row as u8))
@@ -503,11 +518,6 @@ fn composition_is_deterministic_and_resource_rejection_is_structured() -> TestRe
                 ..
             })
         ))
-    ));
-    assert!(matches!(
-        OwnedIndexEntry::raw(&[0; INDEX_KEY_CAPACITY + 1], 0),
-        Err(BootstrapComposeError::IndexKeyTooLong { needed, available })
-            if needed == INDEX_KEY_CAPACITY + 1 && available == INDEX_KEY_CAPACITY
     ));
     Ok(())
 }

--- a/crates/jet3/src/catalog_name_key.rs
+++ b/crates/jet3/src/catalog_name_key.rs
@@ -1,0 +1,155 @@
+//! Crate-private `MSysObjects` `ParentId`/`Name` index key encoding.
+//!
+//! The key grammar and the ASCII primary weight map both come from `EXP-0087`,
+//! which observed them over 90 probed CP1252 bytes at two interior positions in
+//! both orderings across three fresh replicas. The Long component follows
+//! `EXP-0062`.
+//!
+//! `EXP-0087` deliberately derives no weight, expansion rule, or secondary
+//! assignment for name bytes above `0x7E`, so this module rejects them with a
+//! structured error rather than guessing.
+
+#![allow(
+    dead_code,
+    reason = "crate-private writer slice awaiting DAO validation"
+)]
+
+use std::fmt;
+
+/// Lowest name byte `EXP-0087` established a primary weight for.
+const FIRST_MAPPED_BYTE: u8 = 0x20;
+/// Highest name byte `EXP-0087` established a primary weight for.
+const LAST_MAPPED_BYTE: u8 = 0x7e;
+
+/// Primary weight per name byte from `FIRST_MAPPED_BYTE`, `0` where unmapped.
+///
+/// `EXP-0087` observed no weight of `0` and no byte whose weight has a zero
+/// high nibble, so `0` is an unambiguous unmapped marker. The gaps are the five
+/// bytes Access rejects in object names, which therefore never reach a key.
+const PRIMARY_WEIGHTS: [u8; 95] = [
+    0x11, 0x00, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, // 20..27  ' !"#$%&\''
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x00, 0x20, // 28..2f  '()*+,-./'
+    0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, // 30..37  '01234567'
+    0x5e, 0x5f, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, // 38..3f  '89:;<=>?'
+    0x27, 0x60, 0x61, 0x62, 0x64, 0x66, 0x67, 0x68, // 40..47  '@ABCDEFG'
+    0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6f, 0x70, 0x72, // 48..4f  'HIJKLMNO'
+    0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x7a, 0x7b, // 50..57  'PQRSTUVW'
+    0x7c, 0x7d, 0x7e, 0x00, 0x29, 0x00, 0x2b, 0x2c, // 58..5f  'XYZ[\\]^_'
+    0x00, 0x60, 0x61, 0x62, 0x64, 0x66, 0x67, 0x68, // 60..67  '`abcdefg'
+    0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6f, 0x70, 0x72, // 68..6f  'hijklmno'
+    0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x7a, 0x7b, // 70..77  'pqrstuvw'
+    0x7c, 0x7d, 0x7e, 0x2e, 0x2f, 0x30, 0x31, // 78..7e  'xyz{|}~'
+];
+
+/// Marker `EXP-0062` observed before each non-null key component.
+const COMPONENT_MARKER: u8 = 0x7f;
+/// Encoded length of the leading non-null Long `ParentId` component.
+const LONG_COMPONENT_LEN: usize = 5;
+/// The text component's marker plus its terminating nibble-stream byte.
+const TEXT_COMPONENT_OVERHEAD: usize = 2;
+
+/// Structured failure while encoding a `ParentId`/`Name` index key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CatalogNameKeyError {
+    /// The name is empty, so it has no text component to encode.
+    EmptyName,
+    /// `EXP-0087` establishes no primary weight for this name byte.
+    UnmappedNameByte {
+        /// Zero-based position of the rejected byte within the name.
+        position: usize,
+        /// The rejected name byte.
+        byte: u8,
+    },
+    /// The encoded key does not fit the caller's buffer.
+    KeyTooLong {
+        /// Bytes the encoded key needs.
+        needed: usize,
+        /// Bytes the caller supplied.
+        available: usize,
+    },
+}
+
+impl fmt::Display for CatalogNameKeyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyName => formatter.write_str("catalog name key needs a non-empty name"),
+            Self::UnmappedNameByte { position, byte } => write!(
+                formatter,
+                "name byte {byte:#04x} at position {position} has no established primary weight"
+            ),
+            Self::KeyTooLong { needed, available } => write!(
+                formatter,
+                "catalog name key needs {needed} bytes but {available} are available"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CatalogNameKeyError {}
+
+/// Returns the encoded length of the key for `name`, or `None` if it is empty.
+///
+/// `EXP-0087` observed exactly one primary weight per mapped name byte, so the
+/// length depends only on the name's length.
+pub(crate) const fn catalog_name_key_len(name: &[u8]) -> Option<usize> {
+    if name.is_empty() {
+        None
+    } else {
+        Some(LONG_COMPONENT_LEN + TEXT_COMPONENT_OVERHEAD + name.len())
+    }
+}
+
+/// Encodes the `ParentId`/`Name` key for one catalog row into `output`.
+///
+/// Returns the number of bytes written. The key is the `EXP-0062` non-null Long
+/// encoding of `parent`, then the component marker, then one `EXP-0087` primary
+/// weight per name byte, then the nibble stream, which for a name carrying no
+/// secondary weights is a single zero byte: one leading zero nibble, no
+/// secondary nibbles, one terminating zero nibble.
+pub(crate) fn encode_catalog_name_key(
+    parent: i32,
+    name: &[u8],
+    output: &mut [u8],
+) -> Result<usize, CatalogNameKeyError> {
+    let needed = catalog_name_key_len(name).ok_or(CatalogNameKeyError::EmptyName)?;
+    let available = output.len();
+    if needed > available {
+        return Err(CatalogNameKeyError::KeyTooLong { needed, available });
+    }
+    // Resolve every weight before writing so a refused name leaves no partial key.
+    for (position, &byte) in name.iter().enumerate() {
+        if primary_weight(byte).is_none() {
+            return Err(CatalogNameKeyError::UnmappedNameByte { position, byte });
+        }
+    }
+    output[0] = COMPONENT_MARKER;
+    output[1..LONG_COMPONENT_LEN].copy_from_slice(&long_component(parent));
+    output[LONG_COMPONENT_LEN] = COMPONENT_MARKER;
+    let weights = &mut output[LONG_COMPONENT_LEN + 1..needed - 1];
+    for (&byte, slot) in name.iter().zip(weights.iter_mut()) {
+        *slot = primary_weight(byte).unwrap_or_default();
+    }
+    output[needed - 1] = 0;
+    Ok(needed)
+}
+
+/// Returns the `EXP-0062` non-null Long key body: big-endian with a flipped
+/// sign bit so the unsigned byte order matches the signed value order.
+fn long_component(value: i32) -> [u8; LONG_COMPONENT_LEN - 1] {
+    let mut raw = value.to_be_bytes();
+    raw[0] ^= 0x80;
+    raw
+}
+
+/// Returns the established primary weight for one name byte.
+fn primary_weight(byte: u8) -> Option<u8> {
+    if !(FIRST_MAPPED_BYTE..=LAST_MAPPED_BYTE).contains(&byte) {
+        return None;
+    }
+    let weight = PRIMARY_WEIGHTS[usize::from(byte - FIRST_MAPPED_BYTE)];
+    (weight != 0).then_some(weight)
+}
+
+#[cfg(test)]
+#[path = "catalog_name_key_tests.rs"]
+mod tests;

--- a/crates/jet3/src/catalog_name_key_tests.rs
+++ b/crates/jet3/src/catalog_name_key_tests.rs
@@ -1,0 +1,150 @@
+use super::*;
+
+/// Encodes into a fixed buffer and returns the key bytes.
+fn key(parent: i32, name: &[u8]) -> Result<Vec<u8>, CatalogNameKeyError> {
+    let mut buffer = [0_u8; 64];
+    let length = encode_catalog_name_key(parent, name, &mut buffer)?;
+    Ok(buffer[..length].to_vec())
+}
+
+const TABLES_ID: i32 = 0x0f00_0001;
+const ROOT_CONTAINER_ID: i32 = 0x0f00_0000;
+const DATABASES_ID: i32 = 0x0f00_0002;
+
+#[test]
+fn recorded_bootstrap_keys_are_reproduced_exactly() {
+    // EXP-0079 recorded these complete keys; EXP-0087 observed them again.
+    let recorded: [(i32, &[u8], &[u8]); 4] = [
+        (
+            ROOT_CONTAINER_ID,
+            b"Tables",
+            b"\x7f\x8f\x00\x00\x00\x7f\x77\x60\x61\x6d\x66\x76\x00",
+        ),
+        (
+            DATABASES_ID,
+            b"MSysDb",
+            b"\x7f\x8f\x00\x00\x02\x7f\x6f\x76\x7d\x76\x64\x61\x00",
+        ),
+        (
+            TABLES_ID,
+            b"MSysObjects",
+            b"\x7f\x8f\x00\x00\x01\x7f\x6f\x76\x7d\x76\x72\x61\x6b\x66\x62\x77\x76\x00",
+        ),
+        (
+            TABLES_ID,
+            b"Alpha",
+            b"\x7f\x8f\x00\x00\x01\x7f\x60\x6d\x73\x69\x60\x00",
+        ),
+    ];
+    for (parent, name, expected) in recorded {
+        assert_eq!(key(parent, name).as_deref(), Ok(expected), "{name:?}");
+    }
+}
+
+#[test]
+fn recorded_probed_keys_are_reproduced_exactly() {
+    // EXP-0087 recorded these keys for names built only from probed ASCII
+    // bytes, which exercise weights no bootstrap name reaches.
+    let recorded: [(&[u8], &[u8]); 2] = [
+        (
+            b"P01 \"#$%&'()*+,-/01Q",
+            b"\x7f\x8f\x00\x00\x01\x7f\x73\x56\x57\x11\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x20\x56\x57\x74\x00",
+        ),
+        (
+            b"P0110/-,+*)('&%$#\" R",
+            b"\x7f\x8f\x00\x00\x01\x7f\x73\x56\x57\x57\x56\x20\x1e\x1d\x1c\x1b\x1a\x19\x18\x17\x16\x15\x14\x13\x11\x75\x00",
+        ),
+    ];
+    for (name, expected) in recorded {
+        assert_eq!(key(TABLES_ID, name).as_deref(), Ok(expected), "{name:?}");
+    }
+}
+
+#[test]
+fn case_folds_because_letters_share_a_primary_weight() {
+    assert_eq!(key(TABLES_ID, b"Alpha"), key(TABLES_ID, b"ALPHA"));
+    assert_eq!(key(TABLES_ID, b"Alpha"), key(TABLES_ID, b"alpha"));
+}
+
+#[test]
+fn keys_order_by_parent_then_name() -> Result<(), CatalogNameKeyError> {
+    let ordered = [
+        key(ROOT_CONTAINER_ID, b"Tables")?,
+        key(TABLES_ID, b"Alpha")?,
+        key(TABLES_ID, b"Beta")?,
+    ];
+    let mut shuffled = [ordered[2].clone(), ordered[0].clone(), ordered[1].clone()];
+    shuffled.sort_unstable();
+    assert_eq!(shuffled, ordered);
+    Ok(())
+}
+
+#[test]
+fn negative_parents_sort_below_non_negative_ones() -> Result<(), CatalogNameKeyError> {
+    assert!(key(-1, b"A")? < key(0, b"A")?);
+    Ok(())
+}
+
+#[test]
+fn a_name_byte_above_the_established_range_is_refused() {
+    // EXP-0087 deliberately derives no weight for these bytes.
+    assert_eq!(
+        key(TABLES_ID, b"Caf\xe9"),
+        Err(CatalogNameKeyError::UnmappedNameByte {
+            position: 3,
+            byte: 0xe9,
+        })
+    );
+}
+
+#[test]
+fn a_name_byte_access_refuses_in_object_names_has_no_weight() {
+    for (position, byte) in [b'!', b'.', b'[', b']', b'`'].into_iter().enumerate() {
+        assert_eq!(
+            key(TABLES_ID, &[b'A', byte]),
+            Err(CatalogNameKeyError::UnmappedNameByte { position: 1, byte }),
+            "excluded byte {position}"
+        );
+    }
+}
+
+#[test]
+fn a_control_byte_is_refused_rather_than_indexed() {
+    assert_eq!(
+        key(TABLES_ID, b"\x00"),
+        Err(CatalogNameKeyError::UnmappedNameByte {
+            position: 0,
+            byte: 0,
+        })
+    );
+}
+
+#[test]
+fn an_empty_name_is_refused() {
+    assert_eq!(key(TABLES_ID, b""), Err(CatalogNameKeyError::EmptyName));
+    assert_eq!(catalog_name_key_len(b""), None);
+}
+
+#[test]
+fn a_short_buffer_is_refused_without_writing_a_partial_key() {
+    let mut buffer = [0_u8; 8];
+    assert_eq!(
+        encode_catalog_name_key(TABLES_ID, b"Alpha", &mut buffer),
+        Err(CatalogNameKeyError::KeyTooLong {
+            needed: 12,
+            available: 8,
+        })
+    );
+    assert_eq!(buffer, [0; 8]);
+}
+
+#[test]
+fn every_established_weight_has_a_non_zero_high_nibble() {
+    // EXP-0087's key framing splits the primary section on the first byte whose
+    // high nibble is zero, so no weight may have one.
+    for byte in FIRST_MAPPED_BYTE..=LAST_MAPPED_BYTE {
+        if let Some(weight) = primary_weight(byte) {
+            assert_ne!(weight >> 4, 0, "byte {byte:#04x}");
+        }
+    }
+}

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -9,6 +9,7 @@ pub mod binary_writer;
 mod bootstrap_composer;
 pub mod candidate;
 pub mod catalog;
+mod catalog_name_key;
 pub mod catalog_record;
 pub mod catalog_record_writer;
 pub mod column_definition;


### PR DESCRIPTION
The bootstrap composer held nine hard-coded `ParentId`/`Name` index keys copied out of EXP-0079, so it could only ever build the nine tables those keys were recorded for. Any new table needs a key we don't have.

EXP-0087 established the encoding, so this computes them: the `EXP-0062` Long key for `ParentId`, a `0x7f` marker, one primary weight per name byte, and the terminating nibble stream. The recorded nine are now the test that the derivation reproduces the observed bytes exactly.

Name bytes above `0x7E` are refused with a structured error rather than guessed. EXP-0087 deliberately derived no weights for them — accented characters fold onto shared primary weights and carry a secondary nibble tail, and some expand to two weights, so a probe of 16-byte names can't align them to source bytes. That needs its own experiment.

Worth knowing: the map is not injective. `A` and `a` share a weight, so a key cannot be turned back into a name.

No public API change; the module is crate-private alongside the rest of the writer slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)