### PR TITLE
feat(jet3): encode long-value headers and LVAL payload rows

### DIFF
--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -17,16 +17,19 @@
 use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, encode_catalog_name_key};
+use crate::long_value_writer::{
+    LongValueWriteError, external_long_value_header, validate_single_page_row,
+};
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 use crate::whole_file_plan::{WholeFileImagePlan, WholeFilePlanError};
 use crate::{
     ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind,
-    DataPageBuilder, Error, IndexDirection, IndexFieldSpec, InlineUsageMapEncoder,
-    LogicalIndexKindSpec, LogicalIndexSpec, LongValueMapSpec, MapRowLocator, PAGE_BYTES, PageImage,
-    PageImageError, PageKind, PageNumber, PageOffset, PhysicalIndexFlagsSpec, PhysicalIndexSpec,
-    ResourceBudget, RowColumnLayout, RowValue, RowWriteError, SystemColumnClassSpec,
-    TableDefinitionKind, TableDefinitionSpec, TableDefinitionWriteError, UsageMapWriteError,
-    encode_row, encode_table_definition,
+    DataPageBuilder, Error, ExternalLongValueStorage, IndexDirection, IndexFieldSpec,
+    InlineUsageMapEncoder, LogicalIndexKindSpec, LogicalIndexSpec, LongValueMapSpec, MapRowLocator,
+    PAGE_BYTES, PageImage, PageImageError, PageKind, PageNumber, PageOffset,
+    PhysicalIndexFlagsSpec, PhysicalIndexSpec, ResourceBudget, RowColumnLayout, RowLocator,
+    RowValue, RowWriteError, SystemColumnClassSpec, TableDefinitionKind, TableDefinitionSpec,
+    TableDefinitionWriteError, UsageMapWriteError, encode_row, encode_table_definition,
 };
 
 const HEADER_PAGE: u64 = 0;
@@ -95,8 +98,13 @@ pub(crate) enum BootstrapComposeError {
     Row(RowWriteError),
     WholeFile(WholeFilePlanError),
     Encoding(Error),
-    IndexPageFull { needed: usize, available: usize },
+    IndexPageFull {
+        needed: usize,
+        available: usize,
+    },
     NameKey(CatalogNameKeyError),
+    /// Long-value encoding failed.
+    LongValue(LongValueWriteError),
 }
 
 impl fmt::Display for BootstrapComposeError {
@@ -115,6 +123,7 @@ impl std::error::Error for BootstrapComposeError {
             Self::WholeFile(source) => Some(source),
             Self::Encoding(source) => Some(source),
             Self::NameKey(source) => Some(source),
+            Self::LongValue(source) => Some(source),
             Self::IndexPageFull { .. } => None,
         }
     }
