### PR TITLE
test(oracle): preregister multi-table create successor

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -9872,6 +9872,53 @@ Use `not applicable` explicitly rather than omitting a field.
 - Review: pending independent review; no acquisition has occurred
 
 
+### EXP-0109 — Multi-table create successor preregistration
+
+- Recorded: 2026-09-03, Claude Fable 5.1
+- Kind: SHA-256-pinned, development-only local DAO preregistration; no
+  experimental acquisition has occurred
+- Question: the single `EXP-0108` `quad` question, unchanged.
+- Origin: after `EXP-0108` merged as commit
+  `cf1e224b0a67515072f94e5c94acef0f5dcddb0c` (PR `#185`) and the user
+  authorized one run, dispatch `20260903T220845Z-multi-table` failed before
+  any experimental DAO mutation: the staged remote runner passed its optional
+  per-job paths as empty native arguments, which Windows PowerShell drops, so
+  the staged dispatcher rejected the invocation for a missing
+  `LvPropNullSchemasJobPath` value and no candidate or control was created,
+  opened, or read. Only the provider probe's disposable readiness database
+  was created. That pre-mutation failure rejects without a report under the
+  `EXP-0108` decision rule and is an infrastructure defect, not a scientific
+  result. This successor pins the corrected runner, which passes each optional
+  path only when it is non-empty, and leaves the plan text, candidate identity,
+  producer, analyzer, decision rule, and evidence boundary of `EXP-0108`
+  unchanged.
+- Protocol: as `EXP-0108`.
+- Decision rule: as `EXP-0108`.
+- Preregistration artifacts: plan
+  `oracle/windows-dao/acquisition/multi-table-create.plan.json`, SHA-256
+  `5778f3b561de27bc3506fd53b3aea9f6be894b05b205e14743ea49806a14aeb8`; source manifest
+  `oracle/windows-dao/acquisition/multi-table-create.sources.json`, SHA-256
+  `06f483190ecb9351c698d0304bfc20df6b85a77e7db8fda2e72efd15015f5ba8`; corrected runner
+  `oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1`, SHA-256
+  `591bea836a5200f2dc0248492cf5b00f6e5758b421c59b262f101f7ef37523b1`; producer
+  `oracle/windows-dao/scripts/dev/MultiTableCreate.DevJob.ps1`, SHA-256
+  `87f46a9d3da3bbf7cae7ecde7c3d797ec9e85b52060ed16df4db925617924c55`; analyzer
+  `oracle/windows-dao/scripts/multi_table_create.py`, SHA-256
+  `8632f1a53aad740f6f8514e8f86bfa813febbe951317f0047365a836b7037037`. The candidate identity remains 63,488 bytes at SHA-256
+  `f4bad46de7c24ba92c0c9472d128eed48a2dbf1469594372d1098068940545ee`.
+- Authorization: acquisition is forbidden until these exact reviewed bytes
+  reach `main` and a human explicitly authorizes one run. Once the first DAO
+  `CreateDatabase` begins, any failure is a scientific result and no retry is
+  permitted without another human decision.
+- Interpretation: as `EXP-0108`; this entry adds no format evidence.
+- Usage: future result for issue `#100`; `EXP-0108`;
+  `file:oracle/windows-dao/acquisition/multi-table-create.plan.json`;
+  `file:oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1`
+- Rights: future project-generated MDBs and provider outputs remain outside
+  the repository and are neither committed nor redistributed
+- Review: pending independent review; no experimental acquisition has occurred
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/acquisition/multi-table-create.plan.json
+++ b/oracle/windows-dao/acquisition/multi-table-create.plan.json
@@ -13,7 +13,7 @@
   "inputs": {
     "scripts/windows-dao-dev.py": "a794147d34214f9ea43db2ad6b562c6dedfb0fa343d345dffd52f55be6873eda",
     "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
-    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "c644c6713702778cb093b797502bbfca363b2171588091cef0eae5703544568e",
+    "oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1": "591bea836a5200f2dc0248492cf5b00f6e5758b421c59b262f101f7ef37523b1",
     "oracle/windows-dao/scripts/dev/Dispatch.DevJob.ps1": "26307f11a20f780c7bd80f6374998742508311cc86e3b2054b9af53db841de3b",
     "oracle/windows-dao/scripts/dev/Publish.DevJob.ps1": "793839a04be6ad770f7a08da8119a3182c0612c8a1ea71405bbbbae402a9b1f2",
     "oracle/windows-dao/scripts/dev/MultiTableCreate.DevJob.ps1": "87f46a9d3da3bbf7cae7ecde7c3d797ec9e85b52060ed16df4db925617924c55",

--- a/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
+++ b/oracle/windows-dao/scripts/dev/Invoke-Jet3DaoDevJob.ps1
@@ -854,30 +854,45 @@ elseif ($Job -in @("catalog", "table-definition", "row", "value", "index", "boot
         $detail = "The ready provider is not DAO.DBEngine.36."
     }
     else {
-        & (Join-Path $PSHOME "powershell.exe") -NoProfile -NonInteractive `
-            -ExecutionPolicy Bypass -File $DispatchPath -Job $Job -RunRoot $runRoot `
-            -CatalogJobPath $CatalogJobPath -TableDefinitionJobPath $TableDefinitionJobPath `
-            -TableDefinitionTypeInputPath $TableDefinitionTypeInputPath -RowJobPath $RowJobPath `
-            -ValueJobPath $ValueJobPath -IndexJobPath $IndexJobPath `
-            -BootstrapLayoutJobPath $BootstrapLayoutJobPath `
-            -SystemCatalogJobPath $SystemCatalogJobPath `
-            -BootstrapComposerValidationJobPath $BootstrapComposerValidationJobPath `
-            -BootstrapComposerEmptyPath $BootstrapComposerEmptyPath `
-            -BootstrapComposerAlphaPath $BootstrapComposerAlphaPath `
-            -SchemaGeneralizationJobPath $SchemaGeneralizationJobPath `
-            -MultipleIndexesJobPath $MultipleIndexesJobPath `
-            -DefinitionContinuationJobPath $DefinitionContinuationJobPath `
-            -ExtendedNamesJobPath $ExtendedNamesJobPath `
-            -LvPropNullJobPath $LvPropNullJobPath `
-            -LvPropFixedAlphaPath $LvPropFixedAlphaPath `
-            -LvPropNullAlphaPath $LvPropNullAlphaPath `
-            -LvPropNullSchemasJobPath $LvPropNullSchemasJobPath `
-            -LvPropSchemasAlphaPath $LvPropSchemasAlphaPath `
-            -LvPropSchemasIndexedPath $LvPropSchemasIndexedPath `
-            -LvPropSchemasWidePath $LvPropSchemasWidePath `
-            -MultiTableCreateJobPath $MultiTableCreateJobPath `
-            -MultiTableQuadPath $MultiTableQuadPath `
-            -PlanSha256 $PlanSha256 -RunId $RunId
+        $dispatchArguments = @(
+            "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+            "-File", $DispatchPath, "-Job", $Job, "-RunRoot", $runRoot,
+            "-CatalogJobPath", $CatalogJobPath,
+            "-TableDefinitionJobPath", $TableDefinitionJobPath,
+            "-TableDefinitionTypeInputPath", $TableDefinitionTypeInputPath,
+            "-RowJobPath", $RowJobPath,
+            "-ValueJobPath", $ValueJobPath,
+            "-IndexJobPath", $IndexJobPath,
+            "-BootstrapLayoutJobPath", $BootstrapLayoutJobPath,
+            "-SystemCatalogJobPath", $SystemCatalogJobPath,
+            "-BootstrapComposerValidationJobPath", $BootstrapComposerValidationJobPath,
+            "-BootstrapComposerEmptyPath", $BootstrapComposerEmptyPath,
+            "-BootstrapComposerAlphaPath", $BootstrapComposerAlphaPath,
+            "-SchemaGeneralizationJobPath", $SchemaGeneralizationJobPath,
+            "-MultipleIndexesJobPath", $MultipleIndexesJobPath,
+            "-DefinitionContinuationJobPath", $DefinitionContinuationJobPath,
+            "-ExtendedNamesJobPath", $ExtendedNamesJobPath,
+            "-LvPropNullJobPath", $LvPropNullJobPath,
+            "-LvPropFixedAlphaPath", $LvPropFixedAlphaPath,
+            "-LvPropNullAlphaPath", $LvPropNullAlphaPath
+        )
+        # Optional per-job paths are omitted when empty: an empty native
+        # argument is dropped and the dispatcher then reports a missing value.
+        $optionalDispatchArguments = [ordered]@{
+            "-LvPropNullSchemasJobPath" = $LvPropNullSchemasJobPath
+            "-LvPropSchemasAlphaPath" = $LvPropSchemasAlphaPath
+            "-LvPropSchemasIndexedPath" = $LvPropSchemasIndexedPath
+            "-LvPropSchemasWidePath" = $LvPropSchemasWidePath
+            "-MultiTableCreateJobPath" = $MultiTableCreateJobPath
+            "-MultiTableQuadPath" = $MultiTableQuadPath
+        }
+        foreach ($entry in $optionalDispatchArguments.GetEnumerator()) {
+            if (-not [string]::IsNullOrEmpty([string]$entry.Value)) {
+                $dispatchArguments += @([string]$entry.Key, [string]$entry.Value)
+            }
+        }
+        $dispatchArguments += @("-PlanSha256", $PlanSha256, "-RunId", $RunId)
+        & (Join-Path $PSHOME "powershell.exe") @dispatchArguments
         $dispatchExitCode = [int]$LASTEXITCODE
         $dispatchResultPath = Join-Path $runRoot "dispatch-result.json"
         if (-not (Test-Path -LiteralPath $dispatchResultPath -PathType Leaf)) {

--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -1251,6 +1251,24 @@ class WindowsDaoDevRemoteContractTests(unittest.TestCase):
             plan["candidate_source_manifest"]["sha256"],
         )
 
+    def test_optional_dispatch_paths_are_omitted_when_empty(self) -> None:
+        # An empty native argument is dropped, so the dispatcher would report a
+        # missing value; every optional per-job path must be passed conditionally.
+        start = self.remote.index("$optionalDispatchArguments = [ordered]@{")
+        end = self.remote.index("}", start)
+        block = self.remote[start:end]
+        for parameter in (
+            "-LvPropNullSchemasJobPath",
+            "-LvPropSchemasAlphaPath",
+            "-LvPropSchemasIndexedPath",
+            "-LvPropSchemasWidePath",
+            "-MultiTableCreateJobPath",
+            "-MultiTableQuadPath",
+        ):
+            self.assertIn(f'"{parameter}" = ${parameter[1:]}', block)
+        self.assertIn("if (-not [string]::IsNullOrEmpty([string]$entry.Value))", self.remote)
+        self.assertIn('& (Join-Path $PSHOME "powershell.exe") @dispatchArguments', self.remote)
+
     def test_multi_table_create_is_bounded_and_exactly_routed(self) -> None:
         job = CLIENT.MULTI_TABLE_CREATE_JOB.read_text(encoding="utf-8")
         plan = json.loads(CLIENT.MULTI_TABLE_CREATE_PLAN.read_text(encoding="utf-8"))


### PR DESCRIPTION
The first authorized run of the EXP-0108 multi-table experiment never reached DAO. The remote runner forwards every optional per-job path to the staged dispatcher, and Windows PowerShell drops empty native arguments, so the dispatcher stopped with "Missing an argument for parameter LvPropNullSchemasJobPath". No candidate or control was created, opened, or read, so under the preregistered rule this is a pre-mutation rejection without a report, not a scientific result.

- **Runner fix.** Optional dispatcher paths are now appended only when non-empty; the mandatory ones are unchanged. A contract test pins that every optional path goes through that conditional path.
- **Successor preregistration.** EXP-0109 re-pins the plan with the corrected runner hash and records exactly what failed and why. Plan text, candidate identity, producer, analyzer, decision rule, and evidence boundary are byte-for-byte those of EXP-0108.

Acquisition remains forbidden until this merges and a human authorizes one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)