### PR TITLE
feat(jet3): plan arbitrary user tables instead of one fixed table

### DIFF
--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -607,9 +607,16 @@ fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
     assert_eq!(plan.object_id(), ALPHA_ROOT as i32);
     assert_eq!(plan.definition_root(), PageNumber::new(ALPHA_ROOT));
     assert_eq!(plan.map_page(), PageNumber::new(ALPHA_MAP_PAGE));
-    // The planner deliberately plans no long-value page: EXP-0087 observed one
-    // only for a database's first create, and establishes no property grammar.
+    // The accepted Alpha image appends three pages; the planner reports two
+    // because it deliberately plans no long-value page. EXP-0087 observed one
+    // only for a database's first create and establishes no property grammar,
+    // so the composer wiring has to place it.
     assert_eq!(plan.index_root(), None);
     assert_eq!(plan.appended_page_count(), 2);
+    let alpha_pages = bytes(true)?.len() as u64 / JET3_PAGE_SIZE.get();
+    assert_eq!(
+        alpha_pages,
+        EMPTY_DATABASE_PAGE_COUNT + plan.appended_page_count() + 1
+    );
     Ok(())
 }

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -3,12 +3,13 @@ use super::{
     compose_alpha_database, compose_empty_database,
 };
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
-use crate::table_schema_plan::{PlannedColumn, TableSchemaSpec, plan_table_schema};
+use crate::table_schema_plan::{TableSchemaSpec, plan_table_schema};
 use crate::{
-    ByteCount, CatalogObjectClass, ColumnOrdinal, DatabaseReader, JET3_PAGE_SIZE, LongValue,
-    LongValueChunkValue, MapRowLocator, PageKind, PageNumber, ReadLimits, ResourceBudget,
-    ResourceLimitKind, ResourceLimits, SliceSource, TableDefinitionKind, TextCodePage, ValueKind,
-    classify_page, locate_usage_map, page_tag,
+    ByteCount, CatalogObjectClass, ColumnOrdinal, ColumnPhysicalType, ColumnSpec,
+    ColumnStorageKind, DatabaseReader, JET3_PAGE_SIZE, LongValue, LongValueChunkValue,
+    MapRowLocator, PageKind, PageNumber, ReadLimits, ResourceBudget, ResourceLimitKind,
+    ResourceLimits, SliceSource, TableDefinitionKind, TextCodePage, ValueKind, classify_page,
+    locate_usage_map, page_tag,
 };
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -590,12 +591,12 @@ fn candidate_export_refuses_nonempty_directory() -> TestResult {
 fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
     // The Alpha image DAO accepted in EXP-0085 is the fixed case the general
     // EXP-0087 assignment has to agree with.
-    let columns = [PlannedColumn {
-        name: b"Id",
-        physical_type: crate::ColumnPhysicalType::Long,
-        storage: crate::ColumnStorageKind::Fixed,
-        size: 4,
-    }];
+    let columns = [ColumnSpec::new(
+        b"Id",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
     let plan = plan_table_schema(
         &TableSchemaSpec {
             name: b"Alpha",

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -1,6 +1,9 @@
 use super::{
-    ALPHA_LVPROP_PAYLOAD, BootstrapComposeError, compose_alpha_database, compose_empty_database,
+    ALPHA_LVPROP_PAYLOAD, ALPHA_MAP_PAGE, ALPHA_ROOT, BootstrapComposeError,
+    compose_alpha_database, compose_empty_database,
 };
+use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
+use crate::table_schema_plan::{PlannedColumn, TableSchemaSpec, plan_table_schema};
 use crate::{
     ByteCount, CatalogObjectClass, ColumnOrdinal, DatabaseReader, JET3_PAGE_SIZE, LongValue,
     LongValueChunkValue, MapRowLocator, PageKind, PageNumber, ReadLimits, ResourceBudget,
@@ -580,5 +583,33 @@ fn candidate_export_refuses_nonempty_directory() -> TestResult {
     assert!(!root.join("bootstrap-composer-alpha.mdb").exists());
     fs::remove_file(sentinel)?;
     fs::remove_dir(root)?;
+    Ok(())
+}
+
+#[test]
+fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
+    // The Alpha image DAO accepted in EXP-0085 is the fixed case the general
+    // EXP-0087 assignment has to agree with.
+    let columns = [PlannedColumn {
+        name: b"Id",
+        physical_type: crate::ColumnPhysicalType::Long,
+        storage: crate::ColumnStorageKind::Fixed,
+        size: 4,
+    }];
+    let plan = plan_table_schema(
+        &TableSchemaSpec {
+            name: b"Alpha",
+            columns: &columns,
+            indexes: &[],
+        },
+        EMPTY_DATABASE_PAGE_COUNT,
+    )?;
+    assert_eq!(plan.object_id(), ALPHA_ROOT as i32);
+    assert_eq!(plan.definition_root(), PageNumber::new(ALPHA_ROOT));
+    assert_eq!(plan.map_page(), PageNumber::new(ALPHA_MAP_PAGE));
+    // The planner deliberately plans no long-value page: EXP-0087 observed one
+    // only for a database's first create, and establishes no property grammar.
+    assert_eq!(plan.index_root(), None);
+    assert_eq!(plan.appended_page_count(), 2);
     Ok(())
 }

--- a/crates/jet3/src/catalog_name_key.rs
+++ b/crates/jet3/src/catalog_name_key.rs
@@ -99,6 +99,22 @@ pub(crate) const fn catalog_name_key_len(name: &[u8]) -> Option<usize> {
     }
 }
 
+/// Checks that `name` can be encoded into a catalog index key.
+///
+/// This is the same acceptance [`encode_catalog_name_key`] applies, without a
+/// buffer, so a caller can reject a name before planning anything around it.
+pub(crate) fn validate_catalog_name(name: &[u8]) -> Result<(), CatalogNameKeyError> {
+    if name.is_empty() {
+        return Err(CatalogNameKeyError::EmptyName);
+    }
+    for (position, &byte) in name.iter().enumerate() {
+        if primary_weight(byte).is_none() {
+            return Err(CatalogNameKeyError::UnmappedNameByte { position, byte });
+        }
+    }
+    Ok(())
+}
+
 /// Encodes the `ParentId`/`Name` key for one catalog row into `output`.
 ///
 /// Returns the number of bytes written. The key is the `EXP-0062` non-null Long
@@ -117,11 +133,7 @@ pub(crate) fn encode_catalog_name_key(
         return Err(CatalogNameKeyError::KeyTooLong { needed, available });
     }
     // Resolve every weight before writing so a refused name leaves no partial key.
-    for (position, &byte) in name.iter().enumerate() {
-        if primary_weight(byte).is_none() {
-            return Err(CatalogNameKeyError::UnmappedNameByte { position, byte });
-        }
-    }
+    validate_catalog_name(name)?;
     output[0] = COMPONENT_MARKER;
     output[1..LONG_COMPONENT_LEN].copy_from_slice(&long_component(parent));
     output[LONG_COMPONENT_LEN] = COMPONENT_MARKER;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -44,6 +44,7 @@ pub mod row_directory;
 pub mod row_writer;
 pub mod source;
 pub mod table_definition;
+mod table_definition_layout;
 pub mod table_definition_writer;
 mod table_schema_plan;
 pub mod text;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -45,6 +45,7 @@ pub mod row_writer;
 pub mod source;
 pub mod table_definition;
 pub mod table_definition_writer;
+mod table_schema_plan;
 pub mod text;
 pub mod usage_map;
 pub mod usage_map_writer;

--- a/crates/jet3/src/table_definition_layout.rs
+++ b/crates/jet3/src/table_definition_layout.rs
@@ -5,14 +5,81 @@
 //! carrying its own copy of the rules.
 
 use crate::column_definition_writer::{
-    ColumnSpec, MAX_NAME_LEN, SystemColumnClassSpec, resolve_column,
+    COLUMN_RECORD_LEN, ColumnSpec, LOGICAL_RECORD_LEN, MAX_NAME_LEN, PHYSICAL_PREFIX_LEN,
+    PHYSICAL_RECORD_LEN, SystemColumnClassSpec, resolve_column,
 };
 use crate::data_page_directory::MAX_STORED_ROW_LEN;
 use crate::table_definition_writer::TableDefinitionWriteError;
 use crate::{Error, TableDefinitionKind};
 
+use crate::LONG_VALUE_MAP_GROUP_LEN;
+
 /// `EXP-0060`: the one-byte row column count bounds a table's columns.
 const MAX_COLUMN_COUNT: usize = u8::MAX as usize;
+/// `EXP-0059`: fixed bytes before the first physical-index record.
+const DEFINITION_HEADER_LEN: usize = 43;
+/// `EXP-0059`: the two-byte end-of-definition marker.
+const TERMINATOR_LEN: usize = 2;
+
+/// Returns the exact logical length of the definition this shape encodes to.
+///
+/// The length depends only on the counts and name lengths, never on the pages
+/// the definition names, so a planner can measure a definition before it has
+/// assigned any.
+pub(crate) fn definition_len<'a>(
+    columns: &[ColumnSpec<'_>],
+    index_names: impl ExactSizeIterator<Item = &'a [u8]>,
+    physical_index_count: usize,
+    long_value_map_count: usize,
+) -> Result<usize, TableDefinitionWriteError> {
+    if columns.len() > MAX_COLUMN_COUNT {
+        return Err(TableDefinitionWriteError::TooManyColumns {
+            count: columns.len(),
+            maximum: MAX_COLUMN_COUNT,
+        });
+    }
+    for (role, count) in [
+        ("physical", physical_index_count),
+        ("logical", index_names.len()),
+    ] {
+        if u16::try_from(count).is_err() {
+            return Err(TableDefinitionWriteError::TooManyIndexes { role, count });
+        }
+    }
+    let too_long = || TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX };
+    let mut total = DEFINITION_HEADER_LEN;
+    let mut add = |amount: usize| -> Result<(), TableDefinitionWriteError> {
+        total = total.checked_add(amount).ok_or_else(too_long)?;
+        Ok(())
+    };
+    add(physical_index_count
+        .checked_mul(PHYSICAL_PREFIX_LEN + PHYSICAL_RECORD_LEN)
+        .ok_or_else(too_long)?)?;
+    add(columns
+        .len()
+        .checked_mul(COLUMN_RECORD_LEN)
+        .ok_or_else(too_long)?)?;
+    for column in columns {
+        add(1)?;
+        add(column.name().len())?;
+    }
+    add(index_names
+        .len()
+        .checked_mul(LOGICAL_RECORD_LEN)
+        .ok_or_else(too_long)?)?;
+    for name in index_names {
+        add(1)?;
+        add(name.len())?;
+    }
+    add(long_value_map_count
+        .checked_mul(LONG_VALUE_MAP_GROUP_LEN)
+        .ok_or_else(too_long)?)?;
+    add(TERMINATOR_LEN)?;
+    if u32::try_from(total).is_err() {
+        return Err(TableDefinitionWriteError::DefinitionTooLong { length: total });
+    }
+    Ok(total)
+}
 
 /// Validates every column name and class and checks that the row layout they
 /// imply still admits an all-null row in one data-page row slot.

--- a/crates/jet3/src/table_definition_layout.rs
+++ b/crates/jet3/src/table_definition_layout.rs
@@ -1,0 +1,105 @@
+//! Shared validation of the row layout a table's columns imply (`EXP-0059`).
+//!
+//! The table-definition encoder and the table planner both have to accept
+//! exactly the same schemas, so both run these checks rather than each
+//! carrying its own copy of the rules.
+
+use crate::column_definition_writer::{
+    ColumnSpec, MAX_NAME_LEN, SystemColumnClassSpec, resolve_column,
+};
+use crate::data_page_directory::MAX_STORED_ROW_LEN;
+use crate::table_definition_writer::TableDefinitionWriteError;
+use crate::{Error, TableDefinitionKind};
+
+/// `EXP-0060`: the one-byte row column count bounds a table's columns.
+const MAX_COLUMN_COUNT: usize = u8::MAX as usize;
+
+/// Validates every column name and class and checks that the row layout they
+/// imply still admits an all-null row in one data-page row slot.
+///
+/// Returns the number of variable-storage columns the layout carries.
+pub(crate) fn validate_column_layout(
+    columns: &[ColumnSpec<'_>],
+    kind: TableDefinitionKind,
+    system_column_classes: &[SystemColumnClassSpec],
+) -> Result<u16, TableDefinitionWriteError> {
+    if columns.len() > MAX_COLUMN_COUNT {
+        return Err(TableDefinitionWriteError::TooManyColumns {
+            count: columns.len(),
+            maximum: MAX_COLUMN_COUNT,
+        });
+    }
+    let mut next_fixed_offset = 0_u16;
+    let mut variables = 0_u16;
+    for (ordinal, column) in (0_u16..).zip(columns) {
+        validate_name(
+            "column",
+            ordinal,
+            column.name(),
+            columns[..usize::from(ordinal)].iter().map(ColumnSpec::name),
+        )?;
+        resolve_column(
+            ordinal,
+            column,
+            kind,
+            system_column_classes.get(usize::from(ordinal)).copied(),
+            &mut next_fixed_offset,
+            &mut variables,
+        )?;
+    }
+    let variable_trailer = if variables == 0 {
+        0
+    } else {
+        usize::from(variables)
+            .checked_add(2)
+            .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+                operation: "size minimum encoded-row variable trailer",
+            }))?
+    };
+    let mut minimum_row_len = 1_usize
+        .checked_add(usize::from(next_fixed_offset))
+        .and_then(|value| value.checked_add(columns.len().div_ceil(8)))
+        .and_then(|value| value.checked_add(variable_trailer))
+        .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+            operation: "size minimum encoded row",
+        }))?;
+    if variables > 0 && minimum_row_len > u8::MAX as usize {
+        minimum_row_len =
+            minimum_row_len
+                .checked_add(1)
+                .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
+                    operation: "size minimum encoded-row jump table",
+                }))?;
+    }
+    if minimum_row_len > MAX_STORED_ROW_LEN {
+        return Err(TableDefinitionWriteError::RowLayoutTooLarge {
+            minimum: minimum_row_len,
+            maximum: MAX_STORED_ROW_LEN,
+        });
+    }
+    Ok(variables)
+}
+
+pub(crate) fn validate_name<'a>(
+    role: &'static str,
+    ordinal: u16,
+    name: &[u8],
+    earlier: impl Iterator<Item = &'a [u8]>,
+) -> Result<(), TableDefinitionWriteError> {
+    if name.is_empty() {
+        return Err(TableDefinitionWriteError::EmptyName { role, ordinal });
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(TableDefinitionWriteError::NameTooLong {
+            role,
+            ordinal,
+            length: name.len(),
+            maximum: MAX_NAME_LEN,
+        });
+    }
+    let mut earlier = earlier;
+    if earlier.any(|other| other == name) {
+        return Err(TableDefinitionWriteError::DuplicateName { role, ordinal });
+    }
+    Ok(())
+}