@@ -153,6 +162,12 @@ impl From<Error> for BootstrapComposeError {
 impl From<CatalogNameKeyError> for BootstrapComposeError {
     fn from(source: CatalogNameKeyError) -> Self {
         Self::NameKey(source)
+    }
+}
+
+impl From<LongValueWriteError> for BootstrapComposeError {
+    fn from(source: LongValueWriteError) -> Self {
+        Self::LongValue(source)
     }
 }
 
@@ -474,7 +489,9 @@ fn objects_data_page(
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
     for seed in catalog_seeds(alpha) {
-        let lvprop = (seed.id == ALPHA_ROOT as i32).then(alpha_long_value_header);
+        let lvprop = (seed.id == ALPHA_ROOT as i32)
+            .then(alpha_long_value_header)
+            .transpose()?;
         let length = encode_catalog_row(seed, lvprop, &mut row, budget)?;
         builder.append_row(&row[..length], budget)?;
     }
@@ -588,18 +605,19 @@ fn finish_data_builder(
     Ok(image)
 }
 
-fn alpha_long_value_header() -> [u8; 12] {
-    let control = 0x4000_0000_u32 | ALPHA_LVPROP_PAYLOAD.len() as u32;
-    let mut header = [0_u8; 12];
-    header[..4].copy_from_slice(&control.to_le_bytes());
-    header[5..8].copy_from_slice(&(ALPHA_LVPROP_PAGE as u32).to_le_bytes()[..3]);
-    header
+fn alpha_long_value_header() -> Result<[u8; 12], BootstrapComposeError> {
+    Ok(external_long_value_header(
+        ALPHA_LVPROP_PAYLOAD.len(),
+        ExternalLongValueStorage::SinglePage,
+        RowLocator::new(PageNumber::new(ALPHA_LVPROP_PAGE), 0),
+    )?)
 }
 
 fn alpha_long_value_page(budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
-    let mut image = data_page(HEADER_PAGE, &[ALPHA_LVPROP_PAYLOAD], budget)?;
-    image.write_at(PageOffset::new(4), b"LVAL", budget)?;
-    Ok(image)
+    validate_single_page_row(ALPHA_LVPROP_PAYLOAD)?;
+    let mut builder = DataPageBuilder::new_long_value(budget)?;
+    builder.append_row(ALPHA_LVPROP_PAYLOAD, budget)?;
+    finish_data_builder(builder, budget)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -29,6 +29,7 @@ pub mod jet3_page;
 pub mod limits;
 pub mod long_value;
 pub mod long_value_map;
+mod long_value_writer;
 pub mod map_location;
 pub mod offset;
 pub mod page;

--- a/crates/jet3/src/long_value_writer.rs
+++ b/crates/jet3/src/long_value_writer.rs
@@ -1,0 +1,215 @@
+//! Encoders for Jet 3 long-value headers and `LVAL` payload rows, the inverse
+//! of `long_value.rs` (`EXP-0061`).
+//!
+//! `EXP-0061` observed a 12-byte header whose first little-endian `u32` holds
+//! the 24-bit payload length and exactly one storage flag; inline headers
+//! carry eight zero bytes then the payload, and external headers carry a row
+//! slot plus three-byte little-endian page at `[4,8)` and four zero bytes at
+//! `[8,12)`. External rows live on tag-`01` pages owned by ASCII `LVAL`: a
+//! single-page row is exactly the payload, and each chained row is a
+//! slot-plus-page pointer to the next row, all zero at the end of the chain,
+//! followed by a payload fragment.
+//!
+//! `EXP-0061` observed inline, single-page, and chained storage at controlled
+//! lengths only and established no universal threshold between them, so
+//! nothing here chooses a storage class: the caller does, and this module
+//! refuses a payload its chosen class cannot hold.
+
+#![allow(
+    dead_code,
+    reason = "crate-private writer slice awaiting DAO validation"
+)]
+
+use std::fmt;
+
+use crate::data_page_directory::MAX_STORED_ROW_LEN;
+use crate::{ExternalLongValueStorage, PageNumber, RowLocator};
+
+/// Length of every long-value header.
+pub(crate) const HEADER_LEN: usize = 12;
+/// Bytes of a chained row that point at the next row.
+const CHAIN_POINTER_LEN: usize = 4;
+/// Largest payload one single-page `LVAL` row holds.
+pub(crate) const MAX_SINGLE_PAGE_PAYLOAD: usize = MAX_STORED_ROW_LEN;
+/// Largest fragment one chained `LVAL` row holds after its pointer.
+///
+/// `EXP-0061` observed exactly this fragment size, 2,032 bytes, on every
+/// non-final chained row of its 2,048- and 4,096-byte controls.
+pub(crate) const MAX_CHAINED_FRAGMENT: usize = MAX_STORED_ROW_LEN - CHAIN_POINTER_LEN;
+/// Largest length the 24-bit header field declares.
+const MAX_DECLARED_LENGTH: usize = 0x00ff_ffff;
+/// Largest page a three-byte locator names.
+const MAX_LOCATOR_PAGE: u64 = 0x00ff_ffff;
+const INLINE_FLAG: u32 = 0x8000_0000;
+const SINGLE_PAGE_FLAG: u32 = 0x4000_0000;
+const CHAINED_FLAG: u32 = 0;
+
+/// Structured failure while encoding a long value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LongValueWriteError {
+    /// The payload exceeds what its storage class declares or holds.
+    PayloadTooLong {
+        /// Payload length.
+        length: usize,
+        /// Largest length the class accepts.
+        maximum: usize,
+    },
+    /// An external row would hold no payload bytes.
+    EmptyRow,
+    /// A chained fragment exceeds one row.
+    FragmentTooLong {
+        /// Fragment length.
+        length: usize,
+        /// Largest fragment one row holds.
+        maximum: usize,
+    },
+    /// A row locator names a page above the three-byte range.
+    LocatorNotRepresentable {
+        /// The unrepresentable locator.
+        locator: RowLocator,
+    },
+    /// An external header would carry the null locator the reader rejects.
+    NullTarget,
+    /// The output slice cannot hold the encoding.
+    OutputTooSmall {
+        /// Bytes the encoding needs.
+        needed: usize,
+        /// Bytes the caller supplied.
+        available: usize,
+    },
+}
+
+impl fmt::Display for LongValueWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "long-value encoding failed: {self:?}")
+    }
+}
+
+impl std::error::Error for LongValueWriteError {}
+
+/// Encodes an inline long value, header then payload, into `output`.
+///
+/// Returns the number of bytes written.
+pub(crate) fn encode_inline_long_value(
+    payload: &[u8],
+    output: &mut [u8],
+) -> Result<usize, LongValueWriteError> {
+    let control = control_word(payload.len(), INLINE_FLAG, MAX_DECLARED_LENGTH)?;
+    let needed = HEADER_LEN + payload.len();
+    if output.len() < needed {
+        return Err(LongValueWriteError::OutputTooSmall {
+            needed,
+            available: output.len(),
+        });
+    }
+    output[..4].copy_from_slice(&control.to_le_bytes());
+    output[4..HEADER_LEN].fill(0);
+    output[HEADER_LEN..needed].copy_from_slice(payload);
+    Ok(needed)
+}
+
+/// Returns the 12-byte header referencing an external payload of `length`
+/// bytes whose first row is `target`.
+pub(crate) fn external_long_value_header(
+    length: usize,
+    storage: ExternalLongValueStorage,
+    target: RowLocator,
+) -> Result<[u8; HEADER_LEN], LongValueWriteError> {
+    let (flag, maximum) = match storage {
+        ExternalLongValueStorage::SinglePage => (SINGLE_PAGE_FLAG, MAX_SINGLE_PAGE_PAYLOAD),
+        ExternalLongValueStorage::Chained => (CHAINED_FLAG, MAX_DECLARED_LENGTH),
+    };
+    let control = control_word(length, flag, maximum)?;
+    if target.page().get() == 0 && target.slot() == 0 {
+        return Err(LongValueWriteError::NullTarget);
+    }
+    let mut header = [0_u8; HEADER_LEN];
+    header[..4].copy_from_slice(&control.to_le_bytes());
+    header[4..8].copy_from_slice(&encode_locator(target)?);
+    Ok(header)
+}
+
+/// Checks that `payload` can be one single-page `LVAL` row, which is exactly
+/// the payload bytes.
+pub(crate) fn validate_single_page_row(payload: &[u8]) -> Result<(), LongValueWriteError> {
+    if payload.is_empty() {
+        return Err(LongValueWriteError::EmptyRow);
+    }
+    if payload.len() > MAX_SINGLE_PAGE_PAYLOAD {
+        return Err(LongValueWriteError::PayloadTooLong {
+            length: payload.len(),
+            maximum: MAX_SINGLE_PAGE_PAYLOAD,
+        });
+    }
+    Ok(())
+}
+
+/// Splits `payload` into the fragments of a chain, largest first.
+///
+/// This is the split `EXP-0061` observed: every row but the last carries the
+/// largest fragment a row holds, and the last carries the remainder.
+pub(crate) fn chained_fragments(payload: &[u8]) -> impl ExactSizeIterator<Item = &[u8]> {
+    payload.chunks(MAX_CHAINED_FRAGMENT)
+}
+
+/// Encodes one chained `LVAL` row, pointer then fragment, into `output`.
+///
+/// `next` is the following row, or `None` for the last row of the chain.
+/// Returns the number of bytes written.
+pub(crate) fn encode_chained_row(
+    fragment: &[u8],
+    next: Option<RowLocator>,
+    output: &mut [u8],
+) -> Result<usize, LongValueWriteError> {
+    if fragment.is_empty() {
+        return Err(LongValueWriteError::EmptyRow);
+    }
+    if fragment.len() > MAX_CHAINED_FRAGMENT {
+        return Err(LongValueWriteError::FragmentTooLong {
+            length: fragment.len(),
+            maximum: MAX_CHAINED_FRAGMENT,
+        });
+    }
+    let pointer = match next {
+        Some(locator) => encode_locator(locator)?,
+        None => [0; CHAIN_POINTER_LEN],
+    };
+    let needed = CHAIN_POINTER_LEN + fragment.len();
+    if output.len() < needed {
+        return Err(LongValueWriteError::OutputTooSmall {
+            needed,
+            available: output.len(),
+        });
+    }
+    output[..CHAIN_POINTER_LEN].copy_from_slice(&pointer);
+    output[CHAIN_POINTER_LEN..needed].copy_from_slice(fragment);
+    Ok(needed)
+}
+
+/// Returns the header control word: the 24-bit `length` plus one flag.
+fn control_word(length: usize, flag: u32, maximum: usize) -> Result<u32, LongValueWriteError> {
+    if length > maximum {
+        return Err(LongValueWriteError::PayloadTooLong { length, maximum });
+    }
+    // `maximum` never exceeds the 24-bit field, so this cannot truncate.
+    Ok(flag | length as u32)
+}
+
+/// Returns the slot byte then three-byte little-endian page of `locator`.
+fn encode_locator(locator: RowLocator) -> Result<[u8; CHAIN_POINTER_LEN], LongValueWriteError> {
+    let page = locator.page().get();
+    if page > MAX_LOCATOR_PAGE {
+        return Err(LongValueWriteError::LocatorNotRepresentable { locator });
+    }
+    let [low, mid, high, _] = (page as u32).to_le_bytes();
+    Ok([locator.slot(), low, mid, high])
+}
+
+/// Returns the null-locator sentinel the reader treats as end of chain.
+pub(crate) const fn null_locator() -> RowLocator {
+    RowLocator::new(PageNumber::new(0), 0)
+}
+
+#[cfg(test)]
+#[path = "long_value_writer_tests.rs"]
+mod tests;

