### PR TITLE
feat(jet3): create a one-table database with jet3::create_database

### DIFF
--- a/crates/jet3/src/atomic.rs
+++ b/crates/jet3/src/atomic.rs
@@ -1,4 +1,5 @@
-//! Copy-on-write publication for updates to an existing file.
+//! Copy-on-write publication for updates to an existing file, and
+//! link-on-absent publication for creating a new one.
 //!
 //! A private copy is created in the target's directory, mutated, independently
 //! validated, synchronized, identity-checked against its retained file handle,
@@ -276,6 +277,118 @@ where
     })();
 
     match update_result {
+        Err(mut error) if !error.stage().is_post_publication() => {
+            if let Err(cleanup_error) = private.cleanup(&mut before_stage) {
+                error.attach_cleanup_error(cleanup_error);
+            }
+            Err(error)
+        }
+        result => result,
+    }
+}
+
+/// Creates a new file through a validated same-directory private file.
+///
+/// `target` must not exist; an existing entry of any kind fails at
+/// [`PublishStage::PrivateCopyCreation`] with an `AlreadyExists` I/O error
+/// and is left untouched. `write` receives the empty private file, and
+/// `validate` receives the private path exactly as in [`atomic_update`].
+/// Publication links the private file to `target` without replacing anything
+/// that appeared there in the meantime, then removes the private entry. Any
+/// failure before publication removes the private file, so a target that was
+/// absent stays absent.
+///
+/// [`PublishStage::Copy`] and [`PublishStage::Metadata`] are never visited.
+/// The validator is a publication prerequisite only; it is not independent
+/// verification or compatibility evidence.
+pub fn atomic_create<W, V, WE, VE>(
+    target: impl AsRef<Path>,
+    write: W,
+    validate: V,
+) -> Result<(), PublishError>
+where
+    W: FnOnce(&mut File) -> Result<(), WE>,
+    V: FnOnce(&Path) -> Result<(), VE>,
+    WE: StdError + Send + Sync + 'static,
+    VE: StdError + Send + Sync + 'static,
+{
+    atomic_create_with_hook(target, write, validate, |_| Ok::<(), Infallible>(()))
+}
+
+/// Creates a new file with a hook before every publication stage.
+///
+/// Hook semantics match [`atomic_update_with_hook`]. A failure to remove the
+/// private entry after a successful link is reported at
+/// [`PublishStage::DirectorySync`]: the target is published, but a second
+/// directory entry for it remains.
+pub fn atomic_create_with_hook<W, V, H, WE, VE, HE>(
+    target: impl AsRef<Path>,
+    write: W,
+    validate: V,
+    mut before_stage: H,
+) -> Result<(), PublishError>
+where
+    W: FnOnce(&mut File) -> Result<(), WE>,
+    V: FnOnce(&Path) -> Result<(), VE>,
+    H: FnMut(PublishStage) -> Result<(), HE>,
+    WE: StdError + Send + Sync + 'static,
+    VE: StdError + Send + Sync + 'static,
+    HE: StdError + Send + Sync + 'static,
+{
+    let target = target.as_ref();
+    let parent = normalized_parent(target);
+    match fs::symlink_metadata(target) {
+        Ok(_) => {
+            return Err(PublishError::new(
+                PublishStage::PrivateCopyCreation,
+                io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "atomic create target already exists",
+                ),
+            ));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(PublishError::new(PublishStage::PrivateCopyCreation, error));
+        }
+    }
+    call_hook(&mut before_stage, PublishStage::PrivateCopyCreation)?;
+    let mut private = PrivateCopy::create(target, parent)
+        .map_err(|error| PublishError::new(PublishStage::PrivateCopyCreation, error))?;
+
+    let create_result: Result<(), PublishError> = (|| {
+        call_hook(&mut before_stage, PublishStage::Mutation)?;
+        write(private.file_mut())
+            .map_err(|error| PublishError::new(PublishStage::Mutation, error))?;
+
+        call_hook(&mut before_stage, PublishStage::Validation)?;
+        validate(private.path())
+            .map_err(|error| PublishError::new(PublishStage::Validation, error))?;
+
+        call_hook(&mut before_stage, PublishStage::FileSync)?;
+        private
+            .file_mut()
+            .sync_all()
+            .map_err(|error| PublishError::new(PublishStage::FileSync, error))?;
+
+        call_hook(&mut before_stage, PublishStage::PrePublish)?;
+        call_hook(&mut before_stage, PublishStage::Publish)?;
+        private
+            .verify_path_identity()
+            .map_err(|error| PublishError::new(PublishStage::Publish, error))?;
+        platform_publish::link_new(private.path(), target)
+            .map_err(|error| PublishError::new(PublishStage::Publish, error))?;
+        private.mark_published();
+
+        call_hook(&mut before_stage, PublishStage::DirectorySync)?;
+        fs::remove_file(private.path())
+            .map_err(|error| PublishError::new(PublishStage::DirectorySync, error))?;
+        platform_publish::sync_directory(parent)
+            .map_err(|error| PublishError::new(PublishStage::DirectorySync, error))?;
+        Ok(())
+    })();
+
+    match create_result {
         Err(mut error) if !error.stage().is_post_publication() => {
             if let Err(cleanup_error) = private.cleanup(&mut before_stage) {
                 error.attach_cleanup_error(cleanup_error);
@@ -582,6 +695,11 @@ mod platform_publish {
         fs::rename(private, target)
     }
 
+    /// Publishes `private` at `target` only if `target` is still absent.
+    pub(super) fn link_new(private: &Path, target: &Path) -> io::Result<()> {
+        fs::hard_link(private, target)
+    }
+
     pub(super) fn sync_directory(parent: &Path) -> io::Result<()> {
         File::open(parent)?.sync_all()
     }
@@ -604,6 +722,10 @@ mod platform_publish {
     }
 
     pub(super) fn replace(_private: &Path, _target: &Path) -> io::Result<()> {
+        Err(unsupported())
+    }
+
+    pub(super) fn link_new(_private: &Path, _target: &Path) -> io::Result<()> {
         Err(unsupported())
     }
 

--- a/crates/jet3/src/atomic.rs
+++ b/crates/jet3/src/atomic.rs
@@ -3,7 +3,7 @@
 //!
 //! A private copy is created in the target's directory, mutated, independently
 //! validated, synchronized, identity-checked against its retained file handle,
-//! and then published with [`std::fs::rename`].
+//! and then published with an operating-system atomic primitive.
 //! Same-directory placement avoids cross-filesystem rename. Atomic replacement
 //! and crash durability remain subject to the operating system and filesystem
 //! guarantees documented for `rename` and `sync_all`; network and unusual
@@ -42,10 +42,11 @@ type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 /// A fault-injection and diagnostic boundary in atomic publication.
 ///
 /// Hooks run immediately before the named work. A hook failure through
-/// [`PublishStage::Publish`] occurs before rename and leaves the original
-/// target in place. [`PublishStage::DirectorySync`] occurs after rename; an
-/// error at that stage reports that the verified replacement was published but
-/// its directory entry may not be durable across a crash. [`Self::Cleanup`] is
+/// [`PublishStage::Publish`] occurs before the target is published and leaves
+/// the original target in place. [`PublishStage::DirectorySync`] occurs after
+/// publication; an error at that stage reports that the verified file was
+/// published but its directory entry may not be durable across a crash.
+/// [`Self::Cleanup`] is
 /// visited only after a pre-publication failure and immediately before
 /// identity-checking and removing the private entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -64,7 +65,7 @@ pub enum PublishStage {
     FileSync,
     /// Final barrier after validation and synchronization.
     PrePublish,
-    /// Atomically rename the private file over the target.
+    /// Atomically publish the private file at the target.
     Publish,
     /// Synchronize the containing directory where supported.
     DirectorySync,
@@ -142,13 +143,13 @@ impl fmt::Display for PublishError {
         if self.stage.is_post_publication() {
             write!(
                 formatter,
-                "{} failed after replacement publication: {}",
+                "{} failed after publication: {}",
                 self.stage, self.source
             )?;
         } else {
             write!(
                 formatter,
-                "{} failed before replacement publication: {}",
+                "{} failed before publication: {}",
                 self.stage, self.source
             )?;
         }
@@ -713,7 +714,7 @@ mod platform_publish {
     fn unsupported() -> io::Error {
         io::Error::new(
             io::ErrorKind::Unsupported,
-            "atomic overwrite-replace publication and directory durability are not implemented for this platform",
+            "atomic publication and directory durability are not implemented for this platform",
         )
     }
 

--- a/crates/jet3/src/atomic_tests.rs
+++ b/crates/jet3/src/atomic_tests.rs
@@ -1,9 +1,13 @@
+use std::error::Error as StdError;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::{PrivateCopy, PublishStage, atomic_update, atomic_update_with_hook};
+use super::{
+    PrivateCopy, PublishStage, atomic_create, atomic_create_with_hook, atomic_update,
+    atomic_update_with_hook,
+};
 use crate::{ReadLimits, ResourceBudget, ResourceLimits};
 
 static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
@@ -301,5 +305,99 @@ fn identity_capture_failure_removes_exclusively_created_private_file() -> TestRe
     assert_eq!(error.to_string(), "injected identity capture failure");
     assert_eq!(directory.private_entries()?, 0);
     assert_eq!(fs::read(&target)?, b"original");
+    Ok(())
+}
+
+fn write_fresh(file: &mut std::fs::File) -> Result<(), std::io::Error> {
+    file.write_all(b"fresh")
+}
+
+fn validate_fresh(path: &Path) -> Result<(), TestFailure> {
+    if fs::read(path).map_err(|_| TestFailure("validation read failed"))? == b"fresh" {
+        Ok(())
+    } else {
+        Err(TestFailure("fresh file did not validate"))
+    }
+}
+
+#[test]
+fn successful_create_publishes_the_validated_file() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    atomic_create(&target, write_fresh, validate_fresh)?;
+    assert_eq!(fs::read(&target)?, b"fresh");
+    assert_eq!(directory.private_entries()?, 0);
+    Ok(())
+}
+
+#[test]
+fn create_refuses_an_existing_target_and_leaves_it_untouched() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    fs::write(&target, b"original")?;
+    let error = atomic_create(&target, write_fresh, validate_fresh)
+        .err()
+        .ok_or(TestFailure("create over an existing target succeeded"))?;
+    assert_eq!(error.stage(), PublishStage::PrivateCopyCreation);
+    let io_error = StdError::source(&error)
+        .and_then(|source| source.downcast_ref::<std::io::Error>())
+        .ok_or(TestFailure("missing I/O source"))?;
+    assert_eq!(io_error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert_eq!(fs::read(&target)?, b"original");
+    assert_eq!(directory.private_entries()?, 0);
+    Ok(())
+}
+
+#[test]
+fn create_failures_before_publication_leave_the_target_absent() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    for stage in [
+        PublishStage::Mutation,
+        PublishStage::Validation,
+        PublishStage::FileSync,
+        PublishStage::PrePublish,
+        PublishStage::Publish,
+    ] {
+        let error = atomic_create_with_hook(&target, write_fresh, validate_fresh, |visited| {
+            if visited == stage {
+                Err(TestFailure("injected"))
+            } else {
+                Ok(())
+            }
+        })
+        .err()
+        .ok_or(TestFailure("injected failure did not fail the create"))?;
+        assert_eq!(error.stage(), stage);
+        assert!(error.cleanup_error().is_none());
+        assert!(!target.exists(), "target exists after {stage} failure");
+        assert_eq!(directory.private_entries()?, 0);
+    }
+    let error = atomic_create(&target, write_fresh, |_: &Path| {
+        Err::<(), _>(TestFailure("rejected"))
+    })
+    .err()
+    .ok_or(TestFailure("rejected validation did not fail the create"))?;
+    assert_eq!(error.stage(), PublishStage::Validation);
+    assert!(!target.exists());
+    assert_eq!(directory.private_entries()?, 0);
+    Ok(())
+}
+
+#[test]
+fn create_does_not_replace_a_target_that_appears_before_publication() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let error = atomic_create_with_hook(&target, write_fresh, validate_fresh, |visited| {
+        if visited == PublishStage::Publish {
+            fs::write(&target, b"raced")?;
+        }
+        Ok::<(), std::io::Error>(())
+    })
+    .err()
+    .ok_or(TestFailure("publication over a raced target succeeded"))?;
+    assert_eq!(error.stage(), PublishStage::Publish);
+    assert_eq!(fs::read(&target)?, b"raced");
+    assert_eq!(directory.private_entries()?, 0);
     Ok(())
 }

--- a/crates/jet3/src/atomic_tests.rs
+++ b/crates/jet3/src/atomic_tests.rs
@@ -331,6 +331,25 @@ fn successful_create_publishes_the_validated_file() -> TestResult {
 }
 
 #[test]
+fn create_directory_sync_fault_reports_the_published_target() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let error = atomic_create_with_hook(&target, write_fresh, validate_fresh, |stage| {
+        if stage == PublishStage::DirectorySync {
+            Err(TestFailure("injected directory-sync failure"))
+        } else {
+            Ok(())
+        }
+    })
+    .err()
+    .ok_or(TestFailure("directory-sync fault unexpectedly succeeded"))?;
+    assert_eq!(error.stage(), PublishStage::DirectorySync);
+    assert_eq!(fs::read(&target)?, b"fresh");
+    assert_eq!(directory.private_entries()?, 1);
+    Ok(())
+}
+
+#[test]
 fn create_refuses_an_existing_target_and_leaves_it_untouched() -> TestResult {
     let directory = TestDirectory::create()?;
     let target = directory.target();

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -2,19 +2,29 @@
 
 use super::*;
 
-/// Structured failure while composing a fixed bootstrap image.
+/// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum BootstrapComposeError {
+pub enum BootstrapComposeError {
+    /// A table definition could not be encoded.
     Definition(TableDefinitionWriteError),
+    /// A usage map could not be encoded.
     UsageMap(UsageMapWriteError),
+    /// A page image could not be written.
     Page(PageImageError),
+    /// A data row could not be encoded.
     Row(RowWriteError),
+    /// The whole-file page plan could not be extended.
     WholeFile(WholeFilePlanError),
+    /// A low-level encoding or resource limit failed.
     Encoding(Error),
+    /// A bootstrap index page cannot hold its entries.
     IndexPageFull {
+        /// Bytes the entries need.
         needed: usize,
+        /// Bytes the entry area holds.
         available: usize,
     },
+    /// A catalog name could not be encoded into an index key.
     NameKey(CatalogNameKeyError),
     /// The table could not be planned.
     Schema(TableSchemaPlanError),

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -12,16 +12,11 @@
 //! from `EXP-0093`. Any composed image other than the `Alpha` transition is
 //! an unvalidated candidate until a DAO differential accepts it.
 
-#![allow(
-    dead_code,
-    reason = "crate-private writer slice awaiting DAO validation"
-)]
-
 use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, encode_catalog_name_key};
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
-use crate::table_schema_plan::{TableSchemaPlanError, TableSchemaSpec};
+use crate::table_schema_plan::{TableSchemaPlanError, TableSpec};
 use crate::whole_file_plan::{WholeFileImagePlan, WholeFilePlanError};
 use crate::{
     ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind,
@@ -76,13 +71,15 @@ const DATABASE_HEADER_FIXED_OPAQUE: [u8; 126] = [
     0x60, 0x26, 0x5f, 0x95, 0xf8, 0xd0, 0x89, 0x24, 0x85, 0x67, 0xc6, 0x1f, 0x27, 0x44, 0xd2, 0xee,
     0xcf, 0x65, 0xed, 0xff, 0x07, 0xc7, 0x46, 0xa1, 0x78, 0x16, 0x0c, 0xed, 0xe9, 0x2d,
 ];
+#[cfg(test)]
 const ALPHA_COLUMNS: [ColumnSpec<'static>; 1] = [ColumnSpec::new(
     b"Id",
     ColumnPhysicalType::Long,
     ColumnStorageKind::Fixed,
     4,
 )];
