### PR TITLE
feat(jet3): compose multi-index creates in the DAO-observed page order

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -26,13 +26,6 @@ pub(crate) enum BootstrapComposeError {
         /// Largest observed long-value column count.
         observed: usize,
     },
-    /// The encoded definition length differs from the planned length.
-    DefinitionLengthMismatch {
-        /// Length the planner measured.
-        planned: usize,
-        /// Length the encoder produced.
-        encoded: usize,
-    },
 }
 
 impl fmt::Display for BootstrapComposeError {
@@ -54,8 +47,7 @@ impl std::error::Error for BootstrapComposeError {
             Self::Schema(source) => Some(source),
             Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
-            | Self::UnobservedLongValueColumnCount { .. }
-            | Self::DefinitionLengthMismatch { .. } => None,
+            | Self::UnobservedLongValueColumnCount { .. } => None,
         }
     }
 }

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -16,8 +16,6 @@ pub(crate) enum BootstrapComposeError {
         available: usize,
     },
     NameKey(CatalogNameKeyError),
-    /// Long-value encoding failed.
-    LongValue(LongValueWriteError),
     /// The table could not be planned.
     Schema(TableSchemaPlanError),
     /// The table carries both an index and a long-value column, a map-page
@@ -28,17 +26,12 @@ pub(crate) enum BootstrapComposeError {
         /// Largest observed long-value column count.
         observed: usize,
     },
-    /// The `LvProp` payload breaks the `EXP-0087` chunk framing.
-    PropertyFraming {
-        /// Offset of the first byte that could not be framed.
-        offset: usize,
-    },
-    /// The `LvProp` payload does not hold one names chunk plus one per column.
-    PropertyChunkCount {
-        /// Chunks the payload holds.
-        chunks: usize,
-        /// Chunks `EXP-0087` observed for this column count.
-        expected: usize,
+    /// The encoded definition length differs from the planned length.
+    DefinitionLengthMismatch {
+        /// Length the planner measured.
+        planned: usize,
+        /// Length the encoder produced.
+        encoded: usize,
     },
 }
 
@@ -58,13 +51,11 @@ impl std::error::Error for BootstrapComposeError {
             Self::WholeFile(source) => Some(source),
             Self::Encoding(source) => Some(source),
             Self::NameKey(source) => Some(source),
-            Self::LongValue(source) => Some(source),
             Self::Schema(source) => Some(source),
             Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
             | Self::UnobservedLongValueColumnCount { .. }
-            | Self::PropertyFraming { .. }
-            | Self::PropertyChunkCount { .. } => None,
+            | Self::DefinitionLengthMismatch { .. } => None,
         }
     }
 }
@@ -102,12 +93,6 @@ impl From<Error> for BootstrapComposeError {
 impl From<CatalogNameKeyError> for BootstrapComposeError {
     fn from(source: CatalogNameKeyError) -> Self {
         Self::NameKey(source)
-    }
-}
-
-impl From<LongValueWriteError> for BootstrapComposeError {
-    fn from(source: LongValueWriteError) -> Self {
-        Self::LongValue(source)
     }
 }
 

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -5,9 +5,11 @@
 //! makes no DAO-compatibility claim. Page roles and the empty-to-`Alpha`
 //! transition come from `EXP-0073`; the fixed page-zero transition byte comes
 //! from `EXP-0069` and `EXP-0071`; long-value map groups come from `EXP-0077`;
-//! fixed composite keys and the opaque `Alpha.LvProp` value come from
-//! `EXP-0079`; the fixed opaque page-zero candidate hypothesis is
-//! preregistered by `EXP-0084`.
+//! fixed composite keys come from `EXP-0079`; the fixed opaque page-zero
+//! candidate hypothesis is preregistered by `EXP-0084`; the null catalog
+//! `LvProp` with a retained empty long-value page is the `EXP-0091` accepted
+//! construction; first-create page order comes from `EXP-0093` and
+//! definition continuations from `EXP-0105`.
 
 #![allow(
     dead_code,
@@ -17,7 +19,6 @@
 use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, encode_catalog_name_key};
-use crate::long_value_writer::LongValueWriteError;
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 use crate::table_schema_plan::{TableSchemaPlanError, TableSchemaSpec};
 use crate::whole_file_plan::{WholeFileImagePlan, WholeFilePlanError};
@@ -74,10 +75,6 @@ const DATABASE_HEADER_FIXED_OPAQUE: [u8; 126] = [
     0x60, 0x26, 0x5f, 0x95, 0xf8, 0xd0, 0x89, 0x24, 0x85, 0x67, 0xc6, 0x1f, 0x27, 0x44, 0xd2, 0xee,
     0xcf, 0x65, 0xed, 0xff, 0x07, 0xc7, 0x46, 0xa1, 0x78, 0x16, 0x0c, 0xed, 0xe9, 0x2d,
 ];
-// EXP-0079 records this fixed value losslessly; its property grammar remains
-// uninterpreted.
-const ALPHA_LVPROP_PAYLOAD: &[u8] =
-    b"KKD\x00\x10\x00\x00\x00\x80\x00\x08\x00Required\x17\x00\x00\x00\x01\x00\x08\x00\x00\x00\x02\x00Id\x09\x00\x01\x01\x00\x00\x01\x00\x00";
 const ALPHA_COLUMNS: [ColumnSpec<'static>; 1] = [ColumnSpec::new(
     b"Id",
     ColumnPhysicalType::Long,
@@ -104,65 +101,33 @@ pub(crate) use error::BootstrapComposeError;
 pub(crate) fn compose_empty_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    let images = compose_existing_pages(None, CreatedLvProp::External, budget)?;
+    let images = compose_existing_pages(None, budget)?;
     WholeFileImagePlan::from_existing_pages(images, budget).map_err(Into::into)
 }
 
-/// Composes the fixed empty-to-`Alpha(Id Long)` transition from `EXP-0073`,
-/// carrying the `LvProp` payload `EXP-0079` recorded for it.
+/// Composes the empty-to-`Alpha(Id Long)` transition from `EXP-0073` in the
+/// null-`LvProp` form `EXP-0091` accepted.
 pub(crate) fn compose_alpha_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    compose_table_database(alpha_create(), budget)
-}
-
-/// Composes the `#149` candidate with a null catalog `LvProp` and an empty
-/// retained LVAL page. This is test-only until DAO evaluates the candidate.
-#[cfg(test)]
-fn compose_alpha_database_with_null_lvprop(
-    budget: &mut ResourceBudget,
-) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    compose_table_database_with_lvprop(alpha_create(), CreatedLvProp::Null, budget)
-}
-
-const fn alpha_create() -> TableCreate<'static> {
-    TableCreate {
-        spec: &ALPHA_SPEC,
-        properties: ALPHA_LVPROP_PAYLOAD,
-    }
+    compose_table_database(&ALPHA_SPEC, budget)
 }
 
 /// Composes the empty database plus one created user table, following the
-/// `EXP-0087` create observations.
+/// `EXP-0091`, `EXP-0093`, and `EXP-0105` first-create observations.
 pub(crate) fn compose_table_database(
-    create: TableCreate<'_>,
+    spec: &TableSchemaSpec<'_>,
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    compose_table_database_with_lvprop(create, CreatedLvProp::External, budget)
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum CreatedLvProp {
-    External,
-    #[cfg(test)]
-    Null,
-}
-
-fn compose_table_database_with_lvprop(
-    create: TableCreate<'_>,
-    lvprop: CreatedLvProp,
-    budget: &mut ResourceBudget,
-) -> Result<WholeFileImagePlan, BootstrapComposeError> {
-    let planned = PlannedCreate::new(create)?;
-    let images = compose_existing_pages(Some(&planned), lvprop, budget)?;
+    let planned = PlannedCreate::new(spec)?;
+    let images = compose_existing_pages(Some(&planned), budget)?;
     let mut plan = WholeFileImagePlan::from_existing_pages(images, budget)?;
-    planned.append_pages(&mut plan, lvprop, budget)?;
+    planned.append_pages(&mut plan, budget)?;
     Ok(plan)
 }
 
 fn compose_existing_pages(
     create: Option<&PlannedCreate<'_>>,
-    lvprop: CreatedLvProp,
     budget: &mut ResourceBudget,
 ) -> Result<[PageImage; EMPTY_DATABASE_PAGE_COUNT as usize], BootstrapComposeError> {
     let object_count = if create.is_some() { 9 } else { 8 };
@@ -187,7 +152,7 @@ fn compose_existing_pages(
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
-        objects_data_page(create, lvprop, budget)?,
+        objects_data_page(create, budget)?,
         aces_data_page(create, budget)?,
     ])
 }