--- a/crates/jet3/src/long_value_writer.rs
+++ b/crates/jet3/src/long_value_writer.rs
@@ -54,7 +54,7 @@ pub(crate) enum LongValueWriteError {
         /// Largest length the class accepts.
         maximum: usize,
     },
-    /// An external row would hold no payload bytes.
+    /// An external header or row would carry no payload bytes.
     EmptyRow,
     /// A chained fragment exceeds one row.
     FragmentTooLong {
@@ -119,8 +119,13 @@ pub(crate) fn external_long_value_header(
         ExternalLongValueStorage::SinglePage => (SINGLE_PAGE_FLAG, MAX_SINGLE_PAGE_PAYLOAD),
         ExternalLongValueStorage::Chained => (CHAINED_FLAG, MAX_DECLARED_LENGTH),
     };
+    // Every external row holds at least one byte, so no row can back a
+    // zero-length header and the reader would reject the pair.
+    if length == 0 {
+        return Err(LongValueWriteError::EmptyRow);
+    }
     let control = control_word(length, flag, maximum)?;
-    if target.page().get() == 0 && target.slot() == 0 {
+    if is_null(target) {
         return Err(LongValueWriteError::NullTarget);
     }
     let mut header = [0_u8; HEADER_LEN];
@@ -171,6 +176,9 @@ pub(crate) fn encode_chained_row(
         });
     }
     let pointer = match next {
+        // The null locator is the end-of-chain marker, so naming it as a
+        // following row would silently truncate the chain.
+        Some(locator) if is_null(locator) => return Err(LongValueWriteError::NullTarget),
         Some(locator) => encode_locator(locator)?,
         None => [0; CHAIN_POINTER_LEN],
     };
