### PR TITLE
test(oracle): determine multiple-index page assignment

### DIFF
--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -41,6 +41,7 @@ just windows-dev-bootstrap-layout
 just windows-dev-system-catalog
 just windows-dev-bootstrap-composer-semantics
 just windows-dev-schema-generalization
+just windows-dev-multiple-indexes
 just windows-dev-lvprop-null
 ```
 
@@ -130,6 +131,15 @@ catalog and access-control rows and appended page roles per create, and
 decomposes the long-value property payloads under one pinned chunk framing. It
 infers no property semantics, allocation policy, writer correctness,
 compatibility, or support.
+
+`multiple-indexes` is the SHA-256-pinned, development-only experiment for issue
+#150. Three replicas each create one fresh empty database, identity-check four
+pre-mutation copies, and retain closed checkpoints for the empty database plus
+one-index, two-index, three-index, and composite-index arms. Publication accepts
+exactly those 15 MDBs on success and only an ordered per-replica prefix after a
+post-mutation failure. The experiment tests this bounded page-assignment matrix;
+it does not establish arbitrary index shapes, writer correctness, compatibility,
+or support.
 
 `lvprop-null` is the SHA-256-pinned, development-only acceptance experiment for
 issue #149. Three replicas each compare the fixed accepted Alpha composer image,

--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -136,8 +136,9 @@ compatibility, or support.
 #150. Three replicas each create one fresh empty database, identity-check four
 pre-mutation copies, and retain closed checkpoints for the empty database plus
 one-index, two-index, three-index, and composite-index arms. Publication accepts
-exactly those 15 MDBs on success and only an ordered per-replica prefix after a
-post-mutation failure. The experiment tests this bounded page-assignment matrix;
+exactly those 15 MDBs on success and only an ordered per-replica prefix plus at
+most the next checkpoint's identified recovery image after a post-mutation
+failure. The experiment tests this bounded page-assignment matrix;
 it does not establish arbitrary index shapes, writer correctness, compatibility,
 or support.
 

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -8140,9 +8140,11 @@ Use `not applicable` explicitly rather than omitting a field.
   and logical-index assignments does DAO 3.6 produce when the database's first
   user table carries one index, two simple indexes, three mixed indexes, or one
   mixed-direction composite index plus a secondary index?
-- Origin: project-authored clean-room experiment for issue `#150`, using
-  `EXP-0059` and `EXP-0062` only as exploratory design input and `EXP-0073`,
-  `EXP-0087`, and `EXP-0091` as recorded evidence. `EXP-0087` observed user
+- Origin: project-authored clean-room experiment for issue `#150`, using the
+  bounded grammars recorded by `EXP-0059`, `EXP-0061`, `EXP-0062`, and
+  `EXP-0073`, and the create-time evidence in `EXP-0087` and `EXP-0091`.
+  Retained earlier artifacts and post-hoc page-placement observations are design
+  input only. `EXP-0087` observed user
   creates with zero or one index: definition root, map-rows page, then one index
   root. It did not observe a first create with an index or any one-shot user
   create with multiple indexes. `EXP-0073` observed three system indexes share
@@ -8175,12 +8177,13 @@ Use `not applicable` explicitly rather than omitting a field.
   mixed-direction composite index and one descending ordinary secondary. A
   passing run retains five MDBs per replica, exactly fifteen total.
 - Protocol: after each arm's one `TableDefs.Append`, close DAO before copying or
-  decoding the database. Hash and size every retained MDB before and after the
-  bounded read-only DAO metadata pass. Capture the exact table, field, and
-  index inventory; for every index capture name, `Primary`, `Unique`,
-  `Required`, ordered fields, and descending attributes; resolve the table and
-  its container document; and open an empty snapshot. Independently decode the
-  catalog row, complete single-page table definition, table and index usage-map
+  decoding the database. Hash and size every completed checkpoint before and
+  after the bounded read-only DAO metadata pass; an identified recovery image
+  is retained without metadata access and cannot contribute an observation.
+  Capture the exact table, field, and index inventory; for every index capture
+  name, `Primary`, `Unique`, `Required`, ordered fields, and descending
+  attributes. Independently decode the catalog row, complete single-page table
+  definition, table and index usage-map
   locators and rows, every empty index root and its owner, the first-create
   `LvProp` reference and `LVAL` page, and the role of every appended page using
   the `EXP-0073`/`EXP-0087` correlation method.
@@ -8199,13 +8202,15 @@ Use `not applicable` explicitly rather than omitting a field.
     uniqueness, or direction change it?
 - Preregistration artifacts:
   `oracle/windows-dao/acquisition/multiple-indexes.plan.json`, SHA-256
-  `<SHA256_MULTIPLE_INDEXES_PLAN>`; producer
+  `4832f4fe018af2ac951f9952eaa1a87766f3a3e274d7b083795c19620ae60329`;
+  producer
   `oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1`, SHA-256
-  `<SHA256_MULTIPLE_INDEXES_PRODUCER>`; analyzer
+  `a90f794521e514fb8ebd0b6a25f5e78db1eb54c6be12e10d1d2f2ee5017f21df`;
+  analyzer
   `oracle/windows-dao/scripts/multiple_indexes.py`, SHA-256
-  `<SHA256_MULTIPLE_INDEXES_ANALYZER>`. The final plan must pin these and every
-  host, guest, routing, publisher, and analyzer-dependency input before review
-  and merge. These conspicuous placeholders forbid acquisition from this draft.
+  `13e1ffc001c365c2fd4b053d0c0b26eb4a4a0211a65091aa198e2dec5eee14e4`.
+  The plan pins these and every host, guest, routing, publisher, and
+  analyzer-dependency input.
 - Observation: `preregistration.acquisition_started` is `false`. On 2026-09-02
   the user said “Go for it,” authorizing exactly one acquisition only after the
   exact pins replace the placeholders, are independently reviewed, and reach
@@ -8239,8 +8244,13 @@ Use `not applicable` explicitly rather than omitting a field.
   `file:oracle/windows-dao/scripts/multiple_indexes.py`
 - Rights: future project-generated MDBs and provider outputs remain outside
   the repository and are neither committed nor redistributed
-- Review: pending independent protocol, controls, page-role correlation,
-  ordering, exact-pin, decision-rule, evidence-boundary, and false-claim review
+- Review: three independent protocol, producer, publisher, analyzer,
+  page-role-correlation, ordering, failure-recovery, decision-rule,
+  evidence-boundary, and false-claim review rounds completed on 2026-09-02.
+  Findings covering mutation classification, retained-artifact recovery,
+  metadata identity, `LvProp` correlation, empty-root validation, failed-phase
+  consistency, and continuation-page scope were fixed; the final exact-head
+  reviews reported no remaining acquisition blocker.
 
 
 ## Fixtures and black-box results

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -8130,6 +8130,119 @@ Use `not applicable` explicitly rather than omitting a field.
   decision-rule, evidence-boundary, and false-claim review
 
 
+### EXP-0092 — Preregistered multiple-index page-assignment experiment
+
+- Recorded: 2026-09-02, OpenAI Codex
+- Kind: SHA-256-pinned, development-only local DAO preregistration; no provider
+  acquisition has occurred under this plan
+- Question: across three replicas beginning from identity-checked copies of one
+  fresh empty Jet 3 database apiece, what page, usage-map-row, physical-index,
+  and logical-index assignments does DAO 3.6 produce when the database's first
+  user table carries one index, two simple indexes, three mixed indexes, or one
+  mixed-direction composite index plus a secondary index?
+- Origin: project-authored clean-room experiment for issue `#150`, using
+  `EXP-0059` and `EXP-0062` only as exploratory design input and `EXP-0073`,
+  `EXP-0087`, and `EXP-0091` as recorded evidence. `EXP-0087` observed user
+  creates with zero or one index: definition root, map-rows page, then one index
+  root. It did not observe a first create with an index or any one-shot user
+  create with multiple indexes. `EXP-0073` observed three system indexes share
+  one map page and use consecutive map rows and roots. Neither observation
+  establishes the corresponding first-create user-table rule.
+- Motivation: the planner currently refuses more than one index, and the
+  composer places a first create's `LvProp` page after an index root by
+  deduction rather than observation. Multiple indexes also expose two matters
+  beyond page counting: DAO may order logical records and names differently
+  from physical records, and the planner's primary-versus-ordinary kind cannot
+  express the low-level writer's established unique non-primary flag class.
+  The experiment therefore measures page placement, map-row placement,
+  physical/logical ordering, and flags together rather than claiming that only
+  page assignment is open.
+- Controlled design: each arm creates the same empty table shape with the same
+  three fixed Long fields. Table, field, and index names use established ASCII
+  bytes at or below `0x7E`; corresponding names have equal encoded lengths
+  across arms. Index append order and equal-length names deliberately separate
+  physical creation order from logical/name order. Definitions remain within
+  one root page. No arm inserts a row, declares a long-value column or
+  relationship, uses an extended name byte, or needs a definition continuation.
+- Arms: create one fresh empty `dbVersion30` database per replica, close it,
+  retain it as `empty`, and copy and identity-check it before mutation into four
+  independent first-create arms. The `one_index` arm uses one ascending index
+  as the within-run count control and directly tests the previously deduced
+  first-create index-root/`LvProp` order. The `two_simple` arm uses a primary
+  index and an ordinary secondary. The `three_mixed` arm uses primary, unique
+  non-primary, and non-unique indexes with distinguishing append/name orders
+  and directions. The `composite_secondary` arm uses one unique non-primary
+  mixed-direction composite index and one descending ordinary secondary. A
+  passing run retains five MDBs per replica, exactly fifteen total.
+- Protocol: after each arm's one `TableDefs.Append`, close DAO before copying or
+  decoding the database. Hash and size every retained MDB before and after the
+  bounded read-only DAO metadata pass. Capture the exact table, field, and
+  index inventory; for every index capture name, `Primary`, `Unique`,
+  `Required`, ordered fields, and descending attributes; resolve the table and
+  its container document; and open an empty snapshot. Independently decode the
+  catalog row, complete single-page table definition, table and index usage-map
+  locators and rows, every empty index root and its owner, the first-create
+  `LvProp` reference and `LVAL` page, and the role of every appended page using
+  the `EXP-0073`/`EXP-0087` correlation method.
+- Questions:
+  - Page assignment: for each index count, which relative pages are the
+    definition root, map-rows page or pages, index roots, and first-create
+    `LVAL` page, and is the object identifier equal to the definition root?
+  - Map assignment: do all indexes share the table's map page, which rows do
+    their physical records name, and does each map row contain exactly its
+    corresponding root?
+  - Ordering and flags: how do index append order, physical ordinal, logical
+    record/name order, primary class, unique/required flags, field order, and
+    direction correlate?
+  - Shape discriminator: does the equal-count `composite_secondary` arm use the
+    same relative page and map assignment as `two_simple`, or does key arity,
+    uniqueness, or direction change it?
+- Preregistration artifacts:
+  `oracle/windows-dao/acquisition/multiple-indexes.plan.json`, SHA-256
+  `<SHA256_MULTIPLE_INDEXES_PLAN>`; producer
+  `oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1`, SHA-256
+  `<SHA256_MULTIPLE_INDEXES_PRODUCER>`; analyzer
+  `oracle/windows-dao/scripts/multiple_indexes.py`, SHA-256
+  `<SHA256_MULTIPLE_INDEXES_ANALYZER>`. The final plan must pin these and every
+  host, guest, routing, publisher, and analyzer-dependency input before review
+  and merge. These conspicuous placeholders forbid acquisition from this draft.
+- Observation: `preregistration.acquisition_started` is `false`. On 2026-09-02
+  the user said “Go for it,” authorizing exactly one acquisition only after the
+  exact pins replace the placeholders, are independently reviewed, and reach
+  `main`. The checked client must verify those merged bytes before dispatch.
+  Once the first DAO mutation begins, a failure is a scientific event and no
+  retry is permitted without renewed explicit human authorization.
+- Decision rule: each question is `answered` only when all four arms produce
+  their exact declared empty schemas, all retained bytes remain unchanged,
+  every reference correlates uniquely, every appended page has a decoded role,
+  and the complete bounded relative observation agrees across all three
+  replicas. A fully decoded, internally consistent, replicated placement that
+  contradicts the motivating consecutive-page or shared-map hypothesis is an
+  answered result, not `no_outcome`. Post-mutation producer failure, schema or
+  metadata disagreement, changed bytes, incomplete decoding or attribution,
+  ambiguous correlation, or replica disagreement is an honest `no_outcome`.
+  Pre-mutation pin, input, inventory, bound, or result-integrity defects reject
+  or abort without a scientific answer.
+- Interpretation: this entry fixes only an acquisition and analysis contract.
+  A later accepted result may establish assignments and index-definition
+  ordering only for these exact empty first-create arms and at most three
+  indexes. It cannot establish populated composite-key encoding, index-tree or
+  row maintenance, behavior above three indexes, behavior when map rows spill
+  or a map page fills, continuation-page placement, extended-name encoding,
+  initial rows, arbitrary schemas, Rust writer or publication correctness,
+  general Jet 3 or DAO compatibility, a hosted differential or support result,
+  or support-matrix movement.
+- Usage: future result for issue `#150`; `EXP-0059`; `EXP-0062`; `EXP-0073`;
+  `EXP-0087`; `EXP-0091`;
+  `file:oracle/windows-dao/acquisition/multiple-indexes.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/multiple_indexes.py`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: pending independent protocol, controls, page-role correlation,
+  ordering, exact-pin, decision-rule, evidence-boundary, and false-claim review
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -59,11 +59,16 @@ same result for arbitrary schemas or permit omitting the retained page. The
 remaining experiments and implementation slices proceed in small independently
 reviewed changes: multiple indexes, definition continuation placement,
 extended names, public creation, initial rows, relationships, and safe
-filesystem publication.
+filesystem publication. `EXP-0092` preregisters the multiple-index experiment
+as four first-create arms copied from one fresh empty base per replica. Its
+acquisition remains forbidden until the exact plan, producer, and analyzer
+hashes are filled, independently reviewed, and merged.
 
 Three remaining format gaps each need their own preregistered DAO validation