@@ -265,7 +230,7 @@ fn objects_map_page(
     let owned = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let available = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let empty = inline_map_row(&[], budget)?;
-    let long_value_pages = create.map(PlannedCreate::long_value_page);
+    let long_value_pages = create.map(PlannedCreate::property_page);
     let lvprop = inline_map_row(long_value_pages.as_slice(), budget)?;
     let rows: [&[u8]; 15] = [
         &owned, &available, &empty, &empty, &empty, &empty, &empty, &empty, &empty, &empty,
@@ -339,7 +304,6 @@ use definitions::{
 #[path = "bootstrap_table_create.rs"]
 mod table_create;
 use table_create::PlannedCreate;
-pub(crate) use table_create::TableCreate;
 
 const OBJECT_LAYOUT: [RowColumnLayout; 17] = [
     fixed(ColumnPhysicalType::Long, 0, 4),
@@ -458,22 +422,17 @@ fn catalog_seeds<'a>(create: Option<&PlannedCreate<'a>>) -> impl Iterator<Item =
         .chain(create.map(PlannedCreate::catalog_seed))
 }
 
+/// Builds the catalog data page. Every `LvProp` is null: the system rows
+/// carry none (`EXP-0073`), and `EXP-0091` accepted a created table whose
+/// catalog `LvProp` is null while its long-value page stays present.
 fn objects_data_page(
     create: Option<&PlannedCreate<'_>>,
-    lvprop: CreatedLvProp,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, BootstrapComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
-    let created_id = create.map(PlannedCreate::object_id);
     for seed in catalog_seeds(create) {
-        let value = match create {
-            Some(planned) if lvprop == CreatedLvProp::External && Some(seed.id) == created_id => {
-                Some(planned.long_value_header()?)
-            }
-            _ => None,
-        };
-        let length = encode_catalog_row(seed, value, &mut row, budget)?;
+        let length = encode_catalog_row(seed, &mut row, budget)?;
         builder.append_row(&row[..length], budget)?;
     }
     finish_data_builder(builder, budget)
@@ -481,13 +440,9 @@ fn objects_data_page(
 
 fn encode_catalog_row(
     seed: CatalogSeed<'_>,
-    lvprop: Option<[u8; 12]>,
     output: &mut [u8],
     budget: &mut ResourceBudget,
 ) -> Result<usize, BootstrapComposeError> {
-    let lvprop_value = lvprop
-        .as_ref()
-        .map_or(RowValue::Null, |bytes| RowValue::LongValue(bytes));
     let values = [
         RowValue::Long(seed.id),
         RowValue::Long(seed.parent),
@@ -503,7 +458,7 @@ fn encode_catalog_row(
         RowValue::Null,
         RowValue::Null,
         RowValue::Null,
-        lvprop_value,
+        RowValue::Null,
         RowValue::Null,
         RowValue::Null,
     ];

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -8,8 +8,9 @@
 //! fixed composite keys come from `EXP-0079`; the fixed opaque page-zero
 //! candidate hypothesis is preregistered by `EXP-0084`; the null catalog
 //! `LvProp` with a retained empty long-value page is the `EXP-0091` accepted
-//! construction; first-create page order comes from `EXP-0093` and
-//! definition continuations from `EXP-0105`.
+//! construction for `Alpha(Id Long)` only; first-create page order comes
+//! from `EXP-0093`. Any composed image other than the `Alpha` transition is
+//! an unvalidated candidate until a DAO differential accepts it.
 
 #![allow(
     dead_code,
@@ -423,8 +424,9 @@ fn catalog_seeds<'a>(create: Option<&PlannedCreate<'a>>) -> impl Iterator<Item =
 }
 
 /// Builds the catalog data page. Every `LvProp` is null: the system rows
-/// carry none (`EXP-0073`), and `EXP-0091` accepted a created table whose
-/// catalog `LvProp` is null while its long-value page stays present.
+/// carry none (`EXP-0073`), and `EXP-0091` accepted the exact `Alpha`
+/// create with a null catalog `LvProp` and a retained long-value page. For
+/// any other created table the null form is an unvalidated candidate.
 fn objects_data_page(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -1,7 +1,4 @@
-use super::{
-    ALPHA_LVPROP_PAYLOAD, BootstrapComposeError, compose_alpha_database,
-    compose_alpha_database_with_null_lvprop, compose_empty_database,
-};
+use super::{BootstrapComposeError, compose_alpha_database, compose_empty_database};
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 
 // EXP-0073/EXP-0085: the accepted Alpha image's appended page numbers.
@@ -10,10 +7,9 @@ const ALPHA_MAP_PAGE: u64 = 21;
 use crate::table_schema_plan::{TableSchemaSpec, plan_table_schema};
 use crate::{
     ByteCount, CatalogObjectClass, ColumnOrdinal, ColumnPhysicalType, ColumnSpec,
-    ColumnStorageKind, DatabaseReader, JET3_PAGE_SIZE, LongValue, LongValueChunkValue,
-    MapRowLocator, PageKind, PageNumber, ReadLimits, ResourceBudget, ResourceLimitKind,
-    ResourceLimits, SliceSource, TableDefinitionKind, TextCodePage, ValueKind, classify_page,
-    locate_usage_map, page_tag,
+    ColumnStorageKind, DatabaseReader, JET3_PAGE_SIZE, MapRowLocator, PageKind, PageNumber,
+    ReadLimits, ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource,
+    TableDefinitionKind, TextCodePage, ValueKind, classify_page, locate_usage_map, page_tag,
 };
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -37,17 +33,6 @@ fn bytes(alpha: bool) -> Result<Vec<u8>, BootstrapComposeError> {
     } else {
         compose_empty_database(&mut budget)?
     };
-    let mut bytes = Vec::with_capacity(plan.pages().len() * crate::PAGE_BYTES);
-    for (slot, page) in plan.pages().iter().enumerate() {
-        assert_eq!(page.number(), PageNumber::new(slot as u64));
-        bytes.extend_from_slice(page.image().as_bytes());
-    }
-    Ok(bytes)
-}
-
-fn null_lvprop_bytes() -> Result<Vec<u8>, BootstrapComposeError> {
-    let mut budget = compose_budget();
-    let plan = compose_alpha_database_with_null_lvprop(&mut budget)?;
     let mut bytes = Vec::with_capacity(plan.pages().len() * crate::PAGE_BYTES);
     for (slot, page) in plan.pages().iter().enumerate() {
         assert_eq!(page.number(), PageNumber::new(slot as u64));
@@ -476,43 +461,29 @@ fn alpha_transition_appends_three_pages_and_updates_catalog_counts_and_indexes()
             .next_row()?
             .ok_or("missing initial object row")?;
     }
-    let reference = {
-        let mut alpha_row = object_rows.next_row()?.ok_or("missing Alpha object row")?;
-        assert!(matches!(
-            alpha_row
-                .value(ColumnOrdinal::new(6), TextCodePage::Windows1252)?
-                .ok_or("missing Alpha owner")?
-                .kind(),
-            ValueKind::Binary(actual) if *actual == b"\x03\x01"
-        ));
-        match alpha_row
+    // EXP-0091: the accepted construction carries a null catalog LvProp and
+    // an empty, mapped LVAL page.
+    let mut alpha_row = object_rows.next_row()?.ok_or("missing Alpha object row")?;
+    assert!(matches!(
+        alpha_row
+            .value(ColumnOrdinal::new(6), TextCodePage::Windows1252)?
+            .ok_or("missing Alpha owner")?
+            .kind(),
+        ValueKind::Binary(actual) if *actual == b"\x03\x01"
+    ));
+    assert!(matches!(
+        alpha_row
             .value(ColumnOrdinal::new(14), TextCodePage::Windows1252)?
             .ok_or("missing Alpha LvProp")?
-            .kind()
-        {
-            ValueKind::LongValue(LongValue::External(reference)) => *reference,
-            other => return Err(format!("unexpected Alpha LvProp: {other:?}").into()),
-        }
-    };
-    assert_eq!(
-        reference.raw_header(),
-        [
-            0x2b, 0x00, 0x00, 0x40, 0x00, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        ]
-    );
-    assert_eq!(reference.length(), 43);
-    assert_eq!(reference.target().page(), PageNumber::new(22));
-    assert_eq!(reference.target().slot(), 0);
-    let mut long_value = object_rows.long_value(reference)?;
-    let chunk = long_value
-        .next_chunk()?
-        .ok_or("missing Alpha LvProp chunk")?;
-    assert_eq!(chunk.raw_row(), ALPHA_LVPROP_PAYLOAD);
-    assert!(matches!(
-        chunk.value(),
-        LongValueChunkValue::Binary(value) if *value == ALPHA_LVPROP_PAYLOAD
+            .kind(),
+        ValueKind::Null
     ));
-    assert!(long_value.next_chunk()?.is_none());
+    assert_eq!(
+        u16::from_le_bytes(
+            bytes[22 * crate::PAGE_BYTES + 8..22 * crate::PAGE_BYTES + 10].try_into()?
+        ),
+        0
+    );
 
     let alpha = database.table_definition(PageNumber::new(20), &mut budget)?;
     assert_eq!(alpha.kind(), TableDefinitionKind::User);
@@ -523,81 +494,9 @@ fn alpha_transition_appends_three_pages_and_updates_catalog_counts_and_indexes()
 }
 
 #[test]
-fn null_lvprop_candidate_changes_only_the_catalog_and_lval_pages() -> TestResult {
-    let fixed = bytes(true)?;
-    let null = null_lvprop_bytes()?;
-    assert_eq!(fixed.len(), 23 * crate::PAGE_BYTES);
-    assert_eq!(null.len(), fixed.len());
-
-    let differing_pages = fixed
-        .chunks_exact(crate::PAGE_BYTES)
-        .zip(null.chunks_exact(crate::PAGE_BYTES))
-        .enumerate()
-        .filter_map(|(page, (left, right))| (left != right).then_some(page))
-        .collect::<Vec<_>>();
-    assert_eq!(differing_pages, [18, 22]);
-
-    for image in [&fixed, &null] {
-        assert_eq!(
-            &image[22 * crate::PAGE_BYTES + 4..22 * crate::PAGE_BYTES + 8],
-            b"LVAL"
-        );
-        assert!(inline_map_bit(image, 6, 10, 22)?);
-        assert!(inline_map_bit(image, 6, 11, 22)?);
-    }
-    assert_eq!(
-        u16::from_le_bytes(
-            fixed[22 * crate::PAGE_BYTES + 8..22 * crate::PAGE_BYTES + 10].try_into()?
-        ),
-        1
-    );
-    assert_eq!(
-        u16::from_le_bytes(
-            null[22 * crate::PAGE_BYTES + 8..22 * crate::PAGE_BYTES + 10].try_into()?
-        ),
-        0
-    );
-
-    for (image, expected_null) in [(&fixed, false), (&null, true)] {
-        let mut budget = read_budget(image.len());
-        let source = SliceSource::new(image, budget.read_budget())?;
-        let mut database = DatabaseReader::from_source(source, &mut budget)?;
-        let objects = database.table_definition(PageNumber::new(2), &mut budget)?;
-        let mut rows = database.rows(&objects, &mut budget)?;
-        for _ in 0..8 {
-            rows.next_row()?.ok_or("missing initial object row")?;
-        }
-        let mut alpha = rows.next_row()?.ok_or("missing Alpha object row")?;
-        assert!(matches!(
-            alpha
-                .value(ColumnOrdinal::new(0), TextCodePage::Windows1252)?
-                .ok_or("missing Alpha id")?
-                .kind(),
-            ValueKind::Long(20)
-        ));
-        assert!(matches!(
-            alpha
-                .value(ColumnOrdinal::new(2), TextCodePage::Windows1252)?
-                .ok_or("missing Alpha name")?
-                .kind(),
-            ValueKind::Text(name) if name.raw_bytes() == b"Alpha"
-        ));
-        let lvprop = alpha
-            .value(ColumnOrdinal::new(14), TextCodePage::Windows1252)?
-            .ok_or("missing Alpha LvProp value")?;
-        assert!(matches!(
-            (expected_null, lvprop.kind()),
-            (true, ValueKind::Null) | (false, ValueKind::LongValue(LongValue::External(_)))
-        ));
-    }
-    Ok(())
-}
-
-#[test]
 fn composition_is_deterministic_and_resource_rejection_is_structured() -> TestResult {
     assert_eq!(bytes(false)?, bytes(false)?);
     assert_eq!(bytes(true)?, bytes(true)?);
-    assert_eq!(null_lvprop_bytes()?, null_lvprop_bytes()?);
 
     let mut budget =
         ResourceBudget::new(ResourceLimits::default().with_max_allocation_bytes(ByteCount::new(0)));
@@ -623,24 +522,6 @@ fn export_dao_validation_candidates() -> TestResult {
             .ok_or("JET3_BOOTSTRAP_CANDIDATE_DIR is required")?,
     );
     export_candidates(&root)
-}
-
-#[test]
-#[ignore = "writes private deterministic candidates for preregistered DAO validation"]
-fn export_lvprop_null_candidates() -> TestResult {
-    use std::path::PathBuf;
-
-    let root = PathBuf::from(
-        std::env::var_os("JET3_LVPROP_NULL_CANDIDATE_DIR")
-            .ok_or("JET3_LVPROP_NULL_CANDIDATE_DIR is required")?,
-    );
-    export_candidate_set(
-        &root,
-        [
-            ("lvprop-fixed-alpha.mdb", bytes(true)?),
-            ("lvprop-null-alpha.mdb", null_lvprop_bytes()?),
-        ],
-    )
 }
 
 fn export_candidates(root: &std::path::Path) -> TestResult {
@@ -723,16 +604,15 @@ fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
     assert_eq!(plan.object_id(), ALPHA_ROOT as i32);
     assert_eq!(plan.definition_root(), PageNumber::new(ALPHA_ROOT));
     assert_eq!(plan.map_page(), PageNumber::new(ALPHA_MAP_PAGE));
-    // The accepted Alpha image appends three pages; the planner reports two
-    // because it deliberately plans no long-value page. EXP-0087 observed one
-    // only for a database's first create and establishes no property grammar,
-    // so the composer wiring has to place it.
-    assert_eq!(plan.index_root(), None);
-    assert_eq!(plan.appended_page_count(), 2);
+    // EXP-0091/EXP-0093: the retained LvProp page follows the map page, so
+    // the accepted Alpha image appends exactly the planned three pages.
+    assert_eq!(plan.property_page(), PageNumber::new(ALPHA_MAP_PAGE + 1));
+    assert_eq!(plan.index_placements().count(), 0);
+    assert_eq!(plan.appended_page_count(), 3);
     let alpha_pages = bytes(true)?.len() as u64 / JET3_PAGE_SIZE.get();
     assert_eq!(
         alpha_pages,
-        EMPTY_DATABASE_PAGE_COUNT + plan.appended_page_count() + 1
+        EMPTY_DATABASE_PAGE_COUNT + plan.appended_page_count()
     );
     Ok(())
 }

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -1,103 +1,78 @@
 //! Pages a planned user-table create appends to the empty database, derived
-//! from the `EXP-0087` create observations rather than recorded bytes.
+//! from the `EXP-0093` and `EXP-0105` first-create observations rather than
+//! recorded bytes.
 //!
-//! `EXP-0087` observed each create append a definition root, a page of
-//! usage-map rows, an index root directly after it when the table carries an
-//! index, and, on a database's first create only, a long-value page holding
-//! the catalog row's `LvProp` payload. No observed first create carried an
-//! index, so the long-value page's position after an index root is deduced:
-//! the index root was observed directly after the map page, so the long-value
-//! page can only follow it.
+//! `EXP-0093` observed each first create append a definition root, a page of
+//! usage-map rows, a long-value page for the catalog row's `LvProp`, then one
+//! empty index root per physical index in append order. The map page carries
+//! the table's owned and available maps at rows 0 and 1, then one row per
+//! index at `2 + physical_ordinal` mapping only that index's root. Logical
+//! index records appear in name order while referring back to the physical
+//! ordinals.
 //!
-//! The map page carries the table's owned and available maps at rows 0 and 1
-//! (`EXP-0073`), then either the index's map row at row 2 holding the index
-//! root (`EXP-0073`, from `MSysACEs` and the `Alpha` index transition) or one
-//! owned/available pair at rows 2 and 3 for a single Memo or LongBinary
-//! column (`EXP-0077`). No observed create carried both an index and a
+//! `EXP-0105` observed a definition longer than its root page continuing on
+//! one or two further definition pages, chained through the next-page
+//! reference at `[4,8)`. The root holds 2,048 logical bytes and each
+//! continuation 2,040 after a repeated prefix and its own next-page
+//! reference. Only the pointer order is observed; the continuation pages are
+//! placed directly after the long-value page and marked globally in use.
+//!
+//! `EXP-0091` accepted a first create whose catalog `LvProp` is null while
+//! the long-value page stays present and mapped. That bounded result is the
+//! basis for every composed create here; no `LvProp` payload is written.
+//!
+//! One Memo or LongBinary column takes one owned/available map-row pair at
+//! rows 2 and 3 (`EXP-0077`). No observed create carried both an index and a
 //! long-value column, or more than one long-value column, so those layouts
 //! are refused rather than invented.
-//!
-//! `EXP-0087` pinned the `LvProp` payload framing but no grammar, so the
-//! caller supplies the payload and this module checks only the framing. Only
-//! the `Alpha(Id Long)` payload `EXP-0079` recorded is established.
-//!
-//! Column types, column counts, and index field counts beyond the four
-//! observed creates rely on the encoders' established record formats rather
-//! than on an observed create.
 
 use super::*;
-use crate::long_value_writer::{external_long_value_header, validate_single_page_row};
 use crate::table_schema_plan::{
-    PlannedIndexKind, TableSchemaPlan, TableSchemaSpec, plan_table_schema,
+    AVAILABLE_MAP_ROW, CONTINUATION_CAPACITY, CONTINUATION_PAYLOAD_OFFSET,
+    DEFINITION_ROOT_CAPACITY, FIRST_INDEX_MAP_ROW, MAX_OBSERVED_CONTINUATIONS, OWNED_MAP_ROW,
+    TableSchemaPlan, TableSchemaSpec, logical_index_order, plan_table_schema,
 };
-use crate::{ExternalLongValueStorage, LogicalIndexSpec, RowLocator};
 
-/// `EXP-0073`: row of the map page holding the table's owned-page map.
-const OWNED_MAP_ROW: u8 = 0;
-/// `EXP-0073`: row of the map page holding the table's available-page map.
-const AVAILABLE_MAP_ROW: u8 = 1;
-/// First map-page row after the table's own two maps.
-const FIRST_FREE_MAP_ROW: u8 = 2;
-/// `EXP-0087`: `MSysObjects` `Flags` of a created user table.
+/// `EXP-0093`: `MSysObjects` `Flags` of a created user table.
 const USER_FLAGS: i32 = 0;
 /// Long-value column count `EXP-0087` observed on a created table.
 const MAX_OBSERVED_LONG_VALUE_COLUMNS: usize = 1;
-/// `EXP-0087`: every `LvProp` payload began with these bytes.
-const PROPERTY_MAGIC: [u8; 4] = *b"KKD\x00";
-/// `EXP-0087`: a four-byte inclusive length then a two-byte kind per chunk.
-const PROPERTY_CHUNK_HEADER_LEN: usize = 6;
-/// `EXP-0087`: the kind of the one leading chunk of every payload.
-const PROPERTY_NAMES_CHUNK_KIND: u16 = 0x0080;
-
-/// One user table to create in the empty database.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TableCreate<'a> {
-    /// The table's name, columns, and indexes.
-    pub(crate) spec: &'a TableSchemaSpec<'a>,
-    /// The catalog row's `LvProp` payload, whose grammar `EXP-0087` leaves
-    /// unestablished beyond the framing this module checks.
-    pub(crate) properties: &'a [u8],
-}
+/// Longest logical definition the planner admits.
+const MAX_DEFINITION_LEN: usize =
+    DEFINITION_ROOT_CAPACITY + MAX_OBSERVED_CONTINUATIONS * CONTINUATION_CAPACITY;
+/// `EXP-0059`: the next-definition-page reference sits at `[4,8)`.
+const NEXT_PAGE_OFFSET: usize = 4;
+/// `EXP-0059`: the four-byte prefix every definition page repeats.
+const PREFIX_LEN: usize = 4;
 
 /// A create with its pages assigned and its map-page rows laid out.
 #[derive(Debug, Clone)]
 pub(super) struct PlannedCreate<'a> {
-    create: TableCreate<'a>,
+    spec: &'a TableSchemaSpec<'a>,
     plan: TableSchemaPlan,
-    /// The indexed column's root and the map-page row of its usage map.
-    index: Option<(PageNumber, u8)>,
-    /// The long-value column's ordinal and the map-page row of its owned
-    /// map; its available map is the next row.
-    long_value: Option<(u16, u8)>,
-    long_value_page: u64,
+    /// The long-value column's ordinal; its owned map takes the first free
+    /// map-page row and its available map the next.
+    long_value: Option<u16>,
 }
 
 impl<'a> PlannedCreate<'a> {
-    /// Plans `create` as the first create in the empty database.
-    pub(super) fn new(create: TableCreate<'a>) -> Result<Self, BootstrapComposeError> {
-        let plan = plan_table_schema(create.spec, EMPTY_DATABASE_PAGE_COUNT)?;
-        validate_single_page_row(create.properties)?;
-        validate_property_framing(create.properties, create.spec.columns.len())?;
-        let mut long_value_columns = long_value_columns(create.spec);
-        let long_value_column = long_value_columns.next();
+    /// Plans `spec` as the first create in the empty database.
+    pub(super) fn new(spec: &'a TableSchemaSpec<'a>) -> Result<Self, BootstrapComposeError> {
+        let plan = plan_table_schema(spec, EMPTY_DATABASE_PAGE_COUNT)?;
+        let mut long_value_columns = long_value_columns(spec);
+        let long_value = long_value_columns.next();
         if long_value_columns.next().is_some() {
             return Err(BootstrapComposeError::UnobservedLongValueColumnCount {
                 observed: MAX_OBSERVED_LONG_VALUE_COLUMNS,
             });
         }
-        let index = plan.index_root().map(|root| (root, FIRST_FREE_MAP_ROW));
-        let long_value = match (index, long_value_column) {
-            (Some(_), Some(_)) => return Err(BootstrapComposeError::UnobservedMapRowLayout),
-            (None, Some(column)) => Some((column, FIRST_FREE_MAP_ROW)),
-            (_, None) => None,
-        };
-        let long_value_page = plan.definition_root().get() + plan.appended_page_count();
+        if long_value.is_some() && !spec.indexes.is_empty() {
+            return Err(BootstrapComposeError::UnobservedMapRowLayout);
+        }
         Ok(Self {
-            create,
+            spec,
             plan,
-            index,
             long_value,
-            long_value_page,
         })
     }
 
@@ -105,13 +80,14 @@ impl<'a> PlannedCreate<'a> {
         self.plan.object_id()
     }
 
-    pub(super) const fn long_value_page(&self) -> u64 {
-        self.long_value_page
+    /// Returns the page holding the catalog row's `LvProp` long value.
+    pub(super) const fn property_page(&self) -> u64 {
+        self.plan.property_page().get()
     }
 
     /// Returns the page count once every appended page is in place.
     pub(super) const fn page_count(&self) -> u64 {
-        self.long_value_page + 1
+        self.plan.definition_root().get() + self.plan.appended_page_count()
     }
 
     /// Returns the catalog row the create adds (`EXP-0087`).
@@ -119,7 +95,7 @@ impl<'a> PlannedCreate<'a> {
         CatalogSeed {
             id: self.plan.object_id(),
             parent: TABLES_ID,
-            name: self.create.spec.name,
+            name: self.spec.name,
             kind: 1,
             owner: CATALOG_OWNER_0301,
             flags: USER_FLAGS,
@@ -135,47 +111,43 @@ impl<'a> PlannedCreate<'a> {
         ]
     }
 
-    /// Returns the catalog row's `LvProp` reference to the long-value page.
-    pub(super) fn long_value_header(&self) -> Result<[u8; 12], BootstrapComposeError> {
-        Ok(external_long_value_header(
-            self.create.properties.len(),
-            ExternalLongValueStorage::SinglePage,
-            RowLocator::new(PageNumber::new(self.long_value_page), 0),
-        )?)
-    }
-
-    /// Appends the create's pages: definition root, map page, index root when
-    /// indexed, then the long-value page.
+    /// Appends the create's pages in `EXP-0093` order: definition root, map
+    /// page, long-value page, then the index roots; or, per `EXP-0105`, the
+    /// definition continuation pages in ascending physical order.
     pub(super) fn append_pages(
         &self,
         plan: &mut WholeFileImagePlan,
-        lvprop: super::CreatedLvProp,
         budget: &mut ResourceBudget,
     ) -> Result<(), BootstrapComposeError> {
         let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
-        plan.append(self.definition_page(budget)?, &mut append_map, budget)?;
+        let (root, mut continuations) = self.definition_pages(budget)?;
+        plan.append(root, &mut append_map, budget)?;
         plan.append(self.map_page(budget)?, &mut append_map, budget)?;
-        if self.index.is_some() {
-            let owner = self.plan.definition_root().get();
+        let lval = DataPageBuilder::new_long_value(budget)?;
+        plan.append(finish_data_builder(lval, budget)?, &mut append_map, budget)?;
+        let owner = self.plan.definition_root().get();
+        for _ in self.plan.index_placements() {
             plan.append(empty_index_page(owner, budget)?, &mut append_map, budget)?;
         }
-        plan.append(
-            self.long_value_page_image(lvprop, budget)?,
-            &mut append_map,
-            budget,
-        )?;
+        continuations.sort_by_key(|(page, _)| *page);
+        for (_, image) in continuations {
+            plan.append(image, &mut append_map, budget)?;
+        }
         Ok(())
     }
 
-    fn definition_page(
+    /// Encodes the definition and splits it into its root page and its
+    /// continuation pages, each paired with its planned page number.
+    fn definition_pages(
         &self,
         budget: &mut ResourceBudget,
-    ) -> Result<PageImage, BootstrapComposeError> {
+    ) -> Result<(PageImage, Vec<(PageNumber, PageImage)>), BootstrapComposeError> {
         let map = self.plan.map_page();
-        let spec = self.create.spec;
+        let spec = self.spec;
+        // The planner validated one placement per index, so the zip is exact.
         let physical = self
-            .index
-            .into_iter()
+            .plan
+            .index_placements()
             .zip(spec.indexes)
             .map(|((root, row), index)| PhysicalIndexSpec {
                 fields: index.fields,
@@ -186,11 +158,10 @@ impl<'a> PlannedCreate<'a> {
                 entry_count: 0,
             })
             .collect::<Vec<_>>();
-        let logical = spec
-            .indexes
-            .iter()
-            .enumerate()
-            .map(|(ordinal, index)| {
+        let logical = logical_index_order(spec.indexes)
+            .into_iter()
+            .map(|ordinal| {
+                let index = &spec.indexes[ordinal];
                 Ok(LogicalIndexSpec {
                     name: index.name,
                     physical_index: u16::try_from(ordinal).map_err(|_| {
@@ -199,23 +170,21 @@ impl<'a> PlannedCreate<'a> {
                             target: "u16",
                         }
                     })?,
-                    kind: match index.kind {
-                        PlannedIndexKind::Primary => LogicalIndexKindSpec::Primary,
-                        PlannedIndexKind::Ordinary => LogicalIndexKindSpec::Ordinary,
-                    },
+                    kind: index.kind.logical_kind(),
                 })
             })
             .collect::<Result<Vec<_>, BootstrapComposeError>>()?;
         let long_value_maps = self
             .long_value
-            .map(|(column, owned)| LongValueMapSpec {
+            .map(|column| LongValueMapSpec {
                 column,
-                owned: MapRowLocator::new(map, owned),
-                available: MapRowLocator::new(map, owned + 1),
+                owned: MapRowLocator::new(map, FIRST_INDEX_MAP_ROW),
+                available: MapRowLocator::new(map, FIRST_INDEX_MAP_ROW + 1),
             })
             .into_iter()
             .collect::<Vec<_>>();
-        definition_page(
+        let mut logical_bytes = [0_u8; MAX_DEFINITION_LEN];
+        let length = encode_table_definition(
             &TableDefinitionSpec {
                 kind: TableDefinitionKind::User,
                 columns: spec.columns,
@@ -227,38 +196,76 @@ impl<'a> PlannedCreate<'a> {
                 row_count: 0,
                 long_value_maps: &long_value_maps,
             },
+            &mut logical_bytes,
             budget,
-        )
+        )?
+        .get() as usize;
+        if length != self.plan.definition_len() {
+            return Err(BootstrapComposeError::DefinitionLengthMismatch {
+                planned: self.plan.definition_len(),
+                encoded: length,
+            });
+        }
+        split_definition(&logical_bytes[..length], self.plan.continuation_chain())
     }
 
-    /// Builds the map page with the rows `definition_page` names.
+    /// Builds the map page with the rows the definition names.
     fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
         let empty = inline_map_row(&[], budget)?;
         let mut rows: Vec<[u8; 133]> = vec![empty, empty];
-        if let Some((root, row)) = self.index {
-            debug_assert_eq!(usize::from(row), rows.len());
+        for (root, _) in self.plan.index_placements() {
             rows.push(inline_map_row(&[root.get()], budget)?);
         }
-        if let Some((_, owned)) = self.long_value {
-            debug_assert_eq!(usize::from(owned), rows.len());
+        if self.long_value.is_some() {
             rows.push(empty);
             rows.push(empty);
         }
         let rows = rows.iter().map(<[u8; 133]>::as_slice).collect::<Vec<_>>();
         data_page(HEADER_PAGE, &rows, budget)
     }
+}
 
-    fn long_value_page_image(
-        &self,
-        lvprop: super::CreatedLvProp,
-        budget: &mut ResourceBudget,
-    ) -> Result<PageImage, BootstrapComposeError> {
-        let mut builder = DataPageBuilder::new_long_value(budget)?;
-        if lvprop == super::CreatedLvProp::External {
-            builder.append_row(self.create.properties, budget)?;
-        }
-        finish_data_builder(builder, budget)
+/// Splits the logical definition across its root page and the continuation
+/// pages `chain` names in pointer order, filling each next-page reference.
+fn split_definition(
+    logical: &[u8],
+    chain: impl Iterator<Item = PageNumber>,
+) -> Result<(PageImage, Vec<(PageNumber, PageImage)>), BootstrapComposeError> {
+    let chain = chain.collect::<Vec<_>>();
+    let root_len = logical.len().min(DEFINITION_ROOT_CAPACITY);
+    let mut root = [0_u8; PAGE_BYTES];
+    root[..root_len].copy_from_slice(&logical[..root_len]);
+    write_next_page(&mut root, chain.first().copied())?;
+    let mut continuations = Vec::with_capacity(chain.len());
+    let mut rest = &logical[root_len..];
+    for (position, page) in chain.iter().enumerate() {
+        let taken = rest.len().min(CONTINUATION_CAPACITY);
+        let mut image = [0_u8; PAGE_BYTES];
+        image[..PREFIX_LEN].copy_from_slice(&logical[..PREFIX_LEN]);
+        write_next_page(&mut image, chain.get(position + 1).copied())?;
+        image[CONTINUATION_PAYLOAD_OFFSET..CONTINUATION_PAYLOAD_OFFSET + taken]
+            .copy_from_slice(&rest[..taken]);
+        rest = &rest[taken..];
+        continuations.push((*page, PageImage::from_bytes(image)));
     }
+    if !rest.is_empty() {
+        return Err(BootstrapComposeError::DefinitionLengthMismatch {
+            planned: logical.len() - rest.len(),
+            encoded: logical.len(),
+        });
+    }
+    Ok((PageImage::from_bytes(root), continuations))
+}
+
+fn write_next_page(page: &mut [u8; PAGE_BYTES], next: Option<PageNumber>) -> Result<(), Error> {
+    let next = next.map_or(Ok(0), |page| {
+        u32::try_from(page.get()).map_err(|_| Error::IntegerConversion {
+            value: u128::from(page.get()),
+            target: "u32",
+        })
+    })?;
+    page[NEXT_PAGE_OFFSET..NEXT_PAGE_OFFSET + 4].copy_from_slice(&next.to_le_bytes());
+    Ok(())
 }
 
 /// Returns the ordinals of the columns that own long-value map groups.
@@ -273,69 +280,6 @@ fn long_value_columns<'s>(spec: &'s TableSchemaSpec<'_>) -> impl Iterator<Item =
             )
         })
         .filter_map(|(ordinal, _)| u16::try_from(ordinal).ok())
-}
-
-/// Checks `payload` against the `EXP-0087` framing: the magic, exact
-/// coverage by length-prefixed chunks, one leading names chunk exactly
-/// covered by length-prefixed name entries, then one chunk per column. The
-/// column chunk bodies stay uninterpreted.
-fn validate_property_framing(
-    payload: &[u8],
-    column_count: usize,
-) -> Result<(), BootstrapComposeError> {
-    let malformed = |offset: usize| BootstrapComposeError::PropertyFraming { offset };
-    let Some(mut rest) = payload.strip_prefix(&PROPERTY_MAGIC) else {
-        return Err(malformed(0));
-    };
-    let mut offset = PROPERTY_MAGIC.len();
-    let mut chunks = 0_usize;
-    while !rest.is_empty() {
-        let (header, _) = rest
-            .split_at_checked(PROPERTY_CHUNK_HEADER_LEN)
-            .ok_or(malformed(offset))?;
-        let length = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
-        let kind = u16::from_le_bytes([header[4], header[5]]);
-        let length = usize::try_from(length)
-            .ok()
-            .filter(|length| *length >= PROPERTY_CHUNK_HEADER_LEN && *length <= rest.len())
-            .ok_or(malformed(offset))?;
-        if chunks == 0 {
-            if kind != PROPERTY_NAMES_CHUNK_KIND {
-                return Err(malformed(offset));
-            }
-            validate_name_entries(&rest[PROPERTY_CHUNK_HEADER_LEN..length], offset)?;
-        }
-        rest = &rest[length..];
-        offset += length;
-        chunks += 1;
-    }
-    if chunks != column_count + 1 {
-        return Err(BootstrapComposeError::PropertyChunkCount {
-            chunks,
-            expected: column_count + 1,
-        });
-    }
-    Ok(())
-}
-
-/// Checks that the names chunk body is exactly covered by two-byte
-/// length-prefixed entries (`EXP-0087`). `chunk_offset` is the chunk's
-/// position in the payload, for error reporting.
-fn validate_name_entries(
-    mut body: &[u8],
-    chunk_offset: usize,
-) -> Result<(), BootstrapComposeError> {
-    let mut offset = chunk_offset + PROPERTY_CHUNK_HEADER_LEN;
-    while !body.is_empty() {
-        let entry_len = body
-            .split_at_checked(2)
-            .map(|(prefix, _)| usize::from(u16::from_le_bytes([prefix[0], prefix[1]])))
-            .filter(|entry_len| entry_len + 2 <= body.len())
-            .ok_or(BootstrapComposeError::PropertyFraming { offset })?;
-        body = &body[2 + entry_len..];
-        offset += 2 + entry_len;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -10,16 +10,17 @@
 //! index records appear in name order while referring back to the physical
 //! ordinals.
 //!
-//! `EXP-0105` observed a definition longer than its root page continuing on
-//! one or two further definition pages, chained through the next-page
-//! reference at `[4,8)`. The root holds 2,048 logical bytes and each
-//! continuation 2,040 after a repeated prefix and its own next-page
-//! reference. Only the pointer order is observed; the continuation pages are
-//! placed directly after the long-value page and marked globally in use.
+//! The planner refuses definitions that need a continuation page, because
+//! `EXP-0105` established their capacities but not their placement.
 //!
-//! `EXP-0091` accepted a first create whose catalog `LvProp` is null while
-//! the long-value page stays present and mapped. That bounded result is the
-//! basis for every composed create here; no `LvProp` payload is written.
+//! `EXP-0091` accepted the exact `Alpha(Id Long)` first create with a null
+//! catalog `LvProp` and a retained, mapped, empty long-value page. Every
+//! create composed here takes that null form, and no `LvProp` payload is
+//! written, because no experiment established a payload grammar a caller
+//! could satisfy. For any schema other than `Alpha` this is an unvalidated
+//! candidate construction: `EXP-0093`'s indexed creates carried a provider
+//! written payload, and `EXP-0091` explicitly does not extend null
+//! acceptance to arbitrary schemas. Only a DAO differential can.
 //!
 //! One Memo or LongBinary column takes one owned/available map-row pair at
 //! rows 2 and 3 (`EXP-0077`). No observed create carried both an index and a
@@ -28,22 +29,14 @@
 
 use super::*;
 use crate::table_schema_plan::{
-    AVAILABLE_MAP_ROW, CONTINUATION_CAPACITY, CONTINUATION_PAYLOAD_OFFSET,
-    DEFINITION_ROOT_CAPACITY, FIRST_INDEX_MAP_ROW, MAX_OBSERVED_CONTINUATIONS, OWNED_MAP_ROW,
-    TableSchemaPlan, TableSchemaSpec, logical_index_order, plan_table_schema,
+    AVAILABLE_MAP_ROW, FIRST_INDEX_MAP_ROW, OWNED_MAP_ROW, TableSchemaPlan, TableSchemaSpec,
+    logical_index_order, plan_table_schema,
 };
 
 /// `EXP-0093`: `MSysObjects` `Flags` of a created user table.
 const USER_FLAGS: i32 = 0;
 /// Long-value column count `EXP-0087` observed on a created table.
 const MAX_OBSERVED_LONG_VALUE_COLUMNS: usize = 1;
-/// Longest logical definition the planner admits.
-const MAX_DEFINITION_LEN: usize =
-    DEFINITION_ROOT_CAPACITY + MAX_OBSERVED_CONTINUATIONS * CONTINUATION_CAPACITY;
-/// `EXP-0059`: the next-definition-page reference sits at `[4,8)`.
-const NEXT_PAGE_OFFSET: usize = 4;
-/// `EXP-0059`: the four-byte prefix every definition page repeats.
-const PREFIX_LEN: usize = 4;
 
 /// A create with its pages assigned and its map-page rows laid out.
 #[derive(Debug, Clone)]
@@ -112,16 +105,14 @@ impl<'a> PlannedCreate<'a> {
     }
 
     /// Appends the create's pages in `EXP-0093` order: definition root, map
-    /// page, long-value page, then the index roots; or, per `EXP-0105`, the
-    /// definition continuation pages in ascending physical order.
+    /// page, long-value page, then the index roots.
     pub(super) fn append_pages(
         &self,
         plan: &mut WholeFileImagePlan,
         budget: &mut ResourceBudget,
     ) -> Result<(), BootstrapComposeError> {
         let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
-        let (root, mut continuations) = self.definition_pages(budget)?;
-        plan.append(root, &mut append_map, budget)?;
+        plan.append(self.definition_page(budget)?, &mut append_map, budget)?;
         plan.append(self.map_page(budget)?, &mut append_map, budget)?;
         let lval = DataPageBuilder::new_long_value(budget)?;
         plan.append(finish_data_builder(lval, budget)?, &mut append_map, budget)?;
@@ -129,19 +120,13 @@ impl<'a> PlannedCreate<'a> {
         for _ in self.plan.index_placements() {
             plan.append(empty_index_page(owner, budget)?, &mut append_map, budget)?;
         }
-        continuations.sort_by_key(|(page, _)| *page);
-        for (_, image) in continuations {
-            plan.append(image, &mut append_map, budget)?;
-        }
         Ok(())
     }
 
-    /// Encodes the definition and splits it into its root page and its
-    /// continuation pages, each paired with its planned page number.
-    fn definition_pages(
+    fn definition_page(
         &self,
         budget: &mut ResourceBudget,
-    ) -> Result<(PageImage, Vec<(PageNumber, PageImage)>), BootstrapComposeError> {
+    ) -> Result<PageImage, BootstrapComposeError> {
         let map = self.plan.map_page();
         let spec = self.spec;
         // The planner validated one placement per index, so the zip is exact.
@@ -183,8 +168,7 @@ impl<'a> PlannedCreate<'a> {
             })
             .into_iter()
             .collect::<Vec<_>>();
-        let mut logical_bytes = [0_u8; MAX_DEFINITION_LEN];
-        let length = encode_table_definition(
+        definition_page(
             &TableDefinitionSpec {
                 kind: TableDefinitionKind::User,
                 columns: spec.columns,
@@ -196,17 +180,8 @@ impl<'a> PlannedCreate<'a> {
                 row_count: 0,
                 long_value_maps: &long_value_maps,
             },
-            &mut logical_bytes,
             budget,
-        )?
-        .get() as usize;
-        if length != self.plan.definition_len() {
-            return Err(BootstrapComposeError::DefinitionLengthMismatch {
-                planned: self.plan.definition_len(),
-                encoded: length,
-            });
-        }
-        split_definition(&logical_bytes[..length], self.plan.continuation_chain())
+        )
     }
 
     /// Builds the map page with the rows the definition names.
@@ -223,49 +198,6 @@ impl<'a> PlannedCreate<'a> {
         let rows = rows.iter().map(<[u8; 133]>::as_slice).collect::<Vec<_>>();
         data_page(HEADER_PAGE, &rows, budget)
     }
-}
-
-/// Splits the logical definition across its root page and the continuation
-/// pages `chain` names in pointer order, filling each next-page reference.
-fn split_definition(
-    logical: &[u8],
-    chain: impl Iterator<Item = PageNumber>,
-) -> Result<(PageImage, Vec<(PageNumber, PageImage)>), BootstrapComposeError> {
-    let chain = chain.collect::<Vec<_>>();
-    let root_len = logical.len().min(DEFINITION_ROOT_CAPACITY);
-    let mut root = [0_u8; PAGE_BYTES];
-    root[..root_len].copy_from_slice(&logical[..root_len]);
-    write_next_page(&mut root, chain.first().copied())?;
-    let mut continuations = Vec::with_capacity(chain.len());
-    let mut rest = &logical[root_len..];
-    for (position, page) in chain.iter().enumerate() {
-        let taken = rest.len().min(CONTINUATION_CAPACITY);
-        let mut image = [0_u8; PAGE_BYTES];
-        image[..PREFIX_LEN].copy_from_slice(&logical[..PREFIX_LEN]);
-        write_next_page(&mut image, chain.get(position + 1).copied())?;
-        image[CONTINUATION_PAYLOAD_OFFSET..CONTINUATION_PAYLOAD_OFFSET + taken]
-            .copy_from_slice(&rest[..taken]);
-        rest = &rest[taken..];
-        continuations.push((*page, PageImage::from_bytes(image)));
-    }
-    if !rest.is_empty() {
-        return Err(BootstrapComposeError::DefinitionLengthMismatch {
-            planned: logical.len() - rest.len(),
-            encoded: logical.len(),
-        });
-    }
-    Ok((PageImage::from_bytes(root), continuations))
-}
-
-fn write_next_page(page: &mut [u8; PAGE_BYTES], next: Option<PageNumber>) -> Result<(), Error> {
-    let next = next.map_or(Ok(0), |page| {
-        u32::try_from(page.get()).map_err(|_| Error::IntegerConversion {
-            value: u128::from(page.get()),
-            target: "u32",
-        })
-    })?;
-    page[NEXT_PAGE_OFFSET..NEXT_PAGE_OFFSET + 4].copy_from_slice(&next.to_le_bytes());
-    Ok(())
 }
 
 /// Returns the ordinals of the columns that own long-value map groups.

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -1,10 +1,11 @@
 //! Composition of arbitrary planned user tables, decoded back through the
-//! reader to check each `EXP-0093` and `EXP-0105` structure lands where the
-//! plan says.
+//! reader to check each `EXP-0093` structure lands where the plan says.
 
 use super::super::tests::{compose_budget, inline_map_bit, read_budget};
 use super::super::{BootstrapComposeError, compose_table_database};
-use crate::table_schema_plan::{PlannedIndex, PlannedIndexKind, TableSchemaSpec};
+use crate::table_schema_plan::{
+    PlannedIndex, PlannedIndexKind, TableSchemaPlanError, TableSchemaSpec,
+};
 use crate::{
     ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
     IndexDirection, IndexFieldSpec, MapRowLocator, PAGE_BYTES, PageKind, PageNumber, SliceSource,
@@ -25,15 +26,6 @@ fn create_bytes(spec: &TableSchemaSpec<'_>) -> Result<Vec<u8>, BootstrapComposeE
 
 fn page(bytes: &[u8], number: usize) -> &[u8] {
     &bytes[number * PAGE_BYTES..(number + 1) * PAGE_BYTES]
-}
-
-fn u32_at(bytes: &[u8], offset: usize) -> u32 {
-    u32::from_le_bytes([
-        bytes[offset],
-        bytes[offset + 1],
-        bytes[offset + 2],
-        bytes[offset + 3],
-    ])
 }
 
 const ID: ColumnSpec<'static> =
@@ -68,7 +60,7 @@ const fn field(column: u16, direction: IndexDirection) -> IndexFieldSpec {
 }
 
 /// Fixed Long columns with ten-byte names: 70 of them encode to the 2,075-byte
-/// definition and 140 to the 4,105-byte definition `EXP-0105` observed.
+/// definition `EXP-0105` observed needing one continuation.
 fn wide_names(count: usize) -> Vec<Vec<u8>> {
     (0..count)
         .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
@@ -226,65 +218,29 @@ fn a_three_index_first_create_follows_the_observed_page_and_record_order() -> Te
 }
 
 #[test]
-fn a_definition_needing_one_continuation_chains_root_to_the_next_page() -> TestResult {
-    // EXP-0105's `one` shape: a 2,075-byte definition whose root holds 2,048
-    // bytes and whose one continuation holds the remaining 27.
+fn a_definition_needing_a_continuation_is_refused_before_any_page_is_built() {
+    // EXP-0105 established the 2,048/2,040 capacities but placed its
+    // continuations at pages 68 and 219/218 under an unestablished
+    // allocation, so no compact layout can claim to follow it.
     let names = wide_names(70);
     let columns = wide_columns(&names);
-    let bytes = create_bytes(&TableSchemaSpec {
-        name: b"Wide",
-        columns: &columns,
-        indexes: &[],
-    })?;
-    assert_eq!(bytes.len(), 24 * PAGE_BYTES);
-    assert_eq!(&page(&bytes, 22)[4..8], b"LVAL");
-    assert_eq!(u32_at(page(&bytes, 20), 4), 23);
-    assert_eq!(u32_at(page(&bytes, 20), 8), 2075);
-    assert_eq!(&page(&bytes, 23)[..4], &[0x02, 0x01, 0x56, 0x43]);
-    assert_eq!(u32_at(page(&bytes, 23), 4), 0);
-    assert!(!inline_map_bit(&bytes, 1, 0, 23)?);
-    assert!(inline_map_bit(&bytes, 1, 0, 24)?);
-
-    let mut budget = read_budget(bytes.len());
-    let source = SliceSource::new(&bytes, budget.read_budget())?;
-    let mut database = DatabaseReader::from_source(source, &mut budget)?;
-    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
-    assert_eq!(definition.logical_length(), 2075);
-    assert_eq!(definition.columns().len(), 70);
-    assert_eq!(definition.columns()[69].name().raw_bytes(), b"Field00069");
-    Ok(())
-}
-
-#[test]
-fn a_definition_needing_two_continuations_chains_the_later_page_first() -> TestResult {
-    // EXP-0105's `two` shape: a 4,105-byte definition whose chain visits the
-    // physically later continuation before the earlier one.
-    let names = wide_names(140);
-    let columns = wide_columns(&names);
-    let bytes = create_bytes(&TableSchemaSpec {
-        name: b"Wider",
-        columns: &columns,
-        indexes: &[],
-    })?;
-    assert_eq!(bytes.len(), 25 * PAGE_BYTES);
-    assert_eq!(u32_at(page(&bytes, 20), 4), 24);
-    assert_eq!(u32_at(page(&bytes, 20), 8), 4105);
-    assert_eq!(u32_at(page(&bytes, 24), 4), 23);
-    assert_eq!(u32_at(page(&bytes, 23), 4), 0);
-    for continuation in [23_usize, 24] {
-        assert_eq!(&page(&bytes, continuation)[..4], &[0x02, 0x01, 0x56, 0x43]);
-        assert!(!inline_map_bit(&bytes, 1, 0, continuation as u64)?);
-    }
-    assert!(inline_map_bit(&bytes, 1, 0, 25)?);
-
-    let mut budget = read_budget(bytes.len());
-    let source = SliceSource::new(&bytes, budget.read_budget())?;
-    let mut database = DatabaseReader::from_source(source, &mut budget)?;
-    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
-    assert_eq!(definition.logical_length(), 4105);
-    assert_eq!(definition.columns().len(), 140);
-    assert_eq!(definition.columns()[139].name().raw_bytes(), b"Field00139");
-    Ok(())
+    let mut budget = compose_budget();
+    assert!(matches!(
+        compose_table_database(
+            &TableSchemaSpec {
+                name: b"Wide",
+                columns: &columns,
+                indexes: &[],
+            },
+            &mut budget,
+        ),
+        Err(BootstrapComposeError::Schema(
+            TableSchemaPlanError::ContinuationPlacementUnestablished {
+                length: 2075,
+                continuations: 1,
+            }
+        ))
+    ));
 }
 
 #[test]

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -1,24 +1,39 @@
 //! Composition of arbitrary planned user tables, decoded back through the
-//! reader to check each `EXP-0087` structure lands where the plan says.
+//! reader to check each `EXP-0093` and `EXP-0105` structure lands where the
+//! plan says.
 
 use super::super::tests::{compose_budget, inline_map_bit, read_budget};
-use super::super::{BootstrapComposeError, TableCreate, compose_table_database};
+use super::super::{BootstrapComposeError, compose_table_database};
 use crate::table_schema_plan::{PlannedIndex, PlannedIndexKind, TableSchemaSpec};
 use crate::{
     ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
-    IndexDirection, IndexFieldSpec, MapRowLocator, PageKind, PageNumber, SliceSource, page_tag,
+    IndexDirection, IndexFieldSpec, MapRowLocator, PAGE_BYTES, PageKind, PageNumber, SliceSource,
+    page_tag,
 };
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-fn create_bytes(create: TableCreate<'_>) -> Result<Vec<u8>, BootstrapComposeError> {
+fn create_bytes(spec: &TableSchemaSpec<'_>) -> Result<Vec<u8>, BootstrapComposeError> {
     let mut budget = compose_budget();
-    let plan = compose_table_database(create, &mut budget)?;
-    let mut bytes = Vec::with_capacity(plan.pages().len() * crate::PAGE_BYTES);
+    let plan = compose_table_database(spec, &mut budget)?;
+    let mut bytes = Vec::with_capacity(plan.pages().len() * PAGE_BYTES);
     for page in plan.pages() {
         bytes.extend_from_slice(page.image().as_bytes());
     }
     Ok(bytes)
+}
+
+fn page(bytes: &[u8], number: usize) -> &[u8] {
+    &bytes[number * PAGE_BYTES..(number + 1) * PAGE_BYTES]
+}
+
+fn u32_at(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        bytes[offset],
+        bytes[offset + 1],
+        bytes[offset + 2],
+        bytes[offset + 3],
+    ])
 }
 
 const ID: ColumnSpec<'static> =
@@ -29,43 +44,57 @@ const NAME: ColumnSpec<'static> = ColumnSpec::new(
     ColumnStorageKind::Variable,
     50,
 );
+const CODE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Code",
+    ColumnPhysicalType::Text,
+    ColumnStorageKind::Variable,
+    8,
+);
+const SEQUENCE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Sequence",
+    ColumnPhysicalType::Long,
+    ColumnStorageKind::Fixed,
+    4,
+);
 const NOTE: ColumnSpec<'static> = ColumnSpec::new(
     b"Note",
     ColumnPhysicalType::Memo,
     ColumnStorageKind::Variable,
     0,
 );
-/// Builds a payload with the EXP-0087 framing and empty chunk bodies: the
-/// magic, one names chunk, then one chunk per column. Only Alpha's recorded
-/// payload is established; this exercises the framing check alone.
-fn framed_properties(columns: usize) -> Vec<u8> {
-    let mut payload = b"KKD\x00".to_vec();
-    payload.extend_from_slice(&[6, 0, 0, 0, 0x80, 0x00]);
-    for _ in 0..columns {
-        payload.extend_from_slice(&[6, 0, 0, 0, 0x01, 0x00]);
-    }
-    payload
+
+const fn field(column: u16, direction: IndexDirection) -> IndexFieldSpec {
+    IndexFieldSpec { column, direction }
+}
+
+/// Fixed Long columns with ten-byte names: 70 of them encode to the 2,075-byte
+/// definition and 140 to the 4,105-byte definition `EXP-0105` observed.
+fn wide_names(count: usize) -> Vec<Vec<u8>> {
+    (0..count)
+        .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
+        .collect()
+}
+
+fn wide_columns(names: &[Vec<u8>]) -> Vec<ColumnSpec<'_>> {
+    names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .collect()
 }
 
 #[test]
 fn a_created_memo_table_carries_its_long_value_map_groups_on_its_map_page() -> TestResult {
-    // EXP-0087's Beta shape: two appended pages plus the first-create
-    // long-value page, and one EXP-0077 map group for the Memo column.
+    // EXP-0087's Beta shape as a first create: root, map page, empty LvProp
+    // page, and one EXP-0077 map group for the Memo column.
     let columns = [ID, NAME, NOTE];
-    let bytes = create_bytes(TableCreate {
-        spec: &TableSchemaSpec {
-            name: b"Beta",
-            columns: &columns,
-            indexes: &[],
-        },
-        properties: &framed_properties(3),
+    let bytes = create_bytes(&TableSchemaSpec {
+        name: b"Beta",
+        columns: &columns,
+        indexes: &[],
     })?;
-    assert_eq!(bytes.len(), 23 * crate::PAGE_BYTES);
+    assert_eq!(bytes.len(), 23 * PAGE_BYTES);
     assert_eq!(bytes[1538], 2);
-    assert_eq!(
-        &bytes[22 * crate::PAGE_BYTES + 4..22 * crate::PAGE_BYTES + 8],
-        b"LVAL"
-    );
+    assert_eq!(&page(&bytes, 22)[4..8], b"LVAL");
     assert!(inline_map_bit(&bytes, 6, 10, 22)?);
 
     let mut budget = read_budget(bytes.len());
@@ -95,88 +124,185 @@ fn a_created_memo_table_carries_its_long_value_map_groups_on_its_map_page() -> T
     );
     // The map page holds the table's two maps and the group's two.
     assert_eq!(
-        u16::from_le_bytes([
-            bytes[21 * crate::PAGE_BYTES + 8],
-            bytes[21 * crate::PAGE_BYTES + 9]
-        ]),
+        u16::from_le_bytes([page(&bytes, 21)[8], page(&bytes, 21)[9]]),
         4
     );
     Ok(())
 }
 
 #[test]
-fn an_indexed_first_create_places_its_index_root_before_the_long_value_page() -> TestResult {
-    // EXP-0087's Gamma shape as a first create, which no run observed: the
-    // index root was observed directly after the map page, so the
-    // first-create long-value page can only follow it.
-    let columns = [ID];
-    let indexes = [PlannedIndex {
-        name: b"PrimaryKey",
-        fields: &[IndexFieldSpec {
-            column: 0,
-            direction: IndexDirection::Ascending,
-        }],
-        kind: PlannedIndexKind::Primary,
-    }];
-    let bytes = create_bytes(TableCreate {
-        spec: &TableSchemaSpec {
-            name: b"Gamma",
-            columns: &columns,
-            indexes: &indexes,
+fn a_three_index_first_create_follows_the_observed_page_and_record_order() -> TestResult {
+    // EXP-0093's `three` arm shape: primary, unique, and ordinary indexes
+    // appended in that order, the last one composite with a descending field.
+    let columns = [ID, CODE, SEQUENCE];
+    let indexes = [
+        PlannedIndex {
+            name: b"ZPrimary",
+            fields: &[field(0, IndexDirection::Ascending)],
+            kind: PlannedIndexKind::Primary,
         },
-        properties: &framed_properties(1),
+        PlannedIndex {
+            name: b"MUniqueX",
+            fields: &[field(1, IndexDirection::Ascending)],
+            kind: PlannedIndexKind::Unique,
+        },
+        PlannedIndex {
+            name: b"ASecondx",
+            fields: &[
+                field(1, IndexDirection::Descending),
+                field(2, IndexDirection::Ascending),
+            ],
+            kind: PlannedIndexKind::Ordinary,
+        },
+    ];
+    let bytes = create_bytes(&TableSchemaSpec {
+        name: b"Three",
+        columns: &columns,
+        indexes: &indexes,
     })?;
-    assert_eq!(bytes.len(), 24 * crate::PAGE_BYTES);
-    assert_eq!(bytes[22 * crate::PAGE_BYTES], page_tag(PageKind::LeafIndex));
+    assert_eq!(bytes.len(), 26 * PAGE_BYTES);
+    assert_eq!(page(&bytes, 20)[0], page_tag(PageKind::TableDefinition));
+    assert_eq!(page(&bytes, 21)[0], page_tag(PageKind::Data));
+    assert_eq!(&page(&bytes, 22)[4..8], b"LVAL");
+    for root in 23..26 {
+        assert_eq!(page(&bytes, root)[0], page_tag(PageKind::LeafIndex));
+        assert!(!inline_map_bit(&bytes, 1, 0, root as u64)?);
+    }
+    assert!(inline_map_bit(&bytes, 1, 0, 26)?);
+    assert!(inline_map_bit(&bytes, 6, 10, 22)?);
+    // Map rows 2 through 4 each map exactly their own root.
     assert_eq!(
-        &bytes[23 * crate::PAGE_BYTES + 4..23 * crate::PAGE_BYTES + 8],
-        b"LVAL"
+        u16::from_le_bytes([page(&bytes, 21)[8], page(&bytes, 21)[9]]),
+        5
     );
-    assert!(!inline_map_bit(&bytes, 1, 0, 23)?);
-    assert!(inline_map_bit(&bytes, 1, 0, 24)?);
-    assert!(inline_map_bit(&bytes, 6, 10, 23)?);
+    for (row, root) in [(2, 23), (3, 24), (4, 25)] {
+        for candidate in 23..26 {
+            assert_eq!(
+                inline_map_bit(&bytes, 21, row, candidate)?,
+                candidate == root
+            );
+        }
+    }
 
     let mut budget = read_budget(bytes.len());
     let source = SliceSource::new(&bytes, budget.read_budget())?;
     let mut database = DatabaseReader::from_source(source, &mut budget)?;
     let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
-    let [physical] = definition.physical_indexes() else {
-        return Err("expected exactly one physical index".into());
-    };
-    assert_eq!(physical.root(), PageNumber::new(22));
-    assert_eq!(physical.usage_map().page(), PageNumber::new(21));
-    assert_eq!(physical.usage_map().row(), 2);
-    assert!(physical.unique());
-    assert!(physical.required());
-    assert_eq!(definition.indexes()[0].name().raw_bytes(), b"PrimaryKey");
-    assert!(definition.long_value_maps().is_empty());
-    let root = database.index_tree(&definition, 0, &mut budget)?;
-    assert!(root.entries().is_empty());
+    let physical = definition.physical_indexes();
+    assert_eq!(physical.len(), 3);
+    for (ordinal, (root, flags)) in [(23, 0x09), (24, 0x01), (25, 0x00)].into_iter().enumerate() {
+        assert_eq!(physical[ordinal].root(), PageNumber::new(root));
+        assert_eq!(physical[ordinal].usage_map().page(), PageNumber::new(21));
+        assert_eq!(physical[ordinal].usage_map().row(), 2 + ordinal as u8);
+        assert_eq!(physical[ordinal].raw_flags(), flags);
+        assert!(
+            database
+                .index_tree(&definition, ordinal as u16, &mut budget)?
+                .entries()
+                .is_empty()
+        );
+    }
+    let composite = physical[2].fields();
+    assert_eq!(composite.len(), 2);
+    assert_eq!(composite[0].column(), ColumnOrdinal::new(1));
+    assert_eq!(composite[0].direction(), IndexDirection::Descending);
+    assert_eq!(composite[1].column(), ColumnOrdinal::new(2));
+    assert_eq!(composite[1].direction(), IndexDirection::Ascending);
+    // Logical records in name order, referring back to physical ordinals.
+    let logical = definition
+        .indexes()
+        .iter()
+        .map(|index| (index.name().raw_bytes(), index.physical_index()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        logical,
+        [
+            (b"ASecondx".as_slice(), 2),
+            (b"MUniqueX".as_slice(), 1),
+            (b"ZPrimary".as_slice(), 0),
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn a_definition_needing_one_continuation_chains_root_to_the_next_page() -> TestResult {
+    // EXP-0105's `one` shape: a 2,075-byte definition whose root holds 2,048
+    // bytes and whose one continuation holds the remaining 27.
+    let names = wide_names(70);
+    let columns = wide_columns(&names);
+    let bytes = create_bytes(&TableSchemaSpec {
+        name: b"Wide",
+        columns: &columns,
+        indexes: &[],
+    })?;
+    assert_eq!(bytes.len(), 24 * PAGE_BYTES);
+    assert_eq!(&page(&bytes, 22)[4..8], b"LVAL");
+    assert_eq!(u32_at(page(&bytes, 20), 4), 23);
+    assert_eq!(u32_at(page(&bytes, 20), 8), 2075);
+    assert_eq!(&page(&bytes, 23)[..4], &[0x02, 0x01, 0x56, 0x43]);
+    assert_eq!(u32_at(page(&bytes, 23), 4), 0);
+    assert!(!inline_map_bit(&bytes, 1, 0, 23)?);
+    assert!(inline_map_bit(&bytes, 1, 0, 24)?);
+
+    let mut budget = read_budget(bytes.len());
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.logical_length(), 2075);
+    assert_eq!(definition.columns().len(), 70);
+    assert_eq!(definition.columns()[69].name().raw_bytes(), b"Field00069");
+    Ok(())
+}
+
+#[test]
+fn a_definition_needing_two_continuations_chains_the_later_page_first() -> TestResult {
+    // EXP-0105's `two` shape: a 4,105-byte definition whose chain visits the
+    // physically later continuation before the earlier one.
+    let names = wide_names(140);
+    let columns = wide_columns(&names);
+    let bytes = create_bytes(&TableSchemaSpec {
+        name: b"Wider",
+        columns: &columns,
+        indexes: &[],
+    })?;
+    assert_eq!(bytes.len(), 25 * PAGE_BYTES);
+    assert_eq!(u32_at(page(&bytes, 20), 4), 24);
+    assert_eq!(u32_at(page(&bytes, 20), 8), 4105);
+    assert_eq!(u32_at(page(&bytes, 24), 4), 23);
+    assert_eq!(u32_at(page(&bytes, 23), 4), 0);
+    for continuation in [23_usize, 24] {
+        assert_eq!(&page(&bytes, continuation)[..4], &[0x02, 0x01, 0x56, 0x43]);
+        assert!(!inline_map_bit(&bytes, 1, 0, continuation as u64)?);
+    }
+    assert!(inline_map_bit(&bytes, 1, 0, 25)?);
+
+    let mut budget = read_budget(bytes.len());
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.logical_length(), 4105);
+    assert_eq!(definition.columns().len(), 140);
+    assert_eq!(definition.columns()[139].name().raw_bytes(), b"Field00139");
     Ok(())
 }
 
 #[test]
 fn a_table_with_both_an_index_and_a_long_value_column_is_refused() {
-    // No EXP-0087 create carried both, so their map-page row order is unobserved.
+    // No observed create carried both, so their map-page row order is unobserved.
     let columns = [ID, NOTE];
     let indexes = [PlannedIndex {
         name: b"ById",
-        fields: &[IndexFieldSpec {
-            column: 0,
-            direction: IndexDirection::Ascending,
-        }],
+        fields: &[field(0, IndexDirection::Ascending)],
         kind: PlannedIndexKind::Ordinary,
     }];
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            TableCreate {
-                spec: &TableSchemaSpec {
-                    name: b"Mixed",
-                    columns: &columns,
-                    indexes: &indexes,
-                },
-                properties: &framed_properties(2),
+            &TableSchemaSpec {
+                name: b"Mixed",
+                columns: &columns,
+                indexes: &indexes,
             },
             &mut budget,
         ),
@@ -190,31 +316,14 @@ fn a_create_that_cannot_be_planned_reports_the_schema_error() {
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            TableCreate {
-                spec: &TableSchemaSpec {
-                    name: b"",
-                    columns: &columns,
-                    indexes: &[],
-                },
-                properties: &framed_properties(1),
+            &TableSchemaSpec {
+                name: b"",
+                columns: &columns,
+                indexes: &[],
             },
             &mut budget,
         ),
         Err(BootstrapComposeError::Schema(_))
-    ));
-    assert!(matches!(
-        compose_table_database(
-            TableCreate {
-                spec: &TableSchemaSpec {
-                    name: b"Empty",
-                    columns: &columns,
-                    indexes: &[],
-                },
-                properties: b"",
-            },
-            &mut budget,
-        ),
-        Err(BootstrapComposeError::LongValue(_))
     ));
 }
 
@@ -235,89 +344,13 @@ fn a_second_long_value_column_is_refused() {
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            TableCreate {
-                spec: &TableSchemaSpec {
-                    name: b"Wide",
-                    columns: &columns,
-                    indexes: &[],
-                },
-                properties: &framed_properties(3),
+            &TableSchemaSpec {
+                name: b"Wide",
+                columns: &columns,
+                indexes: &[],
             },
             &mut budget,
         ),
         Err(BootstrapComposeError::UnobservedLongValueColumnCount { observed: 1 })
     ));
-}
-
-#[test]
-fn a_property_payload_outside_the_pinned_framing_is_refused() {
-    let columns = [ID];
-    let mut budget = compose_budget();
-    let compose = |properties: &[u8], budget: &mut _| {
-        compose_table_database(
-            TableCreate {
-                spec: &TableSchemaSpec {
-                    name: b"Alpha",
-                    columns: &columns,
-                    indexes: &[],
-                },
-                properties,
-            },
-            budget,
-        )
-    };
-    // Wrong magic.
-    assert!(matches!(
-        compose(b"KKE\x00", &mut budget),
-        Err(BootstrapComposeError::PropertyFraming { offset: 0 })
-    ));
-    // A chunk length running past the payload.
-    assert!(matches!(
-        compose(b"KKD\x00\x09\x00\x00\x00\x80\x00", &mut budget),
-        Err(BootstrapComposeError::PropertyFraming { offset: 4 })
-    ));
-    // A chunk shorter than its own header.
-    assert!(matches!(
-        compose(b"KKD\x00\x05\x00\x00\x00\x80\x00", &mut budget),
-        Err(BootstrapComposeError::PropertyFraming { offset: 4 })
-    ));
-    // A leading chunk that is not the names chunk.
-    assert!(matches!(
-        compose(b"KKD\x00\x06\x00\x00\x00\x01\x00", &mut budget),
-        Err(BootstrapComposeError::PropertyFraming { offset: 4 })
-    ));
-    // A names chunk body not exactly covered by length-prefixed entries: a
-    // one-byte body, then an entry whose length runs past the body.
-    assert!(matches!(
-        compose(
-            b"KKD\x00\x07\x00\x00\x00\x80\x00\x00\x06\x00\x00\x00\x01\x00",
-            &mut budget
-        ),
-        Err(BootstrapComposeError::PropertyFraming { offset: 10 })
-    ));
-    assert!(matches!(
-        compose(
-            b"KKD\x00\x09\x00\x00\x00\x80\x00\x02\x00\x41\x06\x00\x00\x00\x01\x00",
-            &mut budget
-        ),
-        Err(BootstrapComposeError::PropertyFraming { offset: 10 })
-    ));
-    // A names chunk with two exactly-covering entries passes.
-    assert!(
-        compose(
-            b"KKD\x00\x0d\x00\x00\x00\x80\x00\x02\x00\x41\x42\x01\x00\x43\x06\x00\x00\x00\x01\x00",
-            &mut budget
-        )
-        .is_ok()
-    );
-    // Chunk count not matching one names chunk plus one per column.
-    assert!(matches!(
-        compose(&framed_properties(2), &mut budget),
-        Err(BootstrapComposeError::PropertyChunkCount {
-            chunks: 3,
-            expected: 2
-        })
-    ));
-    // Alpha's recorded payload passes the framing for its one column.
-    assert!(compose(super::super::ALPHA_LVPROP_PAYLOAD, &mut budget).is_ok());
 }

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -1,4 +1,5 @@
-//! Crate-private typed planning of one new user table.
+//! Crate-private typed planning of one new user table as a database's first
+//! create.
 //!
 //! This validates a caller-described table and assigns its appended pages. It
 //! builds no page bytes and performs no I/O.
@@ -7,19 +8,22 @@
 //! validated by the same table-definition and catalog encoders that will later
 //! write the table, so a plan this module accepts is one those encoders accept.
 //!
-//! `EXP-0087` observed, identically across three fresh replicas, that creating
-//! a user table appends a definition root page numbered equal to the new
-//! object's `MSysObjects` `Id`, then a page holding the table's usage-map rows,
-//! then one index root when the table carries an index. It observed only tables
-//! with zero or one index, so this module refuses more than one rather than
-//! extrapolating an ordering nobody has observed.
+//! `EXP-0093` observed, identically across three replicas and four arms, that
+//! a first create appends a definition root page numbered equal to the new
+//! object's `MSysObjects` `Id`, then the page holding the table's usage-map
+//! rows, then the page holding the catalog row's `LvProp` long value, then one
+//! empty index root per physical index in append order. Each index's map row
+//! is `2 + physical_ordinal` on the map page. It observed at most three
+//! indexes, so this module refuses more rather than extrapolating.
 //!
-//! `EXP-0087` establishes no property grammar beyond the pinned framing, so
-//! this module plans no `LvProp` payload and no long-value page. `EXP-0087`
-//! observed that a database's first create also appends a long-value page, so
-//! a caller composing that first create must account for it separately. It
-//! also establishes no `Id` allocation rule beyond the observed equality with
-//! the definition root page.
+//! `EXP-0105` observed that a definition longer than its root page continues
+//! on one or two further definition pages, the root holding 2,048 logical
+//! bytes and each continuation 2,040. It observed the two-continuation chain
+//! pointing to the physically later page first. It observed no create carrying
+//! both an index and a continuation, so that combined page order is refused.
+//!
+//! Neither experiment establishes an `Id` allocation rule beyond the observed
+//! equality with the definition root page.
 
 #![allow(
     dead_code,
@@ -34,25 +38,41 @@ use crate::column_definition_writer::{PhysicalIndexSpec, validate_physical_index
 use crate::page_image::PAGE_BYTES;
 use crate::table_definition_layout::{definition_len, validate_column_layout, validate_name};
 use crate::{
-    ColumnPhysicalType, ColumnSpec, IndexFieldSpec, PageNumber, PhysicalIndexFlagsSpec,
-    TableDefinitionKind, TableDefinitionWriteError,
+    ColumnPhysicalType, ColumnSpec, IndexFieldSpec, LogicalIndexKindSpec, PageNumber,
+    PhysicalIndexFlagsSpec, TableDefinitionKind, TableDefinitionWriteError,
 };
 
-/// Index count `EXP-0087` observed on a created table.
-const MAX_OBSERVED_INDEXES: usize = 1;
+/// Largest index count `EXP-0093` observed on a created table.
+pub(crate) const MAX_OBSERVED_INDEXES: usize = 3;
+/// Largest continuation count `EXP-0105` observed on a created table.
+pub(crate) const MAX_OBSERVED_CONTINUATIONS: usize = 2;
 /// `EXP-0057`: usage-map locators hold a three-byte page number.
 const MAX_MAP_PAGE: u64 = 0x00ff_ffff;
-/// Row slot the planned table's own usage map takes on its map page.
-const OWNED_MAP_ROW: u8 = 0;
-/// Bytes of a definition the root page holds; longer needs a continuation.
-const DEFINITION_ROOT_CAPACITY: usize = PAGE_BYTES;
+/// `EXP-0093`: map-page row of the table's owned-page map.
+pub(crate) const OWNED_MAP_ROW: u8 = 0;
+/// `EXP-0093`: map-page row of the table's available-page map.
+pub(crate) const AVAILABLE_MAP_ROW: u8 = 1;
+/// `EXP-0093`: map-page row of the first index's map; later indexes follow.
+pub(crate) const FIRST_INDEX_MAP_ROW: u8 = 2;
+/// `EXP-0059`, `EXP-0105`: logical definition bytes the root page holds.
+pub(crate) const DEFINITION_ROOT_CAPACITY: usize = PAGE_BYTES;
+/// `EXP-0059`, `EXP-0105`: logical definition bytes one continuation holds,
+/// after its four-byte prefix and four-byte next-page reference.
+pub(crate) const CONTINUATION_CAPACITY: usize = PAGE_BYTES - CONTINUATION_PAYLOAD_OFFSET;
+/// `EXP-0059`: continuation payload starts after the prefix and next pointer.
+pub(crate) const CONTINUATION_PAYLOAD_OFFSET: usize = 8;
+/// `EXP-0087`: highest name byte with an established catalog-key weight.
+/// `EXP-0101` is bounded and does not widen this.
+const LAST_ESTABLISHED_NAME_BYTE: u8 = 0x7e;
 
-/// Whether a planned index is the table's primary one.
+/// The uniqueness class of a planned index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PlannedIndexKind {
-    /// The table's primary index, which `EXP-0087` observed is also unique.
+    /// The table's primary index; `EXP-0093` observed physical flags `0x09`.
     Primary,
-    /// Any other index.
+    /// A unique non-primary index; `EXP-0093` observed physical flags `0x01`.
+    Unique,
+    /// Any other index; `EXP-0093` observed physical flags `0x00`.
     Ordinary,
 }
 
@@ -61,7 +81,16 @@ impl PlannedIndexKind {
     pub(crate) const fn flags(self) -> PhysicalIndexFlagsSpec {
         match self {
             Self::Primary => PhysicalIndexFlagsSpec::UniqueRequired,
+            Self::Unique => PhysicalIndexFlagsSpec::Unique,
             Self::Ordinary => PhysicalIndexFlagsSpec::Ordinary,
+        }
+    }
+
+    /// Returns the logical record class this index kind encodes to.
+    pub(crate) const fn logical_kind(self) -> LogicalIndexKindSpec {
+        match self {
+            Self::Primary => LogicalIndexKindSpec::Primary,
+            Self::Unique | Self::Ordinary => LogicalIndexKindSpec::Ordinary,
         }
     }
 }
@@ -73,7 +102,7 @@ pub(crate) struct PlannedIndex<'a> {
     pub(crate) name: &'a [u8],
     /// Ordered key fields.
     pub(crate) fields: &'a [IndexFieldSpec],
-    /// Whether this is the table's primary index.
+    /// The index's uniqueness class.
     pub(crate) kind: PlannedIndexKind,
 }
 
@@ -84,7 +113,7 @@ pub(crate) struct TableSchemaSpec<'a> {
     pub(crate) name: &'a [u8],
     /// The table's columns in ordinal order.
     pub(crate) columns: &'a [ColumnSpec<'a>],
-    /// The table's indexes.
+    /// The table's indexes in physical (append) order.
     pub(crate) indexes: &'a [PlannedIndex<'a>],
 }
 
@@ -99,26 +128,56 @@ pub(crate) enum TableSchemaPlanError {
     Definition(TableDefinitionWriteError),
     /// The table declares no columns.
     NoColumns,
-    /// The definition needs a continuation page, whose placement no experiment
-    /// has established.
-    DefinitionNeedsContinuation {
+    /// A column or index name holds a byte above the range `EXP-0087`
+    /// established weights for.
+    NameByteUnestablished {
+        /// `"column"` or `"logical index"`.
+        role: &'static str,
+        /// Position of the column or index in the spec.
+        ordinal: usize,
+        /// Position of the byte in the name.
+        position: usize,
+        /// The unestablished byte.
+        byte: u8,
+    },
+    /// The definition needs more continuation pages than `EXP-0105`
+    /// observed.
+    UnobservedContinuationCount {
         /// Encoded definition length.
         length: usize,
-        /// Bytes the definition root page holds.
-        capacity: usize,
+        /// Continuations the definition needs.
+        count: usize,
+        /// Largest observed continuation count.
+        observed: usize,
     },
-    /// `EXP-0087` observed no create carrying this many indexes.
+    /// `EXP-0093` observed no create carrying this many indexes.
     UnobservedIndexCount {
         /// Declared index count.
         count: usize,
         /// Largest observed index count.
         observed: usize,
     },
+    /// The table carries both indexes and a definition continuation, a page
+    /// order no experiment has observed together.
+    UnobservedIndexContinuationLayout {
+        /// Declared index count.
+        indexes: usize,
+        /// Continuations the definition needs.
+        continuations: usize,
+    },
     /// The table declares more than one primary index.
     MultiplePrimaryIndexes {
         /// Position of the earlier primary index.
         first: usize,
         /// Position of the later primary index.
+        second: usize,
+    },
+    /// Two index names order differently by byte value and by ASCII
+    /// case-folded value, so their observed name order is underdetermined.
+    UnderdeterminedIndexNameOrder {
+        /// Position of one index.
+        first: usize,
+        /// Position of the other index.
         second: usize,
     },
     /// The appended pages do not fit the addressable page space.
@@ -155,12 +214,17 @@ impl std::error::Error for TableSchemaPlanError {
 }
 
 /// The validated page assignment for one new user table.
+///
+/// The appended run is the definition root, the map page, the `LvProp` page,
+/// then either the index roots or the continuation pages; a plan never carries
+/// both.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableSchemaPlan {
     object_id: i32,
     definition_root: PageNumber,
-    map_page: PageNumber,
-    index_root: Option<PageNumber>,
+    definition_len: usize,
+    index_count: usize,
+    continuation_count: usize,
 }
 
 impl TableSchemaPlan {
@@ -174,28 +238,57 @@ impl TableSchemaPlan {
         self.definition_root
     }
 
+    /// Returns the exact logical length of the encoded definition.
+    pub(crate) const fn definition_len(&self) -> usize {
+        self.definition_len
+    }
+
     /// Returns the page holding the table's usage-map rows.
     pub(crate) const fn map_page(&self) -> PageNumber {
-        self.map_page
+        PageNumber::new(self.definition_root.get() + 1)
     }
 
-    /// Returns the table's index root page, if it carries an index.
-    pub(crate) const fn index_root(&self) -> Option<PageNumber> {
-        self.index_root
+    /// Returns the page holding the catalog row's `LvProp` long value.
+    pub(crate) const fn property_page(&self) -> PageNumber {
+        PageNumber::new(self.definition_root.get() + 2)
     }
 
-    /// Returns how many pages the create appends, excluding the long-value
-    /// page `EXP-0087` observed only on a database's first create.
+    /// Returns each index's root page and map-page row in physical ordinal
+    /// order (`EXP-0093`: roots follow the `LvProp` page, rows follow the
+    /// table's own two maps).
+    pub(crate) fn index_placements(&self) -> impl Iterator<Item = (PageNumber, u8)> {
+        let first_root = self.property_page().get() + 1;
+        (0..self.index_count).map(move |ordinal| {
+            (
+                PageNumber::new(first_root + ordinal as u64),
+                FIRST_INDEX_MAP_ROW + ordinal as u8,
+            )
+        })
+    }
+
+    /// Returns the definition continuation pages in chain order.
+    ///
+    /// The pages are appended in ascending physical order. `EXP-0105`
+    /// observed the two-continuation chain visiting the physically later page
+    /// first, so the two-page chain is reversed relative to file order.
+    pub(crate) fn continuation_chain(&self) -> impl Iterator<Item = PageNumber> {
+        let first = self.property_page().get() + 1;
+        let pages = match self.continuation_count {
+            0 => [None, None],
+            1 => [Some(first), None],
+            _ => [Some(first + 1), Some(first)],
+        };
+        pages.into_iter().flatten().map(PageNumber::new)
+    }
+
+    /// Returns how many pages the create appends.
     pub(crate) const fn appended_page_count(&self) -> u64 {
-        if self.index_root.is_some() { 3 } else { 2 }
+        3 + self.index_count as u64 + self.continuation_count as u64
     }
 }
 
-/// Validates `spec` and assigns its appended pages starting at `first_page`.
-///
-/// `first_page` is the database's current page count, so the appended run is
-/// contiguous from it. The `EXP-0087` assignment is the definition root, then
-/// the map-rows page, then the index root when the table carries an index.
+/// Validates `spec` as a first create and assigns its appended pages starting
+/// at `first_page`, the database's current page count.
 pub(crate) fn plan_table_schema(
     spec: &TableSchemaSpec<'_>,
     first_page: u64,
@@ -204,10 +297,33 @@ pub(crate) fn plan_table_schema(
     if spec.columns.is_empty() {
         return Err(TableSchemaPlanError::NoColumns);
     }
+    for (ordinal, column) in spec.columns.iter().enumerate() {
+        validate_name_bytes("column", ordinal, column.name())?;
+    }
     validate_column_layout(spec.columns, TableDefinitionKind::User, &[])
         .map_err(TableSchemaPlanError::Definition)?;
-    validate_definition_fits_root(spec)?;
-    let plan = assign_pages(spec, first_page)?;
+    if spec.indexes.len() > MAX_OBSERVED_INDEXES {
+        return Err(TableSchemaPlanError::UnobservedIndexCount {
+            count: spec.indexes.len(),
+            observed: MAX_OBSERVED_INDEXES,
+        });
+    }
+    let definition_len = measure_definition(spec)?;
+    let continuation_count = continuation_count(definition_len);
+    if continuation_count > MAX_OBSERVED_CONTINUATIONS {
+        return Err(TableSchemaPlanError::UnobservedContinuationCount {
+            length: definition_len,
+            count: continuation_count,
+            observed: MAX_OBSERVED_CONTINUATIONS,
+        });
+    }
+    if !spec.indexes.is_empty() && continuation_count > 0 {
+        return Err(TableSchemaPlanError::UnobservedIndexContinuationLayout {
+            indexes: spec.indexes.len(),
+            continuations: continuation_count,
+        });
+    }
+    let plan = assign_pages(spec, first_page, definition_len, continuation_count)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
 }
@@ -219,12 +335,28 @@ fn validate_table_name(name: &[u8]) -> Result<(), TableSchemaPlanError> {
     Ok(())
 }
 
-/// Refuses a definition too long for its root page.
-///
-/// `EXP-0087` observed every create appending a definition root, a map-rows
-/// page, and at most an index root, so no observed definition needed a
-/// continuation page and nothing establishes where one would land.
-fn validate_definition_fits_root(spec: &TableSchemaSpec<'_>) -> Result<(), TableSchemaPlanError> {
+/// Refuses name bytes outside the range `EXP-0087` established.
+fn validate_name_bytes(
+    role: &'static str,
+    ordinal: usize,
+    name: &[u8],
+) -> Result<(), TableSchemaPlanError> {
+    match name
+        .iter()
+        .position(|byte| *byte > LAST_ESTABLISHED_NAME_BYTE)
+    {
+        Some(position) => Err(TableSchemaPlanError::NameByteUnestablished {
+            role,
+            ordinal,
+            position,
+            byte: name[position],
+        }),
+        None => Ok(()),
+    }
+}
+
+/// Returns the exact logical length of the definition `spec` encodes to.
+fn measure_definition(spec: &TableSchemaSpec<'_>) -> Result<usize, TableSchemaPlanError> {
     // The writer requires one long-value map group per Memo or LongBinary
     // column, so the group count follows from the columns.
     let long_value_maps = spec
@@ -237,29 +369,31 @@ fn validate_definition_fits_root(spec: &TableSchemaSpec<'_>) -> Result<(), Table
             )
         })
         .count();
-    let length = definition_len(
+    definition_len(
         spec.columns,
         spec.indexes.iter().map(|index| index.name),
         spec.indexes.len(),
         long_value_maps,
     )
-    .map_err(TableSchemaPlanError::Definition)?;
-    if length > DEFINITION_ROOT_CAPACITY {
-        return Err(TableSchemaPlanError::DefinitionNeedsContinuation {
-            length,
-            capacity: DEFINITION_ROOT_CAPACITY,
-        });
-    }
-    Ok(())
+    .map_err(TableSchemaPlanError::Definition)
+}
+
+/// Returns how many continuation pages a definition of `length` bytes needs.
+pub(crate) const fn continuation_count(length: usize) -> usize {
+    length
+        .saturating_sub(DEFINITION_ROOT_CAPACITY)
+        .div_ceil(CONTINUATION_CAPACITY)
 }
 
 /// Assigns the appended page run, refusing numbers the encoders cannot name.
 fn assign_pages(
     spec: &TableSchemaSpec<'_>,
     first_page: u64,
+    definition_len: usize,
+    continuation_count: usize,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
-    let needed = if spec.indexes.is_empty() { 2 } else { 3 };
-    // `EXP-0087` numbers the object equal to its definition root, and
+    let needed = 3 + spec.indexes.len() as u64 + continuation_count as u64;
+    // `EXP-0093` numbers the object equal to its definition root, and
     // `MSysObjects.Id` is a signed Long, so the run must stay in that range.
     let object_id = i32::try_from(first_page)
         .ok()
@@ -278,25 +412,22 @@ fn assign_pages(
     Ok(TableSchemaPlan {
         object_id,
         definition_root: PageNumber::new(first_page),
-        map_page: PageNumber::new(map_page),
-        index_root: (needed == 3).then(|| PageNumber::new(first_page + 2)),
+        definition_len,
+        index_count: spec.indexes.len(),
+        continuation_count,
     })
 }
 
-/// Checks each index against the physical-index encoder and the observed count.
+/// Checks each index against the physical-index encoder, the primary count,
+/// and the name-order rule the logical records will follow.
 fn validate_indexes(
     spec: &TableSchemaSpec<'_>,
     plan: &TableSchemaPlan,
 ) -> Result<(), TableSchemaPlanError> {
-    if spec.indexes.len() > MAX_OBSERVED_INDEXES {
-        return Err(TableSchemaPlanError::UnobservedIndexCount {
-            count: spec.indexes.len(),
-            observed: MAX_OBSERVED_INDEXES,
-        });
-    }
     let mut primary: Option<usize> = None;
     for (position, planned) in spec.indexes.iter().enumerate() {
         let ordinal = position as u16;
+        validate_name_bytes("logical index", position, planned.name)?;
         validate_name(
             "logical index",
             ordinal,
@@ -304,16 +435,16 @@ fn validate_indexes(
             spec.indexes[..position].iter().map(|earlier| earlier.name),
         )
         .map_err(TableSchemaPlanError::Definition)?;
-        let root = plan
-            .index_root
-            .ok_or(TableSchemaPlanError::UnobservedIndexCount {
+        let Some((root, row)) = plan.index_placements().nth(position) else {
+            return Err(TableSchemaPlanError::UnobservedIndexCount {
                 count: spec.indexes.len(),
                 observed: MAX_OBSERVED_INDEXES,
-            })?;
+            });
+        };
         let physical = PhysicalIndexSpec {
             fields: planned.fields,
-            usage_map_page: plan.map_page,
-            usage_map_row: OWNED_MAP_ROW,
+            usage_map_page: plan.map_page(),
+            usage_map_row: row,
             root,
             flags: planned.kind.flags(),
             entry_count: 0,
@@ -328,8 +459,33 @@ fn validate_indexes(
                 second: position,
             });
         }
+        for (earlier, other) in spec.indexes[..position].iter().enumerate() {
+            if other.name.cmp(planned.name)
+                != case_folded(other.name).cmp(case_folded(planned.name))
+            {
+                return Err(TableSchemaPlanError::UnderdeterminedIndexNameOrder {
+                    first: earlier,
+                    second: position,
+                });
+            }
+        }
     }
     Ok(())
+}
+
+/// Returns the logical (name-ordered) positions of `indexes` as physical
+/// ordinals, the order `EXP-0093` observed logical records to take.
+///
+/// Names are compared by byte value; the planner has already refused pairs
+/// whose byte order and ASCII case-folded order disagree.
+pub(crate) fn logical_index_order(indexes: &[PlannedIndex<'_>]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..indexes.len()).collect();
+    order.sort_by(|left, right| indexes[*left].name.cmp(indexes[*right].name));
+    order
+}
+
+fn case_folded(name: &[u8]) -> impl Iterator<Item = u8> + '_ {
+    name.iter().map(u8::to_ascii_lowercase)
 }
 
 #[cfg(test)]

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -18,9 +18,10 @@
 //!
 //! `EXP-0105` observed that a definition longer than its root page continues
 //! on one or two further definition pages, the root holding 2,048 logical
-//! bytes and each continuation 2,040. It observed the two-continuation chain
-//! pointing to the physically later page first. It observed no create carrying
-//! both an index and a continuation, so that combined page order is refused.
+//! bytes and each continuation 2,040. It observed those pages well past the
+//! appended run (`[20, 68]` and `[20, 219, 218]`) and establishes no
+//! allocation rule for them, so this module measures the continuation count
+//! at the established capacities and refuses any definition that needs one.
 //!
 //! Neither experiment establishes an `Id` allocation rule beyond the observed
 //! equality with the definition root page.
@@ -44,8 +45,6 @@ use crate::{
 
 /// Largest index count `EXP-0093` observed on a created table.
 pub(crate) const MAX_OBSERVED_INDEXES: usize = 3;
-/// Largest continuation count `EXP-0105` observed on a created table.
-pub(crate) const MAX_OBSERVED_CONTINUATIONS: usize = 2;
 /// `EXP-0057`: usage-map locators hold a three-byte page number.
 const MAX_MAP_PAGE: u64 = 0x00ff_ffff;
 /// `EXP-0093`: map-page row of the table's owned-page map.
@@ -58,9 +57,7 @@ pub(crate) const FIRST_INDEX_MAP_ROW: u8 = 2;
 pub(crate) const DEFINITION_ROOT_CAPACITY: usize = PAGE_BYTES;
 /// `EXP-0059`, `EXP-0105`: logical definition bytes one continuation holds,
 /// after its four-byte prefix and four-byte next-page reference.
-pub(crate) const CONTINUATION_CAPACITY: usize = PAGE_BYTES - CONTINUATION_PAYLOAD_OFFSET;
-/// `EXP-0059`: continuation payload starts after the prefix and next pointer.
-pub(crate) const CONTINUATION_PAYLOAD_OFFSET: usize = 8;
+pub(crate) const CONTINUATION_CAPACITY: usize = PAGE_BYTES - 8;
 /// `EXP-0087`: highest name byte with an established catalog-key weight.
 /// `EXP-0101` is bounded and does not widen this.
 const LAST_ESTABLISHED_NAME_BYTE: u8 = 0x7e;
@@ -140,15 +137,13 @@ pub(crate) enum TableSchemaPlanError {
         /// The unestablished byte.
         byte: u8,
     },
-    /// The definition needs more continuation pages than `EXP-0105`
-    /// observed.
-    UnobservedContinuationCount {
+    /// The definition needs continuation pages, whose placement `EXP-0105`
+    /// observed only as the provider's own allocation and left unestablished.
+    ContinuationPlacementUnestablished {
         /// Encoded definition length.
         length: usize,
-        /// Continuations the definition needs.
-        count: usize,
-        /// Largest observed continuation count.
-        observed: usize,
+        /// Continuations the definition needs at the established capacities.
+        continuations: usize,
     },
     /// `EXP-0093` observed no create carrying this many indexes.
     UnobservedIndexCount {
@@ -156,14 +151,6 @@ pub(crate) enum TableSchemaPlanError {
         count: usize,
         /// Largest observed index count.
         observed: usize,
-    },
-    /// The table carries both indexes and a definition continuation, a page
-    /// order no experiment has observed together.
-    UnobservedIndexContinuationLayout {
-        /// Declared index count.
-        indexes: usize,
-        /// Continuations the definition needs.
-        continuations: usize,
     },
     /// The table declares more than one primary index.
     MultiplePrimaryIndexes {
@@ -216,15 +203,13 @@ impl std::error::Error for TableSchemaPlanError {
 /// The validated page assignment for one new user table.
 ///
 /// The appended run is the definition root, the map page, the `LvProp` page,
-/// then either the index roots or the continuation pages; a plan never carries
-/// both.
+/// then the index roots.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableSchemaPlan {
     object_id: i32,
     definition_root: PageNumber,
     definition_len: usize,
     index_count: usize,
-    continuation_count: usize,
 }
 
 impl TableSchemaPlan {
@@ -266,24 +251,9 @@ impl TableSchemaPlan {
         })
     }
 
-    /// Returns the definition continuation pages in chain order.
-    ///
-    /// The pages are appended in ascending physical order. `EXP-0105`
-    /// observed the two-continuation chain visiting the physically later page
-    /// first, so the two-page chain is reversed relative to file order.
-    pub(crate) fn continuation_chain(&self) -> impl Iterator<Item = PageNumber> {
-        let first = self.property_page().get() + 1;
-        let pages = match self.continuation_count {
-            0 => [None, None],
-            1 => [Some(first), None],
-            _ => [Some(first + 1), Some(first)],
-        };
-        pages.into_iter().flatten().map(PageNumber::new)
-    }
-
     /// Returns how many pages the create appends.
     pub(crate) const fn appended_page_count(&self) -> u64 {
-        3 + self.index_count as u64 + self.continuation_count as u64
+        3 + self.index_count as u64
     }
 }
 
@@ -309,21 +279,14 @@ pub(crate) fn plan_table_schema(
         });
     }
     let definition_len = measure_definition(spec)?;
-    let continuation_count = continuation_count(definition_len);
-    if continuation_count > MAX_OBSERVED_CONTINUATIONS {
-        return Err(TableSchemaPlanError::UnobservedContinuationCount {
+    let continuations = continuation_count(definition_len);
+    if continuations > 0 {
+        return Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
             length: definition_len,
-            count: continuation_count,
-            observed: MAX_OBSERVED_CONTINUATIONS,
+            continuations,
         });
     }
-    if !spec.indexes.is_empty() && continuation_count > 0 {
-        return Err(TableSchemaPlanError::UnobservedIndexContinuationLayout {
-            indexes: spec.indexes.len(),
-            continuations: continuation_count,
-        });
-    }
-    let plan = assign_pages(spec, first_page, definition_len, continuation_count)?;
+    let plan = assign_pages(spec, first_page, definition_len)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
 }
@@ -378,7 +341,8 @@ fn measure_definition(spec: &TableSchemaSpec<'_>) -> Result<usize, TableSchemaPl
     .map_err(TableSchemaPlanError::Definition)
 }
 
-/// Returns how many continuation pages a definition of `length` bytes needs.
+/// Returns how many continuation pages a definition of `length` bytes needs
+/// at the `EXP-0105` capacities.
 pub(crate) const fn continuation_count(length: usize) -> usize {
     length
         .saturating_sub(DEFINITION_ROOT_CAPACITY)
@@ -390,9 +354,8 @@ fn assign_pages(
     spec: &TableSchemaSpec<'_>,
     first_page: u64,
     definition_len: usize,
-    continuation_count: usize,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
-    let needed = 3 + spec.indexes.len() as u64 + continuation_count as u64;
+    let needed = 3 + spec.indexes.len() as u64;
     // `EXP-0093` numbers the object equal to its definition root, and
     // `MSysObjects.Id` is a signed Long, so the run must stay in that range.
     let object_id = i32::try_from(first_page)
@@ -414,7 +377,6 @@ fn assign_pages(
         definition_root: PageNumber::new(first_page),
         definition_len,
         index_count: spec.indexes.len(),
-        continuation_count,
     })
 }
 

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::physical_index_definition::KEY_SLOT_COUNT;
-use crate::{ColumnPhysicalType, ColumnStorageKind, IndexDirection};
+use crate::{ColumnPhysicalType, ColumnStorageKind, IndexDirection, LogicalIndexKindSpec};
 
 type PlanResult = Result<(), TableSchemaPlanError>;
 
@@ -53,51 +53,157 @@ fn definition_error(spec: &TableSchemaSpec<'_>) -> Option<TableDefinitionWriteEr
     }
 }
 
+/// Fixed Long columns whose definition encodes to exactly `target` bytes.
+fn names_of_definition_len(target: usize) -> Vec<Vec<u8>> {
+    // Header 43 + terminator 2, then 18 record bytes + 1 length byte + 5
+    // name bytes per column; the last name absorbs the remainder.
+    let count = (target - 45) / 24;
+    let remainder = target - 45 - 24 * count;
+    let mut names = (0..count)
+        .map(|ordinal| format!("C{ordinal:04}").into_bytes())
+        .collect::<Vec<_>>();
+    if let Some(last) = names.last_mut() {
+        last.extend(std::iter::repeat_n(b'x', remainder));
+    }
+    names
+}
+
+fn long_columns(names: &[Vec<u8>]) -> Vec<ColumnSpec<'_>> {
+    names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .collect()
+}
+
 #[test]
-fn a_table_without_an_index_appends_a_definition_root_and_a_map_page() -> PlanResult {
-    // EXP-0087's Beta create (Long Id, Text(50) Name, Memo Note): two
-    // appended pages, Id equal to the root page.
+fn a_table_without_an_index_appends_a_root_a_map_page_and_a_property_page() -> PlanResult {
+    // EXP-0093: three appended pages, Id equal to the root page.
     let columns = [ID, NAME, NOTE];
     let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23)?;
     assert_eq!(plan.object_id(), 23);
     assert_eq!(plan.definition_root(), PageNumber::new(23));
     assert_eq!(plan.map_page(), PageNumber::new(24));
-    assert_eq!(plan.index_root(), None);
-    assert_eq!(plan.appended_page_count(), 2);
-    Ok(())
-}
-
-#[test]
-fn an_indexed_table_appends_its_index_root_after_the_map_page() -> PlanResult {
-    // EXP-0087's Delta create: the index root follows the map-rows page.
-    let columns = [LABEL];
-    let indexes = [PlannedIndex {
-        name: b"ByLabel",
-        fields: &[key(0)],
-        kind: PlannedIndexKind::Ordinary,
-    }];
-    let plan = plan_table_schema(&spec(b"Delta", &columns, &indexes), 28)?;
-    assert_eq!(plan.object_id(), 28);
-    assert_eq!(plan.definition_root(), PageNumber::new(28));
-    assert_eq!(plan.map_page(), PageNumber::new(29));
-    assert_eq!(plan.index_root(), Some(PageNumber::new(30)));
+    assert_eq!(plan.property_page(), PageNumber::new(25));
+    assert_eq!(plan.index_placements().count(), 0);
+    assert_eq!(plan.continuation_chain().count(), 0);
     assert_eq!(plan.appended_page_count(), 3);
     Ok(())
 }
 
 #[test]
-fn a_primary_index_plans_the_same_pages_as_an_ordinary_one() -> PlanResult {
-    // EXP-0087's Gamma create carried a primary index and appended three pages.
+fn index_roots_follow_the_property_page_in_physical_order() -> PlanResult {
+    // EXP-0093's `three` arm: one root and one map row per physical ordinal.
+    let columns = [ID, LABEL, NAME];
+    let indexes = [
+        PlannedIndex {
+            name: b"ZPrimary",
+            fields: &[key(0)],
+            kind: PlannedIndexKind::Primary,
+        },
+        PlannedIndex {
+            name: b"MUniqueX",
+            fields: &[key(1)],
+            kind: PlannedIndexKind::Unique,
+        },
+        PlannedIndex {
+            name: b"ASecondx",
+            fields: &[key(2)],
+            kind: PlannedIndexKind::Ordinary,
+        },
+    ];
+    let plan = plan_table_schema(&spec(b"Three", &columns, &indexes), 28)?;
+    assert_eq!(plan.property_page(), PageNumber::new(30));
+    assert_eq!(
+        plan.index_placements().collect::<Vec<_>>(),
+        [
+            (PageNumber::new(31), 2),
+            (PageNumber::new(32), 3),
+            (PageNumber::new(33), 4),
+        ]
+    );
+    assert_eq!(plan.appended_page_count(), 6);
+    assert_eq!(logical_index_order(&indexes), [2, 1, 0]);
+    Ok(())
+}
+
+#[test]
+fn index_kinds_map_to_the_observed_flag_classes() {
+    // EXP-0093: primary 0x09, unique non-primary 0x01, ordinary 0x00.
+    assert_eq!(
+        PlannedIndexKind::Primary.flags(),
+        PhysicalIndexFlagsSpec::UniqueRequired
+    );
+    assert_eq!(
+        PlannedIndexKind::Unique.flags(),
+        PhysicalIndexFlagsSpec::Unique
+    );
+    assert_eq!(
+        PlannedIndexKind::Ordinary.flags(),
+        PhysicalIndexFlagsSpec::Ordinary
+    );
+    assert_eq!(
+        PlannedIndexKind::Unique.logical_kind(),
+        LogicalIndexKindSpec::Ordinary
+    );
+}
+
+#[test]
+fn index_names_whose_order_depends_on_case_folding_are_refused() {
+    // Byte order puts "Banana" first; case-folded order puts "apple" first.
+    let columns = [ID, LABEL];
+    let indexes = [
+        PlannedIndex {
+            name: b"apple",
+            fields: &[key(0)],
+            kind: PlannedIndexKind::Ordinary,
+        },
+        PlannedIndex {
+            name: b"Banana",
+            fields: &[key(1)],
+            kind: PlannedIndexKind::Ordinary,
+        },
+    ];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::UnderdeterminedIndexNameOrder {
+            first: 0,
+            second: 1
+        })
+    );
+}
+
+#[test]
+fn a_name_byte_above_the_established_range_is_refused() {
+    let columns = [ColumnSpec::new(
+        b"Caf\xe9",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
+        Err(TableSchemaPlanError::NameByteUnestablished {
+            role: "column",
+            ordinal: 0,
+            position: 3,
+            byte: 0xe9,
+        })
+    );
     let columns = [ID];
     let indexes = [PlannedIndex {
-        name: b"PrimaryKey",
+        name: b"By\x80",
         fields: &[key(0)],
-        kind: PlannedIndexKind::Primary,
+        kind: PlannedIndexKind::Ordinary,
     }];
-    let plan = plan_table_schema(&spec(b"Gamma", &columns, &indexes), 25)?;
-    assert_eq!(plan.object_id(), 25);
-    assert_eq!(plan.index_root(), Some(PageNumber::new(27)));
-    Ok(())
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::NameByteUnestablished {
+            role: "logical index",
+            ordinal: 0,
+            position: 2,
+            byte: 0x80,
+        })
+    );
 }
 
 #[test]
@@ -284,25 +390,22 @@ fn an_empty_column_name_is_refused() {
 
 #[test]
 fn more_indexes_than_any_create_carried_are_refused() {
-    // EXP-0087 observed only zero or one index per create, so a two-index
-    // ordering has no evidence behind it.
-    let columns = [ID, LABEL];
-    let indexes = [
-        PlannedIndex {
-            name: b"ById",
-            fields: &[key(0)],
-            kind: PlannedIndexKind::Primary,
-        },
-        PlannedIndex {
-            name: b"ByLabel",
-            fields: &[key(1)],
+    // EXP-0093 observed at most three indexes per create.
+    let columns = [ID, LABEL, NAME];
+    let fields = [key(0), key(1), key(2), key(0)];
+    let indexes = fields
+        .iter()
+        .zip([b"A".as_slice(), b"B", b"C", b"D"])
+        .map(|(field, name)| PlannedIndex {
+            name,
+            fields: std::slice::from_ref(field),
             kind: PlannedIndexKind::Ordinary,
-        },
-    ];
+        })
+        .collect::<Vec<_>>();
     assert_eq!(
         plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
         Err(TableSchemaPlanError::UnobservedIndexCount {
-            count: 2,
+            count: 4,
             observed: MAX_OBSERVED_INDEXES,
         })
     );
@@ -398,7 +501,7 @@ fn a_first_page_above_the_signed_id_range_is_refused() {
     let first = i32::MAX as u64 + 1;
     assert_eq!(
         plan_table_schema(&spec(b"Beta", &columns, &[]), first),
-        Err(TableSchemaPlanError::PageOverflow { first, needed: 2 })
+        Err(TableSchemaPlanError::PageOverflow { first, needed: 3 })
     );
 }
 
@@ -421,36 +524,91 @@ fn a_map_page_no_usage_map_locator_could_name_is_refused() -> PlanResult {
 }
 
 #[test]
-fn a_definition_too_long_for_its_root_page_is_refused() {
-    // EXP-0087 saw no create append a continuation page, so where one would
-    // land is unestablished. 100 fixed Long columns overrun the root page.
-    let names = (0..100)
-        .map(|ordinal| format!("Column{ordinal:03}").into_bytes())
-        .collect::<Vec<_>>();
-    let columns = names
-        .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
-        .collect::<Vec<_>>();
-    assert!(matches!(
-        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
-        Err(TableSchemaPlanError::DefinitionNeedsContinuation { length, capacity })
-            if length > capacity && capacity == DEFINITION_ROOT_CAPACITY
-    ));
+fn continuation_counts_follow_the_established_capacities() {
+    // EXP-0105: the root holds 2,048 logical bytes and each continuation
+    // 2,040, so the counts change one byte above each capacity.
+    for (length, expected) in [
+        (2048, 0),
+        (2049, 1),
+        (4088, 1),
+        (4089, 2),
+        (6128, 2),
+        (6129, 3),
+    ] {
+        assert_eq!(continuation_count(length), expected, "length {length}");
+    }
 }
 
 #[test]
-fn a_definition_that_exactly_fills_its_root_page_is_accepted() -> PlanResult {
-    // The refusal must start one byte above the root page, not below it.
-    let names = (0..70)
-        .map(|ordinal| format!("Column{ordinal:03}").into_bytes())
-        .collect::<Vec<_>>();
-    let columns = names
-        .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
-        .collect::<Vec<_>>();
-    let length =
-        definition_len(&columns, [].into_iter(), 0, 0).map_err(TableSchemaPlanError::Definition)?;
-    assert!(length <= DEFINITION_ROOT_CAPACITY);
-    plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+fn a_definition_that_exactly_fills_its_root_page_needs_no_continuation() -> PlanResult {
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY);
+    let columns = long_columns(&names);
+    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    assert_eq!(plan.definition_len(), DEFINITION_ROOT_CAPACITY);
+    assert_eq!(plan.continuation_chain().count(), 0);
+    assert_eq!(plan.appended_page_count(), 3);
     Ok(())
+}
+
+#[test]
+fn one_continuation_follows_the_property_page() -> PlanResult {
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
+    let columns = long_columns(&names);
+    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    assert_eq!(
+        plan.continuation_chain().collect::<Vec<_>>(),
+        [PageNumber::new(23)]
+    );
+    assert_eq!(plan.appended_page_count(), 4);
+    Ok(())
+}
+
+#[test]
+fn two_continuations_chain_the_later_page_first() -> PlanResult {
+    // EXP-0105 observed chain [20, 219, 218]: the root points at the
+    // physically later continuation, which points at the earlier one.
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY + 1);
+    let columns = long_columns(&names);
+    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    assert_eq!(
+        plan.continuation_chain().collect::<Vec<_>>(),
+        [PageNumber::new(24), PageNumber::new(23)]
+    );
+    assert_eq!(plan.appended_page_count(), 5);
+    Ok(())
+}
+
+#[test]
+fn a_definition_needing_a_third_continuation_is_refused() {
+    let length = DEFINITION_ROOT_CAPACITY + 2 * CONTINUATION_CAPACITY + 1;
+    let names = names_of_definition_len(length);
+    let columns = long_columns(&names);
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+        Err(TableSchemaPlanError::UnobservedContinuationCount {
+            length,
+            count: 3,
+            observed: MAX_OBSERVED_CONTINUATIONS,
+        })
+    );
+}
+
+#[test]
+fn an_indexed_definition_needing_a_continuation_is_refused() {
+    // EXP-0093 and EXP-0105 observed index roots and continuations only in
+    // isolation, so their combined page order is unobserved.
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
+    let columns = long_columns(&names);
+    let indexes = [PlannedIndex {
+        name: b"First",
+        fields: &[key(0)],
+        kind: PlannedIndexKind::Ordinary,
+    }];
+    assert!(matches!(
+        plan_table_schema(&spec(b"Wide", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::UnobservedIndexContinuationLayout {
+            indexes: 1,
+            continuations: 1,
+        })
+    ));
 }

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -85,7 +85,6 @@ fn a_table_without_an_index_appends_a_root_a_map_page_and_a_property_page() -> P
     assert_eq!(plan.map_page(), PageNumber::new(24));
     assert_eq!(plan.property_page(), PageNumber::new(25));
     assert_eq!(plan.index_placements().count(), 0);
-    assert_eq!(plan.continuation_chain().count(), 0);
     assert_eq!(plan.appended_page_count(), 3);
     Ok(())
 }
@@ -545,70 +544,26 @@ fn a_definition_that_exactly_fills_its_root_page_needs_no_continuation() -> Plan
     let columns = long_columns(&names);
     let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
     assert_eq!(plan.definition_len(), DEFINITION_ROOT_CAPACITY);
-    assert_eq!(plan.continuation_chain().count(), 0);
     assert_eq!(plan.appended_page_count(), 3);
     Ok(())
 }
 
 #[test]
-fn one_continuation_follows_the_property_page() -> PlanResult {
-    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
-    let columns = long_columns(&names);
-    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
-    assert_eq!(
-        plan.continuation_chain().collect::<Vec<_>>(),
-        [PageNumber::new(23)]
-    );
-    assert_eq!(plan.appended_page_count(), 4);
-    Ok(())
-}
-
-#[test]
-fn two_continuations_chain_the_later_page_first() -> PlanResult {
-    // EXP-0105 observed chain [20, 219, 218]: the root points at the
-    // physically later continuation, which points at the earlier one.
-    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY + 1);
-    let columns = long_columns(&names);
-    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
-    assert_eq!(
-        plan.continuation_chain().collect::<Vec<_>>(),
-        [PageNumber::new(24), PageNumber::new(23)]
-    );
-    assert_eq!(plan.appended_page_count(), 5);
-    Ok(())
-}
-
-#[test]
-fn a_definition_needing_a_third_continuation_is_refused() {
-    let length = DEFINITION_ROOT_CAPACITY + 2 * CONTINUATION_CAPACITY + 1;
-    let names = names_of_definition_len(length);
-    let columns = long_columns(&names);
-    assert_eq!(
-        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
-        Err(TableSchemaPlanError::UnobservedContinuationCount {
-            length,
-            count: 3,
-            observed: MAX_OBSERVED_CONTINUATIONS,
-        })
-    );
-}
-
-#[test]
-fn an_indexed_definition_needing_a_continuation_is_refused() {
-    // EXP-0093 and EXP-0105 observed index roots and continuations only in
-    // isolation, so their combined page order is unobserved.
-    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
-    let columns = long_columns(&names);
-    let indexes = [PlannedIndex {
-        name: b"First",
-        fields: &[key(0)],
-        kind: PlannedIndexKind::Ordinary,
-    }];
-    assert!(matches!(
-        plan_table_schema(&spec(b"Wide", &columns, &indexes), 20),
-        Err(TableSchemaPlanError::UnobservedIndexContinuationLayout {
-            indexes: 1,
-            continuations: 1,
-        })
-    ));
+fn a_definition_needing_a_continuation_is_refused() {
+    // EXP-0105 left continuation placement unestablished, so the refusal
+    // starts one byte above the root capacity and reports the count.
+    for (length, continuations) in [
+        (DEFINITION_ROOT_CAPACITY + 1, 1),
+        (DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY + 1, 2),
+    ] {
+        let names = names_of_definition_len(length);
+        let columns = long_columns(&names);
+        assert_eq!(
+            plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+            Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
+                length,
+                continuations,
+            })
+        );
+    }
 }


### PR DESCRIPTION
The composer could only build a one-index table, and its deduced order (index root before the long-value page) is the opposite of what DAO does. It also carried an opaque `LvProp` payload that only the recorded Alpha table could satisfy, so no other schema could be composed at all.

This makes the planner and composer match the evidence now on record, as the first of two PRs toward `jet3::create_database` (#100):

- **Null `LvProp` in production.** The fixed Alpha payload, the `properties` input, and its framing checks are gone. Every create takes the EXP-0091 form: null catalog `LvProp`, empty retained `LVAL` page, zero catalog dates. The docs state plainly that EXP-0091 validated this for `Alpha(Id Long)` only; every other composed image is an unvalidated candidate until a differential accepts it.
- **Up to three indexes** with the EXP-0093 order (root → map page → `LvProp` page → one root per physical ordinal), map rows `2 + ordinal`, a new unique non-primary kind (flags `0x01`), and logical records in name order referring back to physical ordinals.
- **Continuations are counted, not placed.** The planner measures the count at the EXP-0105 capacities (2,048 root / 2,040 per continuation) and refuses any definition that needs one with `ContinuationPlacementUnestablished`, because EXP-0105 observed placement only under DAO's own allocation.
- **New structured refusals**: index plus long-value column (unchanged), more than three indexes, names with bytes above `0x7E`, and index-name pairs whose byte order and case-folded order disagree.

Tests decode the EXP-0093 three-index arm and the EXP-0087 memo shape back through the reader, check each continuation-count boundary, and cover every refusal. No provenance entry is added; every fact used cites an existing EXP entry.

Note: the two historical discovery recipes `windows-dev-bootstrap-composer-semantics` and `windows-dev-lvprop-null` pinned candidates from the deleted fixed-payload path and can no longer regenerate them. Their experiments are complete; the script is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)