### PR TITLE
test(oracle): preregister extended catalog names

### DIFF
--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -43,6 +43,7 @@ just windows-dev-bootstrap-composer-semantics
 just windows-dev-schema-generalization
 just windows-dev-multiple-indexes
 just windows-dev-definition-continuation
+just windows-dev-extended-names
 just windows-dev-lvprop-null
 ```
 
@@ -157,6 +158,17 @@ locator chain when present, referenced versus unreferenced appended LVAL pages,
 and the complete page-0 changed-offset set plus counter values. It presumes neither consecutive
 placement nor a single-page `LvProp`, and establishes no broader allocation,
 writer, compatibility, or support claim.
+
+`extended-names` is the SHA-256-pinned issue #152 experiment for every defined
+CP1252 byte above `0x7E`. Review and pinning are complete; the preregistration
+commit must merge before the standing authorization permits one acquisition.
+Three replicas each retain an empty checkpoint, 41
+identity-isolated three-byte batch checkpoints, and one explicit rejection-arm
+checkpoint. The analyzer accepts contrary but fully decoded collation behavior
+as an answer and treats incomplete decoding, mutation failure, or replica
+disagreement as `no_outcome`. The 128-page prospective bound accommodates the
+earlier observed 70-page, 24-name image; each new batch remains at 27 catalog
+rows, below the observed 32-row single-leaf count.
 
 `lvprop-null` is the SHA-256-pinned, development-only acceptance experiment for
 issue #149. Three replicas each compare the fixed accepted Alpha composer image,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -8501,7 +8501,6 @@ Use `not applicable` explicitly rather than omitting a field.
   scientific-protocol blocker; one low external-LVAL inventory test gap was
   fixed before pinning.
 
-
 ### EXP-0095 — No-outcome definition-continuation DAO result
 
 - Recorded: 2026-09-02, OpenAI Codex
@@ -8580,6 +8579,121 @@ Use `not applicable` explicitly rather than omitting a field.
   bound, append/close evidence, copied-versus-mutated later arms, dispatch-count
   provenance, and the reopened issue state were resolved; final reviews
   reported no remaining findings.
+
+
+### EXP-0096 — CP1252 extended catalog-name preregistration
+
+- Recorded: 2026-09-02, OpenAI Codex
+- Kind: SHA-256-pinned development-only local DAO preregistration; acquisition
+  has not occurred and is forbidden until the exact preregistration commit is
+  merged
+- Question: across three replicas and exact isolated arms, what catalog
+  ParentId/Name key contributions does DAO emit for every defined CP1252 byte
+  above `0x7E` in three singleton positions, a repeat, and both orders with its
+  next defined neighbor; and does DAO reject the `0x7F` boundary and five
+  undefined-slot controls?
+- Origin: project-authored clean-room experiment for issue `#152`, using the
+  catalog key grammar and ASCII context weights recorded by `EXP-0087` and no
+  external MDB implementation. `EXP-0087` collectively covered `0xA0`-`0xFF`
+  in twelve multi-byte probes and recorded aggregate primary/secondary
+  behavior, but deliberately derived no per-byte map, expansion, or secondary
+  assignment and did not probe `0x80`-`0x9F`; it therefore does not answer this
+  experiment. Windows-1252 repertoire tables define the test inventory but are
+  not treated as Jet collation evidence.
+- Controlled design: the domain is all 123 defined values in `0x80`-`0xFF`,
+  excluding `0x81`, `0x8D`, `0x8F`, `0x90`, and `0x9D`. Their ordered sequence
+  is divided into 41 batches of exactly three. Each batch starts from a fresh
+  copy of its replica's retained empty image and attempts one ASCII canary plus
+  six uniquely ASCII-tagged one-Long-field table names per byte: singleton at
+  the left, interior, and right insertion positions, a repeated pair, and both
+  orders with the next defined byte. The neighbor skips undefined slots and
+  wraps from `0xFF` to `0x80`. Thus each data arm has exactly 19 user creates,
+  below the 32-row single leaf observed in `EXP-0087` after accounting for its
+  eight catalog base rows. The prior 24-name checkpoint occupied 70 pages, so
+  the new 128-page bound is prospective headroom rather than a page-count
+  observation for these new arms.
+  The domain is anchored to Python's strict CP1252/Unicode repertoire. The
+  producer excludes the five undefined slots manually before .NET decoding;
+  no claim is made that .NET itself rejects those byte values.
+- Rejection controls: one independent arm attempts an ASCII canary and names
+  containing U+007F, U+0081, U+008D, U+008F, U+0090, and U+009D. DAO receives
+  Unicode BSTR names. The latter five are controls associated with undefined
+  CP1252 slots, not evidence that those undefined bytes have mappings. Exact
+  acceptance or rejection is recorded; an accepted control is an answer only
+  if its catalog row and key decode and correlate without ambiguity.
+- Protocol: each replica creates and closes one fresh CP1252 `dbVersion30`
+  database and retains `empty`, `b00` through `b40`, and `reject` in exact
+  order. Every working arm is copied and identity-checked against `empty`, one
+  arm exists at a time, DAO is closed after every append and before capture,
+  and bounded read-only metadata must leave each retained image byte-identical.
+  A passing run retains exactly 43 MDBs per replica, 129 total. The producer
+  records the exact UTF-16LE name, intended defined bytes, created/error result,
+  normalized `create_tabledef` or `tabledefs_append` failure operation, bounded
+  sequential DAO table/field/index inventory, mutation state, phase, ordered
+  checkpoint prefix, and at most the active next checkpoint as recovery. Only
+  exceptions thrown directly by those two name-bearing DAO calls continue as
+  rejections; open, field, close, metadata, and cleanup failures stop the
+  replica.
+  A `capture_empty` failure retains `empty` as recovery or removes the partial
+  root artifact. Explicit cleanup phases prevent a completed checkpoint from
+  also appearing as recovery, and working MDBs live only in a non-published
+  subdirectory.
+- Analysis: the analyzer independently regenerates all 123 bytes, batches,
+  neighbors, names, and files; validates the exact JSON, state, size, SHA-256,
+  metadata identity, every retained checkpoint attempt, bounded sequential DAO
+  metadata shape (including actual system indexes and no user indexes), exact
+  phase-to-prefix/recovery state, and case-folded artifact inventory; then uses
+  the `EXP-0087` grammar to correlate every created name with one catalog key.
+  It preserves exact key bytes, primary sections, secondary nibbles, and row
+  locators. It strips only the exact recorded ASCII context contribution and
+  compares singleton positions, repeated contributions, and both pair orders.
+  Expansions, position dependence, non-additivity, contrary order, and stable
+  DAO rejection are retained as answered observations rather than forced into
+  the hypothesis. An accepted rejection control retains its complete decoded
+  key identity and secondary section without asserting an undefined-byte map.
+  Every retained non-empty checkpoint in a failed prefix is decoded and
+  correlated; a failure there is recorded as `decode_error` and yields
+  `no_outcome`. Normalized failure operations remain in the canonical report
+  and participate in exact replica comparison.
+- Decision rule: `accepted` requires three complete exact replicas, 129 exact
+  artifacts, unchanged metadata bytes, complete schema/key correlation for all
+  created names, all defined-byte and rejection-control outcomes, and identical
+  exact observations. Any post-mutation producer failure, incomplete arm,
+  changed metadata, catalog/DAO/attempt disagreement, decode failure, loss of
+  the bounded single-leaf grammar, or replica disagreement is `no_outcome`.
+  A pre-mutation failure, pin/inventory/bound violation, malformed input,
+  inconsistent producer state, or analyzer contract defect rejects validation.
+  No retry is allowed after the first mutation without renewed human direction.
+- Preregistration artifacts: plan
+  `oracle/windows-dao/acquisition/extended-names.plan.json`, SHA-256
+  `201e880ff1e7d08d5151df2fc53388ef296dfbd4158fc84a530510fffbc32236`;
+  producer
+  `oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1`, SHA-256
+  `a177a80638d22605a2f7836005e9cd6b7b296fdcd7a264f49e6a325c5fa39356`;
+  analyzer
+  `oracle/windows-dao/scripts/extended_names.py`, SHA-256
+  `732e8ca5edd597bf54dc73764031e4663d361f9f1c4f21747baab6dbdf352369`.
+  All nine plan inputs carry exact lowercase SHA-256 pins.
+- Interpretation: a later accepted result may establish exact catalog-key
+  observations only for the preregistered CP1252 repertoire, contexts, locale,
+  empty first-create batches, and single-leaf grammar. It cannot establish a
+  general collation, undefined-byte mapping, longer names, larger trees, map or
+  definition spill, rows, indexes, relationships, public creation, writer
+  correctness, compatibility, hosted differential `#102`, or support movement.
+- Usage: future result for issue `#152`; `EXP-0087`;
+  `file:oracle/windows-dao/acquisition/extended-names.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1`;
+  `file:oracle/windows-dao/scripts/extended_names.py`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: three independent review/fix passes completed on 2026-09-02 over the
+  scientific design, byte inventory, state machine, producer, analyzer,
+  routing, publication, bounds, evidence retention, and claim boundary. Fixes
+  covered capture and cleanup failure publication, failed-prefix decoding,
+  rejection-operation retention, source reparse points, strict replica types,
+  duplicate/recovery inventories, and the .NET/CP1252 wording. The final
+  verification reported no remaining findings; 63 focused tests passed. No
+  acquisition was performed.
 
 
 ## Fixtures and black-box results

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -80,3 +80,13 @@ logical records, name-sorted logical order, and the observed primary, unique,
 ordinary, ascending, and descending forms. It cannot infer arbitrary schemas
 or behavior above three indexes. #102 remains the separate hosted write
 differential after database creation is complete.
+
+`EXP-0096` is the SHA-256-pinned #152 preregistration. Its bounded domain is all
+123 defined CP1252 bytes in `0x80`-`0xFF`, plus explicit U+007F and five
+undefined-slot Unicode rejection controls. Acquisition remains forbidden until
+the preregistration commit is merged. An
+accepted result may inform only the planner's catalog-key encoding for those
+exact singleton and pair contexts; it does not establish a general collation
+implementation. Its prospective 128-page bound is above the prior observed
+70-page, 24-name image, while its 19-create batches retain 27 catalog rows,
+below the observed 32-row single-leaf count.

--- a/justfile
+++ b/justfile
@@ -96,6 +96,10 @@ windows-dev-multiple-indexes:
 windows-dev-definition-continuation:
     "{{PYTHON}}" scripts/windows-dao-dev.py definition-continuation --timeout 900
 
+# Run the preregistered CP1252 extended catalog-name experiment.
+windows-dev-extended-names:
+    "{{PYTHON}}" scripts/windows-dao-dev.py extended-names --timeout 900
+
 # Run the preregistered null-LvProp acceptance experiment in the local VM.
 windows-dev-lvprop-null:
     "{{PYTHON}}" scripts/windows-dao-dev.py lvprop-null --timeout 900

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -56,6 +56,10 @@ The retained tooling has three purposes:
   The analyzer uses `scripts/system_catalog.py` for the pinned catalog decoding;
   the experiment is limited to its exact page-assignment matrix and makes no
   arbitrary-index, writer, compatibility, or support claim.
+- `acquisition/extended-names.plan.json`,
+  `scripts/dev/ExtendedNames.DevJob.ps1`, and `scripts/extended_names.py`
+  define the SHA-256-pinned issue #152 preregistration over all defined CP1252
+  bytes above `0x7E`; acquisition still requires the pinned commit to merge.
 - `acquisition/bootstrap-composer-validation.plan.json` is the immutable
   consumed plan for the accepted `EXP-0085` run. Its pins bind the harness at
   that revision, so the client refuses to dispatch it again.
@@ -152,3 +156,15 @@ not assume consecutive continuation placement or a single-page catalog
 `LvProp`. `EXP-0095` records a canonical `no_outcome`: the 69-field arm failed
 the combined geometry/64-page capture bound in all three replicas, so no
 created-arm bytes or continuation placement were retained.
+
+The issue #152 `extended-names` preregistration partitions all 123 defined
+CP1252 bytes in `0x80`-`0xFF` into 41 independent three-byte arms per replica.
+Each arm uses exact singleton, repeated, and neighboring-pair names; a separate
+arm records U+007F and the five undefined-slot Unicode rejection controls. A
+passing run retains 43 closed MDBs per replica, 129 total. This is a bounded
+catalog-key observation, not a general collation or compatibility claim.
+`EXP-0087`'s 24-name checkpoint occupied 70 pages; this prospective job
+therefore permits 128 pages while keeping each batch at 27 catalog rows (eight
+base plus 19 created tables), below the observed 32-row single leaf. Its exact
+inputs are pinned; acquisition remains forbidden until the preregistration
+commit merges.

