### PR TITLE
test(oracle): stop re-verifying the consumed EXP-0110 source manifest

### DIFF
--- a/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
+++ b/oracle/windows-dao/tests/test_windows_dao_dev_contract.py
@@ -419,13 +419,12 @@ class WindowsDaoDevClientTests(unittest.TestCase):
         self.assertEqual(binding.job_result_name, "lvprop-null-schemas-job-result.json")
         self.assertEqual(binding.report_name, "lvprop-null-schemas-report.json")
 
-    def test_multi_table_create_binds_issue_100_and_verifies_plan(self) -> None:
+    def test_multi_table_create_binds_issue_100(self) -> None:
         binding = CLIENT.plan_binding("multi-table-create")
         self.assertEqual(binding.issue, 100)
         self.assertEqual(binding.document_type, "dao_multi_table_create_plan")
         self.assertEqual(binding.job_result_name, "multi-table-create-job-result.json")
         self.assertEqual(binding.report_name, "multi-table-create-report.json")
-        self.assert_plan_bound_job("multi-table-create", "MULTI_TABLE_CREATE_PLAN")
 
     def test_plan_binding_requires_its_exact_issue(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Main's "DAO protocol and development contracts" job went red after #188: the multi-table-create plan pins every `crates/jet3/src/*.rs` hash, EXP-0110 has consumed that plan, and the API change legitimately altered those sources. The contract test still re-verified the manifest against the working tree, so it can never pass again.

This keeps the binding assertions (issue, document type, result and report names) and drops the live manifest verification, exactly as #185 did for the consumed EXP-0107 plan. The pinned plan file itself is untouched; its hashes remain the record of what was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)