### PR TITLE
test(oracle): correct null LvProp property-order validation

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -7980,6 +7980,77 @@ Use `not applicable` explicitly rather than omitting a field.
   remaining findings
 
 
+### EXP-0090 — Preregistered producer-order null-LvProp validation
+
+- Recorded: 2026-09-02, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration successor;
+  no provider acquisition has occurred under this successor plan
+- Question: the exact candidates, three-replica control structure, eight
+  read-only endpoint frontiers, bounds, decision rules, and excluded claims are
+  those fixed by `EXP-0088`.
+- Origin: `EXP-0089` completed its producer once but was validation-rejected
+  without a canonical report. The producer attempted to sort bounded DAO
+  property collections but serialized them in producer order. The plan
+  required sorted collections, and the analyzer enforced Python case-folded
+  order. The raw observations from that rejected run are method-design input
+  only and are not reanalyzed or admitted as an answer.
+- Protocol correction: property sequences are accepted in their bounded
+  producer order while still requiring at most 64 entries, exact `name` and
+  `type` fields, nonempty unique names of at most 256 characters, signed
+  32-bit integer types, the `Required` property, and `Field.Required` false.
+  Snapshot equality remains exact and order-sensitive. Replica disagreement,
+  including disagreement among fresh controls, yields `no_outcome`; one stable
+  null-candidate/control order difference is a semantic mismatch under the
+  existing accepted-negative rule. The analyzer neither sorts nor normalizes
+  an acquired sequence. Every other producer, analyzer, control, candidate,
+  endpoint, bound, retention, and decision predicate is unchanged.
+- Design diagnostic: removing only the rejected ordering predicate in memory
+  allowed every other validator to consume the retained `EXP-0089` job result.
+  This confirms the successor's correction is minimal but is not a canonical
+  report, does not answer either question, and contributes no format fact.
+- Preregistration artifact: the existing
+  `oracle/windows-dao/acquisition/lvprop-null.plan.json` is replaced, not
+  stacked with a revision file, and now has SHA-256
+  `a7a466c9f7f3dbc27869342f5de36ac13420818b47980c12f18104335306d0a5`.
+  It pins the corrected analyzer at SHA-256
+  `5aa0de8e59250adc860477e7763fa6db911ad1edadbdcd952d2ce4f9b4d2f1d2`.
+  The 98-file source manifest SHA-256
+  `3493b9937a53daa5c38d409c7af9ebe4694ba609b26b66259f7dac7214b67d76`,
+  producer SHA-256
+  `952066d689df5daa87723826912c95707357910f4a6cca450471648ac3755236`,
+  all other input pins, and both 47,104-byte candidate identities remain
+  unchanged from `EXP-0088`.
+- Observation: `preregistration.acquisition_started` remains `false` for this
+  successor. Because `EXP-0089` crossed the first DAO mutation, the earlier
+  general authorization does not permit redispatch. One new three-replica run
+  is allowed only after these exact reviewed bytes reach `main` and a human
+  explicitly authorizes the successor; the checked client must then verify
+  every merged pin. No later post-mutation failure may be retried without
+  another new human decision.
+- Decision rule: unchanged from `EXP-0088`. The fixed candidate must be
+  `observed_accepted`; the null candidate may be a consistent
+  `observed_accepted` or accepted negative observation. Control failure,
+  mutation, disagreement including property-sequence order, incomplete work,
+  or an unclassifiable observation is an honest `no_outcome`; pin, inventory,
+  bound, candidate-identity, or result-integrity defects reject without a
+  canonical report.
+- Interpretation: this successor changes only property-sequence validation.
+  It establishes no property ordering semantics or grammar, null-`LvProp`
+  construction fact, permission to omit page 22 or its map references,
+  arbitrary schema acceptance, writer or publication correctness,
+  compatibility, hosted differential result, or support-matrix movement.
+- Usage: future successor result; issue `#149`; `EXP-0088`; `EXP-0089`;
+  `file:oracle/windows-dao/acquisition/lvprop-null.plan.json`;
+  `file:oracle/windows-dao/scripts/lvprop_null.py`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: three independent protocol-correction, exact-pin, analyzer,
+  decision-rule, evidence-boundary, and non-reinterpretation review rounds;
+  findings on stable order-mismatch classification, target-only replica
+  disagreement, sorted-versus-casefold wording, and normalization ambiguity
+  were resolved, and final audits reported no remaining findings
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/acquisition/lvprop-null.plan.json
+++ b/oracle/windows-dao/acquisition/lvprop-null.plan.json
@@ -5,10 +5,10 @@
   "development_only": true,
   "preregistration": {
     "acquisition_started": false,
-    "prior_evidence": "EXP-0061 establishes the checked single-page long-value framing used by the writer. EXP-0085 observed DAO 3.6 consume the exact fixed Alpha composer image without changing it. EXP-0087 observed a non-null LvProp on every created table, fixed its bounded chunk framing without deriving the payload grammar, and observed a long-value page only on a database's first create.",
+    "prior_evidence": "EXP-0061 establishes the checked single-page long-value framing used by the writer. EXP-0085 observed DAO 3.6 consume the exact fixed Alpha composer image without changing it. EXP-0087 observed a non-null LvProp on every created table, fixed its bounded chunk framing without deriving the payload grammar, and observed a long-value page only on a database's first create. EXP-0089 records that the first EXP-0088 acquisition was validation-rejected because the producer emitted bounded unique property collections in producer order while the plan required sorted collections and the analyzer enforced Python casefold order; its raw observations are not admitted evidence.",
     "hypothesis_source": "Issue #149 proposes the cheapest bounded discriminator: test whether DAO accepts a composed table whose catalog LvProp is null. The fixed candidate is the exact EXP-0085 Alpha image. The target candidate changes Alpha's catalog LvProp to null and leaves the observed 23-page first-create layout and map ownership intact while encoding page 22 as an empty LVAL page. This construction is a preregistered hypothesis, not an admitted format fact.",
-    "authorization": "Acquisition is forbidden until this plan and its exact SHA-256 pins are reviewed and committed. The user has authorized experiments generally, but the checked client must still verify the merged preregistration before the one allowed dispatch.",
-    "attempt_policy": "Dispatch exactly one three-replica run. Create the fresh DAO control before reading either candidate. Once the first DAO control mutation begins, any failure is a scientific result and must not be retried without a new human decision."
+    "authorization": "Successor acquisition is forbidden until this corrected plan and its exact SHA-256 pins are reviewed and committed and a human explicitly authorizes redispatch after EXP-0089. The earlier general authorization does not satisfy this post-failure decision. The checked client must verify the merged successor before the one allowed dispatch.",
+    "attempt_policy": "After renewed authorization, dispatch exactly one three-replica successor run. Create the fresh DAO control before reading either candidate. Once the first DAO control mutation begins, any failure is a scientific result and must not be retried without another new human decision."
   },
   "evidence_boundary": {
     "purpose": "Test whether DAO 3.6 structurally consumes the exact null-LvProp Alpha candidate at the same bounded read-only endpoints that accepted the fixed composer image, without repair.",
@@ -28,7 +28,7 @@
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "5bc42fa1e0813bc8b8b1c3904655017101075d052a5e33cbec3b0d110490ee93",
     "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "bb63eb64b0fdf3a14f0beddd2edd1494c6ff9c1a2043e19c6ade524cbeeaa1c2",
     "oracle/windows-dao/scripts/dev/LvPropNull.DevJob.ps1": "952066d689df5daa87723826912c95707357910f4a6cca450471648ac3755236",
-    "oracle/windows-dao/scripts/lvprop_null.py": "a277cc1e0ed777aca0a3e95830740bcdc83de5c6771169ef4585f778aeef192c"
+    "oracle/windows-dao/scripts/lvprop_null.py": "5aa0de8e59250adc860477e7763fa6db911ad1edadbdcd952d2ce4f9b4d2f1d2"
   },
   "candidate_source_manifest": {
     "path": "oracle/windows-dao/acquisition/lvprop-null.sources.json",
@@ -84,16 +84,16 @@
     "TableDefs is exactly Alpha plus MSysACEs, MSysObjects, MSysQueries, and MSysRelationships",
     "TableDefs.Item(Alpha) resolves by name",
     "Fields.Item(Id) resolves exactly one Long field",
-    "the sorted bounded TableDef and Field property collections enumerate and Field.Required is false",
+    "the bounded TableDef and Field property collections enumerate in producer order with unique names and Field.Required is false",
     "OpenRecordset(Alpha, snapshot) succeeds and is empty",
     "Containers(Tables).Documents.Item(Alpha) resolves and the document inventory is exact"
   ],
   "questions": {
-    "fixed_candidate": "Do all three copies of the pinned EXP-0085 fixed Alpha image pass every endpoint unchanged and match their fresh DAO controls at the normalized semantic frontier?",
-    "null_candidate": "Do all three copies of the pinned null-LvProp Alpha image pass every endpoint unchanged and match their fresh DAO controls at the normalized semantic frontier?"
+    "fixed_candidate": "Do all three copies of the pinned EXP-0085 fixed Alpha image pass every endpoint unchanged and match their fresh DAO controls in the bounded exact producer-order observations?",
+    "null_candidate": "Do all three copies of the pinned null-LvProp Alpha image pass every endpoint unchanged and match their fresh DAO controls in the bounded exact producer-order observations?"
   },
   "decision_rule": {
-    "observed_accepted": "All three fresh controls pass unchanged, all three fixed candidates pass unchanged, the selected candidate passes the complete endpoint list unchanged in all replicas, and its normalized observations match the same-replica fresh controls and agree across replicas.",
+    "observed_accepted": "All three fresh controls pass unchanged, all three fixed candidates pass unchanged, the selected candidate passes the complete endpoint list unchanged in all replicas, and its bounded exact producer-order observations match the same-replica fresh controls and agree across replicas.",
     "not_observed_accepted": "Both control classes pass unchanged, and all three selected candidates either stop at the same endpoint with identical bounded observations or complete unchanged with the same stable semantic mismatch against their fresh controls.",
     "no_outcome": "Use when a fresh or fixed control fails or changes, a candidate changes, replicas disagree, the scientific job is incomplete, or observations cannot be classified under the two rules above.",
     "validation_rejection": "Reject without a canonical report when any pin, inventory, bound, preregistered candidate identity, or result-integrity check fails.",

--- a/oracle/windows-dao/scripts/lvprop_null.py
+++ b/oracle/windows-dao/scripts/lvprop_null.py
@@ -130,9 +130,6 @@ def property_shape(value: Any, location: str) -> list[dict[str, Any]]:
         if type(item["type"]) is not int or not -(1 << 31) <= item["type"] < (1 << 31):
             raise AnalysisError(f"{location}[{index}].type is invalid")
         names.add(name)
-    ordered_names = [item["name"] for item in value]
-    if ordered_names != sorted(ordered_names, key=str.casefold):
-        raise AnalysisError(f"{location} properties are not sorted by name")
     return value
 
 

--- a/oracle/windows-dao/tests/test_lvprop_null.py
+++ b/oracle/windows-dao/tests/test_lvprop_null.py
@@ -27,9 +27,13 @@ def endpoint_observation(
             "detail": "rejected",
             "snapshot": {},
         }
-    table_properties = [{"name": "Name", "type": 10}]
+    table_properties = [
+        {"name": "ValidationRule", "type": 10},
+        {"name": "RecordCount", "type": 4},
+        {"name": "Name", "type": 10},
+    ]
     if semantic_mismatch:
-        table_properties = [{"name": "Name", "type": 12}]
+        table_properties[-1] = {"name": "Name", "type": 12}
     return {
         "status": "pass",
         "completed": ANALYZER.ALPHA_ENDPOINTS,
@@ -39,7 +43,10 @@ def endpoint_observation(
             "table_documents": ANALYZER.ALPHA_TABLES,
             "field": {"name": "Id", "type": 4},
             "table_properties": table_properties,
-            "field_properties": [{"name": "Required", "type": 1}],
+            "field_properties": [
+                {"name": "ValidationRule", "type": 10},
+                {"name": "Required", "type": 1},
+            ],
             "field_required": False,
         },
     }
@@ -337,18 +344,60 @@ class LvPropNullTests(unittest.TestCase):
             with self.assertRaisesRegex(ANALYZER.AnalysisError, "retained identity"):
                 self.evaluate(root, document, pins)
 
-    def test_property_shape_accepts_sorted_values_but_rejects_duplicates(self) -> None:
+    def test_property_shape_accepts_bounded_producer_order(self) -> None:
         properties = [
+            {"name": "ValidationRule", "type": 10},
             {"name": "Name", "type": 10},
             {"name": "RecordCount", "type": 4},
-            {"name": "ValidationRule", "type": 10},
         ]
         self.assertEqual(ANALYZER.property_shape(properties, "properties"), properties)
-        with self.assertRaisesRegex(ANALYZER.AnalysisError, "not sorted"):
-            ANALYZER.property_shape(list(reversed(properties)), "properties")
         properties.append({"name": "Name", "type": 10})
         with self.assertRaisesRegex(ANALYZER.AnalysisError, "nonempty and unique"):
             ANALYZER.property_shape(properties, "properties")
+        with self.assertRaisesRegex(ANALYZER.AnalysisError, "nonempty and unique"):
+            ANALYZER.property_shape([{"name": "", "type": 4}], "properties")
+        with self.assertRaisesRegex(ANALYZER.AnalysisError, "type is invalid"):
+            ANALYZER.property_shape([{"name": "Name", "type": True}], "properties")
+        with self.assertRaisesRegex(ANALYZER.AnalysisError, "at most 64"):
+            ANALYZER.property_shape(
+                [{"name": f"P{index}", "type": 4} for index in range(65)],
+                "properties",
+            )
+
+    def test_differing_producer_orders_across_replicas_are_a_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document, pins = job_document(root)
+            document["replicas"][1]["images"][1]["endpoints"]["snapshot"][
+                "table_properties"
+            ].reverse()
+            report = self.evaluate(root, document, pins)
+
+        self.assertEqual(report["status"], "no_outcome")
+        self.assertEqual(
+            report["questions"]["fixed_candidate"]["status"],
+            "observed_accepted",
+        )
+        self.assertEqual(
+            report["questions"]["null_candidate"]["status"],
+            "no_outcome",
+        )
+
+    def test_stable_candidate_order_mismatch_is_an_accepted_negative(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document, pins = job_document(root)
+            for replica in document["replicas"]:
+                replica["images"][1]["endpoints"]["snapshot"][
+                    "table_properties"
+                ].reverse()
+            report = self.evaluate(root, document, pins)
+
+        self.assertEqual(report["status"], "accepted")
+        self.assertEqual(
+            report["questions"]["null_candidate"]["status"],
+            "not_observed_accepted",
+        )
 
     def test_order_status_unique_json_and_inventory_are_enforced(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
The first #149 run was validation-rejected because its producer emitted bounded unique DAO properties in producer order while the pinned plan required sorted collections and the analyzer enforced Python case-fold ordering.

This separately preregisters the minimal successor: accept bounded producer order without sorting or normalization, while preserving entry bounds, exact shape, unique names, signed type bounds, Required validation, order-sensitive cross-replica equality, all candidate/control identities, and every other decision predicate. The previous bundle remains rejected and is not reanalyzed.

The in-place successor plan SHA-256 is a7a466c9f7f3dbc27869342f5de36ac13420818b47980c12f18104335306d0a5. Acquisition remains false and is explicitly forbidden until a new post-failure human authorization is given.

Checks: `just ready`; 55 focused oracle tests; exact plan/input/source/candidate pin verification; three review/fix rounds with no remaining findings.