-const ALPHA_SPEC: TableSchemaSpec<'static> = TableSchemaSpec {
+#[cfg(test)]
+const ALPHA_SPEC: TableSpec<'static> = TableSpec {
     name: b"Alpha",
     columns: &ALPHA_COLUMNS,
     indexes: &[],
@@ -96,9 +93,10 @@ const MSYS_DB_ID: i32 = 0x1000_0000;
 
 #[path = "bootstrap_compose_error.rs"]
 mod error;
-pub(crate) use error::BootstrapComposeError;
+pub use error::BootstrapComposeError;
 
 /// Composes the deterministic 20-page empty image established by `EXP-0073`.
+#[cfg(test)]
 pub(crate) fn compose_empty_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
@@ -108,6 +106,7 @@ pub(crate) fn compose_empty_database(
 
 /// Composes the empty-to-`Alpha(Id Long)` transition from `EXP-0073` in the
 /// null-`LvProp` form `EXP-0091` accepted.
+#[cfg(test)]
 pub(crate) fn compose_alpha_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
@@ -117,7 +116,7 @@ pub(crate) fn compose_alpha_database(
 /// Composes the empty database plus one created user table, following the
 /// `EXP-0091`, `EXP-0093`, and `EXP-0105` first-create observations.
 pub(crate) fn compose_table_database(
-    spec: &TableSchemaSpec<'_>,
+    spec: &TableSpec<'_>,
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, BootstrapComposeError> {
     let planned = PlannedCreate::new(spec)?;

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -4,7 +4,7 @@ use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 // EXP-0073/EXP-0085: the accepted Alpha image's appended page numbers.
 const ALPHA_ROOT: u64 = 20;
 const ALPHA_MAP_PAGE: u64 = 21;
-use crate::table_schema_plan::{TableSchemaSpec, plan_table_schema};
+use crate::table_schema_plan::{TableSpec, plan_table_schema};
 use crate::{
     ByteCount, CatalogObjectClass, ColumnOrdinal, ColumnPhysicalType, ColumnSpec,
     ColumnStorageKind, DatabaseReader, JET3_PAGE_SIZE, MapRowLocator, PageKind, PageNumber,
@@ -594,7 +594,7 @@ fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
         4,
     )];
     let plan = plan_table_schema(
-        &TableSchemaSpec {
+        &TableSpec {
             name: b"Alpha",
             columns: &columns,
             indexes: &[],

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -29,7 +29,7 @@
 
 use super::*;
 use crate::table_schema_plan::{
-    AVAILABLE_MAP_ROW, FIRST_INDEX_MAP_ROW, OWNED_MAP_ROW, TableSchemaPlan, TableSchemaSpec,
+    AVAILABLE_MAP_ROW, FIRST_INDEX_MAP_ROW, OWNED_MAP_ROW, TableSchemaPlan, TableSpec,
     logical_index_order, plan_table_schema,
 };
 
@@ -41,7 +41,7 @@ const MAX_OBSERVED_LONG_VALUE_COLUMNS: usize = 1;
 /// A create with its pages assigned and its map-page rows laid out.
 #[derive(Debug, Clone)]
 pub(super) struct PlannedCreate<'a> {
-    spec: &'a TableSchemaSpec<'a>,
+    spec: &'a TableSpec<'a>,
     plan: TableSchemaPlan,
     /// The long-value column's ordinal; its owned map takes the first free
     /// map-page row and its available map the next.
@@ -50,7 +50,7 @@ pub(super) struct PlannedCreate<'a> {
 
 impl<'a> PlannedCreate<'a> {
     /// Plans `spec` as the first create in the empty database.
-    pub(super) fn new(spec: &'a TableSchemaSpec<'a>) -> Result<Self, BootstrapComposeError> {
+    pub(super) fn new(spec: &'a TableSpec<'a>) -> Result<Self, BootstrapComposeError> {
         let plan = plan_table_schema(spec, EMPTY_DATABASE_PAGE_COUNT)?;
         let mut long_value_columns = long_value_columns(spec);
         let long_value = long_value_columns.next();
@@ -67,10 +67,6 @@ impl<'a> PlannedCreate<'a> {
             plan,
             long_value,
         })
-    }
-
-    pub(super) const fn object_id(&self) -> i32 {
-        self.plan.object_id()
     }
 
     /// Returns the page holding the catalog row's `LvProp` long value.
@@ -201,7 +197,7 @@ impl<'a> PlannedCreate<'a> {
 }
 
 /// Returns the ordinals of the columns that own long-value map groups.
-fn long_value_columns<'s>(spec: &'s TableSchemaSpec<'_>) -> impl Iterator<Item = u16> + 's {
+fn long_value_columns<'s>(spec: &'s TableSpec<'_>) -> impl Iterator<Item = u16> + 's {
     spec.columns
         .iter()
         .enumerate()

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -3,9 +3,7 @@
 
 use super::super::tests::{compose_budget, inline_map_bit, read_budget};
 use super::super::{BootstrapComposeError, compose_table_database};
-use crate::table_schema_plan::{
-    PlannedIndex, PlannedIndexKind, TableSchemaPlanError, TableSchemaSpec,
-};
+use crate::table_schema_plan::{IndexKind, IndexSpec, TableSchemaPlanError, TableSpec};
 use crate::{
     ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
     IndexDirection, IndexFieldSpec, MapRowLocator, PAGE_BYTES, PageKind, PageNumber, SliceSource,
@@ -14,7 +12,7 @@ use crate::{
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-fn create_bytes(spec: &TableSchemaSpec<'_>) -> Result<Vec<u8>, BootstrapComposeError> {
+fn create_bytes(spec: &TableSpec<'_>) -> Result<Vec<u8>, BootstrapComposeError> {
     let mut budget = compose_budget();
     let plan = compose_table_database(spec, &mut budget)?;
     let mut bytes = Vec::with_capacity(plan.pages().len() * PAGE_BYTES);
@@ -79,7 +77,7 @@ fn a_created_memo_table_carries_its_long_value_map_groups_on_its_map_page() -> T
     // EXP-0087's Beta shape as a first create: root, map page, empty LvProp
     // page, and one EXP-0077 map group for the Memo column.
     let columns = [ID, NAME, NOTE];
-    let bytes = create_bytes(&TableSchemaSpec {
+    let bytes = create_bytes(&TableSpec {
         name: b"Beta",
         columns: &columns,
         indexes: &[],
@@ -128,26 +126,26 @@ fn a_three_index_first_create_follows_the_observed_page_and_record_order() -> Te
     // appended in that order, the last one composite with a descending field.
     let columns = [ID, CODE, SEQUENCE];
     let indexes = [
-        PlannedIndex {
+        IndexSpec {
             name: b"ZPrimary",
             fields: &[field(0, IndexDirection::Ascending)],
-            kind: PlannedIndexKind::Primary,
+            kind: IndexKind::Primary,
         },
-        PlannedIndex {
+        IndexSpec {
             name: b"MUniqueX",
             fields: &[field(1, IndexDirection::Ascending)],
-            kind: PlannedIndexKind::Unique,
+            kind: IndexKind::Unique,
         },
-        PlannedIndex {
+        IndexSpec {
             name: b"ASecondx",
             fields: &[
                 field(1, IndexDirection::Descending),
                 field(2, IndexDirection::Ascending),
             ],
-            kind: PlannedIndexKind::Ordinary,
+            kind: IndexKind::Ordinary,
         },
     ];
-    let bytes = create_bytes(&TableSchemaSpec {
+    let bytes = create_bytes(&TableSpec {
         name: b"Three",
         columns: &columns,
         indexes: &indexes,
@@ -227,7 +225,7 @@ fn a_definition_needing_a_continuation_is_refused_before_any_page_is_built() {
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            &TableSchemaSpec {
+            &TableSpec {
                 name: b"Wide",
                 columns: &columns,
                 indexes: &[],
@@ -247,15 +245,15 @@ fn a_definition_needing_a_continuation_is_refused_before_any_page_is_built() {
 fn a_table_with_both_an_index_and_a_long_value_column_is_refused() {
     // No observed create carried both, so their map-page row order is unobserved.
     let columns = [ID, NOTE];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"ById",
         fields: &[field(0, IndexDirection::Ascending)],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            &TableSchemaSpec {
+            &TableSpec {
                 name: b"Mixed",
                 columns: &columns,
                 indexes: &indexes,
@@ -272,7 +270,7 @@ fn a_create_that_cannot_be_planned_reports_the_schema_error() {
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            &TableSchemaSpec {
+            &TableSpec {
                 name: b"",
                 columns: &columns,
                 indexes: &[],
@@ -300,7 +298,7 @@ fn a_second_long_value_column_is_refused() {
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
-            &TableSchemaSpec {
+            &TableSpec {
                 name: b"Wide",
                 columns: &columns,
                 indexes: &[],

--- a/crates/jet3/src/catalog_name_key.rs
+++ b/crates/jet3/src/catalog_name_key.rs
@@ -50,7 +50,7 @@ const TEXT_COMPONENT_OVERHEAD: usize = 2;
 
 /// Structured failure while encoding a `ParentId`/`Name` index key.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CatalogNameKeyError {
+pub enum CatalogNameKeyError {
     /// The name is empty, so it has no text component to encode.
     EmptyName,
     /// `EXP-0087` establishes no primary weight for this name byte.

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -5,7 +5,7 @@
 //! that file through the ordinary reader to check its structure against the
 //! request, and only then publishes it. A destination that already exists is
 //! left untouched, and a destination that was absent stays absent after any
-//! failure.
+//! pre-publication failure.
 //!
 //! The structural reopen is a publication prerequisite, not compatibility
 //! evidence. Only a recorded DAO differential can establish that Microsoft
@@ -23,7 +23,8 @@ use crate::bootstrap_composer::{BootstrapComposeError, compose_table_database};
 use crate::page_append_plan::PlannedPage;
 use crate::{
     CatalogError, CatalogObjectClass, ColumnStorageClass, ColumnStorageKind, DatabaseOpenError,
-    DatabaseReader, PublishError, ResourceBudget, TableDefinitionError, TableSpec,
+    DatabaseReader, IndexDefinitionKind, IndexKind, PublishError, ResourceBudget,
+    TableDefinitionError, TableSpec,
 };
 
 /// Structured failure of [`create_database`].
@@ -99,10 +100,11 @@ impl StdError for CandidateCheckError {
 
 /// Creates the database at `path` holding one empty user table.
 ///
-/// `path` must not exist; an existing entry fails with an `AlreadyExists`
-/// I/O error at [`crate::PublishStage::PrivateCopyCreation`] and is left
-/// unchanged. Composition, the page writes, and the structural reopen are all
-/// charged to `budget`.
+/// After successful composition, `path` must not exist; an existing entry
+/// fails with an `AlreadyExists` I/O error at
+/// [`crate::PublishStage::PrivateCopyCreation`] and is left unchanged.
+/// Composition, the page writes, and the structural reopen are all charged to
+/// `budget`.
 ///
 /// Unsupported layouts fail with [`CreateDatabaseError::Compose`] before
 /// anything is written: more than three indexes, more than one Memo or
@@ -212,7 +214,16 @@ fn check_candidate(
         if logical.name().raw_bytes() != requested.name {
             return Err(mismatch("index name"));
         }
-        let fields = definition.physical_indexes()[physical].fields();
+        let physical_definition = &definition.physical_indexes()[physical];
+        let (logical_kind, physical_flags) = match requested.kind {
+            IndexKind::Primary => (IndexDefinitionKind::Primary, 0x09),
+            IndexKind::Unique => (IndexDefinitionKind::Ordinary, 0x01),
+            IndexKind::Ordinary => (IndexDefinitionKind::Ordinary, 0x00),
+        };
+        if logical.kind() != logical_kind || physical_definition.raw_flags() != physical_flags {
+            return Err(mismatch("index kind"));
+        }
+        let fields = physical_definition.fields();
         if fields.len() != requested.fields.len()
             || fields.iter().zip(requested.fields).any(|(field, wanted)| {
                 field.column().get() != wanted.column || field.direction() != wanted.direction

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -1,0 +1,229 @@
+//! Creation of a fresh Jet 3 database holding one empty user table.
+//!
+//! [`create_database`] composes the complete image in memory, writes every
+//! page in physical order to a private file beside the destination, reopens
+//! that file through the ordinary reader to check its structure against the
+//! request, and only then publishes it. A destination that already exists is
+//! left untouched, and a destination that was absent stays absent after any
+//! failure.
+//!
+//! The structural reopen is a publication prerequisite, not compatibility
+//! evidence. Only a recorded DAO differential can establish that Microsoft
+//! Access or DAO consume a created database; none has been run for schemas
+//! other than the exact `Alpha(Id Long)` construction of `EXP-0091`.
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::Path;
+
+use crate::atomic::atomic_create;
+use crate::bootstrap_composer::{BootstrapComposeError, compose_table_database};
+use crate::page_append_plan::PlannedPage;
+use crate::{
+    CatalogError, CatalogObjectClass, ColumnStorageClass, ColumnStorageKind, DatabaseOpenError,
+    DatabaseReader, PublishError, ResourceBudget, TableDefinitionError, TableSpec,
+};
+
+/// Structured failure of [`create_database`].
+#[derive(Debug)]
+pub enum CreateDatabaseError {
+    /// The table could not be composed into a database image; nothing was
+    /// written.
+    Compose(BootstrapComposeError),
+    /// The composed image could not be written, checked, or published.
+    Publish(PublishError),
+}
+
+impl fmt::Display for CreateDatabaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Compose(source) => write!(formatter, "database composition failed: {source}"),
+            Self::Publish(source) => write!(formatter, "database publication failed: {source}"),
+        }
+    }
+}
+
+impl StdError for CreateDatabaseError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Compose(source) => Some(source),
+            Self::Publish(source) => Some(source),
+        }
+    }
+}
+
+/// A structural difference between the written candidate and the request,
+/// found when the candidate was reopened before publication.
+#[derive(Debug)]
+pub enum CandidateCheckError {
+    /// The candidate could not be opened as a Jet 3 database.
+    Open(DatabaseOpenError),
+    /// The candidate's catalog could not be read.
+    Catalog(CatalogError),
+    /// The created table's definition could not be read.
+    Definition(TableDefinitionError),
+    /// The candidate decodes but does not describe the requested table.
+    Mismatch {
+        /// Which structure differed.
+        detail: &'static str,
+    },
+}
+
+impl fmt::Display for CandidateCheckError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Open(source) => write!(formatter, "candidate did not open: {source}"),
+            Self::Catalog(source) => write!(formatter, "candidate catalog failed: {source}"),
+            Self::Definition(source) => {
+                write!(formatter, "candidate table definition failed: {source}")
+            }
+            Self::Mismatch { detail } => {
+                write!(formatter, "candidate does not match the request: {detail}")
+            }
+        }
+    }
+}
+
+impl StdError for CandidateCheckError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Open(source) => Some(source),
+            Self::Catalog(source) => Some(source),
+            Self::Definition(source) => Some(source),
+            Self::Mismatch { .. } => None,
+        }
+    }
+}
+
+/// Creates the database at `path` holding one empty user table.
+///
+/// `path` must not exist; an existing entry fails with an `AlreadyExists`
+/// I/O error at [`crate::PublishStage::PrivateCopyCreation`] and is left
+/// unchanged. Composition, the page writes, and the structural reopen are all
+/// charged to `budget`.
+///
+/// Unsupported layouts fail with [`CreateDatabaseError::Compose`] before
+/// anything is written: more than three indexes, more than one Memo or
+/// LongBinary column, an index together with such a column, a definition
+/// longer than one page, or a name byte above `0x7E`.
+pub fn create_database(
+    path: impl AsRef<Path>,
+    spec: &TableSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<(), CreateDatabaseError> {
+    let pages = compose_table_database(spec, budget)
+        .map_err(CreateDatabaseError::Compose)?
+        .into_pages();
+    let page_count = pages.len() as u64;
+    budget
+        .charge_work_units(page_count.saturating_mul(crate::PAGE_BYTES as u64))
+        .map_err(|error| CreateDatabaseError::Compose(BootstrapComposeError::Encoding(error)))?;
+    atomic_create(
+        path,
+        |file| write_pages(file, &pages),
+        |candidate| check_candidate(candidate, spec, page_count, budget),
+    )
+    .map_err(CreateDatabaseError::Publish)
+}
+
+/// Writes every page in physical order and sets the exact final length.
+fn write_pages(file: &mut File, pages: &[PlannedPage]) -> Result<(), io::Error> {
+    for (slot, page) in pages.iter().enumerate() {
+        if page.number().get() != slot as u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "planned pages are not in physical order",
+            ));
+        }
+        file.write_all(page.image().as_bytes())?;
+    }
+    file.set_len(pages.len() as u64 * crate::PAGE_BYTES as u64)?;
+    file.flush()
+}
+
+/// Reopens the candidate through the reader and checks its geometry, catalog
+/// row, columns, and indexes against `spec`.
+fn check_candidate(
+    candidate: &Path,
+    spec: &TableSpec<'_>,
+    page_count: u64,
+    budget: &mut ResourceBudget,
+) -> Result<(), CandidateCheckError> {
+    let mismatch = |detail: &'static str| CandidateCheckError::Mismatch { detail };
+    let mut database =
+        DatabaseReader::open(candidate, budget).map_err(CandidateCheckError::Open)?;
+    if database.geometry().page_count() != page_count {
+        return Err(mismatch("page count"));
+    }
+    let mut root = None;
+    {
+        let mut catalog = database
+            .catalog(budget)
+            .map_err(CandidateCheckError::Catalog)?;
+        while let Some(record) = catalog
+            .next_record()
+            .map_err(CandidateCheckError::Catalog)?
+        {
+            if record.name().raw_bytes() == spec.name {
+                if record.class() != CatalogObjectClass::User || root.is_some() {
+                    return Err(mismatch("catalog row"));
+                }
+                root = record.table_definition();
+            }
+        }
+    }
+    let root = root.ok_or(mismatch("catalog row"))?;
+    let definition = database
+        .table_definition(root, budget)
+        .map_err(CandidateCheckError::Definition)?;
+    if definition.columns().len() != spec.columns.len() {
+        return Err(mismatch("column count"));
+    }
+    for (column, requested) in definition.columns().iter().zip(spec.columns) {
+        let storage_matches = matches!(
+            (column.storage(), requested.storage()),
+            (ColumnStorageClass::Fixed { .. }, ColumnStorageKind::Fixed)
+                | (
+                    ColumnStorageClass::Variable { .. },
+                    ColumnStorageKind::Variable
+                )
+        );
+        if column.name().raw_bytes() != requested.name()
+            || column.physical_type() != requested.physical_type()
+            || column.size() != requested.size()
+            || !storage_matches
+        {
+            return Err(mismatch("column"));
+        }
+    }
+    if definition.physical_indexes().len() != spec.indexes.len()
+        || definition.indexes().len() != spec.indexes.len()
+    {
+        return Err(mismatch("index count"));
+    }
+    for logical in definition.indexes() {
+        let physical = usize::from(logical.physical_index());
+        let requested = spec
+            .indexes
+            .get(physical)
+            .ok_or(mismatch("index reference"))?;
+        if logical.name().raw_bytes() != requested.name {
+            return Err(mismatch("index name"));
+        }
+        let fields = definition.physical_indexes()[physical].fields();
+        if fields.len() != requested.fields.len()
+            || fields.iter().zip(requested.fields).any(|(field, wanted)| {
+                field.column().get() != wanted.column || field.direction() != wanted.direction
+            })
+        {
+            return Err(mismatch("index fields"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+#[path = "create_tests.rs"]
+mod tests;

--- a/crates/jet3/src/create_tests.rs
+++ b/crates/jet3/src/create_tests.rs
@@ -1,0 +1,256 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::{CreateDatabaseError, create_database};
+use crate::table_schema_plan::TableSchemaPlanError;
+use crate::{
+    BootstrapComposeError, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
+    IndexDirection, IndexFieldSpec, IndexKind, IndexSpec, PageNumber, PublishStage, ResourceBudget,
+    ResourceLimits, TableSpec,
+};
+
+static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+type Accepts = fn(&BootstrapComposeError) -> bool;
+
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn create() -> Result<Self, std::io::Error> {
+        let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "jet3-create-test-{}-{sequence}",
+            std::process::id()
+        ));
+        fs::create_dir(&path)?;
+        Ok(Self { path })
+    }
+
+    fn target(&self) -> PathBuf {
+        self.path.join("created.mdb")
+    }
+
+    fn entries(&self) -> Result<Vec<String>, std::io::Error> {
+        let mut names = Vec::new();
+        for entry in fs::read_dir(&self.path)? {
+            names.push(entry?.file_name().to_string_lossy().into_owned());
+        }
+        names.sort();
+        Ok(names)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _cleanup_result = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+
+const ID: ColumnSpec<'static> =
+    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4);
+const CODE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Code",
+    ColumnPhysicalType::Text,
+    ColumnStorageKind::Variable,
+    8,
+);
+const SEQUENCE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Sequence",
+    ColumnPhysicalType::Long,
+    ColumnStorageKind::Fixed,
+    4,
+);
+const NOTE: ColumnSpec<'static> = ColumnSpec::new(
+    b"Note",
+    ColumnPhysicalType::Memo,
+    ColumnStorageKind::Variable,
+    0,
+);
+
+const fn field(column: u16, direction: IndexDirection) -> IndexFieldSpec {
+    IndexFieldSpec { column, direction }
+}
+
+#[test]
+fn a_mixed_table_with_three_indexes_is_created_and_reopens() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let columns = [ID, CODE, SEQUENCE];
+    let indexes = [
+        IndexSpec {
+            name: b"PrimaryKey",
+            fields: &[field(0, IndexDirection::Ascending)],
+            kind: IndexKind::Primary,
+        },
+        IndexSpec {
+            name: b"ByCode",
+            fields: &[field(1, IndexDirection::Ascending)],
+            kind: IndexKind::Unique,
+        },
+        IndexSpec {
+            name: b"BySequence",
+            fields: &[
+                field(1, IndexDirection::Descending),
+                field(2, IndexDirection::Ascending),
+            ],
+            kind: IndexKind::Ordinary,
+        },
+    ];
+    let spec = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &indexes,
+    };
+    create_database(&target, &spec, &mut budget())?;
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    assert_eq!(fs::metadata(&target)?.len(), 26 * crate::PAGE_BYTES as u64);
+
+    let mut budget = budget();
+    let mut database = DatabaseReader::open(&target, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.columns().len(), 3);
+    assert_eq!(definition.physical_indexes().len(), 3);
+    assert_eq!(definition.physical_indexes()[1].raw_flags(), 0x01);
+    assert_eq!(
+        definition
+            .indexes()
+            .iter()
+            .map(|index| index.name().raw_bytes())
+            .collect::<Vec<_>>(),
+        [b"ByCode".as_slice(), b"BySequence", b"PrimaryKey"]
+    );
+    for ordinal in 0..3 {
+        assert!(
+            database
+                .index_tree(&definition, ordinal, &mut budget)?
+                .entries()
+                .is_empty()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn a_memo_table_is_created_and_reopens() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let columns = [ID, NOTE];
+    let spec = TableSpec {
+        name: b"Notes",
+        columns: &columns,
+        indexes: &[],
+    };
+    create_database(&target, &spec, &mut budget())?;
+    assert_eq!(fs::metadata(&target)?.len(), 23 * crate::PAGE_BYTES as u64);
+    let mut budget = budget();
+    let mut database = DatabaseReader::open(&target, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.long_value_maps().len(), 1);
+    Ok(())
+}
+
+#[test]
+fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let by_id = [IndexSpec {
+        name: b"ById",
+        fields: &[field(0, IndexDirection::Ascending)],
+        kind: IndexKind::Ordinary,
+    }];
+    let indexed_memo = [ID, NOTE];
+    let high_byte = [ColumnSpec::new(
+        b"Caf\xe9",
+        ColumnPhysicalType::Long,
+        ColumnStorageKind::Fixed,
+        4,
+    )];
+    let wide_names = (0..70)
+        .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
+        .collect::<Vec<_>>();
+    let wide = wide_names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .collect::<Vec<_>>();
+    let cases: [(TableSpec<'_>, Accepts); 3] = [
+        (
+            TableSpec {
+                name: b"Mixed",
+                columns: &indexed_memo,
+                indexes: &by_id,
+            },
+            |error| matches!(error, BootstrapComposeError::UnobservedMapRowLayout),
+        ),
+        (
+            TableSpec {
+                name: b"Accent",
+                columns: &high_byte,
+                indexes: &[],
+            },
+            |error| {
+                matches!(
+                    error,
+                    BootstrapComposeError::Schema(TableSchemaPlanError::NameByteUnestablished {
+                        byte: 0xe9,
+                        ..
+                    })
+                )
+            },
+        ),
+        (
+            TableSpec {
+                name: b"Wide",
+                columns: &wide,
+                indexes: &[],
+            },
+            |error| {
+                matches!(
+                    error,
+                    BootstrapComposeError::Schema(
+                        TableSchemaPlanError::ContinuationPlacementUnestablished {
+                            continuations: 1,
+                            ..
+                        }
+                    )
+                )
+            },
+        ),
+    ];
+    for (spec, accepts) in cases {
+        match create_database(&target, &spec, &mut budget()) {
+            Err(CreateDatabaseError::Compose(error)) if accepts(&error) => {}
+            other => return Err(format!("unexpected result: {other:?}").into()),
+        }
+        assert!(directory.entries()?.is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn an_existing_destination_is_refused_and_left_unchanged() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    fs::write(&target, b"keep me")?;
+    let columns = [ID];
+    let spec = TableSpec {
+        name: b"Alpha",
+        columns: &columns,
+        indexes: &[],
+    };
+    match create_database(&target, &spec, &mut budget()) {
+        Err(CreateDatabaseError::Publish(error)) => {
+            assert_eq!(error.stage(), PublishStage::PrivateCopyCreation);
+        }
+        other => return Err(format!("unexpected result: {other:?}").into()),
+    }
+    assert_eq!(fs::read(&target)?, b"keep me");
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}

--- a/crates/jet3/src/create_tests.rs
+++ b/crates/jet3/src/create_tests.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::{CreateDatabaseError, create_database};
+use super::{CandidateCheckError, CreateDatabaseError, check_candidate, create_database};
 use crate::table_schema_plan::TableSchemaPlanError;
 use crate::{
     BootstrapComposeError, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
@@ -134,6 +134,54 @@ fn a_mixed_table_with_three_indexes_is_created_and_reopens() -> TestResult {
                 .is_empty()
         );
     }
+    Ok(())
+}
+
+#[test]
+fn candidate_check_rejects_an_index_kind_mismatch() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let columns = [ID];
+    let fields = [field(0, IndexDirection::Ascending)];
+    let unique_indexes = [IndexSpec {
+        name: b"ById",
+        fields: &fields,
+        kind: IndexKind::Unique,
+    }];
+    create_database(
+        &target,
+        &TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &unique_indexes,
+        },
+        &mut budget(),
+    )?;
+
+    let ordinary_indexes = [IndexSpec {
+        name: b"ById",
+        fields: &fields,
+        kind: IndexKind::Ordinary,
+    }];
+    let page_count = fs::metadata(&target)?.len() / crate::PAGE_BYTES as u64;
+    let error = check_candidate(
+        &target,
+        &TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &ordinary_indexes,
+        },
+        page_count,
+        &mut budget(),
+    )
+    .err()
+    .ok_or("candidate check accepted mismatched index flags")?;
+    assert!(matches!(
+        error,
+        CandidateCheckError::Mismatch {
+            detail: "index kind"
+        }
+    ));
     Ok(())
 }
 

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -1,5 +1,40 @@
 #![forbid(unsafe_code)]
-#![doc = "Safe, clean-room primitives for Access 97 / Jet 3 databases."]
+//! Safe, clean-room primitives for Access 97 / Jet 3 databases.
+//!
+//! Reading starts at [`DatabaseReader`]. Creating a fresh database holding
+//! one empty user table starts at [`create_database`]:
+//!
+//! ```no_run
+//! use jet3::{
+//!     ColumnPhysicalType, ColumnSpec, ColumnStorageKind, IndexDirection, IndexFieldSpec,
+//!     IndexKind, IndexSpec, ResourceBudget, ResourceLimits, TableSpec, create_database,
+//! };
+//!
+//! let columns = [
+//!     ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
+//!     ColumnSpec::new(b"Name", ColumnPhysicalType::Text, ColumnStorageKind::Variable, 50),
+//! ];
+//! let indexes = [IndexSpec {
+//!     name: b"PrimaryKey",
+//!     fields: &[IndexFieldSpec {
+//!         column: 0,
+//!         direction: IndexDirection::Ascending,
+//!     }],
+//!     kind: IndexKind::Primary,
+//! }];
+//! let spec = TableSpec {
+//!     name: b"People",
+//!     columns: &columns,
+//!     indexes: &indexes,
+//! };
+//! let mut budget = ResourceBudget::new(ResourceLimits::default());
+//! create_database("people.mdb", &spec, &mut budget)?;
+//! # Ok::<(), jet3::CreateDatabaseError>(())
+//! ```
+//!
+//! The created image is reopened structurally before publication. That
+//! self-check is not evidence of Microsoft Access or DAO compatibility; only
+//! a recorded DAO differential can establish that.
 
 pub mod allocation;
 pub mod allocation_traverse;
@@ -15,6 +50,7 @@ pub mod catalog_record_writer;
 pub mod column_definition;
 pub mod column_definition_writer;
 pub mod commit_state;
+pub mod create;
 mod data_page_directory;
 pub mod database;
 pub mod database_header;
@@ -63,11 +99,16 @@ pub use allocation_traverse::{
     AllocationTraversalError, OwnedPages, PageChainWalker, ReachedMapPage, VisitedPages,
     follow_map_page_reference,
 };
-pub use atomic::{PublishError, PublishStage, atomic_update, atomic_update_with_hook};
+pub use atomic::{
+    PublishError, PublishStage, atomic_create, atomic_create_with_hook, atomic_update,
+    atomic_update_with_hook,
+};
 pub use binary::BinaryCursor;
 pub use binary_writer::BinaryWriter;
+pub use bootstrap_composer::BootstrapComposeError;
 pub use candidate::{CandidateError, RawJet3Candidate};
 pub use catalog::{CatalogCursor, CatalogError};
+pub use catalog_name_key::CatalogNameKeyError;
 pub use catalog_record::{
     CatalogName, CatalogNameEncoding, CatalogObjectClass, CatalogObjectId, CatalogObjectKind,
     CatalogRecord, CatalogRecordError,
@@ -87,6 +128,7 @@ pub use commit_state::{
     CommitSlotRole, CommitStateClass, SHARED_COMMIT_SLOT_COUNT, read_commit_region,
     read_commit_region_into,
 };
+pub use create::{CandidateCheckError, CreateDatabaseError, create_database};
 pub use database::{DatabaseOpenError, DatabasePageError, DatabaseReader};
 pub use database_header::{
     DATABASE_HEADER_PAGE_NUMBER, DatabaseFormatError, DatabaseHeaderPage, DatabaseHeaderPageError,
@@ -114,6 +156,7 @@ pub use long_value_map::{LONG_VALUE_MAP_GROUP_LEN, LongValueMapDefinition, LongV
 pub use map_location::{MapLocationError, MapRowLocator, TableMapLocations, locate_table_maps};
 pub use offset::{ByteCount, ByteOffset};
 pub use page::{PageGeometry, PageNumber, PageOffset};
+pub use page_append_plan::AppendPageError;
 pub use page_image::{DataPageBuilder, PAGE_BYTES, PageImage, PageImageError, page_tag};
 pub use page_kind::{ClassifiedPage, PageClassificationError, PageKind, classify_page};
 pub use raw_page_stream::{RawPage, RawPageCursor};
@@ -128,6 +171,7 @@ pub use table_definition_writer::{
     LongValueMapSpec, PhysicalIndexFlagsSpec, TableDefinitionSpec, TableDefinitionWriteError,
     encode_table_definition, table_definition_len,
 };
+pub use table_schema_plan::{IndexKind, IndexSpec, TableSchemaPlanError, TableSpec};
 pub use text::{DecodedText, TextCodePage, TextError};
 pub use usage_map::{UsageMapError, UsageMapRecord, locate_usage_map};
 pub use usage_map_writer::{
@@ -135,6 +179,7 @@ pub use usage_map_writer::{
     encode_indirect_references, indirect_record_len,
 };
 pub use value::{CurrencyValue, DateTimeValue, DecodedValue, GuidValue, ValueError, ValueKind};
+pub use whole_file_plan::WholeFilePlanError;
 
 /// Human-readable name of the only database format targeted by this crate.
 pub const FORMAT_NAME: &str = "Access 97 / Jet 3";

--- a/crates/jet3/src/page_append_plan.rs
+++ b/crates/jet3/src/page_append_plan.rs
@@ -100,7 +100,7 @@ pub(crate) fn plan_existing_pages(
 
 /// Structured failure while planning one fresh page append.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum AppendPageError {
+pub enum AppendPageError {
     /// The current page count cannot advance after another append.
     PageCountOverflow {
         /// Page count that could not be incremented.

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -1,5 +1,5 @@
-//! Crate-private typed planning of one new user table as a database's first
-//! create.
+//! Typed description and crate-private planning of one new user table as a
+//! database's first create.
 //!
 //! This validates a caller-described table and assigns its appended pages. It
 //! builds no page bytes and performs no I/O.
@@ -25,11 +25,6 @@
 //!
 //! Neither experiment establishes an `Id` allocation rule beyond the observed
 //! equality with the definition root page.
-
-#![allow(
-    dead_code,
-    reason = "crate-private writer slice awaiting DAO validation"
-)]
 
 use std::fmt;
 
@@ -62,9 +57,9 @@ pub(crate) const CONTINUATION_CAPACITY: usize = PAGE_BYTES - 8;
 /// `EXP-0101` is bounded and does not widen this.
 const LAST_ESTABLISHED_NAME_BYTE: u8 = 0x7e;
 
-/// The uniqueness class of a planned index.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PlannedIndexKind {
+/// The uniqueness class of an index in a [`TableSpec`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IndexKind {
     /// The table's primary index; `EXP-0093` observed physical flags `0x09`.
     Primary,
     /// A unique non-primary index; `EXP-0093` observed physical flags `0x01`.
@@ -73,7 +68,7 @@ pub(crate) enum PlannedIndexKind {
     Ordinary,
 }
 
-impl PlannedIndexKind {
+impl IndexKind {
     /// Returns the physical flag class this index kind encodes to.
     pub(crate) const fn flags(self) -> PhysicalIndexFlagsSpec {
         match self {
@@ -92,31 +87,31 @@ impl PlannedIndexKind {
     }
 }
 
-/// One index of a table being planned.
+/// One index of a [`TableSpec`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct PlannedIndex<'a> {
-    /// Index name in the database's configured code page.
-    pub(crate) name: &'a [u8],
-    /// Ordered key fields.
-    pub(crate) fields: &'a [IndexFieldSpec],
+pub struct IndexSpec<'a> {
+    /// Index name; bytes must be at most `0x7E`.
+    pub name: &'a [u8],
+    /// Ordered key fields naming table column ordinals.
+    pub fields: &'a [IndexFieldSpec],
     /// The index's uniqueness class.
-    pub(crate) kind: PlannedIndexKind,
+    pub kind: IndexKind,
 }
 
-/// A caller-described user table awaiting validation and page assignment.
+/// One user table to create.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TableSchemaSpec<'a> {
-    /// Table name in the database's configured code page.
-    pub(crate) name: &'a [u8],
+pub struct TableSpec<'a> {
+    /// Table name; bytes must be at most `0x7E`.
+    pub name: &'a [u8],
     /// The table's columns in ordinal order.
-    pub(crate) columns: &'a [ColumnSpec<'a>],
-    /// The table's indexes in physical (append) order.
-    pub(crate) indexes: &'a [PlannedIndex<'a>],
+    pub columns: &'a [ColumnSpec<'a>],
+    /// The table's indexes in physical (append) order; at most three.
+    pub indexes: &'a [IndexSpec<'a>],
 }
 
 /// Structured failure while planning one new user table.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum TableSchemaPlanError {
+pub enum TableSchemaPlanError {
     /// The table name cannot be encoded into a catalog index key.
     TableNameKey(CatalogNameKeyError),
     /// The table name cannot be encoded into an `MSysObjects` row.
@@ -208,7 +203,6 @@ impl std::error::Error for TableSchemaPlanError {
 pub(crate) struct TableSchemaPlan {
     object_id: i32,
     definition_root: PageNumber,
-    definition_len: usize,
     index_count: usize,
 }
 
@@ -221,11 +215,6 @@ impl TableSchemaPlan {
     /// Returns the page holding the table's definition.
     pub(crate) const fn definition_root(&self) -> PageNumber {
         self.definition_root
-    }
-
-    /// Returns the exact logical length of the encoded definition.
-    pub(crate) const fn definition_len(&self) -> usize {
-        self.definition_len
     }
 
     /// Returns the page holding the table's usage-map rows.
@@ -260,7 +249,7 @@ impl TableSchemaPlan {
 /// Validates `spec` as a first create and assigns its appended pages starting
 /// at `first_page`, the database's current page count.
 pub(crate) fn plan_table_schema(
-    spec: &TableSchemaSpec<'_>,
+    spec: &TableSpec<'_>,
     first_page: u64,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
     validate_table_name(spec.name)?;
@@ -278,15 +267,15 @@ pub(crate) fn plan_table_schema(
             observed: MAX_OBSERVED_INDEXES,
         });
     }
-    let definition_len = measure_definition(spec)?;
-    let continuations = continuation_count(definition_len);
+    let length = measure_definition(spec)?;
+    let continuations = continuation_count(length);
     if continuations > 0 {
         return Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
-            length: definition_len,
+            length,
             continuations,
         });
     }
-    let plan = assign_pages(spec, first_page, definition_len)?;
+    let plan = assign_pages(spec, first_page)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
 }
@@ -319,7 +308,7 @@ fn validate_name_bytes(
 }
 
 /// Returns the exact logical length of the definition `spec` encodes to.
-fn measure_definition(spec: &TableSchemaSpec<'_>) -> Result<usize, TableSchemaPlanError> {
+fn measure_definition(spec: &TableSpec<'_>) -> Result<usize, TableSchemaPlanError> {
     // The writer requires one long-value map group per Memo or LongBinary
     // column, so the group count follows from the columns.
     let long_value_maps = spec
@@ -351,9 +340,8 @@ pub(crate) const fn continuation_count(length: usize) -> usize {
 
 /// Assigns the appended page run, refusing numbers the encoders cannot name.
 fn assign_pages(
-    spec: &TableSchemaSpec<'_>,
+    spec: &TableSpec<'_>,
     first_page: u64,
-    definition_len: usize,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
     let needed = 3 + spec.indexes.len() as u64;
     // `EXP-0093` numbers the object equal to its definition root, and
@@ -375,7 +363,6 @@ fn assign_pages(
     Ok(TableSchemaPlan {
         object_id,
         definition_root: PageNumber::new(first_page),
-        definition_len,
         index_count: spec.indexes.len(),
     })
 }
@@ -383,7 +370,7 @@ fn assign_pages(
 /// Checks each index against the physical-index encoder, the primary count,
 /// and the name-order rule the logical records will follow.
 fn validate_indexes(
-    spec: &TableSchemaSpec<'_>,
+    spec: &TableSpec<'_>,
     plan: &TableSchemaPlan,
 ) -> Result<(), TableSchemaPlanError> {
     let mut primary: Option<usize> = None;
@@ -413,7 +400,7 @@ fn validate_indexes(
         };
         validate_physical_index(ordinal, &physical, spec.columns)
             .map_err(TableSchemaPlanError::Definition)?;
-        if planned.kind == PlannedIndexKind::Primary
+        if planned.kind == IndexKind::Primary
             && let Some(first) = primary.replace(position)
         {
             return Err(TableSchemaPlanError::MultiplePrimaryIndexes {
@@ -440,7 +427,7 @@ fn validate_indexes(
 ///
 /// Names are compared by byte value; the planner has already refused pairs
 /// whose byte order and ASCII case-folded order disagree.
-pub(crate) fn logical_index_order(indexes: &[PlannedIndex<'_>]) -> Vec<usize> {
+pub(crate) fn logical_index_order(indexes: &[IndexSpec<'_>]) -> Vec<usize> {
     let mut order: Vec<usize> = (0..indexes.len()).collect();
     order.sort_by(|left, right| indexes[*left].name.cmp(indexes[*right].name));
     order

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -36,9 +36,9 @@ const fn key(column: u16) -> IndexFieldSpec {
 fn spec<'a>(
     name: &'a [u8],
     columns: &'a [ColumnSpec<'a>],
-    indexes: &'a [PlannedIndex<'a>],
-) -> TableSchemaSpec<'a> {
-    TableSchemaSpec {
+    indexes: &'a [IndexSpec<'a>],
+) -> TableSpec<'a> {
+    TableSpec {
         name,
         columns,
         indexes,
@@ -46,7 +46,7 @@ fn spec<'a>(
 }
 
 /// Returns the definition error planning `spec` produced, if it produced one.
-fn definition_error(spec: &TableSchemaSpec<'_>) -> Option<TableDefinitionWriteError> {
+fn definition_error(spec: &TableSpec<'_>) -> Option<TableDefinitionWriteError> {
     match plan_table_schema(spec, 20) {
         Err(TableSchemaPlanError::Definition(error)) => Some(error),
         _ => None,
@@ -94,20 +94,20 @@ fn index_roots_follow_the_property_page_in_physical_order() -> PlanResult {
     // EXP-0093's `three` arm: one root and one map row per physical ordinal.
     let columns = [ID, LABEL, NAME];
     let indexes = [
-        PlannedIndex {
+        IndexSpec {
             name: b"ZPrimary",
             fields: &[key(0)],
-            kind: PlannedIndexKind::Primary,
+            kind: IndexKind::Primary,
         },
-        PlannedIndex {
+        IndexSpec {
             name: b"MUniqueX",
             fields: &[key(1)],
-            kind: PlannedIndexKind::Unique,
+            kind: IndexKind::Unique,
         },
-        PlannedIndex {
+        IndexSpec {
             name: b"ASecondx",
             fields: &[key(2)],
-            kind: PlannedIndexKind::Ordinary,
+            kind: IndexKind::Ordinary,
         },
     ];
     let plan = plan_table_schema(&spec(b"Three", &columns, &indexes), 28)?;
@@ -129,19 +129,16 @@ fn index_roots_follow_the_property_page_in_physical_order() -> PlanResult {
 fn index_kinds_map_to_the_observed_flag_classes() {
     // EXP-0093: primary 0x09, unique non-primary 0x01, ordinary 0x00.
     assert_eq!(
-        PlannedIndexKind::Primary.flags(),
+        IndexKind::Primary.flags(),
         PhysicalIndexFlagsSpec::UniqueRequired
     );
+    assert_eq!(IndexKind::Unique.flags(), PhysicalIndexFlagsSpec::Unique);
     assert_eq!(
-        PlannedIndexKind::Unique.flags(),
-        PhysicalIndexFlagsSpec::Unique
-    );
-    assert_eq!(
-        PlannedIndexKind::Ordinary.flags(),
+        IndexKind::Ordinary.flags(),
         PhysicalIndexFlagsSpec::Ordinary
     );
     assert_eq!(
-        PlannedIndexKind::Unique.logical_kind(),
+        IndexKind::Unique.logical_kind(),
         LogicalIndexKindSpec::Ordinary
     );
 }
@@ -151,15 +148,15 @@ fn index_names_whose_order_depends_on_case_folding_are_refused() {
     // Byte order puts "Banana" first; case-folded order puts "apple" first.
     let columns = [ID, LABEL];
     let indexes = [
-        PlannedIndex {
+        IndexSpec {
             name: b"apple",
             fields: &[key(0)],
-            kind: PlannedIndexKind::Ordinary,
+            kind: IndexKind::Ordinary,
         },
-        PlannedIndex {
+        IndexSpec {
             name: b"Banana",
             fields: &[key(1)],
-            kind: PlannedIndexKind::Ordinary,
+            kind: IndexKind::Ordinary,
         },
     ];
     assert_eq!(
@@ -189,10 +186,10 @@ fn a_name_byte_above_the_established_range_is_refused() {
         })
     );
     let columns = [ID];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"By\x80",
         fields: &[key(0)],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert_eq!(
         plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
@@ -269,10 +266,10 @@ fn a_column_name_too_long_for_the_definition_is_refused() {
 fn an_index_name_too_long_for_the_definition_is_refused() {
     let overlong = vec![b'A'; 256];
     let columns = [ID];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: &overlong,
         fields: &[key(0)],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &indexes)),
@@ -395,10 +392,10 @@ fn more_indexes_than_any_create_carried_are_refused() {
     let indexes = fields
         .iter()
         .zip([b"A".as_slice(), b"B", b"C", b"D"])
-        .map(|(field, name)| PlannedIndex {
+        .map(|(field, name)| IndexSpec {
             name,
             fields: std::slice::from_ref(field),
-            kind: PlannedIndexKind::Ordinary,
+            kind: IndexKind::Ordinary,
         })
         .collect::<Vec<_>>();
     assert_eq!(
@@ -413,10 +410,10 @@ fn more_indexes_than_any_create_carried_are_refused() {
 #[test]
 fn an_index_naming_no_columns_is_refused() {
     let columns = [ID];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"ById",
         fields: &[],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &indexes)),
@@ -427,10 +424,10 @@ fn an_index_naming_no_columns_is_refused() {
 #[test]
 fn an_index_naming_an_undeclared_column_is_refused() {
     let columns = [ID];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"ById",
         fields: &[key(1)],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &indexes)),
@@ -441,10 +438,10 @@ fn an_index_naming_an_undeclared_column_is_refused() {
 #[test]
 fn an_index_over_a_memo_column_is_refused() {
     let columns = [NOTE];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"ByNote",
         fields: &[key(0)],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &indexes)),
@@ -459,10 +456,10 @@ fn an_index_over_a_memo_column_is_refused() {
 #[test]
 fn an_index_naming_one_column_twice_is_refused() {
     let columns = [ID, LABEL];
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"ById",
         fields: &[key(0), key(1), key(0)],
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &indexes)),
@@ -480,10 +477,10 @@ fn an_index_field_count_one_above_the_limit_is_refused() {
         .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
         .collect::<Vec<_>>();
     let fields = (0..=KEY_SLOT_COUNT as u16).map(key).collect::<Vec<_>>();
-    let indexes = [PlannedIndex {
+    let indexes = [IndexSpec {
         name: b"Wide",
         fields: &fields,
-        kind: PlannedIndexKind::Ordinary,
+        kind: IndexKind::Ordinary,
     }];
     assert!(matches!(
         definition_error(&spec(b"Wide", &columns, &indexes)),
@@ -543,7 +540,6 @@ fn a_definition_that_exactly_fills_its_root_page_needs_no_continuation() -> Plan
     let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY);
     let columns = long_columns(&names);
     let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
-    assert_eq!(plan.definition_len(), DEFINITION_ROOT_CAPACITY);
     assert_eq!(plan.appended_page_count(), 3);
     Ok(())
 }

--- a/crates/jet3/src/whole_file_plan.rs
+++ b/crates/jet3/src/whole_file_plan.rs
@@ -21,7 +21,7 @@ const EXISTING_PAGE_COUNT: usize = EMPTY_DATABASE_PAGE_COUNT as usize;
 
 /// Structured failure while aggregating a whole-file page plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum WholeFilePlanError {
+pub enum WholeFilePlanError {
     /// Resource accounting or allocation failed while retaining page plans.
     Resource(Error),
     /// A fresh image could not be appended.


### PR DESCRIPTION
Stacked on #176; retarget to `main` once that merges.

Downstream Rust code had no way to create a Jet 3 database: the composer was crate-private and there was no fresh-file publication primitive. This adds the public entry point from #100:

```rust
jet3::create_database(path, &spec, &mut budget)?;
```

- **Public spec types are the existing planner types**, renamed at their definition site: `TableSpec`, `IndexSpec`, and `IndexKind` (primary, unique, ordinary). `ColumnSpec` and `IndexFieldSpec` were already public. No conversion layer, builder, or new error hierarchy; the planner and composer errors are simply made public. API rustification stays in #175.
- **`atomic_create`** sits beside `atomic_update` and reuses its private-file guard, identity check, sync, and cleanup. It refuses an existing destination with `AlreadyExists` and leaves it untouched, and publishes by hard-linking the private file so a destination that appears mid-operation is never replaced. Any earlier failure leaves an absent destination absent.
- **`create_database`** composes the image, writes every page in physical order, sets the exact length, reopens the private candidate through `DatabaseReader` to check geometry, catalog row, columns, and indexes, then publishes. The docs say plainly that this self-check is not DAO compatibility evidence.

Tests: a mixed fixed/variable table with primary, unique, and composite-descending indexes; a Memo table; each structured refusal leaving the directory empty; an existing destination untouched; and stage-injected `atomic_create` failures leaving the target absent, including a target that appears right before publication. Publication is Unix-only, as `atomic_update` already is, so those tests are Unix-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)