-before the planner can widen, roughly in priority order: the page assignment
-for more than one index (#150), which also covers the composite and descending
-shapes; where a definition continuation page lands (#151); and catalog name
-keys for bytes above `0x7E` (#152). #102 remains the separate hosted write
-differential after database creation is complete.
+before the planner can widen, roughly in priority order: the multiple-index
+page and map layout, physical/logical ordering, and richer primary, unique, and
+ordinary flag model covered by #150/`EXP-0092`; where a definition continuation
+page lands (#151); and catalog name keys for bytes above `0x7E` (#152). If
+`EXP-0092` is accepted, its implementation slice must address all three index
+concerns rather than only assigning additional roots. #102 remains the separate
+hosted write differential after database creation is complete.

--- a/justfile
+++ b/justfile
@@ -88,6 +88,10 @@ windows-dev-bootstrap-composer-semantics:
 windows-dev-schema-generalization:
     "{{PYTHON}}" scripts/windows-dao-dev.py schema-generalization --timeout 900
 
+# Run the preregistered multiple-index page-assignment experiment in the local VM.
+windows-dev-multiple-indexes:
+    "{{PYTHON}}" scripts/windows-dao-dev.py multiple-indexes --timeout 900
+
 # Run the preregistered null-LvProp acceptance experiment in the local VM.
 windows-dev-lvprop-null:
     "{{PYTHON}}" scripts/windows-dao-dev.py lvprop-null --timeout 900

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -49,6 +49,13 @@ The retained tooling has three purposes:
   access-control rows, the per-create page-zero and appended-page assignment,
   and the long-value property chunk framing that a typed schema planner would
   otherwise guess.
+- `acquisition/multiple-indexes.plan.json`,
+  `scripts/dev/MultipleIndexes.DevJob.ps1`, and `scripts/multiple_indexes.py`
+  define the issue #150 experiment that compares closed empty, one-index,
+  two-index, three-index, and composite-index checkpoints across three replicas.
+  The analyzer uses `scripts/system_catalog.py` for the pinned catalog decoding;
+  the experiment is limited to its exact page-assignment matrix and makes no
+  arbitrary-index, writer, compatibility, or support claim.
 - `acquisition/bootstrap-composer-validation.plan.json` is the immutable
   consumed plan for the accepted `EXP-0085` run. Its pins bind the harness at
   that revision, so the client refuses to dispatch it again.
@@ -79,6 +86,7 @@ python3 -B oracle/windows-dao/scripts/dao_allocation_a9.py synthetic-dry-run \
 python3 -B -m unittest oracle/windows-dao/tests/test_bootstrap_layout.py -v
 python3 -B -m unittest oracle/windows-dao/tests/test_bootstrap_composer_semantics.py -v
 python3 -B -m unittest oracle/windows-dao/tests/test_schema_generalization.py -v
+python3 -B -m unittest oracle/windows-dao/tests/test_multiple_indexes.py -v
 python3 -B -m unittest oracle/windows-dao/tests/test_lvprop_null.py -v
 python3 -B -m unittest discover -s oracle/windows-dao/tests -v
 ```

--- a/oracle/windows-dao/acquisition/multiple-indexes.plan.json
+++ b/oracle/windows-dao/acquisition/multiple-indexes.plan.json
@@ -1,0 +1,80 @@
+{
+  "document_type": "dao_multiple_indexes_plan",
+  "experiment_id": "multiple-indexes",
+  "issue": 150,
+  "development_only": true,
+  "purpose": "Observe the first-create page assignment, map-row placement, and logical-to-physical ordering of one, two, three, and composite Jet 3 indexes without guessing beyond the admitted table-definition and page-role grammars.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0059 establishes the bounded physical and logical index-definition records, including key directions, flags, map locators, roots, and logical-to-physical ordinals. EXP-0073 establishes the bounded system-catalog and page-role decoder. EXP-0087 observes first-create assignment for zero or one index but does not observe a second index. Discovery-only index jobs are design input and are not admitted evidence.",
+    "authorization": "Committing this plan does not authorize acquisition. After the exact plan and pinned inputs are reviewed and committed, one explicit human authorization permits one local-VM acquisition.",
+    "attempt_policy": "Dispatch exactly one three-replica run after authorization. Once the first DAO CreateDatabase mutation begins, any failure is a scientific result and must not be retried without another explicit human decision."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/multiple_indexes.py": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/system_catalog.py": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "independence": "Each replica creates and closes one fresh dbVersion30 CP1252 database, retains it as empty, then copies and identity-checks it into four arm working files before any TableDefs mutation. Each arm receives exactly one table create and is closed before metadata capture. No rows are inserted.",
+    "checkpoints": [
+      "empty",
+      "one",
+      "two",
+      "three",
+      "composite"
+    ],
+    "scenarios": {
+      "one": "IdxOne has Long fields Id, Code, Sequence and ZPrimary(Id ascending primary unique required).",
+      "two": "IdxTwo has the same fields and appends ZPrimary before ASecondx(Code ascending ordinary).",
+      "three": "IdxTri has the same fields and appends ZPrimary, then MUniqueX(Code descending unique non-primary), then ASecondx(Sequence ascending ordinary).",
+      "composite": "IdxMix has the same fields and appends ZComposi(Code descending, Sequence ascending, unique non-primary), then ASecondx(Id descending ordinary). All table and index names are fixed-width within their classes and append order deliberately differs from lexical order."
+    },
+    "capture": "Record and validate each arm's pre-mutation size and digest against the retained empty image. Retain all fifteen expected-name MDB checkpoints with exact sizes, before-metadata SHA-256 digests, after-metadata SHA-256 digests, and bounded DAO TableDefs metadata. Capture DAO index Required and every index-field descending flag. Any retained post-mutation recovery image remains an unobserved artifact and cannot turn a failed replica into a pass.",
+    "bounds": {
+      "maximum_replicas": 3,
+      "maximum_checkpoints_per_replica": 5,
+      "maximum_published_databases": 15,
+      "maximum_pages_per_database": 64,
+      "maximum_table_definitions": 16,
+      "maximum_fields_per_table": 8,
+      "maximum_indexes_per_table": 4,
+      "maximum_index_fields": 4,
+      "maximum_detail_characters": 512,
+      "maximum_job_json_bytes": 4194304
+    }
+  },
+  "questions": {
+    "page_assignment": "For each first-create scenario, which pages are appended and which decoded definition, map-row, long-value, or index-root role and owner does each appended page have?",
+    "index_layout": "For every created table, what are its definition root and table maps, each physical index ordinal's keys, directions, flags, map locator, and root, each logical index record's name and physical ordinal, the logical name-sorted order, and the physical creation order?",
+    "map_placement": "Do the second and third indexes use rows on the first map page or cause another map page to be appended, and where does each root land relative to the definition root?",
+    "replication": "Are the complete decoded observations byte-for-byte identical across all three replicas?"
+  },
+  "decision_rule": {
+    "accepted": "The plan and all staged inputs match their SHA-256 pins; all three replicas complete the exact five-checkpoint inventory once; every arm's recorded pre-mutation identity equals its retained empty image; every artifact and DAO schema validates; every appended page is attributed; all logical indexes resolve to distinct in-range physical records with the preregistered keys and directions; and the complete observations agree across replicas. Any fully decoded page or ordering layout is an answered observation even when it differs from an anticipated contiguous layout.",
+    "no_outcome": "A producer failure after the first DAO mutation, metadata digest change, replica disagreement, schema mismatch, decode failure, ambiguous logical-to-physical correlation, unattributed appended page, or incomplete scientific observation is recorded as no_outcome.",
+    "rejected": "A pre-mutation plan, input, provider, or infrastructure failure; digest mismatch; malformed result; unexpected, reordered, duplicate, missing, symlinked, oversized, or extra artifact; bound violation; or result-shape defect rejects validation without a scientific outcome.",
+    "retry": "There is no automatic retry after the first DAO mutation."
+  },
+  "retention": {
+    "publish": "environment.json, result.json, the bounded job result, up to fifteen exact expected-name MDBs including explicitly identified unobserved recovery artifacts (exactly fifteen for a passing job), and the deterministic analyzer report.",
+    "repository": "Never commit MDB bytes or provider binaries. Record the validated report identity and conclusion once as an additive EXP outcome."
+  },
+  "exclusions": [
+    "populated index trees, index key bytes, uniqueness enforcement, and row insertion",
+    "definition continuation pages and names outside the admitted range",
+    "general page-allocation or free-page reuse policy",
+    "long-value property payload grammar",
+    "more than three indexes, more than two fields in a composite index, and other index flags",
+    "relationships, saved queries, public creation API, and filesystem publication",
+    "Rust writer validation, hosted write differential #102, compatibility claims, and support-matrix movement"
+  ]
+}

--- a/oracle/windows-dao/acquisition/multiple-indexes.plan.json
+++ b/oracle/windows-dao/acquisition/multiple-indexes.plan.json
@@ -6,19 +6,19 @@
   "purpose": "Observe the first-create page assignment, map-row placement, and logical-to-physical ordering of one, two, three, and composite Jet 3 indexes without guessing beyond the admitted table-definition and page-role grammars.",
   "preregistration": {
     "acquisition_started": false,
-    "prior_evidence": "EXP-0059 establishes the bounded physical and logical index-definition records, including key directions, flags, map locators, roots, and logical-to-physical ordinals. EXP-0073 establishes the bounded system-catalog and page-role decoder. EXP-0087 observes first-create assignment for zero or one index but does not observe a second index. Discovery-only index jobs are design input and are not admitted evidence.",
-    "authorization": "Committing this plan does not authorize acquisition. After the exact plan and pinned inputs are reviewed and committed, one explicit human authorization permits one local-VM acquisition.",
+    "prior_evidence": "The bounded index-definition grammar recorded by EXP-0059 supplies physical and logical records, key directions, flags, map locators, roots, and logical-to-physical ordinals; EXP-0061 supplies the single-page external long-value header; EXP-0062 supplies the empty leaf-root grammar; and EXP-0073 supplies the bounded system-catalog and page-role decoder. Their retained artifacts and any post-hoc placement observations are design input only, not admitted create-time page-assignment evidence. EXP-0087 observes the first create without an index and later creates with zero or one index, but no first create with an index and no create with multiple indexes.",
+    "authorization": "On 2026-09-02 the user explicitly said 'Go for it' after issue #150 was identified as next. That authorizes exactly one local-VM acquisition only after this exact plan and all pinned inputs are independently reviewed, committed, and merged. It does not authorize a retry after any post-mutation failure.",
     "attempt_policy": "Dispatch exactly one three-replica run after authorization. Once the first DAO CreateDatabase mutation begins, any failure is a scientific result and must not be retried without another explicit human decision."
   },
   "inputs": {
-    "scripts/windows-dao-dev.py": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/probe-provider.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/multiple_indexes.py": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/system_catalog.py": "0000000000000000000000000000000000000000000000000000000000000000"
+    "scripts/windows-dao-dev.py": "a3c2eef62343f5282115257ed8d04eb40d59a46094f7ffb7436524e6196b2e05",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "9ce2565a1addb68269e111d6fbe48f02b900d5864a66f7a53aa1851d06101edf",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "e3e1b6881e55f75561f01f2d196f91982457159bf9adc4c6ce919d5d675df442",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "c365f5a3206a6b9286546be16059bf42f268b104c2303d50ee585ec5711fdd02",
+    "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1": "a90f794521e514fb8ebd0b6a25f5e78db1eb54c6be12e10d1d2f2ee5017f21df",
+    "oracle/windows-dao/scripts/multiple_indexes.py": "13e1ffc001c365c2fd4b053d0c0b26eb4a4a0211a65091aa198e2dec5eee14e4",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9"
   },
   "execution": {
     "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
@@ -38,7 +38,7 @@
       "three": "IdxTri has the same fields and appends ZPrimary, then MUniqueX(Code descending unique non-primary), then ASecondx(Sequence ascending ordinary).",
       "composite": "IdxMix has the same fields and appends ZComposi(Code descending, Sequence ascending, unique non-primary), then ASecondx(Id descending ordinary). All table and index names are fixed-width within their classes and append order deliberately differs from lexical order."
     },
-    "capture": "Record and validate each arm's pre-mutation size and digest against the retained empty image. Retain all fifteen expected-name MDB checkpoints with exact sizes, before-metadata SHA-256 digests, after-metadata SHA-256 digests, and bounded DAO TableDefs metadata. Capture DAO index Required and every index-field descending flag. Any retained post-mutation recovery image remains an unobserved artifact and cannot turn a failed replica into a pass.",
+    "capture": "Record and validate each arm's pre-mutation size and digest against the retained empty image. A passing run retains all fifteen expected-name MDB checkpoints with exact sizes and SHA-256 digests both before and after bounded DAO TableDefs metadata access. Capture DAO index Required and every index-field descending flag. Record whether the experiment reached its first DAO mutation and the exact bounded producer phase. Any retained post-mutation recovery image remains an unobserved artifact and cannot turn a failed replica into a pass.",
     "bounds": {
       "maximum_replicas": 3,
       "maximum_checkpoints_per_replica": 5,
@@ -53,20 +53,27 @@
     }
   },
   "questions": {
-    "page_assignment": "For each first-create scenario, which pages are appended and which decoded definition, map-row, long-value, or index-root role and owner does each appended page have?",
-    "index_layout": "For every created table, what are its definition root and table maps, each physical index ordinal's keys, directions, flags, map locator, and root, each logical index record's name and physical ordinal, the logical name-sorted order, and the physical creation order?",
+    "page_assignment": "For each first-create scenario, which pages are appended, what are their offsets from the empty boundary and definition root, and which decoded definition, map-row, long-value, or index-root role and owner does each appended page have? Which appended LVAL page and row does the created catalog row's EXP-0061 LvProp header reference?",
+    "index_layout": "For every created table, what are its definition root and table maps, the pages named by each map, each physical index ordinal's keys, directions, flags, map locator, mapped pages, and root, each logical index record's name and physical ordinal, the logical definition order, the logical name-sorted order, and the physical creation order?",
     "map_placement": "Do the second and third indexes use rows on the first map page or cause another map page to be appended, and where does each root land relative to the definition root?",
     "replication": "Are the complete decoded observations byte-for-byte identical across all three replicas?"
   },
   "decision_rule": {
     "accepted": "The plan and all staged inputs match their SHA-256 pins; all three replicas complete the exact five-checkpoint inventory once; every arm's recorded pre-mutation identity equals its retained empty image; every artifact and DAO schema validates; every appended page is attributed; all logical indexes resolve to distinct in-range physical records with the preregistered keys and directions; and the complete observations agree across replicas. Any fully decoded page or ordering layout is an answered observation even when it differs from an anticipated contiguous layout.",
-    "no_outcome": "A producer failure after the first DAO mutation, metadata digest change, replica disagreement, schema mismatch, decode failure, ambiguous logical-to-physical correlation, unattributed appended page, or incomplete scientific observation is recorded as no_outcome.",
-    "rejected": "A pre-mutation plan, input, provider, or infrastructure failure; digest mismatch; malformed result; unexpected, reordered, duplicate, missing, symlinked, oversized, or extra artifact; bound violation; or result-shape defect rejects validation without a scientific outcome.",
+    "no_outcome": "A producer failure after the first DAO mutation, metadata size or digest change, replica disagreement, schema mismatch, decode failure, invalid empty-leaf root or LvProp-to-LVAL correlation, ambiguous logical-to-physical correlation, unattributed appended page, or incomplete scientific observation is recorded as no_outcome.",
+    "rejected": "A pre-mutation plan, input, provider, or infrastructure failure; digest mismatch; malformed result; unexpected, reordered, duplicate, missing referenced, symlinked, oversized, or extra artifact; bound violation; or result-shape defect rejects validation without a scientific outcome.",
     "retry": "There is no automatic retry after the first DAO mutation."
   },
   "retention": {
     "publish": "environment.json, result.json, the bounded job result, up to fifteen exact expected-name MDBs including explicitly identified unobserved recovery artifacts (exactly fifteen for a passing job), and the deterministic analyzer report.",
     "repository": "Never commit MDB bytes or provider binaries. Record the validated report identity and conclusion once as an additive EXP outcome."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
   },
   "exclusions": [
     "populated index trees, index key bytes, uniqueness enforcement, and row insertion",

--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]
+    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$RunRoot,
@@ -29,6 +29,8 @@ param(
     [string]$BootstrapComposerAlphaPath,
     [Parameter(Mandatory = $true)]
     [string]$SchemaGeneralizationJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$MultipleIndexesJobPath,
     [Parameter(Mandatory = $true)]
     [string]$LvPropNullJobPath,
     [Parameter(Mandatory = $true)]
@@ -66,6 +68,7 @@ $scriptPath = switch ($Job) {
     "bootstrap-composer-semantics" { $SystemCatalogJobPath }
     "bootstrap-composer-validation" { $BootstrapComposerValidationJobPath }
     "schema-generalization" { $SchemaGeneralizationJobPath }
+    "multiple-indexes" { $MultipleIndexesJobPath }
     "lvprop-null" { $LvPropNullJobPath }
 }
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
@@ -91,7 +94,7 @@ elseif ($Job -ceq "bootstrap-layout") {
 elseif ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId, "-Experiment", $Job)
 }
-elseif ($Job -ceq "schema-generalization") {
+elseif ($Job -in @("schema-generalization", "multiple-indexes")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId)
 }
 elseif ($Job -ceq "lvprop-null") {
@@ -125,6 +128,7 @@ $resultName = switch ($Job) {
     "bootstrap-composer-semantics" { "bootstrap-composer-semantics-job-result.json" }
     "bootstrap-composer-validation" { "bootstrap-composer-validation-job-result.json" }
     "schema-generalization" { "schema-generalization-job-result.json" }
+    "multiple-indexes" { "multiple-indexes-job-result.json" }
     "lvprop-null" { "lvprop-null-job-result.json" }
 }
 $resultPath = Join-Path $RunRoot $resultName
@@ -143,6 +147,7 @@ if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
         bootstrap_layout_replicas = @()
         system_catalog_replicas = @()
         schema_generalization_replicas = @()
+        multiple_indexes_replicas = @()
         lvprop_null_replicas = @()
     }
     Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result
@@ -159,6 +164,7 @@ $indexScenarios = @()
 $bootstrapLayoutReplicas = @()
 $systemCatalogReplicas = @()
 $schemaGeneralizationReplicas = @()
+$multipleIndexesReplicas = @()
 $lvpropNullReplicas = @()
 # The system-catalog result carries no detail field; derive one from its status.
 $detail = if ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics")) {
@@ -175,6 +181,14 @@ elseif ($Job -ceq "schema-generalization") {
     }
     else {
         "At least one schema-generalization replica failed; per-replica error records the message."
+    }
+}
+elseif ($Job -ceq "multiple-indexes") {
+    if ([string]$jobResult.status -ceq "pass") {
+        "Completed all three multiple-indexes replicas once without retry."
+    }
+    else {
+        "At least one multiple-indexes replica failed; per-replica error records the message."
     }
 }
 elseif ($Job -ceq "lvprop-null") {
@@ -214,6 +228,9 @@ elseif ($Job -ceq "bootstrap-composer-validation") {
 elseif ($Job -ceq "schema-generalization") {
     $schemaGeneralizationReplicas = @($jobResult.replicas)
 }
+elseif ($Job -ceq "multiple-indexes") {
+    $multipleIndexesReplicas = @($jobResult.replicas)
+}
 elseif ($Job -ceq "lvprop-null") {
     $lvpropNullReplicas = @($jobResult.replicas)
 }
@@ -231,6 +248,7 @@ $result = [ordered]@{
     bootstrap_layout_replicas = @($bootstrapLayoutReplicas)
     system_catalog_replicas = @($systemCatalogReplicas)
     schema_generalization_replicas = @($schemaGeneralizationReplicas)
+    multiple_indexes_replicas = @($multipleIndexesReplicas)
     lvprop_null_replicas = @($lvpropNullReplicas)
 }
 Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
@@ -38,6 +38,8 @@ param(
     [string]$BootstrapComposerAlphaPath,
     [Parameter(Mandatory = $true)]
     [string]$SchemaGeneralizationJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$MultipleIndexesJobPath,
     [Parameter(Mandatory = $true)]
     [string]$LvPropNullJobPath,
     [Parameter(Mandatory = $true)]
@@ -388,7 +390,7 @@ if ($Job -ceq "table-definition" -and
 foreach ($requiredHelper in @(
     $DispatchPath, $PublicationPath, $RowJobPath, $ValueJobPath, $IndexJobPath,
     $BootstrapLayoutJobPath, $SystemCatalogJobPath, $BootstrapComposerValidationJobPath,
-    $SchemaGeneralizationJobPath, $LvPropNullJobPath
+    $SchemaGeneralizationJobPath, $MultipleIndexesJobPath, $LvPropNullJobPath
 )) {
     if (-not (Test-Path -LiteralPath $requiredHelper -PathType Leaf)) {
         [Console]::Error.WriteLine("INVALID: staged development helper does not exist.")
@@ -405,6 +407,7 @@ $planBoundJobs = @{
     "bootstrap-composer-semantics" = "oracle/windows-dao/scripts/dev/SystemCatalog.DevJob.ps1"
     "bootstrap-composer-validation" = "oracle/windows-dao/scripts/dev/BootstrapComposerValidation.DevJob.ps1"
     "schema-generalization" = "oracle/windows-dao/scripts/dev/SchemaGeneralization.DevJob.ps1"
+    "multiple-indexes" = "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1"
     "lvprop-null" = "oracle/windows-dao/scripts/dev/LvPropNull.DevJob.ps1"
 }
 if ($planBoundJobs.ContainsKey($Job)) {
@@ -430,6 +433,9 @@ if ($planBoundJobs.ContainsKey($Job)) {
     }
     elseif ($Job -ceq "schema-generalization") {
         $SchemaGeneralizationJobPath
+    }
+    elseif ($Job -ceq "multiple-indexes") {
+        $MultipleIndexesJobPath
     }
     elseif ($Job -ceq "lvprop-null") {
         $LvPropNullJobPath
@@ -530,6 +536,7 @@ $indexScenarios = @()
 $bootstrapLayoutReplicas = @()
 $systemCatalogReplicas = @()
 $schemaGeneralizationReplicas = @()
+$multipleIndexesReplicas = @()
 $lvpropNullReplicas = @()
 
 if ($Job -ceq "provider-probe") {
@@ -756,7 +763,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
         }
     }
 }
-elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null") -and $probeExitCode -eq 0) {
+elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null") -and $probeExitCode -eq 0) {
     $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
@@ -773,6 +780,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             -BootstrapComposerEmptyPath $BootstrapComposerEmptyPath `
             -BootstrapComposerAlphaPath $BootstrapComposerAlphaPath `
             -SchemaGeneralizationJobPath $SchemaGeneralizationJobPath `
+            -MultipleIndexesJobPath $MultipleIndexesJobPath `
             -LvPropNullJobPath $LvPropNullJobPath `
             -LvPropFixedAlphaPath $LvPropFixedAlphaPath `
             -LvPropNullAlphaPath $LvPropNullAlphaPath `
@@ -796,6 +804,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             $bootstrapLayoutReplicas = @($dispatchResult.bootstrap_layout_replicas)
             $systemCatalogReplicas = @($dispatchResult.system_catalog_replicas)
             $schemaGeneralizationReplicas = @($dispatchResult.schema_generalization_replicas)
+            $multipleIndexesReplicas = @($dispatchResult.multiple_indexes_replicas)
             $lvpropNullReplicas = @($dispatchResult.lvprop_null_replicas)
             $status = [string]$dispatchResult.status
             $detail = [string]$dispatchResult.detail
@@ -829,6 +838,7 @@ $result = [ordered]@{
     bootstrap_layout_replicas = @($bootstrapLayoutReplicas)
     system_catalog_replicas = @($systemCatalogReplicas)
     schema_generalization_replicas = @($schemaGeneralizationReplicas)
+    multiple_indexes_replicas = @($multipleIndexesReplicas)
     lvprop_null_replicas = @($lvpropNullReplicas)
     completed_at_utc = [DateTimeOffset]::UtcNow.ToString("o")
 }

--- a/oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1
@@ -90,13 +90,14 @@ function Invoke-WithDatabase {
 }
 
 function New-Jet3Database {
-    param([string]$Path)
+    param([string]$Path, [ref]$MutationStarted)
     $engine = $null
     $workspace = $null
     $database = $null
     try {
         $engine = New-Object -ComObject "DAO.DBEngine.36"
         $workspace = $engine.Workspaces.Item(0)
+        $MutationStarted.Value = $true
         $database = $workspace.CreateDatabase($Path, $DatabaseLocale, $DbVersion30)
         $database.Close()
         Release-ComObject -Value $database
@@ -292,8 +293,10 @@ function Save-Checkpoint {
     $size = Get-BoundedSize -Path $destination
     $sha256 = Get-Sha256 -Path $destination
     $dao = Get-DaoMetadata -Path $destination
+    $sizeAfterMetadata = Get-BoundedSize -Path $destination
     return [ordered]@{
         name = $Name; database = $fileName; size = $size; sha256 = $sha256
+        size_after_metadata = $sizeAfterMetadata
         sha256_after_metadata = Get-Sha256 -Path $destination
         arm_before = $ArmBefore; dao = $dao
     }
@@ -301,22 +304,33 @@ function Save-Checkpoint {
 
 function Invoke-Replica {
     param([int]$Replica)
-    $state = [ordered]@{ replica = $Replica; status = "fail"; error = $null; checkpoints = @(); recovery = @() }
+    $state = [ordered]@{
+        replica = $Replica; status = "fail"; error = $null
+        mutation_started = $false; phase = "before_create_database"
+        checkpoints = @(); recovery = @()
+    }
     $checkpoints = New-Object Collections.ArrayList
     $recovery = New-Object Collections.ArrayList
     $workingPaths = New-Object Collections.ArrayList
     $basePath = Join-Path $RunRoot "working-base-r$Replica.mdb"
     $arms = @{}
-    $activeScenario = $null
+    $activeCheckpoint = $null
+    $mutationStarted = $false
     try {
-        New-Jet3Database -Path $basePath
         [void]$workingPaths.Add($basePath)
+        $state.phase = "create_database"
+        $activeCheckpoint = "empty"
+        New-Jet3Database -Path $basePath -MutationStarted ([ref]$mutationStarted)
+        $state.mutation_started = $mutationStarted
+        $state.phase = "capture_empty"
         $empty = Save-Checkpoint -Source $basePath -Replica $Replica -Name "empty" -ArmBefore $null
         [void]$checkpoints.Add($empty)
+        $activeCheckpoint = $null
+        $state.phase = "copy_arms"
         foreach ($scenario in $ScenarioOrder) {
             $arm = Join-Path $RunRoot "working-$scenario-r$Replica.mdb"
-            Copy-Item -LiteralPath $basePath -Destination $arm
             [void]$workingPaths.Add($arm)
+            Copy-Item -LiteralPath $basePath -Destination $arm
             $armSize = Get-BoundedSize -Path $arm
             $armSha256 = Get-Sha256 -Path $arm
             if ($armSize -ne [long]$empty.size -or $armSha256 -cne [string]$empty.sha256) {
@@ -325,30 +339,46 @@ function Invoke-Replica {
             $arms[$scenario] = [pscustomobject]@{ path = $arm; size = $armSize; sha256 = $armSha256 }
         }
         foreach ($scenario in $ScenarioOrder) {
-            $activeScenario = $scenario
+            $activeCheckpoint = $scenario
+            $state.phase = $scenario
             $arm = $arms[$scenario]
             New-ScenarioTable -Path ([string]$arm.path) -Scenario $scenario
             [void]$checkpoints.Add((Save-Checkpoint -Source ([string]$arm.path) -Replica $Replica `
                 -Name $scenario -ArmBefore ([ordered]@{ size = [long]$arm.size; sha256 = [string]$arm.sha256 })))
-            $activeScenario = $null
+            $activeCheckpoint = $null
         }
+        $state.phase = "complete"
         $state.status = "pass"
     }
     catch {
+        $state.mutation_started = $mutationStarted
         $state.error = ConvertTo-BoundedDetail -Detail ($_.Exception.GetType().FullName + ": " + $_.Exception.Message)
-        if ($null -ne $activeScenario -and $arms.ContainsKey($activeScenario)) {
+        if ($null -ne $activeCheckpoint) {
             try {
-                $fileName = "multiple-indexes-r$Replica-$activeScenario.mdb"
-                $destination = Join-Path $RunRoot $fileName
-                if (-not (Test-Path -LiteralPath $destination -PathType Leaf)) {
-                    Copy-Item -LiteralPath ([string]$arms[$activeScenario].path) -Destination $destination
+                $source = if ($activeCheckpoint -ceq "empty") {
+                    $basePath
                 }
+                elseif ($arms.ContainsKey($activeCheckpoint)) {
+                    [string]$arms[$activeCheckpoint].path
+                }
+                else {
+                    throw "Recovery source is unavailable."
+                }
+                $fileName = "multiple-indexes-r$Replica-$activeCheckpoint.mdb"
+                $destination = Join-Path $RunRoot $fileName
+                Copy-Item -LiteralPath $source -Destination $destination -Force
                 [void]$recovery.Add([ordered]@{
-                    name = $activeScenario; database = $fileName
+                    name = $activeCheckpoint; database = $fileName
                     size = Get-BoundedSize -Path $destination; sha256 = Get-Sha256 -Path $destination
                 })
             }
             catch {
+                try {
+                    if (Test-Path -LiteralPath $destination -PathType Leaf) {
+                        Remove-Item -LiteralPath $destination -Force
+                    }
+                }
+                catch { }
                 $state.error = ConvertTo-BoundedDetail -Detail `
                     ($state.error + " Recovery retention failed: " + $_.Exception.Message)
             }
@@ -370,7 +400,14 @@ function Invoke-Replica {
 
 [void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($RunRoot))
 $replicas = New-Object Collections.ArrayList
-foreach ($replica in 1..3) { [void]$replicas.Add((Invoke-Replica -Replica $replica)) }
+foreach ($replica in 1..3) {
+    $entry = Invoke-Replica -Replica $replica
+    [void]$replicas.Add($entry)
+    if ([string]$entry.status -cne "pass" -and
+        -not [bool]$entry.mutation_started -and $replicas.Count -eq 1) {
+        break
+    }
+}
 $status = if (@($replicas | Where-Object { [string]$_.status -cne "pass" }).Count -eq 0) { "pass" } else { "fail" }
 $result = [ordered]@{
     document_type = "dao_multiple_indexes_job_result"; development_only = $true

--- a/oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1
@@ -1,0 +1,380 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RunRoot,
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9a-f]{64}$")]
+    [string]$PlanSha256,
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
+    [string]$RunId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$DbVersion30 = 32
+$DbLong = 4
+$DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
+$PageSize = 2048
+$MaximumPages = 64
+$MaximumTables = 16
+$MaximumFields = 8
+$MaximumIndexes = 4
+$MaximumIndexFields = 4
+$MaximumDetailCharacters = 512
+$ScenarioOrder = @("one", "two", "three", "composite")
+
+function Release-ComObject {
+    param([object]$Value)
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-BoundedSize {
+    param([string]$Path)
+    $item = Get-Item -LiteralPath $Path -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Database must not be a reparse point: $Path"
+    }
+    $length = [long]$item.Length
+    if ($length -lt $PageSize -or ($length % $PageSize) -ne 0 -or
+        ($length / $PageSize) -gt $MaximumPages) {
+        throw "Database is outside the bounded 2 KiB page geometry: $Path"
+    }
+    return $length
+}
+
+function ConvertTo-BoundedDetail {
+    param([AllowNull()][object]$Detail)
+    $text = if ($null -eq $Detail) { "No additional detail was reported." } else { [string]$Detail }
+    if ($text.Length -gt $MaximumDetailCharacters) { return $text.Substring(0, $MaximumDetailCharacters) }
+    return $text
+}
+
+function Write-JsonDocument {
+    param([string]$Path, [object]$Document)
+    $encoding = New-Object Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText(
+        [IO.Path]::GetFullPath($Path),
+        (($Document | ConvertTo-Json -Depth 20) + "`n"),
+        $encoding
+    )
+}
+
+function Invoke-WithDatabase {
+    param([string]$Path, [switch]$ReadOnly, [scriptblock]$Action)
+    $engine = $null
+    $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $database = $engine.OpenDatabase($Path, $false, [bool]$ReadOnly)
+        & $Action $database
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+function New-Jet3Database {
+    param([string]$Path)
+    $engine = $null
+    $workspace = $null
+    $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $workspace = $engine.Workspaces.Item(0)
+        $database = $workspace.CreateDatabase($Path, $DatabaseLocale, $DbVersion30)
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $workspace
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+function Add-Index {
+    param([object]$Table, [object]$Definition)
+    $index = $null
+    try {
+        $index = $Table.CreateIndex([string]$Definition.name)
+        $index.Primary = [bool]$Definition.primary
+        $index.Unique = [bool]$Definition.unique
+        $index.Required = [bool]$Definition.required
+        foreach ($fieldDefinition in $Definition.fields) {
+            $field = $null
+            try {
+                $field = $index.CreateField([string]$fieldDefinition.name)
+                if ([bool]$fieldDefinition.descending) { $field.Attributes = 1 }
+                $index.Fields.Append($field)
+            }
+            finally { Release-ComObject -Value $field }
+        }
+        $Table.Indexes.Append($index)
+    }
+    finally { Release-ComObject -Value $index }
+}
+
+function Get-ScenarioDefinition {
+    param([string]$Name)
+    $primary = [pscustomobject]@{
+        name = "ZPrimary"; primary = $true; unique = $true; required = $true
+        fields = @([pscustomobject]@{ name = "Id"; descending = $false })
+    }
+    $secondaryCode = [pscustomobject]@{
+        name = "ASecondx"; primary = $false; unique = $false; required = $false
+        fields = @([pscustomobject]@{ name = "Code"; descending = $false })
+    }
+    switch ($Name) {
+        "one" { return [pscustomobject]@{ table = "IdxOne"; indexes = @($primary) } }
+        "two" { return [pscustomobject]@{ table = "IdxTwo"; indexes = @($primary, $secondaryCode) } }
+        "three" {
+            $unique = [pscustomobject]@{
+                name = "MUniqueX"; primary = $false; unique = $true; required = $false
+                fields = @([pscustomobject]@{ name = "Code"; descending = $true })
+            }
+            $secondary = [pscustomobject]@{
+                name = "ASecondx"; primary = $false; unique = $false; required = $false
+                fields = @([pscustomobject]@{ name = "Sequence"; descending = $false })
+            }
+            return [pscustomobject]@{ table = "IdxTri"; indexes = @($primary, $unique, $secondary) }
+        }
+        "composite" {
+            $composite = [pscustomobject]@{
+                name = "ZComposi"; primary = $false; unique = $true; required = $false
+                fields = @(
+                    [pscustomobject]@{ name = "Code"; descending = $true },
+                    [pscustomobject]@{ name = "Sequence"; descending = $false }
+                )
+            }
+            $secondary = [pscustomobject]@{
+                name = "ASecondx"; primary = $false; unique = $false; required = $false
+                fields = @([pscustomobject]@{ name = "Id"; descending = $true })
+            }
+            return [pscustomobject]@{ table = "IdxMix"; indexes = @($composite, $secondary) }
+        }
+        default { throw "Unknown scenario $Name." }
+    }
+}
+
+function New-ScenarioTable {
+    param([string]$Path, [string]$Scenario)
+    $definition = Get-ScenarioDefinition -Name $Scenario
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $table = $null
+        $fields = New-Object Collections.ArrayList
+        try {
+            $table = $database.CreateTableDef([string]$definition.table)
+            foreach ($name in @("Id", "Code", "Sequence")) {
+                $field = $table.CreateField($name, $DbLong)
+                [void]$fields.Add($field)
+                $table.Fields.Append($field)
+            }
+            foreach ($index in $definition.indexes) { Add-Index -Table $table -Definition $index }
+            $database.TableDefs.Append($table)
+        }
+        finally {
+            foreach ($field in $fields) { Release-ComObject -Value $field }
+            Release-ComObject -Value $table
+        }
+    }
+}
+
+function Get-DaoMetadata {
+    param([string]$Path)
+    $holder = [pscustomobject]@{ value = $null }
+    Invoke-WithDatabase -Path $Path -ReadOnly -Action {
+        param($database)
+        $definitions = $null
+        $rows = New-Object Collections.ArrayList
+        try {
+            $definitions = $database.TableDefs
+            if ([int]$definitions.Count -gt $MaximumTables) { throw "DAO table bound exceeded." }
+            for ($position = 0; $position -lt [int]$definitions.Count; $position++) {
+                $table = $null
+                $fields = $null
+                $indexes = $null
+                try {
+                    $table = $definitions.Item($position)
+                    $tableName = [string]$table.Name
+                    $fieldRows = New-Object Collections.ArrayList
+                    $indexRows = New-Object Collections.ArrayList
+                    if (-not $tableName.StartsWith("MSys", [StringComparison]::Ordinal)) {
+                        $fields = $table.Fields
+                        if ([int]$fields.Count -gt $MaximumFields) { throw "DAO field bound exceeded." }
+                        for ($fieldPosition = 0; $fieldPosition -lt [int]$fields.Count; $fieldPosition++) {
+                            $field = $null
+                            try {
+                                $field = $fields.Item($fieldPosition)
+                                [void]$fieldRows.Add([ordered]@{
+                                    ordinal = $fieldPosition; name = [string]$field.Name
+                                    type = [int]$field.Type; size = [int]$field.Size
+                                })
+                            }
+                            finally { Release-ComObject -Value $field }
+                        }
+                        $indexes = $table.Indexes
+                        if ([int]$indexes.Count -gt $MaximumIndexes) { throw "DAO index bound exceeded." }
+                        for ($indexPosition = 0; $indexPosition -lt [int]$indexes.Count; $indexPosition++) {
+                            $index = $null
+                            $indexFields = $null
+                            try {
+                                $index = $indexes.Item($indexPosition)
+                                $indexFields = $index.Fields
+                                if ([int]$indexFields.Count -gt $MaximumIndexFields) { throw "DAO index-field bound exceeded." }
+                                $keys = New-Object Collections.ArrayList
+                                for ($keyPosition = 0; $keyPosition -lt [int]$indexFields.Count; $keyPosition++) {
+                                    $key = $null
+                                    try {
+                                        $key = $indexFields.Item($keyPosition)
+                                        [void]$keys.Add([ordered]@{
+                                            ordinal = $keyPosition; name = [string]$key.Name
+                                            descending = (([long]$key.Attributes -band 1) -ne 0)
+                                        })
+                                    }
+                                    finally { Release-ComObject -Value $key }
+                                }
+                                [void]$indexRows.Add([ordered]@{
+                                    ordinal = $indexPosition; name = [string]$index.Name
+                                    primary = [bool]$index.Primary; unique = [bool]$index.Unique
+                                    required = [bool]$index.Required; fields = @($keys)
+                                })
+                            }
+                            finally {
+                                Release-ComObject -Value $indexFields
+                                Release-ComObject -Value $index
+                            }
+                        }
+                    }
+                    [void]$rows.Add([ordered]@{
+                        ordinal = $position; name = $tableName
+                        fields = @($fieldRows); indexes = @($indexRows)
+                    })
+                }
+                finally {
+                    Release-ComObject -Value $indexes
+                    Release-ComObject -Value $fields
+                    Release-ComObject -Value $table
+                }
+            }
+        }
+        finally { Release-ComObject -Value $definitions }
+        $holder.value = [ordered]@{ tabledefs = @($rows) }
+    }
+    return $holder.value
+}
+
+function Save-Checkpoint {
+    param([string]$Source, [int]$Replica, [string]$Name, [object]$ArmBefore)
+    $fileName = "multiple-indexes-r$Replica-$Name.mdb"
+    $destination = Join-Path $RunRoot $fileName
+    Copy-Item -LiteralPath $Source -Destination $destination
+    $size = Get-BoundedSize -Path $destination
+    $sha256 = Get-Sha256 -Path $destination
+    $dao = Get-DaoMetadata -Path $destination
+    return [ordered]@{
+        name = $Name; database = $fileName; size = $size; sha256 = $sha256
+        sha256_after_metadata = Get-Sha256 -Path $destination
+        arm_before = $ArmBefore; dao = $dao
+    }
+}
+
+function Invoke-Replica {
+    param([int]$Replica)
+    $state = [ordered]@{ replica = $Replica; status = "fail"; error = $null; checkpoints = @(); recovery = @() }
+    $checkpoints = New-Object Collections.ArrayList
+    $recovery = New-Object Collections.ArrayList
+    $workingPaths = New-Object Collections.ArrayList
+    $basePath = Join-Path $RunRoot "working-base-r$Replica.mdb"
+    $arms = @{}
+    $activeScenario = $null
+    try {
+        New-Jet3Database -Path $basePath
+        [void]$workingPaths.Add($basePath)
+        $empty = Save-Checkpoint -Source $basePath -Replica $Replica -Name "empty" -ArmBefore $null
+        [void]$checkpoints.Add($empty)
+        foreach ($scenario in $ScenarioOrder) {
+            $arm = Join-Path $RunRoot "working-$scenario-r$Replica.mdb"
+            Copy-Item -LiteralPath $basePath -Destination $arm
+            [void]$workingPaths.Add($arm)
+            $armSize = Get-BoundedSize -Path $arm
+            $armSha256 = Get-Sha256 -Path $arm
+            if ($armSize -ne [long]$empty.size -or $armSha256 -cne [string]$empty.sha256) {
+                throw "Arm $scenario differs from the retained empty baseline before mutation."
+            }
+            $arms[$scenario] = [pscustomobject]@{ path = $arm; size = $armSize; sha256 = $armSha256 }
+        }
+        foreach ($scenario in $ScenarioOrder) {
+            $activeScenario = $scenario
+            $arm = $arms[$scenario]
+            New-ScenarioTable -Path ([string]$arm.path) -Scenario $scenario
+            [void]$checkpoints.Add((Save-Checkpoint -Source ([string]$arm.path) -Replica $Replica `
+                -Name $scenario -ArmBefore ([ordered]@{ size = [long]$arm.size; sha256 = [string]$arm.sha256 })))
+            $activeScenario = $null
+        }
+        $state.status = "pass"
+    }
+    catch {
+        $state.error = ConvertTo-BoundedDetail -Detail ($_.Exception.GetType().FullName + ": " + $_.Exception.Message)
+        if ($null -ne $activeScenario -and $arms.ContainsKey($activeScenario)) {
+            try {
+                $fileName = "multiple-indexes-r$Replica-$activeScenario.mdb"
+                $destination = Join-Path $RunRoot $fileName
+                if (-not (Test-Path -LiteralPath $destination -PathType Leaf)) {
+                    Copy-Item -LiteralPath ([string]$arms[$activeScenario].path) -Destination $destination
+                }
+                [void]$recovery.Add([ordered]@{
+                    name = $activeScenario; database = $fileName
+                    size = Get-BoundedSize -Path $destination; sha256 = Get-Sha256 -Path $destination
+                })
+            }
+            catch {
+                $state.error = ConvertTo-BoundedDetail -Detail `
+                    ($state.error + " Recovery retention failed: " + $_.Exception.Message)
+            }
+        }
+    }
+    finally {
+        foreach ($working in $workingPaths) {
+            try { if (Test-Path -LiteralPath $working -PathType Leaf) { Remove-Item -LiteralPath $working -Force } }
+            catch {
+                $state.status = "fail"
+                $state.error = ConvertTo-BoundedDetail -Detail ($state.error + " Cleanup failed: " + $_.Exception.Message)
+            }
+        }
+    }
+    $state.checkpoints = @($checkpoints)
+    $state.recovery = @($recovery)
+    return $state
+}
+
+[void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($RunRoot))
+$replicas = New-Object Collections.ArrayList
+foreach ($replica in 1..3) { [void]$replicas.Add((Invoke-Replica -Replica $replica)) }
+$status = if (@($replicas | Where-Object { [string]$_.status -cne "pass" }).Count -eq 0) { "pass" } else { "fail" }
+$result = [ordered]@{
+    document_type = "dao_multiple_indexes_job_result"; development_only = $true
+    plan_sha256 = $PlanSha256; run_id = $RunId; status = $status; replicas = @($replicas)
+}
+Write-JsonDocument -Path (Join-Path $RunRoot "multiple-indexes-job-result.json") -Document $result
+if ($status -ceq "pass") { exit 0 } else { exit 1 }

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -295,8 +295,8 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Multiple-indexes result is missing."
         }
-        if ((Get-Item -LiteralPath $jobResultPath).Length -gt 8388608) {
-            throw "Multiple-indexes result exceeds the 8-MiB bound."
+        if ((Get-Item -LiteralPath $jobResultPath).Length -gt 4194304) {
+            throw "Multiple-indexes result exceeds the 4-MiB bound."
         }
         $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
         $checkpointNames = @("empty", "one", "two", "three", "composite")
@@ -305,6 +305,7 @@ switch ($Job) {
         foreach ($replica in @($jobResult.replicas)) {
             $replicaNumber = [int]$replica.replica
             if ($replicaNumber -lt 1 -or $replicaNumber -gt 3 -or
+                $replicaNumber -ne ($seenReplicas.Count + 1) -or
                 $replicaNumber -cin $seenReplicas) {
                 throw "Multiple-indexes result has an unexpected replica inventory."
             }
@@ -323,13 +324,36 @@ switch ($Job) {
                 [void]$referenced.Add($expectedDatabase)
                 $checkpointIndex++
             }
+            $recovery = @($replica.recovery)
+            if ($recovery.Count -gt 1) {
+                throw "Multiple-indexes result exceeds the one-recovery-artifact bound."
+            }
+            foreach ($artifact in $recovery) {
+                if ($checkpointIndex -ge $checkpointNames.Count) {
+                    throw "Multiple-indexes recovery artifact follows a complete checkpoint inventory."
+                }
+                $expectedName = $checkpointNames[$checkpointIndex]
+                $expectedDatabase = "multiple-indexes-r$replicaNumber-$expectedName.mdb"
+                if ([string]$artifact.name -cne $expectedName -or
+                    [string]$artifact.database -cne $expectedDatabase) {
+                    throw "Multiple-indexes recovery artifact is not the next checkpoint."
+                }
+                [void]$referenced.Add($expectedDatabase)
+            }
             if ([string]$replica.status -ceq "pass" -and
-                $checkpointIndex -ne $checkpointNames.Count) {
+                ($checkpointIndex -ne $checkpointNames.Count -or $recovery.Count -ne 0)) {
                 throw "Passing multiple-indexes replica omits a checkpoint."
             }
         }
         if ($seenReplicas.Count -ne 3) {
-            throw "Multiple-indexes result must contain exactly three replicas."
+            $preMutationAbort = (
+                $seenReplicas.Count -eq 1 -and
+                [string]$jobResult.status -ceq "fail" -and
+                -not [bool]@($jobResult.replicas)[0].mutation_started
+            )
+            if (-not $preMutationAbort) {
+                throw "Multiple-indexes result has an incomplete replica inventory."
+            }
         }
         if ($referenced.Count -gt 15) {
             throw "Multiple-indexes output exceeds the 15-database bound."
@@ -342,9 +366,9 @@ switch ($Job) {
             if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
                 throw "Multiple-indexes output contains a reparse-point MDB."
             }
-            if ($item.Length -le 0 -or ($item.Length % 2048) -ne 0 -or
-                $item.Length -gt 1048576) {
-                throw "Multiple-indexes output MDB violates the 512-page bound."
+            if ($item.Length -lt 2048 -or ($item.Length % 2048) -ne 0 -or
+                $item.Length -gt 131072) {
+                throw "Multiple-indexes output MDB violates the 64-page bound."
             }
         }
         $actual = @($actualItems | ForEach-Object { $_.Name } | Sort-Object)

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$Source,
@@ -287,6 +287,73 @@ switch ($Job) {
         $expected = @($referenced | Sort-Object)
         if (($actual -join "`n") -cne ($expected -join "`n")) {
             throw "Schema-generalization MDB inventory differs from its result."
+        }
+    }
+    "multiple-indexes" {
+        [void]$names.Add("multiple-indexes-job-result.json")
+        $jobResultPath = Join-Path $Source "multiple-indexes-job-result.json"
+        if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
+            throw "Multiple-indexes result is missing."
+        }
+        if ((Get-Item -LiteralPath $jobResultPath).Length -gt 8388608) {
+            throw "Multiple-indexes result exceeds the 8-MiB bound."
+        }
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $checkpointNames = @("empty", "one", "two", "three", "composite")
+        $referenced = New-Object Collections.ArrayList
+        $seenReplicas = New-Object Collections.ArrayList
+        foreach ($replica in @($jobResult.replicas)) {
+            $replicaNumber = [int]$replica.replica
+            if ($replicaNumber -lt 1 -or $replicaNumber -gt 3 -or
+                $replicaNumber -cin $seenReplicas) {
+                throw "Multiple-indexes result has an unexpected replica inventory."
+            }
+            [void]$seenReplicas.Add($replicaNumber)
+            $checkpointIndex = 0
+            foreach ($checkpoint in @($replica.checkpoints)) {
+                if ($checkpointIndex -ge $checkpointNames.Count) {
+                    throw "Multiple-indexes result exceeds the five-checkpoint bound."
+                }
+                $checkpointName = $checkpointNames[$checkpointIndex]
+                $expectedDatabase = "multiple-indexes-r$replicaNumber-$checkpointName.mdb"
+                if ([string]$checkpoint.name -cne $checkpointName -or
+                    [string]$checkpoint.database -cne $expectedDatabase) {
+                    throw "Multiple-indexes checkpoints are not an ordered prefix."
+                }
+                [void]$referenced.Add($expectedDatabase)
+                $checkpointIndex++
+            }
+            if ([string]$replica.status -ceq "pass" -and
+                $checkpointIndex -ne $checkpointNames.Count) {
+                throw "Passing multiple-indexes replica omits a checkpoint."
+            }
+        }
+        if ($seenReplicas.Count -ne 3) {
+            throw "Multiple-indexes result must contain exactly three replicas."
+        }
+        if ($referenced.Count -gt 15) {
+            throw "Multiple-indexes output exceeds the 15-database bound."
+        }
+        if ([string]$jobResult.status -ceq "pass" -and $referenced.Count -ne 15) {
+            throw "Passing multiple-indexes result omits a database."
+        }
+        $actualItems = @(Get-ChildItem -LiteralPath $Source -File -Filter "*.mdb")
+        foreach ($item in $actualItems) {
+            if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                throw "Multiple-indexes output contains a reparse-point MDB."
+            }
+            if ($item.Length -le 0 -or ($item.Length % 2048) -ne 0 -or
+                $item.Length -gt 1048576) {
+                throw "Multiple-indexes output MDB violates the 512-page bound."
+            }
+        }
+        $actual = @($actualItems | ForEach-Object { $_.Name } | Sort-Object)
+        $expected = @($referenced | Sort-Object)
+        if (($actual -join "`n") -cne ($expected -join "`n")) {
+            throw "Multiple-indexes MDB inventory differs from its result."
+        }
+        foreach ($name in $actual) {
+            [void]$names.Add($name)
         }
     }
     "lvprop-null" {

--- a/oracle/windows-dao/scripts/multiple_indexes.py
+++ b/oracle/windows-dao/scripts/multiple_indexes.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Validate the bounded multiple-index first-create experiment for issue #150."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import system_catalog as catalog
+
+
+PAGE_BYTES = 2048
+MAX_JSON_BYTES = 4 * 1024 * 1024
+MAX_PAGES = 64
+MAX_TABLES = 16
+MAX_FIELDS = 8
+MAX_INDEXES = 4
+MAX_INDEX_FIELDS = 4
+MAX_TEXT = 512
+DOCUMENT_TYPE = "dao_multiple_indexes_job_result"
+REPORT_TYPE = "multiple_indexes_report"
+CHECKPOINTS = ("empty", "one", "two", "three", "composite")
+SCENARIOS = CHECKPOINTS[1:]
+SAFE_RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+SAFE_MDB = re.compile(r"^multiple-indexes-r[1-3]-(empty|one|two|three|composite)[.]mdb$")
+UNASSIGNED = "unassigned"
+
+
+FIELDS = [
+    {"name": "Id", "ordinal": 0, "size": 4, "type": 4},
+    {"name": "Code", "ordinal": 1, "size": 4, "type": 4},
+    {"name": "Sequence", "ordinal": 2, "size": 4, "type": 4},
+]
+
+
+def index(
+    ordinal: int,
+    name: str,
+    fields: list[tuple[str, bool]],
+    *,
+    primary: bool = False,
+    unique: bool = False,
+    required: bool = False,
+) -> dict[str, Any]:
+    return {
+        "ordinal": ordinal,
+        "name": name,
+        "primary": primary,
+        "unique": unique,
+        "required": required,
+        "fields": [
+            {"ordinal": position, "name": field, "descending": descending}
+            for position, (field, descending) in enumerate(fields)
+        ],
+    }
+
+
+PRIMARY = index(0, "ZPrimary", [("Id", False)], primary=True, unique=True, required=True)
+EXPECTED = {
+    "one": {"table": "IdxOne", "indexes": [PRIMARY]},
+    "two": {
+        "table": "IdxTwo",
+        "indexes": [PRIMARY, index(1, "ASecondx", [("Code", False)])],
+    },
+    "three": {
+        "table": "IdxTri",
+        "indexes": [
+            PRIMARY,
+            index(1, "MUniqueX", [("Code", True)], unique=True),
+            index(2, "ASecondx", [("Sequence", False)]),
+        ],
+    },
+    "composite": {
+        "table": "IdxMix",
+        "indexes": [
+            index(0, "ZComposi", [("Code", True), ("Sequence", False)], unique=True),
+            index(1, "ASecondx", [("Id", True)]),
+        ],
+    },
+}
+
+
+class AnalysisError(ValueError):
+    """The result or retained inventory violates the preregistered contract."""
+
+
+class DecodeError(ValueError):
+    """A complete scientific observation does not satisfy a pinned grammar."""
+
+
+def canonical_bytes(document: Any) -> bytes:
+    return (
+        json.dumps(document, sort_keys=True, ensure_ascii=False, separators=(",", ":"), allow_nan=False).encode()
+        + b"\n"
+    )
+
+
+def no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AnalysisError(f"duplicate JSON field {key!r}")
+        result[key] = value
+    return result
+
+
+def exact(value: Any, keys: set[str], where: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise AnalysisError(f"{where} must contain exactly {sorted(keys)}")
+    return value
+
+
+def digest(value: Any, where: str) -> str:
+    if not isinstance(value, str) or not HEX_64.fullmatch(value):
+        raise AnalysisError(f"{where} must be a lowercase SHA-256 digest")
+    return value
+
+
+def integer(value: Any, where: str, low: int, high: int) -> int:
+    if type(value) is not int or not low <= value <= high:
+        raise AnalysisError(f"{where} must be an integer in [{low},{high}]")
+    return value
+
+
+def text(value: Any, where: str, maximum: int = MAX_TEXT) -> str:
+    if not isinstance(value, str) or len(value) > maximum:
+        raise AnalysisError(f"{where} must be a string of at most {maximum} characters")
+    return value
+
+
+def load(path: Path) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise AnalysisError("job result must be a regular non-link file")
+    raw = path.read_bytes()
+    if len(raw) > MAX_JSON_BYTES:
+        raise AnalysisError("job result exceeds the JSON bound")
+    try:
+        result = json.loads(raw, object_pairs_hook=no_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AnalysisError("job result is not valid UTF-8 JSON") from error
+    if not isinstance(result, dict):
+        raise AnalysisError("job result root must be an object")
+    return result
+
+
+def validate_dao(value: Any, where: str) -> dict[str, Any]:
+    item = exact(value, {"tabledefs"}, where)
+    tables = item["tabledefs"]
+    if not isinstance(tables, list) or len(tables) > MAX_TABLES:
+        raise AnalysisError(f"{where}.tabledefs exceeds the bound")
+    for table_position, raw_table in enumerate(tables):
+        table = exact(raw_table, {"ordinal", "name", "fields", "indexes"}, f"{where}.tabledefs[{table_position}]")
+        if integer(table["ordinal"], "table ordinal", 0, MAX_TABLES - 1) != table_position:
+            raise AnalysisError("DAO table ordinals must be sequential")
+        text(table["name"], "table name", 256)
+        fields = table["fields"]
+        indexes = table["indexes"]
+        if not isinstance(fields, list) or len(fields) > MAX_FIELDS:
+            raise AnalysisError("DAO fields exceed the bound")
+        if not isinstance(indexes, list) or len(indexes) > MAX_INDEXES:
+            raise AnalysisError("DAO indexes exceed the bound")
+        for position, raw_field in enumerate(fields):
+            field = exact(raw_field, {"ordinal", "name", "type", "size"}, "DAO field")
+            if integer(field["ordinal"], "field ordinal", 0, MAX_FIELDS - 1) != position:
+                raise AnalysisError("DAO field ordinals must be sequential")
+            text(field["name"], "field name", 256)
+            integer(field["type"], "field type", 0, 65535)
+            integer(field["size"], "field size", 0, 1 << 20)
+        for position, raw_index in enumerate(indexes):
+            entry = exact(
+                raw_index,
+                {"ordinal", "name", "primary", "unique", "required", "fields"},
+                "DAO index",
+            )
+            if integer(entry["ordinal"], "index ordinal", 0, MAX_INDEXES - 1) != position:
+                raise AnalysisError("DAO index ordinals must be sequential")
+            text(entry["name"], "index name", 256)
+            if any(type(entry[key]) is not bool for key in ("primary", "unique", "required")):
+                raise AnalysisError("DAO index flags must be boolean")
+            keys = entry["fields"]
+            if not isinstance(keys, list) or not 1 <= len(keys) <= MAX_INDEX_FIELDS:
+                raise AnalysisError("DAO index fields violate the bound")
+            for key_position, raw_key in enumerate(keys):
+                key = exact(raw_key, {"ordinal", "name", "descending"}, "DAO index field")
+                if integer(key["ordinal"], "index field ordinal", 0, MAX_INDEX_FIELDS - 1) != key_position:
+                    raise AnalysisError("DAO index field ordinals must be sequential")
+                text(key["name"], "index field name", 256)
+                if type(key["descending"]) is not bool:
+                    raise AnalysisError("DAO descending flag must be boolean")
+    return item
+
+
+def read_checkpoint(
+    root: Path, value: Any, replica: int, name: str
+) -> tuple[bytes, bool, dict[str, Any], Any, dict[str, Any]]:
+    item = exact(
+        value,
+        {"name", "database", "size", "sha256", "sha256_after_metadata", "arm_before", "dao"},
+        f"replica {replica} checkpoint {name}",
+    )
+    if item["name"] != name:
+        raise AnalysisError(f"replica {replica} checkpoint order is invalid")
+    filename = item["database"]
+    expected = f"multiple-indexes-r{replica}-{name}.mdb"
+    if filename != expected or not SAFE_MDB.fullmatch(filename):
+        raise AnalysisError(f"replica {replica} checkpoint filename is invalid")
+    size = integer(item["size"], "checkpoint size", PAGE_BYTES, MAX_PAGES * PAGE_BYTES)
+    if size % PAGE_BYTES:
+        raise AnalysisError("checkpoint is not an exact sequence of pages")
+    before = digest(item["sha256"], "checkpoint digest")
+    after = digest(item["sha256_after_metadata"], "post-metadata digest")
+    path = root / filename
+    if not path.is_file() or path.is_symlink():
+        raise AnalysisError("checkpoint must be a regular non-link file")
+    raw = path.read_bytes()
+    retained = after if before != after else before
+    if len(raw) != size or hashlib.sha256(raw).hexdigest() != retained:
+        raise AnalysisError("checkpoint bytes differ from the recorded identity")
+    return (
+        raw,
+        before != after,
+        validate_dao(item["dao"], f"checkpoint {name}.dao"),
+        item["arm_before"],
+        {"sha256": before, "size": size},
+    )
+
+
+def user_tables(dao: dict[str, Any]) -> list[dict[str, Any]]:
+    return [table for table in dao["tabledefs"] if not table["name"].startswith("MSys")]
+
+
+def validate_schema(scenario: str, dao: dict[str, Any]) -> None:
+    users = user_tables(dao)
+    expected = EXPECTED[scenario]
+    if len(users) != 1 or users[0]["name"] != expected["table"]:
+        raise DecodeError(f"{scenario} DAO metadata does not contain exactly {expected['table']}")
+    table = users[0]
+    if table["fields"] != FIELDS:
+        raise DecodeError(f"{scenario} DAO fields differ from the preregistered schema")
+    if len(table["indexes"]) != len(expected["indexes"]):
+        raise DecodeError(f"{scenario} DAO index count differs from the preregistered schema")
+    observed = {entry["name"]: {key: value for key, value in entry.items() if key != "ordinal"} for entry in table["indexes"]}
+    if len(observed) != len(table["indexes"]):
+        raise DecodeError(f"{scenario} DAO metadata repeats an index name")
+    wanted = {entry["name"]: {key: value for key, value in entry.items() if key != "ordinal"} for entry in expected["indexes"]}
+    if observed != wanted:
+        raise DecodeError(f"{scenario} DAO indexes differ from the preregistered schema")
+
+
+def decoded_user_table(analysis: dict[str, Any], scenario: str) -> dict[str, Any]:
+    expected_name = EXPECTED[scenario]["table"]
+    users = [entry for entry in analysis["tables"].values() if not entry["flags"] & catalog.SYSTEM_FLAG]
+    if len(users) != 1 or users[0]["name"] != expected_name:
+        raise DecodeError(f"{scenario} decoded tables do not contain exactly {expected_name}")
+    return users[0]
+
+
+def index_layout(table: dict[str, Any], scenario: str) -> dict[str, Any]:
+    definition = table["definition"]
+    columns = definition["columns"]
+    if [entry["name"] for entry in columns] != [entry["name"] for entry in FIELDS] or any(
+        entry["type"] != "Long" for entry in columns
+    ):
+        raise DecodeError(f"{scenario} decoded columns differ from the DAO schema")
+    physical = definition["physical_indexes"]
+    logical = definition["logical_indexes"]
+    expected_indexes = EXPECTED[scenario]["indexes"]
+    if len(physical) != len(expected_indexes) or len(logical) != len(expected_indexes):
+        raise DecodeError(f"{scenario} decoded index counts differ from the schema")
+    by_name = {entry["name"]: entry for entry in expected_indexes}
+    if len({entry["name"] for entry in logical}) != len(logical) or set(entry["name"] for entry in logical) != set(by_name):
+        raise DecodeError(f"{scenario} logical index names differ from the schema")
+    named_physical: dict[int, str] = {}
+    logical_rows = []
+    for logical_ordinal, entry in enumerate(logical):
+        physical_ordinal = entry["physical_index"]
+        if type(physical_ordinal) is not int or not 0 <= physical_ordinal < len(physical):
+            raise DecodeError(f"{scenario} logical index names an invalid physical ordinal")
+        if physical_ordinal in named_physical:
+            raise DecodeError(f"{scenario} logical indexes alias one physical index")
+        expected_class = 1 if by_name[entry["name"]]["primary"] else 0
+        if entry["class"] != expected_class:
+            raise DecodeError(f"{scenario} logical class for {entry['name']} differs from DAO metadata")
+        named_physical[physical_ordinal] = entry["name"]
+        logical_rows.append(
+            {"class": entry["class"], "logical_ordinal": logical_ordinal, "name": entry["name"], "physical_ordinal": physical_ordinal}
+        )
+    physical_rows = []
+    for ordinal, entry in enumerate(physical):
+        name = named_physical.get(ordinal)
+        if name is None:
+            raise DecodeError(f"{scenario} physical index {ordinal} has no logical name")
+        keys = []
+        for key in entry["keys"]:
+            column = key["column"]
+            if not 0 <= column < len(columns) or key["direction"] not in (0, 1):
+                raise DecodeError(f"{scenario} physical index {ordinal} has an invalid key")
+            keys.append({"column": column, "name": columns[column]["name"], "direction": key["direction"]})
+        expected_keys = [
+            {"column": next(i for i, field in enumerate(FIELDS) if field["name"] == key["name"]), "name": key["name"], "direction": 0 if key["descending"] else 1}
+            for key in by_name[name]["fields"]
+        ]
+        if keys != expected_keys:
+            raise DecodeError(f"{scenario} physical keys for {name} differ from DAO metadata")
+        expected_flags = (1 if by_name[name]["unique"] else 0) | (8 if by_name[name]["required"] else 0)
+        if entry["flags"] != expected_flags:
+            raise DecodeError(f"{scenario} physical flags for {name} differ from DAO metadata")
+        physical_rows.append(
+            {
+                "entry_count": entry["entry_count"],
+                "flags": entry["flags"],
+                "keys": keys,
+                "map": entry["map"],
+                "name": name,
+                "physical_ordinal": ordinal,
+                "root": entry["root"],
+                "root_delta_from_definition": entry["root"] - definition["root"],
+            }
+        )
+    return {
+        "definition_root": definition["root"],
+        "definition_pages": definition["pages"],
+        "logical_definition_order": logical_rows,
+        "logical_name_sorted_order": sorted(entry["name"] for entry in logical_rows),
+        "physical_ordinal_order": [entry["name"] for entry in physical_rows],
+        "physical_indexes": physical_rows,
+        "table_maps": definition["maps"],
+    }
+
+
+def analyze_scenario(before: bytes, after: bytes, scenario: str) -> dict[str, Any]:
+    before_analysis = catalog.analyze_checkpoint(before)
+    after_analysis = catalog.analyze_checkpoint(after)
+    table = decoded_user_table(after_analysis, scenario)
+    before_pages = len(before) // PAGE_BYTES
+    after_pages = len(after) // PAGE_BYTES
+    if after_pages < before_pages:
+        raise DecodeError(f"{scenario} create shrank the image")
+    roles = {entry["page"]: entry for entry in after_analysis["pages"]}
+    appended = []
+    for page in range(before_pages, after_pages):
+        role = roles.get(page)
+        if role is None or role["role"] == UNASSIGNED:
+            raise DecodeError(f"{scenario} appended page {page} is unattributed")
+        appended.append({"owners": role["owners"], "page": page, "role": role["role"]})
+    layout = index_layout(table, scenario)
+    map_pages = sorted(
+        {layout["table_maps"][kind]["page"] for kind in ("owned", "available")}
+        | {entry["map"]["page"] for entry in layout["physical_indexes"]}
+    )
+    return {
+        "appended_pages": appended,
+        "index_layout": layout,
+        "map_pages": map_pages,
+        "page_count": {"before": before_pages, "after": after_pages},
+    }
+
+
+def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> dict[str, Any]:
+    complete = [entry for entry in replicas if "observations" in entry]
+    questions: dict[str, Any]
+    if document["status"] != "pass" or len(complete) != 3:
+        reason = "at least one replica did not complete"
+        if any(entry.get("metadata_changed") for entry in replicas):
+            reason = "DAO metadata access changed at least one checkpoint"
+        elif any(entry.get("decode_error") for entry in replicas):
+            reason = "at least one complete checkpoint did not decode under the pinned grammars"
+        questions = {name: {"reason": reason, "status": "no_outcome"} for name in ("page_assignment", "index_layout", "map_placement", "replication")}
+    else:
+        observations = [entry["observations"] for entry in complete]
+        if any(value != observations[0] for value in observations[1:]):
+            questions = {name: {"reason": "replicas disagree on the complete decoded observation", "status": "no_outcome"} for name in ("page_assignment", "index_layout", "map_placement", "replication")}
+        else:
+            value = observations[0]
+            questions = {
+                "page_assignment": {"scenarios": {name: value[name]["appended_pages"] for name in SCENARIOS}, "status": "answered"},
+                "index_layout": {"scenarios": {name: value[name]["index_layout"] for name in SCENARIOS}, "status": "answered"},
+                "map_placement": {"scenarios": {name: value[name]["map_pages"] for name in SCENARIOS}, "status": "answered"},
+                "replication": {"replicas": 3, "status": "answered"},
+            }
+    return {
+        "compatibility_claim": False,
+        "development_only": True,
+        "document_type": REPORT_TYPE,
+        "plan_sha256": document["plan_sha256"],
+        "questions": questions,
+        "replicas": [{key: value for key, value in entry.items() if key != "observations"} for entry in replicas],
+        "status": "accepted" if all(value["status"] == "answered" for value in questions.values()) else "no_outcome",
+        "support_movement": False,
+    }
+
+
+def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[str, Any]:
+    expected_plan = digest(expected_plan_sha256, "--expected-plan-sha256")
+    document = exact(load(job_result), {"document_type", "development_only", "plan_sha256", "run_id", "status", "replicas"}, "$")
+    if document["document_type"] != DOCUMENT_TYPE or document["development_only"] is not True:
+        raise AnalysisError("job result identity is invalid")
+    if digest(document["plan_sha256"], "$.plan_sha256") != expected_plan:
+        raise AnalysisError("job result plan digest differs from the approved plan")
+    if not isinstance(document["run_id"], str) or not SAFE_RUN_ID.fullmatch(document["run_id"]):
+        raise AnalysisError("$.run_id is invalid")
+    if document["status"] not in ("pass", "fail"):
+        raise AnalysisError("$.status is invalid")
+    if not isinstance(document["replicas"], list) or len(document["replicas"]) != 3:
+        raise AnalysisError("$.replicas must contain exactly three replicas")
+    replicas = []
+    referenced = []
+    for position, raw_replica in enumerate(document["replicas"]):
+        item = exact(raw_replica, {"replica", "status", "error", "checkpoints", "recovery"}, f"replicas[{position}]")
+        replica = integer(item["replica"], "replica number", 1, 3)
+        if replica != position + 1:
+            raise AnalysisError("replicas must be numbered 1 through 3 in order")
+        if item["status"] not in ("pass", "fail"):
+            raise AnalysisError("replica status is invalid")
+        if item["error"] is not None:
+            text(item["error"], "replica error")
+        checkpoints = item["checkpoints"]
+        if not isinstance(checkpoints, list) or len(checkpoints) > len(CHECKPOINTS):
+            raise AnalysisError("replica checkpoints violate the bound")
+        images: dict[str, bytes] = {}
+        daos: dict[str, dict[str, Any]] = {}
+        identities: dict[str, dict[str, Any]] = {}
+        changed = []
+        for checkpoint_position, raw_checkpoint in enumerate(checkpoints):
+            name = CHECKPOINTS[checkpoint_position]
+            image, repaired, dao, arm_before, identity = read_checkpoint(
+                job_result.parent, raw_checkpoint, replica, name
+            )
+            images[name] = image
+            daos[name] = dao
+            identities[name] = identity
+            referenced.append(f"multiple-indexes-r{replica}-{name}.mdb")
+            if repaired:
+                changed.append(name)
+            if name == "empty":
+                if arm_before is not None:
+                    raise AnalysisError("empty checkpoint must not have an arm identity")
+            else:
+                before = exact(arm_before, {"size", "sha256"}, f"{name}.arm_before")
+                if before["size"] != identities["empty"]["size"] or digest(
+                    before["sha256"], "arm digest"
+                ) != identities["empty"]["sha256"]:
+                    raise AnalysisError(f"{name} arm identity differs from the retained empty image")
+        recovery = item["recovery"]
+        if not isinstance(recovery, list) or len(recovery) > 1:
+            raise AnalysisError("replica recovery inventory violates the bound")
+        checkpoint_names = set(images)
+        for raw_recovery in recovery:
+            value = exact(raw_recovery, {"name", "database", "size", "sha256"}, "recovery artifact")
+            name = value["name"]
+            if name not in SCENARIOS or name in checkpoint_names:
+                raise AnalysisError("recovery artifact name is invalid or duplicated")
+            filename = value["database"]
+            if filename != f"multiple-indexes-r{replica}-{name}.mdb" or not SAFE_MDB.fullmatch(filename):
+                raise AnalysisError("recovery artifact filename is invalid")
+            size = integer(value["size"], "recovery size", PAGE_BYTES, MAX_PAGES * PAGE_BYTES)
+            if size % PAGE_BYTES:
+                raise AnalysisError("recovery artifact is not an exact sequence of pages")
+            path = job_result.parent / filename
+            if not path.is_file() or path.is_symlink():
+                raise AnalysisError("recovery artifact must be a regular non-link file")
+            raw = path.read_bytes()
+            if len(raw) != size or hashlib.sha256(raw).hexdigest() != digest(value["sha256"], "recovery digest"):
+                raise AnalysisError("recovery artifact bytes differ from metadata")
+            referenced.append(filename)
+        entry: dict[str, Any] = {"error": item["error"], "replica": replica, "status": item["status"]}
+        if item["status"] == "pass":
+            if tuple(images) != CHECKPOINTS or item["error"] is not None or recovery:
+                raise AnalysisError("passing replica inventory is incomplete")
+            if changed:
+                entry["metadata_changed"] = changed
+            else:
+                try:
+                    if user_tables(daos["empty"]):
+                        raise DecodeError("empty checkpoint contains a DAO user table")
+                    for name in SCENARIOS:
+                        validate_schema(name, daos[name])
+                    entry["observations"] = {name: analyze_scenario(images["empty"], images[name], name) for name in SCENARIOS}
+                except (catalog.DecodeError, DecodeError) as error:
+                    entry["decode_error"] = str(error)
+        elif item["error"] is None:
+            raise AnalysisError("failed replica omits its error")
+        replicas.append(entry)
+    aggregate = "pass" if all(entry["status"] == "pass" for entry in replicas) else "fail"
+    if document["status"] != aggregate:
+        raise AnalysisError("job status disagrees with replica statuses")
+    retained = sorted(path.name for path in job_result.parent.glob("*.mdb"))
+    if retained != sorted(referenced):
+        raise AnalysisError("retained MDB inventory differs from the job result")
+    report = build_report(document, replicas)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_bytes(report))
+    return report
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job_result", type=Path)
+    parser.add_argument("--expected-plan-sha256", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(arguments)
+    try:
+        evaluate(args.job_result, args.expected_plan_sha256, args.output)
+    except (AnalysisError, OSError) as error:
+        print(f"multiple-index analysis failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/multiple_indexes.py
+++ b/oracle/windows-dao/scripts/multiple_indexes.py
@@ -15,6 +15,8 @@ import system_catalog as catalog
 
 
 PAGE_BYTES = 2048
+INDEX_ENTRY_AREA_OFFSET = 248
+INDEX_ENTRY_AREA_LENGTH = PAGE_BYTES - INDEX_ENTRY_AREA_OFFSET
 MAX_JSON_BYTES = 4 * 1024 * 1024
 MAX_PAGES = 64
 MAX_TABLES = 16
@@ -201,7 +203,16 @@ def read_checkpoint(
 ) -> tuple[bytes, bool, dict[str, Any], Any, dict[str, Any]]:
     item = exact(
         value,
-        {"name", "database", "size", "sha256", "sha256_after_metadata", "arm_before", "dao"},
+        {
+            "name",
+            "database",
+            "size",
+            "size_after_metadata",
+            "sha256",
+            "sha256_after_metadata",
+            "arm_before",
+            "dao",
+        },
         f"replica {replica} checkpoint {name}",
     )
     if item["name"] != name:
@@ -214,17 +225,24 @@ def read_checkpoint(
     if size % PAGE_BYTES:
         raise AnalysisError("checkpoint is not an exact sequence of pages")
     before = digest(item["sha256"], "checkpoint digest")
+    size_after = integer(
+        item["size_after_metadata"],
+        "post-metadata checkpoint size",
+        PAGE_BYTES,
+        MAX_PAGES * PAGE_BYTES,
+    )
+    if size_after % PAGE_BYTES:
+        raise AnalysisError("post-metadata checkpoint is not an exact sequence of pages")
     after = digest(item["sha256_after_metadata"], "post-metadata digest")
     path = root / filename
     if not path.is_file() or path.is_symlink():
         raise AnalysisError("checkpoint must be a regular non-link file")
     raw = path.read_bytes()
-    retained = after if before != after else before
-    if len(raw) != size or hashlib.sha256(raw).hexdigest() != retained:
+    if len(raw) != size_after or hashlib.sha256(raw).hexdigest() != after:
         raise AnalysisError("checkpoint bytes differ from the recorded identity")
     return (
         raw,
-        before != after,
+        size != size_after or before != after,
         validate_dao(item["dao"], f"checkpoint {name}.dao"),
         item["arm_before"],
         {"sha256": before, "size": size},
@@ -261,7 +279,79 @@ def decoded_user_table(analysis: dict[str, Any], scenario: str) -> dict[str, Any
     return users[0]
 
 
-def index_layout(table: dict[str, Any], scenario: str) -> dict[str, Any]:
+def created_lvprop(data: bytes, table_name: str) -> dict[str, Any]:
+    definition, _, rows = catalog._discover_catalog(data)
+    name_ordinal = catalog._ordinal(definition, "Name")
+    lvprop_ordinal = catalog._ordinal(definition, "LvProp")
+    if name_ordinal is None or lvprop_ordinal is None:
+        raise DecodeError("catalog lacks a Name or LvProp column")
+    required = max(name_ordinal, lvprop_ordinal)
+    matches = [
+        row
+        for row in rows
+        if len(row.get("values", [])) > required
+        and row["values"][name_ordinal] == table_name
+    ]
+    if len(matches) != 1:
+        raise DecodeError(f"catalog contains {len(matches)} rows for {table_name}")
+    value = matches[0]["values"][lvprop_ordinal]
+    if not isinstance(value, dict) or set(value) != {
+        "inline_length",
+        "long_value_header_hex",
+    }:
+        raise DecodeError(f"{table_name}.LvProp is not one external header")
+    try:
+        header = bytes.fromhex(value["long_value_header_hex"])
+    except (TypeError, ValueError) as error:
+        raise DecodeError(f"{table_name}.LvProp header is not hex") from error
+    if len(header) != 12 or value["inline_length"] != 12:
+        raise DecodeError(f"{table_name}.LvProp header is not 12 bytes")
+    if header[8:12] != bytes(4):
+        raise DecodeError(f"{table_name}.LvProp reserved bytes are nonzero")
+    control = int.from_bytes(header[:4], "little")
+    if control & 0xFF000000 != 0x40000000:
+        raise DecodeError(f"{table_name}.LvProp is not single-page external")
+    length = control & 0x00FFFFFF
+    row_number = header[4]
+    page_number = int.from_bytes(header[5:8], "little")
+    if length == 0 or length > PAGE_BYTES or page_number >= len(data) // PAGE_BYTES:
+        raise DecodeError(f"{table_name}.LvProp reference is outside the image")
+    page = catalog._page(data, page_number, f"{table_name}.LvProp")
+    if page[0] != 1 or page[4:8] != b"LVAL":
+        raise DecodeError(f"{table_name}.LvProp does not target an LVAL page")
+    directory = catalog._row_directory(page, page_number)
+    if row_number >= len(directory):
+        raise DecodeError(f"{table_name}.LvProp row is absent")
+    row = directory[row_number]
+    if row["hidden"] or row["overflow"]:
+        raise DecodeError(f"{table_name}.LvProp targets a flagged row")
+    payload = page[row["start"] : row["end"]]
+    if len(payload) != length:
+        raise DecodeError(f"{table_name}.LvProp payload length disagrees with its header")
+    return {
+        "header_hex": header.hex(),
+        "length": length,
+        "page": page_number,
+        "payload_sha256": hashlib.sha256(payload).hexdigest(),
+        "row": row_number,
+    }
+
+
+def validate_empty_leaf(data: bytes, root: int, owner: int, what: str) -> None:
+    page = catalog._page(data, root, what)
+    if page[0] != 4 or page[1] != 1 or int.from_bytes(page[4:8], "little") != owner:
+        raise DecodeError(f"{what} is not a leaf root owned by definition {owner}")
+    if any(page[offset : offset + 4] != bytes(4) for offset in (8, 12, 16)):
+        raise DecodeError(f"{what} has a sibling or child reference")
+    if page[20] != 0 or page[21] != 0 or any(page[22:INDEX_ENTRY_AREA_OFFSET]):
+        raise DecodeError(f"{what} has a prefix, branch marker, or entry boundary")
+    if int.from_bytes(page[2:4], "little") != INDEX_ENTRY_AREA_LENGTH:
+        raise DecodeError(f"{what} free space does not describe an empty leaf")
+
+
+def index_layout(
+    data: bytes, page_tags: dict[int, int], table: dict[str, Any], scenario: str
+) -> dict[str, Any]:
     definition = table["definition"]
     columns = definition["columns"]
     if [entry["name"] for entry in columns] != [entry["name"] for entry in FIELDS] or any(
@@ -273,6 +363,10 @@ def index_layout(table: dict[str, Any], scenario: str) -> dict[str, Any]:
     expected_indexes = EXPECTED[scenario]["indexes"]
     if len(physical) != len(expected_indexes) or len(logical) != len(expected_indexes):
         raise DecodeError(f"{scenario} decoded index counts differ from the schema")
+    if definition["row_count"] != 0:
+        raise DecodeError(f"{scenario} decoded table is not empty")
+    if definition["pages"] != [definition["root"]]:
+        raise DecodeError(f"{scenario} definition requires a continuation page")
     by_name = {entry["name"]: entry for entry in expected_indexes}
     if len({entry["name"] for entry in logical}) != len(logical) or set(entry["name"] for entry in logical) != set(by_name):
         raise DecodeError(f"{scenario} logical index names differ from the schema")
@@ -311,18 +405,41 @@ def index_layout(table: dict[str, Any], scenario: str) -> dict[str, Any]:
         expected_flags = (1 if by_name[name]["unique"] else 0) | (8 if by_name[name]["required"] else 0)
         if entry["flags"] != expected_flags:
             raise DecodeError(f"{scenario} physical flags for {name} differ from DAO metadata")
+        if entry["entry_count"] != 0:
+            raise DecodeError(f"{scenario} physical index {ordinal} is not empty")
+        root = entry["root"]
+        if page_tags.get(root) != 4:
+            raise DecodeError(f"{scenario} physical index {ordinal} root is not a leaf page")
+        validate_empty_leaf(
+            data, root, definition["root"], f"{scenario} physical index {ordinal}"
+        )
+        mapped_pages = sorted(
+            catalog._locator_pages(data, entry["map"], f"{scenario} index {ordinal} map")
+        )
         physical_rows.append(
             {
                 "entry_count": entry["entry_count"],
                 "flags": entry["flags"],
                 "keys": keys,
                 "map": entry["map"],
+                "mapped_pages": mapped_pages,
                 "name": name,
                 "physical_ordinal": ordinal,
-                "root": entry["root"],
-                "root_delta_from_definition": entry["root"] - definition["root"],
+                "root": root,
+                "root_delta_from_definition": root - definition["root"],
             }
         )
+    table_maps = {
+        kind: {
+            "locator": definition["maps"][kind],
+            "mapped_pages": sorted(
+                catalog._locator_pages(
+                    data, definition["maps"][kind], f"{scenario} table {kind} map"
+                )
+            ),
+        }
+        for kind in ("owned", "available")
+    }
     return {
         "definition_root": definition["root"],
         "definition_pages": definition["pages"],
@@ -330,13 +447,18 @@ def index_layout(table: dict[str, Any], scenario: str) -> dict[str, Any]:
         "logical_name_sorted_order": sorted(entry["name"] for entry in logical_rows),
         "physical_ordinal_order": [entry["name"] for entry in physical_rows],
         "physical_indexes": physical_rows,
-        "table_maps": definition["maps"],
+        "table_maps": table_maps,
     }
 
 
 def analyze_scenario(before: bytes, after: bytes, scenario: str) -> dict[str, Any]:
     before_analysis = catalog.analyze_checkpoint(before)
     after_analysis = catalog.analyze_checkpoint(after)
+    if any(
+        not entry["flags"] & catalog.SYSTEM_FLAG
+        for entry in before_analysis["tables"].values()
+    ):
+        raise DecodeError(f"{scenario} empty baseline decodes a user table")
     table = decoded_user_table(after_analysis, scenario)
     before_pages = len(before) // PAGE_BYTES
     after_pages = len(after) // PAGE_BYTES
@@ -348,15 +470,35 @@ def analyze_scenario(before: bytes, after: bytes, scenario: str) -> dict[str, An
         role = roles.get(page)
         if role is None or role["role"] == UNASSIGNED:
             raise DecodeError(f"{scenario} appended page {page} is unattributed")
-        appended.append({"owners": role["owners"], "page": page, "role": role["role"]})
-    layout = index_layout(table, scenario)
+        appended.append(
+            {
+                "delta_from_definition": page - table["definition"]["root"],
+                "delta_from_empty": page - before_pages,
+                "owners": role["owners"],
+                "page": page,
+                "role": role["role"],
+            }
+        )
+    layout = index_layout(
+        after, {page: entry["tag"] for page, entry in roles.items()}, table, scenario
+    )
+    lvprop = created_lvprop(after, EXPECTED[scenario]["table"])
+    if not any(
+        entry["page"] == lvprop["page"] and entry["role"] == "long_value"
+        for entry in appended
+    ):
+        raise DecodeError(f"{scenario} LvProp page is not an appended long-value page")
     map_pages = sorted(
-        {layout["table_maps"][kind]["page"] for kind in ("owned", "available")}
+        {
+            layout["table_maps"][kind]["locator"]["page"]
+            for kind in ("owned", "available")
+        }
         | {entry["map"]["page"] for entry in layout["physical_indexes"]}
     )
     return {
         "appended_pages": appended,
         "index_layout": layout,
+        "lvprop": lvprop,
         "map_pages": map_pages,
         "page_count": {"before": before_pages, "after": after_pages},
     }
@@ -379,7 +521,17 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
         else:
             value = observations[0]
             questions = {
-                "page_assignment": {"scenarios": {name: value[name]["appended_pages"] for name in SCENARIOS}, "status": "answered"},
+                "page_assignment": {
+                    "scenarios": {
+                        name: {
+                            "appended_pages": value[name]["appended_pages"],
+                            "lvprop": value[name]["lvprop"],
+                            "page_count": value[name]["page_count"],
+                        }
+                        for name in SCENARIOS
+                    },
+                    "status": "answered",
+                },
                 "index_layout": {"scenarios": {name: value[name]["index_layout"] for name in SCENARIOS}, "status": "answered"},
                 "map_placement": {"scenarios": {name: value[name]["map_pages"] for name in SCENARIOS}, "status": "answered"},
                 "replication": {"replicas": 3, "status": "answered"},
@@ -407,17 +559,41 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         raise AnalysisError("$.run_id is invalid")
     if document["status"] not in ("pass", "fail"):
         raise AnalysisError("$.status is invalid")
-    if not isinstance(document["replicas"], list) or len(document["replicas"]) != 3:
-        raise AnalysisError("$.replicas must contain exactly three replicas")
+    if not isinstance(document["replicas"], list) or not 1 <= len(document["replicas"]) <= 3:
+        raise AnalysisError("$.replicas must contain one through three replicas")
     replicas = []
     referenced = []
     for position, raw_replica in enumerate(document["replicas"]):
-        item = exact(raw_replica, {"replica", "status", "error", "checkpoints", "recovery"}, f"replicas[{position}]")
+        item = exact(
+            raw_replica,
+            {
+                "replica",
+                "status",
+                "error",
+                "mutation_started",
+                "phase",
+                "checkpoints",
+                "recovery",
+            },
+            f"replicas[{position}]",
+        )
         replica = integer(item["replica"], "replica number", 1, 3)
         if replica != position + 1:
             raise AnalysisError("replicas must be numbered 1 through 3 in order")
         if item["status"] not in ("pass", "fail"):
             raise AnalysisError("replica status is invalid")
+        if type(item["mutation_started"]) is not bool:
+            raise AnalysisError("replica mutation_started is invalid")
+        phase = text(item["phase"], "replica phase", 32)
+        if phase not in {
+            "before_create_database",
+            "create_database",
+            "capture_empty",
+            "copy_arms",
+            *SCENARIOS,
+            "complete",
+        }:
+            raise AnalysisError("replica phase is invalid")
         if item["error"] is not None:
             text(item["error"], "replica error")
         checkpoints = item["checkpoints"]
@@ -443,7 +619,12 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
                     raise AnalysisError("empty checkpoint must not have an arm identity")
             else:
                 before = exact(arm_before, {"size", "sha256"}, f"{name}.arm_before")
-                if before["size"] != identities["empty"]["size"] or digest(
+                before_size = integer(
+                    before["size"], "arm size", PAGE_BYTES, MAX_PAGES * PAGE_BYTES
+                )
+                if before_size % PAGE_BYTES:
+                    raise AnalysisError("arm size is not an exact sequence of pages")
+                if before_size != identities["empty"]["size"] or digest(
                     before["sha256"], "arm digest"
                 ) != identities["empty"]["sha256"]:
                     raise AnalysisError(f"{name} arm identity differs from the retained empty image")
@@ -454,7 +635,8 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         for raw_recovery in recovery:
             value = exact(raw_recovery, {"name", "database", "size", "sha256"}, "recovery artifact")
             name = value["name"]
-            if name not in SCENARIOS or name in checkpoint_names:
+            expected_recovery = CHECKPOINTS[len(images)] if len(images) < len(CHECKPOINTS) else None
+            if name != expected_recovery or name not in CHECKPOINTS or name in checkpoint_names:
                 raise AnalysisError("recovery artifact name is invalid or duplicated")
             filename = value["database"]
             if filename != f"multiple-indexes-r{replica}-{name}.mdb" or not SAFE_MDB.fullmatch(filename):
@@ -469,9 +651,44 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
             if len(raw) != size or hashlib.sha256(raw).hexdigest() != digest(value["sha256"], "recovery digest"):
                 raise AnalysisError("recovery artifact bytes differ from metadata")
             referenced.append(filename)
-        entry: dict[str, Any] = {"error": item["error"], "replica": replica, "status": item["status"]}
+        files = [
+            {
+                "arm_before": raw_checkpoint["arm_before"],
+                "database": raw_checkpoint["database"],
+                "name": raw_checkpoint["name"],
+                "sha256": raw_checkpoint["sha256"],
+                "sha256_after_metadata": raw_checkpoint["sha256_after_metadata"],
+                "size": raw_checkpoint["size"],
+                "size_after_metadata": raw_checkpoint["size_after_metadata"],
+            }
+            for raw_checkpoint in checkpoints
+        ]
+        files.extend(
+            {
+                "database": artifact["database"],
+                "name": artifact["name"],
+                "recovery": True,
+                "sha256": artifact["sha256"],
+                "size": artifact["size"],
+            }
+            for artifact in recovery
+        )
+        entry: dict[str, Any] = {
+            "error": item["error"],
+            "files": files,
+            "mutation_started": item["mutation_started"],
+            "phase": phase,
+            "replica": replica,
+            "status": item["status"],
+        }
         if item["status"] == "pass":
-            if tuple(images) != CHECKPOINTS or item["error"] is not None or recovery:
+            if (
+                tuple(images) != CHECKPOINTS
+                or item["error"] is not None
+                or recovery
+                or not item["mutation_started"]
+                or phase != "complete"
+            ):
                 raise AnalysisError("passing replica inventory is incomplete")
             if changed:
                 entry["metadata_changed"] = changed
@@ -486,11 +703,44 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
                     entry["decode_error"] = str(error)
         elif item["error"] is None:
             raise AnalysisError("failed replica omits its error")
+        else:
+            progress = {
+                "create_database": (0, "empty", False),
+                "capture_empty": (0, "empty", True),
+                "copy_arms": (1, None, True),
+                "one": (1, "one", True),
+                "two": (2, "two", True),
+                "three": (3, "three", True),
+                "composite": (4, "composite", True),
+                "complete": (5, None, True),
+            }
+            expected = progress.get(phase)
+            if expected is None:
+                raise AnalysisError("failed replica phase is inconsistent with producer progress")
+            checkpoint_count, recovery_name, mutation_required = expected
+            if len(images) != checkpoint_count:
+                raise AnalysisError("failed replica checkpoint prefix is inconsistent with its phase")
+            if recovery and recovery[0]["name"] != recovery_name:
+                raise AnalysisError("failed replica recovery is inconsistent with its phase")
+            if recovery_name is None and recovery:
+                raise AnalysisError("failed replica phase cannot retain a recovery artifact")
+            if mutation_required and not item["mutation_started"]:
+                raise AnalysisError("failed replica phase requires a started DAO mutation")
+            if not item["mutation_started"] and recovery:
+                raise AnalysisError("pre-mutation failure cannot retain a recovery artifact")
         replicas.append(entry)
+    if not any(entry["mutation_started"] for entry in replicas):
+        raise AnalysisError("acquisition did not reach the first DAO mutation")
+    if len(replicas) != 3:
+        raise AnalysisError("post-mutation result must contain exactly three replicas")
     aggregate = "pass" if all(entry["status"] == "pass" for entry in replicas) else "fail"
     if document["status"] != aggregate:
         raise AnalysisError("job status disagrees with replica statuses")
-    retained = sorted(path.name for path in job_result.parent.glob("*.mdb"))
+    retained = sorted(
+        path.name
+        for path in job_result.parent.iterdir()
+        if path.suffix.casefold() == ".mdb"
+    )
     if retained != sorted(referenced):
         raise AnalysisError("retained MDB inventory differs from the job result")
     report = build_report(document, replicas)

--- a/oracle/windows-dao/tests/test_multiple_indexes.py
+++ b/oracle/windows-dao/tests/test_multiple_indexes.py
@@ -44,7 +44,13 @@ def dao(scenario: str | None) -> dict:
 def fake_analysis(data: bytes, root_shift: int = 0) -> dict:
     marker = data[0]
     if marker == 0:
-        return {"tables": {}, "pages": [{"page": page, "role": "base", "owners": []} for page in range(len(data) // 2048)]}
+        return {
+            "tables": {},
+            "pages": [
+                {"page": page, "role": "base", "owners": [], "tag": 0}
+                for page in range(len(data) // 2048)
+            ],
+        }
     scenario = multiple.SCENARIOS[marker - 1]
     expected = multiple.EXPECTED[scenario]
     logical = []
@@ -80,6 +86,7 @@ def fake_analysis(data: bytes, root_shift: int = 0) -> dict:
         "pages": [2],
         "physical_indexes": physical,
         "root": 2,
+        "row_count": 0,
     }
     count = len(data) // 2048
     pages = []
@@ -90,9 +97,14 @@ def fake_analysis(data: bytes, root_shift: int = 0) -> dict:
             role = "definition_root"
         elif page == 3:
             role = "map_rows"
+        elif page == count - 1:
+            role = "long_value"
         else:
             role = "index_root"
-        pages.append({"page": page, "role": role, "owners": [expected["table"]]})
+        tag = 4 if role == "index_root" else 2 if role == "definition_root" else 1
+        pages.append(
+            {"page": page, "role": role, "owners": [expected["table"]], "tag": tag}
+        )
     return {
         "tables": {2: {"definition": definition, "flags": 0, "name": expected["table"]}},
         "pages": pages,
@@ -109,7 +121,7 @@ class Fixture:
             empty_digest = hashlib.sha256(empty).hexdigest()
             checkpoints.append(self.checkpoint(replica, "empty", empty, None, dao(None)))
             for marker, scenario in enumerate(multiple.SCENARIOS, 1):
-                pages = 4 + len(multiple.EXPECTED[scenario]["indexes"])
+                pages = 12
                 image = bytes([marker]) + bytes(pages * 2048 - 1)
                 checkpoints.append(
                     self.checkpoint(
@@ -121,7 +133,15 @@ class Fixture:
                     )
                 )
             self.replicas.append(
-                {"replica": replica, "status": "pass", "error": None, "checkpoints": checkpoints, "recovery": []}
+                {
+                    "replica": replica,
+                    "status": "pass",
+                    "error": None,
+                    "mutation_started": True,
+                    "phase": "complete",
+                    "checkpoints": checkpoints,
+                    "recovery": [],
+                }
             )
         self.document = {
             "document_type": multiple.DOCUMENT_TYPE,
@@ -140,6 +160,7 @@ class Fixture:
             "name": name,
             "database": filename,
             "size": len(data),
+            "size_after_metadata": len(data),
             "sha256": digest,
             "sha256_after_metadata": digest,
             "arm_before": arm_before,
@@ -156,7 +177,26 @@ class MultipleIndexesTests(unittest.TestCase):
     def evaluate(self, fixture: Fixture, side_effect=fake_analysis):
         result = fixture.write()
         output = fixture.root / "multiple-indexes-report.json"
-        with mock.patch.object(multiple.catalog, "analyze_checkpoint", side_effect=side_effect):
+        with (
+            mock.patch.object(multiple.catalog, "analyze_checkpoint", side_effect=side_effect),
+            mock.patch.object(
+                multiple.catalog,
+                "_locator_pages",
+                side_effect=lambda _data, locator, _what: {locator["page"]},
+            ),
+            mock.patch.object(
+                multiple,
+                "created_lvprop",
+                side_effect=lambda _data, _table: {
+                    "header_hex": "",
+                    "length": 1,
+                    "page": 11,
+                    "payload_sha256": "0" * 64,
+                    "row": 0,
+                },
+            ),
+            mock.patch.object(multiple, "validate_empty_leaf"),
+        ):
             report = multiple.evaluate(result, PLAN, output)
         self.assertEqual(output.read_bytes(), multiple.canonical_bytes(report))
         return report
@@ -169,14 +209,39 @@ class MultipleIndexesTests(unittest.TestCase):
             layout = report["questions"]["index_layout"]["scenarios"]["three"]
             self.assertEqual(layout["physical_ordinal_order"], ["ZPrimary", "MUniqueX", "ASecondx"])
             self.assertEqual(layout["logical_name_sorted_order"], ["ASecondx", "MUniqueX", "ZPrimary"])
+            self.assertEqual(layout["physical_indexes"][0]["mapped_pages"], [3])
+            self.assertEqual(len(report["replicas"][0]["files"]), 5)
+            self.assertEqual(
+                report["questions"]["page_assignment"]["scenarios"]["one"][
+                    "lvprop"
+                ]["page"],
+                11,
+            )
 
     def test_fully_decoded_unanticipated_root_layout_remains_answered(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             fixture = Fixture(Path(directory))
-            report = self.evaluate(fixture, lambda data: fake_analysis(data, root_shift=7))
+            report = self.evaluate(fixture, lambda data: fake_analysis(data, root_shift=2))
             self.assertEqual(report["status"], "accepted")
             roots = report["questions"]["index_layout"]["scenarios"]["two"]["physical_indexes"]
-            self.assertEqual([entry["root"] for entry in roots], [11, 12])
+            self.assertEqual([entry["root"] for entry in roots], [6, 7])
+
+    def test_definition_continuation_is_outside_the_experiment_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+
+            def with_continuation(data: bytes) -> dict:
+                analysis = fake_analysis(data)
+                if data[0]:
+                    analysis["tables"][2]["definition"]["pages"] = [2, 10]
+                return analysis
+
+            report = self.evaluate(fixture, with_continuation)
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn(
+                "continuation page",
+                report["replicas"][0]["decode_error"],
+            )
 
     def test_replica_disagreement_is_no_outcome(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -215,6 +280,7 @@ class MultipleIndexesTests(unittest.TestCase):
                 replica["checkpoints"] = replica["checkpoints"][:2]
                 replica["status"] = "fail"
                 replica["error"] = "bounded DAO failure"
+                replica["phase"] = "two"
             fixture.document["status"] = "fail"
             report = self.evaluate(fixture)
             self.assertEqual(report["status"], "no_outcome")
@@ -237,9 +303,144 @@ class MultipleIndexesTests(unittest.TestCase):
                 replica["checkpoints"] = replica["checkpoints"][:2]
                 replica["status"] = "fail"
                 replica["error"] = "bounded DAO failure"
+                replica["phase"] = "two"
             fixture.document["status"] = "fail"
             report = self.evaluate(fixture)
             self.assertEqual(report["status"], "no_outcome")
+
+    def test_failed_empty_capture_may_retain_empty_recovery_image(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                recovery_source = replica["checkpoints"][0]
+                replica["recovery"] = [
+                    {
+                        "name": "empty",
+                        "database": recovery_source["database"],
+                        "size": recovery_source["size"],
+                        "sha256": recovery_source["sha256"],
+                    }
+                ]
+                for checkpoint in replica["checkpoints"][1:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = []
+                replica["status"] = "fail"
+                replica["error"] = "bounded checkpoint failure"
+                replica["phase"] = "capture_empty"
+            fixture.document["status"] = "fail"
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+
+    def test_failed_replica_phase_must_match_checkpoint_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0]["status"] = "fail"
+            fixture.replicas[0]["error"] = "impossible producer state"
+            fixture.replicas[0]["phase"] = "two"
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(multiple.AnalysisError, "checkpoint prefix"):
+                self.evaluate(fixture)
+
+    def test_failed_replica_phase_must_match_mutation_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for checkpoint in fixture.replicas[0]["checkpoints"][1:]:
+                (Path(directory) / checkpoint["database"]).unlink()
+            fixture.replicas[0]["checkpoints"] = fixture.replicas[0]["checkpoints"][:1]
+            fixture.replicas[0]["status"] = "fail"
+            fixture.replicas[0]["error"] = "impossible producer state"
+            fixture.replicas[0]["mutation_started"] = False
+            fixture.replicas[0]["phase"] = "copy_arms"
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(multiple.AnalysisError, "started DAO mutation"):
+                self.evaluate(fixture)
+
+    def test_recovery_image_must_be_the_next_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            replica = fixture.replicas[0]
+            recovery_source = replica["checkpoints"][4]
+            replica["recovery"] = [
+                {
+                    "name": "composite",
+                    "database": recovery_source["database"],
+                    "size": recovery_source["size"],
+                    "sha256": recovery_source["sha256"],
+                }
+            ]
+            for checkpoint in replica["checkpoints"][2:4]:
+                (Path(directory) / checkpoint["database"]).unlink()
+            replica["checkpoints"] = replica["checkpoints"][:2]
+            replica["status"] = "fail"
+            replica["error"] = "bounded DAO failure"
+            replica["phase"] = "two"
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(multiple.AnalysisError, "recovery artifact"):
+                self.evaluate(fixture)
+
+    def test_empty_leaf_validation_rejects_a_branched_root(self) -> None:
+        page = bytearray(2048)
+        page[0] = 4
+        page[1] = 1
+        page[2:4] = multiple.INDEX_ENTRY_AREA_LENGTH.to_bytes(2, "little")
+        page[4:8] = (2).to_bytes(4, "little")
+        multiple.validate_empty_leaf(bytes(page), 0, 2, "root")
+        page[21] = 1
+        with self.assertRaisesRegex(multiple.DecodeError, "branch marker"):
+            multiple.validate_empty_leaf(bytes(page), 0, 2, "root")
+
+    def test_created_lvprop_correlates_the_external_row(self) -> None:
+        payload = b"abc"
+        header = (0x40000003).to_bytes(4, "little") + bytes([0]) + (2).to_bytes(
+            3, "little"
+        ) + bytes(4)
+        row = {
+            "values": [
+                "IdxOne",
+                {"inline_length": 12, "long_value_header_hex": header.hex()},
+            ]
+        }
+        page = bytearray(2048)
+        page[0] = 1
+        page[4:8] = b"LVAL"
+        page[10:13] = payload
+        with (
+            mock.patch.object(multiple.catalog, "_discover_catalog", return_value=({}, [], [row])),
+            mock.patch.object(
+                multiple.catalog,
+                "_ordinal",
+                side_effect=lambda _definition, name: {"Name": 0, "LvProp": 1}[name],
+            ),
+            mock.patch.object(multiple.catalog, "_page", return_value=bytes(page)),
+            mock.patch.object(
+                multiple.catalog,
+                "_row_directory",
+                return_value=[{"hidden": False, "overflow": False, "start": 10, "end": 13}],
+            ),
+        ):
+            observed = multiple.created_lvprop(bytes(3 * 2048), "IdxOne")
+        self.assertEqual(observed["page"], 2)
+        self.assertEqual(observed["payload_sha256"], hashlib.sha256(payload).hexdigest())
+
+    def test_pre_mutation_abort_is_rejected_without_a_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for checkpoint in fixture.replicas[0]["checkpoints"]:
+                (Path(directory) / checkpoint["database"]).unlink()
+            fixture.document["replicas"] = [
+                {
+                    "replica": 1,
+                    "status": "fail",
+                    "error": "provider unavailable",
+                    "mutation_started": False,
+                    "phase": "create_database",
+                    "checkpoints": [],
+                    "recovery": [],
+                }
+            ]
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(multiple.AnalysisError, "first DAO mutation"):
+                self.evaluate(fixture)
 
     def test_dao_direction_mismatch_is_no_outcome(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/oracle/windows-dao/tests/test_multiple_indexes.py
+++ b/oracle/windows-dao/tests/test_multiple_indexes.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Focused tests for the preregistered issue #150 analyzer."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location("multiple_indexes", SCRIPTS / "multiple_indexes.py")
+assert SPEC and SPEC.loader
+multiple = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(multiple)
+
+
+PLAN = "a" * 64
+
+
+def dao(scenario: str | None) -> dict:
+    tables = []
+    if scenario is not None:
+        expected = multiple.EXPECTED[scenario]
+        tables.append(
+            {
+                "ordinal": 0,
+                "name": expected["table"],
+                "fields": copy.deepcopy(multiple.FIELDS),
+                "indexes": copy.deepcopy(expected["indexes"]),
+            }
+        )
+    return {"tabledefs": tables}
+
+
+def fake_analysis(data: bytes, root_shift: int = 0) -> dict:
+    marker = data[0]
+    if marker == 0:
+        return {"tables": {}, "pages": [{"page": page, "role": "base", "owners": []} for page in range(len(data) // 2048)]}
+    scenario = multiple.SCENARIOS[marker - 1]
+    expected = multiple.EXPECTED[scenario]
+    logical = []
+    for name in sorted(entry["name"] for entry in expected["indexes"]):
+        physical = next(position for position, entry in enumerate(expected["indexes"]) if entry["name"] == name)
+        logical.append(
+            {
+                "class": 1 if expected["indexes"][physical]["primary"] else 0,
+                "name": name,
+                "physical_index": physical,
+            }
+        )
+    physical = []
+    for ordinal, entry in enumerate(expected["indexes"]):
+        keys = []
+        for field in entry["fields"]:
+            column = next(position for position, value in enumerate(multiple.FIELDS) if value["name"] == field["name"])
+            keys.append({"column": column, "direction": 0 if field["descending"] else 1})
+        physical.append(
+            {
+                "entry_count": 0,
+                "flags": (1 if entry["unique"] else 0) | (8 if entry["required"] else 0),
+                "index": ordinal,
+                "keys": keys,
+                "map": {"page": 3, "row": 2 + ordinal},
+                "root": 4 + ordinal + root_shift,
+            }
+        )
+    definition = {
+        "columns": [{"name": field["name"], "type": "Long"} for field in multiple.FIELDS],
+        "logical_indexes": logical,
+        "maps": {"owned": {"page": 3, "row": 0}, "available": {"page": 3, "row": 1}},
+        "pages": [2],
+        "physical_indexes": physical,
+        "root": 2,
+    }
+    count = len(data) // 2048
+    pages = []
+    for page in range(count):
+        if page < 2:
+            role = "base"
+        elif page == 2:
+            role = "definition_root"
+        elif page == 3:
+            role = "map_rows"
+        else:
+            role = "index_root"
+        pages.append({"page": page, "role": role, "owners": [expected["table"]]})
+    return {
+        "tables": {2: {"definition": definition, "flags": 0, "name": expected["table"]}},
+        "pages": pages,
+    }
+
+
+class Fixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.replicas = []
+        for replica in range(1, 4):
+            checkpoints = []
+            empty = bytes(2 * 2048)
+            empty_digest = hashlib.sha256(empty).hexdigest()
+            checkpoints.append(self.checkpoint(replica, "empty", empty, None, dao(None)))
+            for marker, scenario in enumerate(multiple.SCENARIOS, 1):
+                pages = 4 + len(multiple.EXPECTED[scenario]["indexes"])
+                image = bytes([marker]) + bytes(pages * 2048 - 1)
+                checkpoints.append(
+                    self.checkpoint(
+                        replica,
+                        scenario,
+                        image,
+                        {"size": len(empty), "sha256": empty_digest},
+                        dao(scenario),
+                    )
+                )
+            self.replicas.append(
+                {"replica": replica, "status": "pass", "error": None, "checkpoints": checkpoints, "recovery": []}
+            )
+        self.document = {
+            "document_type": multiple.DOCUMENT_TYPE,
+            "development_only": True,
+            "plan_sha256": PLAN,
+            "run_id": "20260902T120000Z-dev-dao",
+            "status": "pass",
+            "replicas": self.replicas,
+        }
+
+    def checkpoint(self, replica: int, name: str, data: bytes, arm_before: dict | None, metadata: dict) -> dict:
+        filename = f"multiple-indexes-r{replica}-{name}.mdb"
+        (self.root / filename).write_bytes(data)
+        digest = hashlib.sha256(data).hexdigest()
+        return {
+            "name": name,
+            "database": filename,
+            "size": len(data),
+            "sha256": digest,
+            "sha256_after_metadata": digest,
+            "arm_before": arm_before,
+            "dao": metadata,
+        }
+
+    def write(self) -> Path:
+        path = self.root / "multiple-indexes-job-result.json"
+        path.write_text(json.dumps(self.document), encoding="utf-8")
+        return path
+
+
+class MultipleIndexesTests(unittest.TestCase):
+    def evaluate(self, fixture: Fixture, side_effect=fake_analysis):
+        result = fixture.write()
+        output = fixture.root / "multiple-indexes-report.json"
+        with mock.patch.object(multiple.catalog, "analyze_checkpoint", side_effect=side_effect):
+            report = multiple.evaluate(result, PLAN, output)
+        self.assertEqual(output.read_bytes(), multiple.canonical_bytes(report))
+        return report
+
+    def test_accepts_exact_replicated_layout_and_reports_both_orders(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "accepted")
+            layout = report["questions"]["index_layout"]["scenarios"]["three"]
+            self.assertEqual(layout["physical_ordinal_order"], ["ZPrimary", "MUniqueX", "ASecondx"])
+            self.assertEqual(layout["logical_name_sorted_order"], ["ASecondx", "MUniqueX", "ZPrimary"])
+
+    def test_fully_decoded_unanticipated_root_layout_remains_answered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            report = self.evaluate(fixture, lambda data: fake_analysis(data, root_shift=7))
+            self.assertEqual(report["status"], "accepted")
+            roots = report["questions"]["index_layout"]["scenarios"]["two"]["physical_indexes"]
+            self.assertEqual([entry["root"] for entry in roots], [11, 12])
+
+    def test_replica_disagreement_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            calls = 0
+
+            def differing(data: bytes) -> dict:
+                nonlocal calls
+                calls += 1
+                return fake_analysis(data, root_shift=1 if calls > 8 else 0)
+
+            report = self.evaluate(fixture, differing)
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertTrue(all(question["status"] == "no_outcome" for question in report["questions"].values()))
+
+    def test_rejects_arm_identity_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0]["checkpoints"][1]["arm_before"]["sha256"] = "b" * 64
+            with self.assertRaisesRegex(multiple.AnalysisError, "arm identity"):
+                self.evaluate(fixture)
+
+    def test_rejects_extra_retained_database(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            (Path(directory) / "unexpected.mdb").write_bytes(bytes(2048))
+            with self.assertRaisesRegex(multiple.AnalysisError, "retained MDB inventory"):
+                self.evaluate(fixture)
+
+    def test_failed_partial_prefix_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                for checkpoint in replica["checkpoints"][2:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = replica["checkpoints"][:2]
+                replica["status"] = "fail"
+                replica["error"] = "bounded DAO failure"
+            fixture.document["status"] = "fail"
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+
+    def test_failed_replica_may_retain_one_bounded_recovery_image(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                recovery_source = replica["checkpoints"][2]
+                replica["recovery"] = [
+                    {
+                        "name": "two",
+                        "database": recovery_source["database"],
+                        "size": recovery_source["size"],
+                        "sha256": recovery_source["sha256"],
+                    }
+                ]
+                for checkpoint in replica["checkpoints"][3:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = replica["checkpoints"][:2]
+                replica["status"] = "fail"
+                replica["error"] = "bounded DAO failure"
+            fixture.document["status"] = "fail"
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+
+    def test_dao_direction_mismatch_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                replica["checkpoints"][3]["dao"]["tabledefs"][0]["indexes"][1]["fields"][0][
+                    "descending"
+                ] = False
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+
+    def test_metadata_digest_change_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                replica["checkpoints"][1]["sha256"] = "b" * 64
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -838,11 +838,13 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             self.publication,
         )
         self.assertIn("checkpoints are not an ordered prefix", self.publication)
+        self.assertIn("recovery artifact is not the next checkpoint", self.publication)
+        self.assertIn("$preMutationAbort", self.publication)
         self.assertIn("15-database bound", self.publication)
         self.assertIn('Get-ChildItem -LiteralPath $Source -File -Filter "*.mdb"', self.publication)
         self.assertIn("$item.Length % 2048", self.publication)
-        self.assertIn("$item.Length -gt 1048576", self.publication)
-        self.assertIn("result exceeds the 8-MiB bound", self.publication)
+        self.assertIn("$item.Length -gt 131072", self.publication)
+        self.assertIn("result exceeds the 4-MiB bound", self.publication)
         self.assertIn("contains a reparse-point MDB", self.publication)
         binding = CLIENT.plan_binding("multiple-indexes")
         self.assertEqual(
@@ -868,6 +870,11 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             plan["inputs"],
         )
         self.assertIn("oracle/windows-dao/scripts/system_catalog.py", plan["inputs"])
+        job = CLIENT.MULTIPLE_INDEXES_JOB.read_text(encoding="utf-8")
+        self.assertIn("[ref]$MutationStarted", job)
+        self.assertIn("mutation_started = $false", job)
+        self.assertIn('phase = "before_create_database"', job)
+        self.assertIn("size_after_metadata", job)
 
     def test_lvprop_null_is_bounded_and_exactly_routed(self) -> None:
         self.assertIn(

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -75,6 +75,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 "bootstrap-composer-semantics",
                 "bootstrap-composer-validation",
                 "schema-generalization",
+                "multiple-indexes",
                 "lvprop-null",
             ),
         )
@@ -105,26 +106,26 @@ class WindowsDaoDevClientTests(unittest.TestCase):
             args = self.args(root, identity)
             CLIENT.validate_args(args)
             staged = CLIENT.stage_job(args)
-            self.assertEqual(
-                {path.name for path in staged.iterdir()},
-                {
-                    CLIENT.REMOTE_RUNNER.name,
-                    CLIENT.PROVIDER_PROBE.name,
-                    CLIENT.CATALOG_JOB.name,
-                    CLIENT.TABLE_DEFINITION_JOB.name,
-                    CLIENT.TABLE_DEFINITION_TYPES.name,
-                    CLIENT.STAGED_DISPATCH.name,
-                    CLIENT.STAGED_PUBLICATION.name,
-                    CLIENT.ROW_JOB.name,
-                    CLIENT.VALUE_JOB.name,
-                    CLIENT.INDEX_JOB.name,
-                    CLIENT.BOOTSTRAP_LAYOUT_JOB.name,
-                    CLIENT.SYSTEM_CATALOG_JOB.name,
-                    CLIENT.BOOTSTRAP_COMPOSER_VALIDATION_JOB.name,
-                    CLIENT.SCHEMA_GENERALIZATION_JOB.name,
-                    CLIENT.LVPROP_NULL_JOB.name,
-                },
-            )
+            expected = {
+                CLIENT.REMOTE_RUNNER.name,
+                CLIENT.PROVIDER_PROBE.name,
+                CLIENT.CATALOG_JOB.name,
+                CLIENT.TABLE_DEFINITION_JOB.name,
+                CLIENT.TABLE_DEFINITION_TYPES.name,
+                CLIENT.STAGED_DISPATCH.name,
+                CLIENT.STAGED_PUBLICATION.name,
+                CLIENT.ROW_JOB.name,
+                CLIENT.VALUE_JOB.name,
+                CLIENT.INDEX_JOB.name,
+                CLIENT.BOOTSTRAP_LAYOUT_JOB.name,
+                CLIENT.SYSTEM_CATALOG_JOB.name,
+                CLIENT.BOOTSTRAP_COMPOSER_VALIDATION_JOB.name,
+                CLIENT.SCHEMA_GENERALIZATION_JOB.name,
+                CLIENT.LVPROP_NULL_JOB.name,
+            }
+            if CLIENT.MULTIPLE_INDEXES_JOB.is_file():
+                expected.add(CLIENT.MULTIPLE_INDEXES_JOB.name)
+            self.assertEqual({path.name for path in staged.iterdir()}, expected)
 
     def test_result_must_match_job_and_exit_status(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -246,6 +247,8 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 CLIENT.ntpath.join(remote_input, "bootstrap-composer-alpha.mdb"),
                 "-SchemaGeneralizationJobPath",
                 staged(CLIENT.SCHEMA_GENERALIZATION_JOB),
+                "-MultipleIndexesJobPath",
+                staged(CLIENT.MULTIPLE_INDEXES_JOB),
                 "-LvPropNullJobPath",
                 staged(CLIENT.LVPROP_NULL_JOB),
                 "-LvPropFixedAlphaPath",
@@ -364,6 +367,14 @@ class WindowsDaoDevClientTests(unittest.TestCase):
     def test_schema_generalization_binds_and_verifies_a_pinned_plan(self) -> None:
         self.assert_plan_bound_job("schema-generalization", "SCHEMA_GENERALIZATION_PLAN")
 
+    def test_multiple_indexes_binds_issue_150_and_verifies_a_pinned_plan(self) -> None:
+        binding = CLIENT.plan_binding("multiple-indexes")
+        self.assertEqual(binding.issue, 150)
+        self.assertEqual(binding.document_type, "dao_multiple_indexes_plan")
+        self.assertEqual(binding.job_result_name, "multiple-indexes-job-result.json")
+        self.assertEqual(binding.report_name, "multiple-indexes-report.json")
+        self.assert_plan_bound_job("multiple-indexes", "MULTIPLE_INDEXES_PLAN")
+
     def test_lvprop_null_binds_issue_149_and_verifies_a_pinned_plan(self) -> None:
         binding = CLIENT.plan_binding("lvprop-null")
         self.assertEqual(binding.issue, 149)
@@ -459,7 +470,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_remote_is_exploratory_and_allowlisted(self) -> None:
         self.assertIn(
-            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]',
+            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]',
             self.remote,
         )
         self.assertIn("development_only = $true", self.remote)
@@ -554,8 +565,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumRows = 64", row)
         self.assertIn("foreach ($replica in 1..3)", row)
         for scenario in (
@@ -575,8 +586,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_value_job_is_repeated_bounded_and_never_compacts(self) -> None:
         value = CLIENT.VALUE_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumDatabaseBytes = 4MB", value)
         self.assertIn("foreach ($replica in 1..3)", value)
         self.assertIn("$LongLengths = @(32, 512, 2048, 4096)", value)
@@ -587,8 +598,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_index_job_is_staged_bounded_and_never_compacts(self) -> None:
         index = CLIENT.INDEX_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumRows = 4096", index)
         self.assertIn("$MaximumDatabaseBytes = 16MB", index)
         for scenario in (
@@ -806,6 +817,57 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertFalse(plan["publication"]["compatibility_claim"])
         self.assertFalse(plan["publication"]["support_matrix_movement"])
         self.assertFalse(plan["publication"]["mdb_bytes_committed"])
+
+    def test_multiple_indexes_is_bounded_and_exactly_routed(self) -> None:
+        self.assertIn(
+            '"multiple-indexes" = "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1"',
+            self.remote,
+        )
+        self.assertIn(
+            '"multiple-indexes" { $MultipleIndexesJobPath }', self.dispatch
+        )
+        self.assertIn(
+            '"multiple-indexes" { "multiple-indexes-job-result.json" }',
+            self.dispatch,
+        )
+        self.assertIn("multiple_indexes_replicas", self.dispatch)
+        self.assertIn("multiple_indexes_replicas", self.remote)
+        self.assertIn('"multiple-indexes" {', self.publication)
+        self.assertIn(
+            '$checkpointNames = @("empty", "one", "two", "three", "composite")',
+            self.publication,
+        )
+        self.assertIn("checkpoints are not an ordered prefix", self.publication)
+        self.assertIn("15-database bound", self.publication)
+        self.assertIn('Get-ChildItem -LiteralPath $Source -File -Filter "*.mdb"', self.publication)
+        self.assertIn("$item.Length % 2048", self.publication)
+        self.assertIn("$item.Length -gt 1048576", self.publication)
+        self.assertIn("result exceeds the 8-MiB bound", self.publication)
+        self.assertIn("contains a reparse-point MDB", self.publication)
+        binding = CLIENT.plan_binding("multiple-indexes")
+        self.assertEqual(
+            binding.plan.name,
+            "multiple-indexes.plan.json",
+        )
+        self.assertEqual(binding.analyzer.name, "multiple_indexes.py")
+        if not binding.plan.is_file() or not binding.analyzer.is_file():
+            self.skipTest("Multiple-indexes experiment artifacts are not present yet")
+        plan = json.loads(binding.plan.read_text(encoding="utf-8"))
+        self.assertEqual(plan["document_type"], "dao_multiple_indexes_plan")
+        self.assertEqual(plan["issue"], 150)
+        self.assertEqual(plan["execution"]["replicas"], 3)
+        self.assertEqual(
+            plan["execution"]["checkpoints"],
+            ["empty", "one", "two", "three", "composite"],
+        )
+        self.assertEqual(
+            plan["execution"]["bounds"]["maximum_published_databases"], 15
+        )
+        self.assertIn(
+            "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1",
+            plan["inputs"],
+        )
+        self.assertIn("oracle/windows-dao/scripts/system_catalog.py", plan["inputs"])
 
     def test_lvprop_null_is_bounded_and_exactly_routed(self) -> None:
         self.assertIn(

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -610,8 +610,7 @@ def stage_job(args: argparse.Namespace) -> Path:
             staging / BOOTSTRAP_COMPOSER_VALIDATION_JOB.name,
         )
         shutil.copyfile(SCHEMA_GENERALIZATION_JOB, staging / SCHEMA_GENERALIZATION_JOB.name)
-        if MULTIPLE_INDEXES_JOB.is_file():
-            shutil.copyfile(MULTIPLE_INDEXES_JOB, staging / MULTIPLE_INDEXES_JOB.name)
+        shutil.copyfile(MULTIPLE_INDEXES_JOB, staging / MULTIPLE_INDEXES_JOB.name)
         shutil.copyfile(LVPROP_NULL_JOB, staging / LVPROP_NULL_JOB.name)
         binding = plan_binding(args.job)
         if binding is not None:

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -141,6 +141,20 @@ SCHEMA_GENERALIZATION_PLAN = (
 SCHEMA_GENERALIZATION_ANALYZER = (
     ROOT / "oracle" / "windows-dao" / "scripts" / "schema_generalization.py"
 )
+MULTIPLE_INDEXES_JOB = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "scripts"
+    / "dev"
+    / "MultipleIndexes.DevJob.ps1"
+)
+MULTIPLE_INDEXES_PLAN = (
+    ROOT / "oracle" / "windows-dao" / "acquisition" / "multiple-indexes.plan.json"
+)
+MULTIPLE_INDEXES_ANALYZER = (
+    ROOT / "oracle" / "windows-dao" / "scripts" / "multiple_indexes.py"
+)
 LVPROP_NULL_JOB = (
     ROOT
     / "oracle"
@@ -179,6 +193,7 @@ ALLOWED_JOBS = (
     "bootstrap-composer-semantics",
     "bootstrap-composer-validation",
     "schema-generalization",
+    "multiple-indexes",
     "lvprop-null",
 )
 
@@ -284,6 +299,14 @@ def plan_binding(job: str) -> PlanBinding | None:
             SCHEMA_GENERALIZATION_ANALYZER,
             "dao_schema_generalization_plan",
             100,
+        )
+    if job == "multiple-indexes":
+        return PlanBinding(
+            job,
+            MULTIPLE_INDEXES_PLAN,
+            MULTIPLE_INDEXES_ANALYZER,
+            "dao_multiple_indexes_plan",
+            150,
         )
     if job == "lvprop-null":
         return PlanBinding(
@@ -587,6 +610,8 @@ def stage_job(args: argparse.Namespace) -> Path:
             staging / BOOTSTRAP_COMPOSER_VALIDATION_JOB.name,
         )
         shutil.copyfile(SCHEMA_GENERALIZATION_JOB, staging / SCHEMA_GENERALIZATION_JOB.name)
+        if MULTIPLE_INDEXES_JOB.is_file():
+            shutil.copyfile(MULTIPLE_INDEXES_JOB, staging / MULTIPLE_INDEXES_JOB.name)
         shutil.copyfile(LVPROP_NULL_JOB, staging / LVPROP_NULL_JOB.name)
         binding = plan_binding(args.job)
         if binding is not None:
@@ -662,6 +687,8 @@ def remote_job_command(args: argparse.Namespace) -> list[str]:
         ntpath.join(remote_input, "bootstrap-composer-alpha.mdb"),
         "-SchemaGeneralizationJobPath",
         ntpath.join(remote_input, SCHEMA_GENERALIZATION_JOB.name),
+        "-MultipleIndexesJobPath",
+        ntpath.join(remote_input, MULTIPLE_INDEXES_JOB.name),
         "-LvPropNullJobPath",
         ntpath.join(remote_input, LVPROP_NULL_JOB.name),
         "-LvPropFixedAlphaPath",


### PR DESCRIPTION
Issue #150 blocks the planner at one index because no first-create image with multiple indexes has been observed. This preregisters one bounded, three-replica DAO experiment that isolates four index shapes from identical empty databases and measures page/map placement, logical-to-physical ordering, flags, directions, and the first indexed-create LvProp position.

The producer, publisher, analyzer, routing, tests, and provenance are SHA-256 pinned. Three independent review/fix rounds closed mutation-state, recovery, metadata-identity, LvProp-correlation, empty-root, phase-consistency, and continuation-scope gaps before acquisition. The user authorized exactly one run after this PR reaches main; no post-mutation retry is authorized.

Checks: `just ready`; 58 focused experiment/transport tests; independent verification of all eight input pins and the plan SHA-256.

Refs #150.