### PR TITLE
feat(jet3): plan arbitrary user tables instead of one fixed table

### DIFF
--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -1,6 +1,9 @@
 use super::{
-    ALPHA_LVPROP_PAYLOAD, BootstrapComposeError, compose_alpha_database, compose_empty_database,
+    ALPHA_LVPROP_PAYLOAD, ALPHA_MAP_PAGE, ALPHA_ROOT, BootstrapComposeError,
+    compose_alpha_database, compose_empty_database,
 };
+use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
+use crate::table_schema_plan::{PlannedColumn, TableSchemaSpec, plan_table_schema};
 use crate::{
     ByteCount, CatalogObjectClass, ColumnOrdinal, DatabaseReader, JET3_PAGE_SIZE, LongValue,
     LongValueChunkValue, MapRowLocator, PageKind, PageNumber, ReadLimits, ResourceBudget,
@@ -580,5 +583,33 @@ fn candidate_export_refuses_nonempty_directory() -> TestResult {
     assert!(!root.join("bootstrap-composer-alpha.mdb").exists());
     fs::remove_file(sentinel)?;
     fs::remove_dir(root)?;
+    Ok(())
+}
+
+#[test]
+fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
+    // The Alpha image DAO accepted in EXP-0085 is the fixed case the general
+    // EXP-0087 assignment has to agree with.
+    let columns = [PlannedColumn {
+        name: b"Id",
+        physical_type: crate::ColumnPhysicalType::Long,
+        storage: crate::ColumnStorageKind::Fixed,
+        size: 4,
+    }];
+    let plan = plan_table_schema(
+        &TableSchemaSpec {
+            name: b"Alpha",
+            columns: &columns,
+            indexes: &[],
+        },
+        EMPTY_DATABASE_PAGE_COUNT,
+    )?;
+    assert_eq!(plan.object_id(), ALPHA_ROOT as i32);
+    assert_eq!(plan.definition_root(), PageNumber::new(ALPHA_ROOT));
+    assert_eq!(plan.map_page(), PageNumber::new(ALPHA_MAP_PAGE));
+    // The planner deliberately plans no long-value page: EXP-0087 observed one
+    // only for a database's first create, and establishes no property grammar.
+    assert_eq!(plan.index_root(), None);
+    assert_eq!(plan.appended_page_count(), 2);
     Ok(())
 }

--- a/crates/jet3/src/catalog_name_key.rs
+++ b/crates/jet3/src/catalog_name_key.rs
@@ -99,6 +99,22 @@ pub(crate) const fn catalog_name_key_len(name: &[u8]) -> Option<usize> {
     }
 }
 
+/// Checks that `name` can be encoded into a catalog index key.
+///
+/// This is the same acceptance [`encode_catalog_name_key`] applies, without a
+/// buffer, so a caller can reject a name before planning anything around it.
+pub(crate) fn validate_catalog_name(name: &[u8]) -> Result<(), CatalogNameKeyError> {
+    if name.is_empty() {
+        return Err(CatalogNameKeyError::EmptyName);
+    }
+    for (position, &byte) in name.iter().enumerate() {
+        if primary_weight(byte).is_none() {
+            return Err(CatalogNameKeyError::UnmappedNameByte { position, byte });
+        }
+    }
+    Ok(())
+}
+
 /// Encodes the `ParentId`/`Name` key for one catalog row into `output`.
 ///
 /// Returns the number of bytes written. The key is the `EXP-0062` non-null Long
@@ -117,11 +133,7 @@ pub(crate) fn encode_catalog_name_key(
         return Err(CatalogNameKeyError::KeyTooLong { needed, available });
     }
     // Resolve every weight before writing so a refused name leaves no partial key.
-    for (position, &byte) in name.iter().enumerate() {
-        if primary_weight(byte).is_none() {
-            return Err(CatalogNameKeyError::UnmappedNameByte { position, byte });
-        }
-    }
+    validate_catalog_name(name)?;
     output[0] = COMPONENT_MARKER;
     output[1..LONG_COMPONENT_LEN].copy_from_slice(&long_component(parent));
     output[LONG_COMPONENT_LEN] = COMPONENT_MARKER;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -45,6 +45,7 @@ pub mod row_writer;
 pub mod source;
 pub mod table_definition;
 pub mod table_definition_writer;