--- a/crates/jet3/src/table_definition_writer.rs
+++ b/crates/jet3/src/table_definition_writer.rs
@@ -9,12 +9,11 @@
 use std::fmt;
 
 use crate::column_definition_writer::{
-    COLUMN_RECORD_LEN, ColumnSpec, ColumnStorageKind, LOGICAL_RECORD_LEN, LogicalIndexKindSpec,
-    LogicalIndexSpec, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, PhysicalIndexSpec,
+    ColumnSpec, ColumnStorageKind, LogicalIndexKindSpec, LogicalIndexSpec, PhysicalIndexSpec,
     SystemColumnClassSpec, physical_flags, resolve_column, validate_physical_index,
     write_column_record, write_logical_record, write_name, write_physical_record,
 };
-use crate::table_definition_layout::{validate_column_layout, validate_name};
+use crate::table_definition_layout::{definition_len, validate_column_layout, validate_name};
 use crate::{
     BinaryWriter, ByteCount, ColumnPhysicalType, Error, MapRowLocator, PageNumber, ResourceBudget,
     TableDefinitionKind,
@@ -23,7 +22,6 @@ use crate::{
 /// `EXP-0059`: four-byte definition page prefix.
 const DEFINITION_PREFIX: [u8; 4] = [0x02, 0x01, 0x56, 0x43];
 /// `EXP-0059`: fixed header before the physical-index prefixes.
-const DEFINITION_HEADER_LEN: usize = 43;
 /// `EXP-0059`: byte 20 marker.
 const USER_HEADER_MARKER: u8 = 0x4e;
 /// `EXP-0073`: byte 20 of every observed system definition.
@@ -328,63 +326,12 @@ impl std::error::Error for TableDefinitionWriteError {
 pub fn table_definition_len(
     spec: &TableDefinitionSpec<'_>,
 ) -> Result<usize, TableDefinitionWriteError> {
-    if spec.columns.len() > MAX_COLUMN_COUNT {
-        return Err(TableDefinitionWriteError::TooManyColumns {
-            count: spec.columns.len(),
-            maximum: MAX_COLUMN_COUNT,
-        });
-    }
-    for (role, count) in [
-        ("physical", spec.physical_indexes.len()),
-        ("logical", spec.indexes.len()),
-    ] {
-        if u16::try_from(count).is_err() {
-            return Err(TableDefinitionWriteError::TooManyIndexes { role, count });
-        }
-    }
-    let mut total = DEFINITION_HEADER_LEN;
-    let mut add = |amount: usize| -> Result<(), TableDefinitionWriteError> {
-        total = total
-            .checked_add(amount)
-            .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
-        Ok(())
-    };
-    let physical_bytes = spec
-        .physical_indexes
-        .len()
-        .checked_mul(PHYSICAL_PREFIX_LEN + PHYSICAL_RECORD_LEN)
-        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
-    add(physical_bytes)?;
-    let column_bytes = spec
-        .columns
-        .len()
-        .checked_mul(COLUMN_RECORD_LEN)
-        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
-    add(column_bytes)?;
-    for column in spec.columns {
-        add(1)?;
-        add(column.name().len())?;
-    }
-    let logical_bytes = spec
-        .indexes
-        .len()
-        .checked_mul(LOGICAL_RECORD_LEN)
-        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?;
-    add(logical_bytes)?;
-    for index in spec.indexes {
-        add(1)?;
-        add(index.name.len())?;
-    }
-    add(spec
-        .long_value_maps
-        .len()
-        .checked_mul(crate::LONG_VALUE_MAP_GROUP_LEN)
-        .ok_or(TableDefinitionWriteError::DefinitionTooLong { length: usize::MAX })?)?;
-    add(TERMINATOR.len())?;
-    if u32::try_from(total).is_err() {
-        return Err(TableDefinitionWriteError::DefinitionTooLong { length: total });
-    }
-    Ok(total)
+    definition_len(
+        spec.columns,
+        spec.indexes.iter().map(|index| index.name),
+        spec.physical_indexes.len(),
+        spec.long_value_maps.len(),
+    )
 }
 
 /// Encodes the logical definition into `output`, returning the encoded length.

--- a/crates/jet3/src/table_definition_writer.rs
+++ b/crates/jet3/src/table_definition_writer.rs
@@ -10,11 +10,11 @@ use std::fmt;
 
 use crate::column_definition_writer::{
     COLUMN_RECORD_LEN, ColumnSpec, ColumnStorageKind, LOGICAL_RECORD_LEN, LogicalIndexKindSpec,
-    LogicalIndexSpec, MAX_NAME_LEN, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, PhysicalIndexSpec,
+    LogicalIndexSpec, PHYSICAL_PREFIX_LEN, PHYSICAL_RECORD_LEN, PhysicalIndexSpec,
     SystemColumnClassSpec, physical_flags, resolve_column, validate_physical_index,
     write_column_record, write_logical_record, write_name, write_physical_record,
 };
-use crate::data_page_directory::MAX_STORED_ROW_LEN;
+use crate::table_definition_layout::{validate_column_layout, validate_name};
 use crate::{
     BinaryWriter, ByteCount, ColumnPhysicalType, Error, MapRowLocator, PageNumber, ResourceBudget,
     TableDefinitionKind,
@@ -519,58 +519,7 @@ fn validate(
         .charge_items(name_work)
         .map_err(TableDefinitionWriteError::Resource)?;
 
-    let mut next_fixed_offset = 0_u16;
-    let mut variables = 0_u16;
-    for (ordinal, column) in (0_u16..).zip(spec.columns) {
-        validate_name(
-            "column",
-            ordinal,
-            column.name(),
-            spec.columns[..usize::from(ordinal)]
-                .iter()
-                .map(ColumnSpec::name),
-        )?;
-        resolve_column(
-            ordinal,
-            column,
-            spec.kind,
-            spec.system_column_classes
-                .get(usize::from(ordinal))
-                .copied(),
-            &mut next_fixed_offset,
-            &mut variables,
-        )?;
-    }
-    let variable_trailer = if variables == 0 {
-        0
-    } else {
-        usize::from(variables)
-            .checked_add(2)
-            .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
-                operation: "size minimum encoded-row variable trailer",
-            }))?
-    };
-    let mut minimum_row_len = 1_usize
-        .checked_add(usize::from(next_fixed_offset))
-        .and_then(|value| value.checked_add(spec.columns.len().div_ceil(8)))
-        .and_then(|value| value.checked_add(variable_trailer))
-        .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
-            operation: "size minimum encoded row",
-        }))?;
-    if variables > 0 && minimum_row_len > u8::MAX as usize {
-        minimum_row_len =
-            minimum_row_len
-                .checked_add(1)
-                .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
-                    operation: "size minimum encoded-row jump table",
-                }))?;
-    }
-    if minimum_row_len > MAX_STORED_ROW_LEN {
-        return Err(TableDefinitionWriteError::RowLayoutTooLarge {
-            minimum: minimum_row_len,
-            maximum: MAX_STORED_ROW_LEN,
-        });
-    }
+    let variables = validate_column_layout(spec.columns, spec.kind, spec.system_column_classes)?;
     for (ordinal, index) in (0_u16..).zip(spec.physical_indexes) {
         validate_physical_index(ordinal, index, spec.columns)?;
         let admitted = match spec.kind {
@@ -719,30 +668,6 @@ fn validate_long_value_maps(
         return Err(TableDefinitionWriteError::MissingLongValueMap {
             column: column as u16,
         });
-    }
-    Ok(())
-}
-
-fn validate_name<'a>(
-    role: &'static str,
-    ordinal: u16,
-    name: &[u8],
-    earlier: impl Iterator<Item = &'a [u8]>,
-) -> Result<(), TableDefinitionWriteError> {
-    if name.is_empty() {
-        return Err(TableDefinitionWriteError::EmptyName { role, ordinal });
-    }
-    if name.len() > MAX_NAME_LEN {
-        return Err(TableDefinitionWriteError::NameTooLong {
-            role,
-            ordinal,
-            length: name.len(),
-            maximum: MAX_NAME_LEN,
-        });
-    }
-    let mut earlier = earlier;
-    if earlier.any(|other| other == name) {
-        return Err(TableDefinitionWriteError::DuplicateName { role, ordinal });
     }
     Ok(())
 }

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -31,10 +31,11 @@ use std::fmt;
 use crate::catalog_name_key::{CatalogNameKeyError, validate_catalog_name};
 use crate::catalog_record_writer::{CatalogRecordWriteError, catalog_record_len};
 use crate::column_definition_writer::{PhysicalIndexSpec, validate_physical_index};
