### PR TITLE
feat(jet3): create databases holding up to four tables

### DIFF
--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -114,6 +114,7 @@ pub(crate) fn compose_alpha_database(
 }
 
 /// Composes the empty database plus one created user table.
+#[cfg(test)]
 pub(crate) fn compose_table_database(
     spec: &TableSpec<'_>,
     budget: &mut ResourceBudget,

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -1,4 +1,4 @@
-//! Creation of a fresh Jet 3 database holding one empty user table.
+//! Creation of a fresh Jet 3 database holding empty user tables.
 //!
 //! [`create_database`] composes the complete image in memory, writes every
 //! page in physical order to a private file beside the destination, reopens
@@ -10,7 +10,10 @@
 //! The structural reopen is a publication prerequisite, not compatibility
 //! evidence. Only a recorded DAO differential can establish that Microsoft
 //! Access or DAO consume a created database; none has been run for schemas
-//! other than the exact `Alpha(Id Long)` construction of `EXP-0091`.
+//! other than the exact `EXP-0091`, `EXP-0107`, and `EXP-0110` constructions.
+//! `EXP-0110` observed DAO read one composed four-table image built from the
+//! `EXP-0087` later-create pattern; it does not establish other table counts,
+//! orders, names, or schemas.
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -19,18 +22,18 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use crate::atomic::atomic_create;
-use crate::bootstrap_composer::{ComposeError, compose_table_database};
+use crate::bootstrap_composer::{ComposeError, compose_database};
 use crate::page_append_plan::PlannedPage;
 use crate::{
     CatalogError, CatalogObjectClass, ColumnStorageClass, ColumnStorageKind, ColumnType,
-    DatabaseOpenError, DatabaseReader, IndexDefinitionKind, IndexKind, PublishError,
+    DatabaseOpenError, DatabaseReader, IndexDefinitionKind, IndexKind, PageNumber, PublishError,
     ResourceBudget, TableDefinitionError, TableSpec,
 };
 
 /// Structured failure of [`create_database`].
 #[derive(Debug)]
 pub enum CreateDatabaseError {
-    /// The table could not be composed into a database image; nothing was
+    /// The tables could not be composed into a database image; nothing was
     /// written.
     Compose(ComposeError),
     /// The composed image could not be written, checked, or published.
@@ -65,7 +68,7 @@ pub enum CandidateCheckError {
     Catalog(CatalogError),
     /// The created table's definition could not be read.
     Definition(TableDefinitionError),
-    /// The candidate decodes but does not describe the requested table.
+    /// The candidate decodes but does not describe the requested tables.
     Mismatch {
         /// Which structure differed.
         detail: &'static str,
@@ -98,7 +101,8 @@ impl StdError for CandidateCheckError {
     }
 }
 
-/// Creates the database at `path` holding one empty user table.
+/// Creates the database at `path` holding `tables`, created in order, each
+/// empty.
 ///
 /// After successful composition, `path` must not exist; an existing entry
 /// fails with an `AlreadyExists` I/O error at
@@ -107,16 +111,18 @@ impl StdError for CandidateCheckError {
 /// `budget`.
 ///
 /// Unsupported layouts fail with [`CreateDatabaseError::Compose`] before
-/// anything is written: more than three indexes, more than one Memo or
-/// LongBinary column, an index together with such a column, a definition
-/// longer than two pages, a definition longer than one page together with an
-/// index, or a name byte above `0x7E`.
+/// anything is written: more than four tables, two tables whose names differ
+/// only by ASCII case, more than three indexes on the first table or more than
+/// one on a later table, more than one Memo or LongBinary column on a table,
+/// an index together with such a column, a definition longer than two pages,
+/// a definition longer than one page together with an index or on a later
+/// table, or a name byte above `0x7E`.
 pub fn create_database(
     path: impl AsRef<Path>,
-    spec: &TableSpec<'_>,
+    tables: &[TableSpec<'_>],
     budget: &mut ResourceBudget,
 ) -> Result<(), CreateDatabaseError> {
-    let pages = compose_table_database(spec, budget)
+    let pages = compose_database(tables, budget)
         .map_err(CreateDatabaseError::Compose)?
         .into_pages();
     let page_count = pages.len() as u64;
@@ -126,7 +132,7 @@ pub fn create_database(
     atomic_create(
         path,
         |file| write_pages(file, &pages),
-        |candidate| check_candidate(candidate, spec, page_count, budget),
+        |candidate| check_candidate(candidate, tables, page_count, budget),
     )
     .map_err(CreateDatabaseError::Publish)
 }
@@ -147,10 +153,10 @@ fn write_pages(file: &mut File, pages: &[PlannedPage]) -> Result<(), io::Error> 
 }
 
 /// Reopens the candidate through the reader and checks its geometry, catalog
-/// row, columns, and indexes against `spec`.
+/// rows, columns, and indexes against `tables`.
 fn check_candidate(
     candidate: &Path,
-    spec: &TableSpec<'_>,
+    tables: &[TableSpec<'_>],
     page_count: u64,
     budget: &mut ResourceBudget,
 ) -> Result<(), CandidateCheckError> {
@@ -160,7 +166,8 @@ fn check_candidate(
     if database.geometry().page_count() != page_count {
         return Err(mismatch("page count"));
     }
-    let mut root = None;
+    let mut roots: Vec<Option<PageNumber>> = vec![None; tables.len()];
+    let mut user_rows = 0_usize;
     {
         let mut catalog = database
             .catalog(budget)
@@ -169,15 +176,38 @@ fn check_candidate(
             .next_record()
             .map_err(CandidateCheckError::Catalog)?
         {
-            if record.name().raw_bytes() == spec.name {
-                if record.class() != CatalogObjectClass::User || root.is_some() {
-                    return Err(mismatch("catalog row"));
-                }
-                root = record.table_definition();
+            if record.class() != CatalogObjectClass::User {
+                continue;
             }
+            user_rows += 1;
+            let position = tables
+                .iter()
+                .position(|table| table.name == record.name().raw_bytes())
+                .ok_or(mismatch("catalog row"))?;
+            if roots[position].is_some() {
+                return Err(mismatch("catalog row"));
+            }
+            roots[position] = Some(record.table_definition().ok_or(mismatch("catalog row"))?);
         }
     }
-    let root = root.ok_or(mismatch("catalog row"))?;
+    if user_rows != tables.len() {
+        return Err(mismatch("catalog row"));
+    }
+    for (spec, root) in tables.iter().zip(roots) {
+        let root = root.ok_or(mismatch("catalog row"))?;
+        check_table(&mut database, spec, root, budget)?;
+    }
+    Ok(())
+}
+
+/// Checks one table's definition at `root` against `spec`.
+fn check_table(
+    database: &mut DatabaseReader<crate::FileSource>,
+    spec: &TableSpec<'_>,
+    root: PageNumber,
+    budget: &mut ResourceBudget,
+) -> Result<(), CandidateCheckError> {
+    let mismatch = |detail: &'static str| CandidateCheckError::Mismatch { detail };
     let definition = database
         .table_definition(root, budget)
         .map_err(CandidateCheckError::Definition)?;

--- a/crates/jet3/src/create_tests.rs
+++ b/crates/jet3/src/create_tests.rs
@@ -96,7 +96,7 @@ fn a_mixed_table_with_three_indexes_is_created_and_reopens() -> TestResult {
         columns: &columns,
         indexes: &indexes,
     };
-    create_database(&target, &spec, &mut budget())?;
+    create_database(&target, std::slice::from_ref(&spec), &mut budget())?;
     assert_eq!(directory.entries()?, ["created.mdb"]);
     assert_eq!(fs::metadata(&target)?.len(), 26 * crate::PAGE_BYTES as u64);
 
@@ -138,11 +138,11 @@ fn candidate_check_rejects_an_index_kind_mismatch() -> TestResult {
     }];
     create_database(
         &target,
-        &TableSpec {
+        &[TableSpec {
             name: b"Items",
             columns: &columns,
             indexes: &unique_indexes,
-        },
+        }],
         &mut budget(),
     )?;
 
@@ -154,11 +154,11 @@ fn candidate_check_rejects_an_index_kind_mismatch() -> TestResult {
     let page_count = fs::metadata(&target)?.len() / crate::PAGE_BYTES as u64;
     let error = check_candidate(
         &target,
-        &TableSpec {
+        &[TableSpec {
             name: b"Items",
             columns: &columns,
             indexes: &ordinary_indexes,
-        },
+        }],
         page_count,
         &mut budget(),
     )
@@ -183,7 +183,7 @@ fn a_memo_table_is_created_and_reopens() -> TestResult {
         columns: &columns,
         indexes: &[],
     };
-    create_database(&target, &spec, &mut budget())?;
+    create_database(&target, std::slice::from_ref(&spec), &mut budget())?;
     assert_eq!(fs::metadata(&target)?.len(), 23 * crate::PAGE_BYTES as u64);
     let mut budget = budget();
     let mut database = DatabaseReader::open(&target, &mut budget)?;
@@ -230,7 +230,7 @@ fn unsupported_layouts_are_refused_before_anything_is_written() -> TestResult {
         ),
     ];
     for (spec, accepts) in cases {
-        match create_database(&target, &spec, &mut budget()) {
+        match create_database(&target, std::slice::from_ref(&spec), &mut budget()) {
             Err(CreateDatabaseError::Compose(error)) if accepts(&error) => {}
             other => return Err(format!("unexpected result: {other:?}").into()),
         }
@@ -250,7 +250,7 @@ fn an_existing_destination_is_refused_and_left_unchanged() -> TestResult {
         columns: &columns,
         indexes: &[],
     };
-    match create_database(&target, &spec, &mut budget()) {
+    match create_database(&target, std::slice::from_ref(&spec), &mut budget()) {
         Err(CreateDatabaseError::Publish(error)) => {
             assert_eq!(error.stage(), PublishStage::PrivateCopyCreation);
         }
@@ -279,11 +279,77 @@ fn a_definition_spanning_one_continuation_is_created_and_reopens() -> TestResult
         columns: &columns,
         indexes: &[],
     };
-    create_database(&target, &spec, &mut budget())?;
+    create_database(&target, std::slice::from_ref(&spec), &mut budget())?;
     assert_eq!(fs::metadata(&target)?.len(), 24 * crate::PAGE_BYTES as u64);
     let mut budget = budget();
     let mut database = DatabaseReader::open(&target, &mut budget)?;
     let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
     assert_eq!(definition.columns().len(), 70);
+    Ok(())
+}
+
+#[test]
+fn too_many_tables_and_case_folded_duplicates_are_refused_before_writing() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let table = |name: &'static [u8]| TableSpec {
+        name,
+        columns: &[ID],
+        indexes: &[],
+    };
+    let five = [
+        table(b"T1"),
+        table(b"T2"),
+        table(b"T3"),
+        table(b"T4"),
+        table(b"T5"),
+    ];
+    match create_database(&target, &five, &mut budget()) {
+        Err(CreateDatabaseError::Compose(ComposeError::UnobservedTableCount {
+            count: 5,
+            observed: 4,
+        })) => {}
+        other => return Err(format!("unexpected result: {other:?}").into()),
+    }
+    let duplicate = [table(b"Alpha"), table(b"ALPHA")];
+    match create_database(&target, &duplicate, &mut budget()) {
+        Err(CreateDatabaseError::Compose(ComposeError::DuplicateTableName {
+            first: 0,
+            second: 1,
+        })) => {}
+        other => return Err(format!("unexpected result: {other:?}").into()),
+    }
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn two_tables_are_created_in_order_and_reopen() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let indexes = [IndexSpec {
+        name: b"PrimaryKey",
+        fields: &[IndexColumnSpec::ascending(b"Id")],
+        kind: IndexKind::Primary,
+    }];
+    let tables = [
+        TableSpec {
+            name: b"Alpha",
+            columns: &[ID],
+            indexes: &[],
+        },
+        TableSpec {
+            name: b"Gamma",
+            columns: &[ID, CODE],
+            indexes: &indexes,
+        },
+    ];
+    create_database(&target, &tables, &mut budget())?;
+    assert_eq!(fs::metadata(&target)?.len(), 26 * crate::PAGE_BYTES as u64);
+    let mut budget = budget();
+    let mut database = DatabaseReader::open(&target, &mut budget)?;
+    let gamma = database.table_definition(PageNumber::new(23), &mut budget)?;
+    assert_eq!(gamma.columns().len(), 2);
+    assert_eq!(gamma.physical_indexes()[0].root(), PageNumber::new(25));
     Ok(())
 }

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -2,7 +2,7 @@
 //! Safe, clean-room primitives for Access 97 / Jet 3 databases.
 //!
 //! Reading starts at [`DatabaseReader`]. Creating a fresh database holding
-//! one empty user table starts at [`create_database`]:
+//! empty user tables starts at [`create_database`]:
 //!
 //! ```no_run
 //! use std::num::NonZeroU8;
@@ -22,13 +22,13 @@
 //!     fields: &[IndexColumnSpec::ascending(b"Id")],
 //!     kind: IndexKind::Primary,
 //! }];
-//! let spec = TableSpec {
+//! let people = TableSpec {
 //!     name: b"People",
 //!     columns: &columns,
 //!     indexes: &indexes,
 //! };
 //! let mut budget = ResourceBudget::new(ResourceLimits::default());
-//! create_database("people.mdb", &spec, &mut budget)?;
+//! create_database("people.mdb", &[people], &mut budget)?;
 //! # Ok::<(), jet3::CreateDatabaseError>(())
 //! ```
 //!


### PR DESCRIPTION
`create_database` could only produce a database with one table, which made it useless for any real schema. With #184's composer and the EXP-0110 result recorded in #187, the multi-table construction now has DAO evidence behind it, so this is issue #100 slice 2.

```rust
jet3::create_database(path, &[alpha, beta, gamma, delta], &mut budget)?;
```

- **API:** `create_database` takes `&[TableSpec]`, created in order. Existing single-table callers pass a one-element slice.
- **Candidate check:** the reopen resolves every requested table by name, rejects a missing, duplicated, or extra user catalog row, and checks each table's columns and indexes as before.
- **Refusals** stay structured and happen before anything is written: more than four tables (EXP-0087's maximum), two names equal under ASCII case folding, and the later-create limits from #184. A test drives both new refusals through the public API and checks the directory stays empty.
- **Docs** state plainly that the only DAO evidence is the exact EXP-0091, EXP-0107, and EXP-0110 candidates. No compatibility claim, no support-matrix change.

The EXP-0110 evidence merged in #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)