### PR TITLE
feat(jet3): create tables whose definition needs one continuation page

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -36,6 +36,14 @@ pub enum ComposeError {
         /// Largest observed long-value column count.
         observed: usize,
     },
+    /// The encoded definition length differs from the length the planner
+    /// measured, so its page split cannot be trusted.
+    DefinitionLengthMismatch {
+        /// Length the planner measured.
+        planned: usize,
+        /// Length the encoder produced.
+        encoded: usize,
+    },
 }
 
 impl fmt::Display for ComposeError {
@@ -57,7 +65,8 @@ impl std::error::Error for ComposeError {
             Self::Schema(source) => Some(source),
             Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
-            | Self::UnobservedLongValueColumnCount { .. } => None,
+            | Self::UnobservedLongValueColumnCount { .. }
+            | Self::DefinitionLengthMismatch { .. } => None,
         }
     }
 }

--- a/crates/jet3/src/bootstrap_composer_schema_candidates_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_schema_candidates_tests.rs
@@ -142,6 +142,39 @@ fn assert_shared_candidate(bytes: &[u8], table_name: &[u8]) -> TestResult {
 }
 
 #[test]
+fn the_composer_reproduces_the_accepted_cont_one_x_candidate() -> TestResult {
+    // EXP-0107 accepted the exact hand-assembled ContOneX image; the general
+    // composer must produce the same 49,152 bytes for the same schema.
+    let names = (0..WIDE_FIELD_COUNT)
+        .map(|ordinal| format!("F{ordinal:03}AAAAAA").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
+        .collect::<Vec<_>>();
+    let mut budget = compose_budget();
+    let composed = compose_table_database(
+        &TableSpec {
+            name: b"ContOneX",
+            columns: &columns,
+            indexes: &[],
+        },
+        &mut budget,
+    )?
+    .pages()
+    .iter()
+    .flat_map(|page| page.image().as_bytes().iter().copied())
+    .collect::<Vec<u8>>();
+    let candidate = wide_candidate_bytes()?;
+    assert_eq!(composed.len(), 24 * crate::PAGE_BYTES);
+    assert!(
+        composed == candidate,
+        "composed image differs from the accepted candidate"
+    );
+    Ok(())
+}
+
+#[test]
 fn the_schema_candidates_decode_to_their_preregistered_shapes() -> TestResult {
     assert_shared_candidate(&bytes(true)?, b"Alpha")?;
     let indexed = indexed_candidate_bytes()?;

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -10,8 +10,13 @@
 //! index records appear in name order while referring back to the physical
 //! ordinals.
 //!
-//! The planner refuses definitions that need a continuation page, because
-//! `EXP-0105` established their capacities but not their placement.
+//! A definition longer than its root page takes one continuation page directly
+//! after the `LvProp` page, the compact construction `EXP-0107` observed DAO
+//! accept for an unindexed table. The root's bytes `[4,8)` name that page and
+//! the continuation repeats the definition prefix, holds zero at `[4,8)`, and
+//! carries the remaining logical bytes from offset 8 (`EXP-0059`,
+//! `EXP-0105`). Longer chains, and a continuation beside an index, are refused
+//! by the planner.
 //!
 //! `EXP-0091` accepted the exact `Alpha(Id Long)` first create with a null
 //! catalog `LvProp` and a retained, mapped, empty long-value page. Every
@@ -29,8 +34,8 @@
 
 use super::*;
 use crate::table_schema_plan::{
-    AVAILABLE_MAP_ROW, FIRST_INDEX_MAP_ROW, OWNED_MAP_ROW, TableSchemaPlan, TableSpec,
-    logical_index_order, plan_table_schema,
+    AVAILABLE_MAP_ROW, CONTINUATION_CAPACITY, DEFINITION_ROOT_CAPACITY, FIRST_INDEX_MAP_ROW,
+    OWNED_MAP_ROW, TableSchemaPlan, TableSpec, logical_index_order, plan_table_schema,
 };
 
 /// `EXP-0093`: `MSysObjects` `Flags` of a created user table.
@@ -101,17 +106,22 @@ impl<'a> PlannedCreate<'a> {
     }
 
     /// Appends the create's pages in `EXP-0093` order: definition root, map
-    /// page, long-value page, then the index roots.
+    /// page, long-value page, the `EXP-0107` continuation if the definition
+    /// needs one, then the index roots.
     pub(super) fn append_pages(
         &self,
         plan: &mut WholeFileImagePlan,
         budget: &mut ResourceBudget,
     ) -> Result<(), ComposeError> {
         let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
-        plan.append(self.definition_page(budget)?, &mut append_map, budget)?;
+        let (root, continuation) = self.definition_pages(budget)?;
+        plan.append(root, &mut append_map, budget)?;
         plan.append(self.map_page(budget)?, &mut append_map, budget)?;
         let lval = DataPageBuilder::new_long_value(budget)?;
         plan.append(finish_data_builder(lval, budget)?, &mut append_map, budget)?;
+        if let Some(continuation) = continuation {
+            plan.append(continuation, &mut append_map, budget)?;
+        }
         let owner = self.plan.definition_root().get();
         for _ in self.plan.index_placements() {
             plan.append(empty_index_page(owner, budget)?, &mut append_map, budget)?;
@@ -119,7 +129,46 @@ impl<'a> PlannedCreate<'a> {
         Ok(())
     }
 
-    fn definition_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+    /// Encodes the definition and splits it into its root page and, when the
+    /// planner assigned one, its continuation page.
+    fn definition_pages(
+        &self,
+        budget: &mut ResourceBudget,
+    ) -> Result<(PageImage, Option<PageImage>), ComposeError> {
+        let mut logical = [0_u8; DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY];
+        let length = self.encode_definition(&mut logical, budget)?.get() as usize;
+        if length != self.plan.definition_len() {
+            return Err(ComposeError::DefinitionLengthMismatch {
+                planned: self.plan.definition_len(),
+                encoded: length,
+            });
+        }
+        let mut root = [0_u8; PAGE_BYTES];
+        root.copy_from_slice(&logical[..PAGE_BYTES]);
+        let Some(continuation_page) = self.plan.continuation_page() else {
+            return Ok((PageImage::from_bytes(root), None));
+        };
+        let next =
+            u32::try_from(continuation_page.get()).map_err(|_| Error::IntegerConversion {
+                value: u128::from(continuation_page.get()),
+                target: "u32",
+            })?;
+        root[4..8].copy_from_slice(&next.to_le_bytes());
+        let mut continuation = [0_u8; PAGE_BYTES];
+        continuation[..4].copy_from_slice(&logical[..4]);
+        let payload = &logical[DEFINITION_ROOT_CAPACITY..length];
+        continuation[8..8 + payload.len()].copy_from_slice(payload);
+        Ok((
+            PageImage::from_bytes(root),
+            Some(PageImage::from_bytes(continuation)),
+        ))
+    }
+
+    fn encode_definition(
+        &self,
+        output: &mut [u8],
+        budget: &mut ResourceBudget,
+    ) -> Result<ByteCount, ComposeError> {
         let map = self.plan.map_page();
         let spec = self.spec;
         // The planner validated one placement per index, so the zip is exact.
@@ -162,7 +211,7 @@ impl<'a> PlannedCreate<'a> {
             })
             .into_iter()
             .collect::<Vec<_>>();
-        definition_page(
+        encode_table_definition(
             &TableDefinitionSpec {
                 kind: TableDefinitionKind::User,
                 columns: spec.columns,
@@ -174,8 +223,10 @@ impl<'a> PlannedCreate<'a> {
                 row_count: 0,
                 long_value_maps: &long_value_maps,
             },
+            output,
             budget,
         )
+        .map_err(Into::into)
     }
 
     /// Builds the map page with the rows the definition names.

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -198,11 +198,41 @@ fn a_three_index_first_create_follows_the_observed_page_and_record_order() -> Te
 }
 
 #[test]
-fn a_definition_needing_a_continuation_is_refused_before_any_page_is_built() {
-    // EXP-0105 established the 2,048/2,040 capacities but placed its
-    // continuations at pages 68 and 219/218 under an unestablished
-    // allocation, so no compact layout can claim to follow it.
+fn a_definition_needing_a_continuation_appends_it_after_the_property_page() -> TestResult {
+    // EXP-0107: the root names page 23 at [4,8), the continuation repeats the
+    // definition prefix with a zero next-page reference, and the payload
+    // starts at offset 8. The reader must decode all 70 columns through it.
     let names = wide_names(70);
+    let columns = wide_columns(&names);
+    let bytes = create_bytes(&TableSpec {
+        name: b"Wide",
+        columns: &columns,
+        indexes: &[],
+    })?;
+    assert_eq!(bytes.len(), 24 * PAGE_BYTES);
+    let root = page(&bytes, 20);
+    let continuation = page(&bytes, 23);
+    assert_eq!(&root[4..8], &23_u32.to_le_bytes());
+    assert_eq!(&continuation[..4], &root[..4]);
+    assert_eq!(&continuation[4..8], &[0, 0, 0, 0]);
+    assert!(continuation[8 + 27..].iter().all(|byte| *byte == 0));
+    assert!(!inline_map_bit(&bytes, 1, 0, 23)?);
+    assert_eq!(&page(&bytes, 22)[..4], b"\x01\x01\xf6\x07");
+    let mut budget = read_budget(bytes.len());
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    assert_eq!(database.geometry().page_count(), 24);
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.columns().len(), 70);
+    assert_eq!(definition.columns()[69].name().raw_bytes(), b"Field00069");
+    Ok(())
+}
+
+#[test]
+fn a_definition_needing_two_continuations_is_refused_before_any_page_is_built() {
+    // 140 ten-byte-named Long columns encode to 4,105 bytes, EXP-0105's
+    // two-continuation arm, whose placement stays unestablished.
+    let names = wide_names(140);
     let columns = wide_columns(&names);
     let mut budget = compose_budget();
     assert!(matches!(
@@ -216,8 +246,8 @@ fn a_definition_needing_a_continuation_is_refused_before_any_page_is_built() {
         ),
         Err(ComposeError::Schema(
             TableSchemaPlanError::ContinuationPlacementUnestablished {
-                length: 2075,
-                continuations: 1,
+                length: 4105,
+                continuations: 2,
             }
         ))
     ));

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -109,7 +109,8 @@ impl StdError for CandidateCheckError {
 /// Unsupported layouts fail with [`CreateDatabaseError::Compose`] before
 /// anything is written: more than three indexes, more than one Memo or
 /// LongBinary column, an index together with such a column, a definition
-/// longer than one page, or a name byte above `0x7E`.
+/// longer than two pages, a definition longer than one page together with an
+/// index, or a name byte above `0x7E`.
 pub fn create_database(
     path: impl AsRef<Path>,
     spec: &TableSpec<'_>,

--- a/crates/jet3/src/create_tests.rs
+++ b/crates/jet3/src/create_tests.rs
@@ -203,14 +203,7 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
     }];
     let indexed_memo = [ID, NOTE];
     let high_byte = [ColumnSpec::new(b"Caf\xe9", ColumnType::Long)];
-    let wide_names = (0..70)
-        .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
-        .collect::<Vec<_>>();
-    let wide = wide_names
-        .iter()
-        .map(|name| ColumnSpec::new(name, ColumnType::Long))
-        .collect::<Vec<_>>();
-    let cases: [(TableSpec<'_>, Accepts); 3] = [
+    let cases: [(TableSpec<'_>, Accepts); 2] = [
         (
             TableSpec {
                 name: b"Mixed",
@@ -232,24 +225,6 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
                         byte: 0xe9,
                         ..
                     })
-                )
-            },
-        ),
-        (
-            TableSpec {
-                name: b"Wide",
-                columns: &wide,
-                indexes: &[],
-            },
-            |error| {
-                matches!(
-                    error,
-                    ComposeError::Schema(
-                        TableSchemaPlanError::ContinuationPlacementUnestablished {
-                            continuations: 1,
-                            ..
-                        }
-                    )
                 )
             },
         ),
@@ -283,5 +258,32 @@ fn an_existing_destination_is_refused_and_left_unchanged() -> TestResult {
     }
     assert_eq!(fs::read(&target)?, b"keep me");
     assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn a_definition_spanning_one_continuation_is_created_and_reopens() -> TestResult {
+    // EXP-0107's compact construction: 70 ten-byte-named Long columns take a
+    // root, map page, LvProp page, and one continuation at page 23.
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let names = (0..70)
+        .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
+        .collect::<Vec<_>>();
+    let spec = TableSpec {
+        name: b"Wide",
+        columns: &columns,
+        indexes: &[],
+    };
+    create_database(&target, &spec, &mut budget())?;
+    assert_eq!(fs::metadata(&target)?.len(), 24 * crate::PAGE_BYTES as u64);
+    let mut budget = budget();
+    let mut database = DatabaseReader::open(&target, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    assert_eq!(definition.columns().len(), 70);
     Ok(())
 }

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -20,8 +20,11 @@
 //! on one or two further definition pages, the root holding 2,048 logical
 //! bytes and each continuation 2,040. It observed those pages well past the
 //! appended run (`[20, 68]` and `[20, 219, 218]`) and establishes no
-//! allocation rule for them, so this module measures the continuation count
-//! at the established capacities and refuses any definition that needs one.
+//! allocation rule for them. `EXP-0107` then observed DAO accept an unindexed
+//! composed table whose single continuation was appended directly after the
+//! `LvProp` page. This module admits exactly that shape: one continuation, on
+//! an unindexed table, at the page after `LvProp`. Longer chains and a
+//! continuation beside an index remain refused rather than extrapolated.
 //!
 //! Neither experiment establishes an `Id` allocation rule beyond the observed
 //! equality with the definition root page.
@@ -40,6 +43,9 @@ use crate::{
 
 /// Largest index count `EXP-0093` observed on a created table.
 pub(crate) const MAX_OBSERVED_INDEXES: usize = 3;
+/// Largest continuation count `EXP-0107` observed DAO accept in the compact
+/// appended position.
+pub(crate) const MAX_OBSERVED_CONTINUATIONS: usize = 1;
 /// `EXP-0057`: usage-map locators hold a three-byte page number.
 const MAX_MAP_PAGE: u64 = 0x00ff_ffff;
 /// `EXP-0093`: map-page row of the table's owned-page map.
@@ -208,13 +214,23 @@ pub enum TableSchemaPlanError {
         /// The unestablished byte.
         byte: u8,
     },
-    /// The definition needs continuation pages, whose placement `EXP-0105`
-    /// observed only as the provider's own allocation and left unestablished.
+    /// The definition needs more continuation pages than `EXP-0107` observed
+    /// DAO accept in the compact appended position; `EXP-0105` observed longer
+    /// chains only under the provider's own unestablished allocation.
     ContinuationPlacementUnestablished {
         /// Encoded definition length.
         length: usize,
         /// Continuations the definition needs at the established capacities.
         continuations: usize,
+    },
+    /// The definition needs a continuation page and the table declares an
+    /// index; no observed create carried both, so their page order is
+    /// unestablished.
+    UnobservedContinuationIndexLayout {
+        /// Continuations the definition needs.
+        continuations: usize,
+        /// Declared index count.
+        indexes: usize,
     },
     /// `EXP-0093` observed no create carrying this many indexes.
     UnobservedIndexCount {
@@ -274,11 +290,13 @@ impl std::error::Error for TableSchemaPlanError {
 /// The validated page assignment for one new user table.
 ///
 /// The appended run is the definition root, the map page, the `LvProp` page,
-/// then the index roots.
+/// the definition continuation if one is needed, then the index roots.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableSchemaPlan {
     object_id: i32,
     definition_root: PageNumber,
+    /// Exact logical length of the encoded definition.
+    definition_len: usize,
     /// Each index's key fields with column references resolved to ordinals.
     index_fields: Vec<Vec<IndexFieldSpec>>,
 }
@@ -304,11 +322,24 @@ impl TableSchemaPlan {
         PageNumber::new(self.definition_root.get() + 2)
     }
 
+    /// Returns the exact logical length of the encoded definition.
+    pub(crate) const fn definition_len(&self) -> usize {
+        self.definition_len
+    }
+
+    /// Returns the page holding the definition's continuation, if the
+    /// definition needs one (`EXP-0107`: directly after the `LvProp` page).
+    pub(crate) fn continuation_page(&self) -> Option<PageNumber> {
+        (continuation_count(self.definition_len) > 0)
+            .then(|| PageNumber::new(self.property_page().get() + 1))
+    }
+
     /// Returns each index's root page and map-page row in physical ordinal
     /// order (`EXP-0093`: roots follow the `LvProp` page, rows follow the
     /// table's own two maps).
     pub(crate) fn index_placements(&self) -> impl Iterator<Item = (PageNumber, u8)> {
-        let first_root = self.property_page().get() + 1;
+        let first_root =
+            self.property_page().get() + 1 + continuation_count(self.definition_len) as u64;
         (0..self.index_fields.len()).map(move |ordinal| {
             (
                 PageNumber::new(first_root + ordinal as u64),
@@ -325,7 +356,7 @@ impl TableSchemaPlan {
 
     /// Returns how many pages the create appends.
     pub(crate) fn appended_page_count(&self) -> u64 {
-        3 + self.index_fields.len() as u64
+        3 + continuation_count(self.definition_len) as u64 + self.index_fields.len() as u64
     }
 }
 
@@ -352,14 +383,20 @@ pub(crate) fn plan_table_schema(
     }
     let length = measure_definition(spec)?;
     let continuations = continuation_count(length);
-    if continuations > 0 {
+    if continuations > MAX_OBSERVED_CONTINUATIONS {
         return Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
             length,
             continuations,
         });
     }
+    if continuations > 0 && !spec.indexes.is_empty() {
+        return Err(TableSchemaPlanError::UnobservedContinuationIndexLayout {
+            continuations,
+            indexes: spec.indexes.len(),
+        });
+    }
     let index_fields = resolve_index_fields(spec)?;
-    let plan = assign_pages(spec, first_page, index_fields)?;
+    let plan = assign_pages(spec, first_page, length, index_fields)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
 }
@@ -463,9 +500,10 @@ pub(crate) const fn continuation_count(length: usize) -> usize {
 fn assign_pages(
     spec: &TableSpec<'_>,
     first_page: u64,
+    definition_len: usize,
     index_fields: Vec<Vec<IndexFieldSpec>>,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
-    let needed = 3 + spec.indexes.len() as u64;
+    let needed = 3 + continuation_count(definition_len) as u64 + spec.indexes.len() as u64;
     // `EXP-0093` numbers the object equal to its definition root, and
     // `MSysObjects.Id` is a signed Long, so the run must stay in that range.
     let object_id = i32::try_from(first_page)
@@ -485,6 +523,7 @@ fn assign_pages(
     Ok(TableSchemaPlan {
         object_id,
         definition_root: PageNumber::new(first_page),
+        definition_len,
         index_fields,
     })
 }

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -534,21 +534,57 @@ fn a_definition_that_exactly_fills_its_root_page_needs_no_continuation() -> Plan
 }
 
 #[test]
-fn a_definition_needing_a_continuation_is_refused() {
-    // EXP-0105 left continuation placement unestablished, so the refusal
-    // starts one byte above the root capacity and reports the count.
-    for (length, continuations) in [
-        (DEFINITION_ROOT_CAPACITY + 1, 1),
-        (DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY + 1, 2),
-    ] {
-        let names = names_of_definition_len(length);
-        let columns = long_columns(&names);
-        assert_eq!(
-            plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
-            Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
-                length,
-                continuations,
-            })
-        );
-    }
+fn a_definition_needing_one_continuation_places_it_after_the_property_page() -> PlanResult {
+    // EXP-0107: the accepted ContOneX image appended its single continuation
+    // at page 23, directly after the LvProp page, with no index roots.
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
+    let columns = long_columns(&names);
+    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    assert_eq!(plan.definition_len(), DEFINITION_ROOT_CAPACITY + 1);
+    assert_eq!(plan.property_page(), PageNumber::new(22));
+    assert_eq!(plan.continuation_page(), Some(PageNumber::new(23)));
+    assert_eq!(plan.appended_page_count(), 4);
+    let full = names_of_definition_len(DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY);
+    let columns = long_columns(&full);
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?.appended_page_count(),
+        4
+    );
+    Ok(())
+}
+
+#[test]
+fn a_definition_needing_two_continuations_is_refused() {
+    // EXP-0105 observed two-continuation chains only under the provider's own
+    // allocation, so the refusal starts one byte above the continuation.
+    let length = DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY + 1;
+    let names = names_of_definition_len(length);
+    let columns = long_columns(&names);
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+        Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
+            length,
+            continuations: 2,
+        })
+    );
+}
+
+#[test]
+fn a_continuation_beside_an_index_is_refused() {
+    // No observed create carried both, so the order of the continuation and
+    // the index roots is unestablished.
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
+    let columns = long_columns(&names);
+    let indexes = [IndexSpec {
+        name: b"ByFirst",
+        fields: &[key(0)],
+        kind: IndexKind::Ordinary,
+    }];
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &indexes), 20),
+        Err(TableSchemaPlanError::UnobservedContinuationIndexLayout {
+            continuations: 1,
+            indexes: 1,
+        })
+    );
 }


### PR DESCRIPTION
Since #177, `create_database` refused any table whose definition did not fit its root page, so a wide table with a few dozen columns could not be created at all. EXP-0107 has now recorded DAO reading the exact 70-field `ContOneX` image with one continuation placed compactly at page 23, directly after the `LvProp` page, so that construction can be admitted.

- **Planner** admits definitions needing exactly one continuation on an unindexed table and places it at the page after `LvProp`. Two-continuation chains and a continuation beside an index remain refused with their existing structured errors, since no experiment has observed them.
- **Composer** splits the encoded definition across the root and continuation pages with the root pointing at the continuation, and checks the encoded length against the planner's measurement so a mismatch fails instead of producing a misplaced split.
- **Evidence gate**: a test asserts the general composer reproduces the accepted `ContOneX` candidate byte for byte, so the admitted construction is exactly the one EXP-0107 observed. A creation test reopens a 70-column table and reads all columns back.

This is issue #100 slice 1. It does not claim DAO compatibility beyond the exact EXP-0107 candidate identity and does not touch the support matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