-use crate::table_definition_layout::{validate_column_layout, validate_name};
+use crate::page_image::PAGE_BYTES;
+use crate::table_definition_layout::{definition_len, validate_column_layout, validate_name};
 use crate::{
-    ColumnSpec, IndexFieldSpec, PageNumber, PhysicalIndexFlagsSpec, TableDefinitionKind,
-    TableDefinitionWriteError,
+    ColumnPhysicalType, ColumnSpec, IndexFieldSpec, PageNumber, PhysicalIndexFlagsSpec,
+    TableDefinitionKind, TableDefinitionWriteError,
 };
 
 /// Index count `EXP-0087` observed on a created table.
@@ -43,6 +44,8 @@ const MAX_OBSERVED_INDEXES: usize = 1;
 const MAX_MAP_PAGE: u64 = 0x00ff_ffff;
 /// Row slot the planned table's own usage map takes on its map page.
 const OWNED_MAP_ROW: u8 = 0;
+/// Bytes of a definition the root page holds; longer needs a continuation.
+const DEFINITION_ROOT_CAPACITY: usize = PAGE_BYTES;
 
 /// Whether a planned index is the table's primary one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,6 +99,14 @@ pub(crate) enum TableSchemaPlanError {
     Definition(TableDefinitionWriteError),
     /// The table declares no columns.
     NoColumns,