--- a/oracle/windows-dao/acquisition/extended-names.plan.json
+++ b/oracle/windows-dao/acquisition/extended-names.plan.json
@@ -1,0 +1,80 @@
+{
+  "document_type": "dao_extended_names_plan",
+  "experiment_id": "extended-names",
+  "issue": 152,
+  "development_only": true,
+  "purpose": "Observe bounded Jet 3 catalog-name key contributions for every defined CP1252 byte above 0x7E, with explicit boundary and undefined-slot rejection controls.",
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0087 records the single-leaf catalog ParentId/Name key grammar, the exact primary weights for the ASCII context alphabet used here, an observed 32-row leaf, and empty first-create page framing. Its one 24-name probe image was 70 pages, so this prospective experiment uses a 128-page safety bound rather than assuming the earlier 64-page bound. Its twelve multi-byte extended-name probes collectively covered 0xA0-0xFF and observed only aggregate primary/secondary behavior; it deliberately derived no per-byte map, expansion, or secondary assignment and did not probe 0x80-0x9F. EXP-0091 records the bounded null-LvProp result but is not used to infer collation. This plan isolates every defined byte above 0x7E and does not treat CP1252 code-page tables as Jet collation evidence.",
+    "authorization": "The exact inputs were pinned after three independent review/fix passes. Acquisition remains forbidden until this preregistration commit is merged. The user's explicit standing authorization permits at most one run after that merge.",
+    "attempt_policy": "Dispatch at most one three-replica run after authorization. Once the first DAO CreateDatabase mutation begins, any failure is a scientific result and must not be retried without another explicit human decision. Only an exception thrown directly by the name-bearing CreateTableDef or TableDefs.Append call is normalized as that name's rejection and allows the bounded batch to continue. Open, field creation/append, close, metadata, and cleanup failures stop the replica."
+  },
+  "inputs": {
+    "scripts/windows-dao-dev.py": "80a7b7e8d95c9f81675e0968ef143bc0460753f9e98983993469216b93444de8",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "2a75b5baadff7f10a479789ae74bb03964b756b86f06157dda596fc8e434122e",
+    "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "6989d940edd83ac7a4d7fdccbb284a460cf9a397b820518633f42ce3addfd2a9",
+    "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "b41138e2e349cda28ffd86f087ec14cc8cee0d3295536c5bdc3e3a8a087250e2",
+    "oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1": "a177a80638d22605a2f7836005e9cd6b7b296fdcd7a264f49e6a325c5fa39356",
+    "oracle/windows-dao/scripts/extended_names.py": "732e8ca5edd597bf54dc73764031e4663d361f9f1c4f21747baab6dbdf352369",
+    "oracle/windows-dao/scripts/schema_generalization.py": "add7667b20d47537d6255df22be42f27d8100b6f43b80bb0b2fb71d049249af7",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9"
+  },
+  "execution": {
+    "environment": "The private local Windows development VM documented in docs/LOCAL_WINDOWS_VM.md, using x86 Windows PowerShell and a ready DAO.DBEngine.36 provider.",
+    "replicas": 3,
+    "attempts_per_replica": 1,
+    "defined_domain": "All 123 byte values in the strict Python cp1252/Unicode repertoire for 0x80-0xFF: every value except 0x81, 0x8D, 0x8F, 0x90, and 0x9D. The producer manually excludes those five slots before using .NET decoding; this plan does not claim that .NET itself rejects or leaves those slots undefined.",
+    "batching": "The ordered defined-byte sequence is partitioned into 41 consecutive batches of exactly three. Each batch starts from a byte-identical copy of that replica's fresh empty database and appends one ASCII canary plus six uniquely tagged forms per byte: left, interior, and right singleton positions; a repeated pair; and both orders with the next defined byte, wrapping 0xFF to 0x80. Thus each batch attempts exactly 19 one-Long-field tables and never uses an undefined byte as a neighbor.",
+    "rejection_controls": "A separate fresh-empty arm attempts one ASCII canary followed by names containing U+007F and U+0081, U+008D, U+008F, U+0090, and U+009D. Because COM receives Unicode BSTR names, the five undefined-slot controls are slot-associated Unicode control-code probes, not observations that an undefined CP1252 byte has a mapping. Their exact DAO acceptance or rejection is recorded; accepted bytes are decoded only if the recorded catalog grammar correlates them unambiguously.",
+    "isolation": "Each replica creates and closes one fresh dbVersion30 CP1252 database. It copies and identity-checks one arm at a time from the retained empty image, closes the database after every table append, and closes it before checkpoint capture. No rows or indexes are added.",
+    "checkpoints": "Retain empty, b00 through b40, and reject in that exact order per replica: 43 databases per replica and 129 for a passing run.",
+    "capture": "Record exact UTF-16LE name identity, intended defined bytes, per-name created/error outcome and normalized create_tabledef or tabledefs_append failure operation, arm-before identity, closed-file SHA-256 and size before and after bounded read-only DAO metadata access, and the bounded sequential DAO table/field/index inventory, including actual system indexes and exact one-field/no-index user schemas. Record mutation state and exact append/cleanup phase plus at most the active next checkpoint as recovery. A capture_empty failure retains empty as the expected recovery or removes a partial root artifact; a cleanup failure after a checkpoint is recorded with that checkpoint in the prefix and never duplicates it as recovery. Working MDBs stay below a non-published subdirectory. The analyzer independently regenerates the domain, batches, neighbors, names, and artifact inventory, validates and decodes every retained non-empty checkpoint even in a failed prefix, correlates created DAO names with decoded catalog keys, preserves normalized failure operations in the canonical report and replica comparison, and preserves complete key bytes, primary sections, secondary nibbles, and row locators.",
+    "bounds": {
+      "maximum_replicas": 3,
+      "maximum_checkpoints_per_replica": 43,
+      "maximum_recovery_databases_per_replica": 1,
+      "maximum_published_databases": 129,
+      "maximum_pages_per_database": 128,
+      "maximum_table_definitions": 32,
+      "maximum_fields_per_table": 32,
+      "maximum_indexes_per_table": 16,
+      "maximum_user_tables_per_batch": 19,
+      "maximum_fields_per_user_table": 1,
+      "maximum_detail_characters": 512,
+      "maximum_job_json_bytes": 8388608
+    }
+  },
+  "questions": {
+    "coverage": "For every exact defined CP1252 byte above 0x7E and each of its six forms, did DAO accept or reject the table name; and what happened for the six explicit rejection controls?",
+    "singleton_positions": "For each accepted byte, what exact primary contribution and secondary nibbles occur in the left, interior, and right singleton contexts, and are those observations position-independent?",
+    "pair_composition": "For each accepted repeated form, does its exact primary contribution and secondary-nibble sequence equal two ordered singleton contributions?",
+    "secondary_order": "For each accepted neighbor pair in both orders, do its exact primary contribution and secondary-nibble sequence equal the corresponding ordered singleton observations, including expansions?",
+    "replication": "Do all three replicas agree on the complete exact attempt and decoded-key observations?"
+  },
+  "decision_rule": {
+    "accepted": "All final pins match; three replicas complete the exact 43-checkpoint inventory once; every arm starts byte-identical to its retained empty image; metadata access does not change bytes; every attempt and bounded sequential DAO table/field/index shape matches the regenerated inventory; every created name correlates to exactly one completely decoded catalog key; all 123 defined-byte observations and six controls are retained; and the exact observations agree across replicas. Stable exact name-bearing DAO rejection, expansions, position dependence, non-additivity, or contrary pair order are answered observations, not validation failures. An accepted rejection control preserves its full decoded key identity without asserting an undefined-byte mapping.",
+    "no_outcome": "Any post-mutation producer failure, including capture or cleanup failure, incomplete arm, changed metadata identity, DAO/attempt/catalog disagreement, undecodable accepted control, retained-prefix key decode or correlation failure, loss of the single-leaf bounded grammar, or replica disagreement including normalized failure-operation disagreement is recorded as no_outcome.",
+    "rejected": "A pre-mutation plan, pin, provider, or infrastructure failure; malformed or duplicate JSON; inconsistent mutation/phase/checkpoint/recovery state; unexpected, reordered, duplicate, missing, symlinked, oversized, or extra artifact; bound violation; or analyzer contract defect rejects validation without a scientific outcome.",
+    "retry": "There is no automatic retry after the first DAO mutation."
+  },
+  "retention": {
+    "publish": "environment.json, result.json, the bounded job result, up to 129 exact expected-name MDBs including at most one active-next-checkpoint recovery artifact per failed replica (exactly 129 for a passing job), and the deterministic analyzer report.",
+    "repository": "Never commit MDB bytes or provider binaries. Record a validated report identity and conclusion once as a later additive EXP outcome."
+  },
+  "publication": {
+    "canonical_result": "One validated deterministic JSON report and one later additive EXP outcome.",
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "compatibility_claim": false,
+    "support_matrix_movement": false
+  },
+  "exclusions": [
+    "CP1252 bytes 0x00-0x7E except the exact ASCII context and U+007F rejection control",
+    "a claimed mapping for undefined CP1252 slots; their Unicode controls only test rejection behavior at the BSTR boundary",
+    "names with more than two non-ASCII characters, other positions or contexts, locale/code-page variants, case folding, or general collation semantics",
+    "catalog trees beyond the recorded single-leaf grammar, more than 19 user tables per arm, rows, indexes, relationships, long field names, continuation pages, or map spill",
+    "public creation API, filesystem publication, writer correctness, hosted differential #102, compatibility claims, and support-matrix movement"
+  ]
+}

