### PR TITLE
refactor(jet3): make invalid column specs unrepresentable in the creation API

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -4,7 +4,7 @@ use super::*;
 
 /// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BootstrapComposeError {
+pub enum ComposeError {
     /// A table definition could not be encoded.
     Definition(TableDefinitionWriteError),
     /// A usage map could not be encoded.
@@ -38,13 +38,13 @@ pub enum BootstrapComposeError {
     },
 }
 
-impl fmt::Display for BootstrapComposeError {
+impl fmt::Display for ComposeError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "Jet 3 bootstrap composition failed: {self:?}")
     }
 }
 
-impl std::error::Error for BootstrapComposeError {
+impl std::error::Error for ComposeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Definition(source) => Some(source),
@@ -62,43 +62,43 @@ impl std::error::Error for BootstrapComposeError {
     }
 }
 
-impl From<TableDefinitionWriteError> for BootstrapComposeError {
+impl From<TableDefinitionWriteError> for ComposeError {
     fn from(source: TableDefinitionWriteError) -> Self {
         Self::Definition(source)
     }
 }
-impl From<UsageMapWriteError> for BootstrapComposeError {
+impl From<UsageMapWriteError> for ComposeError {
     fn from(source: UsageMapWriteError) -> Self {
         Self::UsageMap(source)
     }
 }
-impl From<PageImageError> for BootstrapComposeError {
+impl From<PageImageError> for ComposeError {
     fn from(source: PageImageError) -> Self {
         Self::Page(source)
     }
 }
-impl From<RowWriteError> for BootstrapComposeError {
+impl From<RowWriteError> for ComposeError {
     fn from(source: RowWriteError) -> Self {
         Self::Row(source)
     }
 }
-impl From<WholeFilePlanError> for BootstrapComposeError {
+impl From<WholeFilePlanError> for ComposeError {
     fn from(source: WholeFilePlanError) -> Self {
         Self::WholeFile(source)
     }
 }
-impl From<Error> for BootstrapComposeError {
+impl From<Error> for ComposeError {
     fn from(source: Error) -> Self {
         Self::Encoding(source)
     }
 }
-impl From<CatalogNameKeyError> for BootstrapComposeError {
+impl From<CatalogNameKeyError> for ComposeError {
     fn from(source: CatalogNameKeyError) -> Self {
         Self::NameKey(source)
     }
 }
 
-impl From<TableSchemaPlanError> for BootstrapComposeError {
+impl From<TableSchemaPlanError> for ComposeError {
     fn from(source: TableSchemaPlanError) -> Self {
         Self::Schema(source)
     }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -19,13 +19,12 @@ use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 use crate::table_schema_plan::{TableSchemaPlanError, TableSpec};
 use crate::whole_file_plan::{WholeFileImagePlan, WholeFilePlanError};
 use crate::{
-    ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind,
-    DataPageBuilder, Error, IndexDirection, IndexFieldSpec, InlineUsageMapEncoder,
-    LogicalIndexKindSpec, LogicalIndexSpec, LongValueMapSpec, MapRowLocator, PAGE_BYTES, PageImage,
-    PageImageError, PageKind, PageNumber, PageOffset, PhysicalIndexFlagsSpec, PhysicalIndexSpec,
-    ResourceBudget, RowColumnLayout, RowValue, RowWriteError, SystemColumnClassSpec,
-    TableDefinitionKind, TableDefinitionSpec, TableDefinitionWriteError, UsageMapWriteError,
-    encode_row, encode_table_definition,
+    ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnType, DataPageBuilder,
+    Error, IndexDirection, InlineUsageMapEncoder, LogicalIndexKindSpec, LogicalIndexSpec,
+    LongValueMapSpec, MapRowLocator, PAGE_BYTES, PageImage, PageImageError, PageKind, PageNumber,
+    PageOffset, PhysicalIndexFlagsSpec, PhysicalIndexSpec, ResourceBudget, RowColumnLayout,
+    RowValue, RowWriteError, SystemColumnClassSpec, TableDefinitionKind, TableDefinitionSpec,
+    TableDefinitionWriteError, UsageMapWriteError, encode_row, encode_table_definition,
 };
 
 const HEADER_PAGE: u64 = 0;
@@ -72,12 +71,7 @@ const DATABASE_HEADER_FIXED_OPAQUE: [u8; 126] = [
     0xcf, 0x65, 0xed, 0xff, 0x07, 0xc7, 0x46, 0xa1, 0x78, 0x16, 0x0c, 0xed, 0xe9, 0x2d,
 ];
 #[cfg(test)]
-const ALPHA_COLUMNS: [ColumnSpec<'static>; 1] = [ColumnSpec::new(
-    b"Id",
-    ColumnPhysicalType::Long,
-    ColumnStorageKind::Fixed,
-    4,
-)];
+const ALPHA_COLUMNS: [ColumnSpec<'static>; 1] = [ColumnSpec::new(b"Id", ColumnType::Long)];
 #[cfg(test)]
 const ALPHA_SPEC: TableSpec<'static> = TableSpec {
     name: b"Alpha",
@@ -93,13 +87,13 @@ const MSYS_DB_ID: i32 = 0x1000_0000;
 
 #[path = "bootstrap_compose_error.rs"]
 mod error;
-pub use error::BootstrapComposeError;
+pub use error::ComposeError;
 
 /// Composes the deterministic 20-page empty image established by `EXP-0073`.
 #[cfg(test)]
 pub(crate) fn compose_empty_database(
     budget: &mut ResourceBudget,
-) -> Result<WholeFileImagePlan, BootstrapComposeError> {
+) -> Result<WholeFileImagePlan, ComposeError> {
     let images = compose_existing_pages(None, budget)?;
     WholeFileImagePlan::from_existing_pages(images, budget).map_err(Into::into)
 }
@@ -109,7 +103,7 @@ pub(crate) fn compose_empty_database(
 #[cfg(test)]
 pub(crate) fn compose_alpha_database(
     budget: &mut ResourceBudget,
-) -> Result<WholeFileImagePlan, BootstrapComposeError> {
+) -> Result<WholeFileImagePlan, ComposeError> {
     compose_table_database(&ALPHA_SPEC, budget)
 }
 
@@ -118,7 +112,7 @@ pub(crate) fn compose_alpha_database(
 pub(crate) fn compose_table_database(
     spec: &TableSpec<'_>,
     budget: &mut ResourceBudget,
-) -> Result<WholeFileImagePlan, BootstrapComposeError> {
+) -> Result<WholeFileImagePlan, ComposeError> {
     let planned = PlannedCreate::new(spec)?;
     let images = compose_existing_pages(Some(&planned), budget)?;
     let mut plan = WholeFileImagePlan::from_existing_pages(images, budget)?;
@@ -129,7 +123,7 @@ pub(crate) fn compose_table_database(
 fn compose_existing_pages(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<[PageImage; EMPTY_DATABASE_PAGE_COUNT as usize], BootstrapComposeError> {
+) -> Result<[PageImage; EMPTY_DATABASE_PAGE_COUNT as usize], ComposeError> {
     let object_count = if create.is_some() { 9 } else { 8 };
     let ace_count = if create.is_some() { 18 } else { 16 };
     let page_count = create.map_or(EMPTY_DATABASE_PAGE_COUNT, PlannedCreate::page_count);
@@ -157,10 +151,7 @@ fn compose_existing_pages(
     ])
 }
 
-fn header_page(
-    created: bool,
-    budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+fn header_page(created: bool, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
     let mut image = PageImage::new(PageKind::DatabaseDefinition);
     image.write_at(PageOffset::new(1), &[1], budget)?;
     image.write_at(PageOffset::new(4), b"Standard Jet DB", budget)?;
@@ -179,7 +170,7 @@ fn header_page(
 fn global_map(
     used_pages: u64,
     budget: &mut ResourceBudget,
-) -> Result<InlineUsageMapEncoder, BootstrapComposeError> {
+) -> Result<InlineUsageMapEncoder, ComposeError> {
     let mut map = InlineUsageMapEncoder::new(
         PageNumber::new(0),
         ByteCount::new(GLOBAL_BITMAP_BYTES),
@@ -194,17 +185,14 @@ fn global_map(
 fn global_map_page(
     used_pages: u64,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let map = global_map(used_pages, budget)?;
     let mut row = [0_u8; 133];
     map.encode_into(&mut row, budget)?;
     data_page(GLOBAL_MAP_PAGE, &[&row, &[0; 133]], budget)
 }
 
-fn inline_map_row(
-    pages: &[u64],
-    budget: &mut ResourceBudget,
-) -> Result<[u8; 133], BootstrapComposeError> {
+fn inline_map_row(pages: &[u64], budget: &mut ResourceBudget) -> Result<[u8; 133], ComposeError> {
     let mut map =
         InlineUsageMapEncoder::new(PageNumber::new(0), ByteCount::new(MAP_BITMAP_BYTES), budget)?;
     for &page in pages {
@@ -215,10 +203,7 @@ fn inline_map_row(
     Ok(row)
 }
 
-fn single_map_page(
-    pages: &[u64],
-    budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+fn single_map_page(pages: &[u64], budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
     let row = inline_map_row(pages, budget)?;
     data_page(HEADER_PAGE, &[&row], budget)
 }
@@ -226,7 +211,7 @@ fn single_map_page(
 fn objects_map_page(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let owned = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let available = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let empty = inline_map_row(&[], budget)?;
@@ -239,7 +224,7 @@ fn objects_map_page(
     data_page(HEADER_PAGE, &rows, budget)
 }
 
-fn shared_map_page(budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
+fn shared_map_page(budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
     let ace_owned = inline_map_row(&[MSYS_ACES_DATA_PAGE], budget)?;
     let ace_available = inline_map_row(&[MSYS_ACES_DATA_PAGE], budget)?;
     let ace_index = inline_map_row(&[ACES_OBJECT_ID_ROOT], budget)?;
@@ -270,7 +255,7 @@ fn data_page(
     owner: u64,
     rows: &[&[u8]],
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(owner), budget)?;
     for row in rows {
         builder.append_row(row, budget)?;
@@ -288,7 +273,7 @@ fn data_page(
 fn definition_page(
     spec: &TableDefinitionSpec<'_>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut bytes = [0_u8; PAGE_BYTES];
     encode_table_definition(spec, &mut bytes, budget)?;
     Ok(PageImage::from_bytes(bytes))
@@ -429,7 +414,7 @@ fn catalog_seeds<'a>(create: Option<&PlannedCreate<'a>>) -> impl Iterator<Item =
 fn objects_data_page(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
     for seed in catalog_seeds(create) {
@@ -443,7 +428,7 @@ fn encode_catalog_row(
     seed: CatalogSeed<'_>,
     output: &mut [u8],
     budget: &mut ResourceBudget,
-) -> Result<usize, BootstrapComposeError> {
+) -> Result<usize, ComposeError> {
     let values = [
         RowValue::Long(seed.id),
         RowValue::Long(seed.parent),
@@ -510,7 +495,7 @@ fn ace_seeds(create: Option<&PlannedCreate<'_>>) -> impl Iterator<Item = AceSeed
 fn aces_data_page(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_ACES_ROOT), budget)?;
     let mut row = [0_u8; 64];
     for seed in ace_seeds(create) {
@@ -529,7 +514,7 @@ fn aces_data_page(
 fn finish_data_builder(
     builder: DataPageBuilder,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let free = u16::try_from(builder.free_bytes().get()).map_err(|_| Error::IntegerConversion {
         value: u128::from(builder.free_bytes().get()),
         target: "u16",
@@ -562,7 +547,7 @@ impl OwnedIndexEntry {
         entry.row = row;
         entry
     }
-    fn name(parent: i32, name: &[u8], row: u8) -> Result<Self, BootstrapComposeError> {
+    fn name(parent: i32, name: &[u8], row: u8) -> Result<Self, ComposeError> {
         let mut entry = Self::EMPTY;
         entry.len = encode_catalog_name_key(parent, name, &mut entry.key)?;
         entry.row = row;
@@ -573,7 +558,7 @@ impl OwnedIndexEntry {
 fn objects_parent_name_index(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 9];
     let count = if create.is_some() { 9 } else { 8 };
     for (row, seed) in catalog_seeds(create).enumerate() {
@@ -590,7 +575,7 @@ fn objects_parent_name_index(
 fn objects_id_index(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 9];
     let count = if create.is_some() { 9 } else { 8 };
     for (row, seed) in catalog_seeds(create).enumerate() {
@@ -607,7 +592,7 @@ fn objects_id_index(
 fn aces_index(
     create: Option<&PlannedCreate<'_>>,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let mut entries = [OwnedIndexEntry::EMPTY; 18];
     let mut count = 0;
     for (row, seed) in ace_seeds(create).enumerate() {
@@ -631,10 +616,7 @@ fn sort_index_entries(entries: &mut [OwnedIndexEntry]) {
     });
 }
 
-fn empty_index_page(
-    owner: u64,
-    budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+fn empty_index_page(owner: u64, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
     index_page(owner, 0, &[], budget)
 }
 
@@ -643,7 +625,7 @@ fn index_page(
     row_page: u64,
     entries: &[OwnedIndexEntry],
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let needed = entries
         .iter()
         .try_fold(0_usize, |total, entry| total.checked_add(entry.len + 4))
@@ -651,7 +633,7 @@ fn index_page(
             operation: "size bootstrap index entries",
         })?;
     if needed > INDEX_ENTRY_AREA_LEN {
-        return Err(BootstrapComposeError::IndexPageFull {
+        return Err(ComposeError::IndexPageFull {
             needed,
             available: INDEX_ENTRY_AREA_LEN,
         });

--- a/crates/jet3/src/bootstrap_composer_schema_candidates_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_schema_candidates_tests.rs
@@ -1,42 +1,33 @@
 use super::super::{compose_table_database, global_map_page};
 use super::*;
+use crate::{ColumnRef, IndexColumnSpec};
 
 const IDX_TRI_COLUMNS: [ColumnSpec<'static>; 3] = [
-    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
-    ColumnSpec::new(
-        b"Code",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
-    ColumnSpec::new(
-        b"Sequence",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
+    ColumnSpec::new(b"Id", ColumnType::Long),
+    ColumnSpec::new(b"Code", ColumnType::Long),
+    ColumnSpec::new(b"Sequence", ColumnType::Long),
 ];
 const IDX_TRI_INDEXES: [IndexSpec<'static>; 3] = [
     IndexSpec {
         name: b"ZPrimary",
-        fields: &[IndexFieldSpec {
-            column: 0,
+        fields: &[IndexColumnSpec {
+            column: ColumnRef::Ordinal(0),
             direction: IndexDirection::Ascending,
         }],
         kind: IndexKind::Primary,
     },
     IndexSpec {
         name: b"MUniqueX",
-        fields: &[IndexFieldSpec {
-            column: 1,
+        fields: &[IndexColumnSpec {
+            column: ColumnRef::Ordinal(1),
             direction: IndexDirection::Descending,
         }],
         kind: IndexKind::Unique,
     },
     IndexSpec {
         name: b"ASecondx",
-        fields: &[IndexFieldSpec {
-            column: 2,
+        fields: &[IndexColumnSpec {
+            column: ColumnRef::Ordinal(2),
             direction: IndexDirection::Ascending,
         }],
         kind: IndexKind::Ordinary,
@@ -49,7 +40,7 @@ const IDX_TRI: TableSpec<'static> = TableSpec {
 };
 const WIDE_FIELD_COUNT: usize = 70;
 
-fn indexed_candidate_bytes() -> Result<Vec<u8>, BootstrapComposeError> {
+fn indexed_candidate_bytes() -> Result<Vec<u8>, ComposeError> {
     let mut budget = compose_budget();
     let plan = compose_table_database(&IDX_TRI, &mut budget)?;
     Ok(plan
@@ -65,7 +56,7 @@ fn wide_candidate_bytes() -> CandidateResult<Vec<u8>> {
         .collect::<Vec<_>>();
     let columns = names
         .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
         .collect::<Vec<_>>();
     let base = TableSpec {
         name: b"ContOneX",

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -1,4 +1,4 @@
-use super::{BootstrapComposeError, compose_alpha_database, compose_empty_database};
+use super::{ComposeError, compose_alpha_database, compose_empty_database};
 use crate::page_append_plan::EMPTY_DATABASE_PAGE_COUNT;
 
 // EXP-0073/EXP-0085: the accepted Alpha image's appended page numbers.
@@ -6,11 +6,10 @@ const ALPHA_ROOT: u64 = 20;
 const ALPHA_MAP_PAGE: u64 = 21;
 use crate::table_schema_plan::{IndexKind, IndexSpec, TableSpec, plan_table_schema};
 use crate::{
-    ByteCount, CatalogObjectClass, ColumnOrdinal, ColumnPhysicalType, ColumnSpec,
-    ColumnStorageKind, DatabaseReader, IndexDirection, IndexFieldSpec, JET3_PAGE_SIZE,
-    MapRowLocator, PageKind, PageNumber, ReadLimits, ResourceBudget, ResourceLimitKind,
-    ResourceLimits, SliceSource, TableDefinitionKind, TextCodePage, ValueKind, classify_page,
-    locate_usage_map, page_tag,
+    ByteCount, CatalogObjectClass, ColumnOrdinal, ColumnSpec, ColumnType, DatabaseReader,
+    IndexDirection, JET3_PAGE_SIZE, MapRowLocator, PageKind, PageNumber, ReadLimits,
+    ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource, TableDefinitionKind,
+    TextCodePage, ValueKind, classify_page, locate_usage_map, page_tag,
 };
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -27,7 +26,7 @@ pub(super) fn read_budget(byte_len: usize) -> ResourceBudget {
     )))
 }
 
-fn bytes(alpha: bool) -> Result<Vec<u8>, BootstrapComposeError> {
+fn bytes(alpha: bool) -> Result<Vec<u8>, ComposeError> {
     let mut budget = compose_budget();
     let plan = if alpha {
         compose_alpha_database(&mut budget)?
@@ -503,12 +502,12 @@ fn composition_is_deterministic_and_resource_rejection_is_structured() -> TestRe
         ResourceBudget::new(ResourceLimits::default().with_max_allocation_bytes(ByteCount::new(0)));
     assert!(matches!(
         compose_empty_database(&mut budget),
-        Err(BootstrapComposeError::UsageMap(
-            crate::UsageMapWriteError::Encoding(crate::Error::ResourceLimitExceeded {
+        Err(ComposeError::UsageMap(crate::UsageMapWriteError::Encoding(
+            crate::Error::ResourceLimitExceeded {
                 kind: ResourceLimitKind::AllocationBytes,
                 ..
-            })
-        ))
+            }
+        )))
     ));
     Ok(())
 }
@@ -588,12 +587,7 @@ fn candidate_export_refuses_nonempty_directory() -> TestResult {
 fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
     // The Alpha image DAO accepted in EXP-0085 is the fixed case the general
     // EXP-0087 assignment has to agree with.
-    let columns = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
     let plan = plan_table_schema(
         &TableSpec {
             name: b"Alpha",

--- a/crates/jet3/src/bootstrap_system_definitions.rs
+++ b/crates/jet3/src/bootstrap_system_definitions.rs
@@ -1,30 +1,49 @@
 //! Fixed system-table definition inventory for the bootstrap composer.
 
-use super::*;
+use std::num::NonZeroU8;
 
-const OBJECT_COLUMNS: [ColumnSpec<'static>; 17] = {
-    use ColumnPhysicalType as T;
-    use ColumnStorageKind::{Fixed as F, Variable as V};
-    [
-        ColumnSpec::new(b"Id", T::Long, F, 4),
-        ColumnSpec::new(b"ParentId", T::Long, F, 4),
-        ColumnSpec::new(b"Name", T::Text, V, 255),
-        ColumnSpec::new(b"Type", T::Integer, F, 2),
-        ColumnSpec::new(b"DateCreate", T::DateTime, F, 8),
-        ColumnSpec::new(b"DateUpdate", T::DateTime, F, 8),
-        ColumnSpec::new(b"Owner", T::Binary, V, 255),
-        ColumnSpec::new(b"Flags", T::Long, F, 4),
-        ColumnSpec::new(b"Database", T::Memo, V, 0),
-        ColumnSpec::new(b"Connect", T::Memo, V, 0),
-        ColumnSpec::new(b"ForeignName", T::Text, V, 255),
-        ColumnSpec::new(b"RmtInfoShort", T::Binary, V, 255),
-        ColumnSpec::new(b"RmtInfoLong", T::LongBinary, V, 0),
-        ColumnSpec::new(b"Lv", T::LongBinary, V, 0),
-        ColumnSpec::new(b"LvProp", T::LongBinary, V, 0),
-        ColumnSpec::new(b"LvModule", T::LongBinary, V, 0),
-        ColumnSpec::new(b"LvExtra", T::LongBinary, V, 0),
-    ]
-};
+use super::*;
+use crate::IndexFieldSpec;
+
+const OBJECT_COLUMNS: [ColumnSpec<'static>; 17] = [
+    ColumnSpec::new(b"Id", ColumnType::Long),
+    ColumnSpec::new(b"ParentId", ColumnType::Long),
+    ColumnSpec::new(
+        b"Name",
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
+    ),
+    ColumnSpec::new(b"Type", ColumnType::Integer),
+    ColumnSpec::new(b"DateCreate", ColumnType::DateTime),
+    ColumnSpec::new(b"DateUpdate", ColumnType::DateTime),
+    ColumnSpec::new(
+        b"Owner",
+        ColumnType::Binary {
+            max_len: NonZeroU8::MAX,
+        },
+    ),
+    ColumnSpec::new(b"Flags", ColumnType::Long),
+    ColumnSpec::new(b"Database", ColumnType::Memo),
+    ColumnSpec::new(b"Connect", ColumnType::Memo),
+    ColumnSpec::new(
+        b"ForeignName",
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
+    ),
+    ColumnSpec::new(
+        b"RmtInfoShort",
+        ColumnType::Binary {
+            max_len: NonZeroU8::MAX,
+        },
+    ),
+    ColumnSpec::new(b"RmtInfoLong", ColumnType::LongBinary),
+    ColumnSpec::new(b"Lv", ColumnType::LongBinary),
+    ColumnSpec::new(b"LvProp", ColumnType::LongBinary),
+    ColumnSpec::new(b"LvModule", ColumnType::LongBinary),
+    ColumnSpec::new(b"LvExtra", ColumnType::LongBinary),
+];
 const OBJECT_CLASSES: [SystemColumnClassSpec; 17] = {
     use SystemColumnClassSpec::{Binary as B, Fixed as F, Variable as V};
     [F, F, V, F, F, F, B, F, V, V, V, V, V, V, V, V, V]
@@ -57,7 +76,7 @@ const fn lv_map(
 pub(super) fn msys_objects_definition(
     row_count: u32,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let parent_name_fields = [field(1), field(2)];
     let id_fields = [field(0)];
     let physical = [
@@ -107,30 +126,15 @@ pub(super) fn msys_objects_definition(
 }
 
 const ACE_COLUMNS: [ColumnSpec<'static>; 4] = [
-    ColumnSpec::new(
-        b"ObjectId",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
+    ColumnSpec::new(b"ObjectId", ColumnType::Long),
     ColumnSpec::new(
         b"SID",
-        ColumnPhysicalType::Binary,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Binary {
+            max_len: NonZeroU8::MAX,
+        },
     ),
-    ColumnSpec::new(
-        b"ACM",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
-    ColumnSpec::new(
-        b"FInheritable",
-        ColumnPhysicalType::Boolean,
-        ColumnStorageKind::Fixed,
-        1,
-    ),
+    ColumnSpec::new(b"ACM", ColumnType::Long),
+    ColumnSpec::new(b"FInheritable", ColumnType::Boolean),
 ];
 const ACE_CLASSES: [SystemColumnClassSpec; 4] = [
     SystemColumnClassSpec::Fixed,
@@ -143,7 +147,7 @@ pub(super) fn msys_aces_definition(
     row_count: u32,
     distinct: u32,
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let fields = [field(0)];
     let physical = [physical(
         &fields,
@@ -175,48 +179,28 @@ pub(super) fn msys_aces_definition(
 }
 
 const QUERY_COLUMNS: [ColumnSpec<'static>; 7] = [
-    ColumnSpec::new(
-        b"ObjectId",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
-    ColumnSpec::new(
-        b"Attribute",
-        ColumnPhysicalType::Byte,
-        ColumnStorageKind::Fixed,
-        1,
-    ),
+    ColumnSpec::new(b"ObjectId", ColumnType::Long),
+    ColumnSpec::new(b"Attribute", ColumnType::Byte),
     ColumnSpec::new(
         b"Order",
-        ColumnPhysicalType::Binary,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Binary {
+            max_len: NonZeroU8::MAX,
+        },
     ),
     ColumnSpec::new(
         b"Name1",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
     ColumnSpec::new(
         b"Name2",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
-    ColumnSpec::new(
-        b"Expression",
-        ColumnPhysicalType::Memo,
-        ColumnStorageKind::Variable,
-        0,
-    ),
-    ColumnSpec::new(
-        b"Flag",
-        ColumnPhysicalType::Integer,
-        ColumnStorageKind::Fixed,
-        2,
-    ),
+    ColumnSpec::new(b"Expression", ColumnType::Memo),
+    ColumnSpec::new(b"Flag", ColumnType::Integer),
 ];
 const QUERY_CLASSES: [SystemColumnClassSpec; 7] = {
     use SystemColumnClassSpec::{Fixed as F, Variable as V};
@@ -226,7 +210,7 @@ const QUERY_MAPS: [LongValueMapSpec; 1] = [lv_map(5, 5, SHARED_MAP_PAGE, 6, SHAR
 
 pub(super) fn msys_queries_definition(
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let fields = [field(0), field(1), field(2)];
     let physical = [physical(
         &fields,
@@ -260,51 +244,36 @@ pub(super) fn msys_queries_definition(
 const RELATIONSHIP_COLUMNS: [ColumnSpec<'static>; 8] = [
     ColumnSpec::new(
         b"szRelationship",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
-    ColumnSpec::new(
-        b"grbit",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
-    ColumnSpec::new(
-        b"ccolumn",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
-    ColumnSpec::new(
-        b"icolumn",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    ),
+    ColumnSpec::new(b"grbit", ColumnType::Long),
+    ColumnSpec::new(b"ccolumn", ColumnType::Long),
+    ColumnSpec::new(b"icolumn", ColumnType::Long),
     ColumnSpec::new(
         b"szObject",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
     ColumnSpec::new(
         b"szColumn",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
     ColumnSpec::new(
         b"szReferencedObject",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
     ColumnSpec::new(
         b"szReferencedColumn",
-        ColumnPhysicalType::Text,
-        ColumnStorageKind::Variable,
-        255,
+        ColumnType::Text {
+            max_len: NonZeroU8::MAX,
+        },
     ),
 ];
 const RELATIONSHIP_CLASSES: [SystemColumnClassSpec; 8] = {
@@ -314,7 +283,7 @@ const RELATIONSHIP_CLASSES: [SystemColumnClassSpec; 8] = {
 
 pub(super) fn msys_relationships_definition(
     budget: &mut ResourceBudget,
-) -> Result<PageImage, BootstrapComposeError> {
+) -> Result<PageImage, ComposeError> {
     let name_fields = [field(0)];
     let object_fields = [field(4)];
     let referenced_fields = [field(6)];

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -50,17 +50,17 @@ pub(super) struct PlannedCreate<'a> {
 
 impl<'a> PlannedCreate<'a> {
     /// Plans `spec` as the first create in the empty database.
-    pub(super) fn new(spec: &'a TableSpec<'a>) -> Result<Self, BootstrapComposeError> {
+    pub(super) fn new(spec: &'a TableSpec<'a>) -> Result<Self, ComposeError> {
         let plan = plan_table_schema(spec, EMPTY_DATABASE_PAGE_COUNT)?;
         let mut long_value_columns = long_value_columns(spec);
         let long_value = long_value_columns.next();
         if long_value_columns.next().is_some() {
-            return Err(BootstrapComposeError::UnobservedLongValueColumnCount {
+            return Err(ComposeError::UnobservedLongValueColumnCount {
                 observed: MAX_OBSERVED_LONG_VALUE_COLUMNS,
             });
         }
         if long_value.is_some() && !spec.indexes.is_empty() {
-            return Err(BootstrapComposeError::UnobservedMapRowLayout);
+            return Err(ComposeError::UnobservedMapRowLayout);
         }
         Ok(Self {
             spec,
@@ -75,7 +75,7 @@ impl<'a> PlannedCreate<'a> {
     }
 
     /// Returns the page count once every appended page is in place.
-    pub(super) const fn page_count(&self) -> u64 {
+    pub(super) fn page_count(&self) -> u64 {
         self.plan.definition_root().get() + self.plan.appended_page_count()
     }
 
@@ -106,7 +106,7 @@ impl<'a> PlannedCreate<'a> {
         &self,
         plan: &mut WholeFileImagePlan,
         budget: &mut ResourceBudget,
-    ) -> Result<(), BootstrapComposeError> {
+    ) -> Result<(), ComposeError> {
         let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
         plan.append(self.definition_page(budget)?, &mut append_map, budget)?;
         plan.append(self.map_page(budget)?, &mut append_map, budget)?;
@@ -119,10 +119,7 @@ impl<'a> PlannedCreate<'a> {
         Ok(())
     }
 
-    fn definition_page(
-        &self,
-        budget: &mut ResourceBudget,
-    ) -> Result<PageImage, BootstrapComposeError> {
+    fn definition_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
         let map = self.plan.map_page();
         let spec = self.spec;
         // The planner validated one placement per index, so the zip is exact.
@@ -130,8 +127,9 @@ impl<'a> PlannedCreate<'a> {
             .plan
             .index_placements()
             .zip(spec.indexes)
-            .map(|((root, row), index)| PhysicalIndexSpec {
-                fields: index.fields,
+            .zip(self.plan.index_fields())
+            .map(|(((root, row), index), fields)| PhysicalIndexSpec {
+                fields,
                 usage_map_page: map,
                 usage_map_row: row,
                 root,
@@ -154,7 +152,7 @@ impl<'a> PlannedCreate<'a> {
                     kind: index.kind.logical_kind(),
                 })
             })
-            .collect::<Result<Vec<_>, BootstrapComposeError>>()?;
+            .collect::<Result<Vec<_>, ComposeError>>()?;
         let long_value_maps = self
             .long_value
             .map(|column| LongValueMapSpec {
@@ -181,7 +179,7 @@ impl<'a> PlannedCreate<'a> {
     }
 
     /// Builds the map page with the rows the definition names.
-    fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, BootstrapComposeError> {
+    fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
         let empty = inline_map_row(&[], budget)?;
         let mut rows: Vec<[u8; 133]> = vec![empty, empty];
         for (root, _) in self.plan.index_placements() {
@@ -201,12 +199,7 @@ fn long_value_columns<'s>(spec: &'s TableSpec<'_>) -> impl Iterator<Item = u16> 
     spec.columns
         .iter()
         .enumerate()
-        .filter(|(_, column)| {
-            matches!(
-                column.physical_type(),
-                ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
-            )
-        })
+        .filter(|(_, column)| column.column_type().is_long_value())
         .filter_map(|(ordinal, _)| u16::try_from(ordinal).ok())
 }
 

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -2,17 +2,17 @@
 //! reader to check each `EXP-0093` structure lands where the plan says.
 
 use super::super::tests::{compose_budget, inline_map_bit, read_budget};
-use super::super::{BootstrapComposeError, compose_table_database};
+use super::super::{ComposeError, compose_table_database};
+use crate::column_definition_writer::nz;
 use crate::table_schema_plan::{IndexKind, IndexSpec, TableSchemaPlanError, TableSpec};
 use crate::{
-    ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
-    IndexDirection, IndexFieldSpec, MapRowLocator, PAGE_BYTES, PageKind, PageNumber, SliceSource,
-    page_tag,
+    ColumnOrdinal, ColumnRef, ColumnSpec, ColumnType, DatabaseReader, IndexColumnSpec,
+    IndexDirection, MapRowLocator, PAGE_BYTES, PageKind, PageNumber, SliceSource, page_tag,
 };
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-fn create_bytes(spec: &TableSpec<'_>) -> Result<Vec<u8>, BootstrapComposeError> {
+fn create_bytes(spec: &TableSpec<'_>) -> Result<Vec<u8>, ComposeError> {
     let mut budget = compose_budget();
     let plan = compose_table_database(spec, &mut budget)?;
     let mut bytes = Vec::with_capacity(plan.pages().len() * PAGE_BYTES);
@@ -26,35 +26,17 @@ fn page(bytes: &[u8], number: usize) -> &[u8] {
     &bytes[number * PAGE_BYTES..(number + 1) * PAGE_BYTES]
 }
 
-const ID: ColumnSpec<'static> =
-    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4);
-const NAME: ColumnSpec<'static> = ColumnSpec::new(
-    b"Name",
-    ColumnPhysicalType::Text,
-    ColumnStorageKind::Variable,
-    50,
-);
-const CODE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Code",
-    ColumnPhysicalType::Text,
-    ColumnStorageKind::Variable,
-    8,
-);
-const SEQUENCE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Sequence",
-    ColumnPhysicalType::Long,
-    ColumnStorageKind::Fixed,
-    4,
-);
-const NOTE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Note",
-    ColumnPhysicalType::Memo,
-    ColumnStorageKind::Variable,
-    0,
-);
+const ID: ColumnSpec<'static> = ColumnSpec::new(b"Id", ColumnType::Long);
+const NAME: ColumnSpec<'static> = ColumnSpec::new(b"Name", ColumnType::Text { max_len: nz(50) });
+const CODE: ColumnSpec<'static> = ColumnSpec::new(b"Code", ColumnType::Text { max_len: nz(8) });
+const SEQUENCE: ColumnSpec<'static> = ColumnSpec::new(b"Sequence", ColumnType::Long);
+const NOTE: ColumnSpec<'static> = ColumnSpec::new(b"Note", ColumnType::Memo);
 
-const fn field(column: u16, direction: IndexDirection) -> IndexFieldSpec {
-    IndexFieldSpec { column, direction }
+const fn field(column: u16, direction: IndexDirection) -> IndexColumnSpec<'static> {
+    IndexColumnSpec {
+        column: ColumnRef::Ordinal(column),
+        direction,
+    }
 }
 
 /// Fixed Long columns with ten-byte names: 70 of them encode to the 2,075-byte
@@ -68,7 +50,7 @@ fn wide_names(count: usize) -> Vec<Vec<u8>> {
 fn wide_columns(names: &[Vec<u8>]) -> Vec<ColumnSpec<'_>> {
     names
         .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
         .collect()
 }
 
@@ -232,7 +214,7 @@ fn a_definition_needing_a_continuation_is_refused_before_any_page_is_built() {
             },
             &mut budget,
         ),
-        Err(BootstrapComposeError::Schema(
+        Err(ComposeError::Schema(
             TableSchemaPlanError::ContinuationPlacementUnestablished {
                 length: 2075,
                 continuations: 1,
@@ -260,7 +242,7 @@ fn a_table_with_both_an_index_and_a_long_value_column_is_refused() {
             },
             &mut budget,
         ),
-        Err(BootstrapComposeError::UnobservedMapRowLayout)
+        Err(ComposeError::UnobservedMapRowLayout)
     ));
 }
 
@@ -277,7 +259,7 @@ fn a_create_that_cannot_be_planned_reports_the_schema_error() {
             },
             &mut budget,
         ),
-        Err(BootstrapComposeError::Schema(_))
+        Err(ComposeError::Schema(_))
     ));
 }
 
@@ -285,16 +267,7 @@ fn a_create_that_cannot_be_planned_reports_the_schema_error() {
 fn a_second_long_value_column_is_refused() {
     // EXP-0087's only long-value create, Beta, carried one Memo column, and
     // the one multi-group layout on record (MSysObjects) is not consecutive.
-    let columns = [
-        ID,
-        NOTE,
-        ColumnSpec::new(
-            b"Blob",
-            ColumnPhysicalType::LongBinary,
-            ColumnStorageKind::Variable,
-            0,
-        ),
-    ];
+    let columns = [ID, NOTE, ColumnSpec::new(b"Blob", ColumnType::LongBinary)];
     let mut budget = compose_budget();
     assert!(matches!(
         compose_table_database(
@@ -305,6 +278,6 @@ fn a_second_long_value_column_is_refused() {
             },
             &mut budget,
         ),
-        Err(BootstrapComposeError::UnobservedLongValueColumnCount { observed: 1 })
+        Err(ComposeError::UnobservedLongValueColumnCount { observed: 1 })
     ));
 }

--- a/crates/jet3/src/column_definition_writer.rs
+++ b/crates/jet3/src/column_definition_writer.rs
@@ -6,6 +6,8 @@
 //! `EXP-0073`, and relationship cascade bytes from `EXP-0062`. Names are raw
 //! database-code-page bytes (`EXP-0059`).
 
+use std::num::NonZeroU8;
+
 use crate::table_definition_writer::{PhysicalIndexFlagsSpec, TableDefinitionWriteError};
 use crate::{
     BinaryWriter, ColumnPhysicalType, ColumnStorageClass, Error, IndexDirection, PageNumber,
@@ -75,39 +77,122 @@ pub enum SystemColumnClassSpec {
     Binary,
 }
 
+/// The type of one column to create.
+///
+/// Each variant fixes the physical type, storage class, and size the
+/// `EXP-0059` user-table records carry, so only combinations DAO accepts can
+/// be described. Sizes appear only where DAO lets the caller choose one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ColumnType {
+    /// Yes/No value stored in the row presence bitmap.
+    Boolean,
+    /// Unsigned eight-bit integer.
+    Byte,
+    /// Signed 16-bit integer.
+    Integer,
+    /// Signed 32-bit integer.
+    Long,
+    /// Signed 32-bit integer the engine numbers (`EXP-0059` class 7).
+    AutoIncrement,
+    /// Fixed-scale currency value.
+    Currency,
+    /// IEEE-754 single-precision value.
+    Single,
+    /// IEEE-754 double-precision value.
+    Double,
+    /// OLE Automation date/time value.
+    DateTime,
+    /// Replication identifier.
+    Guid,
+    /// Database-code-page text of at most `max_len` bytes, stored through the
+    /// variable table.
+    Text {
+        /// Longest value the column holds.
+        max_len: NonZeroU8,
+    },
+    /// Database-code-page text of exactly `len` bytes at a fixed row offset.
+    FixedText {
+        /// Fixed value length.
+        len: NonZeroU8,
+    },
+    /// Short binary value of at most `max_len` bytes.
+    Binary {
+        /// Longest value the column holds.
+        max_len: NonZeroU8,
+    },
+    /// Memo text stored as a long value.
+    Memo,
+    /// OLE object stored as a long value.
+    LongBinary,
+}
+
+impl ColumnType {
+    /// Returns the physical type the column record carries.
+    #[must_use]
+    pub const fn physical_type(self) -> ColumnPhysicalType {
+        match self {
+            Self::Boolean => ColumnPhysicalType::Boolean,
+            Self::Byte => ColumnPhysicalType::Byte,
+            Self::Integer => ColumnPhysicalType::Integer,
+            Self::Long | Self::AutoIncrement => ColumnPhysicalType::Long,
+            Self::Currency => ColumnPhysicalType::Currency,
+            Self::Single => ColumnPhysicalType::Single,
+            Self::Double => ColumnPhysicalType::Double,
+            Self::DateTime => ColumnPhysicalType::DateTime,
+            Self::Guid => ColumnPhysicalType::Guid,
+            Self::Text { .. } | Self::FixedText { .. } => ColumnPhysicalType::Text,
+            Self::Binary { .. } => ColumnPhysicalType::Binary,
+            Self::Memo => ColumnPhysicalType::Memo,
+            Self::LongBinary => ColumnPhysicalType::LongBinary,
+        }
+    }
+
+    /// Returns whether the column stores at a fixed offset or variably.
+    #[must_use]
+    pub const fn storage(self) -> ColumnStorageKind {
+        match self {
+            Self::Text { .. } | Self::Binary { .. } | Self::Memo | Self::LongBinary => {
+                ColumnStorageKind::Variable
+            }
+            _ => ColumnStorageKind::Fixed,
+        }
+    }
+
+    /// Returns the size the column record carries (`EXP-0059`): the fixed
+    /// width, the declared maximum length, or zero for long values.
+    #[must_use]
+    pub const fn size(self) -> u16 {
+        match self {
+            Self::Boolean | Self::Byte => 1,
+            Self::Integer => 2,
+            Self::Long | Self::AutoIncrement | Self::Single => 4,
+            Self::Currency | Self::Double | Self::DateTime => 8,
+            Self::Guid => 16,
+            Self::Text { max_len } | Self::Binary { max_len } => max_len.get() as u16,
+            Self::FixedText { len } => len.get() as u16,
+            Self::Memo | Self::LongBinary => 0,
+        }
+    }
+
+    /// Returns whether the column is a long value with an external page map.
+    #[must_use]
+    pub const fn is_long_value(self) -> bool {
+        matches!(self, Self::Memo | Self::LongBinary)
+    }
+}
+
 /// One column to encode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ColumnSpec<'a> {
     name: &'a [u8],
-    physical_type: ColumnPhysicalType,
-    storage: ColumnStorageKind,
-    size: u16,
-    auto_increment: bool,
+    column_type: ColumnType,
 }
 
 impl<'a> ColumnSpec<'a> {
     /// Describes a column with raw database-code-page name bytes.
     #[must_use]
-    pub const fn new(
-        name: &'a [u8],
-        physical_type: ColumnPhysicalType,
-        storage: ColumnStorageKind,
-        size: u16,
-    ) -> Self {
-        Self {
-            name,
-            physical_type,
-            storage,
-            size,
-            auto_increment: false,
-        }
-    }
-
-    /// Marks the column as the auto-increment Long (`EXP-0059` class 7).
-    #[must_use]
-    pub const fn with_auto_increment(mut self) -> Self {
-        self.auto_increment = true;
-        self
+    pub const fn new(name: &'a [u8], column_type: ColumnType) -> Self {
+        Self { name, column_type }
     }
 
     /// Returns the raw name bytes.
@@ -116,22 +201,28 @@ impl<'a> ColumnSpec<'a> {
         self.name
     }
 
-    /// Returns the physical type.
+    /// Returns the column type.
+    #[must_use]
+    pub const fn column_type(&self) -> ColumnType {
+        self.column_type
+    }
+
+    /// Returns the physical type the column record carries.
     #[must_use]
     pub const fn physical_type(&self) -> ColumnPhysicalType {
-        self.physical_type
+        self.column_type.physical_type()
     }
 
-    /// Returns the requested storage kind.
+    /// Returns the storage kind the column record carries.
     #[must_use]
     pub const fn storage(&self) -> ColumnStorageKind {
-        self.storage
+        self.column_type.storage()
     }
 
-    /// Returns the declared fixed or maximum size.
+    /// Returns the size the column record carries.
     #[must_use]
     pub const fn size(&self) -> u16 {
-        self.size
+        self.column_type.size()
     }
 }
 
@@ -204,7 +295,7 @@ pub(crate) struct ResolvedColumn {
     pub(crate) class: u8,
 }
 
-/// Validates one column and derives its fixed offset or variable index.
+/// Derives one column's fixed offset or variable index and its record class.
 pub(crate) fn resolve_column(
     ordinal: u16,
     column: &ColumnSpec<'_>,
@@ -213,65 +304,46 @@ pub(crate) fn resolve_column(
     next_fixed_offset: &mut u16,
     variables_seen: &mut u16,
 ) -> Result<ResolvedColumn, TableDefinitionWriteError> {
-    let physical_type = column.physical_type;
-    validate_size(ordinal, physical_type, column.size)?;
-    let long_or_binary = matches!(
-        physical_type,
-        ColumnPhysicalType::Binary | ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo
-    );
-    let class_error = TableDefinitionWriteError::UnsupportedColumnClass {
+    let physical_type = column.physical_type();
+    let storage = column.storage();
+    let invalid_system_class = || TableDefinitionWriteError::InvalidSystemColumnClass {
         ordinal,
+        class: system_class,
         physical_type,
-        storage: column.storage,
+        storage,
     };
-    let variable_counter = *variables_seen;
-    if definition_kind == TableDefinitionKind::System && column.auto_increment {
-        return Err(class_error);
+    let auto_increment = column.column_type() == ColumnType::AutoIncrement;
+    if definition_kind == TableDefinitionKind::System && auto_increment {
+        return Err(invalid_system_class());
     }
-    match column.storage {
+    let variable_counter = *variables_seen;
+    match storage {
         ColumnStorageKind::Variable => {
-            if !(long_or_binary || physical_type == ColumnPhysicalType::Text)
-                || column.auto_increment
-            {
-                return Err(class_error);
-            }
             let index = *variables_seen;
             *variables_seen = index
                 .checked_add(1)
                 .ok_or(TableDefinitionWriteError::Resource(Error::Arithmetic {
                     operation: "advance variable column count",
                 }))?;
+            let class = match (definition_kind, system_class) {
+                (TableDefinitionKind::User, _) => VARIABLE_CLASS,
+                (TableDefinitionKind::System, Some(SystemColumnClassSpec::Variable)) => {
+                    SYSTEM_VARIABLE_CLASS
+                }
+                (TableDefinitionKind::System, Some(SystemColumnClassSpec::Binary))
+                    if physical_type == ColumnPhysicalType::Binary =>
+                {
+                    SYSTEM_BINARY_CLASS
+                }
+                (TableDefinitionKind::System, _) => return Err(invalid_system_class()),
+            };
             Ok(ResolvedColumn {
                 storage: ColumnStorageClass::Variable { index },
                 variable_counter,
-                class: match definition_kind {
-                    TableDefinitionKind::User => VARIABLE_CLASS,
-                    TableDefinitionKind::System => match system_class {
-                        Some(SystemColumnClassSpec::Variable) => SYSTEM_VARIABLE_CLASS,
-                        Some(SystemColumnClassSpec::Binary)
-                            if physical_type == ColumnPhysicalType::Binary =>
-                        {
-                            SYSTEM_BINARY_CLASS
-                        }
-                        Some(SystemColumnClassSpec::Fixed | SystemColumnClassSpec::Binary)
-                        | None => {
-                            return Err(TableDefinitionWriteError::InvalidSystemColumnClass {
-                                ordinal,
-                                class: system_class,
-                                physical_type,
-                                storage: column.storage,
-                            });
-                        }
-                    },
-                },
+                class,
             })
         }
         ColumnStorageKind::Fixed => {
-            if long_or_binary
-                || (column.auto_increment && physical_type != ColumnPhysicalType::Long)
-            {
-                return Err(class_error);
-            }
             let offset = if definition_kind == TableDefinitionKind::System
                 && physical_type == ColumnPhysicalType::Boolean
             {
@@ -282,59 +354,23 @@ pub(crate) fn resolve_column(
             };
             if physical_type != ColumnPhysicalType::Boolean {
                 *next_fixed_offset = offset
-                    .checked_add(column.size)
+                    .checked_add(column.size())
                     .ok_or(TableDefinitionWriteError::FixedAreaTooLarge { ordinal })?;
             }
+            let class = match (definition_kind, system_class) {
+                (TableDefinitionKind::System, Some(SystemColumnClassSpec::Fixed)) => {
+                    SYSTEM_FIXED_CLASS
+                }
+                (TableDefinitionKind::System, _) => return Err(invalid_system_class()),
+                (TableDefinitionKind::User, _) if auto_increment => AUTO_INCREMENT_CLASS,
+                (TableDefinitionKind::User, _) => FIXED_CLASS,
+            };
             Ok(ResolvedColumn {
                 storage: ColumnStorageClass::Fixed { offset },
                 variable_counter,
-                class: match definition_kind {
-                    TableDefinitionKind::System
-                        if system_class == Some(SystemColumnClassSpec::Fixed) =>
-                    {
-                        SYSTEM_FIXED_CLASS
-                    }
-                    TableDefinitionKind::System => {
-                        return Err(TableDefinitionWriteError::InvalidSystemColumnClass {
-                            ordinal,
-                            class: system_class,
-                            physical_type,
-                            storage: column.storage,
-                        });
-                    }
-                    TableDefinitionKind::User if column.auto_increment => AUTO_INCREMENT_CLASS,
-                    TableDefinitionKind::User => FIXED_CLASS,
-                },
+                class,
             })
         }
-    }
-}
-
-fn validate_size(
-    ordinal: u16,
-    physical_type: ColumnPhysicalType,
-    size: u16,
-) -> Result<(), TableDefinitionWriteError> {
-    // EXP-0059: accepted DAO sizes per physical type.
-    let valid = match physical_type {
-        ColumnPhysicalType::Boolean | ColumnPhysicalType::Byte => size == 1,
-        ColumnPhysicalType::Integer => size == 2,
-        ColumnPhysicalType::Long | ColumnPhysicalType::Single => size == 4,
-        ColumnPhysicalType::Currency
-        | ColumnPhysicalType::Double
-        | ColumnPhysicalType::DateTime => size == 8,
-        ColumnPhysicalType::Guid => size == 16,
-        ColumnPhysicalType::Binary | ColumnPhysicalType::Text => (1..=255).contains(&size),
-        ColumnPhysicalType::LongBinary | ColumnPhysicalType::Memo => size == 0,
-    };
-    if valid {
-        Ok(())
-    } else {
-        Err(TableDefinitionWriteError::UnsupportedColumnSize {
-            ordinal,
-            physical_type,
-            size,
-        })
     }
 }
 
@@ -346,7 +382,7 @@ pub(crate) fn write_column_record(
     resolved: ResolvedColumn,
     definition_kind: TableDefinitionKind,
 ) -> Result<(), Error> {
-    writer.write_u8(column.physical_type.raw())?;
+    writer.write_u8(column.physical_type().raw())?;
     writer.write_u16_le(ordinal)?;
     writer.write_u16_le(resolved.variable_counter)?;
     writer.write_u16_le(match definition_kind {
@@ -365,7 +401,7 @@ pub(crate) fn write_column_record(
         ColumnStorageClass::Variable { .. } => 0,
     };
     writer.write_u16_le(fixed_offset)?;
-    writer.write_u16_le(column.size)
+    writer.write_u16_le(column.size())
 }
 
 /// Validates a definition name and writes its length prefix and bytes.
@@ -544,5 +580,14 @@ pub(crate) fn write_logical_record(
             writer.write_u8(u8::from(cascade_deletes))?;
             writer.write_u8(RELATIONSHIP_CLASS)
         }
+    }
+}
+
+/// Builds a column size from a nonzero test literal.
+#[cfg(test)]
+pub(crate) const fn nz(value: u8) -> NonZeroU8 {
+    match NonZeroU8::new(value) {
+        Some(size) => size,
+        None => NonZeroU8::MIN,
     }
 }

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -19,12 +19,12 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use crate::atomic::atomic_create;
-use crate::bootstrap_composer::{BootstrapComposeError, compose_table_database};
+use crate::bootstrap_composer::{ComposeError, compose_table_database};
 use crate::page_append_plan::PlannedPage;
 use crate::{
-    CatalogError, CatalogObjectClass, ColumnStorageClass, ColumnStorageKind, DatabaseOpenError,
-    DatabaseReader, IndexDefinitionKind, IndexKind, PublishError, ResourceBudget,
-    TableDefinitionError, TableSpec,
+    CatalogError, CatalogObjectClass, ColumnStorageClass, ColumnStorageKind, ColumnType,
+    DatabaseOpenError, DatabaseReader, IndexDefinitionKind, IndexKind, PublishError,
+    ResourceBudget, TableDefinitionError, TableSpec,
 };
 
 /// Structured failure of [`create_database`].
@@ -32,7 +32,7 @@ use crate::{
 pub enum CreateDatabaseError {
     /// The table could not be composed into a database image; nothing was
     /// written.
-    Compose(BootstrapComposeError),
+    Compose(ComposeError),
     /// The composed image could not be written, checked, or published.
     Publish(PublishError),
 }
@@ -121,7 +121,7 @@ pub fn create_database(
     let page_count = pages.len() as u64;
     budget
         .charge_work_units(page_count.saturating_mul(crate::PAGE_BYTES as u64))
-        .map_err(|error| CreateDatabaseError::Compose(BootstrapComposeError::Encoding(error)))?;
+        .map_err(|error| CreateDatabaseError::Compose(ComposeError::Encoding(error)))?;
     atomic_create(
         path,
         |file| write_pages(file, &pages),
@@ -195,6 +195,7 @@ fn check_candidate(
         if column.name().raw_bytes() != requested.name()
             || column.physical_type() != requested.physical_type()
             || column.size() != requested.size()
+            || column.auto_increment() != (requested.column_type() == ColumnType::AutoIncrement)
             || !storage_matches
         {
             return Err(mismatch("column"));
@@ -226,7 +227,8 @@ fn check_candidate(
         let fields = physical_definition.fields();
         if fields.len() != requested.fields.len()
             || fields.iter().zip(requested.fields).any(|(field, wanted)| {
-                field.column().get() != wanted.column || field.direction() != wanted.direction
+                wanted.column.resolve(spec.columns) != Some(field.column().get())
+                    || field.direction() != wanted.direction
             })
         {
             return Err(mismatch("index fields"));

--- a/crates/jet3/src/create_tests.rs
+++ b/crates/jet3/src/create_tests.rs
@@ -1,3 +1,4 @@
+use crate::column_definition_writer::nz;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -5,14 +6,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use super::{CandidateCheckError, CreateDatabaseError, check_candidate, create_database};
 use crate::table_schema_plan::TableSchemaPlanError;
 use crate::{
-    BootstrapComposeError, ColumnPhysicalType, ColumnSpec, ColumnStorageKind, DatabaseReader,
-    IndexDirection, IndexFieldSpec, IndexKind, IndexSpec, PageNumber, PublishStage, ResourceBudget,
-    ResourceLimits, TableSpec,
+    ColumnRef, ColumnSpec, ColumnType, ComposeError, DatabaseReader, IndexColumnSpec,
+    IndexDirection, IndexKind, IndexSpec, PageNumber, PublishStage, ResourceBudget, ResourceLimits,
+    TableSpec,
 };
 
 static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 type TestResult = Result<(), Box<dyn std::error::Error>>;
-type Accepts = fn(&BootstrapComposeError) -> bool;
+type Accepts = fn(&ComposeError) -> bool;
 
 struct TestDirectory {
     path: PathBuf,
@@ -53,29 +54,16 @@ fn budget() -> ResourceBudget {
     ResourceBudget::new(ResourceLimits::default())
 }
 
-const ID: ColumnSpec<'static> =
-    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4);
-const CODE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Code",
-    ColumnPhysicalType::Text,
-    ColumnStorageKind::Variable,
-    8,
-);
-const SEQUENCE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Sequence",
-    ColumnPhysicalType::Long,
-    ColumnStorageKind::Fixed,
-    4,
-);
-const NOTE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Note",
-    ColumnPhysicalType::Memo,
-    ColumnStorageKind::Variable,
-    0,
-);
+const ID: ColumnSpec<'static> = ColumnSpec::new(b"Id", ColumnType::Long);
+const CODE: ColumnSpec<'static> = ColumnSpec::new(b"Code", ColumnType::Text { max_len: nz(8) });
+const SEQUENCE: ColumnSpec<'static> = ColumnSpec::new(b"Sequence", ColumnType::Long);
+const NOTE: ColumnSpec<'static> = ColumnSpec::new(b"Note", ColumnType::Memo);
 
-const fn field(column: u16, direction: IndexDirection) -> IndexFieldSpec {
-    IndexFieldSpec { column, direction }
+const fn field(column: u16, direction: IndexDirection) -> IndexColumnSpec<'static> {
+    IndexColumnSpec {
+        column: ColumnRef::Ordinal(column),
+        direction,
+    }
 }
 
 #[test]
@@ -91,7 +79,7 @@ fn a_mixed_table_with_three_indexes_is_created_and_reopens() -> TestResult {
         },
         IndexSpec {
             name: b"ByCode",
-            fields: &[field(1, IndexDirection::Ascending)],
+            fields: &[IndexColumnSpec::ascending(b"Code")],
             kind: IndexKind::Unique,
         },
         IndexSpec {
@@ -214,18 +202,13 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
         kind: IndexKind::Ordinary,
     }];
     let indexed_memo = [ID, NOTE];
-    let high_byte = [ColumnSpec::new(
-        b"Caf\xe9",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let high_byte = [ColumnSpec::new(b"Caf\xe9", ColumnType::Long)];
     let wide_names = (0..70)
         .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
         .collect::<Vec<_>>();
     let wide = wide_names
         .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
         .collect::<Vec<_>>();
     let cases: [(TableSpec<'_>, Accepts); 3] = [
         (
@@ -234,7 +217,7 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
                 columns: &indexed_memo,
                 indexes: &by_id,
             },
-            |error| matches!(error, BootstrapComposeError::UnobservedMapRowLayout),
+            |error| matches!(error, ComposeError::UnobservedMapRowLayout),
         ),
         (
             TableSpec {
@@ -245,7 +228,7 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
             |error| {
                 matches!(
                     error,
-                    BootstrapComposeError::Schema(TableSchemaPlanError::NameByteUnestablished {
+                    ComposeError::Schema(TableSchemaPlanError::NameByteUnestablished {
                         byte: 0xe9,
                         ..
                     })
@@ -261,7 +244,7 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
             |error| {
                 matches!(
                     error,
-                    BootstrapComposeError::Schema(
+                    ComposeError::Schema(
                         TableSchemaPlanError::ContinuationPlacementUnestablished {
                             continuations: 1,
                             ..

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -5,21 +5,21 @@
 //! one empty user table starts at [`create_database`]:
 //!
 //! ```no_run
+//! use std::num::NonZeroU8;
+//!
 //! use jet3::{
-//!     ColumnPhysicalType, ColumnSpec, ColumnStorageKind, IndexDirection, IndexFieldSpec,
-//!     IndexKind, IndexSpec, ResourceBudget, ResourceLimits, TableSpec, create_database,
+//!     ColumnSpec, ColumnType, IndexColumnSpec, IndexKind, IndexSpec, ResourceBudget,
+//!     ResourceLimits, TableSpec, create_database,
 //! };
 //!
+//! const NAME_LEN: NonZeroU8 = NonZeroU8::new(50).unwrap();
 //! let columns = [
-//!     ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
-//!     ColumnSpec::new(b"Name", ColumnPhysicalType::Text, ColumnStorageKind::Variable, 50),
+//!     ColumnSpec::new(b"Id", ColumnType::AutoIncrement),
+//!     ColumnSpec::new(b"Name", ColumnType::Text { max_len: NAME_LEN }),
 //! ];
 //! let indexes = [IndexSpec {
 //!     name: b"PrimaryKey",
-//!     fields: &[IndexFieldSpec {
-//!         column: 0,
-//!         direction: IndexDirection::Ascending,
-//!     }],
+//!     fields: &[IndexColumnSpec::ascending(b"Id")],
 //!     kind: IndexKind::Primary,
 //! }];
 //! let spec = TableSpec {
@@ -105,7 +105,7 @@ pub use atomic::{
 };
 pub use binary::BinaryCursor;
 pub use binary_writer::BinaryWriter;
-pub use bootstrap_composer::BootstrapComposeError;
+pub use bootstrap_composer::ComposeError;
 pub use candidate::{CandidateError, RawJet3Candidate};
 pub use catalog::{CatalogCursor, CatalogError};
 pub use catalog_name_key::CatalogNameKeyError;
@@ -120,8 +120,8 @@ pub use column_definition::{
     ColumnDefinition, ColumnOrdinal, ColumnPhysicalType, ColumnStorageClass,
 };
 pub use column_definition_writer::{
-    ColumnSpec, ColumnStorageKind, IndexFieldSpec, LogicalIndexKindSpec, LogicalIndexSpec,
-    PhysicalIndexSpec, SystemColumnClassSpec,
+    ColumnSpec, ColumnStorageKind, ColumnType, IndexFieldSpec, LogicalIndexKindSpec,
+    LogicalIndexSpec, PhysicalIndexSpec, SystemColumnClassSpec,
 };
 pub use commit_state::{
     COMMIT_REGION_LENGTH, COMMIT_REGION_OFFSET, COMMIT_SLOT_COUNT, CommitRegion, CommitSlot,
@@ -171,7 +171,9 @@ pub use table_definition_writer::{
     LongValueMapSpec, PhysicalIndexFlagsSpec, TableDefinitionSpec, TableDefinitionWriteError,
     encode_table_definition, table_definition_len,
 };
-pub use table_schema_plan::{IndexKind, IndexSpec, TableSchemaPlanError, TableSpec};
+pub use table_schema_plan::{
+    ColumnRef, IndexColumnSpec, IndexKind, IndexSpec, TableSchemaPlanError, TableSpec,
+};
 pub use text::{DecodedText, TextCodePage, TextError};
 pub use usage_map::{UsageMapError, UsageMapRecord, locate_usage_map};
 pub use usage_map_writer::{

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -1,9 +1,10 @@
 use super::{RowColumnLayout, RowValue, RowWriteError, encode_row};
+use crate::column_definition_writer::nz;
 use crate::{
-    ByteCount, ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageClass,
-    ColumnStorageKind, DatabaseReader, Error, JET3_PAGE_SIZE, LongValueMapSpec, MapRowLocator,
-    PageNumber, ReadLimits, ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource,
-    TableDefinitionKind, TableDefinitionSpec, TextCodePage, ValueKind, encode_table_definition,
+    ByteCount, ColumnOrdinal, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnType,
+    DatabaseReader, Error, JET3_PAGE_SIZE, LongValueMapSpec, MapRowLocator, PageNumber, ReadLimits,
+    ResourceBudget, ResourceLimitKind, ResourceLimits, SliceSource, TableDefinitionKind,
+    TableDefinitionSpec, TextCodePage, ValueKind, encode_table_definition,
 };
 
 const PAGE_BYTES: usize = JET3_PAGE_SIZE.get() as usize;
@@ -12,23 +13,21 @@ const MAP_PAGE: usize = 2;
 const DATA_PAGE: usize = 3;
 
 fn all_type_columns() -> Vec<ColumnSpec<'static>> {
-    use ColumnPhysicalType as T;
-    use ColumnStorageKind::{Fixed, Variable};
     vec![
-        ColumnSpec::new(b"Id", T::Long, Fixed, 4),
-        ColumnSpec::new(b"Flag", T::Boolean, Fixed, 1),
-        ColumnSpec::new(b"Small", T::Byte, Fixed, 1),
-        ColumnSpec::new(b"Short", T::Integer, Fixed, 2),
-        ColumnSpec::new(b"Money", T::Currency, Fixed, 8),
-        ColumnSpec::new(b"Ratio", T::Single, Fixed, 4),
-        ColumnSpec::new(b"Precise", T::Double, Fixed, 8),
-        ColumnSpec::new(b"When", T::DateTime, Fixed, 8),
-        ColumnSpec::new(b"Blob", T::Binary, Variable, 16),
-        ColumnSpec::new(b"Name", T::Text, Variable, 50),
-        ColumnSpec::new(b"Code", T::Text, Fixed, 3),
-        ColumnSpec::new(b"Ole", T::LongBinary, Variable, 0),
-        ColumnSpec::new(b"Notes", T::Memo, Variable, 0),
-        ColumnSpec::new(b"Rid", T::Guid, Fixed, 16),
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Flag", ColumnType::Boolean),
+        ColumnSpec::new(b"Small", ColumnType::Byte),
+        ColumnSpec::new(b"Short", ColumnType::Integer),
+        ColumnSpec::new(b"Money", ColumnType::Currency),
+        ColumnSpec::new(b"Ratio", ColumnType::Single),
+        ColumnSpec::new(b"Precise", ColumnType::Double),
+        ColumnSpec::new(b"When", ColumnType::DateTime),
+        ColumnSpec::new(b"Blob", ColumnType::Binary { max_len: nz(16) }),
+        ColumnSpec::new(b"Name", ColumnType::Text { max_len: nz(50) }),
+        ColumnSpec::new(b"Code", ColumnType::FixedText { len: nz(3) }),
+        ColumnSpec::new(b"Ole", ColumnType::LongBinary),
+        ColumnSpec::new(b"Notes", ColumnType::Memo),
+        ColumnSpec::new(b"Rid", ColumnType::Guid),
     ]
 }
 

--- a/crates/jet3/src/table_definition_writer.rs
+++ b/crates/jet3/src/table_definition_writer.rs
@@ -134,24 +134,6 @@ pub enum TableDefinitionWriteError {
         /// Zero-based ordinal of the repeated name.
         ordinal: u16,
     },
-    /// A column size is incompatible with its physical type.
-    UnsupportedColumnSize {
-        /// Zero-based column ordinal.
-        ordinal: u16,
-        /// Physical type.
-        physical_type: ColumnPhysicalType,
-        /// Requested size.
-        size: u16,
-    },
-    /// A storage kind or auto-increment flag is incompatible with the type.
-    UnsupportedColumnClass {
-        /// Zero-based column ordinal.
-        ordinal: u16,
-        /// Physical type.
-        physical_type: ColumnPhysicalType,
-        /// Requested storage kind.
-        storage: ColumnStorageKind,
-    },
     /// The system class inventory does not match the definition kind and columns.
     InvalidSystemColumnClassCount {
         /// Definition marker class.

--- a/crates/jet3/src/table_definition_writer_tests.rs
+++ b/crates/jet3/src/table_definition_writer_tests.rs
@@ -1,8 +1,9 @@
 use super::{
     TableDefinitionSpec, TableDefinitionWriteError, encode_table_definition, table_definition_len,
 };
+use crate::column_definition_writer::nz;
 use crate::{
-    ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind,
+    ByteCount, ColumnPhysicalType, ColumnSpec, ColumnStorageClass, ColumnStorageKind, ColumnType,
     DatabaseReader, Error, IndexDefinitionKind, IndexDirection, IndexFieldSpec, JET3_PAGE_SIZE,
     LogicalIndexKindSpec, LogicalIndexSpec, LongValueMapSpec, MapRowLocator, PageNumber,
     PhysicalIndexFlagsSpec, PhysicalIndexSpec, ReadLimits, RelationshipSide, ResourceBudget,
@@ -23,23 +24,21 @@ fn budget() -> ResourceBudget {
 }
 
 fn all_type_columns() -> Vec<ColumnSpec<'static>> {
-    use ColumnPhysicalType as T;
-    use ColumnStorageKind::{Fixed, Variable};
     vec![
-        ColumnSpec::new(b"Id", T::Long, Fixed, 4).with_auto_increment(),
-        ColumnSpec::new(b"Flag", T::Boolean, Fixed, 1),
-        ColumnSpec::new(b"Small", T::Byte, Fixed, 1),
-        ColumnSpec::new(b"Short", T::Integer, Fixed, 2),
-        ColumnSpec::new(b"Money", T::Currency, Fixed, 8),
-        ColumnSpec::new(b"Ratio", T::Single, Fixed, 4),
-        ColumnSpec::new(b"Precise", T::Double, Fixed, 8),
-        ColumnSpec::new(b"When", T::DateTime, Fixed, 8),
-        ColumnSpec::new(b"Blob", T::Binary, Variable, 16),
-        ColumnSpec::new(b"Caf\xe9", T::Text, Variable, 50),
-        ColumnSpec::new(b"Code", T::Text, Fixed, 3),
-        ColumnSpec::new(b"Ole", T::LongBinary, Variable, 0),
-        ColumnSpec::new(b"Notes", T::Memo, Variable, 0),
-        ColumnSpec::new(b"Rid", T::Guid, Fixed, 16),
+        ColumnSpec::new(b"Id", ColumnType::AutoIncrement),
+        ColumnSpec::new(b"Flag", ColumnType::Boolean),
+        ColumnSpec::new(b"Small", ColumnType::Byte),
+        ColumnSpec::new(b"Short", ColumnType::Integer),
+        ColumnSpec::new(b"Money", ColumnType::Currency),
+        ColumnSpec::new(b"Ratio", ColumnType::Single),
+        ColumnSpec::new(b"Precise", ColumnType::Double),
+        ColumnSpec::new(b"When", ColumnType::DateTime),
+        ColumnSpec::new(b"Blob", ColumnType::Binary { max_len: nz(16) }),
+        ColumnSpec::new(b"Caf\xe9", ColumnType::Text { max_len: nz(50) }),
+        ColumnSpec::new(b"Code", ColumnType::FixedText { len: nz(3) }),
+        ColumnSpec::new(b"Ole", ColumnType::LongBinary),
+        ColumnSpec::new(b"Notes", ColumnType::Memo),
+        ColumnSpec::new(b"Rid", ColumnType::Guid),
     ]
 }
 
@@ -268,13 +267,8 @@ fn round_trips_every_column_type_and_index_kind() -> Result<(), Box<dyn std::err
 #[test]
 fn round_trips_typed_system_marker_columns_flags_counts_and_maps() -> TestResult {
     let columns = [
-        ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
-        ColumnSpec::new(
-            b"Payload",
-            ColumnPhysicalType::LongBinary,
-            ColumnStorageKind::Variable,
-            0,
-        ),
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Payload", ColumnType::LongBinary),
     ];
     let fields = [IndexFieldSpec {
         column: 0,
@@ -351,12 +345,7 @@ fn round_trips_typed_system_marker_columns_flags_counts_and_maps() -> TestResult
 
 #[test]
 fn rejects_cross_kind_flags_and_incomplete_typed_long_value_maps() {
-    let columns = [ColumnSpec::new(
-        b"Payload",
-        ColumnPhysicalType::LongBinary,
-        ColumnStorageKind::Variable,
-        0,
-    )];
+    let columns = [ColumnSpec::new(b"Payload", ColumnType::LongBinary)];
     let mut missing = spec(&columns, &[], &[]);
     missing.long_value_maps = &[];
     assert_eq!(
@@ -379,12 +368,7 @@ fn rejects_cross_kind_flags_and_incomplete_typed_long_value_maps() {
         })
     ));
 
-    let scalar_columns = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let scalar_columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
     let fields = [IndexFieldSpec {
         column: 0,
         direction: IndexDirection::Ascending,
@@ -430,19 +414,14 @@ fn rejects_structural_errors_before_writing() {
     let long_name = [b'x'; 256];
     let cases: Vec<(Vec<ColumnSpec<'_>>, TableDefinitionWriteError)> = vec![
         (
-            vec![ColumnSpec::new(b"A", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4); 256],
+            vec![ColumnSpec::new(b"A", ColumnType::Long); 256],
             TableDefinitionWriteError::TooManyColumns {
                 count: 256,
                 maximum: 255,
             },
         ),
         (
-            vec![ColumnSpec::new(
-                &long_name,
-                ColumnPhysicalType::Long,
-                ColumnStorageKind::Fixed,
-                4,
-            )],
+            vec![ColumnSpec::new(&long_name, ColumnType::Long)],
             TableDefinitionWriteError::NameTooLong {
                 role: "column",
                 ordinal: 0,
@@ -452,38 +431,12 @@ fn rejects_structural_errors_before_writing() {
         ),
         (
             vec![
-                ColumnSpec::new(b"A", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
-                ColumnSpec::new(b"A", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4),
+                ColumnSpec::new(b"A", ColumnType::Long),
+                ColumnSpec::new(b"A", ColumnType::Long),
             ],
             TableDefinitionWriteError::DuplicateName {
                 role: "column",
                 ordinal: 1,
-            },
-        ),
-        (
-            vec![ColumnSpec::new(
-                b"A",
-                ColumnPhysicalType::Memo,
-                ColumnStorageKind::Fixed,
-                0,
-            )],
-            TableDefinitionWriteError::UnsupportedColumnClass {
-                ordinal: 0,
-                physical_type: ColumnPhysicalType::Memo,
-                storage: ColumnStorageKind::Fixed,
-            },
-        ),
-        (
-            vec![ColumnSpec::new(
-                b"A",
-                ColumnPhysicalType::Guid,
-                ColumnStorageKind::Fixed,
-                8,
-            )],
-            TableDefinitionWriteError::UnsupportedColumnSize {
-                ordinal: 0,
-                physical_type: ColumnPhysicalType::Guid,
-                size: 8,
             },
         ),
     ];
@@ -503,14 +456,7 @@ fn rejects_structural_errors_before_writing() {
     let names: [&[u8]; 9] = [b"A", b"B", b"C", b"D", b"E", b"F", b"G", b"H", b"I"];
     let oversized_columns: Vec<_> = names
         .into_iter()
-        .map(|name| {
-            ColumnSpec::new(
-                name,
-                ColumnPhysicalType::Text,
-                ColumnStorageKind::Fixed,
-                255,
-            )
-        })
+        .map(|name| ColumnSpec::new(name, ColumnType::FixedText { len: nz(255) }))
         .collect();
     assert_eq!(
         encode_table_definition(
@@ -524,12 +470,7 @@ fn rejects_structural_errors_before_writing() {
         })
     );
 
-    let columns = [ColumnSpec::new(
-        b"Notes",
-        ColumnPhysicalType::Memo,
-        ColumnStorageKind::Variable,
-        0,
-    )];
+    let columns = [ColumnSpec::new(b"Notes", ColumnType::Memo)];
     let fields = [IndexFieldSpec {
         column: 0,
         direction: IndexDirection::Ascending,
@@ -548,12 +489,7 @@ fn rejects_structural_errors_before_writing() {
         })
     );
 
-    let columns = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
     let mut invalid_map = spec(&columns, &[], &[]);
     invalid_map.owned_map = MapRowLocator::new(PageNumber::new(0), 0);
     assert_eq!(
@@ -573,12 +509,7 @@ fn rejects_structural_errors_before_writing() {
     );
     assert!(output.iter().all(|byte| *byte == 0));
 
-    let columns = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
     let fields = [IndexFieldSpec {
         column: 0,
         direction: IndexDirection::Ascending,
@@ -609,12 +540,7 @@ fn rejects_structural_errors_before_writing() {
 
 #[test]
 fn rejects_small_output_and_exhausted_budget() -> Result<(), Box<dyn std::error::Error>> {
-    let columns = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
     let spec = spec(&columns, &[], &[]);
     let needed = table_definition_len(&spec)?;
     let mut output = vec![0_u8; needed];

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -34,7 +34,7 @@ use crate::column_definition_writer::{PhysicalIndexSpec, validate_physical_index
 use crate::page_image::PAGE_BYTES;
 use crate::table_definition_layout::{definition_len, validate_column_layout, validate_name};
 use crate::{
-    ColumnPhysicalType, ColumnSpec, IndexFieldSpec, LogicalIndexKindSpec, PageNumber,
+    ColumnSpec, IndexDirection, IndexFieldSpec, LogicalIndexKindSpec, PageNumber,
     PhysicalIndexFlagsSpec, TableDefinitionKind, TableDefinitionWriteError,
 };
 
@@ -87,13 +87,82 @@ impl IndexKind {
     }
 }
 
+/// A reference to one column of a [`TableSpec`], by position or by name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ColumnRef<'a> {
+    /// The column at this zero-based position in [`TableSpec::columns`].
+    Ordinal(u16),
+    /// The column whose raw name bytes equal these.
+    Name(&'a [u8]),
+}
+
+impl ColumnRef<'_> {
+    /// Returns the ordinal this reference names among `columns`, if any.
+    pub(crate) fn resolve(self, columns: &[ColumnSpec<'_>]) -> Option<u16> {
+        match self {
+            Self::Ordinal(ordinal) => (usize::from(ordinal) < columns.len()).then_some(ordinal),
+            Self::Name(name) => columns
+                .iter()
+                .position(|column| column.name() == name)
+                .and_then(|position| u16::try_from(position).ok()),
+        }
+    }
+}
+
+impl From<u16> for ColumnRef<'_> {
+    fn from(ordinal: u16) -> Self {
+        Self::Ordinal(ordinal)
+    }
+}
+
+impl<'a> From<&'a [u8]> for ColumnRef<'a> {
+    fn from(name: &'a [u8]) -> Self {
+        Self::Name(name)
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for ColumnRef<'a> {
+    fn from(name: &'a [u8; N]) -> Self {
+        Self::Name(name)
+    }
+}
+
+/// One key column of an [`IndexSpec`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IndexColumnSpec<'a> {
+    /// The table column the key uses.
+    pub column: ColumnRef<'a>,
+    /// Key direction.
+    pub direction: IndexDirection,
+}
+
+impl<'a> IndexColumnSpec<'a> {
+    /// Describes an ascending key on `column`.
+    #[must_use]
+    pub fn ascending(column: impl Into<ColumnRef<'a>>) -> Self {
+        Self {
+            column: column.into(),
+            direction: IndexDirection::Ascending,
+        }
+    }
+
+    /// Describes a descending key on `column`.
+    #[must_use]
+    pub fn descending(column: impl Into<ColumnRef<'a>>) -> Self {
+        Self {
+            column: column.into(),
+            direction: IndexDirection::Descending,
+        }
+    }
+}
+
 /// One index of a [`TableSpec`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IndexSpec<'a> {
     /// Index name; bytes must be at most `0x7E`.
     pub name: &'a [u8],
-    /// Ordered key fields naming table column ordinals.
-    pub fields: &'a [IndexFieldSpec],
+    /// Ordered key columns.
+    pub fields: &'a [IndexColumnSpec<'a>],
     /// The index's uniqueness class.
     pub kind: IndexKind,
 }
@@ -120,6 +189,13 @@ pub enum TableSchemaPlanError {
     Definition(TableDefinitionWriteError),
     /// The table declares no columns.
     NoColumns,
+    /// An index key names a column the table does not declare.
+    UnknownIndexColumn {
+        /// Position of the index in the spec.
+        index: usize,
+        /// Position of the key within the index.
+        field: usize,
+    },
     /// A column or index name holds a byte above the range `EXP-0087`
     /// established weights for.
     NameByteUnestablished {
@@ -203,7 +279,8 @@ impl std::error::Error for TableSchemaPlanError {
 pub(crate) struct TableSchemaPlan {
     object_id: i32,
     definition_root: PageNumber,
-    index_count: usize,
+    /// Each index's key fields with column references resolved to ordinals.
+    index_fields: Vec<Vec<IndexFieldSpec>>,
 }
 
 impl TableSchemaPlan {
@@ -232,7 +309,7 @@ impl TableSchemaPlan {
     /// table's own two maps).
     pub(crate) fn index_placements(&self) -> impl Iterator<Item = (PageNumber, u8)> {
         let first_root = self.property_page().get() + 1;
-        (0..self.index_count).map(move |ordinal| {
+        (0..self.index_fields.len()).map(move |ordinal| {
             (
                 PageNumber::new(first_root + ordinal as u64),
                 FIRST_INDEX_MAP_ROW + ordinal as u8,
@@ -240,9 +317,15 @@ impl TableSchemaPlan {
         })
     }
 
+    /// Returns each index's key fields, resolved to column ordinals, in
+    /// physical ordinal order.
+    pub(crate) fn index_fields(&self) -> impl Iterator<Item = &[IndexFieldSpec]> {
+        self.index_fields.iter().map(Vec::as_slice)
+    }
+
     /// Returns how many pages the create appends.
-    pub(crate) const fn appended_page_count(&self) -> u64 {
-        3 + self.index_count as u64
+    pub(crate) fn appended_page_count(&self) -> u64 {
+        3 + self.index_fields.len() as u64
     }
 }
 
@@ -275,9 +358,42 @@ pub(crate) fn plan_table_schema(
             continuations,
         });
     }
-    let plan = assign_pages(spec, first_page)?;
+    let index_fields = resolve_index_fields(spec)?;
+    let plan = assign_pages(spec, first_page, index_fields)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
+}
+
+/// Resolves every index key to a column ordinal; ordinal bounds are checked
+/// later by the physical-index encoder.
+fn resolve_index_fields(
+    spec: &TableSpec<'_>,
+) -> Result<Vec<Vec<IndexFieldSpec>>, TableSchemaPlanError> {
+    spec.indexes
+        .iter()
+        .enumerate()
+        .map(|(index, planned)| {
+            planned
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(field, key)| match key.column {
+                    ColumnRef::Ordinal(column) => Ok(IndexFieldSpec {
+                        column,
+                        direction: key.direction,
+                    }),
+                    ColumnRef::Name(_) => key
+                        .column
+                        .resolve(spec.columns)
+                        .map(|column| IndexFieldSpec {
+                            column,
+                            direction: key.direction,
+                        })
+                        .ok_or(TableSchemaPlanError::UnknownIndexColumn { index, field }),
+                })
+                .collect()
+        })
+        .collect()
 }
 
 /// Checks the table name against both encodings that will carry it.
@@ -314,12 +430,7 @@ fn measure_definition(spec: &TableSpec<'_>) -> Result<usize, TableSchemaPlanErro
     let long_value_maps = spec
         .columns
         .iter()
-        .filter(|column| {
-            matches!(
-                column.physical_type(),
-                ColumnPhysicalType::Memo | ColumnPhysicalType::LongBinary
-            )
-        })
+        .filter(|column| column.column_type().is_long_value())
         .count();
     definition_len(
         spec.columns,
@@ -342,6 +453,7 @@ pub(crate) const fn continuation_count(length: usize) -> usize {
 fn assign_pages(
     spec: &TableSpec<'_>,
     first_page: u64,
+    index_fields: Vec<Vec<IndexFieldSpec>>,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
     let needed = 3 + spec.indexes.len() as u64;
     // `EXP-0093` numbers the object equal to its definition root, and
@@ -363,7 +475,7 @@ fn assign_pages(
     Ok(TableSchemaPlan {
         object_id,
         definition_root: PageNumber::new(first_page),
-        index_count: spec.indexes.len(),
+        index_fields,
     })
 }
 
@@ -374,7 +486,7 @@ fn validate_indexes(
     plan: &TableSchemaPlan,
 ) -> Result<(), TableSchemaPlanError> {
     let mut primary: Option<usize> = None;
-    for (position, planned) in spec.indexes.iter().enumerate() {
+    for ((position, planned), fields) in spec.indexes.iter().enumerate().zip(plan.index_fields()) {
         let ordinal = position as u16;
         validate_name_bytes("logical index", position, planned.name)?;
         validate_name(
@@ -391,7 +503,7 @@ fn validate_indexes(
             });
         };
         let physical = PhysicalIndexSpec {
-            fields: planned.fields,
+            fields,
             usage_map_page: plan.map_page(),
             usage_map_row: row,
             root,

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -30,7 +30,7 @@ use std::fmt;
 
 use crate::catalog_name_key::{CatalogNameKeyError, validate_catalog_name};
 use crate::catalog_record_writer::{CatalogRecordWriteError, catalog_record_len};
-use crate::column_definition_writer::{PhysicalIndexSpec, validate_physical_index};
+use crate::column_definition_writer::{KEY_SLOT_COUNT, PhysicalIndexSpec, validate_physical_index};
 use crate::page_image::PAGE_BYTES;
 use crate::table_definition_layout::{definition_len, validate_column_layout, validate_name};
 use crate::{
@@ -364,8 +364,9 @@ pub(crate) fn plan_table_schema(
     Ok(plan)
 }
 
-/// Resolves every index key to a column ordinal; ordinal bounds are checked
-/// later by the physical-index encoder.
+/// Resolves every index key to a column ordinal. The key count is bounded
+/// before anything is allocated; ordinal bounds are checked later by the
+/// physical-index encoder.
 fn resolve_index_fields(
     spec: &TableSpec<'_>,
 ) -> Result<Vec<Vec<IndexFieldSpec>>, TableSchemaPlanError> {
@@ -373,6 +374,15 @@ fn resolve_index_fields(
         .iter()
         .enumerate()
         .map(|(index, planned)| {
+            if planned.fields.len() > KEY_SLOT_COUNT {
+                return Err(TableSchemaPlanError::Definition(
+                    TableDefinitionWriteError::TooManyKeyFields {
+                        physical_index: index as u16,
+                        count: planned.fields.len(),
+                        maximum: KEY_SLOT_COUNT,
+                    },
+                ));
+            }
             planned
                 .fields
                 .iter()

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -462,7 +462,10 @@ fn an_index_field_count_one_above_the_limit_is_refused() {
         .iter()
         .map(|name| ColumnSpec::new(name, ColumnType::Long))
         .collect::<Vec<_>>();
-    let fields = (0..=KEY_SLOT_COUNT as u16).map(key).collect::<Vec<_>>();
+    // An unknown name past the limit must not be reached: the count is
+    // refused before any key is resolved or stored.
+    let mut fields = (0..=KEY_SLOT_COUNT as u16).map(key).collect::<Vec<_>>();
+    fields.push(IndexColumnSpec::ascending(b"Missing"));
     let indexes = [IndexSpec {
         name: b"Wide",
         fields: &fields,
@@ -471,7 +474,7 @@ fn an_index_field_count_one_above_the_limit_is_refused() {
     assert!(matches!(
         definition_error(&spec(b"Wide", &columns, &indexes)),
         Some(TableDefinitionWriteError::TooManyKeyFields { count, .. })
-            if count == KEY_SLOT_COUNT + 1
+            if count == KEY_SLOT_COUNT + 2
     ));
 }
 

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -1,34 +1,22 @@
 use super::*;
 
+use crate::column_definition_writer::nz;
 use crate::physical_index_definition::KEY_SLOT_COUNT;
-use crate::{ColumnPhysicalType, ColumnStorageKind, IndexDirection, LogicalIndexKindSpec};
+use crate::{
+    ColumnPhysicalType, ColumnRef, ColumnType, IndexColumnSpec, IndexDirection,
+    LogicalIndexKindSpec,
+};
 
 type PlanResult = Result<(), TableSchemaPlanError>;
 
-const ID: ColumnSpec<'static> =
-    ColumnSpec::new(b"Id", ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4);
-const LABEL: ColumnSpec<'static> = ColumnSpec::new(
-    b"Label",
-    ColumnPhysicalType::Text,
-    ColumnStorageKind::Variable,
-    30,
-);
-const NAME: ColumnSpec<'static> = ColumnSpec::new(
-    b"Name",
-    ColumnPhysicalType::Text,
-    ColumnStorageKind::Variable,
-    50,
-);
-const NOTE: ColumnSpec<'static> = ColumnSpec::new(
-    b"Note",
-    ColumnPhysicalType::Memo,
-    ColumnStorageKind::Variable,
-    0,
-);
+const ID: ColumnSpec<'static> = ColumnSpec::new(b"Id", ColumnType::Long);
+const LABEL: ColumnSpec<'static> = ColumnSpec::new(b"Label", ColumnType::Text { max_len: nz(30) });
+const NAME: ColumnSpec<'static> = ColumnSpec::new(b"Name", ColumnType::Text { max_len: nz(50) });
+const NOTE: ColumnSpec<'static> = ColumnSpec::new(b"Note", ColumnType::Memo);
 
-const fn key(column: u16) -> IndexFieldSpec {
-    IndexFieldSpec {
-        column,
+const fn key(column: u16) -> IndexColumnSpec<'static> {
+    IndexColumnSpec {
+        column: ColumnRef::Ordinal(column),
         direction: IndexDirection::Ascending,
     }
 }
@@ -71,7 +59,7 @@ fn names_of_definition_len(target: usize) -> Vec<Vec<u8>> {
 fn long_columns(names: &[Vec<u8>]) -> Vec<ColumnSpec<'_>> {
     names
         .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
         .collect()
 }
 
@@ -170,12 +158,7 @@ fn index_names_whose_order_depends_on_case_folding_are_refused() {
 
 #[test]
 fn a_name_byte_above_the_established_range_is_refused() {
-    let columns = [ColumnSpec::new(
-        b"Caf\xe9",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(b"Caf\xe9", ColumnType::Long)];
     assert_eq!(
         plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
         Err(TableSchemaPlanError::NameByteUnestablished {
@@ -246,12 +229,7 @@ fn a_table_name_too_long_for_a_catalog_row_is_refused() {
 #[test]
 fn a_column_name_too_long_for_the_definition_is_refused() {
     let overlong = vec![b'A'; 256];
-    let columns = [ColumnSpec::new(
-        &overlong,
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(&overlong, ColumnType::Long)];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &[])),
         Some(TableDefinitionWriteError::NameTooLong {
@@ -282,35 +260,55 @@ fn an_index_name_too_long_for_the_definition_is_refused() {
 }
 
 #[test]
-fn a_column_size_its_type_does_not_accept_is_refused() {
-    let columns = [ColumnSpec::new(
-        b"Id",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        1,
-    )];
-    assert!(matches!(
-        definition_error(&spec(b"Beta", &columns, &[])),
-        Some(TableDefinitionWriteError::UnsupportedColumnSize {
-            ordinal: 0,
-            size: 1,
-            ..
-        })
-    ));
+fn index_columns_named_by_name_resolve_to_the_same_ordinals() -> PlanResult {
+    let columns = [ID, LABEL, NAME];
+    let by_name = [IndexSpec {
+        name: b"ByLabel",
+        fields: &[
+            IndexColumnSpec::descending(b"Label"),
+            IndexColumnSpec::ascending(b"Id"),
+        ],
+        kind: IndexKind::Ordinary,
+    }];
+    let by_ordinal = [IndexSpec {
+        name: b"ByLabel",
+        fields: &[IndexColumnSpec::descending(1), key(0)],
+        kind: IndexKind::Ordinary,
+    }];
+    let named = plan_table_schema(&spec(b"Beta", &columns, &by_name), 20)?;
+    let ordinal = plan_table_schema(&spec(b"Beta", &columns, &by_ordinal), 20)?;
+    assert_eq!(named, ordinal);
+    assert_eq!(
+        named.index_fields().collect::<Vec<_>>(),
+        [&[
+            IndexFieldSpec {
+                column: 1,
+                direction: IndexDirection::Descending,
+            },
+            IndexFieldSpec {
+                column: 0,
+                direction: IndexDirection::Ascending,
+            },
+        ][..]]
+    );
+    Ok(())
 }
 
 #[test]
-fn a_memo_column_in_fixed_storage_is_refused() {
-    let columns = [ColumnSpec::new(
-        b"Note",
-        ColumnPhysicalType::Memo,
-        ColumnStorageKind::Fixed,
-        0,
-    )];
-    assert!(matches!(
-        definition_error(&spec(b"Beta", &columns, &[])),
-        Some(TableDefinitionWriteError::UnsupportedColumnClass { ordinal: 0, .. })
-    ));
+fn an_index_column_name_the_table_lacks_is_refused() {
+    let columns = [ID, NAME];
+    let indexes = [IndexSpec {
+        name: b"ByLabel",
+        fields: &[
+            IndexColumnSpec::ascending(b"Id"),
+            IndexColumnSpec::ascending(b"Label"),
+        ],
+        kind: IndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::UnknownIndexColumn { index: 0, field: 1 })
+    );
 }
 
 #[test]
@@ -321,14 +319,7 @@ fn a_fixed_area_no_row_slot_could_hold_is_refused() {
         .collect::<Vec<_>>();
     let columns = names
         .iter()
-        .map(|name| {
-            ColumnSpec::new(
-                name,
-                ColumnPhysicalType::Text,
-                ColumnStorageKind::Fixed,
-                255,
-            )
-        })
+        .map(|name| ColumnSpec::new(name, ColumnType::FixedText { len: nz(255) }))
         .collect::<Vec<_>>();
     assert!(matches!(
         definition_error(&spec(b"Wide", &columns, &[])),
@@ -369,12 +360,7 @@ fn a_repeated_column_name_is_refused() {
 
 #[test]
 fn an_empty_column_name_is_refused() {
-    let columns = [ColumnSpec::new(
-        b"",
-        ColumnPhysicalType::Long,
-        ColumnStorageKind::Fixed,
-        4,
-    )];
+    let columns = [ColumnSpec::new(b"", ColumnType::Long)];
     assert!(matches!(
         definition_error(&spec(b"Beta", &columns, &[])),
         Some(TableDefinitionWriteError::EmptyName {
@@ -474,7 +460,7 @@ fn an_index_field_count_one_above_the_limit_is_refused() {
         .collect::<Vec<_>>();
     let columns = names
         .iter()
-        .map(|name| ColumnSpec::new(name, ColumnPhysicalType::Long, ColumnStorageKind::Fixed, 4))
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
         .collect::<Vec<_>>();
     let fields = (0..=KEY_SLOT_COUNT as u16).map(key).collect::<Vec<_>>();
     let indexes = [IndexSpec {


### PR DESCRIPTION
The first-pass creation API (#177) asked callers to spell every column as a `(physical type, storage kind, size)` triple and then rejected the combinations DAO never accepts at plan time, and index keys could only point at column ordinals. This batches the breaking cleanups from #175 into one surface break.

- `ColumnSpec::new(name, ColumnType)`: each `ColumnType` variant fixes the physical type, storage class, and record size. Sizes appear only on `Text`, `FixedText`, and `Binary` as `NonZeroU8`, and `AutoIncrement` is its own variant. The `UnsupportedColumnSize` and `UnsupportedColumnClass` writer errors this made unreachable are deleted.
- `IndexSpec::fields` now takes `IndexColumnSpec`, whose `ColumnRef` names a column by ordinal or by raw name bytes (`IndexColumnSpec::ascending(b"Id")`). The planner resolves names once and reports `TableSchemaPlanError::UnknownIndexColumn` for a missing name; the composer and the pre-publication reopen check consume the resolved ordinals.
- `BootstrapComposeError` is renamed `ComposeError`.
- The crate doc example and every internal caller (system-table definitions, composer, tests) move to the new spelling.

No format behavior changes and no new provenance facts. Module and file structure are intentionally left alone for a follow-up issue.

Validation: `just ready` (fmt-check, clippy, tests, docs, quick acceptance) and `scripts/check-source-size.sh` pass. New focused tests cover name-referenced keys resolving identically to ordinals and an unknown key name being refused.

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)