### PR TITLE
docs: record extended-name no-outcome

### DIFF
--- a/docs/LOCAL_WINDOWS_VM.md
+++ b/docs/LOCAL_WINDOWS_VM.md
@@ -160,15 +160,19 @@ placement nor a single-page `LvProp`, and establishes no broader allocation,
 writer, compatibility, or support claim.
 
 `extended-names` is the SHA-256-pinned issue #152 experiment for every defined
-CP1252 byte above `0x7E`. Review and pinning are complete; the preregistration
-commit must merge before the standing authorization permits one acquisition.
-Three replicas each retain an empty checkpoint, 41
+CP1252 byte above `0x7E`. Three replicas each retain an empty checkpoint, 41
 identity-isolated three-byte batch checkpoints, and one explicit rejection-arm
 checkpoint. The analyzer accepts contrary but fully decoded collation behavior
 as an answer and treats incomplete decoding, mutation failure, or replica
 disagreement as `no_outcome`. The 128-page prospective bound accommodates the
 earlier observed 70-page, 24-name image; each new batch remains at 27 catalog
 rows, below the observed 32-row single-leaf count.
+`EXP-0097` records the only dispatch as `no_outcome`: all DAO attempts reported
+creation and bounded metadata agreed, but each replica's rejection checkpoint
+failed catalog-key decoding with a malformed identity field. The defined arms
+cannot be promoted outside the preregistered all-or-`no_outcome` decision rule.
+#152 remains open and evidence-blocked. A separately pinned successor and
+renewed explicit human authorization are required before another dispatch.
 
 `lvprop-null` is the SHA-256-pinned, development-only acceptance experiment for
 issue #149. Three replicas each compare the fixed accepted Alpha composer image,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -8696,6 +8696,102 @@ Use `not applicable` explicitly rather than omitting a field.
   acquisition was performed.
 
 
