### PR TITLE
fix(oracle): decode transported JSON as UTF-8

### DIFF
--- a/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1
@@ -164,7 +164,7 @@ if (-not (Test-Path -LiteralPath $resultPath -PathType Leaf)) {
     exit 1
 }
 
-$jobResult = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+$jobResult = Get-Content -LiteralPath $resultPath -Raw -Encoding UTF8 | ConvertFrom-Json
 $catalogCheckpoints = @()
 $tableDefinitionCheckpoints = @()
 $tableDefinitionTypeResults = @()

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -431,7 +431,7 @@ if ($planBoundJobs.ContainsKey($Job)) {
         [Console]::Error.WriteLine("INVALID: $Job plan digest differs after staging.")
         exit 2
     }
-    $plan = Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-Json
+    $plan = Get-Content -LiteralPath $PlanPath -Raw -Encoding UTF8 | ConvertFrom-Json
     $jobPath = if ($Job -ceq "bootstrap-layout") {
         $BootstrapLayoutJobPath
     }
@@ -567,7 +567,7 @@ if ($Job -ceq "provider-probe") {
     }
 }
 elseif ($Job -ceq "create-empty" -and $probeExitCode -eq 0) {
-    $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
+    $environment = Get-Content -LiteralPath $environmentPath -Raw -Encoding UTF8 | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
     }
@@ -615,7 +615,7 @@ elseif ($Job -ceq "create-empty" -and $probeExitCode -eq 0) {
     }
 }
 elseif ($Job -ceq "opening-matrix" -and $probeExitCode -eq 0) {
-    $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
+    $environment = Get-Content -LiteralPath $environmentPath -Raw -Encoding UTF8 | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
     }
@@ -649,7 +649,7 @@ elseif ($Job -ceq "opening-matrix" -and $probeExitCode -eq 0) {
     }
 }
 elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
-    $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
+    $environment = Get-Content -LiteralPath $environmentPath -Raw -Encoding UTF8 | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
     }
@@ -779,7 +779,7 @@ elseif ($Job -ceq "allocation-map" -and $probeExitCode -eq 0) {
     }
 }
 elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null") -and $probeExitCode -eq 0) {
-    $environment = Get-Content -LiteralPath $environmentPath -Raw | ConvertFrom-Json
+    $environment = Get-Content -LiteralPath $environmentPath -Raw -Encoding UTF8 | ConvertFrom-Json
     if ([string]$environment.accepted_provider.prog_id -cne "DAO.DBEngine.36") {
         $detail = "The ready provider is not DAO.DBEngine.36."
     }
