### PR TITLE
feat(jet3): compose a planned user table instead of the fixed Alpha

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -1,0 +1,118 @@
+//! Structured failures of the bootstrap composer.
+
+use super::*;
+
+/// Structured failure while composing a fixed bootstrap image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BootstrapComposeError {
+    Definition(TableDefinitionWriteError),
+    UsageMap(UsageMapWriteError),
+    Page(PageImageError),
+    Row(RowWriteError),
+    WholeFile(WholeFilePlanError),
+    Encoding(Error),
+    IndexPageFull {
+        needed: usize,
+        available: usize,
+    },
+    NameKey(CatalogNameKeyError),
+    /// Long-value encoding failed.
+    LongValue(LongValueWriteError),
+    /// The table could not be planned.
+    Schema(TableSchemaPlanError),
+    /// The table carries both an index and a long-value column, a map-page
+    /// row layout `EXP-0087` never observed.
+    UnobservedMapRowLayout,
+    /// `EXP-0087` observed no create carrying this many long-value columns.
+    UnobservedLongValueColumnCount {
+        /// Largest observed long-value column count.
+        observed: usize,
+    },
+    /// The `LvProp` payload breaks the `EXP-0087` chunk framing.
+    PropertyFraming {
+        /// Offset of the first byte that could not be framed.
+        offset: usize,
+    },
+    /// The `LvProp` payload does not hold one names chunk plus one per column.
+    PropertyChunkCount {
+        /// Chunks the payload holds.
+        chunks: usize,
+        /// Chunks `EXP-0087` observed for this column count.
+        expected: usize,
+    },
+}
+
+impl fmt::Display for BootstrapComposeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "Jet 3 bootstrap composition failed: {self:?}")
+    }
+}
+
+impl std::error::Error for BootstrapComposeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Definition(source) => Some(source),
+            Self::UsageMap(source) => Some(source),
+            Self::Page(source) => Some(source),
+            Self::Row(source) => Some(source),
+            Self::WholeFile(source) => Some(source),
+            Self::Encoding(source) => Some(source),
+            Self::NameKey(source) => Some(source),
+            Self::LongValue(source) => Some(source),
+            Self::Schema(source) => Some(source),
+            Self::IndexPageFull { .. }
+            | Self::UnobservedMapRowLayout
+            | Self::UnobservedLongValueColumnCount { .. }
+            | Self::PropertyFraming { .. }
+            | Self::PropertyChunkCount { .. } => None,
+        }
+    }
+}
+
+impl From<TableDefinitionWriteError> for BootstrapComposeError {
+    fn from(source: TableDefinitionWriteError) -> Self {
+        Self::Definition(source)
+    }
+}
+impl From<UsageMapWriteError> for BootstrapComposeError {
+    fn from(source: UsageMapWriteError) -> Self {
+        Self::UsageMap(source)
+    }
+}
+impl From<PageImageError> for BootstrapComposeError {
+    fn from(source: PageImageError) -> Self {
+        Self::Page(source)
+    }
+}
+impl From<RowWriteError> for BootstrapComposeError {
+    fn from(source: RowWriteError) -> Self {
+        Self::Row(source)
+    }
+}
+impl From<WholeFilePlanError> for BootstrapComposeError {
+    fn from(source: WholeFilePlanError) -> Self {
+        Self::WholeFile(source)
+    }
+}
+impl From<Error> for BootstrapComposeError {
+    fn from(source: Error) -> Self {
+        Self::Encoding(source)
+    }
+}
+impl From<CatalogNameKeyError> for BootstrapComposeError {
+    fn from(source: CatalogNameKeyError) -> Self {
+        Self::NameKey(source)
+    }
+}
+
+impl From<LongValueWriteError> for BootstrapComposeError {
+    fn from(source: LongValueWriteError) -> Self {
+        Self::LongValue(source)
+    }
+}
+
+impl From<TableSchemaPlanError> for BootstrapComposeError {
+    fn from(source: TableSchemaPlanError) -> Self {
+        Self::Schema(source)
+    }
+}

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -17,19 +17,18 @@
 use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, encode_catalog_name_key};
-use crate::long_value_writer::{
-    LongValueWriteError, external_long_value_header, validate_single_page_row,
-};
+use crate::long_value_writer::LongValueWriteError;
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
+use crate::table_schema_plan::{TableSchemaPlanError, TableSchemaSpec};
 use crate::whole_file_plan::{WholeFileImagePlan, WholeFilePlanError};
 use crate::{
     ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind,
-    DataPageBuilder, Error, ExternalLongValueStorage, IndexDirection, IndexFieldSpec,
-    InlineUsageMapEncoder, LogicalIndexKindSpec, LogicalIndexSpec, LongValueMapSpec, MapRowLocator,
-    PAGE_BYTES, PageImage, PageImageError, PageKind, PageNumber, PageOffset,
-    PhysicalIndexFlagsSpec, PhysicalIndexSpec, ResourceBudget, RowColumnLayout, RowLocator,
-    RowValue, RowWriteError, SystemColumnClassSpec, TableDefinitionKind, TableDefinitionSpec,
-    TableDefinitionWriteError, UsageMapWriteError, encode_row, encode_table_definition,
+    DataPageBuilder, Error, IndexDirection, IndexFieldSpec, InlineUsageMapEncoder,
+    LogicalIndexKindSpec, LogicalIndexSpec, LongValueMapSpec, MapRowLocator, PAGE_BYTES, PageImage,
+    PageImageError, PageKind, PageNumber, PageOffset, PhysicalIndexFlagsSpec, PhysicalIndexSpec,
+    ResourceBudget, RowColumnLayout, RowValue, RowWriteError, SystemColumnClassSpec,
+    TableDefinitionKind, TableDefinitionSpec, TableDefinitionWriteError, UsageMapWriteError,
+    encode_row, encode_table_definition,
 };
 
 const HEADER_PAGE: u64 = 0;
@@ -52,9 +51,6 @@ const RELATIONSHIPS_OBJECT_ROOT: u64 = 16;
 const RELATIONSHIPS_REFERENCED_ROOT: u64 = 17;
 const MSYS_OBJECTS_DATA_PAGE: u64 = 18;
 const MSYS_ACES_DATA_PAGE: u64 = 19;
-const ALPHA_ROOT: u64 = 20;
-const ALPHA_MAP_PAGE: u64 = 21;
-const ALPHA_LVPROP_PAGE: u64 = 22;
 
 const GLOBAL_BITMAP_BYTES: u64 = 128;
 const MAP_BITMAP_BYTES: u64 = 128;
@@ -89,141 +85,88 @@ const RELATIONSHIPS_ID: i32 = 0x0f00_0003;
 const ROOT_CONTAINER_ID: i32 = 0x0f00_0000;
 const MSYS_DB_ID: i32 = 0x1000_0000;
 