+### EXP-0097 — No-outcome CP1252 extended catalog-name DAO result
+
+- Recorded: 2026-09-02, OpenAI Codex
+- Kind: validated SHA-256-pinned, development-only local DAO `no_outcome`
+  derived from a canonical analyzer report
+- Question: for the exact isolated arms preregistered by `EXP-0096`, what
+  catalog ParentId/Name key contributions does DAO emit for every defined
+  CP1252 byte above `0x7E` in the bounded singleton, repeat, and neighboring
+  pair contexts, and what happens for the U+007F and five undefined-slot
+  Unicode controls?
+- Origin: project-authored clean-room experiment using the exact `EXP-0096`
+  bytes merged as commit `9987d606dbd1c36608cff6a8c1160e26073548cd`
+  (PR `#164`) and plan SHA-256
+  `201e880ff1e7d08d5151df2fc53388ef296dfbd4158fc84a530510fffbc32236`.
+  The user had explicitly authorized local experiments. An initial local
+  client invocation stopped before opening SSH because required configuration
+  was absent; it staged, dispatched, and acquired nothing and is not a run.
+  Run ID `20260902T210813Z-dev-dao` was then the one and only DAO dispatch and
+  was not retried. The dispatch count and pre-SSH failure are operator-history
+  observations, not facts inferred from the retained artifacts.
+- Input identity: the retained staged plan matched the exact plan digest above,
+  and each of its nine staged inputs matched its embedded SHA-256 pin and the
+  corresponding bytes on merged `main`. The staged and merged producer bytes
+  were identical at
+  `oracle/windows-dao/scripts/dev/ExtendedNames.DevJob.ps1` at SHA-256
+  `a177a80638d22605a2f7836005e9cd6b7b296fdcd7a264f49e6a325c5fa39356`
+  and the staged and merged analyzer bytes were identical at
+  `oracle/windows-dao/scripts/extended_names.py` at SHA-256
+  `732e8ca5edd597bf54dc73764031e4663d361f9f1c4f21747baab6dbdf352369`.
+- Environment: private local Windows development VM; Windows NT 10.0.20348.0
+  build 20348 on AMD64; x86 Windows PowerShell Desktop 5.1.20348.558; .NET
+  4.0.30319.42000; culture/UI culture `en-US`; ANSI code page 1252; OEM code
+  page 437; `Pacific Standard Time` at UTC-07:00. The provider probe reported
+  `ready` for x86 `DAO.DBEngine.36` provider 3.6 from `dao360.dll` file version
+  03.60.9765.0, SHA-256
+  `4cc28a5be8dc7425a4c4c1ef275ca392f18be35d70232e777dce6d9f3b4d79ac`.
+  Guest embedded UTC timestamps were seven hours ahead of the host run/report
+  clock while reporting Pacific UTC-07:00; they are retained as reported but
+  are not used as wall-clock or dispatch-order evidence.
+- Producer result: all three replicas reached phase `complete` with status
+  `pass`, `mutation_started: true`, 43 checkpoints, and no recovery artifact.
+  All 2,337 defined-arm attempts and all 21 rejection-arm attempts reported
+  `created` with no failure operation or error. The rejection arms comprised
+  seven attempts per replica: one ASCII canary, U+007F, and five Unicode BSTR
+  controls corresponding to undefined CP1252 slots. The producer's bounded DAO
+  operation path returned successfully through `TableDefs.Append` and close for
+  each exact control, and post-close bounded DAO metadata listed every exact
+  name. All 129 retained images kept identical size and SHA-256 through the
+  metadata pass.
+- Analyzer result: the pinned analyzer validated the complete result and
+  artifact contract and wrote a deterministic canonical report with top-level
+  status `no_outcome`, `compatibility_claim: false`, and
+  `support_movement: false`. Both the staged and merged analyzers reproduced
+  that report byte-for-byte. Each replica has the exact decode error
+  `checkpoint reject: a catalog row has malformed identity fields`. All five
+  questions—coverage, singleton positions, pair composition, secondary order,
+  and replication—have status `no_outcome` for the reason `at least one
+  retained checkpoint failed a recorded grammar or control`.
+- JSON artifacts: external `environment.json`, 4,277 bytes, SHA-256
+  `1a7440a0e1610d5efe9e1b0d9c64f67ab64240c91ddda96688540f70a59f201b`;
+  external `extended-names-job-result.json`, 6,429,106 bytes, SHA-256
+  `0d629b009acee1e7e82915c79b4a60a7ab0b64288dcbba30d0037929a62d4166`;
+  external `result.json`, 7,478,632 bytes, SHA-256
+  `0de5e47df7b95401c7f037fb8b02a4c1ec9daf25664e11befaf12484ebc55501`;
+  external canonical `extended-names-report.json`, 824,988 bytes, SHA-256
+  `3c08b7499b23f02e31bf3b13d5ee18f54644be4e07d3acc92804b3db7fbf4a32`.
+  The outer `result.json` is transport and status evidence only: its duplicated
+  Unicode-bearing replica values contain 4,458 scalar differences from the
+  byte-preserved job result because the dispatcher read UTF-8 using the Windows
+  PowerShell default encoding. Exact name evidence comes only from the direct
+  job result consumed by the pinned analyzer, not that duplicated outer copy.
+- Retained MDB identities: exactly 129 files totaling 15,200,256 bytes: three
+  40,960-byte empty images, 123 120,832-byte batch images, and three
+  71,680-byte rejection-arm images. The SHA-256 of the filename-sorted JSON
+  array of `name`/`size`/`sha256` objects, serialized as UTF-8 with indent 2,
+  keys sorted, and one trailing LF, is
+  `e409731b49974150b99ea54b3cc8b3d62a3d8fccb9830631c0cc5101b834e3cf`.
+- Interpretation: the validated producer metadata agrees with the exact
+  attempt-acceptance records, but this is not a general DAO name-acceptance
+  claim. The preregistered decision was all-or-`no_outcome`; therefore the
+  defined-arm bytes cannot be promoted post hoc after the rejection checkpoint
+  failed catalog-key decoding. This result establishes no catalog-key mapping,
+  primary weight, expansion, secondary-nibble ordering, undefined-byte
+  mapping, general collation, writer correctness, compatibility, hosted
+  differential result, or support movement. Issue `#152` remains open and
+  evidence-blocked. Any new acquisition requires a separately pinned successor
+  and renewed explicit human authorization.
+- Usage: issue `#152`; `EXP-0087`; `EXP-0096`; future separately
+  preregistered successor
+- Rights: all project-generated MDBs and provider outputs remain outside the
+  repository and are neither committed nor redistributed
+- Review: direct artifact-identity, producer-state, inventory, and canonical
+  classification checks completed on 2026-09-02; independent outcome-entry
+  review is pending
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -81,12 +81,11 @@ ordinary, ascending, and descending forms. It cannot infer arbitrary schemas
 or behavior above three indexes. #102 remains the separate hosted write
 differential after database creation is complete.
 