--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]
+    [ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$RunRoot,
@@ -33,6 +33,8 @@ param(
     [string]$MultipleIndexesJobPath,
     [Parameter(Mandatory = $true)]
     [string]$DefinitionContinuationJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ExtendedNamesJobPath,
     [Parameter(Mandatory = $true)]
     [string]$LvPropNullJobPath,
     [Parameter(Mandatory = $true)]
@@ -72,6 +74,7 @@ $scriptPath = switch ($Job) {
     "schema-generalization" { $SchemaGeneralizationJobPath }
     "multiple-indexes" { $MultipleIndexesJobPath }
     "definition-continuation" { $DefinitionContinuationJobPath }
+    "extended-names" { $ExtendedNamesJobPath }
     "lvprop-null" { $LvPropNullJobPath }
 }
 if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
@@ -97,7 +100,7 @@ elseif ($Job -ceq "bootstrap-layout") {
 elseif ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId, "-Experiment", $Job)
 }
-elseif ($Job -in @("schema-generalization", "multiple-indexes", "definition-continuation")) {
+elseif ($Job -in @("schema-generalization", "multiple-indexes", "definition-continuation", "extended-names")) {
     $arguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId)
 }
 elseif ($Job -ceq "lvprop-null") {
@@ -133,6 +136,7 @@ $resultName = switch ($Job) {
     "schema-generalization" { "schema-generalization-job-result.json" }
     "multiple-indexes" { "multiple-indexes-job-result.json" }
     "definition-continuation" { "definition-continuation-job-result.json" }
+    "extended-names" { "extended-names-job-result.json" }
     "lvprop-null" { "lvprop-null-job-result.json" }
 }
 $resultPath = Join-Path $RunRoot $resultName
@@ -153,6 +157,7 @@ if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
         schema_generalization_replicas = @()
         multiple_indexes_replicas = @()
         definition_continuation_replicas = @()
+        extended_names_replicas = @()
         lvprop_null_replicas = @()
     }
     Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result
@@ -171,6 +176,7 @@ $systemCatalogReplicas = @()
 $schemaGeneralizationReplicas = @()
 $multipleIndexesReplicas = @()
 $definitionContinuationReplicas = @()
+$extendedNamesReplicas = @()
 $lvpropNullReplicas = @()
 # The system-catalog result carries no detail field; derive one from its status.
 $detail = if ($Job -in @("system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics")) {
@@ -203,6 +209,14 @@ elseif ($Job -ceq "definition-continuation") {
     }
     else {
         "At least one definition-continuation replica failed; per-replica error records the message."
+    }
+}
+elseif ($Job -ceq "extended-names") {
+    if ([string]$jobResult.status -ceq "pass") {
+        "Completed all three extended-names replicas once without retry."
+    }
+    else {
+        "At least one extended-names replica failed; per-replica error records the message."
     }
 }
 elseif ($Job -ceq "lvprop-null") {
@@ -248,6 +262,9 @@ elseif ($Job -ceq "multiple-indexes") {
 elseif ($Job -ceq "definition-continuation") {
     $definitionContinuationReplicas = @($jobResult.replicas)
 }
+elseif ($Job -ceq "extended-names") {
+    $extendedNamesReplicas = @($jobResult.replicas)
+}
 elseif ($Job -ceq "lvprop-null") {
     $lvpropNullReplicas = @($jobResult.replicas)
 }
@@ -267,6 +284,7 @@ $result = [ordered]@{
     schema_generalization_replicas = @($schemaGeneralizationReplicas)
     multiple_indexes_replicas = @($multipleIndexesReplicas)
     definition_continuation_replicas = @($definitionContinuationReplicas)
+    extended_names_replicas = @($extendedNamesReplicas)
     lvprop_null_replicas = @($lvpropNullReplicas)
 }
 Write-JsonDocument -Path (Join-Path $RunRoot "dispatch-result.json") -Document $result

--- a/oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1
@@ -1,0 +1,262 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RunRoot,
+    [Parameter(Mandatory = $true)][ValidatePattern("^[0-9a-f]{64}$")][string]$PlanSha256,
+    [Parameter(Mandatory = $true)][ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")][string]$RunId
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$DbVersion30 = 32
+$DbLong = 4
+$DatabaseLocale = ";LANGID=0x0409;CP=1252;COUNTRY=0"
+$PageSize = 2048
+$MaximumPages = 128
+$MaximumTables = 32
+$MaximumFieldsPerTable = 32
+$MaximumIndexesPerTable = 16
+$MaximumDetailCharacters = 512
+$UndefinedSlots = @(0x81, 0x8D, 0x8F, 0x90, 0x9D)
+$DefinedBytes = @(0x80..0xFF | Where-Object { $_ -notin $UndefinedSlots })
+$Cp1252 = [Text.Encoding]::GetEncoding(1252, [Text.EncoderFallback]::ExceptionFallback, [Text.DecoderFallback]::ExceptionFallback)
+
+function Release-ComObject { param([object]$Value); if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value) } }
+function Get-Sha256 { param([string]$Path); return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant() }
+function Get-BoundedSize {
+    param([string]$Path)
+    $item = Get-Item -LiteralPath $Path -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw "Database must not be a reparse point: $Path" }
+    $length = [long]$item.Length
+    if ($length -lt $PageSize -or ($length % $PageSize) -ne 0 -or ($length / $PageSize) -gt $MaximumPages) { throw "Database is outside the bounded 2 KiB page geometry: $Path" }
+    return $length
+}
+function ConvertTo-BoundedDetail {
+    param([AllowNull()][object]$Detail)
+    $text = if ($null -eq $Detail) { "No additional detail was reported." } else { [string]$Detail }
+    if ($text.Length -gt $MaximumDetailCharacters) { return $text.Substring(0, $MaximumDetailCharacters) }
+    return $text
+}
+function Write-JsonDocument {
+    param([string]$Path, [object]$Document)
+    $encoding = New-Object Text.UTF8Encoding($false)
+    [IO.File]::WriteAllText([IO.Path]::GetFullPath($Path), (($Document | ConvertTo-Json -Depth 20) + "`n"), $encoding)
+}
+function Invoke-WithDatabase {
+    param([string]$Path, [switch]$ReadOnly, [scriptblock]$Action)
+    $engine = $null; $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $database = $engine.OpenDatabase($Path, $false, [bool]$ReadOnly)
+        & $Action $database
+        $database.Close(); Release-ComObject $database; $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject $database; Release-ComObject $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+}
+function New-Jet3Database {
+    param([string]$Path, [ref]$MutationStarted)
+    $engine = $null; $workspace = $null; $database = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"; $workspace = $engine.Workspaces.Item(0)
+        $MutationStarted.Value = $true
+        $database = $workspace.CreateDatabase($Path, $DatabaseLocale, $DbVersion30)
+        $database.Close(); Release-ComObject $database; $database = $null
+    }
+    finally {
+        if ($null -ne $database) { try { $database.Close() } catch { } }
+        Release-ComObject $database; Release-ComObject $workspace; Release-ComObject $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+}
+function ConvertTo-Utf16LeHex { param([string]$Value); return (([Text.Encoding]::Unicode.GetBytes($Value) | ForEach-Object { $_.ToString("x2") }) -join "") }
+function Get-DefinedCharacter { param([int]$Byte); return $Cp1252.GetString([byte[]]@($Byte)) }
+function Get-BatchSpecs {
+    param([int]$BatchIndex, [int[]]$Bytes)
+    $result = New-Object Collections.ArrayList
+    [void]$result.Add([pscustomobject]@{ role = "ascii_control"; name = "C" + $BatchIndex.ToString("D2") + "B"; bytes = @() })
+    foreach ($point in $Bytes) {
+        $position = [Array]::IndexOf($DefinedBytes, [int]$point)
+        $neighborPoint = [int]$DefinedBytes[($position + 1) % $DefinedBytes.Count]
+        $tag = ([int]$point).ToString("X2"); $current = Get-DefinedCharacter $point; $neighbor = Get-DefinedCharacter $neighborPoint
+        foreach ($spec in @(
+            [pscustomobject]@{ role = "single_left"; name = "N${tag}L${current}AZ"; bytes = @($point) },
+            [pscustomobject]@{ role = "single_middle"; name = "N${tag}MA${current}Z"; bytes = @($point) },
+            [pscustomobject]@{ role = "single_right"; name = "N${tag}RAZ${current}"; bytes = @($point) },
+            [pscustomobject]@{ role = "repeat"; name = "N${tag}DA${current}${current}Z"; bytes = @($point, $point) },
+            [pscustomobject]@{ role = "forward"; name = "N${tag}FA${current}${neighbor}Z"; bytes = @($point, $neighborPoint) },
+            [pscustomobject]@{ role = "reverse"; name = "N${tag}VA${neighbor}${current}Z"; bytes = @($neighborPoint, $point) }
+        )) { [void]$result.Add($spec) }
+    }
+    return @($result)
+}
+function Get-RejectionSpecs {
+    $result = New-Object Collections.ArrayList
+    [void]$result.Add([pscustomobject]@{ role = "ascii_control"; name = "CREJECTB"; bytes = @() })
+    foreach ($point in @(0x7F, 0x81, 0x8D, 0x8F, 0x90, 0x9D)) {
+        $tag = ([int]$point).ToString("X2")
+        [void]$result.Add([pscustomobject]@{ role = if ($point -eq 0x7F) { "boundary_7f" } else { "undefined_$tag" }; name = "R${tag}A" + [char]$point + "Z"; bytes = @() })
+    }
+    return @($result)
+}
+function Add-ProbeTable {
+    param([string]$Path, [object]$Spec)
+    $created = $false; $errorText = $null; $failureOperation = $null
+    $engine = $null; $database = $null; $table = $null; $field = $null
+    try {
+        $engine = New-Object -ComObject "DAO.DBEngine.36"
+        $database = $engine.OpenDatabase($Path, $false, $false)
+        try {
+            try { $table = $database.CreateTableDef([string]$Spec.name) }
+            catch {
+                $failureOperation = "create_tabledef"
+                $errorText = ConvertTo-BoundedDetail ($_.Exception.GetType().FullName + ": " + $_.Exception.Message)
+            }
+            if ($null -eq $failureOperation) {
+                $field = $table.CreateField("Id", $DbLong)
+                $table.Fields.Append($field)
+                try { $database.TableDefs.Append($table) }
+                catch {
+                    $failureOperation = "tabledefs_append"
+                    $errorText = ConvertTo-BoundedDetail ($_.Exception.GetType().FullName + ": " + $_.Exception.Message)
+                }
+            }
+        }
+        finally {
+            Release-ComObject $field
+            Release-ComObject $table
+        }
+        $database.Close(); Release-ComObject $database; $database = $null
+        $created = $null -eq $failureOperation
+    }
+    finally {
+        if ($null -ne $database) { $database.Close() }
+        Release-ComObject $database; Release-ComObject $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return [ordered]@{ role = [string]$Spec.role; name = [string]$Spec.name; name_utf16le_hex = ConvertTo-Utf16LeHex ([string]$Spec.name); inserted_bytes = @($Spec.bytes); created = $created; failure_operation = $failureOperation; error = $errorText }
+}
+function Get-DaoMetadata {
+    param([string]$Path)
+    $holder = [pscustomobject]@{ value = $null }
+    Invoke-WithDatabase -Path $Path -ReadOnly -Action {
+        param($database)
+        $definitions = $null; $rows = New-Object Collections.ArrayList
+        try {
+            $definitions = $database.TableDefs
+            if ([int]$definitions.Count -gt $MaximumTables) { throw "DAO table bound exceeded." }
+            for ($position = 0; $position -lt [int]$definitions.Count; $position++) {
+                $table = $null; $fields = $null; $indexes = $null
+                try {
+                    $table = $definitions.Item($position); $tableName = [string]$table.Name
+                    $fieldRows = New-Object Collections.ArrayList; $indexRows = New-Object Collections.ArrayList
+                    $fields = $table.Fields
+                    if ([int]$fields.Count -gt $MaximumFieldsPerTable) { throw "DAO field bound exceeded." }
+                    for ($fieldPosition = 0; $fieldPosition -lt [int]$fields.Count; $fieldPosition++) {
+                        $field = $null
+                        try { $field = $fields.Item($fieldPosition); [void]$fieldRows.Add([ordered]@{ ordinal = $fieldPosition; name = [string]$field.Name; type = [int]$field.Type; size = [int]$field.Size }) }
+                        finally { Release-ComObject $field }
+                    }
+                    $indexes = $table.Indexes
+                    if ([int]$indexes.Count -gt $MaximumIndexesPerTable) { throw "DAO index bound exceeded." }
+                    for ($indexPosition = 0; $indexPosition -lt [int]$indexes.Count; $indexPosition++) {
+                        $index = $null
+                        try { $index = $indexes.Item($indexPosition); [void]$indexRows.Add([ordered]@{ ordinal = $indexPosition; name = [string]$index.Name; primary = [bool]$index.Primary; unique = [bool]$index.Unique }) }
+                        finally { Release-ComObject $index }
+                    }
+                    [void]$rows.Add([ordered]@{ ordinal = $position; name = $tableName; fields = @($fieldRows); indexes = @($indexRows) })
+                }
+                finally { Release-ComObject $indexes; Release-ComObject $fields; Release-ComObject $table }
+            }
+        }
+        finally { Release-ComObject $definitions }
+        $holder.value = [ordered]@{ tabledefs = @($rows) }
+    }
+    return $holder.value
+}
+function Save-Checkpoint {
+    param([string]$Source, [int]$Replica, [string]$Name, [AllowNull()][object]$ArmBefore, [object[]]$Attempts)
+    $fileName = "extended-names-r$Replica-$Name.mdb"; $destination = Join-Path $RunRoot $fileName
+    Copy-Item -LiteralPath $Source -Destination $destination -Force
+    $size = Get-BoundedSize $destination; $sha256 = Get-Sha256 $destination; $dao = Get-DaoMetadata $destination
+    return [ordered]@{ name = $Name; database = $fileName; size = $size; sha256 = $sha256; size_after_metadata = Get-BoundedSize $destination; sha256_after_metadata = Get-Sha256 $destination; arm_before = $ArmBefore; attempts = @($Attempts); dao = $dao }
+}
+function Invoke-Replica {
+    param([int]$Replica)
+    $state = [ordered]@{ replica = $Replica; status = "fail"; error = $null; mutation_started = $false; phase = "before_create_database"; checkpoints = @(); recovery = @() }
+    $checkpoints = New-Object Collections.ArrayList; $recovery = New-Object Collections.ArrayList
+    $replicaWork = Join-Path (Join-Path $RunRoot "_working") "r$Replica"
+    $basePath = Join-Path $replicaWork "base.mdb"; $activeName = $null; $activePath = $null
+    $mutationStarted = $false; $recoveryEligible = $false
+    try {
+        [void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($replicaWork))
+        $state.phase = "create_database"; New-Jet3Database $basePath ([ref]$mutationStarted); $state.mutation_started = $mutationStarted
+        $state.phase = "capture_empty"; $activeName = "empty"; $activePath = $basePath; $recoveryEligible = $true
+        $empty = Save-Checkpoint $basePath $Replica "empty" $null @(); [void]$checkpoints.Add($empty)
+        $activeName = $null; $activePath = $null; $recoveryEligible = $false
+        for ($batchIndex = 0; $batchIndex -lt 41; $batchIndex++) {
+            $batchOffset = $batchIndex * 3
+            $batchBytes = @($DefinedBytes[$batchOffset..($batchOffset + 2)])
+            $activeName = "b" + $batchIndex.ToString("D2"); $state.phase = "append_$activeName"; $activePath = Join-Path $replicaWork "$activeName.mdb"
+            Copy-Item -LiteralPath $basePath -Destination $activePath; $recoveryEligible = $true
+            $armSize = Get-BoundedSize $activePath; $armSha256 = Get-Sha256 $activePath
+            if ($armSize -ne [long]$empty.size -or $armSha256 -cne [string]$empty.sha256) { throw "Batch $activeName differs from the retained empty baseline before mutation." }
+            $attempts = New-Object Collections.ArrayList
+            foreach ($spec in Get-BatchSpecs $batchIndex $batchBytes) {
+                $attempt = Add-ProbeTable $activePath $spec; [void]$attempts.Add($attempt)
+                if ([string]$spec.role -ceq "ascii_control" -and -not [bool]$attempt.created) { throw "Batch $activeName ASCII control was rejected." }
+            }
+            [void]$checkpoints.Add((Save-Checkpoint $activePath $Replica $activeName ([ordered]@{ size = $armSize; sha256 = $armSha256 }) @($attempts)))
+            $state.phase = "cleanup_$activeName"; $recoveryEligible = $false
+            Remove-Item -LiteralPath $activePath -Force; $activeName = $null; $activePath = $null
+        }
+        $activeName = "reject"; $state.phase = "append_reject"; $activePath = Join-Path $replicaWork "reject.mdb"
+        Copy-Item -LiteralPath $basePath -Destination $activePath; $recoveryEligible = $true
+        $armSize = Get-BoundedSize $activePath; $armSha256 = Get-Sha256 $activePath
+        if ($armSize -ne [long]$empty.size -or $armSha256 -cne [string]$empty.sha256) { throw "Rejection arm differs from the retained empty baseline before mutation." }
+        $attempts = New-Object Collections.ArrayList
+        foreach ($spec in Get-RejectionSpecs) {
+            $attempt = Add-ProbeTable $activePath $spec; [void]$attempts.Add($attempt)
+            if ([string]$spec.role -ceq "ascii_control" -and -not [bool]$attempt.created) { throw "Rejection-arm ASCII control was rejected." }
+        }
+        [void]$checkpoints.Add((Save-Checkpoint $activePath $Replica $activeName ([ordered]@{ size = $armSize; sha256 = $armSha256 }) @($attempts)))
+        $state.phase = "cleanup_reject"; $recoveryEligible = $false
+        Remove-Item -LiteralPath $activePath -Force; $activeName = $null; $activePath = $null
+        $state.phase = "cleanup_complete"; $state.status = "pass"
+    }
+    catch {
+        $state.mutation_started = $mutationStarted; $state.error = ConvertTo-BoundedDetail ($_.Exception.GetType().FullName + ": " + $_.Exception.Message)
+        if ($recoveryEligible -and $null -ne $activePath -and $null -ne $activeName) {
+            try {
+                $fileName = "extended-names-r$Replica-$activeName.mdb"; $destination = Join-Path $RunRoot $fileName
+                Copy-Item -LiteralPath $activePath -Destination $destination -Force
+                [void]$recovery.Add([ordered]@{ name = $activeName; database = $fileName; size = Get-BoundedSize $destination; sha256 = Get-Sha256 $destination })
+            }
+            catch {
+                try { if (Test-Path -LiteralPath $destination -PathType Leaf) { Remove-Item -LiteralPath $destination -Force } } catch { }
+                $state.error = ConvertTo-BoundedDetail ($state.error + " Recovery retention failed: " + $_.Exception.Message)
+            }
+        }
+    }
+    finally {
+        foreach ($working in @($activePath, $basePath)) {
+            try { if ($null -ne $working -and (Test-Path -LiteralPath $working -PathType Leaf)) { Remove-Item -LiteralPath $working -Force } }
+            catch { $state.status = "fail"; $state.error = ConvertTo-BoundedDetail ($state.error + " Cleanup failed: " + $_.Exception.Message) }
+        }
+        try { if (Test-Path -LiteralPath $replicaWork -PathType Container) { Remove-Item -LiteralPath $replicaWork -Force } }
+        catch { $state.status = "fail"; $state.error = ConvertTo-BoundedDetail ($state.error + " Working-directory cleanup failed: " + $_.Exception.Message) }
+    }
+    if ([string]$state.status -ceq "pass") { $state.phase = "complete" }
+    $state.checkpoints = @($checkpoints); $state.recovery = @($recovery); return $state
+}
+[void][IO.Directory]::CreateDirectory([IO.Path]::GetFullPath($RunRoot))
+$replicas = New-Object Collections.ArrayList
+foreach ($replica in 1..3) {
+    $entry = Invoke-Replica $replica; [void]$replicas.Add($entry)
+    if ([string]$entry.status -cne "pass" -and -not [bool]$entry.mutation_started -and $replicas.Count -eq 1) { break }
+}
+$status = if (@($replicas | Where-Object { [string]$_.status -cne "pass" }).Count -eq 0) { "pass" } else { "fail" }
+$result = [ordered]@{ document_type = "dao_extended_names_job_result"; development_only = $true; plan_sha256 = $PlanSha256; run_id = $RunId; status = $status; replicas = @($replicas) }
+Write-JsonDocument (Join-Path $RunRoot "extended-names-job-result.json") $result
+if ($status -ceq "pass") { exit 0 } else { exit 1 }

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}$")]
@@ -42,6 +42,8 @@ param(
     [string]$MultipleIndexesJobPath,
     [Parameter(Mandatory = $true)]
     [string]$DefinitionContinuationJobPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ExtendedNamesJobPath,
     [Parameter(Mandatory = $true)]
     [string]$LvPropNullJobPath,
     [Parameter(Mandatory = $true)]
@@ -392,7 +394,7 @@ if ($Job -ceq "table-definition" -and
 foreach ($requiredHelper in @(
     $DispatchPath, $PublicationPath, $RowJobPath, $ValueJobPath, $IndexJobPath,
     $BootstrapLayoutJobPath, $SystemCatalogJobPath, $BootstrapComposerValidationJobPath,
-    $SchemaGeneralizationJobPath, $MultipleIndexesJobPath, $DefinitionContinuationJobPath,
+    $SchemaGeneralizationJobPath, $MultipleIndexesJobPath, $DefinitionContinuationJobPath, $ExtendedNamesJobPath,
     $LvPropNullJobPath
 )) {
     if (-not (Test-Path -LiteralPath $requiredHelper -PathType Leaf)) {
@@ -412,6 +414,7 @@ $planBoundJobs = @{
     "schema-generalization" = "oracle/windows-dao/scripts/dev/SchemaGeneralization.DevJob.ps1"
     "multiple-indexes" = "oracle/windows-dao/scripts/dev/MultipleIndexes.DevJob.ps1"
     "definition-continuation" = "oracle/windows-dao/scripts/dev/DefinitionContinuation.DevJob.ps1"
+    "extended-names" = "oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1"
     "lvprop-null" = "oracle/windows-dao/scripts/dev/LvPropNull.DevJob.ps1"
 }
 if ($planBoundJobs.ContainsKey($Job)) {
@@ -443,6 +446,9 @@ if ($planBoundJobs.ContainsKey($Job)) {
     }
     elseif ($Job -ceq "definition-continuation") {
         $DefinitionContinuationJobPath
+    }
+    elseif ($Job -ceq "extended-names") {
+        $ExtendedNamesJobPath
     }
     elseif ($Job -ceq "lvprop-null") {
         $LvPropNullJobPath
@@ -545,6 +551,7 @@ $systemCatalogReplicas = @()
 $schemaGeneralizationReplicas = @()
 $multipleIndexesReplicas = @()
 $definitionContinuationReplicas = @()
+$extendedNamesReplicas = @()
 $lvpropNullReplicas = @()
 
 if ($Job -ceq "provider-probe") {
@@ -771,7 +778,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
         }
     }
 }
-elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null") -and $probeExitCode -eq 0) {
+elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null") -and $probeExitCode -eq 0) {
     $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
@@ -790,6 +797,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             -SchemaGeneralizationJobPath $SchemaGeneralizationJobPath `
             -MultipleIndexesJobPath $MultipleIndexesJobPath `
             -DefinitionContinuationJobPath $DefinitionContinuationJobPath `
+            -ExtendedNamesJobPath $ExtendedNamesJobPath `
             -LvPropNullJobPath $LvPropNullJobPath `
             -LvPropFixedAlphaPath $LvPropFixedAlphaPath `
             -LvPropNullAlphaPath $LvPropNullAlphaPath `
@@ -815,6 +823,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             $schemaGeneralizationReplicas = @($dispatchResult.schema_generalization_replicas)
             $multipleIndexesReplicas = @($dispatchResult.multiple_indexes_replicas)
             $definitionContinuationReplicas = @($dispatchResult.definition_continuation_replicas)
+            $extendedNamesReplicas = @($dispatchResult.extended_names_replicas)
             $lvpropNullReplicas = @($dispatchResult.lvprop_null_replicas)
             $status = [string]$dispatchResult.status
             $detail = [string]$dispatchResult.detail
@@ -850,6 +859,7 @@ $result = [ordered]@{
     schema_generalization_replicas = @($schemaGeneralizationReplicas)
     multiple_indexes_replicas = @($multipleIndexesReplicas)
     definition_continuation_replicas = @($definitionContinuationReplicas)
+    extended_names_replicas = @($extendedNamesReplicas)
     lvprop_null_replicas = @($lvpropNullReplicas)
     completed_at_utc = [DateTimeOffset]::UtcNow.ToString("o")
 }

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]
+    [ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]
     [string]$Job,
     [Parameter(Mandatory = $true)]
     [string]$Source,
@@ -470,6 +470,59 @@ switch ($Job) {
         foreach ($name in $actual) {
             [void]$names.Add($name)
         }
+    }
+    "extended-names" {
+        [void]$names.Add("extended-names-job-result.json")
+        $jobResultPath = Join-Path $Source "extended-names-job-result.json"
+        if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) { throw "Extended-names result is missing." }
+        $jobResultItem = Get-Item -LiteralPath $jobResultPath -Force
+        if (($jobResultItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw "Extended-names result must not be a reparse point." }
+        if ($jobResultItem.Length -gt 8388608) { throw "Extended-names result exceeds the 8-MiB bound." }
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $checkpointNames = New-Object Collections.ArrayList
+        [void]$checkpointNames.Add("empty")
+        foreach ($index in 0..40) { [void]$checkpointNames.Add("b" + $index.ToString("D2")) }
+        [void]$checkpointNames.Add("reject")
+        $referenced = New-Object Collections.ArrayList
+        $seenReplicas = New-Object Collections.ArrayList
+        foreach ($replica in @($jobResult.replicas)) {
+            $replicaNumber = [int]$replica.replica
+            if ($replicaNumber -lt 1 -or $replicaNumber -gt 3 -or $replicaNumber -ne ($seenReplicas.Count + 1) -or $replicaNumber -cin $seenReplicas) { throw "Extended-names result has an unexpected replica inventory." }
+            [void]$seenReplicas.Add($replicaNumber)
+            $checkpointIndex = 0
+            foreach ($checkpoint in @($replica.checkpoints)) {
+                if ($checkpointIndex -ge $checkpointNames.Count) { throw "Extended-names result exceeds the 43-checkpoint bound." }
+                $checkpointName = $checkpointNames[$checkpointIndex]
+                $expectedDatabase = "extended-names-r$replicaNumber-$checkpointName.mdb"
+                if ([string]$checkpoint.name -cne $checkpointName -or [string]$checkpoint.database -cne $expectedDatabase) { throw "Extended-names checkpoints are not an ordered prefix." }
+                [void]$referenced.Add($expectedDatabase); $checkpointIndex++
+            }
+            $recovery = @($replica.recovery)
+            if ($recovery.Count -gt 1) { throw "Extended-names result exceeds the one-recovery-artifact bound." }
+            foreach ($artifact in $recovery) {
+                if ($checkpointIndex -ge $checkpointNames.Count) { throw "Extended-names recovery follows a complete checkpoint inventory." }
+                $expectedName = $checkpointNames[$checkpointIndex]
+                $expectedDatabase = "extended-names-r$replicaNumber-$expectedName.mdb"
+                if ([string]$artifact.name -cne $expectedName -or [string]$artifact.database -cne $expectedDatabase) { throw "Extended-names recovery is not the active next checkpoint." }
+                [void]$referenced.Add($expectedDatabase)
+            }
+            if ([string]$replica.status -ceq "pass" -and ($checkpointIndex -ne $checkpointNames.Count -or $recovery.Count -ne 0)) { throw "Passing extended-names replica omits a checkpoint." }
+        }
+        if ($seenReplicas.Count -ne 3) {
+            $preMutationAbort = ($seenReplicas.Count -eq 1 -and [string]$jobResult.status -ceq "fail" -and -not [bool]@($jobResult.replicas)[0].mutation_started)
+            if (-not $preMutationAbort) { throw "Extended-names result has an incomplete replica inventory." }
+        }
+        if ($referenced.Count -gt 129) { throw "Extended-names output exceeds the 129-database bound." }
+        if ([string]$jobResult.status -ceq "pass" -and $referenced.Count -ne 129) { throw "Passing extended-names result omits a database." }
+        $actualItems = @(Get-ChildItem -LiteralPath $Source -File -Filter "*.mdb")
+        foreach ($item in $actualItems) {
+            if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw "Extended-names output contains a reparse-point MDB." }
+            if ($item.Length -lt 2048 -or ($item.Length % 2048) -ne 0 -or $item.Length -gt 262144) { throw "Extended-names output MDB violates the 128-page bound." }
+        }
+        $actual = @($actualItems | ForEach-Object { $_.Name.ToLowerInvariant() } | Sort-Object)
+        $expected = @($referenced | ForEach-Object { $_.ToLowerInvariant() } | Sort-Object)
+        if (($actual -join "`n") -cne ($expected -join "`n")) { throw "Extended-names MDB inventory differs from its result." }
+        foreach ($name in $actualItems.Name) { [void]$names.Add($name) }
     }
     "lvprop-null" {
         [void]$names.Add("lvprop-null-job-result.json")

--- a/oracle/windows-dao/scripts/extended_names.py
+++ b/oracle/windows-dao/scripts/extended_names.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Validate the bounded CP1252 extended catalog-name experiment for issue #152."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import schema_generalization as schema
+
+
+DOCUMENT_TYPE = "dao_extended_names_job_result"
+REPORT_TYPE = "extended_names_report"
+PAGE_BYTES = 2048
+UNDEFINED_SLOTS = (0x81, 0x8D, 0x8F, 0x90, 0x9D)
+DEFINED_BYTES = tuple(value for value in range(0x80, 0x100) if value not in UNDEFINED_SLOTS)
+BATCHES = tuple(tuple(DEFINED_BYTES[offset : offset + 3]) for offset in range(0, len(DEFINED_BYTES), 3))
+CHECKPOINT_NAMES = ("empty", *(f"b{index:02d}" for index in range(len(BATCHES))), "reject")
+REJECTION_POINTS = (0x7F, *UNDEFINED_SLOTS)
+PLAN_DIGEST = re.compile(r"[0-9a-f]{64}")
+RUN_ID = re.compile(r"[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}")
+MAXIMUM_JSON_BYTES = 8 * 1024 * 1024
+MAXIMUM_PAGES = 128
+MAXIMUM_TABLES = 32
+MAXIMUM_FIELDS = 32
+MAXIMUM_INDEXES = 16
+MAXIMUM_DETAIL = 512
+ASCII_WEIGHTS = {
+    **{byte: 0x56 + byte - ord("0") for byte in range(ord("0"), ord("9") + 1)},
+    ord("A"): 0x60, ord("B"): 0x61, ord("C"): 0x62,
+    ord("D"): 0x64, ord("E"): 0x66, ord("F"): 0x67,
+    ord("J"): 0x6B,
+    ord("L"): 0x6D, ord("M"): 0x6F, ord("N"): 0x70,
+    ord("R"): 0x75, ord("T"): 0x77, ord("V"): 0x7A, ord("Z"): 0x7E,
+}
+
+
+class ValidationError(ValueError):
+    pass
+
+
+def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValidationError(f"duplicate JSON field {key!r}")
+        result[key] = value
+    return result
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def digest(value: str, what: str) -> str:
+    if not isinstance(value, str) or not PLAN_DIGEST.fullmatch(value):
+        raise ValidationError(f"{what} is not a lowercase SHA-256 digest")
+    return value
+
+
+def names_for(point: int) -> list[dict[str, Any]]:
+    if point not in DEFINED_BYTES:
+        raise ValidationError("extended byte is not defined in CP1252 above 0x7E")
+    tag = f"{point:02X}"
+    current = bytes([point]).decode("cp1252")
+    position = DEFINED_BYTES.index(point)
+    neighbor_point = DEFINED_BYTES[(position + 1) % len(DEFINED_BYTES)]
+    neighbor = bytes([neighbor_point]).decode("cp1252")
+    return [
+        {"role": "single_left", "name": f"N{tag}L{current}AZ", "inserted": [point], "prefix": f"N{tag}L", "suffix": "AZ"},
+        {"role": "single_middle", "name": f"N{tag}MA{current}Z", "inserted": [point], "prefix": f"N{tag}MA", "suffix": "Z"},
+        {"role": "single_right", "name": f"N{tag}RAZ{current}", "inserted": [point], "prefix": f"N{tag}RAZ", "suffix": ""},
+        {"role": "repeat", "name": f"N{tag}DA{current}{current}Z", "inserted": [point, point], "prefix": f"N{tag}DA", "suffix": "Z"},
+        {"role": "forward", "name": f"N{tag}FA{current}{neighbor}Z", "inserted": [point, neighbor_point], "prefix": f"N{tag}FA", "suffix": "Z"},
+        {"role": "reverse", "name": f"N{tag}VA{neighbor}{current}Z", "inserted": [neighbor_point, point], "prefix": f"N{tag}VA", "suffix": "Z"},
+    ]
+
+
+def batch_specs(index: int) -> list[dict[str, Any]]:
+    specs = [{"role": "ascii_control", "name": f"C{index:02d}B", "inserted": [], "prefix": f"C{index:02d}B", "suffix": ""}]
+    for point in BATCHES[index]:
+        specs.extend(names_for(point))
+    return specs
+
+
+def rejection_specs() -> list[dict[str, Any]]:
+    specs = [{"role": "ascii_control", "name": "CREJECTB", "inserted": [], "prefix": "CREJECTB", "suffix": ""}]
+    for point in REJECTION_POINTS:
+        specs.append({
+            "role": "boundary_7f" if point == 0x7F else f"undefined_{point:02X}",
+            "name": f"R{point:02X}A{chr(point)}Z",
+            "inserted": [],
+            "prefix": f"R{point:02X}A",
+            "suffix": "Z",
+        })
+    return specs
+
+
+def expected_database(replica: int, name: str) -> str:
+    return f"extended-names-r{replica}-{name}.mdb"
+
+
+def exact_keys(value: dict[str, Any], expected: set[str], what: str) -> None:
+    if set(value) != expected:
+        raise ValidationError(f"{what} has an unexpected field inventory")
+
+
+def load_document(path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ValidationError("job result must be a regular non-link file")
+    try:
+        raw = path.read_bytes()
+    except OSError as error:
+        raise ValidationError("job result is unreadable") from error
+    if len(raw) > MAXIMUM_JSON_BYTES:
+        raise ValidationError("job result exceeds the 8-MiB bound")
+    try:
+        value = json.loads(raw, object_pairs_hook=reject_duplicates)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValidationError("job result is malformed") from error
+    if not isinstance(value, dict):
+        raise ValidationError("job result is not an object")
+    exact_keys(value, {"document_type", "development_only", "plan_sha256", "run_id", "status", "replicas"}, "job result")
+    if value["document_type"] != DOCUMENT_TYPE or value["development_only"] is not True:
+        raise ValidationError("job result identity is invalid")
+    digest(value["plan_sha256"], "job plan digest")
+    if not isinstance(value["run_id"], str) or not RUN_ID.fullmatch(value["run_id"]):
+        raise ValidationError("job run ID is invalid")
+    if value["status"] not in ("pass", "fail") or not isinstance(value["replicas"], list):
+        raise ValidationError("job status or replicas are invalid")
+    return value
+
+
+def read_image(root: Path, filename: str, size: Any, sha256: Any) -> bytes:
+    if not isinstance(filename, str) or not re.fullmatch(r"extended-names-r[1-3]-(?:empty|b(?:0[0-9]|[1-3][0-9]|40)|reject)\.mdb", filename):
+        raise ValidationError("checkpoint database name is invalid")
+    path = root / filename
+    if path.is_symlink() or not path.is_file():
+        raise ValidationError(f"checkpoint {filename} is not a regular file")
+    data = path.read_bytes()
+    if type(size) is not int or size != len(data) or size < PAGE_BYTES or size % PAGE_BYTES or size > MAXIMUM_PAGES * PAGE_BYTES:
+        raise ValidationError(f"checkpoint {filename} violates its size or page bound")
+    if not isinstance(sha256, str) or hashlib.sha256(data).hexdigest() != sha256:
+        raise ValidationError(f"checkpoint {filename} differs from its digest")
+    return data
+
+
+def validate_attempts(name: str, attempts: Any) -> list[dict[str, Any]]:
+    expected = rejection_specs() if name == "reject" else batch_specs(int(name[1:]))
+    if not isinstance(attempts, list) or len(attempts) != len(expected):
+        raise ValidationError(f"checkpoint {name} attempt inventory is invalid")
+    result = []
+    for observed, wanted in zip(attempts, expected, strict=True):
+        if not isinstance(observed, dict):
+            raise ValidationError("attempt is not an object")
+        exact_keys(observed, {"role", "name", "name_utf16le_hex", "inserted_bytes", "created", "failure_operation", "error"}, "attempt")
+        if not isinstance(observed["name"], str):
+            raise ValidationError("attempt name is not text")
+        name_hex = observed["name"].encode("utf-16le").hex()
+        if observed["role"] != wanted["role"] or observed["name"] != wanted["name"] or observed["name_utf16le_hex"] != name_hex or observed["inserted_bytes"] != wanted["inserted"]:
+            raise ValidationError(f"checkpoint {name} attempt differs from the generated inventory")
+        if type(observed["created"]) is not bool or (observed["error"] is not None and not isinstance(observed["error"], str)):
+            raise ValidationError("attempt outcome is malformed")
+        if observed["error"] is not None and len(observed["error"]) > MAXIMUM_DETAIL:
+            raise ValidationError("attempt error exceeds its bound")
+        if observed["created"]:
+            if observed["error"] is not None or observed["failure_operation"] is not None:
+                raise ValidationError("successful attempt carries failure detail")
+        elif observed["error"] is None or observed["failure_operation"] not in ("create_tabledef", "tabledefs_append"):
+            raise ValidationError("rejected attempt lacks an exact name-bearing DAO operation")
+        result.append(observed)
+    if not result[0]["created"]:
+        raise ValidationError(f"checkpoint {name} ASCII control was rejected")
+    return result
+
+
+def user_tables(dao: Any) -> set[str]:
+    if not isinstance(dao, dict) or set(dao) != {"tabledefs"} or not isinstance(dao["tabledefs"], list):
+        raise ValidationError("DAO metadata is malformed")
+    if len(dao["tabledefs"]) > MAXIMUM_TABLES:
+        raise ValidationError("DAO table metadata exceeds its bound")
+    names: list[str] = []
+    semantic_error = None
+    for position, entry in enumerate(dao["tabledefs"]):
+        if not isinstance(entry, dict) or set(entry) != {"ordinal", "name", "fields", "indexes"}:
+            raise ValidationError("DAO table metadata is malformed")
+        if type(entry["ordinal"]) is not int or entry["ordinal"] != position or not isinstance(entry["name"], str) or len(entry["name"]) > 128:
+            raise ValidationError("DAO table identity is malformed")
+        if not isinstance(entry["fields"], list) or len(entry["fields"]) > MAXIMUM_FIELDS:
+            raise ValidationError("DAO field metadata violates its bound")
+        if not isinstance(entry["indexes"], list) or len(entry["indexes"]) > MAXIMUM_INDEXES:
+            raise ValidationError("DAO index metadata violates its bound")
+        for ordinal, field in enumerate(entry["fields"]):
+            if not isinstance(field, dict) or set(field) != {"ordinal", "name", "type", "size"}:
+                raise ValidationError("DAO field metadata is malformed")
+            if type(field["ordinal"]) is not int or field["ordinal"] != ordinal or not isinstance(field["name"], str) or len(field["name"]) > 128 or type(field["type"]) is not int or type(field["size"]) is not int or not 0 <= field["type"] <= 65535 or not 0 <= field["size"] <= 1 << 20:
+                raise ValidationError("DAO field metadata value is invalid")
+        for ordinal, index in enumerate(entry["indexes"]):
+            if not isinstance(index, dict) or set(index) != {"ordinal", "name", "primary", "unique"}:
+                raise ValidationError("DAO index metadata is malformed")
+            if type(index["ordinal"]) is not int or index["ordinal"] != ordinal or not isinstance(index["name"], str) or len(index["name"]) > 128 or type(index["primary"]) is not bool or type(index["unique"]) is not bool:
+                raise ValidationError("DAO index metadata value is invalid")
+        if not entry["name"].startswith("MSys"):
+            if entry["fields"] != [{"ordinal": 0, "name": "Id", "type": 4, "size": 4}] or entry["indexes"] != []:
+                semantic_error = "DAO user-table schema differs from the probe"
+            names.append(entry["name"])
+    if len(names) != len(set(names)):
+        semantic_error = "DAO metadata repeats a user table"
+    if semantic_error is not None:
+        raise schema.DecodeError(semantic_error)
+    return set(names)
+
+
+def ascii_primary(value: str) -> bytes:
+    try:
+        return bytes(ASCII_WEIGHTS[byte] for byte in value.encode("cp1252"))
+    except KeyError as error:
+        raise schema.DecodeError("generated context uses an unmapped EXP-0087 ASCII byte") from error
+
+
+def isolate_primary(primary: bytes, prefix: str, suffix: str, what: str) -> bytes:
+    left = ascii_primary(prefix)
+    right = ascii_primary(suffix)
+    if not primary.startswith(left) or (right and not primary.endswith(right)):
+        raise schema.DecodeError(f"{what} primary section does not retain its ASCII context")
+    end = len(primary) - len(right) if right else len(primary)
+    if end < len(left):
+        raise schema.DecodeError(f"{what} primary context overlaps")
+    return primary[len(left):end]
+
+
+def analyze_arm(data: bytes, name: str, attempts: list[dict[str, Any]], dao: Any) -> dict[str, Any]:
+    expected = rejection_specs() if name == "reject" else batch_specs(int(name[1:]))
+    wanted_names = {entry["name"] for entry in expected}
+    created = {entry["name"] for entry in attempts if entry["created"]}
+    if user_tables(dao) != created:
+        raise schema.DecodeError(f"checkpoint {name} DAO inventory disagrees with attempts")
+    keys = schema.catalog_name_keys(data)
+    matching = [entry for entry in keys if entry["name"] in wanted_names]
+    by_name = {entry["name"]: entry for entry in matching}
+    if len(matching) != len(by_name):
+        raise schema.DecodeError(f"checkpoint {name} repeats a catalog key name")
+    if set(by_name) != created:
+        raise schema.DecodeError(f"checkpoint {name} catalog inventory disagrees with attempts")
+    forms = []
+    for spec, attempt in zip(expected, attempts, strict=True):
+        row: dict[str, Any] = {
+            "role": spec["role"], "name": spec["name"],
+            "name_utf16le_hex": attempt["name_utf16le_hex"], "inserted_bytes": spec["inserted"],
+            "created": attempt["created"], "failure_operation": attempt["failure_operation"],
+            "error": attempt["error"],
+        }
+        if attempt["created"]:
+            key = by_name[spec["name"]]
+            primary = bytes.fromhex(key["primary_hex"])
+            contribution = isolate_primary(primary, spec["prefix"], spec["suffix"], spec["name"])
+            row.update({
+                "id": key["id"], "key_hex": key["key_hex"], "parent_id": key["parent_id"],
+                "primary_hex": key["primary_hex"],
+                "secondary_nibbles": key["secondary_nibbles"],
+                "row_page": key["row_page"], "row_slot": key["row_slot"],
+            })
+            if name != "reject" or spec["role"] == "ascii_control":
+                row["isolated_primary_hex"] = contribution.hex()
+            if spec["role"] == "ascii_control" and (contribution or key["secondary_nibbles"]):
+                raise schema.DecodeError(f"checkpoint {name} ASCII control does not match EXP-0087 weights")
+        forms.append(row)
+    return {"checkpoint": name, "bytes": list(BATCHES[int(name[1:])]) if name != "reject" else [], "forms": forms}
+
+
+def validate_replica(root: Path, value: Any, expected_replica: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationError("replica is not an object")
+    exact_keys(value, {"replica", "status", "error", "mutation_started", "phase", "checkpoints", "recovery"}, "replica")
+    if type(value["replica"]) is not int or value["replica"] != expected_replica or value["status"] not in ("pass", "fail") or type(value["mutation_started"]) is not bool or not isinstance(value["phase"], str):
+        raise ValidationError("replica state is malformed")
+    if value["error"] is not None and (not isinstance(value["error"], str) or len(value["error"]) > MAXIMUM_DETAIL):
+        raise ValidationError("replica error is malformed")
+    if not isinstance(value["checkpoints"], list) or not isinstance(value["recovery"], list) or len(value["recovery"]) > 1:
+        raise ValidationError("replica artifact inventory is malformed")
+    images: dict[str, bytes] = {}
+    attempts_by_name: dict[str, list[dict[str, Any]]] = {}
+    dao_by_name: dict[str, Any] = {}
+    files = []
+    metadata_changed = False
+    semantic_errors: list[str] = []
+    empty_identity: dict[str, Any] | None = None
+    for index, checkpoint in enumerate(value["checkpoints"]):
+        if index >= len(CHECKPOINT_NAMES) or not isinstance(checkpoint, dict):
+            raise ValidationError("replica exceeds the checkpoint bound")
+        name = CHECKPOINT_NAMES[index]
+        exact_keys(checkpoint, {"name", "database", "size", "sha256", "size_after_metadata", "sha256_after_metadata", "arm_before", "attempts", "dao"}, "checkpoint")
+        filename = expected_database(expected_replica, name)
+        if checkpoint["name"] != name or checkpoint["database"] != filename:
+            raise ValidationError("replica checkpoints are not an ordered prefix")
+        original_size = checkpoint["size"]
+        if type(original_size) is not int or original_size < PAGE_BYTES or original_size % PAGE_BYTES or original_size > MAXIMUM_PAGES * PAGE_BYTES:
+            raise ValidationError("checkpoint pre-metadata size violates its bound")
+        original_sha = digest(checkpoint["sha256"], "checkpoint pre-metadata digest")
+        data = read_image(root, filename, checkpoint["size_after_metadata"], checkpoint["sha256_after_metadata"])
+        metadata_changed |= original_size != len(data) or original_sha != checkpoint["sha256_after_metadata"]
+        if name == "empty":
+            if checkpoint["arm_before"] is not None or checkpoint["attempts"] != []:
+                raise ValidationError("empty checkpoint is not empty")
+            empty_identity = {"size": original_size, "sha256": original_sha}
+            attempts = []
+        else:
+            before = checkpoint["arm_before"]
+            if not isinstance(before, dict) or set(before) != {"size", "sha256"}:
+                raise ValidationError("arm baseline identity is malformed")
+            if before != empty_identity:
+                raise ValidationError("arm baseline differs from the retained empty image")
+            attempts = validate_attempts(name, checkpoint["attempts"])
+        try:
+            observed_users = user_tables(checkpoint["dao"])
+            expected_users = {attempt["name"] for attempt in attempts if attempt["created"]}
+            if observed_users != expected_users:
+                semantic_errors.append(f"checkpoint {name} DAO inventory disagrees with attempts")
+        except schema.DecodeError as error:
+            semantic_errors.append(f"checkpoint {name}: {error}")
+        images[name] = data
+        attempts_by_name[name] = attempts
+        dao_by_name[name] = checkpoint["dao"]
+        files.append({k: checkpoint[k] for k in ("name", "database", "size", "sha256", "size_after_metadata", "sha256_after_metadata")})
+    complete = len(value["checkpoints"]) == len(CHECKPOINT_NAMES)
+    if not value["mutation_started"] and (value["checkpoints"] or value["recovery"]):
+        raise ValidationError("pre-mutation replica retained an impossible artifact")
+    if not value["mutation_started"] and value["phase"] not in ("before_create_database", "create_database"):
+        raise ValidationError("pre-mutation replica phase is inconsistent")
+    if value["status"] == "pass" and (value["phase"] != "complete" or value["error"] is not None):
+        raise ValidationError("passing replica state is inconsistent")
+    if value["status"] == "fail" and value["error"] is None:
+        raise ValidationError("failed replica omits its bounded error")
+    phase_next_name = None
+    if value["status"] == "fail":
+        batch_phase = re.fullmatch(r"append_b(\d{2})", value["phase"])
+        cleanup_batch_phase = re.fullmatch(r"cleanup_b(\d{2})", value["phase"])
+        if batch_phase:
+            phase_index = int(batch_phase.group(1))
+            if phase_index >= len(BATCHES) or len(value["checkpoints"]) != phase_index + 1:
+                raise ValidationError("failed phase disagrees with checkpoint prefix")
+            phase_next_name = f"b{phase_index:02d}"
+        elif cleanup_batch_phase:
+            phase_index = int(cleanup_batch_phase.group(1))
+            if phase_index >= len(BATCHES) or len(value["checkpoints"]) != phase_index + 2:
+                raise ValidationError("failed cleanup phase disagrees with checkpoint prefix")
+        elif value["phase"] == "append_reject":
+            if len(value["checkpoints"]) != 1 + len(BATCHES):
+                raise ValidationError("failed phase disagrees with checkpoint prefix")
+            phase_next_name = "reject"
+        elif value["phase"] in ("cleanup_reject", "cleanup_complete"):
+            if not complete:
+                raise ValidationError("failed cleanup phase disagrees with checkpoint prefix")
+        elif value["phase"] in ("before_create_database", "create_database", "capture_empty"):
+            if value["checkpoints"]:
+                raise ValidationError("failed phase disagrees with checkpoint prefix")
+            if value["phase"] == "capture_empty":
+                phase_next_name = "empty"
+        else:
+            raise ValidationError("failed phase is outside the bounded state machine")
+        if phase_next_name is not None and not value["mutation_started"]:
+            raise ValidationError("failed phase and mutation state disagree")
+        if value["phase"] == "before_create_database" and value["mutation_started"]:
+            raise ValidationError("failed phase and mutation state disagree")
+        if value["phase"] == "capture_empty" and not value["mutation_started"]:
+            raise ValidationError("failed phase and mutation state disagree")
+    if value["status"] == "pass" and (not complete or value["recovery"]):
+        raise ValidationError("passing replica has an incomplete inventory")
+    if value["status"] == "fail" and complete and value["phase"] not in ("cleanup_reject", "cleanup_complete"):
+        raise ValidationError("failed replica has a complete inventory")
+    if complete and value["recovery"]:
+        raise ValidationError("complete replica cannot retain a recovery artifact")
+    if value["recovery"]:
+        recovery = value["recovery"][0]
+        expected_name = CHECKPOINT_NAMES[len(value["checkpoints"])]
+        exact_keys(recovery, {"name", "database", "size", "sha256"}, "recovery")
+        if recovery["name"] != expected_name or recovery["database"] != expected_database(expected_replica, expected_name):
+            raise ValidationError("recovery is not the next checkpoint")
+        if phase_next_name != expected_name:
+            raise ValidationError("recovery does not match the failed phase")
+        read_image(root, recovery["database"], recovery["size"], recovery["sha256"])
+        files.append(recovery)
+    result = {k: value[k] for k in ("replica", "status", "error", "mutation_started", "phase")}
+    result["files"] = files
+    result["metadata_changed"] = metadata_changed
+    result["attempts"] = {
+        name: attempts_by_name[name] for name in CHECKPOINT_NAMES[: len(value["checkpoints"])]
+    }
+    observations = []
+    for name in CHECKPOINT_NAMES[1 : len(value["checkpoints"])]:
+        try:
+            observations.append(analyze_arm(images[name], name, attempts_by_name[name], dao_by_name[name]))
+        except (ValueError, schema.DecodeError) as error:
+            semantic_errors.append(f"checkpoint {name}: {error}")
+    if observations and not complete:
+        result["partial_observation"] = observations
+    if semantic_errors:
+        result["decode_error"] = "; ".join(semantic_errors)
+    elif complete and not metadata_changed:
+        result["observation"] = observations
+    return result
+
+
+def summarize(observation: list[dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any]]:
+    all_forms = [form for arm in observation if arm["checkpoint"] != "reject" for form in arm["forms"]]
+    by_byte: dict[str, Any] = {}
+    for point in DEFINED_BYTES:
+        tag = f"N{point:02X}"
+        forms = {entry["role"]: entry for entry in all_forms if entry["name"].startswith(tag)}
+        singles = [forms[name] for name in ("single_left", "single_middle", "single_right")]
+        created = [name for name, entry in forms.items() if entry["created"]]
+        rejected = [name for name, entry in forms.items() if not entry["created"]]
+        summary: dict[str, Any] = {"created_forms": created, "rejected_forms": rejected, "forms": list(forms.values())}
+        if all(entry["created"] for entry in singles):
+            primary = [entry["isolated_primary_hex"] for entry in singles]
+            secondary = [entry["secondary_nibbles"] for entry in singles]
+            summary["singleton_primary_position_independent"] = len(set(primary)) == 1
+            summary["singleton_secondary_position_independent"] = all(value == secondary[0] for value in secondary[1:])
+        else:
+            summary["singleton_primary_position_independent"] = None
+            summary["singleton_secondary_position_independent"] = None
+        single = forms["single_middle"]
+        repeat = forms["repeat"]
+        if single["created"] and repeat["created"]:
+            summary["repeat_primary_is_two_singletons"] = repeat["isolated_primary_hex"] == single["isolated_primary_hex"] * 2
+            summary["repeat_secondary_is_two_singletons"] = repeat["secondary_nibbles"] == single["secondary_nibbles"] * 2
+        else:
+            summary["repeat_primary_is_two_singletons"] = None
+            summary["repeat_secondary_is_two_singletons"] = None
+        neighbor = DEFINED_BYTES[(DEFINED_BYTES.index(point) + 1) % len(DEFINED_BYTES)]
+        neighbor_single = next(entry for entry in all_forms if entry["role"] == "single_middle" and entry["inserted_bytes"] == [neighbor])
+        for role, order in (("forward", (single, neighbor_single)), ("reverse", (neighbor_single, single))):
+            pair = forms[role]
+            if pair["created"] and all(entry["created"] for entry in order):
+                summary[f"{role}_primary_is_ordered_singletons"] = pair["isolated_primary_hex"] == "".join(entry["isolated_primary_hex"] for entry in order)
+                summary[f"{role}_secondary_is_ordered_singletons"] = pair["secondary_nibbles"] == sum((entry["secondary_nibbles"] for entry in order), [])
+            else:
+                summary[f"{role}_primary_is_ordered_singletons"] = None
+                summary[f"{role}_secondary_is_ordered_singletons"] = None
+        by_byte[f"{point:02x}"] = summary
+    rejection_arm = next(arm for arm in observation if arm["checkpoint"] == "reject")
+    controls = {entry["role"]: entry for entry in rejection_arm["forms"]}
+    return by_byte, controls
+
+
+def build_report(document: dict[str, Any], replicas: list[dict[str, Any]]) -> dict[str, Any]:
+    complete = [entry for entry in replicas if "observation" in entry]
+    question_names = ("coverage", "singleton_positions", "pair_composition", "secondary_order", "replication")
+    if document["status"] != "pass" or len(complete) != 3:
+        reason = "at least one replica did not yield a complete decoded observation"
+        if any(entry.get("metadata_changed") for entry in replicas):
+            reason = "DAO metadata access changed at least one checkpoint"
+        elif any(entry.get("decode_error") for entry in replicas):
+            reason = "at least one retained checkpoint failed a recorded grammar or control"
+        questions = {name: {"status": "no_outcome", "reason": reason} for name in question_names}
+    elif any(entry["observation"] != complete[0]["observation"] for entry in complete[1:]):
+        reason = "replicas disagree on the exact decoded observations"
+        questions = {name: {"status": "no_outcome", "reason": reason} for name in question_names}
+    else:
+        summary, controls = summarize(complete[0]["observation"])
+        questions = {
+            "coverage": {"status": "answered", "bytes": {key: {k: value[k] for k in ("created_forms", "rejected_forms")} for key, value in summary.items()}, "rejection_controls": controls},
+            "singleton_positions": {"status": "answered", "bytes": {key: {k: value[k] for k in ("singleton_primary_position_independent", "singleton_secondary_position_independent")} for key, value in summary.items()}},
+            "pair_composition": {"status": "answered", "bytes": {key: {k: value[k] for k in ("repeat_primary_is_two_singletons", "repeat_secondary_is_two_singletons")} for key, value in summary.items()}},
+            "secondary_order": {"status": "answered", "bytes": summary},
+            "replication": {"status": "answered", "replicas": 3},
+        }
+    return {
+        "compatibility_claim": False, "development_only": True,
+        "document_type": REPORT_TYPE, "plan_sha256": document["plan_sha256"],
+        "questions": questions, "replicas": [{k: v for k, v in entry.items() if k != "observation"} for entry in replicas],
+        "status": "accepted" if all(value["status"] == "answered" for value in questions.values()) else "no_outcome",
+        "support_movement": False,
+    }
+
+
+def evaluate(job_result: Path, expected_plan_sha256: str, output: Path) -> dict[str, Any]:
+    expected = digest(expected_plan_sha256, "--expected-plan-sha256")
+    document = load_document(job_result)
+    if document["plan_sha256"] != expected:
+        raise ValidationError("job result plan digest differs from the expected plan")
+    values = document["replicas"]
+    pre_mutation_abort = len(values) == 1 and values[0].get("status") == "fail" and values[0].get("mutation_started") is False
+    if len(values) != 3 and not pre_mutation_abort:
+        raise ValidationError("job result has an incomplete replica inventory")
+    if pre_mutation_abort:
+        raise ValidationError("job stopped before the first DAO mutation")
+    replicas = [validate_replica(job_result.parent, value, index) for index, value in enumerate(values, 1)]
+    if document["status"] == "pass" and any(entry["status"] != "pass" for entry in replicas):
+        raise ValidationError("job and replica statuses disagree")
+    if document["status"] == "fail" and all(entry["status"] == "pass" for entry in replicas):
+        raise ValidationError("failed job has no failed replica")
+    referenced = [file["database"] for replica in replicas for file in replica["files"]]
+    if len(referenced) != len({name.casefold() for name in referenced}):
+        raise ValidationError("retained MDB inventory repeats a database")
+    actual = []
+    for path in job_result.parent.iterdir():
+        if path.name.lower().endswith(".mdb"):
+            if path.is_symlink() or not path.is_file():
+                raise ValidationError("retained MDB inventory contains a non-regular file")
+            actual.append(path.name)
+    if len(actual) != len({name.casefold() for name in actual}):
+        raise ValidationError("retained MDB inventory repeats a case-folded database")
+    if {name.casefold() for name in actual} != {name.casefold() for name in referenced}:
+        raise ValidationError("retained MDB inventory differs from the job result")
+    report = build_report(document, replicas)
+    output.write_bytes(canonical_bytes(report))
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job_result", type=Path)
+    parser.add_argument("--expected-plan-sha256", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        evaluate(args.job_result, args.expected_plan_sha256, args.output)
+    except (OSError, ValidationError, schema.DecodeError) as error:
+        print(f"INVALID: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oracle/windows-dao/tests/test_extended_names.py
+++ b/oracle/windows-dao/tests/test_extended_names.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Focused tests for the preregistered issue #152 analyzer."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "oracle" / "windows-dao" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+SPEC = importlib.util.spec_from_file_location("extended_names", SCRIPTS / "extended_names.py")
+assert SPEC and SPEC.loader
+names = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(names)
+PLAN = "a" * 64
+
+
+def attempts_for(checkpoint: str) -> list[dict]:
+    specs = names.rejection_specs() if checkpoint == "reject" else names.batch_specs(int(checkpoint[1:]))
+    result = []
+    for spec in specs:
+        created = checkpoint != "reject" or spec["role"] == "ascii_control"
+        result.append(
+            {
+                "role": spec["role"],
+                "name": spec["name"],
+                "name_utf16le_hex": spec["name"].encode("utf-16le").hex(),
+                "inserted_bytes": spec["inserted"],
+                "created": created,
+                "failure_operation": None if created else "tabledefs_append",
+                "error": None if created else "DAO rejected the control",
+            }
+        )
+    return result
+
+
+def dao_for(attempts: list[dict]) -> dict:
+    created = [attempt for attempt in attempts if attempt["created"]]
+    return {
+        "tabledefs": [
+            {
+                "ordinal": index,
+                "name": attempt["name"],
+                "fields": [{"ordinal": 0, "name": "Id", "type": 4, "size": 4}],
+                "indexes": [],
+            }
+            for index, attempt in enumerate(created)
+        ]
+    }
+
+
+def fake_keys(data: bytes) -> list[dict]:
+    checkpoint = names.CHECKPOINT_NAMES[data[0]]
+    specs = names.rejection_specs() if checkpoint == "reject" else names.batch_specs(int(checkpoint[1:]))
+    result = []
+    for spec in specs:
+        if checkpoint == "reject" and spec["role"] != "ascii_control":
+            continue
+        contribution = bytes((value - 0x7E) & 0xFF for value in spec["inserted"])
+        primary = names.ascii_primary(spec["prefix"]) + contribution + names.ascii_primary(spec["suffix"])
+        result.append(
+            {
+                "id": len(result) + 1,
+                "name": spec["name"],
+                "key_hex": primary.hex() + "00",
+                "parent_id": 0x80000000,
+                "primary_hex": primary.hex(),
+                "secondary_nibbles": [],
+                "row_page": 2,
+                "row_slot": len(result),
+            }
+        )
+    return result
+
+
+class Fixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.replicas = []
+        for replica in range(1, 4):
+            checkpoints = []
+            empty = bytes(names.PAGE_BYTES)
+            empty_sha = hashlib.sha256(empty).hexdigest()
+            for index, checkpoint in enumerate(names.CHECKPOINT_NAMES):
+                data = bytes([index]) + bytes(names.PAGE_BYTES - 1)
+                if checkpoint == "empty":
+                    attempts = []
+                    metadata = {"tabledefs": []}
+                    before = None
+                else:
+                    attempts = attempts_for(checkpoint)
+                    metadata = dao_for(attempts)
+                    before = {"size": len(empty), "sha256": empty_sha}
+                filename = names.expected_database(replica, checkpoint)
+                (root / filename).write_bytes(data)
+                digest = hashlib.sha256(data).hexdigest()
+                checkpoints.append(
+                    {
+                        "name": checkpoint,
+                        "database": filename,
+                        "size": len(data),
+                        "sha256": digest,
+                        "size_after_metadata": len(data),
+                        "sha256_after_metadata": digest,
+                        "arm_before": before,
+                        "attempts": attempts,
+                        "dao": metadata,
+                    }
+                )
+            self.replicas.append(
+                {
+                    "replica": replica,
+                    "status": "pass",
+                    "error": None,
+                    "mutation_started": True,
+                    "phase": "complete",
+                    "checkpoints": checkpoints,
+                    "recovery": [],
+                }
+            )
+        self.document = {
+            "document_type": names.DOCUMENT_TYPE,
+            "development_only": True,
+            "plan_sha256": PLAN,
+            "run_id": "20260902T120000Z-dev-dao",
+            "status": "pass",
+            "replicas": self.replicas,
+        }
+
+    def write(self) -> Path:
+        path = self.root / "extended-names-job-result.json"
+        path.write_text(json.dumps(self.document), encoding="utf-8")
+        return path
+
+
+class ExtendedNamesTests(unittest.TestCase):
+    def evaluate(self, fixture: Fixture):
+        output = fixture.root / "extended-names-report.json"
+        with mock.patch.object(names.schema, "catalog_name_keys", side_effect=fake_keys):
+            report = names.evaluate(fixture.write(), PLAN, output)
+        self.assertEqual(output.read_bytes(), names.canonical_bytes(report))
+        return report
+
+    def test_inventory_covers_every_defined_cp1252_byte_in_bounded_batches(self) -> None:
+        self.assertEqual(len(names.DEFINED_BYTES), 123)
+        self.assertEqual(len(names.BATCHES), 41)
+        self.assertTrue(all(len(batch) == 3 for batch in names.BATCHES))
+        self.assertEqual(set(range(0x80, 0x100)) - set(names.DEFINED_BYTES), set(names.UNDEFINED_SLOTS))
+        self.assertEqual(names.names_for(0xFF)[-2]["inserted"], [0xFF, 0x80])
+
+    def test_producer_isolates_working_files_and_names_cleanup_phases(self) -> None:
+        producer = (SCRIPTS / "dev" / "ExtendedNames.DevJob.ps1").read_text(encoding="utf-8")
+        self.assertIn('Join-Path $RunRoot "_working"', producer)
+        self.assertIn('$state.phase = "cleanup_$activeName"', producer)
+        self.assertIn('$state.phase = "cleanup_reject"', producer)
+        self.assertIn('$state.phase = "cleanup_complete"', producer)
+        self.assertIn("if ($recoveryEligible -and", producer)
+
+    def test_accepts_complete_replicated_observation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = self.evaluate(Fixture(Path(directory)))
+            self.assertEqual(report["status"], "accepted")
+            self.assertEqual(len(report["questions"]["coverage"]["bytes"]), 123)
+            controls = report["questions"]["coverage"]["rejection_controls"]
+            self.assertTrue(controls["ascii_control"]["created"])
+            self.assertFalse(controls["boundary_7f"]["created"])
+            self.assertEqual(controls["boundary_7f"]["failure_operation"], "tabledefs_append")
+
+    def test_exact_pair_order_and_position_answers_are_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = self.evaluate(Fixture(Path(directory)))
+            byte_80 = report["questions"]["secondary_order"]["bytes"]["80"]
+            self.assertTrue(byte_80["singleton_primary_position_independent"])
+            self.assertTrue(byte_80["repeat_primary_is_two_singletons"])
+            self.assertTrue(byte_80["forward_primary_is_ordered_singletons"])
+            self.assertTrue(byte_80["reverse_primary_is_ordered_singletons"])
+
+    def test_replica_disagreement_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[2]["checkpoints"][1]["attempts"][1]["created"] = False
+            fixture.replicas[2]["checkpoints"][1]["attempts"][1]["error"] = "rejected"
+            fixture.replicas[2]["checkpoints"][1]["attempts"][1]["failure_operation"] = "tabledefs_append"
+            fixture.replicas[2]["checkpoints"][1]["dao"] = dao_for(fixture.replicas[2]["checkpoints"][1]["attempts"])
+            self.assertEqual(self.evaluate(fixture)["status"], "no_outcome")
+
+    def test_failure_operation_is_retained_and_replica_disagreement_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[2]["checkpoints"][-1]["attempts"][1]["failure_operation"] = "create_tabledef"
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+            retained = report["replicas"][2]["attempts"]["reject"][1]
+            self.assertEqual(retained["failure_operation"], "create_tabledef")
+
+    def test_decode_failure_and_changed_metadata_are_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            output = fixture.root / "extended-names-report.json"
+            with mock.patch.object(
+                names.schema,
+                "catalog_name_keys",
+                side_effect=names.schema.DecodeError("bad catalog key"),
+            ):
+                report = names.evaluate(fixture.write(), PLAN, output)
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("recorded grammar", report["questions"]["coverage"]["reason"])
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            checkpoint = fixture.replicas[0]["checkpoints"][1]
+            checkpoint["sha256"] = "b" * 64
+            report = self.evaluate(fixture)
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("metadata access changed", report["questions"]["coverage"]["reason"])
+
+    def test_ascii_context_mismatch_is_scientific_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+
+            def bad_ascii(data: bytes):
+                result = fake_keys(data)
+                if data[0] == 1:
+                    result[0]["primary_hex"] = "ff"
+                return result
+
+            output = fixture.root / "extended-names-report.json"
+            with mock.patch.object(names.schema, "catalog_name_keys", side_effect=bad_ascii):
+                report = names.evaluate(fixture.write(), PLAN, output)
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("recorded grammar", report["questions"]["coverage"]["reason"])
+
+    def test_accepted_rejection_control_preserves_key_without_mapping_claim(self) -> None:
+        attempts = attempts_for("reject")
+        attempts[1].update(created=True, failure_operation=None, error=None)
+        specs = names.rejection_specs()
+        primary = names.ascii_primary(specs[1]["prefix"]) + b"\xaa" + names.ascii_primary(specs[1]["suffix"])
+        keys = fake_keys(bytes([42]) + bytes(names.PAGE_BYTES - 1))
+        keys.append(
+            {
+                "id": 99,
+                "name": specs[1]["name"],
+                "key_hex": "deadbeef",
+                "parent_id": 7,
+                "primary_hex": primary.hex(),
+                "secondary_nibbles": [3, 5],
+                "row_page": 9,
+                "row_slot": 2,
+            }
+        )
+        with mock.patch.object(names.schema, "catalog_name_keys", return_value=keys):
+            arm = names.analyze_arm(bytes(names.PAGE_BYTES), "reject", attempts, dao_for(attempts))
+        control = arm["forms"][1]
+        self.assertEqual(control["key_hex"], "deadbeef")
+        self.assertEqual(control["primary_hex"], primary.hex())
+        self.assertEqual(control["secondary_nibbles"], [3, 5])
+        self.assertNotIn("isolated_primary_hex", control)
+
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                reject = replica["checkpoints"][-1]
+                reject["attempts"][1].update(created=True, failure_operation=None, error=None)
+                reject["dao"] = dao_for(reject["attempts"])
+
+            def accepted_control_keys(data: bytes):
+                result = fake_keys(data)
+                if data[0] == 42:
+                    result.append(keys[-1])
+                return result
+
+            output = fixture.root / "extended-names-report.json"
+            with mock.patch.object(names.schema, "catalog_name_keys", side_effect=accepted_control_keys):
+                report = names.evaluate(fixture.write(), PLAN, output)
+            self.assertEqual(
+                report["questions"]["coverage"]["rejection_controls"]["boundary_7f"]["key_hex"],
+                "deadbeef",
+            )
+
+    def test_metadata_bounds_and_real_index_shapes_are_validated(self) -> None:
+        system = {
+            "tabledefs": [
+                {
+                    "ordinal": 0,
+                    "name": "MSysObjects",
+                    "fields": [{"ordinal": 0, "name": "Id", "type": 4, "size": 4}],
+                    "indexes": [{"ordinal": 0, "name": "PrimaryKey", "primary": True, "unique": True}],
+                }
+            ]
+        }
+        self.assertEqual(names.user_tables(system), set())
+        malformed = copy.deepcopy(system)
+        malformed["tabledefs"][0]["indexes"][0]["ordinal"] = 1
+        with self.assertRaisesRegex(names.ValidationError, "index metadata value"):
+            names.user_tables(malformed)
+        user = dao_for(attempts_for("b00"))
+        user["tabledefs"][0]["indexes"] = [{"ordinal": 0, "name": "I", "primary": False, "unique": False}]
+        with self.assertRaisesRegex(names.schema.DecodeError, "schema differs"):
+            names.user_tables(user)
+
+    def test_post_mutation_failed_prefix_is_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                for checkpoint in replica["checkpoints"][2:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = replica["checkpoints"][:2]
+                replica["status"] = "fail"
+                replica["error"] = "bounded DAO failure"
+                replica["phase"] = "append_b01"
+            fixture.document["status"] = "fail"
+            self.assertEqual(self.evaluate(fixture)["status"], "no_outcome")
+
+    def test_capture_empty_recovery_and_cleanup_failures_are_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = Fixture(root)
+            for path in root.glob("*.mdb"):
+                path.unlink()
+            for replica in fixture.replicas:
+                data = bytes(names.PAGE_BYTES)
+                filename = names.expected_database(replica["replica"], "empty")
+                (root / filename).write_bytes(data)
+                replica.update(
+                    status="fail",
+                    error="capture failed after mutation",
+                    mutation_started=True,
+                    phase="capture_empty",
+                    checkpoints=[],
+                    recovery=[
+                        {
+                            "name": "empty",
+                            "database": filename,
+                            "size": len(data),
+                            "sha256": hashlib.sha256(data).hexdigest(),
+                        }
+                    ],
+                )
+            fixture.document["status"] = "fail"
+            self.assertEqual(self.evaluate(fixture)["status"], "no_outcome")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = Fixture(root)
+            for replica in fixture.replicas:
+                for checkpoint in replica["checkpoints"][2:]:
+                    (root / checkpoint["database"]).unlink()
+                replica.update(
+                    status="fail",
+                    error="working-file cleanup failed",
+                    phase="cleanup_b00",
+                    checkpoints=replica["checkpoints"][:2],
+                )
+            fixture.document["status"] = "fail"
+            self.assertEqual(self.evaluate(fixture)["status"], "no_outcome")
+
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                replica.update(status="fail", error="final cleanup failed", phase="cleanup_complete")
+            fixture.document["status"] = "fail"
+            self.assertEqual(self.evaluate(fixture)["status"], "no_outcome")
+
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0].update(
+                status="fail",
+                error="final cleanup failed",
+                phase="cleanup_complete",
+                recovery=[
+                    {
+                        "name": "reject",
+                        "database": names.expected_database(1, "reject"),
+                        "size": names.PAGE_BYTES,
+                        "sha256": "a" * 64,
+                    }
+                ],
+            )
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(names.ValidationError, "complete replica"):
+                self.evaluate(fixture)
+
+    def test_failed_prefix_catalog_corruption_is_decode_error_no_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = Fixture(root)
+            for replica in fixture.replicas:
+                for checkpoint in replica["checkpoints"][2:]:
+                    (root / checkpoint["database"]).unlink()
+                replica.update(
+                    status="fail",
+                    error="stopped after retained b00",
+                    phase="append_b01",
+                    checkpoints=replica["checkpoints"][:2],
+                )
+            fixture.document["status"] = "fail"
+
+            def corrupt_prefix(data: bytes):
+                if data[0] == 1:
+                    raise names.schema.DecodeError("corrupt retained prefix key")
+                return fake_keys(data)
+
+            output = root / "extended-names-report.json"
+            with mock.patch.object(names.schema, "catalog_name_keys", side_effect=corrupt_prefix):
+                report = names.evaluate(fixture.write(), PLAN, output)
+            self.assertEqual(report["status"], "no_outcome")
+            self.assertIn("corrupt retained prefix key", report["replicas"][0]["decode_error"])
+
+    def test_failed_prefix_still_validates_attempts_metadata_and_recovery_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                for checkpoint in replica["checkpoints"][2:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = replica["checkpoints"][:2]
+                replica["status"] = "fail"; replica["error"] = "stopped"; replica["phase"] = "append_b01"
+            fixture.document["status"] = "fail"
+            fixture.replicas[0]["checkpoints"][1]["attempts"][0]["failure_operation"] = "open_database"
+            with self.assertRaisesRegex(names.ValidationError, "successful attempt carries"):
+                self.evaluate(fixture)
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            for replica in fixture.replicas:
+                for checkpoint in replica["checkpoints"][2:]:
+                    (Path(directory) / checkpoint["database"]).unlink()
+                replica["checkpoints"] = replica["checkpoints"][:2]
+                replica["status"] = "fail"; replica["error"] = "stopped"; replica["phase"] = "append_b01"
+            fixture.document["status"] = "fail"
+            fixture.replicas[0]["checkpoints"][1]["dao"]["tabledefs"][0]["ordinal"] = 2
+            with self.assertRaisesRegex(names.ValidationError, "table identity"):
+                self.evaluate(fixture)
+
+    def test_rejects_pre_mutation_abort_and_bad_phase(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.document["replicas"] = [{"replica": 1, "status": "fail", "error": "no provider", "mutation_started": False, "phase": "before_create_database", "checkpoints": [], "recovery": []}]
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(names.ValidationError, "before the first DAO mutation"):
+                self.evaluate(fixture)
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0]["status"] = "fail"; fixture.replicas[0]["error"] = "bad"; fixture.replicas[0]["phase"] = "append_b02"
+            fixture.document["status"] = "fail"
+            with self.assertRaisesRegex(names.ValidationError, "checkpoint prefix"):
+                self.evaluate(fixture)
+
+    def test_rejects_non_integer_replica_identities(self) -> None:
+        for invalid in (True, 1.0):
+            with self.subTest(invalid=invalid), tempfile.TemporaryDirectory() as directory:
+                fixture = Fixture(Path(directory))
+                fixture.replicas[0]["replica"] = invalid
+                with self.assertRaisesRegex(names.ValidationError, "replica state"):
+                    self.evaluate(fixture)
+
+    def test_rejects_attempt_corruption_and_extra_mdb(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory))
+            fixture.replicas[0]["checkpoints"][1]["attempts"][1]["inserted_bytes"] = [0x81]
+            with self.assertRaisesRegex(names.ValidationError, "generated inventory"):
+                self.evaluate(fixture)
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(Path(directory)); (Path(directory) / "extra.mdb").write_bytes(bytes(names.PAGE_BYTES))
+            with self.assertRaisesRegex(names.ValidationError, "retained MDB inventory"):
+                self.evaluate(fixture)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = Fixture(root)
+            original = root / names.expected_database(1, "empty")
+            (root / original.name.upper()).write_bytes(original.read_bytes())
+            with self.assertRaisesRegex(names.ValidationError, "case-folded"):
+                self.evaluate(fixture)
+
+    def test_rejects_symlinked_job_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = Fixture(root)
+            real = fixture.write()
+            link = root / "linked-job-result.json"
+            link.symlink_to(real)
+            with self.assertRaisesRegex(names.ValidationError, "regular non-link"):
+                names.evaluate(link, PLAN, root / "report.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -77,6 +77,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 "schema-generalization",
                 "multiple-indexes",
                 "definition-continuation",
+                "extended-names",
                 "lvprop-null",
             ),
         )
@@ -123,6 +124,7 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 CLIENT.BOOTSTRAP_COMPOSER_VALIDATION_JOB.name,
                 CLIENT.SCHEMA_GENERALIZATION_JOB.name,
                 CLIENT.DEFINITION_CONTINUATION_JOB.name,
+                CLIENT.EXTENDED_NAMES_JOB.name,
                 CLIENT.LVPROP_NULL_JOB.name,
             }
             if CLIENT.MULTIPLE_INDEXES_JOB.is_file():
@@ -253,6 +255,8 @@ class WindowsDaoDevClientTests(unittest.TestCase):
                 staged(CLIENT.MULTIPLE_INDEXES_JOB),
                 "-DefinitionContinuationJobPath",
                 staged(CLIENT.DEFINITION_CONTINUATION_JOB),
+                "-ExtendedNamesJobPath",
+                staged(CLIENT.EXTENDED_NAMES_JOB),
                 "-LvPropNullJobPath",
                 staged(CLIENT.LVPROP_NULL_JOB),
                 "-LvPropFixedAlphaPath",
@@ -391,6 +395,14 @@ class WindowsDaoDevClientTests(unittest.TestCase):
             "definition-continuation", "DEFINITION_CONTINUATION_PLAN"
         )
 
+    def test_extended_names_binds_issue_152(self) -> None:
+        binding = CLIENT.plan_binding("extended-names")
+        self.assertEqual(binding.issue, 152)
+        self.assertEqual(binding.document_type, "dao_extended_names_plan")
+        self.assertEqual(binding.job_result_name, "extended-names-job-result.json")
+        self.assertEqual(binding.report_name, "extended-names-report.json")
+        self.assert_plan_bound_job("extended-names", "EXTENDED_NAMES_PLAN")
+
     def test_lvprop_null_binds_issue_149_and_verifies_a_pinned_plan(self) -> None:
         binding = CLIENT.plan_binding("lvprop-null")
         self.assertEqual(binding.issue, 149)
@@ -486,7 +498,7 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_remote_is_exploratory_and_allowlisted(self) -> None:
         self.assertIn(
-            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]',
+            '[ValidateSet("provider-probe", "create-empty", "opening-matrix", "allocation-map", "catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]',
             self.remote,
         )
         self.assertIn("development_only = $true", self.remote)
@@ -581,8 +593,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumRows = 64", row)
         self.assertIn("foreach ($replica in 1..3)", row)
         for scenario in (
@@ -602,8 +614,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_value_job_is_repeated_bounded_and_never_compacts(self) -> None:
         value = CLIENT.VALUE_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumDatabaseBytes = 4MB", value)
         self.assertIn("foreach ($replica in 1..3)", value)
         self.assertIn("$LongLengths = @(32, 512, 2048, 4096)", value)
@@ -614,8 +626,8 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
 
     def test_index_job_is_staged_bounded_and_never_compacts(self) -> None:
         index = CLIENT.INDEX_JOB.read_text(encoding="utf-8")
-        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")', self.remote)
-        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "lvprop-null")]', self.dispatch)
+        self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")', self.remote)
+        self.assertIn('[ValidateSet("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")]', self.dispatch)
         self.assertIn("$MaximumRows = 4096", index)
         self.assertIn("$MaximumDatabaseBytes = 16MB", index)
         for scenario in (
@@ -925,6 +937,40 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertEqual(
             plan["execution"]["bounds"]["maximum_published_databases"], 12
         )
+        self.assertTrue(
+            all(
+                isinstance(value, str)
+                and len(value) == 64
+                and value != "0" * 64
+                and all(character in "0123456789abcdef" for character in value)
+                for value in plan["inputs"].values()
+            )
+        )
+        job = CLIENT.DEFINITION_CONTINUATION_JOB.read_text(encoding="utf-8")
+        self.assertIn('$ScenarioFields = @{ zero = 69; one = 70; two = 140 }', job)
+
+    def test_extended_names_is_batched_bounded_and_exactly_routed(self) -> None:
+        self.assertIn(
+            '"extended-names" = "oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1"',
+            self.remote,
+        )
+        self.assertIn('"extended-names" { $ExtendedNamesJobPath }', self.dispatch)
+        self.assertIn(
+            '"extended-names" { "extended-names-job-result.json" }', self.dispatch
+        )
+        self.assertIn("extended_names_replicas", self.dispatch)
+        self.assertIn("extended_names_replicas", self.remote)
+        self.assertIn('"extended-names" {', self.publication)
+        self.assertIn("Extended-names result must not be a reparse point.", self.publication)
+        self.assertIn("43-checkpoint bound", self.publication)
+        self.assertIn("129-database bound", self.publication)
+        self.assertIn("128-page bound", self.publication)
+        binding = CLIENT.plan_binding("extended-names")
+        plan = json.loads(binding.plan.read_text(encoding="utf-8"))
+        self.assertEqual(plan["issue"], 152)
+        self.assertEqual(plan["execution"]["bounds"]["maximum_published_databases"], 129)
+        self.assertEqual(plan["execution"]["bounds"]["maximum_pages_per_database"], 128)
+        self.assertEqual(len(plan["inputs"]), 9)
         self.assertEqual(
             plan["inputs"],
             {
@@ -932,11 +978,17 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
                 for relative in plan["inputs"]
             },
         )
-        job = CLIENT.DEFINITION_CONTINUATION_JOB.read_text(encoding="utf-8")
-        self.assertIn('$ScenarioFields = @{ zero = 69; one = 70; two = 140 }', job)
+        job = CLIENT.EXTENDED_NAMES_JOB.read_text(encoding="utf-8")
+        self.assertIn("$UndefinedSlots = @(0x81, 0x8D, 0x8F, 0x90, 0x9D)", job)
+        self.assertIn("for ($batchIndex = 0; $batchIndex -lt 41; $batchIndex++)", job)
+        self.assertIn("foreach ($replica in 1..3)", job)
         self.assertIn("[ref]$MutationStarted", job)
         self.assertIn('phase = "before_create_database"', job)
         self.assertIn("size_after_metadata", job)
+        self.assertIn("$MaximumPages = 128", job)
+        self.assertIn('$failureOperation = "create_tabledef"', job)
+        self.assertIn('$failureOperation = "tabledefs_append"', job)
+        self.assertIn("$indexes = $table.Indexes", job)
 
     def test_lvprop_null_is_bounded_and_exactly_routed(self) -> None:
         self.assertIn(

--- a/scripts/windows-dao-dev.py
+++ b/scripts/windows-dao-dev.py
@@ -173,6 +173,15 @@ DEFINITION_CONTINUATION_PLAN = (
 DEFINITION_CONTINUATION_ANALYZER = (
     ROOT / "oracle" / "windows-dao" / "scripts" / "definition_continuation.py"
 )
+EXTENDED_NAMES_JOB = (
+    ROOT / "oracle" / "windows-dao" / "scripts" / "dev" / "ExtendedNames.DevJob.ps1"
+)
+EXTENDED_NAMES_PLAN = (
+    ROOT / "oracle" / "windows-dao" / "acquisition" / "extended-names.plan.json"
+)
+EXTENDED_NAMES_ANALYZER = (
+    ROOT / "oracle" / "windows-dao" / "scripts" / "extended_names.py"
+)
 LVPROP_NULL_JOB = (
     ROOT
     / "oracle"
@@ -213,6 +222,7 @@ ALLOWED_JOBS = (
     "schema-generalization",
     "multiple-indexes",
     "definition-continuation",
+    "extended-names",
     "lvprop-null",
 )
 
@@ -334,6 +344,14 @@ def plan_binding(job: str) -> PlanBinding | None:
             DEFINITION_CONTINUATION_ANALYZER,
             "dao_definition_continuation_plan",
             151,
+        )
+    if job == "extended-names":
+        return PlanBinding(
+            job,
+            EXTENDED_NAMES_PLAN,
+            EXTENDED_NAMES_ANALYZER,
+            "dao_extended_names_plan",
+            152,
         )
     if job == "lvprop-null":
         return PlanBinding(
@@ -642,6 +660,7 @@ def stage_job(args: argparse.Namespace) -> Path:
             DEFINITION_CONTINUATION_JOB,
             staging / DEFINITION_CONTINUATION_JOB.name,
         )
+        shutil.copyfile(EXTENDED_NAMES_JOB, staging / EXTENDED_NAMES_JOB.name)
         shutil.copyfile(LVPROP_NULL_JOB, staging / LVPROP_NULL_JOB.name)
         binding = plan_binding(args.job)
         if binding is not None:
@@ -721,6 +740,8 @@ def remote_job_command(args: argparse.Namespace) -> list[str]:
         ntpath.join(remote_input, MULTIPLE_INDEXES_JOB.name),
         "-DefinitionContinuationJobPath",
         ntpath.join(remote_input, DEFINITION_CONTINUATION_JOB.name),
+        "-ExtendedNamesJobPath",
+        ntpath.join(remote_input, EXTENDED_NAMES_JOB.name),
         "-LvPropNullJobPath",
         ntpath.join(remote_input, LVPROP_NULL_JOB.name),
         "-LvPropFixedAlphaPath",


### PR DESCRIPTION
## Summary

- preregister issue #152 over all 123 defined CP1252 bytes above `0x7E`
- isolate 41 three-byte batches plus explicit U+007F and undefined-slot controls across three replicas
- pin the producer, analyzer, routing, publisher, and shared decoders by SHA-256 before acquisition
- validate exact attempt outcomes, DAO metadata, catalog keys, failure states, and bounded artifact inventories

## Scientific boundary

This is a development-only local DAO preregistration. It makes no compatibility or support claim, and no acquisition occurred on this branch. The merged plan authorizes at most one run under the user's standing approval; any failure after the first DAO mutation is a scientific result and cannot be retried without a new human decision.

Plan SHA-256: `201e880ff1e7d08d5151df2fc53388ef296dfbd4158fc84a530510fffbc32236`

## Review

Three independent review/fix passes covered the protocol, byte inventory, producer/analyzer state machine, routing/publication, evidence retention, bounds, and claim boundary. Final verification reported no findings.

## Checks

- 63 focused Python/contract tests passed
- `just ready` passed
- all nine embedded input pins were recomputed and verified

Supports #152.
