### PR TITLE
feat(jet3): compose databases holding up to four tables

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -36,6 +36,20 @@ pub enum ComposeError {
         /// Largest observed long-value column count.
         observed: usize,
     },
+    /// `EXP-0087` observed no database receiving this many creates.
+    UnobservedTableCount {
+        /// Requested table count.
+        count: usize,
+        /// Largest observed create count.
+        observed: usize,
+    },
+    /// Two tables share a name under the provider's case-folding comparison.
+    DuplicateTableName {
+        /// Position of the earlier table.
+        first: usize,
+        /// Position of the later table.
+        second: usize,
+    },
     /// The encoded definition length differs from the length the planner
     /// measured, so its page split cannot be trusted.
     DefinitionLengthMismatch {
@@ -66,6 +80,8 @@ impl std::error::Error for ComposeError {
             Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
             | Self::UnobservedLongValueColumnCount { .. }
+            | Self::UnobservedTableCount { .. }
+            | Self::DuplicateTableName { .. }
             | Self::DefinitionLengthMismatch { .. } => None,
         }
     }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -79,6 +79,12 @@ const ALPHA_SPEC: TableSpec<'static> = TableSpec {
     indexes: &[],
 };
 
+/// `EXP-0073`: catalog and access-control rows of the empty database.
+const SYSTEM_OBJECT_COUNT: usize = 8;
+const SYSTEM_ACE_COUNT: usize = 16;
+/// `EXP-0087`: creates observed in one database.
+const MAX_OBSERVED_TABLES: usize = 4;
+
 const TABLES_ID: i32 = 0x0f00_0001;
 const DATABASES_ID: i32 = 0x0f00_0002;
 const RELATIONSHIPS_ID: i32 = 0x0f00_0003;