-`EXP-0096` is the SHA-256-pinned #152 preregistration. Its bounded domain is all
-123 defined CP1252 bytes in `0x80`-`0xFF`, plus explicit U+007F and five
-undefined-slot Unicode rejection controls. Acquisition remains forbidden until
-the preregistration commit is merged. An
-accepted result may inform only the planner's catalog-key encoding for those
-exact singleton and pair contexts; it does not establish a general collation
-implementation. Its prospective 128-page bound is above the prior observed
-70-page, 24-name image, while its 19-create batches retain 27 catalog rows,
-below the observed 32-row single-leaf count.
+`EXP-0096` is the SHA-256-pinned #152 preregistration. `EXP-0097` records its
+canonical `no_outcome`: all 2,358 DAO name attempts reported creation and the
+bounded DAO metadata agreed, but every replica failed catalog-key decoding at
+the rejection checkpoint with `checkpoint reject: a catalog row has malformed
+identity fields`. Under the preregistered all-or-`no_outcome` rule, the defined
+arms cannot be promoted post hoc and establish no catalog-name mapping or
+weights. #152 remains open and evidence-blocked; another acquisition requires
+a separately pinned successor and renewed explicit human authorization.

--- a/oracle/windows-dao/README.md
+++ b/oracle/windows-dao/README.md
@@ -166,5 +166,10 @@ catalog-key observation, not a general collation or compatibility claim.
 `EXP-0087`'s 24-name checkpoint occupied 70 pages; this prospective job
 therefore permits 128 pages while keeping each batch at 27 catalog rows (eight
 base plus 19 created tables), below the observed 32-row single leaf. Its exact
-inputs are pinned; acquisition remains forbidden until the preregistration
-commit merges.
+inputs are pinned. `EXP-0097` records the one run as a canonical `no_outcome`:
+all DAO attempts reported creation and their bounded metadata agreed, but every
+replica's rejection checkpoint failed catalog-key decoding with a malformed
+identity field. The preregistered all-or-`no_outcome` rule prevents promoting
+the defined batches after that failure. #152 remains open and evidence-blocked;
+a new run requires a separately pinned successor and renewed explicit human
+authorization.


### PR DESCRIPTION
## Summary

- record the single EXP-0096 acquisition as canonical `no_outcome`
- preserve exact plan, staged-input, JSON, and 129-MDB inventory identities
- document that all 2,358 bounded DAO attempts completed and post-close metadata agreed
- keep all catalog-key questions unanswered because every rejection checkpoint failed the preregistered strict row decoder
- leave #152 open and require a separately pinned successor plus renewed human authorization

## Evidence boundary

The direct UTF-8 job result and canonical analyzer report are the exact-name evidence. The outer transport `result.json` is retained only for run/status evidence because its duplicated Unicode values were decoded with the Windows PowerShell default encoding. No MDB or provider bytes are committed, and no compatibility or support claim is made.

## Review and checks

- independent artifact and wording audit passed
- staged and merged analyzers reproduced the retained report byte-for-byte
- `just ready` passed
- `git diff --check` passed

Supports #152; does not close it.