-/// Structured failure while composing a fixed bootstrap image.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum BootstrapComposeError {
-    Definition(TableDefinitionWriteError),
-    UsageMap(UsageMapWriteError),
-    Page(PageImageError),
-    Row(RowWriteError),
-    WholeFile(WholeFilePlanError),
-    Encoding(Error),
-    IndexPageFull {
-        needed: usize,
-        available: usize,
-    },
-    NameKey(CatalogNameKeyError),
-    /// Long-value encoding failed.
-    LongValue(LongValueWriteError),
-}
-
-impl fmt::Display for BootstrapComposeError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "Jet 3 bootstrap composition failed: {self:?}")
-    }
-}
-
-impl std::error::Error for BootstrapComposeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Definition(source) => Some(source),
-            Self::UsageMap(source) => Some(source),
-            Self::Page(source) => Some(source),
-            Self::Row(source) => Some(source),
-            Self::WholeFile(source) => Some(source),
-            Self::Encoding(source) => Some(source),
-            Self::NameKey(source) => Some(source),
-            Self::LongValue(source) => Some(source),
-            Self::IndexPageFull { .. } => None,
-        }
-    }
-}
-
-impl From<TableDefinitionWriteError> for BootstrapComposeError {
-    fn from(source: TableDefinitionWriteError) -> Self {
-        Self::Definition(source)
-    }
-}
-impl From<UsageMapWriteError> for BootstrapComposeError {
-    fn from(source: UsageMapWriteError) -> Self {
-        Self::UsageMap(source)
-    }
-}
-impl From<PageImageError> for BootstrapComposeError {
-    fn from(source: PageImageError) -> Self {
-        Self::Page(source)
-    }
-}
-impl From<RowWriteError> for BootstrapComposeError {
-    fn from(source: RowWriteError) -> Self {
-        Self::Row(source)
-    }
-}
-impl From<WholeFilePlanError> for BootstrapComposeError {
-    fn from(source: WholeFilePlanError) -> Self {
-        Self::WholeFile(source)
-    }
-}
-impl From<Error> for BootstrapComposeError {
-    fn from(source: Error) -> Self {
-        Self::Encoding(source)
-    }
-}
-impl From<CatalogNameKeyError> for BootstrapComposeError {
-    fn from(source: CatalogNameKeyError) -> Self {
-        Self::NameKey(source)
-    }
-}
-
-impl From<LongValueWriteError> for BootstrapComposeError {
-    fn from(source: LongValueWriteError) -> Self {
-        Self::LongValue(source)
-    }
-}
+#[path = "bootstrap_compose_error.rs"]
+mod error;
+pub(crate) use error::BootstrapComposeError;
 
 /// Composes the deterministic 20-page empty image established by `EXP-0073`.
 pub(crate) fn compose_empty_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    let images = compose_existing_pages(false, budget)?;
+    let images = compose_existing_pages(None, budget)?;
     WholeFileImagePlan::from_existing_pages(images, budget).map_err(Into::into)
 }
 
-/// Composes the fixed empty-to-`Alpha(Id Long)` transition from `EXP-0073`.
+/// Composes the fixed empty-to-`Alpha(Id Long)` transition from `EXP-0073`,
+/// carrying the `LvProp` payload `EXP-0079` recorded for it.
 pub(crate) fn compose_alpha_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    let images = compose_existing_pages(true, budget)?;