+    /// The definition needs a continuation page, whose placement no experiment
+    /// has established.
+    DefinitionNeedsContinuation {
+        /// Encoded definition length.
+        length: usize,
+        /// Bytes the definition root page holds.
+        capacity: usize,
+    },
     /// `EXP-0087` observed no create carrying this many indexes.
     UnobservedIndexCount {
         /// Declared index count.
@@ -195,6 +206,7 @@ pub(crate) fn plan_table_schema(
     }
     validate_column_layout(spec.columns, TableDefinitionKind::User, &[])
         .map_err(TableSchemaPlanError::Definition)?;
+    validate_definition_fits_root(spec)?;
     let plan = assign_pages(spec, first_page)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
@@ -204,6 +216,40 @@ pub(crate) fn plan_table_schema(
 fn validate_table_name(name: &[u8]) -> Result<(), TableSchemaPlanError> {
     validate_catalog_name(name).map_err(TableSchemaPlanError::TableNameKey)?;
     catalog_record_len(name.len()).map_err(TableSchemaPlanError::TableNameRow)?;
+    Ok(())
+}
+
+/// Refuses a definition too long for its root page.
+///
+/// `EXP-0087` observed every create appending a definition root, a map-rows
+/// page, and at most an index root, so no observed definition needed a
+/// continuation page and nothing establishes where one would land.
+fn validate_definition_fits_root(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+    // The writer requires one long-value map group per Memo or LongBinary
+    // column, so the group count follows from the columns.
+    let long_value_maps = spec
+        .columns
+        .iter()
+        .filter(|column| {
+            matches!(
+                column.physical_type(),
+                ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
+            )
+        })
+        .count();
+    let length = definition_len(
+        spec.columns,
+        spec.indexes.iter().map(|index| index.name),
+        spec.indexes.len(),
+        long_value_maps,
+    )
+    .map_err(TableSchemaPlanError::Definition)?;
+    if length > DEFINITION_ROOT_CAPACITY {
+        return Err(TableSchemaPlanError::DefinitionNeedsContinuation {
+            length,
+            capacity: DEFINITION_ROOT_CAPACITY,
+        });
+    }
     Ok(())
 }
 

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -1,0 +1,328 @@
+//! Crate-private typed planning of one new user table.
+//!
+//! This validates a caller-described table and assigns its appended pages. It
+//! builds no page bytes and performs no I/O.
+//!
+//! `EXP-0087` observed, identically across three fresh replicas, that creating
+//! a user table appends a definition root page numbered equal to the new
+//! object's `MSysObjects` `Id`, then a page holding the table's usage-map rows,
+//! then one index root when the table carries an index. It observed only tables
+//! with zero or one index, so this module refuses more than one rather than
+//! extrapolating an ordering nobody has observed.
+//!
+//! `EXP-0087` establishes no property grammar beyond the pinned framing, so
+//! this module plans no `LvProp` payload. It also establishes no `Id`
+//! allocation rule beyond the observed equality with the definition root page.
+
+#![allow(
+    dead_code,
+    reason = "crate-private writer slice awaiting DAO validation"
+)]
+
+use std::fmt;
+
+use crate::catalog_name_key::{CatalogNameKeyError, validate_catalog_name};
+use crate::{ColumnPhysicalType, ColumnStorageKind, PageNumber};
+
+/// Largest column count a planned table may carry.
+const MAX_COLUMNS: usize = 255;
+/// Largest field count one planned index may carry.
+const MAX_INDEX_FIELDS: usize = 10;
+/// Index count `EXP-0087` observed on a created table.
+const MAX_OBSERVED_INDEXES: usize = 1;
+
+/// One column of a table being planned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PlannedColumn<'a> {
+    /// Column name in the database's configured code page.
+    pub(crate) name: &'a [u8],
+    /// Stored physical type.
+    pub(crate) physical_type: ColumnPhysicalType,
+    /// Whether the column occupies a fixed row slot or a variable one.
+    pub(crate) storage: ColumnStorageKind,
+    /// Declared size in bytes; zero for the long types that carry none.
+    pub(crate) size: u16,
+}
+
+/// Whether a planned index is the table's primary one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlannedIndexKind {
+    /// The table's primary index, which `EXP-0087` observed is also unique.
+    Primary,
+    /// Any other index.
+    Ordinary,
+}
+
+/// One index of a table being planned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PlannedIndex<'a> {
+    /// Index name in the database's configured code page.
+    pub(crate) name: &'a [u8],
+    /// Zero-based ordinals of the indexed columns, in key order.
+    pub(crate) fields: &'a [u16],
+    /// Whether this is the table's primary index.
+    pub(crate) kind: PlannedIndexKind,
+}
+
+/// A caller-described user table awaiting validation and page assignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TableSchemaSpec<'a> {
+    /// Table name in the database's configured code page.
+    pub(crate) name: &'a [u8],
+    /// The table's columns in ordinal order.
+    pub(crate) columns: &'a [PlannedColumn<'a>],
+    /// The table's indexes.
+    pub(crate) indexes: &'a [PlannedIndex<'a>],
+}
+
+/// Structured failure while planning one new user table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TableSchemaPlanError {
+    /// The table name cannot be encoded into a catalog index key.
+    TableName(CatalogNameKeyError),
+    /// A column declares an empty name.
+    EmptyColumnName {
+        /// Zero-based ordinal of the rejected column.
+        ordinal: usize,
+    },
+    /// An index declares an empty name.
+    EmptyIndexName {
+        /// Zero-based position of the rejected index.
+        index: usize,
+    },
+    /// The table declares no columns.
+    NoColumns,
+    /// The table declares more columns than a planned table may carry.
+    TooManyColumns {
+        /// Declared column count.
+        count: usize,
+        /// Largest supported column count.
+        limit: usize,
+    },
+    /// Two columns share a name.
+    DuplicateColumnName {
+        /// Ordinal of the earlier column.
+        first: usize,
+        /// Ordinal of the later column.
+        second: usize,
+    },
+    /// Two indexes share a name.
+    DuplicateIndexName {
+        /// Position of the earlier index.
+        first: usize,
+        /// Position of the later index.
+        second: usize,
+    },
+    /// `EXP-0087` observed no create carrying this many indexes.
+    UnobservedIndexCount {
+        /// Declared index count.
+        count: usize,
+        /// Largest observed index count.
+        observed: usize,
+    },
+    /// An index names no columns.
+    IndexWithoutFields {
+        /// Position of the rejected index.
+        index: usize,
+    },
+    /// An index names more columns than one index may carry.
+    TooManyIndexFields {
+        /// Position of the rejected index.
+        index: usize,
+        /// Declared field count.
+        count: usize,
+        /// Largest supported field count.
+        limit: usize,
+    },
+    /// An index names a column the table does not declare.
+    IndexFieldOutOfRange {
+        /// Position of the rejected index.
+        index: usize,
+        /// The out-of-range column ordinal.
+        column: u16,
+    },
+    /// An index names the same column twice.
+    DuplicateIndexField {
+        /// Position of the rejected index.
+        index: usize,
+        /// The repeated column ordinal.
+        column: u16,
+    },
+    /// The table declares more than one primary index.
+    MultiplePrimaryIndexes {
+        /// Position of the earlier primary index.
+        first: usize,
+        /// Position of the later primary index.
+        second: usize,
+    },
+    /// The appended pages do not fit the addressable page space.
+    PageOverflow {
+        /// Page the appended run would have started at.
+        first: u64,
+        /// Pages the run needs.
+        needed: u64,
+    },
+}
+
+impl fmt::Display for TableSchemaPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Jet 3 table schema planning failed: {self:?}")
+    }
+}
+
+impl std::error::Error for TableSchemaPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TableName(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// The validated page assignment for one new user table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableSchemaPlan {
+    object_id: i32,
+    definition_root: PageNumber,
+    map_page: PageNumber,
+    index_root: Option<PageNumber>,
+}
+
+impl TableSchemaPlan {
+    /// Returns the `MSysObjects` `Id` the new table takes.
+    pub(crate) const fn object_id(&self) -> i32 {
+        self.object_id
+    }
+
+    /// Returns the page holding the table's definition.
+    pub(crate) const fn definition_root(&self) -> PageNumber {
+        self.definition_root
+    }
+
+    /// Returns the page holding the table's usage-map rows.
+    pub(crate) const fn map_page(&self) -> PageNumber {
+        self.map_page
+    }
+
+    /// Returns the table's index root page, if it carries an index.
+    pub(crate) const fn index_root(&self) -> Option<PageNumber> {
+        self.index_root
+    }
+
+    /// Returns how many pages the create appends.
+    pub(crate) const fn appended_page_count(&self) -> u64 {
+        if self.index_root.is_some() { 3 } else { 2 }
+    }
+}
+
+/// Validates `spec` and assigns its appended pages starting at `first_page`.
+///
+/// `first_page` is the database's current page count, so the appended run is
+/// contiguous from it. The `EXP-0087` assignment is the definition root, then
+/// the map-rows page, then the index root when the table carries an index.
+pub(crate) fn plan_table_schema(
+    spec: &TableSchemaSpec<'_>,
+    first_page: u64,
+) -> Result<TableSchemaPlan, TableSchemaPlanError> {
+    validate_names(spec)?;
+    validate_indexes(spec)?;
+    let needed = if spec.indexes.is_empty() { 2 } else { 3 };
+    let object_id = i32::try_from(first_page)
+        .ok()
+        .filter(|_| first_page.checked_add(needed).is_some())
+        .ok_or(TableSchemaPlanError::PageOverflow {
+            first: first_page,
+            needed,
+        })?;
+    Ok(TableSchemaPlan {
+        object_id,
+        definition_root: PageNumber::new(first_page),
+        map_page: PageNumber::new(first_page + 1),
+        index_root: (needed == 3).then(|| PageNumber::new(first_page + 2)),
+    })
+}
+
+fn validate_names(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+    validate_catalog_name(spec.name).map_err(TableSchemaPlanError::TableName)?;
+    if spec.columns.is_empty() {
+        return Err(TableSchemaPlanError::NoColumns);
+    }
+    if spec.columns.len() > MAX_COLUMNS {
+        return Err(TableSchemaPlanError::TooManyColumns {
+            count: spec.columns.len(),
+            limit: MAX_COLUMNS,
+        });
+    }
+    for (ordinal, column) in spec.columns.iter().enumerate() {
+        if column.name.is_empty() {
+            return Err(TableSchemaPlanError::EmptyColumnName { ordinal });
+        }
+        if let Some(first) = spec.columns[..ordinal]
+            .iter()
+            .position(|earlier| earlier.name == column.name)
+        {
+            return Err(TableSchemaPlanError::DuplicateColumnName {
+                first,
+                second: ordinal,
+            });
+        }
+    }
+    for (index, planned) in spec.indexes.iter().enumerate() {
+        if planned.name.is_empty() {
+            return Err(TableSchemaPlanError::EmptyIndexName { index });
+        }
+        if let Some(first) = spec.indexes[..index]
+            .iter()
+            .position(|earlier| earlier.name == planned.name)
+        {
+            return Err(TableSchemaPlanError::DuplicateIndexName {
+                first,
+                second: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_indexes(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+    if spec.indexes.len() > MAX_OBSERVED_INDEXES {
+        return Err(TableSchemaPlanError::UnobservedIndexCount {
+            count: spec.indexes.len(),
+            observed: MAX_OBSERVED_INDEXES,
+        });
+    }
+    let mut primary: Option<usize> = None;
+    for (index, planned) in spec.indexes.iter().enumerate() {
+        if planned.fields.is_empty() {
+            return Err(TableSchemaPlanError::IndexWithoutFields { index });
+        }
+        if planned.fields.len() > MAX_INDEX_FIELDS {
+            return Err(TableSchemaPlanError::TooManyIndexFields {
+                index,
+                count: planned.fields.len(),
+                limit: MAX_INDEX_FIELDS,
+            });
+        }
+        for (position, &column) in planned.fields.iter().enumerate() {
+            if usize::from(column) >= spec.columns.len() {
+                return Err(TableSchemaPlanError::IndexFieldOutOfRange { index, column });
+            }
+            if planned.fields[..position].contains(&column) {
+                return Err(TableSchemaPlanError::DuplicateIndexField { index, column });
+            }
+        }
+        if planned.kind == PlannedIndexKind::Primary
+            && let Some(first) = primary.replace(index)
+        {
+            return Err(TableSchemaPlanError::MultiplePrimaryIndexes {
+                first,
+                second: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "table_schema_plan_tests.rs"]
+mod tests;

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -11,8 +11,11 @@
 //! extrapolating an ordering nobody has observed.
 //!
 //! `EXP-0087` establishes no property grammar beyond the pinned framing, so
-//! this module plans no `LvProp` payload. It also establishes no `Id`
-//! allocation rule beyond the observed equality with the definition root page.
+//! this module plans no `LvProp` payload and no long-value page. `EXP-0087`
+//! observed that a database's first create also appends a long-value page, so
+//! a caller composing that first create must account for it separately. It
+//! also establishes no `Id` allocation rule beyond the observed equality with
+//! the definition root page.
 
 #![allow(
     dead_code,
@@ -22,12 +25,13 @@
 use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, validate_catalog_name};
+use crate::physical_index_definition::KEY_SLOT_COUNT;
 use crate::{ColumnPhysicalType, ColumnStorageKind, PageNumber};
 
-/// Largest column count a planned table may carry.
+/// `EXP-0060`: one-byte column count, so at most 255 columns.
 const MAX_COLUMNS: usize = 255;
-/// Largest field count one planned index may carry.
-const MAX_INDEX_FIELDS: usize = 10;
+/// `EXP-0059`: one key slot per indexed column in the physical definition.
+const MAX_INDEX_FIELDS: usize = KEY_SLOT_COUNT;
 /// Index count `EXP-0087` observed on a created table.
 const MAX_OBSERVED_INDEXES: usize = 1;
 
@@ -209,7 +213,8 @@ impl TableSchemaPlan {
         self.index_root
     }
 
-    /// Returns how many pages the create appends.
+    /// Returns how many pages the create appends, excluding the long-value
+    /// page `EXP-0087` observed only on a database's first create.
     pub(crate) const fn appended_page_count(&self) -> u64 {
         if self.index_root.is_some() { 3 } else { 2 }
     }

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -3,6 +3,10 @@
 //! This validates a caller-described table and assigns its appended pages. It
 //! builds no page bytes and performs no I/O.
 //!
+//! Column classes, sizes, row layout, key columns, and name lengths are
+//! validated by the same table-definition and catalog encoders that will later
+//! write the table, so a plan this module accepts is one those encoders accept.
+//!
 //! `EXP-0087` observed, identically across three fresh replicas, that creating
 //! a user table appends a definition root page numbered equal to the new
 //! object's `MSysObjects` `Id`, then a page holding the table's usage-map rows,
@@ -25,28 +29,20 @@
 use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, validate_catalog_name};
-use crate::physical_index_definition::KEY_SLOT_COUNT;
-use crate::{ColumnPhysicalType, ColumnStorageKind, PageNumber};
+use crate::catalog_record_writer::{CatalogRecordWriteError, catalog_record_len};
+use crate::column_definition_writer::{PhysicalIndexSpec, validate_physical_index};
+use crate::table_definition_layout::{validate_column_layout, validate_name};
+use crate::{
+    ColumnSpec, IndexFieldSpec, PageNumber, PhysicalIndexFlagsSpec, TableDefinitionKind,
+    TableDefinitionWriteError,
+};
 
-/// `EXP-0060`: one-byte column count, so at most 255 columns.
-const MAX_COLUMNS: usize = 255;
-/// `EXP-0059`: one key slot per indexed column in the physical definition.
-const MAX_INDEX_FIELDS: usize = KEY_SLOT_COUNT;
 /// Index count `EXP-0087` observed on a created table.
 const MAX_OBSERVED_INDEXES: usize = 1;
-
-/// One column of a table being planned.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct PlannedColumn<'a> {
-    /// Column name in the database's configured code page.
-    pub(crate) name: &'a [u8],
-    /// Stored physical type.
-    pub(crate) physical_type: ColumnPhysicalType,
-    /// Whether the column occupies a fixed row slot or a variable one.
-    pub(crate) storage: ColumnStorageKind,
-    /// Declared size in bytes; zero for the long types that carry none.
-    pub(crate) size: u16,
-}
+/// `EXP-0057`: usage-map locators hold a three-byte page number.
+const MAX_MAP_PAGE: u64 = 0x00ff_ffff;
+/// Row slot the planned table's own usage map takes on its map page.
+const OWNED_MAP_ROW: u8 = 0;
 
 /// Whether a planned index is the table's primary one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,13 +53,23 @@ pub(crate) enum PlannedIndexKind {
     Ordinary,
 }
 
+impl PlannedIndexKind {
+    /// Returns the physical flag class this index kind encodes to.
+    const fn flags(self) -> PhysicalIndexFlagsSpec {
+        match self {
+            Self::Primary => PhysicalIndexFlagsSpec::UniqueRequired,
+            Self::Ordinary => PhysicalIndexFlagsSpec::Ordinary,
+        }
+    }
+}
+
 /// One index of a table being planned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PlannedIndex<'a> {
     /// Index name in the database's configured code page.
     pub(crate) name: &'a [u8],
-    /// Zero-based ordinals of the indexed columns, in key order.
-    pub(crate) fields: &'a [u16],
+    /// Ordered key fields.
+    pub(crate) fields: &'a [IndexFieldSpec],
     /// Whether this is the table's primary index.
     pub(crate) kind: PlannedIndexKind,
 }
@@ -74,7 +80,7 @@ pub(crate) struct TableSchemaSpec<'a> {
     /// Table name in the database's configured code page.
     pub(crate) name: &'a [u8],
     /// The table's columns in ordinal order.
-    pub(crate) columns: &'a [PlannedColumn<'a>],
+    pub(crate) columns: &'a [ColumnSpec<'a>],
     /// The table's indexes.
     pub(crate) indexes: &'a [PlannedIndex<'a>],
 }