+mod table_schema_plan;
 pub mod text;
 pub mod usage_map;
 pub mod usage_map_writer;

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -1,0 +1,328 @@
+//! Crate-private typed planning of one new user table.
+//!
+//! This validates a caller-described table and assigns its appended pages. It
+//! builds no page bytes and performs no I/O.
+//!
+//! `EXP-0087` observed, identically across three fresh replicas, that creating
+//! a user table appends a definition root page numbered equal to the new
+//! object's `MSysObjects` `Id`, then a page holding the table's usage-map rows,
+//! then one index root when the table carries an index. It observed only tables
+//! with zero or one index, so this module refuses more than one rather than
+//! extrapolating an ordering nobody has observed.
+//!
+//! `EXP-0087` establishes no property grammar beyond the pinned framing, so
+//! this module plans no `LvProp` payload. It also establishes no `Id`
+//! allocation rule beyond the observed equality with the definition root page.
+
+#![allow(
+    dead_code,
+    reason = "crate-private writer slice awaiting DAO validation"
+)]
+
+use std::fmt;
+
+use crate::catalog_name_key::{CatalogNameKeyError, validate_catalog_name};
+use crate::{ColumnPhysicalType, ColumnStorageKind, PageNumber};
+
+/// Largest column count a planned table may carry.
+const MAX_COLUMNS: usize = 255;
+/// Largest field count one planned index may carry.
+const MAX_INDEX_FIELDS: usize = 10;
+/// Index count `EXP-0087` observed on a created table.
+const MAX_OBSERVED_INDEXES: usize = 1;
+
+/// One column of a table being planned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PlannedColumn<'a> {
+    /// Column name in the database's configured code page.
+    pub(crate) name: &'a [u8],
+    /// Stored physical type.
+    pub(crate) physical_type: ColumnPhysicalType,
+    /// Whether the column occupies a fixed row slot or a variable one.
+    pub(crate) storage: ColumnStorageKind,
+    /// Declared size in bytes; zero for the long types that carry none.
+    pub(crate) size: u16,
+}
+
+/// Whether a planned index is the table's primary one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlannedIndexKind {
+    /// The table's primary index, which `EXP-0087` observed is also unique.
+    Primary,
+    /// Any other index.
+    Ordinary,
+}
+
+/// One index of a table being planned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PlannedIndex<'a> {
+    /// Index name in the database's configured code page.
+    pub(crate) name: &'a [u8],
+    /// Zero-based ordinals of the indexed columns, in key order.
+    pub(crate) fields: &'a [u16],
+    /// Whether this is the table's primary index.
+    pub(crate) kind: PlannedIndexKind,
+}
+
+/// A caller-described user table awaiting validation and page assignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TableSchemaSpec<'a> {
+    /// Table name in the database's configured code page.
+    pub(crate) name: &'a [u8],
+    /// The table's columns in ordinal order.
+    pub(crate) columns: &'a [PlannedColumn<'a>],
+    /// The table's indexes.
+    pub(crate) indexes: &'a [PlannedIndex<'a>],
+}
+
+/// Structured failure while planning one new user table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TableSchemaPlanError {
+    /// The table name cannot be encoded into a catalog index key.
+    TableName(CatalogNameKeyError),
+    /// A column declares an empty name.
+    EmptyColumnName {
+        /// Zero-based ordinal of the rejected column.
+        ordinal: usize,
+    },
+    /// An index declares an empty name.
+    EmptyIndexName {
+        /// Zero-based position of the rejected index.
+        index: usize,
+    },
+    /// The table declares no columns.
+    NoColumns,
+    /// The table declares more columns than a planned table may carry.
+    TooManyColumns {
+        /// Declared column count.
+        count: usize,
+        /// Largest supported column count.
+        limit: usize,
+    },
+    /// Two columns share a name.
+    DuplicateColumnName {
+        /// Ordinal of the earlier column.
+        first: usize,
+        /// Ordinal of the later column.
+        second: usize,
+    },
+    /// Two indexes share a name.
+    DuplicateIndexName {
+        /// Position of the earlier index.
+        first: usize,
+        /// Position of the later index.
+        second: usize,
+    },
+    /// `EXP-0087` observed no create carrying this many indexes.
+    UnobservedIndexCount {
+        /// Declared index count.
+        count: usize,
+        /// Largest observed index count.
+        observed: usize,
+    },
+    /// An index names no columns.
+    IndexWithoutFields {
+        /// Position of the rejected index.
+        index: usize,
+    },
+    /// An index names more columns than one index may carry.
+    TooManyIndexFields {
+        /// Position of the rejected index.
+        index: usize,
+        /// Declared field count.
+        count: usize,
+        /// Largest supported field count.
+        limit: usize,
+    },
+    /// An index names a column the table does not declare.
+    IndexFieldOutOfRange {
+        /// Position of the rejected index.
+        index: usize,
+        /// The out-of-range column ordinal.
+        column: u16,
+    },
+    /// An index names the same column twice.
+    DuplicateIndexField {
+        /// Position of the rejected index.
+        index: usize,
+        /// The repeated column ordinal.
+        column: u16,
+    },
+    /// The table declares more than one primary index.
+    MultiplePrimaryIndexes {
+        /// Position of the earlier primary index.
+        first: usize,
+        /// Position of the later primary index.
+        second: usize,
+    },
+    /// The appended pages do not fit the addressable page space.
+    PageOverflow {
+        /// Page the appended run would have started at.
+        first: u64,
+        /// Pages the run needs.
+        needed: u64,
+    },
+}
+
+impl fmt::Display for TableSchemaPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Jet 3 table schema planning failed: {self:?}")
+    }
+}
+
+impl std::error::Error for TableSchemaPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TableName(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// The validated page assignment for one new user table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableSchemaPlan {
+    object_id: i32,
+    definition_root: PageNumber,
+    map_page: PageNumber,
+    index_root: Option<PageNumber>,
+}
+
+impl TableSchemaPlan {
+    /// Returns the `MSysObjects` `Id` the new table takes.
+    pub(crate) const fn object_id(&self) -> i32 {
+        self.object_id
+    }
+
+    /// Returns the page holding the table's definition.
+    pub(crate) const fn definition_root(&self) -> PageNumber {
+        self.definition_root
+    }
+
+    /// Returns the page holding the table's usage-map rows.
+    pub(crate) const fn map_page(&self) -> PageNumber {
+        self.map_page
+    }
+
+    /// Returns the table's index root page, if it carries an index.
+    pub(crate) const fn index_root(&self) -> Option<PageNumber> {
+        self.index_root
+    }
+
+    /// Returns how many pages the create appends.
+    pub(crate) const fn appended_page_count(&self) -> u64 {
+        if self.index_root.is_some() { 3 } else { 2 }
+    }
+}
+
+/// Validates `spec` and assigns its appended pages starting at `first_page`.
+///
+/// `first_page` is the database's current page count, so the appended run is
+/// contiguous from it. The `EXP-0087` assignment is the definition root, then
+/// the map-rows page, then the index root when the table carries an index.
+pub(crate) fn plan_table_schema(
+    spec: &TableSchemaSpec<'_>,
+    first_page: u64,
+) -> Result<TableSchemaPlan, TableSchemaPlanError> {
+    validate_names(spec)?;
+    validate_indexes(spec)?;
+    let needed = if spec.indexes.is_empty() { 2 } else { 3 };
+    let object_id = i32::try_from(first_page)
+        .ok()
+        .filter(|_| first_page.checked_add(needed).is_some())
+        .ok_or(TableSchemaPlanError::PageOverflow {
+            first: first_page,
+            needed,
+        })?;
+    Ok(TableSchemaPlan {
+        object_id,
+        definition_root: PageNumber::new(first_page),
+        map_page: PageNumber::new(first_page + 1),
+        index_root: (needed == 3).then(|| PageNumber::new(first_page + 2)),
+    })
+}
+
+fn validate_names(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+    validate_catalog_name(spec.name).map_err(TableSchemaPlanError::TableName)?;
+    if spec.columns.is_empty() {
+        return Err(TableSchemaPlanError::NoColumns);
+    }
+    if spec.columns.len() > MAX_COLUMNS {
+        return Err(TableSchemaPlanError::TooManyColumns {
+            count: spec.columns.len(),
+            limit: MAX_COLUMNS,
+        });
+    }
+    for (ordinal, column) in spec.columns.iter().enumerate() {
+        if column.name.is_empty() {
+            return Err(TableSchemaPlanError::EmptyColumnName { ordinal });
+        }
+        if let Some(first) = spec.columns[..ordinal]
+            .iter()
+            .position(|earlier| earlier.name == column.name)
+        {
+            return Err(TableSchemaPlanError::DuplicateColumnName {
+                first,
+                second: ordinal,
+            });
+        }
+    }
+    for (index, planned) in spec.indexes.iter().enumerate() {
+        if planned.name.is_empty() {
+            return Err(TableSchemaPlanError::EmptyIndexName { index });
+        }
+        if let Some(first) = spec.indexes[..index]
+            .iter()
+            .position(|earlier| earlier.name == planned.name)
+        {
+            return Err(TableSchemaPlanError::DuplicateIndexName {
+                first,
+                second: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_indexes(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+    if spec.indexes.len() > MAX_OBSERVED_INDEXES {
+        return Err(TableSchemaPlanError::UnobservedIndexCount {
+            count: spec.indexes.len(),
+            observed: MAX_OBSERVED_INDEXES,
+        });
+    }
+    let mut primary: Option<usize> = None;
+    for (index, planned) in spec.indexes.iter().enumerate() {
+        if planned.fields.is_empty() {
+            return Err(TableSchemaPlanError::IndexWithoutFields { index });
+        }
+        if planned.fields.len() > MAX_INDEX_FIELDS {
+            return Err(TableSchemaPlanError::TooManyIndexFields {
+                index,
+                count: planned.fields.len(),
+                limit: MAX_INDEX_FIELDS,
+            });
+        }
+        for (position, &column) in planned.fields.iter().enumerate() {
+            if usize::from(column) >= spec.columns.len() {
+                return Err(TableSchemaPlanError::IndexFieldOutOfRange { index, column });
+            }
+            if planned.fields[..position].contains(&column) {
+                return Err(TableSchemaPlanError::DuplicateIndexField { index, column });
+            }
+        }
+        if planned.kind == PlannedIndexKind::Primary
+            && let Some(first) = primary.replace(index)
+        {
+            return Err(TableSchemaPlanError::MultiplePrimaryIndexes {
+                first,
+                second: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "table_schema_plan_tests.rs"]
+mod tests;

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -1,0 +1,288 @@
+use super::*;
+
+type PlanResult = Result<(), TableSchemaPlanError>;
+
+const ID: PlannedColumn<'static> = PlannedColumn {
+    name: b"Id",
+    physical_type: ColumnPhysicalType::Long,
+    storage: ColumnStorageKind::Fixed,
+    size: 4,
+};
+const LABEL: PlannedColumn<'static> = PlannedColumn {
+    name: b"Label",
+    physical_type: ColumnPhysicalType::Text,
+    storage: ColumnStorageKind::Variable,
+    size: 30,
+};
+
+fn spec<'a>(
+    name: &'a [u8],
+    columns: &'a [PlannedColumn<'a>],
+    indexes: &'a [PlannedIndex<'a>],
+) -> TableSchemaSpec<'a> {
+    TableSchemaSpec {
+        name,
+        columns,
+        indexes,
+    }
+}
+
+#[test]
+fn a_table_without_an_index_appends_a_definition_root_and_a_map_page() -> PlanResult {
+    // EXP-0087's Beta create: two appended pages, Id equal to the root page.
+    let columns = [ID];
+    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23)?;
+    assert_eq!(plan.object_id(), 23);
+    assert_eq!(plan.definition_root(), PageNumber::new(23));
+    assert_eq!(plan.map_page(), PageNumber::new(24));
+    assert_eq!(plan.index_root(), None);
+    assert_eq!(plan.appended_page_count(), 2);
+    Ok(())
+}
+
+#[test]
+fn an_indexed_table_appends_its_index_root_after_the_map_page() -> PlanResult {
+    // EXP-0087's Delta create: the index root follows the map-rows page.
+    let columns = [LABEL];
+    let indexes = [PlannedIndex {
+        name: b"ByLabel",
+        fields: &[0],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    let plan = plan_table_schema(&spec(b"Delta", &columns, &indexes), 28)?;
+    assert_eq!(plan.object_id(), 28);
+    assert_eq!(plan.definition_root(), PageNumber::new(28));
+    assert_eq!(plan.map_page(), PageNumber::new(29));
+    assert_eq!(plan.index_root(), Some(PageNumber::new(30)));
+    assert_eq!(plan.appended_page_count(), 3);
+    Ok(())
+}
+
+#[test]
+fn a_primary_index_plans_the_same_pages_as_an_ordinary_one() -> PlanResult {
+    // EXP-0087's Gamma create carried a primary index and appended three pages.
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"PrimaryKey",
+        fields: &[0],
+        kind: PlannedIndexKind::Primary,
+    }];
+    let plan = plan_table_schema(&spec(b"Gamma", &columns, &indexes), 25)?;
+    assert_eq!(plan.object_id(), 25);
+    assert_eq!(plan.index_root(), Some(PageNumber::new(27)));
+    Ok(())
+}
+
+#[test]
+fn a_table_name_byte_without_an_established_weight_is_refused() {
+    let columns = [ID];
+    assert_eq!(
+        plan_table_schema(&spec(b"Caf\xe9", &columns, &[]), 20),
+        Err(TableSchemaPlanError::TableName(
+            CatalogNameKeyError::UnmappedNameByte {
+                position: 3,
+                byte: 0xe9,
+            }
+        ))
+    );
+}
+
+#[test]
+fn an_empty_table_name_is_refused() {
+    let columns = [ID];
+    assert_eq!(
+        plan_table_schema(&spec(b"", &columns, &[]), 20),
+        Err(TableSchemaPlanError::TableName(
+            CatalogNameKeyError::EmptyName
+        ))
+    );
+}
+
+#[test]
+fn a_table_without_columns_is_refused() {
+    assert_eq!(
+        plan_table_schema(&spec(b"Empty", &[], &[]), 20),
+        Err(TableSchemaPlanError::NoColumns)
+    );
+}
+
+#[test]
+fn a_column_count_one_above_the_limit_is_refused() {
+    let columns = vec![ID; MAX_COLUMNS + 1];
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+        Err(TableSchemaPlanError::TooManyColumns {
+            count: MAX_COLUMNS + 1,
+            limit: MAX_COLUMNS,
+        })
+    );
+    // The duplicate names inside a limit-sized spec must still be caught.
+    let at_limit = vec![ID; MAX_COLUMNS];
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &at_limit, &[]), 20),
+        Err(TableSchemaPlanError::DuplicateColumnName {
+            first: 0,
+            second: 1,
+        })
+    );
+}
+
+#[test]
+fn a_repeated_column_name_is_refused() {
+    let columns = [ID, LABEL, ID];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
+        Err(TableSchemaPlanError::DuplicateColumnName {
+            first: 0,
+            second: 2,
+        })
+    );
+}
+
+#[test]
+fn an_empty_column_name_is_refused() {
+    let columns = [PlannedColumn { name: b"", ..ID }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
+        Err(TableSchemaPlanError::EmptyColumnName { ordinal: 0 })
+    );
+}
+
+#[test]
+fn more_indexes_than_any_create_carried_are_refused() {
+    // EXP-0087 observed only zero or one index per create, so a two-index
+    // ordering has no evidence behind it.
+    let columns = [ID, LABEL];
+    let indexes = [
+        PlannedIndex {
+            name: b"ById",
+            fields: &[0],
+            kind: PlannedIndexKind::Primary,
+        },
+        PlannedIndex {
+            name: b"ByLabel",
+            fields: &[1],
+            kind: PlannedIndexKind::Ordinary,
+        },
+    ];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::UnobservedIndexCount {
+            count: 2,
+            observed: MAX_OBSERVED_INDEXES,
+        })
+    );
+}
+
+#[test]
+fn an_index_naming_no_columns_is_refused() {
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::IndexWithoutFields { index: 0 })
+    );
+}
+
+#[test]
+fn an_index_naming_an_undeclared_column_is_refused() {
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[1],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::IndexFieldOutOfRange {
+            index: 0,
+            column: 1,
+        })
+    );
+}
+
+#[test]
+fn an_index_naming_one_column_twice_is_refused() {
+    let columns = [ID, LABEL];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[0, 1, 0],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::DuplicateIndexField {
+            index: 0,
+            column: 0,
+        })
+    );
+}
+
+#[test]
+fn an_index_field_count_one_above_the_limit_is_refused() {
+    let columns = vec![ID; MAX_INDEX_FIELDS + 1];
+    let fields = (0..=MAX_INDEX_FIELDS as u16).collect::<Vec<_>>();
+    let indexes = [PlannedIndex {
+        name: b"Wide",
+        fields: &fields,
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    // Duplicate column names would mask the field-count check, so name them apart.
+    let named = columns
+        .iter()
+        .enumerate()
+        .map(|(ordinal, column)| PlannedColumn {
+            name: COLUMN_NAMES[ordinal],
+            ..*column
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &named, &indexes), 20),
+        Err(TableSchemaPlanError::TooManyIndexFields {
+            index: 0,
+            count: MAX_INDEX_FIELDS + 1,
+            limit: MAX_INDEX_FIELDS,
+        })
+    );
+}
+
+const COLUMN_NAMES: [&[u8]; MAX_INDEX_FIELDS + 1] = [
+    b"C0", b"C1", b"C2", b"C3", b"C4", b"C5", b"C6", b"C7", b"C8", b"C9", b"CA",
+];
+
+#[test]
+fn an_empty_index_name_is_refused() {
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"",
+        fields: &[0],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::EmptyIndexName { index: 0 })
+    );
+}
+
+#[test]
+fn a_first_page_above_the_signed_id_range_is_refused() {
+    // EXP-0087 observed the object Id equal to the definition root page, and
+    // MSysObjects.Id is a signed Long, so the run must stay inside that range.
+    let columns = [ID];
+    let first = i32::MAX as u64 + 1;
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), first),
+        Err(TableSchemaPlanError::PageOverflow { first, needed: 2 })
+    );
+}
+
+#[test]
+fn the_highest_representable_first_page_is_accepted() -> PlanResult {
+    let plan = plan_table_schema(&spec(b"Beta", &[ID], &[]), i32::MAX as u64)?;
+    assert_eq!(plan.object_id(), i32::MAX);
+    Ok(())
+}

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -43,14 +43,19 @@ delivered in this order:
 
 ## Current next step
 