@@ -810,7 +810,7 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
             $exitCode = 1
         }
         else {
-            $dispatchResult = Get-Content -LiteralPath $dispatchResultPath -Raw |
+            $dispatchResult = Get-Content -LiteralPath $dispatchResultPath -Raw -Encoding UTF8 |
                 ConvertFrom-Json
             $catalogCheckpoints = @($dispatchResult.catalog_checkpoints)
             $tableDefinitionCheckpoints = @($dispatchResult.table_definition_checkpoints)

--- a/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Publish.DevJob.ps1
@@ -88,7 +88,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Bootstrap-layout result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($checkpoint in @($replica.checkpoints)) {
@@ -130,7 +130,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "System-catalog result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($checkpoint in @($replica.checkpoints)) {
@@ -163,7 +163,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Long-value-maps result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($checkpoint in @($replica.checkpoints)) {
@@ -196,7 +196,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Long-value-maps follow-up result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($checkpoint in @($replica.checkpoints)) {
@@ -229,7 +229,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Bootstrap-composer-semantics result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($checkpoint in @($replica.checkpoints)) {
@@ -262,7 +262,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Schema-generalization result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($checkpoint in @($replica.checkpoints)) {
@@ -298,7 +298,7 @@ switch ($Job) {
         if ((Get-Item -LiteralPath $jobResultPath).Length -gt 4194304) {
             throw "Multiple-indexes result exceeds the 4-MiB bound."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $checkpointNames = @("empty", "one", "two", "three", "composite")
         $referenced = New-Object Collections.ArrayList
         $seenReplicas = New-Object Collections.ArrayList
@@ -389,7 +389,7 @@ switch ($Job) {
         if ((Get-Item -LiteralPath $jobResultPath).Length -gt 4194304) {
             throw "Definition-continuation result exceeds the 4-MiB bound."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $checkpointNames = @("empty", "zero", "one", "two")
         $referenced = New-Object Collections.ArrayList
         $seenReplicas = New-Object Collections.ArrayList
@@ -478,7 +478,7 @@ switch ($Job) {
         $jobResultItem = Get-Item -LiteralPath $jobResultPath -Force
         if (($jobResultItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw "Extended-names result must not be a reparse point." }
         if ($jobResultItem.Length -gt 8388608) { throw "Extended-names result exceeds the 8-MiB bound." }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $checkpointNames = New-Object Collections.ArrayList
         [void]$checkpointNames.Add("empty")
         foreach ($index in 0..40) { [void]$checkpointNames.Add("b" + $index.ToString("D2")) }
@@ -530,7 +530,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "LvProp-null result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($image in @($replica.images)) {
@@ -586,7 +586,7 @@ switch ($Job) {
         if (-not (Test-Path -LiteralPath $jobResultPath -PathType Leaf)) {
             throw "Bootstrap-composer validation result is missing."
         }
-        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw | ConvertFrom-Json
+        $jobResult = Get-Content -LiteralPath $jobResultPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $referenced = New-Object Collections.ArrayList
         foreach ($replica in @($jobResult.replicas)) {
             foreach ($image in @($replica.images)) {

--- a/oracle/windows-dao/scripts/dev/TableDefinition.DevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/TableDefinition.DevJob.ps1
@@ -440,7 +440,7 @@ function Save-Checkpoint {
     }
 }
 
-$typeInput = Get-Content -LiteralPath $TypeInputPath -Raw | ConvertFrom-Json
+$typeInput = Get-Content -LiteralPath $TypeInputPath -Raw -Encoding UTF8 | ConvertFrom-Json
 if ([int]$typeInput.schema_version -ne 1 -or
     [string]$typeInput.source_commit -cne "eedbd61ca40689e7cfed5e1cfd9440a9dc3ab7a5" -or
     [string]$typeInput.source_sha256 -cne "51147cb927489b36583de4729355fccc78cc0781032453775f2a011f58535d7b" -or

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -591,6 +591,31 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         )
         self.assertIn("[IO.Directory]::Move($staging, $Destination)", self.publication)
 
+    def test_json_transport_reads_explicit_utf8(self) -> None:
+        for name, script in (
+            ("dispatcher", self.dispatch),
+            ("runner", self.remote),
+            ("publisher", self.publication),
+            (
+                "table-definition producer",
+                CLIENT.TABLE_DEFINITION_JOB.read_text(encoding="utf-8"),
+            ),
+        ):
+            lines = script.splitlines()
+            reads = []
+            for position, line in enumerate(lines):
+                if "Get-Content" not in line:
+                    continue
+                command = line
+                if "ConvertFrom-Json" not in command and command.rstrip().endswith("|"):
+                    command += " " + lines[position + 1].strip()
+                if "ConvertFrom-Json" in command:
+                    reads.append(command)
+
+            self.assertTrue(reads, f"{name} has no JSON reads")
+            for command in reads:
+                self.assertIn("-Raw -Encoding UTF8", command, name)
+
     def test_row_job_is_repeated_bounded_and_never_compacts(self) -> None:
         row = CLIENT.ROW_JOB.read_text(encoding="utf-8")
         self.assertIn('$Job -in @("catalog", "table-definition", "row", "value", "index", "bootstrap-layout", "system-catalog", "long-value-maps", "long-value-maps-followup", "bootstrap-composer-semantics", "bootstrap-composer-validation", "schema-generalization", "multiple-indexes", "definition-continuation", "extended-names", "lvprop-null")', self.remote)
@@ -972,12 +997,20 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
         self.assertEqual(plan["execution"]["bounds"]["maximum_pages_per_database"], 128)
         self.assertEqual(len(plan["inputs"]), 9)
         self.assertEqual(
-            plan["inputs"],
-            {
-                relative: hashlib.sha256((ROOT / relative).read_bytes()).hexdigest()
-                for relative in plan["inputs"]
-            },
+            hashlib.sha256(binding.plan.read_bytes()).hexdigest(),
+            "201e880ff1e7d08d5151df2fc53388ef296dfbd4158fc84a530510fffbc32236",
         )
+        self.assertTrue(
+            all(
+                isinstance(value, str)
+                and len(value) == 64
+                and value != "0" * 64
+                and all(character in "0123456789abcdef" for character in value)
+                for value in plan["inputs"].values()
+            )
+        )
+        with self.assertRaisesRegex(CLIENT.DevClientError, "differs from its plan"):
+            CLIENT.verified_plan_sha256(binding)
         job = CLIENT.EXTENDED_NAMES_JOB.read_text(encoding="utf-8")
         self.assertIn("$UndefinedSlots = @(0x81, 0x8D, 0x8F, 0x90, 0x9D)", job)
         self.assertIn("for ($batchIndex = 0; $batchIndex -lt 41; $batchIndex++)", job)


### PR DESCRIPTION
## Summary

- decode all JSON transported through the Windows DAO development pipeline with explicit UTF-8
- cover the dispatcher, runner, publisher, and table-definition producer reads
- keep the consumed EXP-0096 preregistration immutable while proving its shared-tool pins are now intentionally stale

## Checks

- `python3 -m unittest oracle/windows-dao/tests/test_windows_dao_dev_contract.py` (46 passed)
- `just ready`