@@ -83,74 +89,19 @@ pub(crate) struct TableSchemaSpec<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TableSchemaPlanError {
     /// The table name cannot be encoded into a catalog index key.
-    TableName(CatalogNameKeyError),
-    /// A column declares an empty name.
-    EmptyColumnName {
-        /// Zero-based ordinal of the rejected column.
-        ordinal: usize,
-    },
-    /// An index declares an empty name.
-    EmptyIndexName {
-        /// Zero-based position of the rejected index.
-        index: usize,
-    },
+    TableNameKey(CatalogNameKeyError),
+    /// The table name cannot be encoded into an `MSysObjects` row.
+    TableNameRow(CatalogRecordWriteError),
+    /// The columns or indexes cannot be encoded into a table definition.
+    Definition(TableDefinitionWriteError),
     /// The table declares no columns.
     NoColumns,
-    /// The table declares more columns than a planned table may carry.
-    TooManyColumns {
-        /// Declared column count.
-        count: usize,
-        /// Largest supported column count.
-        limit: usize,
-    },
-    /// Two columns share a name.
-    DuplicateColumnName {
-        /// Ordinal of the earlier column.
-        first: usize,
-        /// Ordinal of the later column.
-        second: usize,
-    },
-    /// Two indexes share a name.
-    DuplicateIndexName {
-        /// Position of the earlier index.
-        first: usize,
-        /// Position of the later index.
-        second: usize,
-    },
     /// `EXP-0087` observed no create carrying this many indexes.
     UnobservedIndexCount {
         /// Declared index count.
         count: usize,
         /// Largest observed index count.
         observed: usize,
-    },
-    /// An index names no columns.
-    IndexWithoutFields {
-        /// Position of the rejected index.
-        index: usize,
-    },
-    /// An index names more columns than one index may carry.
-    TooManyIndexFields {
-        /// Position of the rejected index.
-        index: usize,
-        /// Declared field count.
-        count: usize,
-        /// Largest supported field count.
-        limit: usize,
-    },
-    /// An index names a column the table does not declare.
-    IndexFieldOutOfRange {
-        /// Position of the rejected index.
-        index: usize,
-        /// The out-of-range column ordinal.
-        column: u16,
-    },
-    /// An index names the same column twice.
-    DuplicateIndexField {
-        /// Position of the rejected index.
-        index: usize,
-        /// The repeated column ordinal.
-        column: u16,
     },
     /// The table declares more than one primary index.
     MultiplePrimaryIndexes {
@@ -166,6 +117,13 @@ pub(crate) enum TableSchemaPlanError {
         /// Pages the run needs.
         needed: u64,
     },
+    /// The map page cannot be named by a three-byte usage-map locator.
+    MapPageNotAddressable {
+        /// The unaddressable map page.
+        page: u64,
+        /// Highest page a locator can name.
+        maximum: u64,
+    },
 }
 
 impl fmt::Display for TableSchemaPlanError {
@@ -177,7 +135,9 @@ impl fmt::Display for TableSchemaPlanError {
 impl std::error::Error for TableSchemaPlanError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::TableName(source) => Some(source),
+            Self::TableNameKey(source) => Some(source),
+            Self::TableNameRow(source) => Some(source),
+            Self::Definition(source) => Some(source),
             _ => None,
         }
     }
@@ -229,9 +189,32 @@ pub(crate) fn plan_table_schema(
     spec: &TableSchemaSpec<'_>,
     first_page: u64,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
-    validate_names(spec)?;
-    validate_indexes(spec)?;
+    validate_table_name(spec.name)?;
+    if spec.columns.is_empty() {
+        return Err(TableSchemaPlanError::NoColumns);
+    }
+    validate_column_layout(spec.columns, TableDefinitionKind::User, &[])
+        .map_err(TableSchemaPlanError::Definition)?;
+    let plan = assign_pages(spec, first_page)?;
+    validate_indexes(spec, &plan)?;
+    Ok(plan)
+}
+
+/// Checks the table name against both encodings that will carry it.
+fn validate_table_name(name: &[u8]) -> Result<(), TableSchemaPlanError> {
+    validate_catalog_name(name).map_err(TableSchemaPlanError::TableNameKey)?;
+    catalog_record_len(name.len()).map_err(TableSchemaPlanError::TableNameRow)?;
+    Ok(())
+}
+
+/// Assigns the appended page run, refusing numbers the encoders cannot name.
+fn assign_pages(
+    spec: &TableSchemaSpec<'_>,
+    first_page: u64,
+) -> Result<TableSchemaPlan, TableSchemaPlanError> {
     let needed = if spec.indexes.is_empty() { 2 } else { 3 };
+    // `EXP-0087` numbers the object equal to its definition root, and
+    // `MSysObjects.Id` is a signed Long, so the run must stay in that range.
     let object_id = i32::try_from(first_page)
         .ok()
         .filter(|_| first_page.checked_add(needed).is_some())
@@ -239,57 +222,26 @@ pub(crate) fn plan_table_schema(
             first: first_page,
             needed,
         })?;
+    let map_page = first_page + 1;
+    if map_page > MAX_MAP_PAGE {
+        return Err(TableSchemaPlanError::MapPageNotAddressable {
+            page: map_page,
+            maximum: MAX_MAP_PAGE,
+        });
+    }
     Ok(TableSchemaPlan {
         object_id,
         definition_root: PageNumber::new(first_page),
-        map_page: PageNumber::new(first_page + 1),
+        map_page: PageNumber::new(map_page),
         index_root: (needed == 3).then(|| PageNumber::new(first_page + 2)),
     })
 }
 