+    const COLUMNS: [ColumnSpec<'static>; 1] = [ColumnSpec::new(
+        b"Id",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    compose_table_database(
+        TableCreate {
+            spec: &TableSchemaSpec {
+                name: b"Alpha",
+                columns: &COLUMNS,
+                indexes: &[],
+            },
+            properties: ALPHA_LVPROP_PAYLOAD,
+        },
+        budget,
+    )
+}
+
+/// Composes the empty database plus one created user table, following the
+/// `EXP-0087` create observations.
+pub(crate) fn compose_table_database(
+    create: TableCreate<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, BootstrapComposeError> {
+    let planned = PlannedCreate::new(create)?;
+    let images = compose_existing_pages(Some(&planned), budget)?;
     let mut plan = WholeFileImagePlan::from_existing_pages(images, budget)?;
-    let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
-    plan.append(alpha_definition_page(budget)?, &mut append_map, budget)?;
-    plan.append(alpha_map_page(budget)?, &mut append_map, budget)?;
-    plan.append(alpha_long_value_page(budget)?, &mut append_map, budget)?;
+    planned.append_pages(&mut plan, budget)?;
     Ok(plan)
 }
 
 fn compose_existing_pages(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<[PageImage; EMPTY_DATABASE_PAGE_COUNT as usize], BootstrapComposeError> {
-    let object_count = if alpha { 9 } else { 8 };
-    let ace_count = if alpha { 18 } else { 16 };
+    let object_count = if create.is_some() { 9 } else { 8 };
+    let ace_count = if create.is_some() { 18 } else { 16 };
+    let page_count = create.map_or(EMPTY_DATABASE_PAGE_COUNT, PlannedCreate::page_count);
     Ok([
-        header_page(alpha, budget)?,
-        global_map_page(if alpha { 23 } else { 20 }, budget)?,
+        header_page(create.is_some(), budget)?,
+        global_map_page(page_count, budget)?,
         msys_objects_definition(object_count, budget)?,
         msys_aces_definition(ace_count, object_count, budget)?,
         msys_queries_definition(budget)?,
         msys_relationships_definition(budget)?,
-        objects_map_page(alpha, budget)?,
+        objects_map_page(create, budget)?,
         single_map_page(&[], budget)?,
         single_map_page(&[OBJECTS_PARENT_NAME_ROOT], budget)?,
-        objects_parent_name_index(alpha, budget)?,
+        objects_parent_name_index(create, budget)?,
         single_map_page(&[OBJECTS_ID_ROOT], budget)?,
-        objects_id_index(alpha, budget)?,
+        objects_id_index(create, budget)?,
         shared_map_page(budget)?,
-        aces_index(alpha, budget)?,
+        aces_index(create, budget)?,
         empty_index_page(MSYS_QUERIES_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
-        objects_data_page(alpha, budget)?,
-        aces_data_page(alpha, budget)?,
+        objects_data_page(create, budget)?,
+        aces_data_page(create, budget)?,
     ])
 }
 
 fn header_page(
-    alpha: bool,
+    created: bool,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut image = PageImage::new(PageKind::DatabaseDefinition);
@@ -235,8 +178,8 @@ fn header_page(
     for offset in (1..commit_state.len()).step_by(2) {
         commit_state[offset] = 1;
     }
-    // EXP-0069/0071: fixed empty/first-create values 0/2; no general counter rule.
-    commit_state[2] = if alpha { 2 } else { 0 };
+    // EXP-0087: byte 1538 advanced by 2 per create from 0; no rule beyond that.
+    commit_state[2] = if created { 2 } else { 0 };
     image.write_at(PageOffset::new(1536), &commit_state, budget)?;
     Ok(image)
 }
@@ -289,13 +232,14 @@ fn single_map_page(
 }
 
 fn objects_map_page(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let owned = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let available = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let empty = inline_map_row(&[], budget)?;
-    let lvprop = inline_map_row(if alpha { &[ALPHA_LVPROP_PAGE] } else { &[] }, budget)?;
+    let long_value_pages = create.map(PlannedCreate::long_value_page);
+    let lvprop = inline_map_row(long_value_pages.as_slice(), budget)?;
     let rows: [&[u8]; 15] = [
         &owned, &available, &empty, &empty, &empty, &empty, &empty, &empty, &empty, &empty,
         &lvprop, &lvprop, &empty, &empty, &empty,
@@ -330,11 +274,6 @@ fn shared_map_page(budget: &mut ResourceBudget) -> Result<PageImage, BootstrapCo
     data_page(HEADER_PAGE, &rows, budget)
 }
 
-fn alpha_map_page(budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
-    let empty = inline_map_row(&[], budget)?;
-    data_page(HEADER_PAGE, &[&empty, &empty], budget)
-}
-
 fn data_page(
     owner: u64,
     rows: &[&[u8]],
@@ -366,9 +305,14 @@ fn definition_page(
 #[path = "bootstrap_system_definitions.rs"]
 mod definitions;
 use definitions::{
-    alpha_definition_page, msys_aces_definition, msys_objects_definition, msys_queries_definition,
+    msys_aces_definition, msys_objects_definition, msys_queries_definition,
     msys_relationships_definition,
 };
+
+#[path = "bootstrap_table_create.rs"]
+mod table_create;
+use table_create::PlannedCreate;
+pub(crate) use table_create::TableCreate;
 
 const OBJECT_LAYOUT: [RowColumnLayout; 17] = [
     fixed(ColumnPhysicalType::Long, 0, 4),
@@ -403,20 +347,24 @@ const fn variable(kind: ColumnPhysicalType, index: u16, size: u16) -> RowColumnL
 }
 
 #[derive(Clone, Copy)]
-struct CatalogSeed {
+struct CatalogSeed<'a> {
     id: i32,
     parent: i32,
-    name: &'static [u8],
+    name: &'a [u8],
     kind: i16,
     owner: &'static [u8],
+    flags: i32,
 }
-const CATALOG_SEEDS: [CatalogSeed; 8] = [
+// EXP-0058: system objects carry flags `0x80000000`.
+const SYSTEM_FLAGS: i32 = i32::MIN;
+const CATALOG_SEEDS: [CatalogSeed<'static>; 8] = [
     CatalogSeed {
         id: TABLES_ID,
         parent: ROOT_CONTAINER_ID,
         name: b"Tables",
         kind: 3,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: DATABASES_ID,
@@ -424,6 +372,7 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"Databases",
         kind: 3,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: RELATIONSHIPS_ID,
@@ -431,6 +380,7 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"Relationships",
         kind: 3,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: MSYS_DB_ID,
@@ -438,6 +388,7 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"MSysDb",
         kind: 2,
         owner: CATALOG_OWNER_0301,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: MSYS_OBJECTS_ROOT as i32,
@@ -445,6 +396,7 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"MSysObjects",
         kind: 1,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: MSYS_ACES_ROOT as i32,
@@ -452,6 +404,7 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"MSysACEs",
         kind: 1,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: MSYS_QUERIES_ROOT as i32,
@@ -459,6 +412,7 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"MSysQueries",
         kind: 1,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
     CatalogSeed {
         id: MSYS_RELATIONSHIPS_ROOT as i32,
@@ -466,32 +420,29 @@ const CATALOG_SEEDS: [CatalogSeed; 8] = [
         name: b"MSysRelationships",
         kind: 1,
         owner: CATALOG_OWNER_0203,
+        flags: SYSTEM_FLAGS,
     },
 ];
 
-const ALPHA_SEED: CatalogSeed = CatalogSeed {
-    id: ALPHA_ROOT as i32,
-    parent: TABLES_ID,
-    name: b"Alpha",
-    kind: 1,
-    owner: CATALOG_OWNER_0301,
-};
-
 /// Returns the catalog rows the composed image holds, in stored row order.
-fn catalog_seeds(alpha: bool) -> impl Iterator<Item = CatalogSeed> {
-    CATALOG_SEEDS.into_iter().chain(alpha.then_some(ALPHA_SEED))
+fn catalog_seeds<'a>(create: Option<&PlannedCreate<'a>>) -> impl Iterator<Item = CatalogSeed<'a>> {
+    CATALOG_SEEDS
+        .into_iter()
+        .chain(create.map(PlannedCreate::catalog_seed))
 }
 
 fn objects_data_page(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
-    for seed in catalog_seeds(alpha) {
-        let lvprop = (seed.id == ALPHA_ROOT as i32)
-            .then(alpha_long_value_header)
-            .transpose()?;
+    let created_id = create.map(PlannedCreate::object_id);
+    for seed in catalog_seeds(create) {
+        let lvprop = match create {
+            Some(planned) if Some(seed.id) == created_id => Some(planned.long_value_header()?),
+            _ => None,
+        };
         let length = encode_catalog_row(seed, lvprop, &mut row, budget)?;
         builder.append_row(&row[..length], budget)?;
     }
@@ -499,7 +450,7 @@ fn objects_data_page(
 }
 
 fn encode_catalog_row(
-    seed: CatalogSeed,
+    seed: CatalogSeed<'_>,
     lvprop: Option<[u8; 12]>,
     output: &mut [u8],
     budget: &mut ResourceBudget,
@@ -507,11 +458,6 @@ fn encode_catalog_row(
     let lvprop_value = lvprop
         .as_ref()
         .map_or(RowValue::Null, |bytes| RowValue::LongValue(bytes));
-    let system_flags = if seed.id == ALPHA_ROOT as i32 {
-        0
-    } else {
-        i32::MIN
-    };
     let values = [
         RowValue::Long(seed.id),
         RowValue::Long(seed.parent),
@@ -520,7 +466,7 @@ fn encode_catalog_row(
         RowValue::DateTime { days: 0.0 },
         RowValue::DateTime { days: 0.0 },
         RowValue::Binary(seed.owner),
-        RowValue::Long(system_flags),
+        RowValue::Long(seed.flags),
         RowValue::Null,
         RowValue::Null,
         RowValue::Null,
@@ -568,17 +514,20 @@ const fn ace(object: i32, sid: &'static [u8], acm: i32, inheritable: bool) -> Ac
     }
 }
 
+/// Returns the access-control rows the composed image holds, in stored order.
+fn ace_seeds(create: Option<&PlannedCreate<'_>>) -> impl Iterator<Item = AceSeed> {
+    ACE_SEEDS
+        .into_iter()
+        .chain(create.map(PlannedCreate::ace_seeds).into_iter().flatten())
+}
+
 fn aces_data_page(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_ACES_ROOT), budget)?;
     let mut row = [0_u8; 64];
-    for seed in ACE_SEEDS
-        .into_iter()
-        .chain(alpha.then_some(ace(ALPHA_ROOT as i32, b"\x03\x01", 983294, false)))
-        .chain(alpha.then_some(ace(ALPHA_ROOT as i32, b"\x02\x01", 1048319, false)))
-    {
+    for seed in ace_seeds(create) {
         let values = [
             RowValue::Long(seed.object),
             RowValue::Binary(seed.sid),
@@ -603,21 +552,6 @@ fn finish_data_builder(
     let [low, high] = free.to_le_bytes();
     image.write_at(PageOffset::new(1), &[1, low, high], budget)?;
     Ok(image)
-}
-
-fn alpha_long_value_header() -> Result<[u8; 12], BootstrapComposeError> {
-    Ok(external_long_value_header(
-        ALPHA_LVPROP_PAYLOAD.len(),
-        ExternalLongValueStorage::SinglePage,
-        RowLocator::new(PageNumber::new(ALPHA_LVPROP_PAGE), 0),
-    )?)
-}
-
-fn alpha_long_value_page(budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
-    validate_single_page_row(ALPHA_LVPROP_PAYLOAD)?;
-    let mut builder = DataPageBuilder::new_long_value(budget)?;
-    builder.append_row(ALPHA_LVPROP_PAYLOAD, budget)?;
-    finish_data_builder(builder, budget)
 }
 
 #[derive(Clone, Copy)]
@@ -651,12 +585,12 @@ impl OwnedIndexEntry {
 }
 
 fn objects_parent_name_index(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 9];
-    let count = if alpha { 9 } else { 8 };
-    for (row, seed) in catalog_seeds(alpha).enumerate() {
+    let count = if create.is_some() { 9 } else { 8 };
+    for (row, seed) in catalog_seeds(create).enumerate() {
         entries[row] = OwnedIndexEntry::name(seed.parent, seed.name, row as u8)?;
     }
     sort_index_entries(&mut entries[..count]);
@@ -668,12 +602,12 @@ fn objects_parent_name_index(
     )
 }
 fn objects_id_index(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 9];
-    let count = if alpha { 9 } else { 8 };
-    for (row, seed) in catalog_seeds(alpha).enumerate() {
+    let count = if create.is_some() { 9 } else { 8 };
+    for (row, seed) in catalog_seeds(create).enumerate() {
         entries[row] = OwnedIndexEntry::long(seed.id, row as u8);
     }
     sort_index_entries(&mut entries[..count]);
@@ -685,16 +619,15 @@ fn objects_id_index(
     )
 }
 fn aces_index(
-    alpha: bool,
+    create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 18];
-    for (row, seed) in ACE_SEEDS.iter().enumerate() {
+    let mut count = 0;
+    for (row, seed) in ace_seeds(create).enumerate() {
         entries[row] = OwnedIndexEntry::long(seed.object, row as u8);
+        count = row + 1;
     }
-    entries[16] = OwnedIndexEntry::long(ALPHA_ROOT as i32, 16);
-    entries[17] = OwnedIndexEntry::long(ALPHA_ROOT as i32, 17);
-    let count = if alpha { 18 } else { 16 };
     sort_index_entries(&mut entries[..count]);
     index_page(
         MSYS_ACES_ROOT,

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -1,8 +1,11 @@
 use super::{
-    ALPHA_LVPROP_PAYLOAD, ALPHA_MAP_PAGE, ALPHA_ROOT, BootstrapComposeError,
-    compose_alpha_database, compose_empty_database,
+    ALPHA_LVPROP_PAYLOAD, BootstrapComposeError, compose_alpha_database, compose_empty_database,
 };
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
+
+// EXP-0073/EXP-0085: the accepted Alpha image's appended page numbers.
+const ALPHA_ROOT: u64 = 20;
+const ALPHA_MAP_PAGE: u64 = 21;
 use crate::table_schema_plan::{TableSchemaSpec, plan_table_schema};
 use crate::{
     ByteCount, CatalogObjectClass, ColumnOrdinal, ColumnPhysicalType, ColumnSpec,
@@ -14,11 +17,11 @@ use crate::{
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-fn compose_budget() -> ResourceBudget {
+pub(super) fn compose_budget() -> ResourceBudget {
     ResourceBudget::new(ResourceLimits::default())
 }
 
-fn read_budget(byte_len: usize) -> ResourceBudget {
+pub(super) fn read_budget(byte_len: usize) -> ResourceBudget {
     ResourceBudget::new(ResourceLimits::new(ReadLimits::new(
         ByteCount::new(byte_len as u64),
         JET3_PAGE_SIZE,
@@ -67,7 +70,7 @@ fn expected_parent_entries(count: usize) -> Vec<(&'static [u8], PageNumber, u8)>
     entries
 }
 
-fn inline_map_bit(
+pub(super) fn inline_map_bit(
     bytes: &[u8],
     map_page: u64,
     map_row: u8,

--- a/crates/jet3/src/bootstrap_system_definitions.rs
+++ b/crates/jet3/src/bootstrap_system_definitions.rs
@@ -377,31 +377,6 @@ pub(super) fn msys_relationships_definition(
     )
 }
 
-pub(super) fn alpha_definition_page(
-    budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
-    const COLUMNS: [ColumnSpec<'static>; 1] = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
-    definition_page(
-        &TableDefinitionSpec {
-            kind: TableDefinitionKind::User,
-            columns: &COLUMNS,
-            system_column_classes: &[],
-            physical_indexes: &[],
-            indexes: &[],
-            owned_map: locator(ALPHA_MAP_PAGE, 0),
-            available_map: locator(ALPHA_MAP_PAGE, 1),
-            row_count: 0,
-            long_value_maps: &[],
-        },
-        budget,
-    )
-}
-
 const fn field(column: u16) -> IndexFieldSpec {
     IndexFieldSpec {
         column,

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -1,0 +1,311 @@
+//! Pages a planned user-table create appends to the empty database, derived
+//! from the `EXP-0087` create observations rather than recorded bytes.
+//!
+//! `EXP-0087` observed each create append a definition root, a page of
+//! usage-map rows, an index root directly after it when the table carries an
+//! index, and, on a database's first create only, a long-value page holding
+//! the catalog row's `LvProp` payload. No observed first create carried an
+//! index, so the long-value page's position after an index root is deduced:
+//! the index root was observed directly after the map page, so the long-value
+//! page can only follow it.
+//!
+//! The map page carries the table's owned and available maps at rows 0 and 1
+//! (`EXP-0073`), then either the index's map row at row 2 holding the index
+//! root (`EXP-0073`, from `MSysACEs` and the `Alpha` index transition) or one
+//! owned/available pair at rows 2 and 3 for a single Memo or LongBinary
+//! column (`EXP-0077`). No observed create carried both an index and a
+//! long-value column, or more than one long-value column, so those layouts
+//! are refused rather than invented.
+//!
+//! `EXP-0087` pinned the `LvProp` payload framing but no grammar, so the
+//! caller supplies the payload and this module checks only the framing. Only
+//! the `Alpha(Id Long)` payload `EXP-0079` recorded is established.
+//!
+//! Column types, column counts, and index field counts beyond the four
+//! observed creates rely on the encoders' established record formats rather
+//! than on an observed create.
+
+use super::*;
+use crate::long_value_writer::{external_long_value_header, validate_single_page_row};
+use crate::table_schema_plan::{
+    PlannedIndexKind, TableSchemaPlan, TableSchemaSpec, plan_table_schema,
+};
+use crate::{ExternalLongValueStorage, LogicalIndexSpec, RowLocator};
+
+/// `EXP-0073`: row of the map page holding the table's owned-page map.
+const OWNED_MAP_ROW: u8 = 0;
+/// `EXP-0073`: row of the map page holding the table's available-page map.
+const AVAILABLE_MAP_ROW: u8 = 1;
+/// First map-page row after the table's own two maps.
+const FIRST_FREE_MAP_ROW: u8 = 2;
+/// `EXP-0087`: `MSysObjects` `Flags` of a created user table.
+const USER_FLAGS: i32 = 0;
+/// Long-value column count `EXP-0087` observed on a created table.
+const MAX_OBSERVED_LONG_VALUE_COLUMNS: usize = 1;
+/// `EXP-0087`: every `LvProp` payload began with these bytes.
+const PROPERTY_MAGIC: [u8; 4] = *b"KKD\x00";
+/// `EXP-0087`: a four-byte inclusive length then a two-byte kind per chunk.
+const PROPERTY_CHUNK_HEADER_LEN: usize = 6;
+/// `EXP-0087`: the kind of the one leading chunk of every payload.
+const PROPERTY_NAMES_CHUNK_KIND: u16 = 0x0080;
+
+/// One user table to create in the empty database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TableCreate<'a> {
+    /// The table's name, columns, and indexes.
+    pub(crate) spec: &'a TableSchemaSpec<'a>,
+    /// The catalog row's `LvProp` payload, whose grammar `EXP-0087` leaves
+    /// unestablished beyond the framing this module checks.
+    pub(crate) properties: &'a [u8],
+}
+
+/// A create with its pages assigned and its map-page rows laid out.
+#[derive(Debug, Clone)]
+pub(super) struct PlannedCreate<'a> {
+    create: TableCreate<'a>,
+    plan: TableSchemaPlan,
+    /// The indexed column's root and the map-page row of its usage map.
+    index: Option<(PageNumber, u8)>,
+    /// The long-value column's ordinal and the map-page row of its owned
+    /// map; its available map is the next row.
+    long_value: Option<(u16, u8)>,
+    long_value_page: u64,
+}
+
+impl<'a> PlannedCreate<'a> {
+    /// Plans `create` as the first create in the empty database.
+    pub(super) fn new(create: TableCreate<'a>) -> Result<Self, BootstrapComposeError> {
+        let plan = plan_table_schema(create.spec, EMPTY_DATABASE_PAGE_COUNT)?;
+        validate_single_page_row(create.properties)?;
+        validate_property_framing(create.properties, create.spec.columns.len())?;
+        let mut long_value_columns = long_value_columns(create.spec);
+        let long_value_column = long_value_columns.next();
+        if long_value_columns.next().is_some() {
+            return Err(BootstrapComposeError::UnobservedLongValueColumnCount {
+                observed: MAX_OBSERVED_LONG_VALUE_COLUMNS,
+            });
+        }
+        let index = plan.index_root().map(|root| (root, FIRST_FREE_MAP_ROW));
+        let long_value = match (index, long_value_column) {
+            (Some(_), Some(_)) => return Err(BootstrapComposeError::UnobservedMapRowLayout),
+            (None, Some(column)) => Some((column, FIRST_FREE_MAP_ROW)),
+            (_, None) => None,
+        };
+        let long_value_page = plan.definition_root().get() + plan.appended_page_count();
+        Ok(Self {
+            create,
+            plan,
+            index,
+            long_value,
+            long_value_page,
+        })
+    }
+
+    pub(super) const fn object_id(&self) -> i32 {
+        self.plan.object_id()
+    }
+
+    pub(super) const fn long_value_page(&self) -> u64 {
+        self.long_value_page
+    }
+
+    /// Returns the page count once every appended page is in place.
+    pub(super) const fn page_count(&self) -> u64 {
+        self.long_value_page + 1
+    }
+
+    /// Returns the catalog row the create adds (`EXP-0087`).
+    pub(super) const fn catalog_seed(&self) -> CatalogSeed<'a> {
+        CatalogSeed {
+            id: self.plan.object_id(),
+            parent: TABLES_ID,
+            name: self.create.spec.name,
+            kind: 1,
+            owner: CATALOG_OWNER_0301,
+            flags: USER_FLAGS,
+        }
+    }
+
+    /// Returns the two access-control rows the create adds (`EXP-0087`).
+    pub(super) const fn ace_seeds(&self) -> [AceSeed; 2] {
+        let id = self.plan.object_id();
+        [
+            ace(id, b"\x03\x01", 983294, false),
+            ace(id, b"\x02\x01", 1048319, false),
+        ]
+    }
+
+    /// Returns the catalog row's `LvProp` reference to the long-value page.
+    pub(super) fn long_value_header(&self) -> Result<[u8; 12], BootstrapComposeError> {
+        Ok(external_long_value_header(
+            self.create.properties.len(),
+            ExternalLongValueStorage::SinglePage,
+            RowLocator::new(PageNumber::new(self.long_value_page), 0),
+        )?)
+    }
+
+    /// Appends the create's pages: definition root, map page, index root when
+    /// indexed, then the long-value page.
+    pub(super) fn append_pages(
+        &self,
+        plan: &mut WholeFileImagePlan,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), BootstrapComposeError> {
+        let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
+        plan.append(self.definition_page(budget)?, &mut append_map, budget)?;
+        plan.append(self.map_page(budget)?, &mut append_map, budget)?;
+        if self.index.is_some() {
+            let owner = self.plan.definition_root().get();
+            plan.append(empty_index_page(owner, budget)?, &mut append_map, budget)?;
+        }
+        plan.append(self.long_value_page_image(budget)?, &mut append_map, budget)?;
+        Ok(())
+    }
+
+    fn definition_page(
+        &self,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, BootstrapComposeError> {
+        let map = self.plan.map_page();
+        let spec = self.create.spec;
+        let physical = self
+            .index
+            .into_iter()
+            .zip(spec.indexes)
+            .map(|((root, row), index)| PhysicalIndexSpec {
+                fields: index.fields,
+                usage_map_page: map,
+                usage_map_row: row,
+                root,
+                flags: index.kind.flags(),
+                entry_count: 0,
+            })
+            .collect::<Vec<_>>();
+        let logical = spec
+            .indexes
+            .iter()
+            .enumerate()
+            .map(|(ordinal, index)| {
+                Ok(LogicalIndexSpec {
+                    name: index.name,
+                    physical_index: u16::try_from(ordinal).map_err(|_| {
+                        Error::IntegerConversion {
+                            value: ordinal as u128,
+                            target: "u16",
+                        }
+                    })?,
+                    kind: match index.kind {
+                        PlannedIndexKind::Primary => LogicalIndexKindSpec::Primary,
+                        PlannedIndexKind::Ordinary => LogicalIndexKindSpec::Ordinary,
+                    },
+                })
+            })
+            .collect::<Result<Vec<_>, BootstrapComposeError>>()?;
+        let long_value_maps = self
+            .long_value
+            .map(|(column, owned)| LongValueMapSpec {
+                column,
+                owned: MapRowLocator::new(map, owned),
+                available: MapRowLocator::new(map, owned + 1),
+            })
+            .into_iter()
+            .collect::<Vec<_>>();
+        definition_page(
+            &TableDefinitionSpec {
+                kind: TableDefinitionKind::User,
+                columns: spec.columns,
+                system_column_classes: &[],
+                physical_indexes: &physical,
+                indexes: &logical,
+                owned_map: MapRowLocator::new(map, OWNED_MAP_ROW),
+                available_map: MapRowLocator::new(map, AVAILABLE_MAP_ROW),
+                row_count: 0,
+                long_value_maps: &long_value_maps,
+            },
+            budget,
+        )
+    }
+
+    /// Builds the map page with the rows `definition_page` names.
+    fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
+        let empty = inline_map_row(&[], budget)?;
+        let mut rows: Vec<[u8; 133]> = vec![empty, empty];
+        if let Some((root, row)) = self.index {
+            debug_assert_eq!(usize::from(row), rows.len());
+            rows.push(inline_map_row(&[root.get()], budget)?);
+        }
+        if let Some((_, owned)) = self.long_value {
+            debug_assert_eq!(usize::from(owned), rows.len());
+            rows.push(empty);
+            rows.push(empty);
+        }
+        let rows = rows.iter().map(<[u8; 133]>::as_slice).collect::<Vec<_>>();
+        data_page(HEADER_PAGE, &rows, budget)
+    }
+
+    fn long_value_page_image(
+        &self,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, BootstrapComposeError> {
+        let mut builder = DataPageBuilder::new_long_value(budget)?;
+        builder.append_row(self.create.properties, budget)?;
+        finish_data_builder(builder, budget)
+    }
+}
+
+/// Returns the ordinals of the columns that own long-value map groups.
+fn long_value_columns<'s>(spec: &'s TableSchemaSpec<'_>) -> impl Iterator<Item = u16> + 's {
+    spec.columns
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| {
+            matches!(
+                column.physical_type(),
+                ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
+            )
+        })
+        .filter_map(|(ordinal, _)| u16::try_from(ordinal).ok())
+}
+
+/// Checks `payload` against the `EXP-0087` framing: the magic, exact
+/// coverage by length-prefixed chunks, one leading names chunk, then one
+/// chunk per column. Chunk bodies stay uninterpreted.
+fn validate_property_framing(
+    payload: &[u8],
+    column_count: usize,
+) -> Result<(), BootstrapComposeError> {
+    let malformed = |offset: usize| BootstrapComposeError::PropertyFraming { offset };
+    let Some(mut rest) = payload.strip_prefix(&PROPERTY_MAGIC) else {
+        return Err(malformed(0));
+    };
+    let mut offset = PROPERTY_MAGIC.len();
+    let mut chunks = 0_usize;
+    while !rest.is_empty() {
+        let (header, _) = rest
+            .split_at_checked(PROPERTY_CHUNK_HEADER_LEN)
+            .ok_or(malformed(offset))?;
+        let length = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        let kind = u16::from_le_bytes([header[4], header[5]]);
+        let length = usize::try_from(length)
+            .ok()
+            .filter(|length| *length >= PROPERTY_CHUNK_HEADER_LEN && *length <= rest.len())
+            .ok_or(malformed(offset))?;
+        if chunks == 0 && kind != PROPERTY_NAMES_CHUNK_KIND {
+            return Err(malformed(offset));
+        }
+        rest = &rest[length..];
+        offset += length;
+        chunks += 1;
+    }
+    if chunks != column_count + 1 {
+        return Err(BootstrapComposeError::PropertyChunkCount {
+            chunks,
+            expected: column_count + 1,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "bootstrap_table_create_tests.rs"]
+mod tests;

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -268,8 +268,9 @@ fn long_value_columns<'s>(spec: &'s TableSchemaSpec<'_>) -> impl Iterator<Item =
 }
 
 /// Checks `payload` against the `EXP-0087` framing: the magic, exact
-/// coverage by length-prefixed chunks, one leading names chunk, then one
-/// chunk per column. Chunk bodies stay uninterpreted.
+/// coverage by length-prefixed chunks, one leading names chunk exactly
+/// covered by length-prefixed name entries, then one chunk per column. The
+/// column chunk bodies stay uninterpreted.
 fn validate_property_framing(
     payload: &[u8],
     column_count: usize,
@@ -290,8 +291,11 @@ fn validate_property_framing(
             .ok()
             .filter(|length| *length >= PROPERTY_CHUNK_HEADER_LEN && *length <= rest.len())
             .ok_or(malformed(offset))?;
-        if chunks == 0 && kind != PROPERTY_NAMES_CHUNK_KIND {
-            return Err(malformed(offset));
+        if chunks == 0 {
+            if kind != PROPERTY_NAMES_CHUNK_KIND {
+                return Err(malformed(offset));
+            }
+            validate_name_entries(&rest[PROPERTY_CHUNK_HEADER_LEN..length], offset)?;
         }
         rest = &rest[length..];
         offset += length;
@@ -302,6 +306,26 @@ fn validate_property_framing(
             chunks,
             expected: column_count + 1,
         });
+    }
+    Ok(())
+}
+
+/// Checks that the names chunk body is exactly covered by two-byte
+/// length-prefixed entries (`EXP-0087`). `chunk_offset` is the chunk's
+/// position in the payload, for error reporting.
+fn validate_name_entries(
+    mut body: &[u8],
+    chunk_offset: usize,
+) -> Result<(), BootstrapComposeError> {
+    let mut offset = chunk_offset + PROPERTY_CHUNK_HEADER_LEN;
+    while !body.is_empty() {
+        let entry_len = body
+            .split_at_checked(2)
+            .map(|(prefix, _)| usize::from(u16::from_le_bytes([prefix[0], prefix[1]])))
+            .filter(|entry_len| entry_len + 2 <= body.len())
+            .ok_or(BootstrapComposeError::PropertyFraming { offset })?;
+        body = &body[2 + entry_len..];
+        offset += 2 + entry_len;
     }
     Ok(())
 }

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -286,6 +286,30 @@ fn a_property_payload_outside_the_pinned_framing_is_refused() {
         compose(b"KKD\x00\x06\x00\x00\x00\x01\x00", &mut budget),
         Err(BootstrapComposeError::PropertyFraming { offset: 4 })
     ));
+    // A names chunk body not exactly covered by length-prefixed entries: a
+    // one-byte body, then an entry whose length runs past the body.
+    assert!(matches!(
+        compose(
+            b"KKD\x00\x07\x00\x00\x00\x80\x00\x00\x06\x00\x00\x00\x01\x00",
+            &mut budget
+        ),
+        Err(BootstrapComposeError::PropertyFraming { offset: 10 })
+    ));
+    assert!(matches!(
+        compose(
+            b"KKD\x00\x09\x00\x00\x00\x80\x00\x02\x00\x41\x06\x00\x00\x00\x01\x00",
+            &mut budget
+        ),
+        Err(BootstrapComposeError::PropertyFraming { offset: 10 })
+    ));
+    // A names chunk with two exactly-covering entries passes.
+    assert!(
+        compose(
+            b"KKD\x00\x0d\x00\x00\x00\x80\x00\x02\x00\x41\x42\x01\x00\x43\x06\x00\x00\x00\x01\x00",
+            &mut budget
+        )
+        .is_ok()
+    );
     // Chunk count not matching one names chunk plus one per column.
     assert!(matches!(
         compose(&framed_properties(2), &mut budget),

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -1,0 +1,299 @@
+//! Composition of arbitrary planned user tables, decoded back through the
+//! reader to check each `EXP-0087` structure lands where the plan says.
+
+use super::super::tests::{compose_budget, inline_map_bit, read_budget};
+use super::super::{BootstrapComposeError, TableCreate, compose_table_database};
+use crate::table_schema_plan::{PlannedIndex, PlannedIndexKind, TableSchemaSpec};
+use crate::{
+    ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
+    IndexDirection, IndexFieldSpec, MapRowLocator, PageKind, PageNumber, SliceSource, page_tag,
+};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn create_bytes(create: TableCreate<'_>) -> Result<Vec<u8>, BootstrapComposeError> {
+    let mut budget = compose_budget();
+    let plan = compose_table_database(create, &mut budget)?;
+    let mut bytes = Vec::with_capacity(plan.pages().len() * crate::PAGE_BYTES);
+    for page in plan.pages() {
+        bytes.extend_from_slice(page.image().as_bytes());
+    }
+    Ok(bytes)
+}
+
+const ID: ColumnSpec<'static> =
+    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4);
+const NAME: ColumnSpec<'static> = ColumnSpec::new(
+    b"Name",
+    ColumnPhysicalType::Text,
+    ColumnStorageKind::Variable,
+    50,
+);
+const NOTE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Note",
+    ColumnPhysicalType::Memo,
+    ColumnStorageKind::Variable,
+    0,
+);
+/// Builds a payload with the EXP-0087 framing and empty chunk bodies: the
+/// magic, one names chunk, then one chunk per column. Only Alpha's recorded
+/// payload is established; this exercises the framing check alone.
+fn framed_properties(columns: usize) -> Vec<u8> {
+    let mut payload = b"KKD\x00".to_vec();
+    payload.extend_from_slice(&[6, 0, 0, 0, 0x80, 0x00]);
+    for _ in 0..columns {
+        payload.extend_from_slice(&[6, 0, 0, 0, 0x01, 0x00]);
+    }
+    payload
+}
+
+#[test]
+fn a_created_memo_table_carries_its_long_value_map_groups_on_its_map_page() -> TestResult {
+    // EXP-0087's Beta shape: two appended pages plus the first-create
+    // long-value page, and one EXP-0077 map group for the Memo column.
+    let columns = [ID, NAME, NOTE];
+    let bytes = create_bytes(TableCreate {
+        spec: &TableSchemaSpec {
+            name: b"Beta",
+            columns: &columns,
+            indexes: &[],
+        },
+        properties: &framed_properties(3),
+    })?;
+    assert_eq!(bytes.len(), 23 * crate::PAGE_BYTES);
+    assert_eq!(bytes[1538], 2);
+    assert_eq!(
+        &bytes[22 * crate::PAGE_BYTES + 4..22 * crate::PAGE_BYTES + 8],
+        b"LVAL"
+    );
+    assert!(inline_map_bit(&bytes, 6, 10, 22)?);
+
+    let mut budget = read_budget(bytes.len());
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let mut beta = None;
+    {
+        let mut catalog = database.catalog(&mut budget)?;
+        while let Some(record) = catalog.next_record()? {
+            if record.name().raw_bytes() == b"Beta" {
+                beta = Some((record.id().get(), record.table_definition()));
+            }
+        }
+    }
+    assert_eq!(beta, Some((20, Some(PageNumber::new(20)))));
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.columns().len(), 3);
+    assert!(definition.physical_indexes().is_empty());
+    let [group] = definition.long_value_maps() else {
+        return Err("expected exactly one long-value map group".into());
+    };
+    assert_eq!(group.column(), ColumnOrdinal::new(2));
+    assert_eq!(group.owned(), MapRowLocator::new(PageNumber::new(21), 2));
+    assert_eq!(
+        group.available(),
+        MapRowLocator::new(PageNumber::new(21), 3)
+    );
+    // The map page holds the table's two maps and the group's two.
+    assert_eq!(
+        u16::from_le_bytes([
+            bytes[21 * crate::PAGE_BYTES + 8],
+            bytes[21 * crate::PAGE_BYTES + 9]
+        ]),
+        4
+    );
+    Ok(())
+}
+
+#[test]
+fn an_indexed_first_create_places_its_index_root_before_the_long_value_page() -> TestResult {
+    // EXP-0087's Gamma shape as a first create, which no run observed: the
+    // index root was observed directly after the map page, so the
+    // first-create long-value page can only follow it.
+    let columns = [ID];
+    let indexes = [PlannedIndex {
+        name: b"PrimaryKey",
+        fields: &[IndexFieldSpec {
+            column: 0,
+            direction: IndexDirection::Ascending,
+        }],
+        kind: PlannedIndexKind::Primary,
+    }];
+    let bytes = create_bytes(TableCreate {
+        spec: &TableSchemaSpec {
+            name: b"Gamma",
+            columns: &columns,
+            indexes: &indexes,
+        },
+        properties: &framed_properties(1),
+    })?;
+    assert_eq!(bytes.len(), 24 * crate::PAGE_BYTES);
+    assert_eq!(bytes[22 * crate::PAGE_BYTES], page_tag(PageKind::LeafIndex));
+    assert_eq!(
+        &bytes[23 * crate::PAGE_BYTES + 4..23 * crate::PAGE_BYTES + 8],
+        b"LVAL"
+    );
+    assert!(!inline_map_bit(&bytes, 1, 0, 23)?);
+    assert!(inline_map_bit(&bytes, 1, 0, 24)?);
+    assert!(inline_map_bit(&bytes, 6, 10, 23)?);
+
+    let mut budget = read_budget(bytes.len());
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    let [physical] = definition.physical_indexes() else {
+        return Err("expected exactly one physical index".into());
+    };
+    assert_eq!(physical.root(), PageNumber::new(22));
+    assert_eq!(physical.usage_map().page(), PageNumber::new(21));
+    assert_eq!(physical.usage_map().row(), 2);
+    assert!(physical.unique());
+    assert!(physical.required());
+    assert_eq!(definition.indexes()[0].name().raw_bytes(), b"PrimaryKey");
+    assert!(definition.long_value_maps().is_empty());
+    let root = database.index_tree(&definition, 0, &mut budget)?;
+    assert!(root.entries().is_empty());
+    Ok(())
+}
+
+#[test]
+fn a_table_with_both_an_index_and_a_long_value_column_is_refused() {
+    // No EXP-0087 create carried both, so their map-page row order is unobserved.
+    let columns = [ID, NOTE];
+    let indexes = [PlannedIndex {
+        name: b"ById",
+        fields: &[IndexFieldSpec {
+            column: 0,
+            direction: IndexDirection::Ascending,
+        }],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    let mut budget = compose_budget();
+    assert!(matches!(
+        compose_table_database(
+            TableCreate {
+                spec: &TableSchemaSpec {
+                    name: b"Mixed",
+                    columns: &columns,
+                    indexes: &indexes,
+                },
+                properties: &framed_properties(2),
+            },
+            &mut budget,
+        ),
+        Err(BootstrapComposeError::UnobservedMapRowLayout)
+    ));
+}
+
+#[test]
+fn a_create_that_cannot_be_planned_reports_the_schema_error() {
+    let columns = [ID];
+    let mut budget = compose_budget();
+    assert!(matches!(
+        compose_table_database(
+            TableCreate {
+                spec: &TableSchemaSpec {
+                    name: b"",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                properties: &framed_properties(1),
+            },
+            &mut budget,
+        ),
+        Err(BootstrapComposeError::Schema(_))
+    ));
+    assert!(matches!(
+        compose_table_database(
+            TableCreate {
+                spec: &TableSchemaSpec {
+                    name: b"Empty",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                properties: b"",
+            },
+            &mut budget,
+        ),
+        Err(BootstrapComposeError::LongValue(_))
+    ));
+}
+
+#[test]
+fn a_second_long_value_column_is_refused() {
+    // EXP-0087's only long-value create, Beta, carried one Memo column, and
+    // the one multi-group layout on record (MSysObjects) is not consecutive.
+    let columns = [
+        ID,
+        NOTE,
+        ColumnSpec::new(
+            b"Blob",
+            ColumnPhysicalType::LongBinary,
+            ColumnStorageKind::Variable,
+            0,
+        ),
+    ];
+    let mut budget = compose_budget();
+    assert!(matches!(
+        compose_table_database(
+            TableCreate {
+                spec: &TableSchemaSpec {
+                    name: b"Wide",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                properties: &framed_properties(3),
+            },
+            &mut budget,
+        ),
+        Err(BootstrapComposeError::UnobservedLongValueColumnCount { observed: 1 })
+    ));
+}
+
+#[test]
+fn a_property_payload_outside_the_pinned_framing_is_refused() {
+    let columns = [ID];
+    let mut budget = compose_budget();
+    let compose = |properties: &[u8], budget: &mut _| {
+        compose_table_database(
+            TableCreate {
+                spec: &TableSchemaSpec {
+                    name: b"Alpha",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                properties,
+            },
+            budget,
+        )
+    };
+    // Wrong magic.
+    assert!(matches!(
+        compose(b"KKE\x00", &mut budget),
+        Err(BootstrapComposeError::PropertyFraming { offset: 0 })
+    ));
+    // A chunk length running past the payload.
+    assert!(matches!(
+        compose(b"KKD\x00\x09\x00\x00\x00\x80\x00", &mut budget),
+        Err(BootstrapComposeError::PropertyFraming { offset: 4 })
+    ));
+    // A chunk shorter than its own header.
+    assert!(matches!(
+        compose(b"KKD\x00\x05\x00\x00\x00\x80\x00", &mut budget),
+        Err(BootstrapComposeError::PropertyFraming { offset: 4 })
+    ));
+    // A leading chunk that is not the names chunk.
+    assert!(matches!(
+        compose(b"KKD\x00\x06\x00\x00\x00\x01\x00", &mut budget),
+        Err(BootstrapComposeError::PropertyFraming { offset: 4 })
+    ));
+    // Chunk count not matching one names chunk plus one per column.
+    assert!(matches!(
+        compose(&framed_properties(2), &mut budget),
+        Err(BootstrapComposeError::PropertyChunkCount {
+            chunks: 3,
+            expected: 2
+        })
+    ));
+    // Alpha's recorded payload passes the framing for its one column.
+    assert!(compose(super::super::ALPHA_LVPROP_PAYLOAD, &mut budget).is_ok());
+}

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -58,7 +58,7 @@ pub(crate) enum PlannedIndexKind {
 
 impl PlannedIndexKind {
     /// Returns the physical flag class this index kind encodes to.
-    const fn flags(self) -> PhysicalIndexFlagsSpec {
+    pub(crate) const fn flags(self) -> PhysicalIndexFlagsSpec {
         match self {
             Self::Primary => PhysicalIndexFlagsSpec::UniqueRequired,
             Self::Ordinary => PhysicalIndexFlagsSpec::Ordinary,


### PR DESCRIPTION
The composer could only build `Alpha(Id Long)` because every page number, catalog row, and access-control row in it was a constant. This threads a planned create through it so the catalog row, the two ACE rows, the catalog index entries, the page-zero step, the global map, and the appended definition, map, index-root, and long-value pages all derive from the `EXP-0087` create observations. The Alpha composition becomes one call through that path carrying its `EXP-0079` payload, and the existing Alpha byte-level tests still pass.

The caller supplies the `LvProp` payload because `EXP-0087` pinned its framing but no grammar (#149). The composer checks the framing it did pin: the magic, exact coverage by length-prefixed chunks, one leading names chunk, then one chunk per column. Chunk bodies stay uninterpreted.

Refusals, each because no observed create had the shape rather than because the code cannot build it:

- **An index plus a long-value column.** Their map-page row order is unobserved.
- **More than one long-value column.** Beta had one, and the only multi-group layout on record (`MSysObjects`) is not consecutive pairs from row 2.

One deduction is documented rather than observed: no observed first create carried an index, so the long-value page's position after an index root is deduced from the index root being observed directly after the map page. The test for that shape says so.

Map rows 0 and 1 and the index map row at row 2 cite `EXP-0073`, not `EXP-0087`, which says nothing about map rows. The row layout is derived by construction so relaxing a refusal later cannot silently misnumber a row.

Generic-path tests compose Beta and Gamma shapes with a framing-only stand-in payload and decode them back through the reader. The composer's error type moved to its own file to stay under the line limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)