@@ -94,7 +100,7 @@ pub use error::ComposeError;
 pub(crate) fn compose_empty_database(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, ComposeError> {
-    let images = compose_existing_pages(None, budget)?;
+    let images = compose_existing_pages(&[], budget)?;
     WholeFileImagePlan::from_existing_pages(images, budget).map_err(Into::into)
 }
 
@@ -107,51 +113,93 @@ pub(crate) fn compose_alpha_database(
     compose_table_database(&ALPHA_SPEC, budget)
 }
 
-/// Composes the empty database plus one created user table, following the
-/// `EXP-0091`, `EXP-0093`, and `EXP-0105` first-create observations.
+/// Composes the empty database plus one created user table.
 pub(crate) fn compose_table_database(
     spec: &TableSpec<'_>,
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, ComposeError> {
-    let planned = PlannedCreate::new(spec)?;
-    let images = compose_existing_pages(Some(&planned), budget)?;
+    compose_database(std::slice::from_ref(spec), budget)
+}
+
+/// Composes the empty database plus the given user tables created in order.
+///
+/// The first table follows the `EXP-0091`, `EXP-0093`, and `EXP-0105`
+/// first-create observations; each later table follows the `EXP-0087`
+/// later-create observations, appending its pages after the previous table's
+/// and carrying no `LvProp` page. `EXP-0087` observed four creates in one
+/// database, later creates with at most one index, and no later create with a
+/// continuation, so more are refused rather than extrapolated. Every table's
+/// catalog `LvProp` is null, which no experiment has yet observed DAO accept
+/// for a database holding more than one table.
+pub(crate) fn compose_database(
+    specs: &[TableSpec<'_>],
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, ComposeError> {
+    if specs.len() > MAX_OBSERVED_TABLES {
+        return Err(ComposeError::UnobservedTableCount {
+            count: specs.len(),
+            observed: MAX_OBSERVED_TABLES,
+        });
+    }
+    let mut creates: Vec<PlannedCreate<'_>> = Vec::with_capacity(specs.len());
+    let mut next_page = EMPTY_DATABASE_PAGE_COUNT;
+    for (position, spec) in specs.iter().enumerate() {
+        if let Some(first) = specs[..position]
+            .iter()
+            .position(|earlier| earlier.name.eq_ignore_ascii_case(spec.name))
+        {
+            return Err(ComposeError::DuplicateTableName {
+                first,
+                second: position,
+            });
+        }
+        let planned = PlannedCreate::new(spec, next_page, position == 0)?;
+        next_page = planned.page_count();
+        creates.push(planned);
+    }
+    let images = compose_existing_pages(&creates, budget)?;
     let mut plan = WholeFileImagePlan::from_existing_pages(images, budget)?;
-    planned.append_pages(&mut plan, budget)?;
+    let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
+    for planned in &creates {
+        planned.append_pages(&mut plan, &mut append_map, budget)?;
+    }
     Ok(plan)
 }
 
 fn compose_existing_pages(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<[PageImage; EMPTY_DATABASE_PAGE_COUNT as usize], ComposeError> {
-    let object_count = if create.is_some() { 9 } else { 8 };
-    let ace_count = if create.is_some() { 18 } else { 16 };
-    let page_count = create.map_or(EMPTY_DATABASE_PAGE_COUNT, PlannedCreate::page_count);
+    let object_count = (SYSTEM_OBJECT_COUNT + creates.len()) as u32;
+    let ace_count = (SYSTEM_ACE_COUNT + 2 * creates.len()) as u32;
+    let page_count = creates
+        .last()
+        .map_or(EMPTY_DATABASE_PAGE_COUNT, PlannedCreate::page_count);
     Ok([
-        header_page(create.is_some(), budget)?,
+        header_page(creates.len(), budget)?,
         global_map_page(page_count, budget)?,
         msys_objects_definition(object_count, budget)?,
         msys_aces_definition(ace_count, object_count, budget)?,
         msys_queries_definition(budget)?,
         msys_relationships_definition(budget)?,
-        objects_map_page(create, budget)?,
+        objects_map_page(creates, budget)?,
         single_map_page(&[], budget)?,
         single_map_page(&[OBJECTS_PARENT_NAME_ROOT], budget)?,
-        objects_parent_name_index(create, budget)?,
+        objects_parent_name_index(creates, budget)?,
         single_map_page(&[OBJECTS_ID_ROOT], budget)?,
-        objects_id_index(create, budget)?,
+        objects_id_index(creates, budget)?,
         shared_map_page(budget)?,
-        aces_index(create, budget)?,
+        aces_index(creates, budget)?,
         empty_index_page(MSYS_QUERIES_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
-        objects_data_page(create, budget)?,
-        aces_data_page(create, budget)?,
+        objects_data_page(creates, budget)?,
+        aces_data_page(creates, budget)?,
     ])
 }
 
-fn header_page(created: bool, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+fn header_page(table_count: usize, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
     let mut image = PageImage::new(PageKind::DatabaseDefinition);
     image.write_at(PageOffset::new(1), &[1], budget)?;
     image.write_at(PageOffset::new(4), b"Standard Jet DB", budget)?;
@@ -161,8 +209,9 @@ fn header_page(created: bool, budget: &mut ResourceBudget) -> Result<PageImage, 
     for offset in (1..commit_state.len()).step_by(2) {
         commit_state[offset] = 1;
     }
-    // EXP-0087: byte 1538 advanced by 2 per create from 0; no rule beyond that.
-    commit_state[2] = if created { 2 } else { 0 };
+    // EXP-0087: byte 1538 advanced by 2 per create from 0 through four
+    // creates; no rule beyond that.
+    commit_state[2] = 2 * table_count as u8;
     image.write_at(PageOffset::new(1536), &commit_state, budget)?;
     Ok(image)
 }
@@ -209,13 +258,13 @@ fn single_map_page(pages: &[u64], budget: &mut ResourceBudget) -> Result<PageIma
 }
 
 fn objects_map_page(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let owned = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let available = inline_map_row(&[MSYS_OBJECTS_DATA_PAGE], budget)?;
     let empty = inline_map_row(&[], budget)?;
-    let long_value_pages = create.map(PlannedCreate::property_page);
+    let long_value_pages = creates.first().and_then(PlannedCreate::property_page);
     let lvprop = inline_map_row(long_value_pages.as_slice(), budget)?;
     let rows: [&[u8]; 15] = [
         &owned, &available, &empty, &empty, &empty, &empty, &empty, &empty, &empty, &empty,
@@ -401,10 +450,12 @@ const CATALOG_SEEDS: [CatalogSeed<'static>; 8] = [
 ];
 
 /// Returns the catalog rows the composed image holds, in stored row order.
-fn catalog_seeds<'a>(create: Option<&PlannedCreate<'a>>) -> impl Iterator<Item = CatalogSeed<'a>> {
+fn catalog_seeds<'a>(
+    creates: &'a [PlannedCreate<'a>],
+) -> impl Iterator<Item = CatalogSeed<'a>> + 'a {
     CATALOG_SEEDS
         .into_iter()
-        .chain(create.map(PlannedCreate::catalog_seed))
+        .chain(creates.iter().map(PlannedCreate::catalog_seed))
 }
 
 /// Builds the catalog data page. Every `LvProp` is null: the system rows
@@ -412,12 +463,12 @@ fn catalog_seeds<'a>(create: Option<&PlannedCreate<'a>>) -> impl Iterator<Item =
 /// create with a null catalog `LvProp` and a retained long-value page. For
 /// any other created table the null form is an unvalidated candidate.
 fn objects_data_page(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
-    for seed in catalog_seeds(create) {
+    for seed in catalog_seeds(creates) {
         let length = encode_catalog_row(seed, &mut row, budget)?;
         builder.append_row(&row[..length], budget)?;
     }
@@ -486,19 +537,19 @@ const fn ace(object: i32, sid: &'static [u8], acm: i32, inheritable: bool) -> Ac
 }
 
 /// Returns the access-control rows the composed image holds, in stored order.
-fn ace_seeds(create: Option<&PlannedCreate<'_>>) -> impl Iterator<Item = AceSeed> {
+fn ace_seeds<'a>(creates: &'a [PlannedCreate<'a>]) -> impl Iterator<Item = AceSeed> + 'a {
     ACE_SEEDS
         .into_iter()
-        .chain(create.map(PlannedCreate::ace_seeds).into_iter().flatten())
+        .chain(creates.iter().flat_map(PlannedCreate::ace_seeds))
 }
 
 fn aces_data_page(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_ACES_ROOT), budget)?;
     let mut row = [0_u8; 64];
-    for seed in ace_seeds(create) {
+    for seed in ace_seeds(creates) {
         let values = [
             RowValue::Long(seed.object),
             RowValue::Binary(seed.sid),
@@ -556,56 +607,37 @@ impl OwnedIndexEntry {
 }
 
 fn objects_parent_name_index(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    let mut entries = [OwnedIndexEntry::EMPTY; 9];
-    let count = if create.is_some() { 9 } else { 8 };
-    for (row, seed) in catalog_seeds(create).enumerate() {
-        entries[row] = OwnedIndexEntry::name(seed.parent, seed.name, row as u8)?;
-    }
-    sort_index_entries(&mut entries[..count]);
-    index_page(
-        MSYS_OBJECTS_ROOT,
-        MSYS_OBJECTS_DATA_PAGE,
-        &entries[..count],
-        budget,
-    )
+    let mut entries = catalog_seeds(creates)
+        .enumerate()
+        .map(|(row, seed)| OwnedIndexEntry::name(seed.parent, seed.name, row as u8))
+        .collect::<Result<Vec<_>, ComposeError>>()?;
+    sort_index_entries(&mut entries);
+    index_page(MSYS_OBJECTS_ROOT, MSYS_OBJECTS_DATA_PAGE, &entries, budget)
 }
 fn objects_id_index(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    let mut entries = [OwnedIndexEntry::EMPTY; 9];
-    let count = if create.is_some() { 9 } else { 8 };
-    for (row, seed) in catalog_seeds(create).enumerate() {
-        entries[row] = OwnedIndexEntry::long(seed.id, row as u8);
-    }
-    sort_index_entries(&mut entries[..count]);
-    index_page(
-        MSYS_OBJECTS_ROOT,
-        MSYS_OBJECTS_DATA_PAGE,
-        &entries[..count],
-        budget,
-    )
+    let mut entries = catalog_seeds(creates)
+        .enumerate()
+        .map(|(row, seed)| OwnedIndexEntry::long(seed.id, row as u8))
+        .collect::<Vec<_>>();
+    sort_index_entries(&mut entries);
+    index_page(MSYS_OBJECTS_ROOT, MSYS_OBJECTS_DATA_PAGE, &entries, budget)
 }
 fn aces_index(
-    create: Option<&PlannedCreate<'_>>,
+    creates: &[PlannedCreate<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    let mut entries = [OwnedIndexEntry::EMPTY; 18];
-    let mut count = 0;
-    for (row, seed) in ace_seeds(create).enumerate() {
-        entries[row] = OwnedIndexEntry::long(seed.object, row as u8);
-        count = row + 1;
-    }
-    sort_index_entries(&mut entries[..count]);
-    index_page(
-        MSYS_ACES_ROOT,
-        MSYS_ACES_DATA_PAGE,
-        &entries[..count],
-        budget,
-    )
+    let mut entries = ace_seeds(creates)
+        .enumerate()
+        .map(|(row, seed)| OwnedIndexEntry::long(seed.object, row as u8))
+        .collect::<Vec<_>>();
+    sort_index_entries(&mut entries);
+    index_page(MSYS_ACES_ROOT, MSYS_ACES_DATA_PAGE, &entries, budget)
 }
 
 fn sort_index_entries(entries: &mut [OwnedIndexEntry]) {

--- a/crates/jet3/src/bootstrap_composer_tests.rs
+++ b/crates/jet3/src/bootstrap_composer_tests.rs
@@ -595,13 +595,17 @@ fn the_planner_reproduces_the_accepted_alpha_page_assignment() -> TestResult {
             indexes: &[],
         },
         EMPTY_DATABASE_PAGE_COUNT,
+        true,
     )?;
     assert_eq!(plan.object_id(), ALPHA_ROOT as i32);
     assert_eq!(plan.definition_root(), PageNumber::new(ALPHA_ROOT));
     assert_eq!(plan.map_page(), PageNumber::new(ALPHA_MAP_PAGE));
     // EXP-0091/EXP-0093: the retained LvProp page follows the map page, so
     // the accepted Alpha image appends exactly the planned three pages.
-    assert_eq!(plan.property_page(), PageNumber::new(ALPHA_MAP_PAGE + 1));
+    assert_eq!(
+        plan.property_page(),
+        Some(PageNumber::new(ALPHA_MAP_PAGE + 1))
+    );
     assert_eq!(plan.index_placements().count(), 0);
     assert_eq!(plan.appended_page_count(), 3);
     let alpha_pages = bytes(true)?.len() as u64 / JET3_PAGE_SIZE.get();

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -1,6 +1,6 @@
-//! Pages a planned user-table create appends to the empty database, derived
-//! from the `EXP-0093` and `EXP-0105` first-create observations rather than
-//! recorded bytes.
+//! Pages a planned user-table create appends to the database, derived from
+//! the `EXP-0093` and `EXP-0105` first-create observations and the `EXP-0087`
+//! later-create observations rather than recorded bytes.
 //!
 //! `EXP-0093` observed each first create append a definition root, a page of
 //! usage-map rows, a long-value page for the catalog row's `LvProp`, then one
@@ -54,9 +54,14 @@ pub(super) struct PlannedCreate<'a> {
 }
 
 impl<'a> PlannedCreate<'a> {
-    /// Plans `spec` as the first create in the empty database.
-    pub(super) fn new(spec: &'a TableSpec<'a>) -> Result<Self, ComposeError> {
-        let plan = plan_table_schema(spec, EMPTY_DATABASE_PAGE_COUNT)?;
+    /// Plans `spec` as the create that appends at `first_page`; only the
+    /// database's first create carries the `LvProp` page.
+    pub(super) fn new(
+        spec: &'a TableSpec<'a>,
+        first_page: u64,
+        first_create: bool,
+    ) -> Result<Self, ComposeError> {
+        let plan = plan_table_schema(spec, first_page, first_create)?;
         let mut long_value_columns = long_value_columns(spec);
         let long_value = long_value_columns.next();
         if long_value_columns.next().is_some() {
@@ -74,9 +79,10 @@ impl<'a> PlannedCreate<'a> {
         })
     }
 
-    /// Returns the page holding the catalog row's `LvProp` long value.
-    pub(super) const fn property_page(&self) -> u64 {
-        self.plan.property_page().get()
+    /// Returns the page holding the catalog row's `LvProp` long value, present
+    /// only on the database's first create.
+    pub(super) fn property_page(&self) -> Option<u64> {
+        self.plan.property_page().map(|page| page.get())
     }
 
     /// Returns the page count once every appended page is in place.
@@ -106,25 +112,27 @@ impl<'a> PlannedCreate<'a> {
     }
 
     /// Appends the create's pages in `EXP-0093` order: definition root, map
-    /// page, long-value page, the `EXP-0107` continuation if the definition
-    /// needs one, then the index roots.
+    /// page, the first create's long-value page, the `EXP-0107` continuation
+    /// if the definition needs one, then the index roots.
     pub(super) fn append_pages(
         &self,
         plan: &mut WholeFileImagePlan,
+        append_map: &mut InlineUsageMapEncoder,
         budget: &mut ResourceBudget,
     ) -> Result<(), ComposeError> {
-        let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
         let (root, continuation) = self.definition_pages(budget)?;
-        plan.append(root, &mut append_map, budget)?;
-        plan.append(self.map_page(budget)?, &mut append_map, budget)?;
-        let lval = DataPageBuilder::new_long_value(budget)?;
-        plan.append(finish_data_builder(lval, budget)?, &mut append_map, budget)?;
+        plan.append(root, append_map, budget)?;
+        plan.append(self.map_page(budget)?, append_map, budget)?;
+        if self.plan.property_page().is_some() {
+            let lval = DataPageBuilder::new_long_value(budget)?;
+            plan.append(finish_data_builder(lval, budget)?, append_map, budget)?;
+        }
         if let Some(continuation) = continuation {
-            plan.append(continuation, &mut append_map, budget)?;
+            plan.append(continuation, append_map, budget)?;
         }
         let owner = self.plan.definition_root().get();
         for _ in self.plan.index_placements() {
-            plan.append(empty_index_page(owner, budget)?, &mut append_map, budget)?;
+            plan.append(empty_index_page(owner, budget)?, append_map, budget)?;
         }
         Ok(())
     }

--- a/crates/jet3/src/bootstrap_table_create_tests.rs
+++ b/crates/jet3/src/bootstrap_table_create_tests.rs
@@ -2,7 +2,7 @@
 //! reader to check each `EXP-0093` structure lands where the plan says.
 
 use super::super::tests::{compose_budget, inline_map_bit, read_budget};
-use super::super::{ComposeError, compose_table_database};
+use super::super::{ComposeError, compose_database, compose_table_database};
 use crate::column_definition_writer::nz;
 use crate::table_schema_plan::{IndexKind, IndexSpec, TableSchemaPlanError, TableSpec};
 use crate::{
@@ -309,5 +309,184 @@ fn a_second_long_value_column_is_refused() {
             &mut budget,
         ),
         Err(ComposeError::UnobservedLongValueColumnCount { observed: 1 })
+    ));
+}
+
+/// The exact `EXP-0087` create sequence: Alpha, Beta, Gamma, then Delta.
+fn exp_0087_tables<'a>(
+    gamma_indexes: &'a [IndexSpec<'a>],
+    delta_indexes: &'a [IndexSpec<'a>],
+    label: &'a [ColumnSpec<'a>],
+) -> [TableSpec<'a>; 4] {
+    [
+        TableSpec {
+            name: b"Alpha",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"Beta",
+            columns: &[ID, NAME, NOTE],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"Gamma",
+            columns: &[ID],
+            indexes: gamma_indexes,
+        },
+        TableSpec {
+            name: b"Delta",
+            columns: label,
+            indexes: delta_indexes,
+        },
+    ]
+}
+
+fn database_bytes(specs: &[TableSpec<'_>]) -> Result<Vec<u8>, ComposeError> {
+    let mut budget = compose_budget();
+    let plan = compose_database(specs, &mut budget)?;
+    Ok(plan
+        .pages()
+        .iter()
+        .flat_map(|page| page.image().as_bytes().iter().copied())
+        .collect())
+}
+
+#[test]
+fn later_creates_follow_the_observed_page_and_row_pattern() -> TestResult {
+    // EXP-0087: the alpha, beta, gamma, and delta checkpoints were 23, 25, 28,
+    // and 31 pages; each create added one catalog row and two ACE rows, and
+    // page-zero byte 1538 advanced by two per create.
+    let gamma_indexes = [IndexSpec {
+        name: b"PrimaryKey",
+        fields: &[field(0, IndexDirection::Ascending)],
+        kind: IndexKind::Primary,
+    }];
+    let label = [ColumnSpec::new(
+        b"Label",
+        ColumnType::Text { max_len: nz(30) },
+    )];
+    let delta_indexes = [IndexSpec {
+        name: b"ByLabel",
+        fields: &[field(0, IndexDirection::Ascending)],
+        kind: IndexKind::Ordinary,
+    }];
+    let tables = exp_0087_tables(&gamma_indexes, &delta_indexes, &label);
+    for (count, pages) in [(1, 23), (2, 25), (3, 28), (4, 31)] {
+        let bytes = database_bytes(&tables[..count])?;
+        assert_eq!(bytes.len(), pages * PAGE_BYTES, "{count} tables");
+        assert_eq!(bytes[1538], 2 * count as u8);
+    }
+    let bytes = database_bytes(&tables)?;
+    // Only the first create appends the LvProp page; later roots follow.
+    assert_eq!(&page(&bytes, 22)[..8], b"\x01\x01\xf6\x07LVAL");
+    for root in [20, 23, 25, 28] {
+        assert_eq!(page(&bytes, root)[0], 2, "definition root {root}");
+        assert_eq!(page(&bytes, root + 1)[0], 1, "map page after {root}");
+    }
+    for index_root in [27, 30] {
+        assert_eq!(page(&bytes, index_root)[0], 4, "index root {index_root}");
+    }
+    let mut budget = read_budget(bytes.len());
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let mut roots = Vec::new();
+    {
+        let mut catalog = database.catalog(&mut budget)?;
+        while let Some(record) = catalog.next_record()? {
+            if record.class() == crate::CatalogObjectClass::User {
+                roots.push((
+                    record.name().raw_bytes().to_vec(),
+                    record.id().get(),
+                    record.table_definition(),
+                ));
+            }
+        }
+    }
+    assert_eq!(
+        roots,
+        [
+            (b"Alpha".to_vec(), 20, Some(PageNumber::new(20))),
+            (b"Beta".to_vec(), 23, Some(PageNumber::new(23))),
+            (b"Gamma".to_vec(), 25, Some(PageNumber::new(25))),
+            (b"Delta".to_vec(), 28, Some(PageNumber::new(28))),
+        ]
+    );
+    let gamma = database.table_definition(PageNumber::new(25), &mut budget)?;
+    assert_eq!(gamma.physical_indexes()[0].root(), PageNumber::new(27));
+    assert_eq!(
+        gamma.physical_indexes()[0].usage_map().page(),
+        PageNumber::new(26)
+    );
+    let aces = database.table_definition(PageNumber::new(3), &mut budget)?;
+    let mut ace_rows = 0;
+    let mut rows = database.rows(&aces, &mut budget)?;
+    while rows.next_row()?.is_some() {
+        ace_rows += 1;
+    }
+    assert_eq!(ace_rows, 16 + 2 * 4);
+    Ok(())
+}
+
+#[test]
+fn a_fifth_table_and_a_case_folded_duplicate_name_are_refused() {
+    let five = [
+        TableSpec {
+            name: b"T1",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"T2",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"T3",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"T4",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"T5",
+            columns: &[ID],
+            indexes: &[],
+        },
+    ];
+    let mut budget = compose_budget();
+    assert!(matches!(
+        compose_database(&five, &mut budget),
+        Err(ComposeError::UnobservedTableCount {
+            count: 5,
+            observed: 4
+        })
+    ));
+    let duplicate = [
+        TableSpec {
+            name: b"Alpha",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"Beta",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"ALPHA",
+            columns: &[ID],
+            indexes: &[],
+        },
+    ];
+    assert!(matches!(
+        compose_database(&duplicate, &mut budget),
+        Err(ComposeError::DuplicateTableName {
+            first: 0,
+            second: 2
+        })
     ));
 }

--- a/crates/jet3/src/table_schema_plan.rs
+++ b/crates/jet3/src/table_schema_plan.rs
@@ -16,6 +16,13 @@
 //! is `2 + physical_ordinal` on the map page. It observed at most three
 //! indexes, so this module refuses more rather than extrapolating.
 //!
+//! `EXP-0087` observed three further creates in the same database, each
+//! appending a definition root numbered equal to its `Id`, then its map page,
+//! then an index root when it carried one index, and no further `LvProp`
+//! page. A later create is therefore planned without the property page. No
+//! later create was observed with more than one index or with a continuation,
+//! so this module refuses those rather than extrapolating.
+//!
 //! `EXP-0105` observed that a definition longer than its root page continues
 //! on one or two further definition pages, the root holding 2,048 logical
 //! bytes and each continuation 2,040. It observed those pages well past the
@@ -46,6 +53,8 @@ pub(crate) const MAX_OBSERVED_INDEXES: usize = 3;
 /// Largest continuation count `EXP-0107` observed DAO accept in the compact
 /// appended position.
 pub(crate) const MAX_OBSERVED_CONTINUATIONS: usize = 1;
+/// Largest index count `EXP-0087` observed on a later create.
+pub(crate) const MAX_OBSERVED_LATER_CREATE_INDEXES: usize = 1;
 /// `EXP-0057`: usage-map locators hold a three-byte page number.
 const MAX_MAP_PAGE: u64 = 0x00ff_ffff;
 /// `EXP-0093`: map-page row of the table's owned-page map.
@@ -232,6 +241,23 @@ pub enum TableSchemaPlanError {
         /// Declared index count.
         indexes: usize,
     },
+    /// `EXP-0087` observed no later create carrying this many indexes; the
+    /// `EXP-0093` three-index layout was observed only on a first create.
+    UnobservedLaterCreateIndexCount {
+        /// Declared index count.
+        count: usize,
+        /// Largest observed later-create index count.
+        observed: usize,
+    },
+    /// A later create needs a continuation page; `EXP-0107` observed the
+    /// compact placement only after a first create's `LvProp` page, and
+    /// `EXP-0087` observed no later create with a continuation.
+    UnobservedLaterCreateContinuation {
+        /// Encoded definition length.
+        length: usize,
+        /// Continuations the definition needs.
+        continuations: usize,
+    },
     /// `EXP-0093` observed no create carrying this many indexes.
     UnobservedIndexCount {
         /// Declared index count.
@@ -289,12 +315,15 @@ impl std::error::Error for TableSchemaPlanError {
 
 /// The validated page assignment for one new user table.
 ///
-/// The appended run is the definition root, the map page, the `LvProp` page,
-/// the definition continuation if one is needed, then the index roots.
+/// The appended run is the definition root, the map page, the `LvProp` page
+/// for the database's first create only, the definition continuation if one
+/// is needed, then the index roots.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableSchemaPlan {
     object_id: i32,
     definition_root: PageNumber,
+    /// Whether the run carries the first-create `LvProp` page.
+    property_page: bool,
     /// Exact logical length of the encoded definition.
     definition_len: usize,
     /// Each index's key fields with column references resolved to ordinals.
@@ -317,9 +346,19 @@ impl TableSchemaPlan {
         PageNumber::new(self.definition_root.get() + 1)
     }
 
-    /// Returns the page holding the catalog row's `LvProp` long value.
-    pub(crate) const fn property_page(&self) -> PageNumber {
-        PageNumber::new(self.definition_root.get() + 2)
+    /// Returns the page holding the catalog row's `LvProp` long value, which
+    /// only the database's first create appends (`EXP-0087`, `EXP-0093`).
+    pub(crate) const fn property_page(&self) -> Option<PageNumber> {
+        if self.property_page {
+            Some(PageNumber::new(self.definition_root.get() + 2))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the first page after the root, map, and any `LvProp` page.
+    const fn after_fixed_pages(&self) -> u64 {
+        self.definition_root.get() + 2 + self.property_page as u64
     }
 
     /// Returns the exact logical length of the encoded definition.
@@ -331,15 +370,14 @@ impl TableSchemaPlan {
     /// definition needs one (`EXP-0107`: directly after the `LvProp` page).
     pub(crate) fn continuation_page(&self) -> Option<PageNumber> {
         (continuation_count(self.definition_len) > 0)
-            .then(|| PageNumber::new(self.property_page().get() + 1))
+            .then(|| PageNumber::new(self.after_fixed_pages()))
     }
 
     /// Returns each index's root page and map-page row in physical ordinal
     /// order (`EXP-0093`: roots follow the `LvProp` page, rows follow the
     /// table's own two maps).
     pub(crate) fn index_placements(&self) -> impl Iterator<Item = (PageNumber, u8)> {
-        let first_root =
-            self.property_page().get() + 1 + continuation_count(self.definition_len) as u64;
+        let first_root = self.after_fixed_pages() + continuation_count(self.definition_len) as u64;
         (0..self.index_fields.len()).map(move |ordinal| {
             (
                 PageNumber::new(first_root + ordinal as u64),
@@ -356,15 +394,19 @@ impl TableSchemaPlan {
 
     /// Returns how many pages the create appends.
     pub(crate) fn appended_page_count(&self) -> u64 {
-        3 + continuation_count(self.definition_len) as u64 + self.index_fields.len() as u64
+        self.after_fixed_pages() - self.definition_root.get()
+            + continuation_count(self.definition_len) as u64
+            + self.index_fields.len() as u64
     }
 }
 
-/// Validates `spec` as a first create and assigns its appended pages starting
-/// at `first_page`, the database's current page count.
+/// Validates `spec` and assigns its appended pages starting at `first_page`,
+/// the database's current page count. Only the database's first create
+/// (`first_create`) appends the catalog row's `LvProp` page.
 pub(crate) fn plan_table_schema(
     spec: &TableSpec<'_>,
     first_page: u64,
+    first_create: bool,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
     validate_table_name(spec.name)?;
     if spec.columns.is_empty() {
@@ -395,8 +437,22 @@ pub(crate) fn plan_table_schema(
             indexes: spec.indexes.len(),
         });
     }
+    if !first_create {
+        if spec.indexes.len() > MAX_OBSERVED_LATER_CREATE_INDEXES {
+            return Err(TableSchemaPlanError::UnobservedLaterCreateIndexCount {
+                count: spec.indexes.len(),
+                observed: MAX_OBSERVED_LATER_CREATE_INDEXES,
+            });
+        }
+        if continuations > 0 {
+            return Err(TableSchemaPlanError::UnobservedLaterCreateContinuation {
+                length,
+                continuations,
+            });
+        }
+    }
     let index_fields = resolve_index_fields(spec)?;
-    let plan = assign_pages(spec, first_page, length, index_fields)?;
+    let plan = assign_pages(spec, first_page, first_create, length, index_fields)?;
     validate_indexes(spec, &plan)?;
     Ok(plan)
 }
@@ -500,10 +556,14 @@ pub(crate) const fn continuation_count(length: usize) -> usize {
 fn assign_pages(
     spec: &TableSpec<'_>,
     first_page: u64,
+    first_create: bool,
     definition_len: usize,
     index_fields: Vec<Vec<IndexFieldSpec>>,
 ) -> Result<TableSchemaPlan, TableSchemaPlanError> {
-    let needed = 3 + continuation_count(definition_len) as u64 + spec.indexes.len() as u64;
+    let needed = 2
+        + first_create as u64
+        + continuation_count(definition_len) as u64
+        + spec.indexes.len() as u64;
     // `EXP-0093` numbers the object equal to its definition root, and
     // `MSysObjects.Id` is a signed Long, so the run must stay in that range.
     let object_id = i32::try_from(first_page)
@@ -523,6 +583,7 @@ fn assign_pages(
     Ok(TableSchemaPlan {
         object_id,
         definition_root: PageNumber::new(first_page),
+        property_page: first_create,
         definition_len,
         index_fields,
     })

--- a/crates/jet3/src/table_schema_plan_tests.rs
+++ b/crates/jet3/src/table_schema_plan_tests.rs
@@ -35,7 +35,7 @@ fn spec<'a>(
 
 /// Returns the definition error planning `spec` produced, if it produced one.
 fn definition_error(spec: &TableSpec<'_>) -> Option<TableDefinitionWriteError> {
-    match plan_table_schema(spec, 20) {
+    match plan_table_schema(spec, 20, true) {
         Err(TableSchemaPlanError::Definition(error)) => Some(error),
         _ => None,
     }
@@ -67,14 +67,76 @@ fn long_columns(names: &[Vec<u8>]) -> Vec<ColumnSpec<'_>> {
 fn a_table_without_an_index_appends_a_root_a_map_page_and_a_property_page() -> PlanResult {
     // EXP-0093: three appended pages, Id equal to the root page.
     let columns = [ID, NAME, NOTE];
-    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23)?;
+    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23, true)?;
     assert_eq!(plan.object_id(), 23);
     assert_eq!(plan.definition_root(), PageNumber::new(23));
     assert_eq!(plan.map_page(), PageNumber::new(24));
-    assert_eq!(plan.property_page(), PageNumber::new(25));
+    assert_eq!(plan.property_page(), Some(PageNumber::new(25)));
     assert_eq!(plan.index_placements().count(), 0);
     assert_eq!(plan.appended_page_count(), 3);
     Ok(())
+}
+
+#[test]
+fn a_later_create_appends_no_property_page() -> PlanResult {
+    // EXP-0087: Beta, the second create, appended only its root and map page;
+    // Gamma, with one index, appended root, map page, then the index root.
+    let columns = [ID, NAME, NOTE];
+    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), 23, false)?;
+    assert_eq!(plan.object_id(), 23);
+    assert_eq!(plan.property_page(), None);
+    assert_eq!(plan.appended_page_count(), 2);
+    let indexes = [IndexSpec {
+        name: b"PrimaryKey",
+        fields: &[key(0)],
+        kind: IndexKind::Primary,
+    }];
+    let plan = plan_table_schema(&spec(b"Gamma", &[ID], &indexes), 25, false)?;
+    assert_eq!(plan.map_page(), PageNumber::new(26));
+    assert_eq!(
+        plan.index_placements().collect::<Vec<_>>(),
+        [(PageNumber::new(27), 2)]
+    );
+    assert_eq!(plan.appended_page_count(), 3);
+    Ok(())
+}
+
+#[test]
+fn a_later_create_with_two_indexes_or_a_continuation_is_refused() {
+    // EXP-0087 observed later creates with at most one index and no
+    // continuation; EXP-0093 and EXP-0107 observed wider layouts only on a
+    // first create.
+    let columns = [ID, NAME];
+    let indexes = [
+        IndexSpec {
+            name: b"PrimaryKey",
+            fields: &[key(0)],
+            kind: IndexKind::Primary,
+        },
+        IndexSpec {
+            name: b"ByName",
+            fields: &[key(1)],
+            kind: IndexKind::Ordinary,
+        },
+    ];
+    assert!(plan_table_schema(&spec(b"Beta", &columns, &indexes), 23, true).is_ok());
+    assert_eq!(
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 23, false),
+        Err(TableSchemaPlanError::UnobservedLaterCreateIndexCount {
+            count: 2,
+            observed: MAX_OBSERVED_LATER_CREATE_INDEXES,
+        })
+    );
+    let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
+    let columns = long_columns(&names);
+    assert!(plan_table_schema(&spec(b"Wide", &columns, &[]), 23, true).is_ok());
+    assert_eq!(
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 23, false),
+        Err(TableSchemaPlanError::UnobservedLaterCreateContinuation {
+            length: DEFINITION_ROOT_CAPACITY + 1,
+            continuations: 1,
+        })
+    );
 }
 
 #[test]
@@ -98,8 +160,8 @@ fn index_roots_follow_the_property_page_in_physical_order() -> PlanResult {
             kind: IndexKind::Ordinary,
         },
     ];
-    let plan = plan_table_schema(&spec(b"Three", &columns, &indexes), 28)?;
-    assert_eq!(plan.property_page(), PageNumber::new(30));
+    let plan = plan_table_schema(&spec(b"Three", &columns, &indexes), 28, true)?;
+    assert_eq!(plan.property_page(), Some(PageNumber::new(30)));
     assert_eq!(
         plan.index_placements().collect::<Vec<_>>(),
         [
@@ -148,7 +210,7 @@ fn index_names_whose_order_depends_on_case_folding_are_refused() {
         },
     ];
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20, true),
         Err(TableSchemaPlanError::UnderdeterminedIndexNameOrder {
             first: 0,
             second: 1
@@ -160,7 +222,7 @@ fn index_names_whose_order_depends_on_case_folding_are_refused() {
 fn a_name_byte_above_the_established_range_is_refused() {
     let columns = [ColumnSpec::new(b"Caf\xe9", ColumnType::Long)];
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &[]), 20),
+        plan_table_schema(&spec(b"Beta", &columns, &[]), 20, true),
         Err(TableSchemaPlanError::NameByteUnestablished {
             role: "column",
             ordinal: 0,
@@ -175,7 +237,7 @@ fn a_name_byte_above_the_established_range_is_refused() {
         kind: IndexKind::Ordinary,
     }];
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20, true),
         Err(TableSchemaPlanError::NameByteUnestablished {
             role: "logical index",
             ordinal: 0,
@@ -189,7 +251,7 @@ fn a_name_byte_above_the_established_range_is_refused() {
 fn a_table_name_byte_without_an_established_weight_is_refused() {
     let columns = [ID];
     assert_eq!(
-        plan_table_schema(&spec(b"Caf\xe9", &columns, &[]), 20),
+        plan_table_schema(&spec(b"Caf\xe9", &columns, &[]), 20, true),
         Err(TableSchemaPlanError::TableNameKey(
             CatalogNameKeyError::UnmappedNameByte {
                 position: 3,
@@ -203,7 +265,7 @@ fn a_table_name_byte_without_an_established_weight_is_refused() {
 fn an_empty_table_name_is_refused() {
     let columns = [ID];
     assert_eq!(
-        plan_table_schema(&spec(b"", &columns, &[]), 20),
+        plan_table_schema(&spec(b"", &columns, &[]), 20, true),
         Err(TableSchemaPlanError::TableNameKey(
             CatalogNameKeyError::EmptyName
         ))
@@ -216,10 +278,10 @@ fn a_table_name_too_long_for_a_catalog_row_is_refused() {
     // longest writable name must still plan.
     let columns = [ID];
     let longest = vec![b'A'; 224];
-    assert!(plan_table_schema(&spec(&longest, &columns, &[]), 20).is_ok());
+    assert!(plan_table_schema(&spec(&longest, &columns, &[]), 20, true).is_ok());
     let overlong = vec![b'A'; 225];
     assert!(matches!(
-        plan_table_schema(&spec(&overlong, &columns, &[]), 20),
+        plan_table_schema(&spec(&overlong, &columns, &[]), 20, true),
         Err(TableSchemaPlanError::TableNameRow(
             CatalogRecordWriteError::NameTooLong { length: 225, .. }
         ))
@@ -275,8 +337,8 @@ fn index_columns_named_by_name_resolve_to_the_same_ordinals() -> PlanResult {
         fields: &[IndexColumnSpec::descending(1), key(0)],
         kind: IndexKind::Ordinary,
     }];
-    let named = plan_table_schema(&spec(b"Beta", &columns, &by_name), 20)?;
-    let ordinal = plan_table_schema(&spec(b"Beta", &columns, &by_ordinal), 20)?;
+    let named = plan_table_schema(&spec(b"Beta", &columns, &by_name), 20, true)?;
+    let ordinal = plan_table_schema(&spec(b"Beta", &columns, &by_ordinal), 20, true)?;
     assert_eq!(named, ordinal);
     assert_eq!(
         named.index_fields().collect::<Vec<_>>(),
@@ -306,7 +368,7 @@ fn an_index_column_name_the_table_lacks_is_refused() {
         kind: IndexKind::Ordinary,
     }];
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20, true),
         Err(TableSchemaPlanError::UnknownIndexColumn { index: 0, field: 1 })
     );
 }
@@ -332,7 +394,7 @@ const MANY_COLUMNS: usize = 32;
 #[test]
 fn a_table_without_columns_is_refused() {
     assert_eq!(
-        plan_table_schema(&spec(b"Empty", &[], &[]), 20),
+        plan_table_schema(&spec(b"Empty", &[], &[]), 20, true),
         Err(TableSchemaPlanError::NoColumns)
     );
 }
@@ -385,7 +447,7 @@ fn more_indexes_than_any_create_carried_are_refused() {
         })
         .collect::<Vec<_>>();
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20),
+        plan_table_schema(&spec(b"Beta", &columns, &indexes), 20, true),
         Err(TableSchemaPlanError::UnobservedIndexCount {
             count: 4,
             observed: MAX_OBSERVED_INDEXES,
@@ -485,7 +547,7 @@ fn a_first_page_above_the_signed_id_range_is_refused() {
     let columns = [ID];
     let first = i32::MAX as u64 + 1;
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &[]), first),
+        plan_table_schema(&spec(b"Beta", &columns, &[]), first, true),
         Err(TableSchemaPlanError::PageOverflow { first, needed: 3 })
     );
 }
@@ -496,10 +558,10 @@ fn a_map_page_no_usage_map_locator_could_name_is_refused() -> PlanResult {
     // run well below the signed Id range.
     let columns = [ID];
     let highest = MAX_MAP_PAGE - 1;
-    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), highest)?;
+    let plan = plan_table_schema(&spec(b"Beta", &columns, &[]), highest, true)?;
     assert_eq!(plan.map_page(), PageNumber::new(MAX_MAP_PAGE));
     assert_eq!(
-        plan_table_schema(&spec(b"Beta", &columns, &[]), highest + 1),
+        plan_table_schema(&spec(b"Beta", &columns, &[]), highest + 1, true),
         Err(TableSchemaPlanError::MapPageNotAddressable {
             page: MAX_MAP_PAGE + 1,
             maximum: MAX_MAP_PAGE,
@@ -528,7 +590,7 @@ fn continuation_counts_follow_the_established_capacities() {
 fn a_definition_that_exactly_fills_its_root_page_needs_no_continuation() -> PlanResult {
     let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY);
     let columns = long_columns(&names);
-    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20, true)?;
     assert_eq!(plan.appended_page_count(), 3);
     Ok(())
 }
@@ -539,15 +601,15 @@ fn a_definition_needing_one_continuation_places_it_after_the_property_page() -> 
     // at page 23, directly after the LvProp page, with no index roots.
     let names = names_of_definition_len(DEFINITION_ROOT_CAPACITY + 1);
     let columns = long_columns(&names);
-    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?;
+    let plan = plan_table_schema(&spec(b"Wide", &columns, &[]), 20, true)?;
     assert_eq!(plan.definition_len(), DEFINITION_ROOT_CAPACITY + 1);
-    assert_eq!(plan.property_page(), PageNumber::new(22));
+    assert_eq!(plan.property_page(), Some(PageNumber::new(22)));
     assert_eq!(plan.continuation_page(), Some(PageNumber::new(23)));
     assert_eq!(plan.appended_page_count(), 4);
     let full = names_of_definition_len(DEFINITION_ROOT_CAPACITY + CONTINUATION_CAPACITY);
     let columns = long_columns(&full);
     assert_eq!(
-        plan_table_schema(&spec(b"Wide", &columns, &[]), 20)?.appended_page_count(),
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20, true)?.appended_page_count(),
         4
     );
     Ok(())
@@ -561,7 +623,7 @@ fn a_definition_needing_two_continuations_is_refused() {
     let names = names_of_definition_len(length);
     let columns = long_columns(&names);
     assert_eq!(
-        plan_table_schema(&spec(b"Wide", &columns, &[]), 20),
+        plan_table_schema(&spec(b"Wide", &columns, &[]), 20, true),
         Err(TableSchemaPlanError::ContinuationPlacementUnestablished {
             length,
             continuations: 2,
@@ -581,7 +643,7 @@ fn a_continuation_beside_an_index_is_refused() {
         kind: IndexKind::Ordinary,
     }];
     assert_eq!(
-        plan_table_schema(&spec(b"Wide", &columns, &indexes), 20),
+        plan_table_schema(&spec(b"Wide", &columns, &indexes), 20, true),
         Err(TableSchemaPlanError::UnobservedContinuationIndexLayout {
             continuations: 1,
             indexes: 1,


### PR DESCRIPTION
The composer could only lay out a database with a single created table, so issue #100's multi-table creation had nowhere to go. EXP-0087 recorded what DAO does for each later create in the same database, and this teaches the crate-private composer that pattern.

- **Later creates** append their definition root, map page, and index roots directly after the previous table and carry no `LvProp` page. The first table keeps its EXP-0091/EXP-0093 shape. Catalog rows, access-control rows, both catalog indexes, and the page-zero counter grow per create.
- **Refusals** stay structured and evidence-bounded: more than four tables (EXP-0087's maximum), two names equal under ASCII case folding, and, for later creates, more than one index or a definition needing a continuation, since no experiment observed those layouts after a first create.
- **Tests** reproduce the EXP-0087 checkpoint page counts (23, 25, 28, 31) and counter values for the exact Alpha/Beta/Gamma/Delta sequence, reopen the four-table image through the reader, and cover each refusal.

The public `create_database` still takes one table. Widening it waits for a DAO differential over a composed multi-table image, which is preregistered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)