### PR TITLE
test(oracle): determine definition continuation placement

### DIFF
--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -42,6 +42,7 @@ just windows-dev-system-catalog
 just windows-dev-bootstrap-composer-semantics
 just windows-dev-schema-generalization
 just windows-dev-multiple-indexes
+just windows-dev-definition-continuation
 just windows-dev-lvprop-null
 ```
 
@@ -141,6 +142,20 @@ most the next checkpoint's identified recovery image after a post-mutation
 failure. The experiment tests this bounded page-assignment matrix;
 it does not establish arbitrary index shapes, writer correctness, compatibility,
 or support.
+
+`definition-continuation` is the SHA-placeholder development-only experiment
+draft for issue #151. It cannot run until final input pins are reviewed and
+merged. Three replicas each create one fresh empty database,
+identity-check three pre-mutation copies, and retain closed checkpoints for the
+empty database plus exact 2,046-, 2,075-, and 4,105-byte table definitions. The
+controls require zero, one, and two continuation pages under the recorded
+grammar. Publication accepts exactly those 12 MDBs on success and only an
+ordered per-replica prefix plus the active checkpoint's one bounded recovery
+image after failure. The analyzer records chain pointers, logical chunks,
+appended-page roles, map locators, raw `LvProp` framing and its bounded external
+locator chain when present, and page-0 counters. It presumes neither consecutive
+placement nor a single-page `LvProp`, and establishes no broader allocation,
+writer, compatibility, or support claim.
 
 `lvprop-null` is the SHA-256-pinned, development-only acceptance experiment for
 issue #149. Three replicas each compare the fixed accepted Alpha composer image,

--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -143,17 +143,18 @@ failure. The experiment tests this bounded page-assignment matrix;
 it does not establish arbitrary index shapes, writer correctness, compatibility,
 or support.
 
-`definition-continuation` is the SHA-placeholder development-only experiment
-draft for issue #151. It cannot run until final input pins are reviewed and
-merged. Three replicas each create one fresh empty database,
+`definition-continuation` is the SHA-256-pinned development-only experiment for
+issue #151. It cannot run until the exact preregistration is merged and the
+standing human authorization remains in effect. Three replicas each create one fresh empty database,
 identity-check three pre-mutation copies, and retain closed checkpoints for the
 empty database plus exact 2,046-, 2,075-, and 4,105-byte table definitions. The
 controls require zero, one, and two continuation pages under the recorded
 grammar. Publication accepts exactly those 12 MDBs on success and only an
 ordered per-replica prefix plus the active checkpoint's one bounded recovery
 image after failure. The analyzer records chain pointers, logical chunks,
-appended-page roles, map locators, raw `LvProp` framing and its bounded external
-locator chain when present, and page-0 counters. It presumes neither consecutive
+appended-page roles, map locators, raw `LvProp` framing, its bounded external
+locator chain when present, referenced versus unreferenced appended LVAL pages,
+and the complete page-0 changed-offset set plus counter values. It presumes neither consecutive
 placement nor a single-page `LvProp`, and establishes no broader allocation,
 writer, compatibility, or support claim.
 

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -8382,20 +8382,21 @@ Use `not applicable` explicitly rather than omitting a field.
   no findings.
 
 
-### EXP-0094 — Draft table-definition continuation placement preregistration
+### EXP-0094 — Table-definition continuation placement preregistration
 
 - Recorded: 2026-09-02, OpenAI Codex
-- Kind: SHA-256-placeholder, development-only local DAO preregistration draft;
-  acquisition is forbidden until exact pins replace every placeholder, review
-  is complete, the result is committed and merged, and a human explicitly
-  authorizes one run
+- Kind: SHA-256-pinned, development-only local DAO preregistration; acquisition
+  is forbidden until this exact result is committed and merged and the standing
+  human authorization for one run remains in effect
 - Question: across three replicas beginning from identity-checked copies of one
   fresh empty Jet 3 database apiece, where does DAO place and how does it chain
   exactly zero, one, and two table-definition continuation pages?
 - Origin: project-authored clean-room experiment for issue `#151`, using only
-  the bounded definition grammar recorded by `EXP-0059`, the catalog and page
-  correlation recorded by `EXP-0073`, and the empty first-create framing in
-  `EXP-0087` and `EXP-0093`. The 2,048-byte definition-root capacity, 2,040-byte
+  the bounded definition grammar recorded by `EXP-0059`, the long-value
+  framing recorded by `EXP-0061`, the null `LvProp` form accepted by
+  `EXP-0091`, the catalog and page correlation recorded by `EXP-0073`, and the
+  empty first-create framing in `EXP-0087` and `EXP-0093`. The 2,048-byte
+  definition-root capacity, 2,040-byte
   continuation contribution, 18-byte physical-column records, and one-byte
   name length followed by CP1252 bytes yield exact no-index logical lengths
   `45 + 29n` for the fixed ten-byte names below. Earlier boundary placement is
@@ -8426,24 +8427,32 @@ Use `not applicable` explicitly rather than omitting a field.
   It widens only the shared decoder's per-process work bound from 64 to 140
   columns; the admitted byte grammar is unchanged. It decodes every definition
   page and pointer, requires the controls' exact zero/one/two continuation
-  counts, records each page's logical interval/capacity/used bytes, identifies
+  counts and exact logical lengths, records each page's logical
+  interval/capacity/used bytes, identifies
   the catalog object ID with the definition root, records table maps and the
-  page-0 counter before/after/delta, and requires a recorded role and owner for
-  every appended page. Nonconsecutive continuation placement is accepted when
+  complete set of changed page-0 offsets plus counter before/after/delta, and
+  requires a recorded role and owner for every appended page. Nonconsecutive
+  continuation placement is accepted when
   the complete chain and all page roles correlate. Because a wide catalog
   `LvProp` may itself change storage class, analysis preserves its raw 12-byte
   header, classifies only the `EXP-0061` inline/single/chained flag, and for an
-  external value validates the bounded locator chain, exact declared payload
-  length, terminal pointer, active attributed `LVAL` rows, and total appended
-  `LVAL` inventory; it does not preregister a single-page property assumption.
+  external value validates exact 12-byte external framing, the bounded locator
+  chain, exact declared payload length, terminal pointer, and active attributed
+  `LVAL` rows. For every storage class, analysis records all attributed
+  appended `LVAL` pages and distinguishes the subset referenced by the catalog
+  property from unreferenced nuisance allocation. Null and consistently framed
+  inline values are also admitted. The experiment does not preregister a
+  single-page property assumption or require every appended `LVAL` page to be
+  referenced.
 - Questions:
   - Counts: do exact logical lengths 2,046, 2,075, and 4,105 carry zero, one,
     and two continuation pages?
   - Placement: where do the root and continuation pages land relative to the
     empty boundary, what pointer order and logical chunks do they carry, and
     what role and owner accounts for every appended page?
-  - Counters: what page-0 counter values and deltas accompany each bounded
-    create and catalog object ID, without assigning an unrecorded semantic?
+  - Counters: what complete changed-offset set and page-0 counter values and
+    deltas accompany each bounded create and catalog object ID, without
+    assigning an unrecorded semantic?
   - Replication: do all complete relative observations agree across replicas?
 - Decision rule: an `accepted` report requires final exact plan and input pins,
   three complete replicas, exact four-checkpoint inventories, pre-mutation arm
@@ -8451,22 +8460,24 @@ Use `not applicable` explicitly rather than omitting a field.
   with the required continuation counts, total appended-page attribution,
   counter/catalog-root observations, and identical complete relative
   observations. A fully decoded nonconsecutive layout is answered evidence.
-  Changed bytes, schema or replica disagreement, an unexpected continuation
-  count, incomplete decoding or page attribution, ambiguous correlation, or a
-  post-mutation producer failure is `no_outcome`. A stable same-arm DAO refusal
-  may be recorded only as a bounded rejection when all retained prior and
-  active-arm bytes fully correlate; it cannot answer an unattempted later arm.
+  Changed metadata bytes, schema or replica disagreement, an unexpected
+  logical length or continuation count, incomplete decoding or page
+  attribution, ambiguous correlation, or any post-mutation producer failure is
+  `no_outcome`.
   A pre-mutation failure, pin/inventory/bound violation, inconsistent producer
   state, or result-contract defect rejects validation without a scientific
   answer. No retry is permitted after the first DAO mutation without a renewed
   explicit human decision.
-- Preregistration artifacts: draft plan
-  `oracle/windows-dao/acquisition/definition-continuation.plan.json`; producer
-  `oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1`; analyzer
-  `oracle/windows-dao/scripts/definition_continuation.py`; shared host, guest,
-  dispatch, publication, focused contract-test, recipe, and documentation
-  changes. All eight plan input hashes and the plan hash remain deliberate
-  64-zero placeholders in this draft and convey no acquisition authority.
+- Preregistration artifacts: plan
+  `oracle/windows-dao/acquisition/definition-continuation.plan.json`, SHA-256
+  `9acd16d15c911f6552347271ab55827c7936ba829e3d10f190d6b9fe1a4d86e1`;
+  producer `oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1`,
+  SHA-256
+  `7e812dec1b76c801d6e307e503f43a6d11c34e2e71195aad7ba8386f5223ed5e`;
+  analyzer `oracle/windows-dao/scripts/definition_continuation.py`, SHA-256
+  `240259fe0d8d93087d0f36255e7ef8d47fc3940a70ea03bdb178ce9311a72fd6`.
+  The plan pins those files and the five shared host/guest/publication inputs
+  plus the shared catalog decoder by their exact SHA-256 identities.
 - Interpretation: a later accepted result may establish continuation count,
   placement, pointer order, page roles, and counter observations only for these
   exact empty first-create fixed-Long schemas through 140 fields and two
@@ -8476,15 +8487,19 @@ Use `not applicable` explicitly rather than omitting a field.
   extended names, public creation, initial rows, relationships, filesystem
   publication, writer correctness, general Jet 3 or DAO compatibility, hosted
   differential #102, or support-matrix movement.
-- Usage: future result for issue `#151`; `EXP-0059`; `EXP-0073`; `EXP-0087`;
-  `EXP-0093`; `file:oracle/windows-dao/acquisition/definition-continuation.plan.json`;
+- Usage: future result for issue `#151`; `EXP-0059`; `EXP-0061`; `EXP-0073`;
+  `EXP-0087`; `EXP-0091`; `EXP-0093`;
+  `file:oracle/windows-dao/acquisition/definition-continuation.plan.json`;
   `file:oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1`;
   `file:oracle/windows-dao/scripts/definition_continuation.py`
 - Rights: future project-generated MDBs and provider outputs remain outside
   the repository and are neither committed nor redistributed
-- Review: pending independent protocol, boundary-calculation, producer,
-  analyzer, routing, publication, failure-state, evidence-boundary, and
-  false-claim review before pins may be finalized
+- Review: three review/fix passes completed on 2026-09-02. Independent reviews
+  covered the protocol, boundary arithmetic, producer, analyzer, routing,
+  publication, failure state, evidence boundary, nuisance `LvProp` allocation,
+  and false-claim controls. The final pass reported no correctness or
+  scientific-protocol blocker; one low external-LVAL inventory test gap was
+  fixed before pinning.
 
 
 ## Fixtures and black-box results

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -8382,6 +8382,111 @@ Use `not applicable` explicitly rather than omitting a field.
   no findings.
 
 