-fn validate_names(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
-    validate_catalog_name(spec.name).map_err(TableSchemaPlanError::TableName)?;
-    if spec.columns.is_empty() {
-        return Err(TableSchemaPlanError::NoColumns);
-    }
-    if spec.columns.len() > MAX_COLUMNS {
-        return Err(TableSchemaPlanError::TooManyColumns {
-            count: spec.columns.len(),
-            limit: MAX_COLUMNS,
-        });
-    }
-    for (ordinal, column) in spec.columns.iter().enumerate() {
-        if column.name.is_empty() {
-            return Err(TableSchemaPlanError::EmptyColumnName { ordinal });
-        }
-        if let Some(first) = spec.columns[..ordinal]
-            .iter()
-            .position(|earlier| earlier.name == column.name)
-        {
-            return Err(TableSchemaPlanError::DuplicateColumnName {
-                first,
-                second: ordinal,
-            });
-        }
-    }
-    for (index, planned) in spec.indexes.iter().enumerate() {
-        if planned.name.is_empty() {
-            return Err(TableSchemaPlanError::EmptyIndexName { index });
-        }
-        if let Some(first) = spec.indexes[..index]
-            .iter()
-            .position(|earlier| earlier.name == planned.name)
-        {
-            return Err(TableSchemaPlanError::DuplicateIndexName {
-                first,
-                second: index,
-            });
-        }
-    }
-    Ok(())
-}
-
-fn validate_indexes(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+/// Checks each index against the physical-index encoder and the observed count.
+fn validate_indexes(
+    spec: &TableSchemaSpec<'_>,
+    plan: &TableSchemaPlan,
+) -> Result<(), TableSchemaPlanError> {
     if spec.indexes.len() > MAX_OBSERVED_INDEXES {
         return Err(TableSchemaPlanError::UnobservedIndexCount {
             count: spec.indexes.len(),
@@ -297,31 +249,37 @@ fn validate_indexes(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanErr
         });
     }
     let mut primary: Option<usize> = None;
-    for (index, planned) in spec.indexes.iter().enumerate() {
-        if planned.fields.is_empty() {
-            return Err(TableSchemaPlanError::IndexWithoutFields { index });
-        }
-        if planned.fields.len() > MAX_INDEX_FIELDS {
-            return Err(TableSchemaPlanError::TooManyIndexFields {
-                index,
-                count: planned.fields.len(),
-                limit: MAX_INDEX_FIELDS,
-            });
-        }
-        for (position, &column) in planned.fields.iter().enumerate() {
-            if usize::from(column) >= spec.columns.len() {
-                return Err(TableSchemaPlanError::IndexFieldOutOfRange { index, column });
-            }
-            if planned.fields[..position].contains(&column) {
-                return Err(TableSchemaPlanError::DuplicateIndexField { index, column });
-            }
-        }
+    for (position, planned) in spec.indexes.iter().enumerate() {
+        let ordinal = position as u16;
+        validate_name(
+            "logical index",
+            ordinal,
+            planned.name,
+            spec.indexes[..position].iter().map(|earlier| earlier.name),
+        )
+        .map_err(TableSchemaPlanError::Definition)?;
+        let root = plan
+            .index_root
+            .ok_or(TableSchemaPlanError::UnobservedIndexCount {
+                count: spec.indexes.len(),
+                observed: MAX_OBSERVED_INDEXES,
+            })?;
+        let physical = PhysicalIndexSpec {
+            fields: planned.fields,
+            usage_map_page: plan.map_page,
+            usage_map_row: OWNED_MAP_ROW,
+            root,
+            flags: planned.kind.flags(),
+            entry_count: 0,
+        };
+        validate_physical_index(ordinal, &physical, spec.columns)
+            .map_err(TableSchemaPlanError::Definition)?;
         if planned.kind == PlannedIndexKind::Primary
-            && let Some(first) = primary.replace(index)
+            && let Some(first) = primary.replace(position)
         {
             return Err(TableSchemaPlanError::MultiplePrimaryIndexes {
                 first,
-                second: index,
+                second: position,
             });
         }
     }

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -1,41 +1,55 @@
 use super::*;
 
+use crate::physical_index_definition::KEY_SLOT_COUNT;
+use crate::{ColumnPhysicalType, ColumnStorageKind, IndexDirection};
+
 type PlanResult = Result<(), TableSchemaPlanError>;
 
-const ID: PlannedColumn<'static> = PlannedColumn {
-    name: b"Id",
-    physical_type: ColumnPhysicalType::Long,
-    storage: ColumnStorageKind::Fixed,
-    size: 4,
-};
-const LABEL: PlannedColumn<'static> = PlannedColumn {
-    name: b"Label",
-    physical_type: ColumnPhysicalType::Text,
-    storage: ColumnStorageKind::Variable,
-    size: 30,
-};
-const NAME: PlannedColumn<'static> = PlannedColumn {
-    name: b"Name",
-    physical_type: ColumnPhysicalType::Text,
-    storage: ColumnStorageKind::Variable,
-    size: 50,
-};
-const NOTE: PlannedColumn<'static> = PlannedColumn {
-    name: b"Note",
-    physical_type: ColumnPhysicalType::Memo,
-    storage: ColumnStorageKind::Variable,
-    size: 0,
-};
+const ID: ColumnSpec<'static> =
+    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4);
+const LABEL: ColumnSpec<'static> = ColumnSpec::new(
+    b"Label",
+    ColumnPhysicalType::Text,
+    ColumnStorageKind::Variable,
+    30,
+);
+const NAME: ColumnSpec<'static> = ColumnSpec::new(
+    b"Name",
+    ColumnPhysicalType::Text,
+    ColumnStorageKind::Variable,
+    50,
+);
+const NOTE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Note",
+    ColumnPhysicalType::Memo,
+    ColumnStorageKind::Variable,
+    0,
+);
+
+const fn key(column: u16) -> IndexFieldSpec {
+    IndexFieldSpec {
+        column,
+        direction: IndexDirection::Ascending,
+    }
+}
 
 fn spec<'a>(
     name: &'a [u8],
-    columns: &'a [PlannedColumn<'a>],
+    columns: &'a [ColumnSpec<'a>],
     indexes: &'a [PlannedIndex<'a>],
 ) -> TableSchemaSpec<'a> {
     TableSchemaSpec {
         name,
         columns,
         indexes,
+    }
+}
+
+/// Returns the definition error planning `spec` produced, if it produced one.
+fn definition_error(spec: &TableSchemaSpec<'_>) -> Option<TableDefinitionWriteError> {
+    match plan_table_schema(spec, 20) {
+        Err(TableSchemaPlanError::Definition(error)) => Some(error),
+        _ => None,
     }
 }
 
@@ -59,7 +73,7 @@ fn an_indexed_table_appends_its_index_root_after_the_map_page() -> PlanResult {
     let columns = [LABEL];
     let indexes = [PlannedIndex {
         name: b"ByLabel",
-        fields: &[0],
+        fields: &[key(0)],
         kind: PlannedIndexKind::Ordinary,
     }];
     let plan = plan_table_schema(&spec(b"Delta", &columns, &indexes), 28)?;
@@ -77,7 +91,7 @@ fn a_primary_index_plans_the_same_pages_as_an_ordinary_one() -> PlanResult {
     let columns = [ID];
     let indexes = [PlannedIndex {
         name: b"PrimaryKey",
-        fields: &[0],
+        fields: &[key(0)],
         kind: PlannedIndexKind::Primary,
     }];
     let plan = plan_table_schema(&spec(b"Gamma", &columns, &indexes), 25)?;
@@ -91,7 +105,7 @@ fn a_table_name_byte_without_an_established_weight_is_refused() {
     let columns = [ID];
     assert_eq!(
         plan_table_schema(&spec(b"Caf\xe9", &columns, &[]), 20),
-        Err(TableSchemaPlanError::TableName(
+        Err(TableSchemaPlanError::TableNameKey(
             CatalogNameKeyError::UnmappedNameByte {
                 position: 3,
                 byte: 0xe9,
@@ -105,11 +119,122 @@ fn an_empty_table_name_is_refused() {
     let columns = [ID];
     assert_eq!(
         plan_table_schema(&spec(b"", &columns, &[]), 20),
-        Err(TableSchemaPlanError::TableName(
+        Err(TableSchemaPlanError::TableNameKey(
             CatalogNameKeyError::EmptyName
         ))
     );
 }
+
+#[test]
+fn a_table_name_too_long_for_a_catalog_row_is_refused() {
+    // The MSysObjects row's one-byte name-end offset bounds the name; the
+    // longest writable name must still plan.
+    let columns = [ID];
+    let longest = vec![b'A'; 224];
+    assert!(plan_table_schema(&spec(&longest, &columns, &[]), 20).is_ok());
+    let overlong = vec![b'A'; 225];
+    assert!(matches!(
+        plan_table_schema(&spec(&overlong, &columns, &[]), 20),
+        Err(TableSchemaPlanError::TableNameRow(
+            CatalogRecordWriteError::NameTooLong { length: 225, .. }
+        ))
+    ));
+}
+
+#[test]
+fn a_column_name_too_long_for_the_definition_is_refused() {
+    let overlong = vec![b'A'; 256];
+    let columns = [ColumnSpec::new(
+        &overlong,
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &[])),
+        Some(TableDefinitionWriteError::NameTooLong {
+            role: "column",
+            length: 256,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn an_index_name_too_long_for_the_definition_is_refused() {
+    let overlong = vec![b'A'; 256];
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: &overlong,
+        fields: &[key(0)],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &indexes)),
+        Some(TableDefinitionWriteError::NameTooLong {
+            role: "logical index",
+            length: 256,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_column_size_its_type_does_not_accept_is_refused() {
+    let columns = [ColumnSpec::new(
+        b"Id",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        1,
+    )];
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &[])),
+        Some(TableDefinitionWriteError::UnsupportedColumnSize {
+            ordinal: 0,
+            size: 1,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn a_memo_column_in_fixed_storage_is_refused() {
+    let columns = [ColumnSpec::new(
+        b"Note",
+        ColumnPhysicalType::Memo,
+        ColumnStorageKind::Fixed,
+        0,
+    )];
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &[])),
+        Some(TableDefinitionWriteError::UnsupportedColumnClass { ordinal: 0, .. })
+    ));
+}
+
+#[test]
+fn a_fixed_area_no_row_slot_could_hold_is_refused() {
+    // Each column is a fixed Text(255); enough of them overrun the row slot.
+    let names = (0..MANY_COLUMNS)
+        .map(|ordinal| format!("C{ordinal:03}").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| {
+            ColumnSpec::new(
+                name,
+                ColumnPhysicalType::Text,
+                ColumnStorageKind::Fixed,
+                255,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        definition_error(&spec(b"Wide", &columns, &[])),
+        Some(TableDefinitionWriteError::RowLayoutTooLarge { .. })
+    ));
+}
+
+const MANY_COLUMNS: usize = 32;
 
 #[test]
 fn a_table_without_columns_is_refused() {
@@ -121,44 +246,40 @@ fn a_table_without_columns_is_refused() {
 
 #[test]
 fn a_column_count_one_above_the_limit_is_refused() {
-    let columns = vec![ID; MAX_COLUMNS + 1];
-    assert_eq!(
-        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
-        Err(TableSchemaPlanError::TooManyColumns {
-            count: MAX_COLUMNS + 1,
-            limit: MAX_COLUMNS,
-        })
-    );
-    // The duplicate names inside a limit-sized spec must still be caught.
-    let at_limit = vec![ID; MAX_COLUMNS];
-    assert_eq!(
-        plan_table_schema(&spec(b"Wide", &at_limit, &[]), 20),
-        Err(TableSchemaPlanError::DuplicateColumnName {
-            first: 0,
-            second: 1,
-        })
-    );
+    let columns = vec![ID; 256];
+    assert!(matches!(
+        definition_error(&spec(b"Wide", &columns, &[])),
+        Some(TableDefinitionWriteError::TooManyColumns { count: 256, .. })
+    ));
 }
 
 #[test]
 fn a_repeated_column_name_is_refused() {
     let columns = [ID, LABEL, ID];
-    assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
-        Err(TableSchemaPlanError::DuplicateColumnName {
-            first: 0,
-            second: 2,
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &[])),
+        Some(TableDefinitionWriteError::DuplicateName {
+            role: "column",
+            ordinal: 2,
         })
-    );
+    ));
 }
 
 #[test]
 fn an_empty_column_name_is_refused() {
-    let columns = [PlannedColumn { name: b"", ..ID }];
-    assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
-        Err(TableSchemaPlanError::EmptyColumnName { ordinal: 0 })
-    );
+    let columns = [ColumnSpec::new(
+        b"",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &[])),
+        Some(TableDefinitionWriteError::EmptyName {
+            role: "column",
+            ordinal: 0,
+        })
+    ));
 }
 
 #[test]
@@ -169,12 +290,12 @@ fn more_indexes_than_any_create_carried_are_refused() {
     let indexes = [
         PlannedIndex {
             name: b"ById",
-            fields: &[0],
+            fields: &[key(0)],
             kind: PlannedIndexKind::Primary,
         },
         PlannedIndex {
             name: b"ByLabel",
-            fields: &[1],
+            fields: &[key(1)],
             kind: PlannedIndexKind::Ordinary,
         },
     ];
@@ -195,10 +316,10 @@ fn an_index_naming_no_columns_is_refused() {
         fields: &[],
         kind: PlannedIndexKind::Ordinary,
     }];
-    assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
-        Err(TableSchemaPlanError::IndexWithoutFields { index: 0 })
-    );
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &indexes)),
+        Some(TableDefinitionWriteError::EmptyPhysicalIndex { physical_index: 0 })
+    ));
 }
 
 #[test]
@@ -206,16 +327,31 @@ fn an_index_naming_an_undeclared_column_is_refused() {
     let columns = [ID];
     let indexes = [PlannedIndex {
         name: b"ById",
-        fields: &[1],
+        fields: &[key(1)],
         kind: PlannedIndexKind::Ordinary,
     }];
-    assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
-        Err(TableSchemaPlanError::IndexFieldOutOfRange {
-            index: 0,
-            column: 1,
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &indexes)),
+        Some(TableDefinitionWriteError::InvalidKeyColumn { ordinal: 1, .. })
+    ));
+}
+
+#[test]
+fn an_index_over_a_memo_column_is_refused() {
+    let columns = [NOTE];
+    let indexes = [PlannedIndex {
+        name: b"ByNote",
+        fields: &[key(0)],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &indexes)),
+        Some(TableDefinitionWriteError::UnsupportedKeyColumn {
+            ordinal: 0,
+            physical_type: ColumnPhysicalType::Memo,
+            ..
         })
-    );
+    ));
 }
 
 #[test]