@@ -208,6 +216,10 @@ fn encode_locator(locator: RowLocator) -> Result<[u8; CHAIN_POINTER_LEN], LongVa
 /// Returns the null-locator sentinel the reader treats as end of chain.
 pub(crate) const fn null_locator() -> RowLocator {
     RowLocator::new(PageNumber::new(0), 0)
+}
+
+fn is_null(locator: RowLocator) -> bool {
+    locator.page().get() == 0 && locator.slot() == 0
 }
 
 #[cfg(test)]

--- a/crates/jet3/src/long_value_writer_tests.rs
+++ b/crates/jet3/src/long_value_writer_tests.rs
@@ -1,0 +1,228 @@
+use super::*;
+
+use crate::{
+    ByteCount, InlineLongValue, JET3_PAGE_SIZE, LongValue, LongValueError, LongValueKind,
+    ReadLimits, ResourceBudget, ResourceLimits, TextCodePage,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::new(ReadLimits::new(
+        ByteCount::new(1 << 20),
+        JET3_PAGE_SIZE,
+        ByteCount::new(1 << 20),
+    )))
+}
+
+fn locator(page: u64, slot: u8) -> RowLocator {
+    RowLocator::new(PageNumber::new(page), slot)
+}
+
+#[test]
+fn an_inline_value_round_trips_through_the_reader() -> TestResult {
+    let mut output = [0_u8; 64];
+    let written = encode_inline_long_value(b"hello", &mut output)?;
+    assert_eq!(written, HEADER_LEN + 5);
+    let decoded = LongValue::decode(
+        &output[..written],
+        locator(30, 0),
+        LongValueKind::Ole,
+        TextCodePage::Windows1252,
+        &mut budget(),
+    )?;
+    assert!(matches!(
+        decoded,
+        LongValue::Inline {
+            value: InlineLongValue::Binary(b"hello"),
+            ..
+        }
+    ));
+    Ok(())
+}
+
+#[test]
+fn an_empty_inline_value_is_a_bare_header() -> TestResult {
+    let mut output = [0xff_u8; HEADER_LEN];
+    assert_eq!(encode_inline_long_value(b"", &mut output)?, HEADER_LEN);
+    assert_eq!(output, [0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0, 0, 0]);
+    Ok(())
+}
+
+#[test]
+fn external_headers_round_trip_through_the_reader() -> TestResult {
+    for (storage, length) in [
+        (ExternalLongValueStorage::SinglePage, 512),
+        (ExternalLongValueStorage::Chained, 4096),
+    ] {
+        let header = external_long_value_header(length, storage, locator(0x01_0203, 7))?;
+        assert_eq!(&header[4..8], &[7, 0x03, 0x02, 0x01]);
+        let decoded = LongValue::decode(
+            &header,
+            locator(30, 0),
+            LongValueKind::Memo,
+            TextCodePage::Windows1252,
+            &mut budget(),
+        )?;
+        let LongValue::External(reference) = decoded else {
+            return Err("expected an external reference".into());
+        };
+        assert_eq!(reference.storage(), storage);
+        assert_eq!(reference.length(), length as u32);
+        assert_eq!(reference.target(), locator(0x01_0203, 7));
+    }
+    Ok(())
+}
+
+#[test]
+fn the_null_target_is_refused_because_the_reader_rejects_it() {
+    assert_eq!(
+        external_long_value_header(8, ExternalLongValueStorage::SinglePage, null_locator()),
+        Err(LongValueWriteError::NullTarget)
+    );
+    // Pin the reader's side of that contract.
+    let mut header = [0_u8; HEADER_LEN];
+    header[..4].copy_from_slice(&(SINGLE_PAGE_FLAG | 8).to_le_bytes());
+    assert_eq!(
+        LongValue::decode(
+            &header,
+            locator(30, 0),
+            LongValueKind::Ole,
+            TextCodePage::Windows1252,
+            &mut budget()
+        ),
+        Err(LongValueError::MissingExternalTarget)
+    );
+}
+
+#[test]
+fn a_locator_page_above_the_three_byte_range_is_refused() {
+    let too_high = locator(MAX_LOCATOR_PAGE + 1, 0);
+    assert_eq!(
+        external_long_value_header(8, ExternalLongValueStorage::Chained, too_high),
+        Err(LongValueWriteError::LocatorNotRepresentable { locator: too_high })
+    );
+    assert!(
+        external_long_value_header(
+            8,
+            ExternalLongValueStorage::Chained,
+            locator(MAX_LOCATOR_PAGE, 0)
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn each_storage_class_refuses_one_byte_over_its_limit() {
+    let mut output = vec![0_u8; HEADER_LEN + MAX_DECLARED_LENGTH + 1];
+    let inline = vec![0_u8; MAX_DECLARED_LENGTH + 1];
+    assert_eq!(
+        encode_inline_long_value(&inline, &mut output),
+        Err(LongValueWriteError::PayloadTooLong {
+            length: MAX_DECLARED_LENGTH + 1,
+            maximum: MAX_DECLARED_LENGTH,
+        })
+    );
+    assert_eq!(
+        external_long_value_header(
+            MAX_SINGLE_PAGE_PAYLOAD + 1,
+            ExternalLongValueStorage::SinglePage,
+            locator(30, 0)
+        ),
+        Err(LongValueWriteError::PayloadTooLong {
+            length: MAX_SINGLE_PAGE_PAYLOAD + 1,
+            maximum: MAX_SINGLE_PAGE_PAYLOAD,
+        })
+    );
+    assert_eq!(
+        external_long_value_header(
+            MAX_DECLARED_LENGTH + 1,
+            ExternalLongValueStorage::Chained,
+            locator(30, 0)
+        ),
+        Err(LongValueWriteError::PayloadTooLong {
+            length: MAX_DECLARED_LENGTH + 1,
+            maximum: MAX_DECLARED_LENGTH,
+        })
+    );
+    let single = vec![0_u8; MAX_SINGLE_PAGE_PAYLOAD + 1];
+    assert_eq!(
+        validate_single_page_row(&single),
+        Err(LongValueWriteError::PayloadTooLong {
+            length: MAX_SINGLE_PAGE_PAYLOAD + 1,
+            maximum: MAX_SINGLE_PAGE_PAYLOAD,
+        })
+    );
+    assert_eq!(
+        validate_single_page_row(b""),
+        Err(LongValueWriteError::EmptyRow)
+    );
+}
+
+#[test]
+fn chained_fragments_match_the_observed_controls() {
+    // EXP-0061: 2,048 bytes chained as 2,032 then 16; 4,096 as 2,032, 2,032, 32.
+    let sizes = |length: usize| {
+        chained_fragments(&vec![0_u8; length])
+            .map(<[u8]>::len)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(sizes(2048), [2032, 16]);
+    assert_eq!(sizes(4096), [2032, 2032, 32]);
+    assert_eq!(sizes(2032), [2032]);
+}
+
+#[test]
+fn a_chained_row_carries_its_pointer_then_its_fragment() -> TestResult {
+    let mut output = [0_u8; 16];
+    let written = encode_chained_row(b"abc", Some(locator(0x2a, 3)), &mut output)?;
+    assert_eq!(&output[..written], &[3, 0x2a, 0, 0, b'a', b'b', b'c']);
+    let written = encode_chained_row(b"abc", None, &mut output)?;
+    assert_eq!(&output[..written], &[0, 0, 0, 0, b'a', b'b', b'c']);
+    Ok(())
+}
+
+#[test]
+fn a_chained_row_refuses_an_empty_or_oversized_fragment() {
+    let mut output = vec![0_u8; MAX_STORED_ROW_LEN + 8];
+    assert_eq!(
+        encode_chained_row(b"", None, &mut output),
+        Err(LongValueWriteError::EmptyRow)
+    );
+    let oversized = vec![0_u8; MAX_CHAINED_FRAGMENT + 1];
+    assert_eq!(
+        encode_chained_row(&oversized, None, &mut output),
+        Err(LongValueWriteError::FragmentTooLong {
+            length: MAX_CHAINED_FRAGMENT + 1,
+            maximum: MAX_CHAINED_FRAGMENT,
+        })
+    );
+    // The largest fragment fills exactly one stored row.
+    let largest = vec![0_u8; MAX_CHAINED_FRAGMENT];
+    assert_eq!(
+        encode_chained_row(&largest, None, &mut output),
+        Ok(MAX_STORED_ROW_LEN)
+    );
+}
+
+#[test]
+fn a_short_output_is_refused_without_a_partial_write() {
+    let mut output = [0xaa_u8; HEADER_LEN + 2];
+    assert_eq!(
+        encode_inline_long_value(b"abc", &mut output),
+        Err(LongValueWriteError::OutputTooSmall {
+            needed: HEADER_LEN + 3,
+            available: HEADER_LEN + 2,
+        })
+    );
+    assert!(output.iter().all(|byte| *byte == 0xaa));
+    let mut output = [0xaa_u8; 5];
+    assert_eq!(
+        encode_chained_row(b"ab", None, &mut output),
+        Err(LongValueWriteError::OutputTooSmall {
+            needed: 6,
+            available: 5,
+        })
+    );
+    assert!(output.iter().all(|byte| *byte == 0xaa));
+}

--- a/crates/jet3/src/long_value_writer_tests.rs
+++ b/crates/jet3/src/long_value_writer_tests.rs
@@ -96,6 +96,32 @@ fn the_null_target_is_refused_because_the_reader_rejects_it() {
 }
 
 #[test]
+fn a_zero_length_external_header_is_refused() {
+    // No external row can be empty, so nothing could back such a header.
+    for storage in [
+        ExternalLongValueStorage::SinglePage,
+        ExternalLongValueStorage::Chained,
+    ] {
+        assert_eq!(
+            external_long_value_header(0, storage, locator(30, 0)),
+            Err(LongValueWriteError::EmptyRow)
+        );
+    }
+}
+
+#[test]
+fn a_chained_row_refuses_the_null_locator_as_its_next_row() {
+    // The null locator is the end-of-chain marker; naming it as a following
+    // row would encode a terminal row while claiming the chain continues.
+    let mut output = [0xaa_u8; 8];
+    assert_eq!(
+        encode_chained_row(b"abc", Some(null_locator()), &mut output),
+        Err(LongValueWriteError::NullTarget)
+    );
+    assert!(output.iter().all(|byte| *byte == 0xaa));
+}
+
+#[test]
 fn a_locator_page_above_the_three_byte_range_is_refused() {
     let too_high = locator(MAX_LOCATOR_PAGE + 1, 0);
     assert_eq!(

--- a/crates/jet3/src/page_image.rs
+++ b/crates/jet3/src/page_image.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+use crate::data_page_directory::LONG_VALUE_OWNER;
 use crate::{
     BinaryWriter, ByteCount, ByteOffset, Error, JET3_PAGE_SIZE, PageKind, PageNumber, PageOffset,
     ResourceBudget,
@@ -192,6 +193,20 @@ impl DataPageBuilder {
                 &owner_value.to_le_bytes(),
                 budget,
             )
+            .map_err(PageImageError::Encoding)?;
+        Ok(Self {
+            image,
+            row_count: 0,
+            free_end: PAGE_BYTES,
+        })
+    }
+
+    /// Starts an empty long-value page, owned by the ASCII `LVAL` marker
+    /// `EXP-0061` observed on every external payload page.
+    pub fn new_long_value(budget: &mut ResourceBudget) -> Result<Self, PageImageError> {
+        let mut image = PageImage::new(PageKind::Data);
+        image
+            .write_at(PageOffset::new(OWNER_OFFSET), &LONG_VALUE_OWNER, budget)
             .map_err(PageImageError::Encoding)?;
         Ok(Self {
             image,


### PR DESCRIPTION
Adds the write side of `EXP-0061`: the 12-byte long-value header for inline, single-page, and chained storage, the chained row layout of a slot-plus-page pointer followed by a fragment, and the fragment split the experiment observed on its 2,048- and 4,096-byte controls. Each encoder mirrors the reader in `long_value.rs`, and the tests round-trip headers through it.

Nothing here chooses a storage class. `EXP-0061` observed inline at 32 bytes, single-page at 512, and chained at 2,048 and 4,096, and explicitly called those controls rather than thresholds. The caller picks the class and the encoder refuses a payload the class cannot declare or hold.

Two small consequences elsewhere:

- `DataPageBuilder` gains a long-value page constructor that writes the ASCII `LVAL` owner marker, so callers stop overwriting the owner field after the fact.
- The composer's Alpha long-value header and page now go through the encoder rather than hand-assembled bytes. The existing composer tests, which decode the Alpha image, still pass, which is the check that the encoder reproduces the accepted bytes.

This is the `LVAL` page writing that `row_writer.rs` defers as a separate concern, so it unblocks Memo and OLE row values in #100. It is unrelated to the `LvProp` property grammar (#149): that is about what bytes a property payload contains, and this is about how any payload bytes are stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)