-Continue #100 toward a typed schema planner for arbitrary tables, columns, and
-indexes. `EXP-0085` accepted bounded DAO consumption of the two fixed composer
-candidates, but the composer still carries fixed bytes rather than rules: the
-catalog name keys, the per-table catalog and access-control rows, the page-zero
-transition, and the `LvProp` payload are all recorded values for one exact
-table. The next step is the preregistered `schema-generalization` experiment,
-which resolves the name-key encoding, the per-create row and page assignment,
-and the property chunk framing. The planner, a public creation API, initial
-rows, relationships, and safe filesystem publication follow as separate
-reviewable slices. #102 remains the separate hosted write differential after
-database creation is complete.
+Finish #100. `EXP-0087` accepted the `schema-generalization` experiment, which
+established the catalog name-key encoding and its ASCII collation map, the
+per-create catalog and access-control rows, the page-zero counter step, and the
+appended-page assignment. The key encoder and the typed table planner now
+derive what the composer used to carry as recorded bytes.
+
+What is still fixed rather than ruled: the composer's page-zero opaque region,
+the `LvProp` payloads, and the per-create catalog/ACE row writing. Wiring the
+composer to emit planned tables is the next slice, followed by a public
+creation API, initial rows, relationships, and safe filesystem publication.
+
+Two gaps need their own focused DAO validation before the planner can widen:
+table names containing bytes above `0x7E`, whose secondary weights and
+expansions `EXP-0087` deliberately left uninterpreted, and tables carrying more
+than one index, which no observed create had. #102 remains the separate hosted
+write differential after database creation is complete.


### PR DESCRIPTION
Stacked on #146.

The composer can only build `Alpha(Id Long)` because every page number in it is a constant. This adds the typed layer that decides those numbers for any table: you describe a name, columns, and indexes, and it validates the description and assigns the pages the create appends.

The assignment is the one EXP-0087 observed across three replicas — definition root numbered equal to the new object's `Id`, then the map-rows page, then an index root when the table has an index. The tests pin it against the real Beta, Gamma, and Delta creates, and against the Alpha image DAO already accepted in EXP-0085.

Two deliberate refusals, both because the evidence isn't there yet rather than because the code can't:

- **More than one index.** Every create EXP-0087 watched had zero or one. Where a second index root lands is a guess, so the planner says so instead of picking.
- **Table name bytes above `0x7E`**, inherited from the key encoder in #146.

It also plans no `LvProp` payload. EXP-0087 pinned the property framing but not the grammar, and the long-value page only appears on a database's first create — so generating one for an arbitrary table would be invention.

This is validation and page assignment only. It builds no bytes and touches no I/O; wiring the composer to emit tables through it is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)