@@ -223,62 +359,35 @@ fn an_index_naming_one_column_twice_is_refused() {
     let columns = [ID, LABEL];
     let indexes = [PlannedIndex {
         name: b"ById",
-        fields: &[0, 1, 0],
+        fields: &[key(0), key(1), key(0)],
         kind: PlannedIndexKind::Ordinary,
     }];
-    assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
-        Err(TableSchemaPlanError::DuplicateIndexField {
-            index: 0,
-            column: 0,
-        })
-    );
+    assert!(matches!(
+        definition_error(&spec(b"Beta", &columns, &indexes)),
+        Some(TableDefinitionWriteError::DuplicateKeyColumn { ordinal: 0, .. })
+    ));
 }
 
 #[test]
 fn an_index_field_count_one_above_the_limit_is_refused() {
-    let columns = vec![ID; MAX_INDEX_FIELDS + 1];
-    let fields = (0..=MAX_INDEX_FIELDS as u16).collect::<Vec<_>>();
+    let names = (0..=KEY_SLOT_COUNT)
+        .map(|ordinal| format!("C{ordinal}").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .collect::<Vec<_>>();
+    let fields = (0..=KEY_SLOT_COUNT as u16).map(key).collect::<Vec<_>>();
     let indexes = [PlannedIndex {
         name: b"Wide",
         fields: &fields,
         kind: PlannedIndexKind::Ordinary,
     }];
-    // Duplicate column names would mask the field-count check, so name them apart.
-    let named = columns
-        .iter()
-        .enumerate()
-        .map(|(ordinal, column)| PlannedColumn {
-            name: COLUMN_NAMES[ordinal],
-            ..*column
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(
-        plan_table_schema(&spec(b"Wide", &named, &indexes), 20),
-        Err(TableSchemaPlanError::TooManyIndexFields {
-            index: 0,
-            count: MAX_INDEX_FIELDS + 1,
-            limit: MAX_INDEX_FIELDS,
-        })
-    );
-}
-
-const COLUMN_NAMES: [&[u8]; MAX_INDEX_FIELDS + 1] = [
-    b"C0", b"C1", b"C2", b"C3", b"C4", b"C5", b"C6", b"C7", b"C8", b"C9", b"CA",
-];
-
-#[test]
-fn an_empty_index_name_is_refused() {
-    let columns = [ID];
-    let indexes = [PlannedIndex {
-        name: b"",
-        fields: &[0],
-        kind: PlannedIndexKind::Ordinary,
-    }];
-    assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
-        Err(TableSchemaPlanError::EmptyIndexName { index: 0 })
-    );
+    assert!(matches!(
+        definition_error(&spec(b"Wide", &columns, &indexes)),
+        Some(TableDefinitionWriteError::TooManyKeyFields { count, .. })
+            if count == KEY_SLOT_COUNT + 1
+    ));
 }
 
 #[test]
@@ -294,8 +403,19 @@ fn a_first_page_above_the_signed_id_range_is_refused() {
 }
 
 #[test]
-fn the_highest_representable_first_page_is_accepted() -> PlanResult {
-    let plan = plan_table_schema(&spec(b"Beta", &[ID], &[]), i32::MAX as u64)?;
-    assert_eq!(plan.object_id(), i32::MAX);
+fn a_map_page_no_usage_map_locator_could_name_is_refused() -> PlanResult {
+    // Usage-map locators hold a three-byte page, so the map page bounds the
+    // run well below the signed Id range.
+    let columns = [ID];
+    let highest = MAX_MAP_PAGE - 1;
+    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), highest)?;
+    assert_eq!(plan.map_page(), PageNumber::new(MAX_MAP_PAGE));
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), highest + 1),
+        Err(TableSchemaPlanError::MapPageNotAddressable {
+            page: MAX_MAP_PAGE + 1,
+            maximum: MAX_MAP_PAGE,
+        })
+    );
     Ok(())
 }

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -419,3 +419,38 @@ fn a_map_page_no_usage_map_locator_could_name_is_refused() -> PlanResult {
     );
     Ok(())
 }
+
+#[test]
+fn a_definition_too_long_for_its_root_page_is_refused() {
+    // EXP-0087 saw no create append a continuation page, so where one would
+    // land is unestablished. 100 fixed Long columns overrun the root page.
+    let names = (0..100)
+        .map(|ordinal| format!("Column{ordinal:03}").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+        Err(TableSchemaPlanError::DefinitionNeedsContinuation { length, capacity })
+            if length > capacity && capacity == DEFINITION_ROOT_CAPACITY
+    ));
+}
+
+#[test]
+fn a_definition_that_exactly_fills_its_root_page_is_accepted() -> PlanResult {
+    // The refusal must start one byte above the root page, not below it.
+    let names = (0..70)
+        .map(|ordinal| format!("Column{ordinal:03}").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .collect::<Vec<_>>();
+    let length =
+        definition_len(&columns, [].into_iter(), 0, 0).map_err(TableSchemaPlanError::Definition)?;
+    assert!(length <= DEFINITION_ROOT_CAPACITY);
+    plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    Ok(())
+}

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -14,6 +14,18 @@ const LABEL: PlannedColumn<'static> = PlannedColumn {
     storage: ColumnStorageKind::Variable,
     size: 30,
 };
+const NAME: PlannedColumn<'static> = PlannedColumn {
+    name: b"Name",
+    physical_type: ColumnPhysicalType::Text,
+    storage: ColumnStorageKind::Variable,
+    size: 50,
+};
+const NOTE: PlannedColumn<'static> = PlannedColumn {
+    name: b"Note",
+    physical_type: ColumnPhysicalType::Memo,
+    storage: ColumnStorageKind::Variable,
+    size: 0,
+};
 
 fn spec<'a>(
     name: &'a [u8],