+### EXP-0094 — Draft table-definition continuation placement preregistration
+
+- Recorded: 2026-09-02, OpenAI Codex
+- Kind: SHA-256-placeholder, development-only local DAO preregistration draft;
+  acquisition is forbidden until exact pins replace every placeholder, review
+  is complete, the result is committed and merged, and a human explicitly
+  authorizes one run
+- Question: across three replicas beginning from identity-checked copies of one
+  fresh empty Jet 3 database apiece, where does DAO place and how does it chain
+  exactly zero, one, and two table-definition continuation pages?
+- Origin: project-authored clean-room experiment for issue `#151`, using only
+  the bounded definition grammar recorded by `EXP-0059`, the catalog and page
+  correlation recorded by `EXP-0073`, and the empty first-create framing in
+  `EXP-0087` and `EXP-0093`. The 2,048-byte definition-root capacity, 2,040-byte
+  continuation contribution, 18-byte physical-column records, and one-byte
+  name length followed by CP1252 bytes yield exact no-index logical lengths
+  `45 + 29n` for the fixed ten-byte names below. Earlier boundary placement is
+  design input only; it does not establish the requested DAO placement.
+- Controlled design: every arm uses only fixed `dbLong` fields, no index, no
+  rows, and equal eight-byte ASCII table names. Every field name is ten ASCII
+  bytes at or below `0x7E`: `F000AAAAAA` through the arm's final ordinal. The
+  `zero` arm has 69 fields and logical length 2,046, two bytes below the root
+  capacity. The `one` arm has 70 fields and logical length 2,075, crossing that
+  capacity by 27 bytes. The `two` arm has 140 fields and logical length 4,105,
+  crossing the root plus one continuation capacity of 4,088 by 17 bytes. These
+  require zero, one, and two continuation contributions under the recorded
+  grammar without using an extended name byte or exceeding DAO's field count.
+- Protocol: each of three replicas creates and closes one fresh CP1252
+  `dbVersion30` database, retains it as `empty`, then copies and identity-checks
+  it into independent `zero`, `one`, and `two` working arms before mutation.
+  Each arm receives exactly one `TableDefs.Append` and is closed before copying
+  and bounded read-only DAO metadata capture. A passing run retains four MDBs
+  per replica, exactly twelve total. Every image is hashed and sized before and
+  after metadata access; every arm records its pre-mutation identity. The
+  producer records `mutation_started`, a bounded phase, an ordered checkpoint
+  prefix, and at most the active arm's recovery image, then stops that replica
+  after a failure. A pre-mutation failure may stop the run after replica one;
+  any post-mutation result must contain all three replica records.
+- Analysis: the analyzer validates the exact result shape, plan binding, file
+  type, name, inventory, size, digest, ordered checkpoint prefix, active-arm
+  recovery, phase, mutation state, DAO schema, and unchanged metadata identity.
+  It widens only the shared decoder's per-process work bound from 64 to 140
+  columns; the admitted byte grammar is unchanged. It decodes every definition
+  page and pointer, requires the controls' exact zero/one/two continuation
+  counts, records each page's logical interval/capacity/used bytes, identifies
+  the catalog object ID with the definition root, records table maps and the
+  page-0 counter before/after/delta, and requires a recorded role and owner for
+  every appended page. Nonconsecutive continuation placement is accepted when
+  the complete chain and all page roles correlate. Because a wide catalog
+  `LvProp` may itself change storage class, analysis preserves its raw 12-byte
+  header, classifies only the `EXP-0061` inline/single/chained flag, and for an
+  external value validates the bounded locator chain, exact declared payload
+  length, terminal pointer, active attributed `LVAL` rows, and total appended
+  `LVAL` inventory; it does not preregister a single-page property assumption.
+- Questions:
+  - Counts: do exact logical lengths 2,046, 2,075, and 4,105 carry zero, one,
+    and two continuation pages?
+  - Placement: where do the root and continuation pages land relative to the
+    empty boundary, what pointer order and logical chunks do they carry, and
+    what role and owner accounts for every appended page?
+  - Counters: what page-0 counter values and deltas accompany each bounded
+    create and catalog object ID, without assigning an unrecorded semantic?
+  - Replication: do all complete relative observations agree across replicas?
+- Decision rule: an `accepted` report requires final exact plan and input pins,
+  three complete replicas, exact four-checkpoint inventories, pre-mutation arm
+  identity, unchanged metadata bytes, exact DAO schemas, fully decoded chains
+  with the required continuation counts, total appended-page attribution,
+  counter/catalog-root observations, and identical complete relative
+  observations. A fully decoded nonconsecutive layout is answered evidence.
+  Changed bytes, schema or replica disagreement, an unexpected continuation
+  count, incomplete decoding or page attribution, ambiguous correlation, or a
+  post-mutation producer failure is `no_outcome`. A stable same-arm DAO refusal
+  may be recorded only as a bounded rejection when all retained prior and
+  active-arm bytes fully correlate; it cannot answer an unattempted later arm.
+  A pre-mutation failure, pin/inventory/bound violation, inconsistent producer
+  state, or result-contract defect rejects validation without a scientific
+  answer. No retry is permitted after the first DAO mutation without a renewed
+  explicit human decision.
+- Preregistration artifacts: draft plan
+  `oracle/windows-dao/acquisition/definition-continuation.plan.json`; producer
+  `oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1`; analyzer
+  `oracle/windows-dao/scripts/definition_continuation.py`; shared host, guest,
+  dispatch, publication, focused contract-test, recipe, and documentation
+  changes. All eight plan input hashes and the plan hash remain deliberate
+  64-zero placeholders in this draft and convey no acquisition authority.
+- Interpretation: a later accepted result may establish continuation count,
+  placement, pointer order, page roles, and counter observations only for these
+  exact empty first-create fixed-Long schemas through 140 fields and two
+  continuation pages. It cannot establish longer chains, other field types or
+  name lengths, indexed or populated wide definitions, long-value property
+  grammar, general allocation or free-page reuse, continuation writing,
+  extended names, public creation, initial rows, relationships, filesystem
+  publication, writer correctness, general Jet 3 or DAO compatibility, hosted
+  differential #102, or support-matrix movement.
+- Usage: future result for issue `#151`; `EXP-0059`; `EXP-0073`; `EXP-0087`;
+  `EXP-0093`; `file:oracle/windows-dao/acquisition/definition-continuation.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/definition_continuation.py`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: pending independent protocol, boundary-calculation, producer,
+  analyzer, routing, publication, failure-state, evidence-boundary, and
+  false-claim review before pins may be finalized
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -68,11 +68,11 @@ one-index order, which places the first root before `LvProp`.
 Two remaining format gaps each need their own preregistered DAO validation
 before the planner can widen: where a definition continuation page lands
 (#151), then catalog name keys for bytes above `0x7E` (#152). `EXP-0094`
-contains the SHA-placeholder #151 draft: three replicas cross the recorded
+contains the SHA-256-pinned #151 preregistration: three replicas cross the recorded
 definition capacities with exact 2,046-, 2,075-, and 4,105-byte first-create
 controls requiring zero, one, and two continuation pages. Acquisition remains
-forbidden until final pins replace every placeholder, independent review is
-complete, the result is merged, and a human explicitly authorizes one run. #150 is
+forbidden until the exact preregistration is merged and the standing human
+authorization remains in effect. #150 is
 evidence-complete. Its bounded implementation slice is unblocked but must
 correct the existing one-index page order while adding multiple physical and
 logical records, name-sorted logical order, and the observed primary, unique,

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -67,7 +67,12 @@ one-index order, which places the first root before `LvProp`.
 
 Two remaining format gaps each need their own preregistered DAO validation
 before the planner can widen: where a definition continuation page lands
-(#151), then catalog name keys for bytes above `0x7E` (#152). #150 is
+(#151), then catalog name keys for bytes above `0x7E` (#152). `EXP-0094`
+contains the SHA-placeholder #151 draft: three replicas cross the recorded
+definition capacities with exact 2,046-, 2,075-, and 4,105-byte first-create
+controls requiring zero, one, and two continuation pages. Acquisition remains
+forbidden until final pins replace every placeholder, independent review is
+complete, the result is merged, and a human explicitly authorizes one run. #150 is
 evidence-complete. Its bounded implementation slice is unblocked but must
 correct the existing one-index page order while adding multiple physical and
 logical records, name-sorted logical order, and the observed primary, unique,

--- a/justfile
+++ b/justfile
@@ -92,6 +92,10 @@ windows-dev-schema-generalization:
 windows-dev-multiple-indexes:
     "{{PYTHON}}" scripts/windows-dao-dev.py multiple-indexes --timeout 900
 
+# Run the preregistered table-definition continuation placement experiment.
+windows-dev-definition-continuation:
+    "{{PYTHON}}" scripts/windows-dao-dev.py definition-continuation --timeout 900
+
 # Run the preregistered null-LvProp acceptance experiment in the local VM.
 windows-dev-lvprop-null:
     "{{PYTHON}}" scripts/windows-dao-dev.py lvprop-null --timeout 900

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -141,3 +141,12 @@ DAO, and the host analyzer writes the canonical report after publication.
 Record the validated outcome once as an additive `EXP-` entry. A failure after
 the first DAO mutation is a scientific result and must not be retried without
 a human decision.
+
+The issue #151 `definition-continuation` draft local job uses one fresh empty
+base per replica and exact 69-, 70-, and 140-field first-create arms to bracket
+the 2,048-byte root capacity and cross the root-plus-continuation capacity by
+17 bytes. Its
+publisher retains an exact ordered prefix and at most the active arm's bounded
+recovery image; its analyzer requires complete chain, page-role, schema,
+identity, and replica correlation. The preregistration does not assume
+consecutive continuation placement or a single-page catalog `LvProp`.

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -142,7 +142,7 @@ Record the validated outcome once as an additive `EXP-` entry. A failure after
 the first DAO mutation is a scientific result and must not be retried without
 a human decision.
 
-The issue #151 `definition-continuation` draft local job uses one fresh empty
+The issue #151 `definition-continuation` SHA-256-pinned local job uses one fresh empty
 base per replica and exact 69-, 70-, and 140-field first-create arms to bracket
 the 2,048-byte root capacity and cross the root-plus-continuation capacity by
 17 bytes. Its

--- a/oracle/windows-dao/acquisition/definition-continuation.plan.json
+++ b/oracle/windows-dao/acquisition/definition-continuation.plan.json
@@ -6,19 +6,19 @@
   "purpose": "Observe the placement and chaining of exactly zero, one, and two Jet 3 table-definition continuation pages under bounded empty first-create controls.",
   "preregistration": {
     "acquisition_started": false,
-    "prior_evidence": "EXP-0059 records the bounded 18-byte physical-column record, one-byte CP1252 column-name length and bytes, definition logical-length field, 2,048-byte root capacity, and 2,040-byte continuation contribution. EXP-0073 records the bounded catalog, page-role, usage-map, and continuation-chain decoder. EXP-0087 and EXP-0093 record empty first-create framing and page roles for definitions that fit one page. The exact earlier boundary placement is design input only and does not establish where DAO places continuation pages in these controls.",
-    "authorization": "This SHA-placeholder draft does not authorize acquisition. After every placeholder is replaced by the exact merged input identity and the complete plan is independently reviewed and merged, one local-VM run requires explicit human authorization.",
+    "prior_evidence": "EXP-0059 records the bounded 18-byte physical-column record, one-byte CP1252 column-name length and bytes, definition logical-length field, 2,048-byte root capacity, and 2,040-byte continuation contribution. EXP-0061 records the bounded inline, single-page, and chained long-value framing used only to account for a created catalog LvProp value; EXP-0091 records null as a bounded consumable LvProp form. EXP-0073 records the bounded catalog, page-role, usage-map, and continuation-chain decoder. EXP-0087 and EXP-0093 record empty first-create framing and page roles for definitions that fit one page. The exact earlier boundary placement is design input only and does not establish where DAO places continuation pages in these controls.",
+    "authorization": "This SHA-256-pinned plan does not itself authorize acquisition. One local-VM run is allowed only after the exact preregistration is independently reviewed, committed, and merged and the user's explicit standing authorization to run experiments remains in effect.",
     "attempt_policy": "Dispatch at most one three-replica run after explicit authorization. Once the first DAO CreateDatabase mutation begins, any failure is a scientific result and must not be retried without another explicit human decision. A replica stops immediately after its first post-mutation failure."
   },
   "inputs": {
-    "scripts/windows-dao-dev.py": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/probe-provider.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/definition_continuation.py": "0000000000000000000000000000000000000000000000000000000000000000",
-    "oracle/windows-dao/scripts/system_catalog.py": "0000000000000000000000000000000000000000000000000000000000000000"
+    "scripts/windows-dao-dev.py": "c81b558f0c8f2b3aa9b18c07b9a7db687b7ab0ef42bfc0e4d03ff539dc4e3566",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "4aa8cae8ab11cd622ca6cab0320188f6bdcb4791c88138fd4ab38db946429d32",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "9c57d56428ac62d611b317e1c0572d8171623d846e49b9ac39769fe1ff5e45f6",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "87676d1fa18c7e74ae84cc31103500d5942f018df51f237b1ebb7d6e8d03b0a7",
+    "oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1": "7e812dec1b76c801d6e307e503f43a6d11c34e2e71195aad7ba8386f5223ed5e",
+    "oracle/windows-dao/scripts/definition_continuation.py": "240259fe0d8d93087d0f36255e7ef8d47fc3940a70ea03bdb178ce9311a72fd6",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9"
   },
   "execution": {
     "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
@@ -36,7 +36,7 @@
       "one": "ContOneX has 70 otherwise identical fields F000AAAAAA through F069AAAAAA. The recorded grammar gives a 2,075-byte logical definition, requiring one continuation contribution.",
       "two": "ContTwoX has 140 otherwise identical fields F000AAAAAA through F139AAAAAA. The recorded grammar gives a 4,105-byte logical definition, exceeding the root plus one 2,040-byte continuation contribution by 17 bytes and requiring a second continuation contribution."
     },
-    "capture": "Record and validate every arm's pre-mutation size and SHA-256 against its replica's retained empty image. A passing producer retains exactly twelve closed MDB checkpoints with sizes and SHA-256 values before and after bounded read-only DAO TableDefs metadata access. Capture the exact DAO table and field inventory, mutation_started, the bounded producer phase, and at most the active arm's recovery image on failure. Recovery bytes receive no DAO metadata access and remain unobserved unless the analyzer can fully decode and attribute them under the recorded grammars.",
+    "capture": "Record and validate every arm's pre-mutation size and SHA-256 against its replica's retained empty image. A passing producer retains exactly twelve closed MDB checkpoints with sizes and SHA-256 values before and after bounded read-only DAO TableDefs metadata access. Capture the exact DAO table and field inventory, mutation_started, the bounded producer phase, and at most the active arm's recovery image on failure. Recovery bytes receive no DAO metadata access and are not interpreted. For each completed arm, preserve all attributed appended LVAL pages and distinguish those referenced by the catalog LvProp from attributed but unreferenced nuisance allocation.",
     "bounds": {
       "maximum_replicas": 3,
       "maximum_checkpoints_per_replica": 4,
@@ -54,12 +54,12 @@
     "continuation_counts": "Do the 2,046-, 2,075-, and 4,105-byte definitions decode to exactly zero, one, and two continuation pages, respectively?",
     "placement": "For each arm, where do the definition root and continuation pages land relative to the empty boundary; how does each chain pointer order them; what logical interval and used byte count does each page carry; and what recorded role and owner accounts for every appended page? No consecutive or relative page order is presumed.",
     "counters": "What are the bounded page-0 counter values before and after each create, and how do their deltas correlate with the appended page count and catalog object identifier without assigning an unrecorded semantic?",
-    "producer_outcome": "Did each exact arm complete, or did all three replicas produce the same fully correlated DAO rejection at the active append?",
+    "producer_outcome": "Did all three replicas complete every exact arm?",
     "replication": "Do the complete decoded relative observations agree across all three replicas?"
   },
   "decision_rule": {
-    "accepted": "The plan and all executed inputs match their final SHA-256 pins; all three replicas complete the exact four-checkpoint inventory once; every arm begins byte-identical to its retained empty image; DAO metadata matches the exact declared schema; all retained bytes remain unchanged by metadata access; each definition and chain decodes completely with the required zero, one, or two continuation pages; every appended page is attributed; counter and catalog-root observations are present; and complete relative observations agree across replicas. A fully decoded nonconsecutive placement is an answered result. A stable DAO refusal of an exact arm may be reported as a bounded answered rejection only if all three replicas stop at the same arm and the retained active-arm bytes and prior checkpoints fully correlate; it does not answer any later unattempted arm.",
-    "no_outcome": "A post-mutation producer failure that is not the fully correlated stable rejection above, changed metadata identity, schema disagreement, decode or chain failure, unexpected continuation count, unattributed page, ambiguous counter/catalog correlation, incomplete later arm, or replica disagreement is recorded as no_outcome.",
+    "accepted": "The plan and all executed inputs match their final SHA-256 pins; all three replicas complete the exact four-checkpoint inventory once; every arm begins byte-identical to its retained empty image; DAO metadata matches the exact declared schema; all retained bytes remain unchanged by metadata access; each definition has its exact preregistered logical length and decodes completely with the required zero, one, or two continuation pages; every appended page is attributed; the complete page-0 changed-offset set, counter, and catalog-root observations are present; and complete relative observations agree across replicas. A fully decoded nonconsecutive placement is an answered result.",
+    "no_outcome": "Any post-mutation producer failure, changed metadata identity, schema disagreement, decode or chain failure, unexpected logical length or continuation count, unattributed page, ambiguous counter/catalog correlation, incomplete later arm, or replica disagreement is recorded as no_outcome.",
     "rejected": "A pre-mutation plan, input, provider, or infrastructure failure; pin mismatch; malformed result; inconsistent mutation/phase/checkpoint/recovery state; unexpected, reordered, duplicate, missing, symlinked, oversized, or extra artifact; bound violation; or analyzer contract defect rejects validation without a scientific outcome.",
     "retry": "There is no automatic retry after the first DAO mutation."
   },
@@ -78,7 +78,7 @@
     "definition chains longer than two continuation pages or tables above 140 columns",
     "variable, Boolean, long-value, indexed, relationship, saved-query, or populated table definitions",
     "general allocation policy, free-page reuse, or a presumption that continuation pages are consecutive",
-    "catalog LvProp payload grammar or a presumption that its storage remains single-page; only its raw header/reference and attributed LVAL roles may be preserved",
+    "catalog LvProp payload grammar, a presumption that its storage remains single-page, or a claim that every attributed appended LVAL page must be referenced; only its raw header/reference and referenced versus unreferenced LVAL inventory may be preserved",
     "names above ASCII 0x7E, names of other lengths, and locale or collation behavior",
     "public creation API, initial rows, filesystem publication, writer correctness, hosted differential #102, compatibility claims, and support-matrix movement"
   ]

--- a/oracle/windows-dao/acquisition/definition-continuation.plan.json
+++ b/oracle/windows-dao/acquisition/definition-continuation.plan.json
@@ -1,0 +1,85 @@
+{
+  "document_type": "dao_definition_continuation_plan",
+  "experiment_id": "definition-continuation",
+  "issue": 151,
+  "development_only": true,
+  "purpose": "Observe the placement and chaining of exactly zero, one, and two Jet 3 table-definition continuation pages under bounded empty first-create controls.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0059 records the bounded 18-byte physical-column record, one-byte CP1252 column-name length and bytes, definition logical-length field, 2,048-byte root capacity, and 2,040-byte continuation contribution. EXP-0073 records the bounded catalog, page-role, usage-map, and continuation-chain decoder. EXP-0087 and EXP-0093 record empty first-create framing and page roles for definitions that fit one page. The exact earlier boundary placement is design input only and does not establish where DAO places continuation pages in these controls.",
+    "authorization": "This SHA-placeholder draft does not authorize acquisition. After every placeholder is replaced by the exact merged input identity and the complete plan is independently reviewed and merged, one local-VM run requires explicit human authorization.",
+    "attempt_policy": "Dispatch at most one three-replica run after explicit authorization. Once the first DAO CreateDatabase mutation begins, any failure is a scientific result and must not be retried without another explicit human decision. A replica stops immediately after its first post-mutation failure."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/definition_continuation.py": "0000000000000000000000000000000000000000000000000000000000000000",
+    "oracle/windows-dao/scripts/system_catalog.py": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "independence": "Each replica creates and closes one fresh dbVersion30 CP1252 database, retains it as empty, then copies and identity-checks it into three working arms before any TableDefs mutation. Each arm receives exactly one table append and is closed before metadata capture. No rows or indexes are added.",
+    "checkpoints": [
+      "empty",
+      "zero",
+      "one",
+      "two"
+    ],
+    "scenarios": {
+      "zero": "ContZero has 69 fixed dbLong fields with exact ten-byte ASCII names F000AAAAAA through F068AAAAAA. The recorded grammar gives a 2,046-byte logical definition, fitting the root with zero continuations.",
+      "one": "ContOneX has 70 otherwise identical fields F000AAAAAA through F069AAAAAA. The recorded grammar gives a 2,075-byte logical definition, requiring one continuation contribution.",
+      "two": "ContTwoX has 140 otherwise identical fields F000AAAAAA through F139AAAAAA. The recorded grammar gives a 4,105-byte logical definition, exceeding the root plus one 2,040-byte continuation contribution by 17 bytes and requiring a second continuation contribution."
+    },
+    "capture": "Record and validate every arm's pre-mutation size and SHA-256 against its replica's retained empty image. A passing producer retains exactly twelve closed MDB checkpoints with sizes and SHA-256 values before and after bounded read-only DAO TableDefs metadata access. Capture the exact DAO table and field inventory, mutation_started, the bounded producer phase, and at most the active arm's recovery image on failure. Recovery bytes receive no DAO metadata access and remain unobserved unless the analyzer can fully decode and attribute them under the recorded grammars.",
+    "bounds": {
+      "maximum_replicas": 3,
+      "maximum_checkpoints_per_replica": 4,
+      "maximum_recovery_databases_per_replica": 1,
+      "maximum_published_databases": 12,
+      "maximum_pages_per_database": 64,
+      "maximum_table_definitions": 16,
+      "maximum_fields_per_table": 140,
+      "maximum_field_name_bytes": 10,
+      "maximum_detail_characters": 512,
+      "maximum_job_json_bytes": 4194304
+    }
+  },
+  "questions": {
+    "continuation_counts": "Do the 2,046-, 2,075-, and 4,105-byte definitions decode to exactly zero, one, and two continuation pages, respectively?",
+    "placement": "For each arm, where do the definition root and continuation pages land relative to the empty boundary; how does each chain pointer order them; what logical interval and used byte count does each page carry; and what recorded role and owner accounts for every appended page? No consecutive or relative page order is presumed.",
+    "counters": "What are the bounded page-0 counter values before and after each create, and how do their deltas correlate with the appended page count and catalog object identifier without assigning an unrecorded semantic?",
+    "producer_outcome": "Did each exact arm complete, or did all three replicas produce the same fully correlated DAO rejection at the active append?",
+    "replication": "Do the complete decoded relative observations agree across all three replicas?"
+  },
+  "decision_rule": {
+    "accepted": "The plan and all executed inputs match their final SHA-256 pins; all three replicas complete the exact four-checkpoint inventory once; every arm begins byte-identical to its retained empty image; DAO metadata matches the exact declared schema; all retained bytes remain unchanged by metadata access; each definition and chain decodes completely with the required zero, one, or two continuation pages; every appended page is attributed; counter and catalog-root observations are present; and complete relative observations agree across replicas. A fully decoded nonconsecutive placement is an answered result. A stable DAO refusal of an exact arm may be reported as a bounded answered rejection only if all three replicas stop at the same arm and the retained active-arm bytes and prior checkpoints fully correlate; it does not answer any later unattempted arm.",
+    "no_outcome": "A post-mutation producer failure that is not the fully correlated stable rejection above, changed metadata identity, schema disagreement, decode or chain failure, unexpected continuation count, unattributed page, ambiguous counter/catalog correlation, incomplete later arm, or replica disagreement is recorded as no_outcome.",
+    "rejected": "A pre-mutation plan, input, provider, or infrastructure failure; pin mismatch; malformed result; inconsistent mutation/phase/checkpoint/recovery state; unexpected, reordered, duplicate, missing, symlinked, oversized, or extra artifact; bound violation; or analyzer contract defect rejects validation without a scientific outcome.",
+    "retry": "There is no automatic retry after the first DAO mutation."
+  },
+  "retention": {
+    "publish": "environment.json, result.json, the bounded job result, up to twelve exact expected-name MDBs including at most one explicitly identified active-arm recovery artifact per failed replica (exactly twelve for a passing job), and the deterministic analyzer report.",
+    "repository": "Never commit MDB bytes or provider binaries. Record a validated report identity and conclusion once as a later additive EXP outcome."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one later additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "definition chains longer than two continuation pages or tables above 140 columns",
+    "variable, Boolean, long-value, indexed, relationship, saved-query, or populated table definitions",
+    "general allocation policy, free-page reuse, or a presumption that continuation pages are consecutive",
+    "catalog LvProp payload grammar or a presumption that its storage remains single-page; only its raw header/reference and attributed LVAL roles may be preserved",
+    "names above ASCII 0x7E, names of other lengths, and locale or collation behavior",
+    "public creation API, initial rows, filesystem publication, writer correctness, hosted differential #102, compatibility claims, and support-matrix movement"
+  ]
+}

--- a/oracle/windows-dao/scripts/definition_continuation.py
+++ b/oracle/windows-dao/scripts/definition_continuation.py
@@ -25,6 +25,7 @@ REPORT_TYPE = "definition_continuation_report"
 CHECKPOINTS = ("empty", "zero", "one", "two")
 SCENARIOS = CHECKPOINTS[1:]
 EXPECTED_CONTINUATIONS = {"zero": 0, "one": 1, "two": 2}
+EXPECTED_LOGICAL_LENGTHS = {"zero": 2046, "one": 2075, "two": 4105}
 FIELD_COUNTS = {"zero": 69, "one": 70, "two": 140}
 TABLE_NAMES = {"zero": "ContZero", "one": "ContOneX", "two": "ContTwoX"}
 SAFE_RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")
@@ -219,10 +220,29 @@ def created_lvprop(
     lvprop_ordinal = catalog._ordinal(definition, "LvProp")
     if name_ordinal is None or lvprop_ordinal is None:
         raise DecodeError("catalog lacks a Name or LvProp column")
-    matches = [row for row in rows if row["values"][name_ordinal] == table_name]
+    required = max(name_ordinal, lvprop_ordinal)
+    matches = [
+        row
+        for row in rows
+        if len(row.get("values", [])) > required
+        and row["values"][name_ordinal] == table_name
+    ]
     if len(matches) != 1:
         raise DecodeError(f"catalog contains {len(matches)} rows for {table_name}")
     value = matches[0]["values"][lvprop_ordinal]
+    roles = {entry["page"]: entry for entry in analysis["pages"]}
+    appended_lval = {
+        page
+        for page, role in roles.items()
+        if page >= before_pages and role["role"] == "long_value"
+    }
+    lval_inventory = {
+        "appended_lval_pages": sorted(appended_lval),
+        "referenced_appended_lval_pages": [],
+        "unreferenced_appended_lval_pages": sorted(appended_lval),
+    }
+    if value is None:
+        return {"storage": "null", **lval_inventory}
     if not isinstance(value, dict) or set(value) != {
         "inline_length",
         "long_value_header_hex",
@@ -245,14 +265,20 @@ def created_lvprop(
         "inline_length": value["inline_length"],
         "storage": storage,
     }
+    if observation["declared_length"] == 0:
+        raise DecodeError(f"{table_name}.LvProp has an empty non-null payload")
     if storage == "inline":
         if header[4:12] != bytes(8):
             raise DecodeError(f"{table_name}.LvProp inline header has nonzero reserved bytes")
+        if value["inline_length"] != 12 + observation["declared_length"]:
+            raise DecodeError(f"{table_name}.LvProp inline framing is inconsistent")
         observation["first_locator"] = None
+        observation.update(lval_inventory)
         return observation
+    if value["inline_length"] != 12:
+        raise DecodeError(f"{table_name}.LvProp external framing is not 12 bytes")
     if header[8:12] != bytes(4):
         raise DecodeError(f"{table_name}.LvProp external header has nonzero reserved bytes")
-    roles = {entry["page"]: entry for entry in analysis["pages"]}
     locator = {"row": header[4], "page": int.from_bytes(header[5:8], "little")}
     seen: set[tuple[int, int]] = set()
     locators = []
@@ -296,16 +322,19 @@ def created_lvprop(
         locator = {"row": following[0], "page": int.from_bytes(following[1:4], "little")}
     if len(payload) != observation["declared_length"]:
         raise DecodeError(f"{table_name}.LvProp chain length differs from its header")
-    appended_lval = {
-        page
-        for page, role in roles.items()
-        if page >= before_pages and role["role"] == "long_value"
+    referenced_appended = {
+        entry["page"] for entry in locators if entry["appended"]
     }
-    if appended_lval != {entry["page"] for entry in locators if entry["appended"]}:
-        raise DecodeError(f"{table_name}.LvProp does not account for every appended LVAL page")
     observation["first_locator"] = locators[0]
     observation["locators"] = locators
     observation["payload_sha256"] = hashlib.sha256(payload).hexdigest()
+    observation.update(
+        {
+            "appended_lval_pages": sorted(appended_lval),
+            "referenced_appended_lval_pages": sorted(referenced_appended),
+            "unreferenced_appended_lval_pages": sorted(appended_lval - referenced_appended),
+        }
+    )
     return observation
 
 
@@ -347,6 +376,10 @@ def analyze_scenario(before: bytes, after: bytes, scenario: str) -> dict[str, An
         raise DecodeError(f"{scenario} empty baseline decodes a user table")
     table = decoded_user_table(after_analysis, scenario)
     definition = table["definition"]
+    if definition["logical_length"] != EXPECTED_LOGICAL_LENGTHS[scenario]:
+        raise DecodeError(
+            f"{scenario} logical definition length differs from the boundary control"
+        )
     expected_names = [field_name(value) for value in range(FIELD_COUNTS[scenario])]
     columns = definition["columns"]
     if (
@@ -415,52 +448,18 @@ def analyze_scenario(before: bytes, after: bytes, scenario: str) -> dict[str, An
         "definition_root": definition["root"],
         "logical_length": definition["logical_length"],
         "lvprop": lvprop,
-        "page0_counter": {
+        "page_zero": {
             "after": after[catalog.PAGE0_COUNTER],
             "before": before[catalog.PAGE0_COUNTER],
+            "changed_offsets": [
+                offset
+                for offset in range(PAGE_BYTES)
+                if before[offset] != after[offset]
+            ],
             "delta": after[catalog.PAGE0_COUNTER] - before[catalog.PAGE0_COUNTER],
         },
         "page_count": {"after": after_pages, "before": before_pages},
         "table_maps": table_maps,
-    }
-
-
-def analyze_rejected_arm(before: bytes, after: bytes, scenario: str) -> dict[str, Any]:
-    before_analysis = catalog.analyze_checkpoint(before)
-    after_analysis = catalog.analyze_checkpoint(after)
-    if any(
-        not entry["flags"] & catalog.SYSTEM_FLAG
-        for entry in before_analysis["tables"].values()
-    ):
-        raise DecodeError("rejection baseline contains a user table")
-    users = [
-        entry
-        for entry in after_analysis["tables"].values()
-        if not entry["flags"] & catalog.SYSTEM_FLAG
-    ]
-    if users:
-        raise DecodeError("active-arm recovery contains a persisted user table")
-    before_pages = len(before) // PAGE_BYTES
-    after_pages = len(after) // PAGE_BYTES
-    roles = {entry["page"]: entry for entry in after_analysis["pages"]}
-    appended = []
-    for page in range(before_pages, after_pages):
-        role = roles.get(page)
-        if role is None or role["role"] == "unassigned":
-            raise DecodeError("rejected active arm has an unattributed appended page")
-        appended.append(
-            {"owners": role["owners"], "page": page, "role": role["role"]}
-        )
-    return {
-        "appended_pages": appended,
-        "page0_counter": {
-            "after": after[catalog.PAGE0_COUNTER],
-            "before": before[catalog.PAGE0_COUNTER],
-            "delta": after[catalog.PAGE0_COUNTER] - before[catalog.PAGE0_COUNTER],
-        },
-        "page_count": {"after": after_pages, "before": before_pages},
-        "scenario": scenario,
-        "user_table_persisted": False,
     }
 
 
@@ -480,22 +479,6 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
         elif any(entry.get("decode_error") for entry in replicas):
             reason = "at least one complete checkpoint failed a recorded grammar or control"
         questions = {name: {"reason": reason, "status": "no_outcome"} for name in question_names}
-        rejected = [entry.get("bounded_rejection") for entry in replicas]
-        phases = {entry["phase"] for entry in replicas}
-        errors = {entry["error"] for entry in replicas}
-        if (
-            len(replicas) == 3
-            and len(phases) == 1
-            and len(errors) == 1
-            and next(iter(phases)).startswith("append_")
-            and all(value is not None and value == rejected[0] for value in rejected)
-        ):
-            questions["producer_outcome"] = {
-                "kind": "bounded_dao_rejection",
-                "observation": rejected[0],
-                "replicas": 3,
-                "status": "answered",
-            }
     else:
         observations = [entry["observations"] for entry in complete]
         if any(value != observations[0] for value in observations[1:]):
@@ -537,7 +520,7 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
                 },
                 "counters": {
                     "scenarios": {
-                        name: value[name]["page0_counter"] for name in SCENARIOS
+                        name: value[name]["page_zero"] for name in SCENARIOS
                     },
                     "status": "answered",
                 },
@@ -554,7 +537,7 @@ def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> di
             {
                 key: value
                 for key, value in entry.items()
-                if key not in {"observations", "bounded_rejection"}
+                if key != "observations"
             }
             for entry in replicas
         ],
@@ -651,7 +634,6 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
         if not isinstance(recovery, list) or len(recovery) > 1:
             raise AnalysisError("replica recovery inventory violates the bound")
         checkpoint_names = set(images)
-        recovery_bytes = None
         for raw_recovery in recovery:
             value = exact(
                 raw_recovery,
@@ -683,7 +665,6 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
                 value["sha256"], "recovery digest"
             ):
                 raise AnalysisError("recovery artifact bytes differ from metadata")
-            recovery_bytes = raw
             referenced.append(filename)
         files = [
             {
@@ -769,17 +750,6 @@ def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[
                 raise AnalysisError("failed replica phase requires a started DAO mutation")
             if not item["mutation_started"] and recovery:
                 raise AnalysisError("pre-mutation failure cannot retain a recovery artifact")
-            if (
-                phase.startswith("append_")
-                and recovery_bytes is not None
-                and "empty" in images
-            ):
-                try:
-                    entry["bounded_rejection"] = analyze_rejected_arm(
-                        images["empty"], recovery_bytes, phase.removeprefix("append_")
-                    )
-                except (catalog.DecodeError, DecodeError) as error:
-                    entry["recovery_decode_error"] = str(error)
         replicas.append(entry)
     if not any(entry["mutation_started"] for entry in replicas):
         raise AnalysisError("acquisition did not reach the first DAO mutation")

--- a/oracle/windows-dao/scripts/definition_continuation.py
+++ b/oracle/windows-dao/scripts/definition_continuation.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python3
+"""Validate the bounded table-definition continuation experiment for issue #151."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import system_catalog as catalog
+
+
+PAGE_BYTES = 2048
+MAX_JSON_BYTES = 4 * 1024 * 1024
+MAX_PAGES = 64
+MAX_TABLES = 16
+MAX_FIELDS = 140
+MAX_TEXT = 512
+DOCUMENT_TYPE = "dao_definition_continuation_job_result"
+REPORT_TYPE = "definition_continuation_report"
+CHECKPOINTS = ("empty", "zero", "one", "two")
+SCENARIOS = CHECKPOINTS[1:]
+EXPECTED_CONTINUATIONS = {"zero": 0, "one": 1, "two": 2}
+FIELD_COUNTS = {"zero": 69, "one": 70, "two": 140}
+TABLE_NAMES = {"zero": "ContZero", "one": "ContOneX", "two": "ContTwoX"}
+SAFE_RUN_ID = re.compile(r"^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")
+SAFE_MDB = re.compile(r"^definition-continuation-r[1-3]-(empty|zero|one|two)[.]mdb$")
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+
+# The shared decoder's default is the earlier experiment's 64-column work bound.
+# This process widens only that work bound; the decoded grammar is unchanged.
+catalog.MAX_COLUMNS = MAX_FIELDS
+
+
+class AnalysisError(ValueError):
+    """The result or retained inventory violates the preregistered contract."""
+
+
+class DecodeError(ValueError):
+    """A complete observation does not satisfy a recorded grammar or control."""
+
+
+def canonical_bytes(document: Any) -> bytes:
+    return (
+        json.dumps(
+            document,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
+        + b"\n"
+    )
+
+
+def no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AnalysisError(f"duplicate JSON field {key!r}")
+        result[key] = value
+    return result
+
+
+def exact(value: Any, keys: set[str], where: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise AnalysisError(f"{where} must contain exactly {sorted(keys)}")
+    return value
+
+
+def integer(value: Any, where: str, low: int, high: int) -> int:
+    if type(value) is not int or not low <= value <= high:
+        raise AnalysisError(f"{where} must be an integer in [{low},{high}]")
+    return value
+
+
+def text(value: Any, where: str, maximum: int = MAX_TEXT) -> str:
+    if not isinstance(value, str) or len(value) > maximum:
+        raise AnalysisError(f"{where} must be a string of at most {maximum} characters")
+    return value
+
+
+def digest(value: Any, where: str) -> str:
+    if not isinstance(value, str) or not HEX_64.fullmatch(value):
+        raise AnalysisError(f"{where} must be a lowercase SHA-256 digest")
+    return value
+
+
+def load(path: Path) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise AnalysisError("job result must be a regular non-link file")
+    raw = path.read_bytes()
+    if len(raw) > MAX_JSON_BYTES:
+        raise AnalysisError("job result exceeds the JSON bound")
+    try:
+        value = json.loads(raw, object_pairs_hook=no_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AnalysisError("job result is not valid UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise AnalysisError("job result root must be an object")
+    return value
+
+
+def field_name(ordinal: int) -> str:
+    return f"F{ordinal:03d}AAAAAA"
+
+
+def validate_dao(value: Any, where: str) -> dict[str, Any]:
+    item = exact(value, {"tabledefs"}, where)
+    tables = item["tabledefs"]
+    if not isinstance(tables, list) or len(tables) > MAX_TABLES:
+        raise AnalysisError(f"{where}.tabledefs violates the bound")
+    for table_position, raw_table in enumerate(tables):
+        table = exact(raw_table, {"ordinal", "name", "fields"}, "DAO table")
+        if integer(table["ordinal"], "DAO table ordinal", 0, MAX_TABLES - 1) != table_position:
+            raise AnalysisError("DAO table ordinals must be sequential")
+        text(table["name"], "DAO table name", 256)
+        fields = table["fields"]
+        if not isinstance(fields, list) or len(fields) > MAX_FIELDS:
+            raise AnalysisError("DAO fields violate the bound")
+        for field_position, raw_field in enumerate(fields):
+            field = exact(raw_field, {"ordinal", "name", "type", "size"}, "DAO field")
+            if integer(field["ordinal"], "DAO field ordinal", 0, MAX_FIELDS - 1) != field_position:
+                raise AnalysisError("DAO field ordinals must be sequential")
+            text(field["name"], "DAO field name", 64)
+            integer(field["type"], "DAO field type", 0, 65535)
+            integer(field["size"], "DAO field size", 0, 1 << 20)
+    return item
+
+
+def read_checkpoint(
+    root: Path, value: Any, replica: int, name: str
+) -> tuple[bytes, bool, dict[str, Any], Any, dict[str, Any]]:
+    item = exact(
+        value,
+        {
+            "name",
+            "database",
+            "size",
+            "size_after_metadata",
+            "sha256",
+            "sha256_after_metadata",
+            "arm_before",
+            "dao",
+        },
+        f"replica {replica} checkpoint {name}",
+    )
+    if item["name"] != name:
+        raise AnalysisError(f"replica {replica} checkpoint order is invalid")
+    filename = item["database"]
+    expected = f"definition-continuation-r{replica}-{name}.mdb"
+    if filename != expected or not SAFE_MDB.fullmatch(filename):
+        raise AnalysisError(f"replica {replica} checkpoint filename is invalid")
+    size = integer(item["size"], "checkpoint size", PAGE_BYTES, MAX_PAGES * PAGE_BYTES)
+    size_after = integer(
+        item["size_after_metadata"],
+        "post-metadata checkpoint size",
+        PAGE_BYTES,
+        MAX_PAGES * PAGE_BYTES,
+    )
+    if size % PAGE_BYTES or size_after % PAGE_BYTES:
+        raise AnalysisError("checkpoint is not an exact sequence of pages")
+    before = digest(item["sha256"], "checkpoint digest")
+    after = digest(item["sha256_after_metadata"], "post-metadata digest")
+    path = root / filename
+    if not path.is_file() or path.is_symlink():
+        raise AnalysisError("checkpoint must be a regular non-link file")
+    raw = path.read_bytes()
+    if len(raw) != size_after or hashlib.sha256(raw).hexdigest() != after:
+        raise AnalysisError("checkpoint bytes differ from the recorded identity")
+    return (
+        raw,
+        size != size_after or before != after,
+        validate_dao(item["dao"], f"checkpoint {name}.dao"),
+        item["arm_before"],
+        {"sha256": before, "size": size},
+    )
+
+
+def user_tables(dao: dict[str, Any]) -> list[dict[str, Any]]:
+    return [entry for entry in dao["tabledefs"] if not entry["name"].startswith("MSys")]
+
+
+def expected_fields(scenario: str) -> list[dict[str, Any]]:
+    return [
+        {"ordinal": ordinal, "name": field_name(ordinal), "type": 4, "size": 4}
+        for ordinal in range(FIELD_COUNTS[scenario])
+    ]
+
+
+def validate_schema(scenario: str, dao: dict[str, Any]) -> None:
+    users = user_tables(dao)
+    if len(users) != 1 or users[0]["name"] != TABLE_NAMES[scenario]:
+        raise DecodeError(f"{scenario} DAO metadata lacks the exact user table")
+    if users[0]["fields"] != expected_fields(scenario):
+        raise DecodeError(f"{scenario} DAO fields differ from the preregistered schema")
+
+
+def decoded_user_table(analysis: dict[str, Any], scenario: str) -> dict[str, Any]:
+    users = [
+        entry
+        for entry in analysis["tables"].values()
+        if not entry["flags"] & catalog.SYSTEM_FLAG
+    ]
+    if len(users) != 1 or users[0]["name"] != TABLE_NAMES[scenario]:
+        raise DecodeError(f"{scenario} decoded tables lack the exact user table")
+    return users[0]
+
+
+def created_lvprop(
+    data: bytes, analysis: dict[str, Any], table_name: str, before_pages: int
+) -> dict[str, Any]:
+    definition, _, rows = catalog._discover_catalog(data)
+    name_ordinal = catalog._ordinal(definition, "Name")
+    lvprop_ordinal = catalog._ordinal(definition, "LvProp")
+    if name_ordinal is None or lvprop_ordinal is None:
+        raise DecodeError("catalog lacks a Name or LvProp column")
+    matches = [row for row in rows if row["values"][name_ordinal] == table_name]
+    if len(matches) != 1:
+        raise DecodeError(f"catalog contains {len(matches)} rows for {table_name}")
+    value = matches[0]["values"][lvprop_ordinal]
+    if not isinstance(value, dict) or set(value) != {
+        "inline_length",
+        "long_value_header_hex",
+    }:
+        raise DecodeError(f"{table_name}.LvProp does not expose a bounded raw header")
+    try:
+        header = bytes.fromhex(value["long_value_header_hex"])
+    except (TypeError, ValueError) as error:
+        raise DecodeError(f"{table_name}.LvProp header is not hex") from error
+    if len(header) != 12 or type(value["inline_length"]) is not int:
+        raise DecodeError(f"{table_name}.LvProp does not carry a 12-byte header")
+    control = int.from_bytes(header[:4], "little")
+    flag = control & 0xFF000000
+    storage = {0: "chained", 0x40000000: "single_page", 0x80000000: "inline"}.get(flag)
+    if storage is None:
+        raise DecodeError(f"{table_name}.LvProp storage flag is outside EXP-0061")
+    observation: dict[str, Any] = {
+        "declared_length": control & 0x00FFFFFF,
+        "header_hex": header.hex(),
+        "inline_length": value["inline_length"],
+        "storage": storage,
+    }
+    if storage == "inline":
+        if header[4:12] != bytes(8):
+            raise DecodeError(f"{table_name}.LvProp inline header has nonzero reserved bytes")
+        observation["first_locator"] = None
+        return observation
+    if header[8:12] != bytes(4):
+        raise DecodeError(f"{table_name}.LvProp external header has nonzero reserved bytes")
+    roles = {entry["page"]: entry for entry in analysis["pages"]}
+    locator = {"row": header[4], "page": int.from_bytes(header[5:8], "little")}
+    seen: set[tuple[int, int]] = set()
+    locators = []
+    payload = bytearray()
+    while True:
+        key = (locator["page"], locator["row"])
+        if key in seen or len(seen) >= MAX_PAGES:
+            raise DecodeError(f"{table_name}.LvProp chain repeats or exceeds the bound")
+        seen.add(key)
+        if locator["page"] >= len(data) // PAGE_BYTES:
+            raise DecodeError(f"{table_name}.LvProp locator is outside the image")
+        page = catalog._page(data, locator["page"], f"{table_name}.LvProp")
+        if page[0] != 1 or page[4:8] != b"LVAL":
+            raise DecodeError(f"{table_name}.LvProp locator does not target an LVAL page")
+        rows_on_page = catalog._row_directory(page, locator["page"])
+        if locator["row"] >= len(rows_on_page):
+            raise DecodeError(f"{table_name}.LvProp row is absent")
+        row = rows_on_page[locator["row"]]
+        if row["hidden"] or row["overflow"]:
+            raise DecodeError(f"{table_name}.LvProp row is flagged")
+        role = roles.get(locator["page"])
+        if role is None or role["role"] != "long_value":
+            raise DecodeError(f"{table_name}.LvProp lacks an attributed LVAL role")
+        raw_row = page[row["start"] : row["end"]]
+        locators.append(
+            {
+                **locator,
+                "appended": locator["page"] >= before_pages,
+                "row_length": len(raw_row),
+            }
+        )
+        if storage == "single_page":
+            payload.extend(raw_row)
+            break
+        if len(raw_row) <= 4:
+            raise DecodeError(f"{table_name}.LvProp chained row has no payload fragment")
+        following = raw_row[:4]
+        payload.extend(raw_row[4:])
+        if following == bytes(4):
+            break
+        locator = {"row": following[0], "page": int.from_bytes(following[1:4], "little")}
+    if len(payload) != observation["declared_length"]:
+        raise DecodeError(f"{table_name}.LvProp chain length differs from its header")
+    appended_lval = {
+        page
+        for page, role in roles.items()
+        if page >= before_pages and role["role"] == "long_value"
+    }
+    if appended_lval != {entry["page"] for entry in locators if entry["appended"]}:
+        raise DecodeError(f"{table_name}.LvProp does not account for every appended LVAL page")
+    observation["first_locator"] = locators[0]
+    observation["locators"] = locators
+    observation["payload_sha256"] = hashlib.sha256(payload).hexdigest()
+    return observation
+
+
+def definition_chunks(data: bytes, pages: list[int], logical_length: int) -> list[dict[str, int]]:
+    chunks = []
+    consumed = 0
+    for position, page in enumerate(pages):
+        capacity = PAGE_BYTES if position == 0 else PAGE_BYTES - 8
+        used = min(capacity, logical_length - consumed)
+        if used <= 0:
+            raise DecodeError("definition chain contains an unnecessary continuation page")
+        image = catalog._page(data, page, "definition chain")
+        following = int.from_bytes(image[4:8], "little")
+        expected_following = pages[position + 1] if position + 1 < len(pages) else 0
+        if following != expected_following:
+            raise DecodeError("definition continuation pointer differs from decoded chain order")
+        chunks.append(
+            {
+                "capacity": capacity,
+                "logical_end": consumed + used,
+                "logical_start": consumed,
+                "page": page,
+                "used": used,
+            }
+        )
+        consumed += used
+    if consumed != logical_length:
+        raise DecodeError("definition chunks do not cover the logical length exactly")
+    return chunks
+
+
+def analyze_scenario(before: bytes, after: bytes, scenario: str) -> dict[str, Any]:
+    before_analysis = catalog.analyze_checkpoint(before)
+    after_analysis = catalog.analyze_checkpoint(after)
+    if any(
+        not entry["flags"] & catalog.SYSTEM_FLAG
+        for entry in before_analysis["tables"].values()
+    ):
+        raise DecodeError(f"{scenario} empty baseline decodes a user table")
+    table = decoded_user_table(after_analysis, scenario)
+    definition = table["definition"]
+    expected_names = [field_name(value) for value in range(FIELD_COUNTS[scenario])]
+    columns = definition["columns"]
+    if (
+        [entry["name"] for entry in columns] != expected_names
+        or any(entry["type"] != "Long" or entry["size"] != 4 for entry in columns)
+        or definition["physical_indexes"]
+        or definition["logical_indexes"]
+        or definition["long_value_maps"]
+        or definition["row_count"] != 0
+    ):
+        raise DecodeError(f"{scenario} decoded definition differs from the empty fixed schema")
+    pages = definition["pages"]
+    expected_continuations = EXPECTED_CONTINUATIONS[scenario]
+    if len(pages) != expected_continuations + 1:
+        raise DecodeError(
+            f"{scenario} has {len(pages) - 1} continuation pages; "
+            f"the control requires {expected_continuations}"
+        )
+    if pages[0] != definition["root"] or len(set(pages)) != len(pages):
+        raise DecodeError(f"{scenario} definition chain is malformed")
+    chunks = definition_chunks(after, pages, definition["logical_length"])
+    roles = {entry["page"]: entry for entry in after_analysis["pages"]}
+    owner = f"table {definition['root']} {TABLE_NAMES[scenario]}"
+    for position, page in enumerate(pages):
+        expected_role = "definition_root" if position == 0 else "definition_continuation"
+        role = roles.get(page)
+        if role is None or role["role"] != expected_role or owner not in role["owners"]:
+            raise DecodeError(f"{scenario} definition page {page} has the wrong role or owner")
+    before_pages = len(before) // PAGE_BYTES
+    after_pages = len(after) // PAGE_BYTES
+    for chunk in chunks:
+        chunk["delta_from_definition"] = chunk["page"] - definition["root"]
+        chunk["delta_from_empty"] = chunk["page"] - before_pages
+    if after_pages < before_pages:
+        raise DecodeError(f"{scenario} create shrank the image")
+    appended = []
+    for page in range(before_pages, after_pages):
+        role = roles.get(page)
+        if role is None or role["role"] == "unassigned":
+            raise DecodeError(f"{scenario} appended page {page} is unattributed")
+        appended.append(
+            {
+                "delta_from_definition": page - definition["root"],
+                "delta_from_empty": page - before_pages,
+                "owners": role["owners"],
+                "page": page,
+                "role": role["role"],
+            }
+        )
+    table_maps = {}
+    for kind in ("owned", "available"):
+        locator = definition["maps"][kind]
+        table_maps[kind] = {
+            "locator": locator,
+            "mapped_pages": sorted(
+                catalog._locator_pages(after, locator, f"{scenario} {kind} map")
+            ),
+        }
+    lvprop = created_lvprop(after, after_analysis, TABLE_NAMES[scenario], before_pages)
+    return {
+        "appended_pages": appended,
+        "catalog_object_id": definition["root"],
+        "continuation_count": len(pages) - 1,
+        "definition_chunks": chunks,
+        "definition_pages": pages,
+        "definition_root": definition["root"],
+        "logical_length": definition["logical_length"],
+        "lvprop": lvprop,
+        "page0_counter": {
+            "after": after[catalog.PAGE0_COUNTER],
+            "before": before[catalog.PAGE0_COUNTER],
+            "delta": after[catalog.PAGE0_COUNTER] - before[catalog.PAGE0_COUNTER],
+        },
+        "page_count": {"after": after_pages, "before": before_pages},
+        "table_maps": table_maps,
+    }
+
+
+def analyze_rejected_arm(before: bytes, after: bytes, scenario: str) -> dict[str, Any]:
+    before_analysis = catalog.analyze_checkpoint(before)
+    after_analysis = catalog.analyze_checkpoint(after)
+    if any(
+        not entry["flags"] & catalog.SYSTEM_FLAG
+        for entry in before_analysis["tables"].values()
+    ):
+        raise DecodeError("rejection baseline contains a user table")
+    users = [
+        entry
+        for entry in after_analysis["tables"].values()
+        if not entry["flags"] & catalog.SYSTEM_FLAG
+    ]
+    if users:
+        raise DecodeError("active-arm recovery contains a persisted user table")
+    before_pages = len(before) // PAGE_BYTES
+    after_pages = len(after) // PAGE_BYTES
+    roles = {entry["page"]: entry for entry in after_analysis["pages"]}
+    appended = []
+    for page in range(before_pages, after_pages):
+        role = roles.get(page)
+        if role is None or role["role"] == "unassigned":
+            raise DecodeError("rejected active arm has an unattributed appended page")
+        appended.append(
+            {"owners": role["owners"], "page": page, "role": role["role"]}
+        )
+    return {
+        "appended_pages": appended,
+        "page0_counter": {
+            "after": after[catalog.PAGE0_COUNTER],
+            "before": before[catalog.PAGE0_COUNTER],
+            "delta": after[catalog.PAGE0_COUNTER] - before[catalog.PAGE0_COUNTER],
+        },
+        "page_count": {"after": after_pages, "before": before_pages},
+        "scenario": scenario,
+        "user_table_persisted": False,
+    }
+
+
+def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> dict[str, Any]:
+    complete = [entry for entry in replicas if "observations" in entry]
+    question_names = (
+        "continuation_counts",
+        "placement",
+        "counters",
+        "producer_outcome",
+        "replication",
+    )
+    if document["status"] != "pass" or len(complete) != 3:
+        reason = "at least one replica did not complete"
+        if any(entry.get("metadata_changed") for entry in replicas):
+            reason = "DAO metadata access changed at least one checkpoint"
+        elif any(entry.get("decode_error") for entry in replicas):
+            reason = "at least one complete checkpoint failed a recorded grammar or control"
+        questions = {name: {"reason": reason, "status": "no_outcome"} for name in question_names}
+        rejected = [entry.get("bounded_rejection") for entry in replicas]
+        phases = {entry["phase"] for entry in replicas}
+        errors = {entry["error"] for entry in replicas}
+        if (
+            len(replicas) == 3
+            and len(phases) == 1
+            and len(errors) == 1
+            and next(iter(phases)).startswith("append_")
+            and all(value is not None and value == rejected[0] for value in rejected)
+        ):
+            questions["producer_outcome"] = {
+                "kind": "bounded_dao_rejection",
+                "observation": rejected[0],
+                "replicas": 3,
+                "status": "answered",
+            }
+    else:
+        observations = [entry["observations"] for entry in complete]
+        if any(value != observations[0] for value in observations[1:]):
+            questions = {
+                name: {
+                    "reason": "replicas disagree on the complete decoded observation",
+                    "status": "no_outcome",
+                }
+                for name in question_names
+            }
+        else:
+            value = observations[0]
+            questions = {
+                "continuation_counts": {
+                    "scenarios": {
+                        name: {
+                            "continuation_count": value[name]["continuation_count"],
+                            "definition_pages": value[name]["definition_pages"],
+                            "logical_length": value[name]["logical_length"],
+                            "lvprop": value[name]["lvprop"],
+                        }
+                        for name in SCENARIOS
+                    },
+                    "status": "answered",
+                },
+                "placement": {
+                    "scenarios": {
+                        name: {
+                            "appended_pages": value[name]["appended_pages"],
+                            "catalog_object_id": value[name]["catalog_object_id"],
+                            "definition_chunks": value[name]["definition_chunks"],
+                            "definition_root": value[name]["definition_root"],
+                            "page_count": value[name]["page_count"],
+                            "table_maps": value[name]["table_maps"],
+                        }
+                        for name in SCENARIOS
+                    },
+                    "status": "answered",
+                },
+                "counters": {
+                    "scenarios": {
+                        name: value[name]["page0_counter"] for name in SCENARIOS
+                    },
+                    "status": "answered",
+                },
+                "producer_outcome": {"kind": "completed", "status": "answered"},
+                "replication": {"replicas": 3, "status": "answered"},
+            }
+    return {
+        "compatibility_claim": False,
+        "development_only": True,
+        "document_type": REPORT_TYPE,
+        "plan_sha256": document["plan_sha256"],
+        "questions": questions,
+        "replicas": [
+            {
+                key: value
+                for key, value in entry.items()
+                if key not in {"observations", "bounded_rejection"}
+            }
+            for entry in replicas
+        ],
+        "status": (
+            "accepted"
+            if all(value["status"] == "answered" for value in questions.values())
+            else "no_outcome"
+        ),
+        "support_movement": False,
+    }
+
+
+def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[str, Any]:
+    expected_plan = digest(expected_plan_sha256, "--expected-plan-sha256")
+    document = exact(
+        load(job_result),
+        {"document_type", "development_only", "plan_sha256", "run_id", "status", "replicas"},
+        "$",
+    )
+    if document["document_type"] != DOCUMENT_TYPE or document["development_only"] is not True:
+        raise AnalysisError("job result identity is invalid")
+    if digest(document["plan_sha256"], "$.plan_sha256") != expected_plan:
+        raise AnalysisError("job result plan digest differs from the approved plan")
+    if not isinstance(document["run_id"], str) or not SAFE_RUN_ID.fullmatch(document["run_id"]):
+        raise AnalysisError("$.run_id is invalid")
+    if document["status"] not in ("pass", "fail"):
+        raise AnalysisError("$.status is invalid")
+    raw_replicas = document["replicas"]
+    if not isinstance(raw_replicas, list) or not 1 <= len(raw_replicas) <= 3:
+        raise AnalysisError("$.replicas must contain one through three replicas")
+    replicas = []
+    referenced = []
+    for position, raw_replica in enumerate(raw_replicas):
+        item = exact(
+            raw_replica,
+            {"replica", "status", "error", "mutation_started", "phase", "checkpoints", "recovery"},
+            f"replicas[{position}]",
+        )
+        replica = integer(item["replica"], "replica number", 1, 3)
+        if replica != position + 1:
+            raise AnalysisError("replicas must be numbered 1 through 3 in order")
+        if item["status"] not in ("pass", "fail"):
+            raise AnalysisError("replica status is invalid")
+        if type(item["mutation_started"]) is not bool:
+            raise AnalysisError("replica mutation_started is invalid")
+        phase = text(item["phase"], "replica phase", 32)
+        if phase not in {
+            "before_create_database",
+            "create_database",
+            "capture_empty",
+            "copy_arms",
+            *(f"append_{name}" for name in SCENARIOS),
+            *(f"capture_{name}" for name in SCENARIOS),
+            "complete",
+        }:
+            raise AnalysisError("replica phase is invalid")
+        if item["error"] is not None:
+            text(item["error"], "replica error")
+        checkpoints = item["checkpoints"]
+        if not isinstance(checkpoints, list) or len(checkpoints) > len(CHECKPOINTS):
+            raise AnalysisError("replica checkpoints violate the bound")
+        images: dict[str, bytes] = {}
+        daos: dict[str, dict[str, Any]] = {}
+        identities: dict[str, dict[str, Any]] = {}
+        changed = []
+        for checkpoint_position, raw_checkpoint in enumerate(checkpoints):
+            name = CHECKPOINTS[checkpoint_position]
+            image, repaired, dao, arm_before, identity = read_checkpoint(
+                job_result.parent, raw_checkpoint, replica, name
+            )
+            images[name] = image
+            daos[name] = dao
+            identities[name] = identity
+            referenced.append(f"definition-continuation-r{replica}-{name}.mdb")
+            if repaired:
+                changed.append(name)
+            if name == "empty":
+                if arm_before is not None:
+                    raise AnalysisError("empty checkpoint must not have an arm identity")
+            else:
+                before = exact(arm_before, {"size", "sha256"}, f"{name}.arm_before")
+                before_size = integer(
+                    before["size"], "arm size", PAGE_BYTES, MAX_PAGES * PAGE_BYTES
+                )
+                if before_size % PAGE_BYTES:
+                    raise AnalysisError("arm size is not an exact sequence of pages")
+                if before_size != identities["empty"]["size"] or digest(
+                    before["sha256"], "arm digest"
+                ) != identities["empty"]["sha256"]:
+                    raise AnalysisError(
+                        f"{name} arm identity differs from the retained empty image"
+                    )
+        recovery = item["recovery"]
+        if not isinstance(recovery, list) or len(recovery) > 1:
+            raise AnalysisError("replica recovery inventory violates the bound")
+        checkpoint_names = set(images)
+        recovery_bytes = None
+        for raw_recovery in recovery:
+            value = exact(
+                raw_recovery,
+                {"name", "database", "size", "sha256"},
+                "recovery artifact",
+            )
+            name = value["name"]
+            expected_recovery = (
+                CHECKPOINTS[len(images)] if len(images) < len(CHECKPOINTS) else None
+            )
+            if name != expected_recovery or name in checkpoint_names:
+                raise AnalysisError("recovery artifact name is invalid or duplicated")
+            filename = value["database"]
+            if (
+                filename != f"definition-continuation-r{replica}-{name}.mdb"
+                or not SAFE_MDB.fullmatch(filename)
+            ):
+                raise AnalysisError("recovery artifact filename is invalid")
+            size = integer(
+                value["size"], "recovery size", PAGE_BYTES, MAX_PAGES * PAGE_BYTES
+            )
+            if size % PAGE_BYTES:
+                raise AnalysisError("recovery artifact is not an exact sequence of pages")
+            path = job_result.parent / filename
+            if not path.is_file() or path.is_symlink():
+                raise AnalysisError("recovery artifact must be a regular non-link file")
+            raw = path.read_bytes()
+            if len(raw) != size or hashlib.sha256(raw).hexdigest() != digest(
+                value["sha256"], "recovery digest"
+            ):
+                raise AnalysisError("recovery artifact bytes differ from metadata")
+            recovery_bytes = raw
+            referenced.append(filename)
+        files = [
+            {
+                "arm_before": raw_checkpoint["arm_before"],
+                "database": raw_checkpoint["database"],
+                "name": raw_checkpoint["name"],
+                "sha256": raw_checkpoint["sha256"],
+                "sha256_after_metadata": raw_checkpoint["sha256_after_metadata"],
+                "size": raw_checkpoint["size"],
+                "size_after_metadata": raw_checkpoint["size_after_metadata"],
+            }
+            for raw_checkpoint in checkpoints
+        ]
+        files.extend(
+            {
+                "database": artifact["database"],
+                "name": artifact["name"],
+                "recovery": True,
+                "sha256": artifact["sha256"],
+                "size": artifact["size"],
+            }
+            for artifact in recovery
+        )
+        entry: dict[str, Any] = {
+            "error": item["error"],
+            "files": files,
+            "mutation_started": item["mutation_started"],
+            "phase": phase,
+            "replica": replica,
+            "status": item["status"],
+        }
+        if item["status"] == "pass":
+            if (
+                tuple(images) != CHECKPOINTS
+                or item["error"] is not None
+                or recovery
+                or not item["mutation_started"]
+                or phase != "complete"
+            ):
+                raise AnalysisError("passing replica inventory is incomplete")
+            if changed:
+                entry["metadata_changed"] = changed
+            else:
+                try:
+                    if user_tables(daos["empty"]):
+                        raise DecodeError("empty checkpoint contains a DAO user table")
+                    for name in SCENARIOS:
+                        validate_schema(name, daos[name])
+                    entry["observations"] = {
+                        name: analyze_scenario(images["empty"], images[name], name)
+                        for name in SCENARIOS
+                    }
+                except (catalog.DecodeError, DecodeError) as error:
+                    entry["decode_error"] = str(error)
+        elif item["error"] is None:
+            raise AnalysisError("failed replica omits its error")
+        else:
+            progress = {
+                "create_database": (0, "empty", False),
+                "capture_empty": (0, "empty", True),
+                "copy_arms": (1, None, True),
+                "append_zero": (1, "zero", True),
+                "capture_zero": (1, "zero", True),
+                "append_one": (2, "one", True),
+                "capture_one": (2, "one", True),
+                "append_two": (3, "two", True),
+                "capture_two": (3, "two", True),
+                "complete": (4, None, True),
+            }
+            expected = progress.get(phase)
+            if expected is None:
+                raise AnalysisError("failed replica phase is inconsistent with producer progress")
+            checkpoint_count, recovery_name, mutation_required = expected
+            if len(images) != checkpoint_count:
+                raise AnalysisError(
+                    "failed replica checkpoint prefix is inconsistent with its phase"
+                )
+            if recovery and recovery[0]["name"] != recovery_name:
+                raise AnalysisError("failed replica recovery is inconsistent with its phase")
+            if recovery_name is None and recovery:
+                raise AnalysisError("failed replica phase cannot retain a recovery artifact")
+            if mutation_required and not item["mutation_started"]:
+                raise AnalysisError("failed replica phase requires a started DAO mutation")
+            if not item["mutation_started"] and recovery:
+                raise AnalysisError("pre-mutation failure cannot retain a recovery artifact")
+            if (
+                phase.startswith("append_")
+                and recovery_bytes is not None
+                and "empty" in images
+            ):
+                try:
+                    entry["bounded_rejection"] = analyze_rejected_arm(
+                        images["empty"], recovery_bytes, phase.removeprefix("append_")
+                    )
+                except (catalog.DecodeError, DecodeError) as error:
+                    entry["recovery_decode_error"] = str(error)
+        replicas.append(entry)
+    if not any(entry["mutation_started"] for entry in replicas):
+        raise AnalysisError("acquisition did not reach the first DAO mutation")
+    if len(replicas) != 3:
+        raise AnalysisError("post-mutation result must contain exactly three replicas")
+    aggregate = "pass" if all(entry["status"] == "pass" for entry in replicas) else "fail"
+    if document["status"] != aggregate:
+        raise AnalysisError("job status disagrees with replica statuses")
+    retained = sorted(
+        path.name
+        for path in job_result.parent.iterdir()
+        if path.suffix.casefold() == ".mdb"
+    )
+    if retained != sorted(referenced):
+        raise AnalysisError("retained MDB inventory differs from the job result")
+    report = build_report(document, replicas)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_bytes(report))
+    return report
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job_result", type=Path)
+    parser.add_argument("--expected-plan-sha256", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(arguments)
+    try:
+        evaluate(args.job_result, args.expected_plan_sha256, args.output)
+    except (AnalysisError, OSError) as error:
+        print(f"definition-continuation analysis failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1
@@ -1,0 +1,350 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RunRoot,
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9a-f]{64}$")]
+    [string]$PlanSha256,
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
+    [string]$RunId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$DbVersion30 = 32
+$DbLong = 4
+$DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
+$PageSize = 2048
+$MaximumPages = 64
+$MaximumTables = 16
+$MaximumFields = 140
+$MaximumDetailCharacters = 512
+$ScenarioOrder = @("zero", "one", "two")
+$ScenarioFields = @{ zero = 69; one = 70; two = 140 }
+$ScenarioTables = @{ zero = "ContZero"; one = "ContOneX"; two = "ContTwoX" }
+
+function Release-ComObject {
+    param([object]$Value)
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-BoundedSize {
+    param([string]$Path)
+    $item = Get-Item -LiteralPath $Path -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Database must not be a reparse point: $Path"
+    }
+    $length = [long]$item.Length
+    if ($length -lt $PageSize -or ($length % $PageSize) -ne 0 -or
+        ($length / $PageSize) -gt $MaximumPages) {
+        throw "Database is outside the bounded 2 KiB page geometry: $Path"
+    }
+    return $length
+}
+
+function ConvertTo-BoundedDetail {
+    param([AllowNull()][object]$Detail)
+    $text = if ($null -eq $Detail) { "No additional detail was reported." } else { [string]$Detail }
+    if ($text.Length -gt $MaximumDetailCharacters) { return $text.Substring(0, $MaximumDetailCharacters) }
+    return $text
+}
+
+function Write-JsonDocument {
+    param([string]$Path, [object]$Document)
+    $encoding = New-Object Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText(
+        [IO.Path]::GetFullPath($Path),
+        (($Document | ConvertTo-Json -Depth 20) + "`n"),
+        $encoding
+    )
+}
+
+function Invoke-WithDatabase {
+    param([string]$Path, [switch]$ReadOnly, [scriptblock]$Action)
+    $engine = $null
+    $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $database = $engine.OpenDatabase($Path, $false, [bool]$ReadOnly)
+        & $Action $database
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+function New-Jet3Database {
+    param([string]$Path, [ref]$MutationStarted)
+    $engine = $null
+    $workspace = $null
+    $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $workspace = $engine.Workspaces.Item(0)
+        $MutationStarted.Value = $true
+        $database = $workspace.CreateDatabase($Path, $DatabaseLocale, $DbVersion30)
+        $database.Close()
+        Release-ComObject -Value $database
+        $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject -Value $database
+        Release-ComObject -Value $workspace
+        Release-ComObject -Value $engine
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+    }
+}
+
+function Get-FieldName {
+    param([int]$Ordinal)
+    return "F{0:D3}AAAAAA" -f $Ordinal
+}
+
+function New-ScenarioTable {
+    param([string]$Path, [string]$Scenario)
+    $count = [int]$ScenarioFields[$Scenario]
+    $tableName = [string]$ScenarioTables[$Scenario]
+    Invoke-WithDatabase -Path $Path -Action {
+        param($database)
+        $table = $null
+        $fields = New-Object Collections.ArrayList
+        try {
+            $table = $database.CreateTableDef($tableName)
+            for ($ordinal = 0; $ordinal -lt $count; $ordinal++) {
+                $field = $table.CreateField((Get-FieldName -Ordinal $ordinal), $DbLong)
+                [void]$fields.Add($field)
+                $table.Fields.Append($field)
+            }
+            $database.TableDefs.Append($table)
+        }
+        finally {
+            foreach ($field in $fields) { Release-ComObject -Value $field }
+            Release-ComObject -Value $table
+        }
+    }
+}
+
+function Get-DaoMetadata {
+    param([string]$Path)
+    $holder = [pscustomobject]@{ value = $null }
+    Invoke-WithDatabase -Path $Path -ReadOnly -Action {
+        param($database)
+        $definitions = $null
+        $rows = New-Object Collections.ArrayList
+        try {
+            $definitions = $database.TableDefs
+            if ([int]$definitions.Count -gt $MaximumTables) { throw "DAO table bound exceeded." }
+            for ($position = 0; $position -lt [int]$definitions.Count; $position++) {
+                $table = $null
+                $fields = $null
+                try {
+                    $table = $definitions.Item($position)
+                    $tableName = [string]$table.Name
+                    $fieldRows = New-Object Collections.ArrayList
+                    if (-not $tableName.StartsWith("MSys", [StringComparison]::Ordinal)) {
+                        $fields = $table.Fields
+                        if ([int]$fields.Count -gt $MaximumFields) { throw "DAO field bound exceeded." }
+                        for ($fieldPosition = 0; $fieldPosition -lt [int]$fields.Count; $fieldPosition++) {
+                            $field = $null
+                            try {
+                                $field = $fields.Item($fieldPosition)
+                                [void]$fieldRows.Add([ordered]@{
+                                    ordinal = $fieldPosition
+                                    name = [string]$field.Name
+                                    type = [int]$field.Type
+                                    size = [int]$field.Size
+                                })
+                            }
+                            finally { Release-ComObject -Value $field }
+                        }
+                    }
+                    [void]$rows.Add([ordered]@{
+                        ordinal = $position
+                        name = $tableName
+                        fields = @($fieldRows)
+                    })
+                }
+                finally {
+                    Release-ComObject -Value $fields
+                    Release-ComObject -Value $table
+                }
+            }
+        }
+        finally { Release-ComObject -Value $definitions }
+        $holder.value = [ordered]@{ tabledefs = @($rows) }
+    }
+    return $holder.value
+}
+
+function Save-Checkpoint {
+    param([string]$Source, [int]$Replica, [string]$Name, [object]$ArmBefore)
+    $fileName = "definition-continuation-r$Replica-$Name.mdb"
+    $destination = Join-Path $RunRoot $fileName
+    Copy-Item -LiteralPath $Source -Destination $destination -Force
+    $size = Get-BoundedSize -Path $destination
+    $sha256 = Get-Sha256 -Path $destination
+    $dao = Get-DaoMetadata -Path $destination
+    return [ordered]@{
+        name = $Name
+        database = $fileName
+        size = $size
+        sha256 = $sha256
+        size_after_metadata = Get-BoundedSize -Path $destination
+        sha256_after_metadata = Get-Sha256 -Path $destination
+        arm_before = $ArmBefore
+        dao = $dao
+    }
+}
+
+function Invoke-Replica {
+    param([int]$Replica)
+    $state = [ordered]@{
+        replica = $Replica
+        status = "fail"
+        error = $null
+        mutation_started = $false
+        phase = "before_create_database"
+        checkpoints = @()
+        recovery = @()
+    }
+    $checkpoints = New-Object Collections.ArrayList
+    $recovery = New-Object Collections.ArrayList
+    $workingPaths = New-Object Collections.ArrayList
+    $basePath = Join-Path $RunRoot "working-continuation-base-r$Replica.mdb"
+    $arms = @{}
+    $activeCheckpoint = $null
+    $mutationStarted = $false
+    try {
+        [void]$workingPaths.Add($basePath)
+        $state.phase = "create_database"
+        $activeCheckpoint = "empty"
+        New-Jet3Database -Path $basePath -MutationStarted ([ref]$mutationStarted)
+        $state.mutation_started = $mutationStarted
+        $state.phase = "capture_empty"
+        $empty = Save-Checkpoint -Source $basePath -Replica $Replica -Name "empty" -ArmBefore $null
+        [void]$checkpoints.Add($empty)
+        $activeCheckpoint = $null
+        $state.phase = "copy_arms"
+        foreach ($scenario in $ScenarioOrder) {
+            $arm = Join-Path $RunRoot "working-continuation-$scenario-r$Replica.mdb"
+            [void]$workingPaths.Add($arm)
+            Copy-Item -LiteralPath $basePath -Destination $arm
+            $armSize = Get-BoundedSize -Path $arm
+            $armSha256 = Get-Sha256 -Path $arm
+            if ($armSize -ne [long]$empty.size -or $armSha256 -cne [string]$empty.sha256) {
+                throw "Arm $scenario differs from the retained empty baseline before mutation."
+            }
+            $arms[$scenario] = [pscustomobject]@{ path = $arm; size = $armSize; sha256 = $armSha256 }
+        }
+        foreach ($scenario in $ScenarioOrder) {
+            $activeCheckpoint = $scenario
+            $state.phase = "append_$scenario"
+            $arm = $arms[$scenario]
+            New-ScenarioTable -Path ([string]$arm.path) -Scenario $scenario
+            $state.phase = "capture_$scenario"
+            [void]$checkpoints.Add((Save-Checkpoint -Source ([string]$arm.path) -Replica $Replica `
+                -Name $scenario -ArmBefore ([ordered]@{
+                    size = [long]$arm.size
+                    sha256 = [string]$arm.sha256
+                })))
+            $activeCheckpoint = $null
+        }
+        $state.phase = "complete"
+        $state.status = "pass"
+    }
+    catch {
+        $state.mutation_started = $mutationStarted
+        $state.error = ConvertTo-BoundedDetail -Detail `
+            ($_.Exception.GetType().FullName + ": " + $_.Exception.Message)
+        if ($null -ne $activeCheckpoint) {
+            try {
+                $source = if ($activeCheckpoint -ceq "empty") {
+                    $basePath
+                }
+                elseif ($arms.ContainsKey($activeCheckpoint)) {
+                    [string]$arms[$activeCheckpoint].path
+                }
+                else { throw "Recovery source is unavailable." }
+                $fileName = "definition-continuation-r$Replica-$activeCheckpoint.mdb"
+                $destination = Join-Path $RunRoot $fileName
+                Copy-Item -LiteralPath $source -Destination $destination -Force
+                [void]$recovery.Add([ordered]@{
+                    name = $activeCheckpoint
+                    database = $fileName
+                    size = Get-BoundedSize -Path $destination
+                    sha256 = Get-Sha256 -Path $destination
+                })
+            }
+            catch {
+                try {
+                    if (Test-Path -LiteralPath $destination -PathType Leaf) {
+                        Remove-Item -LiteralPath $destination -Force
+                    }
+                }
+                catch { }
+                $state.error = ConvertTo-BoundedDetail -Detail `
+                    ($state.error + " Recovery retention failed: " + $_.Exception.Message)
+            }
+        }
+    }
+    finally {
+        foreach ($working in $workingPaths) {
+            try {
+                if (Test-Path -LiteralPath $working -PathType Leaf) {
+                    Remove-Item -LiteralPath $working -Force
+                }
+            }
+            catch {
+                $state.status = "fail"
+                $state.error = ConvertTo-BoundedDetail -Detail `
+                    ($state.error + " Cleanup failed: " + $_.Exception.Message)
+            }
+        }
+    }
+    $state.checkpoints = @($checkpoints)
+    $state.recovery = @($recovery)
+    return $state
+}
+
+[void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($RunRoot))
+$replicas = New-Object Collections.ArrayList
+foreach ($replica in 1..3) {
+    $entry = Invoke-Replica -Replica $replica
+    [void]$replicas.Add($entry)
+    if ([string]$entry.status -cne "pass" -and
+        -not [bool]$entry.mutation_started -and $replicas.Count -eq 1) {
+        break
+    }
+}
+$status = if (@($replicas | Where-Object { [string]$_.status -cne "pass" }).Count -eq 0) {
+    "pass"
+} else { "fail" }
+$result = [ordered]@{
+    document_type = "dao_definition_continuation_job_result"
+    development_only = $true
+    plan_sha256 = $PlanSha256
+    run_id = $RunId
+    status = $status
+    replicas = @($replicas)
+}
+Write-JsonDocument -Path (Join-Path $RunRoot "definition-continuation-job-result.json") `
+    -Document $result
+if ($status -ceq "pass") { exit 0 } else { exit 1 }

--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]
+    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$RunRoot,
@@ -31,6 +31,8 @@ param(
     [string]$SchemaGeneralizationJobPath,
     [Parameter(Mandatory = $true)]
     [string]$MultipleIndexesJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$DefinitionContinuationJobPath,
     [Parameter(Mandatory = $true)]
     [string]$LvPropNullJobPath,
     [Parameter(Mandatory = $true)]
@@ -69,6 +71,7 @@ $scriptPath = switch ($Job) {
     "bootstrap-composer-validation" { $BootstrapComposerValidationJobPath }
     "schema-generalization" { $SchemaGeneralizationJobPath }
     "multiple-indexes" { $MultipleIndexesJobPath }
+    "definition-continuation" { $DefinitionContinuationJobPath }
     "lvprop-null" { $LvPropNullJobPath }
 }
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
@@ -94,7 +97,7 @@ elseif ($Job -ceq "bootstrap-layout") {
 elseif ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId, "-Experiment", $Job)
 }
-elseif ($Job -in @("schema-generalization", "multiple-indexes")) {
+elseif ($Job -in @("schema-generalization", "multiple-indexes", "definition-continuation")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId)
 }
 elseif ($Job -ceq "lvprop-null") {
@@ -129,6 +132,7 @@ $resultName = switch ($Job) {
     "bootstrap-composer-validation" { "bootstrap-composer-validation-job-result.json" }
     "schema-generalization" { "schema-generalization-job-result.json" }
     "multiple-indexes" { "multiple-indexes-job-result.json" }
+    "definition-continuation" { "definition-continuation-job-result.json" }
     "lvprop-null" { "lvprop-null-job-result.json" }
 }
 $resultPath = Join-Path $RunRoot $resultName
@@ -148,6 +152,7 @@ if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
         system_catalog_replicas = @()
         schema_generalization_replicas = @()
         multiple_indexes_replicas = @()
+        definition_continuation_replicas = @()
         lvprop_null_replicas = @()
     }
     Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result
@@ -165,6 +170,7 @@ $bootstrapLayoutReplicas = @()
 $systemCatalogReplicas = @()
 $schemaGeneralizationReplicas = @()
 $multipleIndexesReplicas = @()
+$definitionContinuationReplicas = @()
 $lvpropNullReplicas = @()
 # The system-catalog result carries no detail field; derive one from its status.
 $detail = if ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics")) {
@@ -189,6 +195,14 @@ elseif ($Job -ceq "multiple-indexes") {
     }
     else {
         "At least one multiple-indexes replica failed; per-replica error records the message."
+    }
+}
+elseif ($Job -ceq "definition-continuation") {
+    if ([string]$jobResult.status -ceq "pass") {
+        "Completed all three definition-continuation replicas once without retry."
+    }
+    else {
+        "At least one definition-continuation replica failed; per-replica error records the message."
     }
 }
 elseif ($Job -ceq "lvprop-null") {
@@ -231,6 +245,9 @@ elseif ($Job -ceq "schema-generalization") {
 elseif ($Job -ceq "multiple-indexes") {
     $multipleIndexesReplicas = @($jobResult.replicas)
 }
+elseif ($Job -ceq "definition-continuation") {
+    $definitionContinuationReplicas = @($jobResult.replicas)
+}
 elseif ($Job -ceq "lvprop-null") {
     $lvpropNullReplicas = @($jobResult.replicas)
 }
@@ -249,6 +266,7 @@ $result = [ordered]@{
     system_catalog_replicas = @($systemCatalogReplicas)
     schema_generalization_replicas = @($schemaGeneralizationReplicas)
     multiple_indexes_replicas = @($multipleIndexesReplicas)
+    definition_continuation_replicas = @($definitionContinuationReplicas)
     lvprop_null_replicas = @($lvpropNullReplicas)
 }
 Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
@@ -40,6 +40,8 @@ param(
     [string]$SchemaGeneralizationJobPath,
     [Parameter(Mandatory = $true)]
     [string]$MultipleIndexesJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$DefinitionContinuationJobPath,
     [Parameter(Mandatory = $true)]
     [string]$LvPropNullJobPath,
     [Parameter(Mandatory = $true)]
@@ -390,7 +392,8 @@ if ($Job -ceq "table-definition" -and
 foreach ($requiredHelper in @(
     $DispatchPath, $PublicationPath, $RowJobPath, $ValueJobPath, $IndexJobPath,
     $BootstrapLayoutJobPath, $SystemCatalogJobPath, $BootstrapComposerValidationJobPath,
-    $SchemaGeneralizationJobPath, $MultipleIndexesJobPath, $LvPropNullJobPath
+    $SchemaGeneralizationJobPath, $MultipleIndexesJobPath, $DefinitionContinuationJobPath,
+    $LvPropNullJobPath
 )) {
     if (-not (Test-Path -LiteralPath $requiredHelper -PathType Leaf)) {
         [Console]::Error.WriteLine("INVALID: staged development helper does not exist.")
@@ -408,6 +411,7 @@ $planBoundJobs = @{
     "bootstrap-composer-validation" = "oracle/windows-dao/scripts/dev/BootstrapComposerValidation.DevJob.ps1"
     "schema-generalization" = "oracle/windows-dao/scripts/dev/SchemaGeneralization.DevJob.ps1"
     "multiple-indexes" = "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1"
+    "definition-continuation" = "oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1"
     "lvprop-null" = "oracle/windows-dao/scripts/dev/LvPropNull.DevJob.ps1"
 }
 if ($planBoundJobs.ContainsKey($Job)) {
@@ -436,6 +440,9 @@ if ($planBoundJobs.ContainsKey($Job)) {
     }
     elseif ($Job -ceq "multiple-indexes") {
         $MultipleIndexesJobPath
+    }
+    elseif ($Job -ceq "definition-continuation") {
+        $DefinitionContinuationJobPath
     }
     elseif ($Job -ceq "lvprop-null") {
         $LvPropNullJobPath
@@ -537,6 +544,7 @@ $bootstrapLayoutReplicas = @()
 $systemCatalogReplicas = @()
 $schemaGeneralizationReplicas = @()
 $multipleIndexesReplicas = @()
+$definitionContinuationReplicas = @()
 $lvpropNullReplicas = @()
 
 if ($Job -ceq "provider-probe") {
@@ -763,7 +771,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
         }
     }
 }
-elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null") -and $probeExitCode -eq 0) {
+elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null") -and $probeExitCode -eq 0) {
     $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
@@ -781,6 +789,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             -BootstrapComposerAlphaPath $BootstrapComposerAlphaPath `
             -SchemaGeneralizationJobPath $SchemaGeneralizationJobPath `
             -MultipleIndexesJobPath $MultipleIndexesJobPath `
+            -DefinitionContinuationJobPath $DefinitionContinuationJobPath `
             -LvPropNullJobPath $LvPropNullJobPath `
             -LvPropFixedAlphaPath $LvPropFixedAlphaPath `
             -LvPropNullAlphaPath $LvPropNullAlphaPath `
@@ -805,6 +814,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             $systemCatalogReplicas = @($dispatchResult.system_catalog_replicas)
             $schemaGeneralizationReplicas = @($dispatchResult.schema_generalization_replicas)
             $multipleIndexesReplicas = @($dispatchResult.multiple_indexes_replicas)
+            $definitionContinuationReplicas = @($dispatchResult.definition_continuation_replicas)
             $lvpropNullReplicas = @($dispatchResult.lvprop_null_replicas)
             $status = [string]$dispatchResult.status
             $detail = [string]$dispatchResult.detail
@@ -839,6 +849,7 @@ $result = [ordered]@{
     system_catalog_replicas = @($systemCatalogReplicas)
     schema_generalization_replicas = @($schemaGeneralizationReplicas)
     multiple_indexes_replicas = @($multipleIndexesReplicas)
+    definition_continuation_replicas = @($definitionContinuationReplicas)
     lvprop_null_replicas = @($lvpropNullReplicas)
     completed_at_utc = [DateTimeOffset]::UtcNow.ToString("o")
 }

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$Source,
@@ -375,6 +375,97 @@ switch ($Job) {
         $expected = @($referenced | Sort-Object)
         if (($actual -join "`n") -cne ($expected -join "`n")) {
             throw "Multiple-indexes MDB inventory differs from its result."
+        }
+        foreach ($name in $actual) {
+            [void]$names.Add($name)
+        }
+    }
+    "definition-continuation" {
+        [void]$names.Add("definition-continuation-job-result.json")
+        $jobResultPath = Join-Path $Source "definition-continuation-job-result.json"
+        if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
+            throw "Definition-continuation result is missing."
+        }
+        if ((Get-Item -LiteralPath $jobResultPath).Length -gt 4194304) {
+            throw "Definition-continuation result exceeds the 4-MiB bound."
+        }
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $checkpointNames = @("empty", "zero", "one", "two")
+        $referenced = New-Object Collections.ArrayList
+        $seenReplicas = New-Object Collections.ArrayList
+        foreach ($replica in @($jobResult.replicas)) {
+            $replicaNumber = [int]$replica.replica
+            if ($replicaNumber -lt 1 -or $replicaNumber -gt 3 -or
+                $replicaNumber -ne ($seenReplicas.Count + 1) -or
+                $replicaNumber -cin $seenReplicas) {
+                throw "Definition-continuation result has an unexpected replica inventory."
+            }
+            [void]$seenReplicas.Add($replicaNumber)
+            $checkpointIndex = 0
+            foreach ($checkpoint in @($replica.checkpoints)) {
+                if ($checkpointIndex -ge $checkpointNames.Count) {
+                    throw "Definition-continuation result exceeds the four-checkpoint bound."
+                }
+                $checkpointName = $checkpointNames[$checkpointIndex]
+                $expectedDatabase = "definition-continuation-r$replicaNumber-$checkpointName.mdb"
+                if ([string]$checkpoint.name -cne $checkpointName -or
+                    [string]$checkpoint.database -cne $expectedDatabase) {
+                    throw "Definition-continuation checkpoints are not an ordered prefix."
+                }
+                [void]$referenced.Add($expectedDatabase)
+                $checkpointIndex++
+            }
+            $recovery = @($replica.recovery)
+            if ($recovery.Count -gt 1) {
+                throw "Definition-continuation result exceeds the one-recovery-artifact bound."
+            }
+            foreach ($artifact in $recovery) {
+                if ($checkpointIndex -ge $checkpointNames.Count) {
+                    throw "Definition-continuation recovery follows a complete checkpoint inventory."
+                }
+                $expectedName = $checkpointNames[$checkpointIndex]
+                $expectedDatabase = "definition-continuation-r$replicaNumber-$expectedName.mdb"
+                if ([string]$artifact.name -cne $expectedName -or
+                    [string]$artifact.database -cne $expectedDatabase) {
+                    throw "Definition-continuation recovery is not the active next checkpoint."
+                }
+                [void]$referenced.Add($expectedDatabase)
+            }
+            if ([string]$replica.status -ceq "pass" -and
+                ($checkpointIndex -ne $checkpointNames.Count -or $recovery.Count -ne 0)) {
+                throw "Passing definition-continuation replica omits a checkpoint."
+            }
+        }
+        if ($seenReplicas.Count -ne 3) {
+            $preMutationAbort = (
+                $seenReplicas.Count -eq 1 -and
+                [string]$jobResult.status -ceq "fail" -and
+                -not [bool]@($jobResult.replicas)[0].mutation_started
+            )
+            if (-not $preMutationAbort) {
+                throw "Definition-continuation result has an incomplete replica inventory."
+            }
+        }
+        if ($referenced.Count -gt 12) {
+            throw "Definition-continuation output exceeds the 12-database bound."
+        }
+        if ([string]$jobResult.status -ceq "pass" -and $referenced.Count -ne 12) {
+            throw "Passing definition-continuation result omits a database."
+        }
+        $actualItems = @(Get-ChildItem -LiteralPath $Source -File -Filter "*.mdb")
+        foreach ($item in $actualItems) {
+            if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+                throw "Definition-continuation output contains a reparse-point MDB."
+            }
+            if ($item.Length -lt 2048 -or ($item.Length % 2048) -ne 0 -or
+                $item.Length -gt 131072) {
+                throw "Definition-continuation output MDB violates the 64-page bound."
+            }
+        }
+        $actual = @($actualItems | ForEach-Object { $_.Name } | Sort-Object)
+        $expected = @($referenced | Sort-Object)
+        if (($actual -join "`n") -cne ($expected -join "`n")) {
+            throw "Definition-continuation MDB inventory differs from its result."
         }
         foreach ($name in $actual) {
             [void]$names.Add($name)

--- a/oracle/windows-dao/tests/test_definition_continuation.py
+++ b/oracle/windows-dao/tests/test_definition_continuation.py
@@ -57,7 +57,13 @@ def scenario_image(scenario: str) -> bytes:
     return bytes(data)
 
 
-def fake_analysis(data: bytes, *, bad_count: bool = False, unattributed: bool = False) -> dict:
+def fake_analysis(
+    data: bytes,
+    *,
+    bad_count: bool = False,
+    bad_length: bool = False,
+    unattributed: bool = False,
+) -> dict:
     marker = data[1]
     count = len(data) // continuation.PAGE_BYTES
     if marker == 0:
@@ -77,6 +83,8 @@ def fake_analysis(data: bytes, *, bad_count: bool = False, unattributed: bool = 
     if bad_count and scenario == "one":
         pages = [20]
     logical_length = {"zero": 2046, "one": 2075, "two": 4105}[scenario]
+    if bad_length and scenario == "one":
+        logical_length += 1
     fields = continuation.expected_fields(scenario)
     definition = {
         "columns": [
@@ -217,6 +225,8 @@ class DefinitionContinuationTests(unittest.TestCase):
             self.assertEqual(counts["two"]["definition_pages"], [20, 25, 23])
             chunks = report["questions"]["placement"]["scenarios"]["two"]["definition_chunks"]
             self.assertEqual([chunk["used"] for chunk in chunks], [2048, 2040, 17])
+            counters = report["questions"]["counters"]["scenarios"]
+            self.assertEqual(counters["zero"]["changed_offsets"], [1])
 
     def test_wrong_continuation_count_is_no_outcome(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -278,7 +288,7 @@ class DefinitionContinuationTests(unittest.TestCase):
             with self.assertRaisesRegex(continuation.AnalysisError, "checkpoint prefix"):
                 self.evaluate(fixture)
 
-    def test_stable_final_arm_dao_rejection_is_preserved_as_answered_partial(self) -> None:
+    def test_repeatable_final_arm_failure_remains_no_outcome(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             fixture = Fixture(Path(directory))
             empty = bytes(20 * continuation.PAGE_BYTES)
@@ -301,9 +311,15 @@ class DefinitionContinuationTests(unittest.TestCase):
             fixture.document["status"] = "fail"
             report = self.evaluate(fixture)
             self.assertEqual(report["status"], "no_outcome")
-            outcome = report["questions"]["producer_outcome"]
-            self.assertEqual(outcome["status"], "answered")
-            self.assertEqual(outcome["kind"], "bounded_dao_rejection")
+            self.assertEqual(report["questions"]["producer_outcome"]["status"], "no_outcome")
+
+    def test_wrong_logical_length_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = self.evaluate(
+                Fixture(Path(directory)), lambda data: fake_analysis(data, bad_length=True)
+            )
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("logical definition length", report["replicas"][0]["decode_error"])
 
     def test_definition_chunks_rejects_pointer_corruption(self) -> None:
         data = bytearray(3 * continuation.PAGE_BYTES)
@@ -335,13 +351,77 @@ class DefinitionContinuationTests(unittest.TestCase):
             ),
         ):
             value = continuation.created_lvprop(
-                bytes(3 * continuation.PAGE_BYTES),
-                {"pages": [{"page": 2, "role": "long_value"}]},
+                bytes(4 * continuation.PAGE_BYTES),
+                {
+                    "pages": [
+                        {"page": 2, "role": "long_value"},
+                        {"page": 3, "role": "long_value"},
+                    ]
+                },
                 "ContTwoX",
-                20,
+                2,
             )
         self.assertEqual(value["storage"], "chained")
-        self.assertEqual(value["first_locator"], {"row": 0, "page": 2, "appended": False, "row_length": 20})
+        self.assertEqual(value["first_locator"], {"row": 0, "page": 2, "appended": True, "row_length": 20})
+        self.assertEqual(value["appended_lval_pages"], [2, 3])
+        self.assertEqual(value["referenced_appended_lval_pages"], [2])
+        self.assertEqual(value["unreferenced_appended_lval_pages"], [3])
+
+    def test_lvprop_allows_null_with_unreferenced_appended_lval_page(self) -> None:
+        with (
+            mock.patch.object(
+                continuation.catalog,
+                "_discover_catalog",
+                return_value=({}, [], [{"values": ["ContZero", None]}]),
+            ),
+            mock.patch.object(
+                continuation.catalog,
+                "_ordinal",
+                side_effect=lambda _definition, name: {"Name": 0, "LvProp": 1}[name],
+            ),
+        ):
+            value = continuation.created_lvprop(
+                bytes(21 * continuation.PAGE_BYTES),
+                {
+                    "pages": [
+                        {"page": page, "role": "long_value" if page == 20 else "base"}
+                        for page in range(21)
+                    ]
+                },
+                "ContZero",
+                20,
+            )
+        self.assertEqual(
+            value,
+            {
+                "appended_lval_pages": [20],
+                "referenced_appended_lval_pages": [],
+                "storage": "null",
+                "unreferenced_appended_lval_pages": [20],
+            },
+        )
+
+    def test_lvprop_rejects_malformed_external_inline_length(self) -> None:
+        header = (0x40000001).to_bytes(4, "little") + bytes([0]) + (2).to_bytes(3, "little") + bytes(4)
+        with (
+            mock.patch.object(
+                continuation.catalog,
+                "_discover_catalog",
+                return_value=({}, [], [{"values": ["ContOneX", {"inline_length": 13, "long_value_header_hex": header.hex()}]}]),
+            ),
+            mock.patch.object(
+                continuation.catalog,
+                "_ordinal",
+                side_effect=lambda _definition, name: {"Name": 0, "LvProp": 1}[name],
+            ),
+        ):
+            with self.assertRaisesRegex(continuation.DecodeError, "external framing"):
+                continuation.created_lvprop(
+                    bytes(3 * continuation.PAGE_BYTES),
+                    {"pages": [{"page": 2, "role": "long_value"}]},
+                    "ContOneX",
+                    2,
+                )
 
 
 if __name__ == "__main__":

--- a/oracle/windows-dao/tests/test_definition_continuation.py
+++ b/oracle/windows-dao/tests/test_definition_continuation.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Focused tests for the preregistered issue #151 analyzer."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location(
+    "definition_continuation", SCRIPTS / "definition_continuation.py"
+)
+assert SPEC and SPEC.loader
+continuation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(continuation)
+
+PLAN = "a" * 64
+
+
+def dao(scenario: str | None) -> dict:
+    tables = []
+    if scenario is not None:
+        tables.append(
+            {
+                "ordinal": 0,
+                "name": continuation.TABLE_NAMES[scenario],
+                "fields": copy.deepcopy(continuation.expected_fields(scenario)),
+            }
+        )
+    return {"tabledefs": tables}
+
+
+def scenario_image(scenario: str) -> bytes:
+    page_count = 28
+    data = bytearray(page_count * continuation.PAGE_BYTES)
+    data[1] = continuation.SCENARIOS.index(scenario) + 1
+    pages = {
+        "zero": [20],
+        "one": [20, 24],
+        "two": [20, 25, 23],
+    }[scenario]
+    for position, page in enumerate(pages):
+        start = page * continuation.PAGE_BYTES
+        data[start : start + 4] = b"\x02\x01VC"
+        following = pages[position + 1] if position + 1 < len(pages) else 0
+        data[start + 4 : start + 8] = following.to_bytes(4, "little")
+    return bytes(data)
+
+
+def fake_analysis(data: bytes, *, bad_count: bool = False, unattributed: bool = False) -> dict:
+    marker = data[1]
+    count = len(data) // continuation.PAGE_BYTES
+    if marker == 0:
+        return {
+            "tables": {},
+            "pages": [
+                {"page": page, "role": "base", "owners": [], "tag": 0}
+                for page in range(count)
+            ],
+        }
+    scenario = continuation.SCENARIOS[marker - 1]
+    pages = {
+        "zero": [20],
+        "one": [20, 24],
+        "two": [20, 25, 23],
+    }[scenario]
+    if bad_count and scenario == "one":
+        pages = [20]
+    logical_length = {"zero": 2046, "one": 2075, "two": 4105}[scenario]
+    fields = continuation.expected_fields(scenario)
+    definition = {
+        "columns": [
+            {"name": field["name"], "ordinal": field["ordinal"], "size": 4, "type": "Long"}
+            for field in fields
+        ],
+        "logical_indexes": [],
+        "logical_length": logical_length,
+        "long_value_maps": [],
+        "maps": {"owned": {"page": 21, "row": 0}, "available": {"page": 21, "row": 1}},
+        "pages": pages,
+        "physical_indexes": [],
+        "root": 20,
+        "row_count": 0,
+    }
+    owner = f"table 20 {continuation.TABLE_NAMES[scenario]}"
+    output_pages = []
+    for page in range(count):
+        if page == 20:
+            role = "definition_root"
+        elif page in pages[1:]:
+            role = "definition_continuation"
+        elif page == 21:
+            role = "map_rows"
+        elif page >= 22:
+            role = "long_value"
+        else:
+            role = "base"
+        if unattributed and scenario == "two" and page == count - 1:
+            role = "unassigned"
+        output_pages.append(
+            {"page": page, "role": role, "owners": [owner], "tag": 2 if page in pages else 1}
+        )
+    return {
+        "tables": {20: {"definition": definition, "flags": 0, "name": continuation.TABLE_NAMES[scenario]}},
+        "pages": output_pages,
+    }
+
+
+class Fixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.replicas = []
+        for replica in range(1, 4):
+            empty = bytes(20 * continuation.PAGE_BYTES)
+            empty_digest = hashlib.sha256(empty).hexdigest()
+            checkpoints = [self.checkpoint(replica, "empty", empty, None, dao(None))]
+            for scenario in continuation.SCENARIOS:
+                checkpoints.append(
+                    self.checkpoint(
+                        replica,
+                        scenario,
+                        scenario_image(scenario),
+                        {"size": len(empty), "sha256": empty_digest},
+                        dao(scenario),
+                    )
+                )
+            self.replicas.append(
+                {
+                    "replica": replica,
+                    "status": "pass",
+                    "error": None,
+                    "mutation_started": True,
+                    "phase": "complete",
+                    "checkpoints": checkpoints,
+                    "recovery": [],
+                }
+            )
+        self.document = {
+            "document_type": continuation.DOCUMENT_TYPE,
+            "development_only": True,
+            "plan_sha256": PLAN,
+            "run_id": "20260902T120000Z-dev-dao",
+            "status": "pass",
+            "replicas": self.replicas,
+        }
+
+    def checkpoint(
+        self,
+        replica: int,
+        name: str,
+        data: bytes,
+        arm_before: dict | None,
+        metadata: dict,
+    ) -> dict:
+        filename = f"definition-continuation-r{replica}-{name}.mdb"
+        (self.root / filename).write_bytes(data)
+        digest_value = hashlib.sha256(data).hexdigest()
+        return {
+            "name": name,
+            "database": filename,
+            "size": len(data),
+            "size_after_metadata": len(data),
+            "sha256": digest_value,
+            "sha256_after_metadata": digest_value,
+            "arm_before": arm_before,
+            "dao": metadata,
+        }
+
+    def write(self) -> Path:
+        path = self.root / "definition-continuation-job-result.json"
+        path.write_text(json.dumps(self.document), encoding="utf-8")
+        return path
+
+
+class DefinitionContinuationTests(unittest.TestCase):
+    def evaluate(self, fixture: Fixture, analysis=fake_analysis):
+        output = fixture.root / "definition-continuation-report.json"
+        with (
+            mock.patch.object(continuation.catalog, "analyze_checkpoint", side_effect=analysis),
+            mock.patch.object(
+                continuation.catalog,
+                "_locator_pages",
+                side_effect=lambda _data, _locator, _what: set(),
+            ),
+            mock.patch.object(
+                continuation,
+                "created_lvprop",
+                side_effect=lambda *_args: {
+                    "declared_length": 1,
+                    "first_locator": None,
+                    "header_hex": "0" * 24,
+                    "inline_length": 13,
+                    "storage": "inline",
+                },
+            ),
+        ):
+            report = continuation.evaluate(fixture.write(), PLAN, output)
+        self.assertEqual(output.read_bytes(), continuation.canonical_bytes(report))
+        return report
+
+    def test_accepts_exact_counts_and_nonconsecutive_chain_placement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = self.evaluate(Fixture(Path(directory)))
+            self.assertEqual(report["status"], "accepted")
+            counts = report["questions"]["continuation_counts"]["scenarios"]
+            self.assertEqual([counts[name]["continuation_count"] for name in continuation.SCENARIOS], [0, 1, 2])
+            self.assertEqual(counts["two"]["definition_pages"], [20, 25, 23])
+            chunks = report["questions"]["placement"]["scenarios"]["two"]["definition_chunks"]
+            self.assertEqual([chunk["used"] for chunk in chunks], [2048, 2040, 17])
+
+    def test_wrong_continuation_count_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = self.evaluate(
+                Fixture(Path(directory)), lambda data: fake_analysis(data, bad_count=True)
+            )
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("control requires", report["replicas"][0]["decode_error"])
+
+    def test_unattributed_appended_page_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = self.evaluate(
+                Fixture(Path(directory)), lambda data: fake_analysis(data, unattributed=True)
+            )
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("unattributed", report["replicas"][0]["decode_error"])
+
+    def test_rejects_arm_identity_mismatch_and_extra_database(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0]["checkpoints"][1]["arm_before"]["sha256"] = "b" * 64
+            with self.assertRaisesRegex(continuation.AnalysisError, "arm identity"):
+                self.evaluate(fixture)
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            (Path(directory) / "unexpected.mdb").write_bytes(bytes(2048))
+            with self.assertRaisesRegex(continuation.AnalysisError, "retained MDB inventory"):
+                self.evaluate(fixture)
+
+    def test_failed_prefix_and_recovery_are_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                recovery_source = replica["checkpoints"][2]
+                replica["recovery"] = [
+                    {
+                        "name": "one",
+                        "database": recovery_source["database"],
+                        "size": recovery_source["size"],
+                        "sha256": recovery_source["sha256"],
+                    }
+                ]
+                for checkpoint in replica["checkpoints"][3:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = replica["checkpoints"][:2]
+                replica["status"] = "fail"
+                replica["error"] = "bounded DAO failure"
+                replica["phase"] = "append_one"
+            fixture.document["status"] = "fail"
+            self.assertEqual(self.evaluate(fixture)["status"], "no_outcome")
+
+    def test_failed_phase_must_match_checkpoint_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0]["status"] = "fail"
+            fixture.replicas[0]["error"] = "impossible state"
+            fixture.replicas[0]["phase"] = "append_one"
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(continuation.AnalysisError, "checkpoint prefix"):
+                self.evaluate(fixture)
+
+    def test_stable_final_arm_dao_rejection_is_preserved_as_answered_partial(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            empty = bytes(20 * continuation.PAGE_BYTES)
+            empty_digest = hashlib.sha256(empty).hexdigest()
+            for replica in fixture.replicas:
+                recovery = replica["checkpoints"][3]
+                (Path(directory) / recovery["database"]).write_bytes(empty)
+                replica["recovery"] = [
+                    {
+                        "name": "two",
+                        "database": recovery["database"],
+                        "size": len(empty),
+                        "sha256": empty_digest,
+                    }
+                ]
+                replica["checkpoints"] = replica["checkpoints"][:3]
+                replica["status"] = "fail"
+                replica["error"] = "DAO rejected the exact schema"
+                replica["phase"] = "append_two"
+            fixture.document["status"] = "fail"
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+            outcome = report["questions"]["producer_outcome"]
+            self.assertEqual(outcome["status"], "answered")
+            self.assertEqual(outcome["kind"], "bounded_dao_rejection")
+
+    def test_definition_chunks_rejects_pointer_corruption(self) -> None:
+        data = bytearray(3 * continuation.PAGE_BYTES)
+        data[4:8] = (2).to_bytes(4, "little")
+        with self.assertRaisesRegex(continuation.DecodeError, "pointer"):
+            continuation.definition_chunks(bytes(data), [0, 1], 2050)
+
+    def test_correlates_chained_lvprop_first_locator_without_assuming_placement(self) -> None:
+        header = (16).to_bytes(4, "little") + bytes([0]) + (2).to_bytes(3, "little") + bytes(4)
+        page = bytearray(continuation.PAGE_BYTES)
+        page[0] = 1
+        page[4:8] = b"LVAL"
+        with (
+            mock.patch.object(
+                continuation.catalog,
+                "_discover_catalog",
+                return_value=({}, [], [{"values": ["ContTwoX", {"inline_length": 12, "long_value_header_hex": header.hex()}]}]),
+            ),
+            mock.patch.object(
+                continuation.catalog,
+                "_ordinal",
+                side_effect=lambda _definition, name: {"Name": 0, "LvProp": 1}[name],
+            ),
+            mock.patch.object(continuation.catalog, "_page", return_value=bytes(page)),
+            mock.patch.object(
+                continuation.catalog,
+                "_row_directory",
+                return_value=[{"hidden": False, "overflow": False, "start": 10, "end": 30}],
+            ),
+        ):
+            value = continuation.created_lvprop(
+                bytes(3 * continuation.PAGE_BYTES),
+                {"pages": [{"page": 2, "role": "long_value"}]},
+                "ContTwoX",
+                20,
+            )
+        self.assertEqual(value["storage"], "chained")
+        self.assertEqual(value["first_locator"], {"row": 0, "page": 2, "appended": False, "row_length": 20})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -76,6 +76,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 "bootstrap-composer-validation",
                 "schema-generalization",
                 "multiple-indexes",
+                "definition-continuation",
                 "lvprop-null",
             ),
         )
@@ -121,6 +122,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 CLIENT.SYSTEM_CATALOG_JOB.name,
                 CLIENT.BOOTSTRAP_COMPOSER_VALIDATION_JOB.name,
                 CLIENT.SCHEMA_GENERALIZATION_JOB.name,
+                CLIENT.DEFINITION_CONTINUATION_JOB.name,
                 CLIENT.LVPROP_NULL_JOB.name,
             }
             if CLIENT.MULTIPLE_INDEXES_JOB.is_file():
@@ -249,6 +251,8 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 staged(CLIENT.SCHEMA_GENERALIZATION_JOB),
                 "-MultipleIndexesJobPath",
                 staged(CLIENT.MULTIPLE_INDEXES_JOB),
+                "-DefinitionContinuationJobPath",
+                staged(CLIENT.DEFINITION_CONTINUATION_JOB),
                 "-LvPropNullJobPath",
                 staged(CLIENT.LVPROP_NULL_JOB),
                 "-LvPropFixedAlphaPath",
@@ -375,6 +379,18 @@ class WindowsDaoDevClientTests(unittest.TestCase):
         self.assertEqual(binding.report_name, "multiple-indexes-report.json")
         self.assert_plan_bound_job("multiple-indexes", "MULTIPLE_INDEXES_PLAN")
 
+    def test_definition_continuation_binds_issue_151(self) -> None:
+        binding = CLIENT.plan_binding("definition-continuation")
+        self.assertEqual(binding.issue, 151)
+        self.assertEqual(binding.document_type, "dao_definition_continuation_plan")
+        self.assertEqual(
+            binding.job_result_name, "definition-continuation-job-result.json"
+        )
+        self.assertEqual(binding.report_name, "definition-continuation-report.json")
+        self.assert_plan_bound_job(
+            "definition-continuation", "DEFINITION_CONTINUATION_PLAN"
+        )
+
     def test_lvprop_null_binds_issue_149_and_verifies_a_pinned_plan(self) -> None:
         binding = CLIENT.plan_binding("lvprop-null")
         self.assertEqual(binding.issue, 149)
@@ -470,7 +486,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_remote_is_exploratory_and_allowlisted(self) -> None:
         self.assertIn(
-            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]',
+            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]',
             self.remote,
         )
         self.assertIn("development_only = $true", self.remote)
@@ -565,8 +581,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumRows = 64", row)
         self.assertIn("foreach ($replica in 1..3)", row)
         for scenario in (
@@ -586,8 +602,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_value_job_is_repeated_bounded_and_never_compacts(self) -> None:
         value = CLIENT.VALUE_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumDatabaseBytes = 4MB", value)
         self.assertIn("foreach ($replica in 1..3)", value)
         self.assertIn("$LongLengths = @(32, 512, 2048, 4096)", value)
@@ -598,8 +614,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_index_job_is_staged_bounded_and_never_compacts(self) -> None:
         index = CLIENT.INDEX_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumRows = 4096", index)
         self.assertIn("$MaximumDatabaseBytes = 16MB", index)
         for scenario in (
@@ -873,6 +889,49 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         job = CLIENT.MULTIPLE_INDEXES_JOB.read_text(encoding="utf-8")
         self.assertIn("[ref]$MutationStarted", job)
         self.assertIn("mutation_started = $false", job)
+        self.assertIn('phase = "before_create_database"', job)
+        self.assertIn("size_after_metadata", job)
+
+    def test_definition_continuation_is_bounded_and_exactly_routed(self) -> None:
+        self.assertIn(
+            '"definition-continuation" = "oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1"',
+            self.remote,
+        )
+        self.assertIn(
+            '"definition-continuation" { $DefinitionContinuationJobPath }',
+            self.dispatch,
+        )
+        self.assertIn(
+            '"definition-continuation" { "definition-continuation-job-result.json" }',
+            self.dispatch,
+        )
+        self.assertIn("definition_continuation_replicas", self.dispatch)
+        self.assertIn("definition_continuation_replicas", self.remote)
+        self.assertIn('"definition-continuation" {', self.publication)
+        self.assertIn(
+            '$checkpointNames = @("empty", "zero", "one", "two")',
+            self.publication,
+        )
+        self.assertIn("checkpoints are not an ordered prefix", self.publication)
+        self.assertIn("recovery is not the active next checkpoint", self.publication)
+        self.assertIn("12-database bound", self.publication)
+        self.assertIn("64-page bound", self.publication)
+        binding = CLIENT.plan_binding("definition-continuation")
+        self.assertEqual(binding.plan.name, "definition-continuation.plan.json")
+        self.assertEqual(binding.analyzer.name, "definition_continuation.py")
+        plan = json.loads(binding.plan.read_text(encoding="utf-8"))
+        self.assertEqual(plan["issue"], 151)
+        self.assertEqual(plan["execution"]["checkpoints"], ["empty", "zero", "one", "two"])
+        self.assertEqual(
+            plan["execution"]["bounds"]["maximum_published_databases"], 12
+        )
+        self.assertEqual(
+            {name: value.count("0") for name, value in plan["inputs"].items()},
+            {name: 64 for name in plan["inputs"]},
+        )
+        job = CLIENT.DEFINITION_CONTINUATION_JOB.read_text(encoding="utf-8")
+        self.assertIn('$ScenarioFields = @{ zero = 69; one = 70; two = 140 }', job)
+        self.assertIn("[ref]$MutationStarted", job)
         self.assertIn('phase = "before_create_database"', job)
         self.assertIn("size_after_metadata", job)
 

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -926,8 +926,11 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             plan["execution"]["bounds"]["maximum_published_databases"], 12
         )
         self.assertEqual(
-            {name: value.count("0") for name, value in plan["inputs"].items()},
-            {name: 64 for name in plan["inputs"]},
+            plan["inputs"],
+            {
+                relative: hashlib.sha256((ROOT / relative).read_bytes()).hexdigest()
+                for relative in plan["inputs"]
+            },
         )
         job = CLIENT.DEFINITION_CONTINUATION_JOB.read_text(encoding="utf-8")
         self.assertIn('$ScenarioFields = @{ zero = 69; one = 70; two = 140 }', job)

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -155,6 +155,24 @@ MULTIPLE_INDEXES_PLAN = (
 MULTIPLE_INDEXES_ANALYZER = (
     ROOT / "oracle" / "windows-dao" / "scripts" / "multiple_indexes.py"
 )
+DEFINITION_CONTINUATION_JOB = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "scripts"
+    / "dev"
+    / "DefinitionContinuation.DevJob.ps1"
+)
+DEFINITION_CONTINUATION_PLAN = (
+    ROOT
+    / "oracle"
+    / "windows-dao"
+    / "acquisition"
+    / "definition-continuation.plan.json"
+)
+DEFINITION_CONTINUATION_ANALYZER = (
+    ROOT / "oracle" / "windows-dao" / "scripts" / "definition_continuation.py"
+)
 LVPROP_NULL_JOB = (
     ROOT
     / "oracle"
@@ -194,6 +212,7 @@ ALLOWED_JOBS = (
     "bootstrap-composer-validation",
     "schema-generalization",
     "multiple-indexes",
+    "definition-continuation",
     "lvprop-null",
 )
 
@@ -307,6 +326,14 @@ def plan_binding(job: str) -> PlanBinding | None:
             MULTIPLE_INDEXES_ANALYZER,
             "dao_multiple_indexes_plan",
             150,
+        )
+    if job == "definition-continuation":
+        return PlanBinding(
+            job,
+            DEFINITION_CONTINUATION_PLAN,
+            DEFINITION_CONTINUATION_ANALYZER,
+            "dao_definition_continuation_plan",
+            151,
         )
     if job == "lvprop-null":
         return PlanBinding(
@@ -611,6 +638,10 @@ def stage_job(args: argparse.Namespace) -> Path:
         )
         shutil.copyfile(SCHEMA_GENERALIZATION_JOB, staging / SCHEMA_GENERALIZATION_JOB.name)
         shutil.copyfile(MULTIPLE_INDEXES_JOB, staging / MULTIPLE_INDEXES_JOB.name)
+        shutil.copyfile(
+            DEFINITION_CONTINUATION_JOB,
+            staging / DEFINITION_CONTINUATION_JOB.name,
+        )
         shutil.copyfile(LVPROP_NULL_JOB, staging / LVPROP_NULL_JOB.name)
         binding = plan_binding(args.job)
         if binding is not None:
@@ -688,6 +719,8 @@ def remote_job_command(args: argparse.Namespace) -> list[str]:
         ntpath.join(remote_input, SCHEMA_GENERALIZATION_JOB.name),
         "-MultipleIndexesJobPath",
         ntpath.join(remote_input, MULTIPLE_INDEXES_JOB.name),
+        "-DefinitionContinuationJobPath",
+        ntpath.join(remote_input, DEFINITION_CONTINUATION_JOB.name),
         "-LvPropNullJobPath",
         ntpath.join(remote_input, LVPROP_NULL_JOB.name),
         "-LvPropFixedAlphaPath",


### PR DESCRIPTION
Issue #151 blocks wide table definitions because the earlier boundary experiment did not establish where DAO places continuation pages during an empty first create.

This preregisters one SHA-256-pinned, three-replica local-VM experiment around exact 0/1/2-continuation boundaries. It validates independent arm identities, exact DAO schemas and logical lengths, complete chain/page-role attribution, page-zero changes, and bounded LvProp nuisance allocation. Any post-mutation failure remains `no_outcome`, and no compatibility or writer claim is made.

Checks:
- `python -m unittest oracle.windows-dao.tests.test_definition_continuation oracle.windows-dao.tests.test_windows_dao_dev_contract`
- `just ready`
- independent three-pass protocol/implementation review and final eight-pin identity audit

Closes #151 only after the separately recorded accepted outcome is merged.