@@ -29,8 +41,9 @@ fn spec<'a>(
 
 #[test]
 fn a_table_without_an_index_appends_a_definition_root_and_a_map_page() -> PlanResult {
-    // EXP-0087's Beta create: two appended pages, Id equal to the root page.
-    let columns = [ID];
+    // EXP-0087's Beta create (Long Id, Text(50) Name, Memo Note): two
+    // appended pages, Id equal to the root page.
+    let columns = [ID, NAME, NOTE];
     let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23)?;
     assert_eq!(plan.object_id(), 23);
     assert_eq!(plan.definition_root(), PageNumber::new(23));

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -1,0 +1,288 @@
+use super::*;
+
+type PlanResult = Result<(), TableSchemaPlanError>;
+
+const ID: PlannedColumn<'static> = PlannedColumn {
+    name: b"Id",
+    physical_type: ColumnPhysicalType::Long,
+    storage: ColumnStorageKind::Fixed,
+    size: 4,
+};
+const LABEL: PlannedColumn<'static> = PlannedColumn {
+    name: b"Label",
+    physical_type: ColumnPhysicalType::Text,
+    storage: ColumnStorageKind::Variable,
+    size: 30,
+};
+
+fn spec<'a>(
+    name: &'a [u8],
+    columns: &'a [PlannedColumn<'a>],
+    indexes: &'a [PlannedIndex<'a>],
+) -> TableSchemaSpec<'a> {
+    TableSchemaSpec {
+        name,
+        columns,
+        indexes,
+    }
+}
+
+#[test]
+fn a_table_without_an_index_appends_a_definition_root_and_a_map_page() -> PlanResult {
+    // EXP-0087's Beta create: two appended pages, Id equal to the root page.
+    let columns = [ID];
+    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23)?;
+    assert_eq!(plan.object_id(), 23);
+    assert_eq!(plan.definition_root(), PageNumber::new(23));
+    assert_eq!(plan.map_page(), PageNumber::new(24));
+    assert_eq!(plan.index_root(), None);
+    assert_eq!(plan.appended_page_count(), 2);
+    Ok(())
+}
+
+#[test]
+fn an_indexed_table_appends_its_index_root_after_the_map_page() -> PlanResult {
+    // EXP-0087's Delta create: the index root follows the map-rows page.
+    let columns = [LABEL];
+    let indexes = [PlannedIndex {
+        name: b"ByLabel",
+        fields: &[0],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    let plan = plan_table_schema(&spec(b"Delta", &columns, &indexes), 28)?;
+    assert_eq!(plan.object_id(), 28);
+    assert_eq!(plan.definition_root(), PageNumber::new(28));
+    assert_eq!(plan.map_page(), PageNumber::new(29));
+    assert_eq!(plan.index_root(), Some(PageNumber::new(30)));
+    assert_eq!(plan.appended_page_count(), 3);
+    Ok(())
+}
+
+#[test]
+fn a_primary_index_plans_the_same_pages_as_an_ordinary_one() -> PlanResult {
+    // EXP-0087's Gamma create carried a primary index and appended three pages.
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"PrimaryKey",
+        fields: &[0],
+        kind: PlannedIndexKind::Primary,
+    }];
+    let plan = plan_table_schema(&spec(b"Gamma", &columns, &indexes), 25)?;
+    assert_eq!(plan.object_id(), 25);
+    assert_eq!(plan.index_root(), Some(PageNumber::new(27)));
+    Ok(())
+}
+
+#[test]
+fn a_table_name_byte_without_an_established_weight_is_refused() {
+    let columns = [ID];
+    assert_eq!(
+        plan_table_schema(&spec(b"Caf\xe9", &columns, &[]), 20),
+        Err(TableSchemaPlanError::TableName(
+            CatalogNameKeyError::UnmappedNameByte {
+                position: 3,
+                byte: 0xe9,
+            }
+        ))
+    );
+}
+
+#[test]
+fn an_empty_table_name_is_refused() {
+    let columns = [ID];
+    assert_eq!(
+        plan_table_schema(&spec(b"", &columns, &[]), 20),
+        Err(TableSchemaPlanError::TableName(
+            CatalogNameKeyError::EmptyName
+        ))
+    );
+}
+
+#[test]
+fn a_table_without_columns_is_refused() {
+    assert_eq!(
+        plan_table_schema(&spec(b"Empty", &[], &[]), 20),
+        Err(TableSchemaPlanError::NoColumns)
+    );
+}
+
+#[test]
+fn a_column_count_one_above_the_limit_is_refused() {
+    let columns = vec![ID; MAX_COLUMNS + 1];
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+        Err(TableSchemaPlanError::TooManyColumns {
+            count: MAX_COLUMNS + 1,
+            limit: MAX_COLUMNS,
+        })
+    );
+    // The duplicate names inside a limit-sized spec must still be caught.
+    let at_limit = vec![ID; MAX_COLUMNS];
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &at_limit, &[]), 20),
+        Err(TableSchemaPlanError::DuplicateColumnName {
+            first: 0,
+            second: 1,
+        })
+    );
+}
+
+#[test]
+fn a_repeated_column_name_is_refused() {
+    let columns = [ID, LABEL, ID];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
+        Err(TableSchemaPlanError::DuplicateColumnName {
+            first: 0,
+            second: 2,
+        })
+    );
+}
+
+#[test]
+fn an_empty_column_name_is_refused() {
+    let columns = [PlannedColumn { name: b"", ..ID }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
+        Err(TableSchemaPlanError::EmptyColumnName { ordinal: 0 })
+    );
+}
+
+#[test]
+fn more_indexes_than_any_create_carried_are_refused() {
+    // EXP-0087 observed only zero or one index per create, so a two-index
+    // ordering has no evidence behind it.
+    let columns = [ID, LABEL];
+    let indexes = [
+        PlannedIndex {
+            name: b"ById",
+            fields: &[0],
+            kind: PlannedIndexKind::Primary,
+        },
+        PlannedIndex {
+            name: b"ByLabel",
+            fields: &[1],
+            kind: PlannedIndexKind::Ordinary,
+        },
+    ];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::UnobservedIndexCount {
+            count: 2,
+            observed: MAX_OBSERVED_INDEXES,
+        })
+    );
+}
+
+#[test]
+fn an_index_naming_no_columns_is_refused() {
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::IndexWithoutFields { index: 0 })
+    );
+}
+
+#[test]
+fn an_index_naming_an_undeclared_column_is_refused() {
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[1],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::IndexFieldOutOfRange {
+            index: 0,
+            column: 1,
+        })
+    );
+}
+
+#[test]
+fn an_index_naming_one_column_twice_is_refused() {
+    let columns = [ID, LABEL];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[0, 1, 0],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::DuplicateIndexField {
+            index: 0,
+            column: 0,
+        })
+    );
+}
+
+#[test]
+fn an_index_field_count_one_above_the_limit_is_refused() {
+    let columns = vec![ID; MAX_INDEX_FIELDS + 1];
+    let fields = (0..=MAX_INDEX_FIELDS as u16).collect::<Vec<_>>();
+    let indexes = [PlannedIndex {
+        name: b"Wide",
+        fields: &fields,
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    // Duplicate column names would mask the field-count check, so name them apart.
+    let named = columns
+        .iter()
+        .enumerate()
+        .map(|(ordinal, column)| PlannedColumn {
+            name: COLUMN_NAMES[ordinal],
+            ..*column
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &named, &indexes), 20),
+        Err(TableSchemaPlanError::TooManyIndexFields {
+            index: 0,
+            count: MAX_INDEX_FIELDS + 1,
+            limit: MAX_INDEX_FIELDS,
+        })
+    );
+}
+
+const COLUMN_NAMES: [&[u8]; MAX_INDEX_FIELDS + 1] = [
+    b"C0", b"C1", b"C2", b"C3", b"C4", b"C5", b"C6", b"C7", b"C8", b"C9", b"CA",
+];
+
+#[test]
+fn an_empty_index_name_is_refused() {
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"",
+        fields: &[0],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::EmptyIndexName { index: 0 })
+    );
+}
+
+#[test]
+fn a_first_page_above_the_signed_id_range_is_refused() {
+    // EXP-0087 observed the object Id equal to the definition root page, and
+    // MSysObjects.Id is a signed Long, so the run must stay inside that range.
+    let columns = [ID];
+    let first = i32::MAX as u64 + 1;
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), first),
+        Err(TableSchemaPlanError::PageOverflow { first, needed: 2 })
+    );
+}
+
+#[test]
+fn the_highest_representable_first_page_is_accepted() -> PlanResult {
+    let plan = plan_table_schema(&spec(b"Beta", &[ID], &[]), i32::MAX as u64)?;
+    assert_eq!(plan.object_id(), i32::MAX);
+    Ok(())
+}

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -50,9 +50,11 @@ appended-page assignment. The key encoder and the typed table planner now
 derive what the composer used to carry as recorded bytes.
 
 What is still fixed rather than ruled: the composer's page-zero opaque region,
-the `LvProp` payloads, and the per-create catalog/ACE row writing. Wiring the
-composer to emit planned tables is the next slice, followed by a public
-creation API, initial rows, relationships, and safe filesystem publication.
+the `LvProp` payloads, and the per-create catalog/ACE row writing. The planner
+also assigns no long-value page, which `EXP-0087` observed only on a
+database's first create. Wiring the composer to emit planned tables, including
+that first-create page, is the next slice, followed by a public creation API,
+initial rows, relationships, and safe filesystem publication.
 
 Two gaps need their own focused DAO validation before the planner can widen:
 table names containing bytes above `0x7E`, whose secondary weights and

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -43,14 +43,19 @@ delivered in this order:
 
 ## Current next step
 
-Continue #100 toward a typed schema planner for arbitrary tables, columns, and
-indexes. `EXP-0085` accepted bounded DAO consumption of the two fixed composer
-candidates, but the composer still carries fixed bytes rather than rules: the
-catalog name keys, the per-table catalog and access-control rows, the page-zero
-transition, and the `LvProp` payload are all recorded values for one exact
-table. The next step is the preregistered `schema-generalization` experiment,
-which resolves the name-key encoding, the per-create row and page assignment,
-and the property chunk framing. The planner, a public creation API, initial
-rows, relationships, and safe filesystem publication follow as separate
-reviewable slices. #102 remains the separate hosted write differential after
-database creation is complete.
+Finish #100. `EXP-0087` accepted the `schema-generalization` experiment, which
+established the catalog name-key encoding and its ASCII collation map, the
+per-create catalog and access-control rows, the page-zero counter step, and the
+appended-page assignment. The key encoder and the typed table planner now
+derive what the composer used to carry as recorded bytes.
+
+What is still fixed rather than ruled: the composer's page-zero opaque region,
+the `LvProp` payloads, and the per-create catalog/ACE row writing. Wiring the
+composer to emit planned tables is the next slice, followed by a public
+creation API, initial rows, relationships, and safe filesystem publication.
+
+Two gaps need their own focused DAO validation before the planner can widen:
+table names containing bytes above `0x7E`, whose secondary weights and
+expansions `EXP-0087` deliberately left uninterpreted, and tables carrying more
+than one index, which no observed create had. #102 remains the separate hosted
+write differential after database creation is complete.


### PR DESCRIPTION
Replaces #147, which GitHub closed when its base branch was deleted on merging #146.

The composer can only build `Alpha(Id Long)` because every page number in it is a constant. This adds the typed layer that decides those numbers for any table: you describe a name, columns, and indexes, and it validates the description and assigns the pages the create appends.

The assignment is the one EXP-0087 observed across three replicas — definition root numbered equal to the new object's `Id`, then the map-rows page, then an index root when the table has an index. The tests pin it against the real Beta, Gamma, and Delta creates, and against the Alpha image DAO already accepted in EXP-0085.

Validation is delegated, not duplicated: the planner runs the same column, row-layout, name-length, and key-column checks as the table-definition and catalog encoders that will write the table, so a plan it accepts is one those encoders accept. Shared checks live in a new `table_definition_layout` module that both call.

Deliberate refusals, each because the evidence isn't there yet rather than because the code can't:

- **More than one index.** Every create EXP-0087 watched had zero or one. Where a second index root lands is a guess, so the planner says so instead of picking.
- **Table name bytes above `0x7E`**, inherited from the key encoder in #146.
- **Definitions needing a continuation page.** Every observed create appended a definition root, a map-rows page, and at most an index root, so nothing establishes where a continuation lands.
- **Map pages above the three-byte usage-map locator range**, which bounds the appended run well below the signed `Id` range.

It also plans no `LvProp` payload. EXP-0087 pinned the property framing but not the grammar, and the long-value page only appears on a database's first create — so generating one for an arbitrary table would be invention. The planner therefore also assigns no long-value page; the Alpha test shows the accepted image appends one more page than the plan, and the composer wiring slice has to place it.

This is validation and page assignment only. It builds no bytes and touches no I/O; wiring the composer to emit tables through it is the next slice. Also refreshes the stale "current next step" in `V1_SCOPE.md`, which still described the experiment as pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

