### PR TITLE
feat(jet3): create a database with initial scalar rows

### DIFF
--- a/crates/jet3/examples/initial_row_candidate.rs
+++ b/crates/jet3/examples/initial_row_candidate.rs
@@ -1,0 +1,39 @@
+//! Deterministic scalar-row candidate for a separately preregistered DAO run.
+use std::num::NonZeroU8;
+
+use jet3::{
+    ColumnSpec, ColumnType, ResourceBudget, ResourceLimits, RowValue, TableSpec,
+    create_database_with_rows,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args_os()
+        .nth(1)
+        .ok_or("usage: initial_row_candidate OUTPUT.mdb")?;
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(
+            b"Code",
+            ColumnType::Text {
+                max_len: NonZeroU8::new(8).ok_or("invalid text length")?,
+            },
+        ),
+    ];
+    let table = TableSpec {
+        name: b"Rows",
+        columns: &columns,
+        indexes: &[],
+    };
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(1), RowValue::Text(b"one")],
+        &[RowValue::Long(-2), RowValue::Text(b"two")],
+        &[RowValue::Null, RowValue::Null],
+    ];
+    create_database_with_rows(
+        path,
+        &table,
+        rows,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -5,6 +5,9 @@ use super::*;
 /// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
+    /// Initial rows require an unindexed, single-page definition without
+    /// AutoIncrement or long-value columns.
+    UnsupportedInitialRowSchema,
     /// A table definition could not be encoded.
     Definition(TableDefinitionWriteError),
     /// A usage map could not be encoded.
@@ -77,7 +80,8 @@ impl std::error::Error for ComposeError {
             Self::Encoding(source) => Some(source),
             Self::NameKey(source) => Some(source),
             Self::Schema(source) => Some(source),
-            Self::IndexPageFull { .. }
+            Self::UnsupportedInitialRowSchema
+            | Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
             | Self::UnobservedLongValueColumnCount { .. }
             | Self::UnobservedTableCount { .. }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -158,13 +158,66 @@ pub(crate) fn compose_database(
         next_page = planned.page_count();
         creates.push(planned);
     }
-    let images = compose_existing_pages(&creates, budget)?;
+    compose_planned_creates(&creates, budget)
+}
+
+fn compose_planned_creates(
+    creates: &[PlannedCreate<'_>],
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, ComposeError> {
+    let images = compose_existing_pages(creates, budget)?;
     let mut plan = WholeFileImagePlan::from_existing_pages(images, budget)?;
     let mut append_map = global_map(EMPTY_DATABASE_PAGE_COUNT, budget)?;
-    for planned in &creates {
+    for planned in creates {
         planned.append_pages(&mut plan, &mut append_map, budget)?;
     }
     Ok(plan)
+}
+
+/// Composes one unindexed table with a single page of scalar initial rows.
+pub(crate) fn compose_database_with_rows(
+    spec: &TableSpec<'_>,
+    rows: &[&[RowValue<'_>]],
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, ComposeError> {
+    let planned =
+        PlannedCreate::new(spec, EMPTY_DATABASE_PAGE_COUNT, true)?.with_rows(rows, budget)?;
+    compose_planned_creates(&[planned], budget)
+}
+
+/// Resolves precisely the same column placements as the definition encoder.
+pub(crate) fn initial_row_layout(
+    spec: &TableSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<Vec<RowColumnLayout>, ComposeError> {
+    budget.charge_allocation(ByteCount::new(
+        (spec.columns.len() * std::mem::size_of::<RowColumnLayout>()) as u64,
+    ))?;
+    let mut layout = Vec::new();
+    layout
+        .try_reserve_exact(spec.columns.len())
+        .map_err(|_| Error::Io {
+            operation: "reserve initial row layout",
+            kind: std::io::ErrorKind::OutOfMemory,
+        })?;
+    let mut fixed = 0;
+    let mut variable = 0;
+    for (ordinal, column) in (0_u16..).zip(spec.columns) {
+        let resolved = crate::column_definition_writer::resolve_column(
+            ordinal,
+            column,
+            TableDefinitionKind::User,
+            None,
+            &mut fixed,
+            &mut variable,
+        )?;
+        layout.push(RowColumnLayout::new(
+            column.physical_type(),
+            resolved.storage,
+            column.size(),
+        ));
+    }
+    Ok(layout)
 }
 
 fn compose_existing_pages(

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -111,6 +111,15 @@ impl<'a> PlannedCreate<'a> {
             let length = encode_row(&layout, row, &mut encoded, budget)?.get() as usize;
             builder.append_row(&encoded[..length], budget)?;
         }
+        // EXP-0057 establishes available-page maps, but not the transition
+        // for exhausted pages. Refuse those candidates: the page must still
+        // have a slot and room for its smallest row, with every field null.
+        // This is a construction bound, not a DAO free-space threshold.
+        // EXP-0060 bounds the one-byte column count to 255.
+        let nulls = [RowValue::Null; u8::MAX as usize];
+        let minimum =
+            encode_row(&layout, &nulls[..layout.len()], &mut encoded, budget)?.get() as usize;
+        builder.clone().append_row(&encoded[..minimum], budget)?;
         self.initial_row_count =
             u32::try_from(rows.len()).map_err(|_| Error::IntegerConversion {
                 value: rows.len() as u128,

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -51,6 +51,8 @@ pub(super) struct PlannedCreate<'a> {
     /// The long-value column's ordinal; its owned map takes the first free
     /// map-page row and its available map the next.
     long_value: Option<u16>,
+    initial_data: Option<PageImage>,
+    initial_row_count: u32,
 }
 
 impl<'a> PlannedCreate<'a> {
@@ -76,7 +78,46 @@ impl<'a> PlannedCreate<'a> {
             spec,
             plan,
             long_value,
+            initial_data: None,
+            initial_row_count: 0,
         })
+    }
+
+    /// Adds a single data page using EXP-0060/0061 row encoding and EXP-0065
+    /// Q2 append placement. EXP-0057 supplies the owned/available map roles;
+    /// EXP-0073 supplies the definition row count. This is a candidate
+    /// construction, without a generalized page-zero insertion transition.
+    pub(super) fn with_rows(
+        mut self,
+        rows: &[&[RowValue<'_>]],
+        budget: &mut ResourceBudget,
+    ) -> Result<Self, ComposeError> {
+        if !self.spec.indexes.is_empty()
+            || self.plan.continuation_page().is_some()
+            || self.spec.columns.iter().any(|column| {
+                column.column_type().is_long_value()
+                    || column.column_type() == ColumnType::AutoIncrement
+            })
+        {
+            return Err(ComposeError::UnsupportedInitialRowSchema);
+        }
+        if rows.is_empty() {
+            return Ok(self);
+        }
+        let layout = initial_row_layout(self.spec, budget)?;
+        let mut builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
+        let mut encoded = [0_u8; PAGE_BYTES];
+        for row in rows {
+            let length = encode_row(&layout, row, &mut encoded, budget)?.get() as usize;
+            builder.append_row(&encoded[..length], budget)?;
+        }
+        self.initial_row_count =
+            u32::try_from(rows.len()).map_err(|_| Error::IntegerConversion {
+                value: rows.len() as u128,
+                target: "u32",
+            })?;
+        self.initial_data = Some(finish_data_builder(builder, budget)?);
+        Ok(self)
     }
 
     /// Returns the page holding the catalog row's `LvProp` long value, present
@@ -87,7 +128,9 @@ impl<'a> PlannedCreate<'a> {
 
     /// Returns the page count once every appended page is in place.
     pub(super) fn page_count(&self) -> u64 {
-        self.plan.definition_root().get() + self.plan.appended_page_count()
+        self.plan.definition_root().get()
+            + self.plan.appended_page_count()
+            + u64::from(self.initial_data.is_some())
     }
 
     /// Returns the catalog row the create adds (`EXP-0087`).
@@ -133,6 +176,9 @@ impl<'a> PlannedCreate<'a> {
         let owner = self.plan.definition_root().get();
         for _ in self.plan.index_placements() {
             plan.append(empty_index_page(owner, budget)?, append_map, budget)?;
+        }
+        if let Some(image) = &self.initial_data {
+            plan.append(image.clone(), append_map, budget)?;
         }
         Ok(())
     }
@@ -228,7 +274,7 @@ impl<'a> PlannedCreate<'a> {
                 indexes: &logical,
                 owned_map: MapRowLocator::new(map, OWNED_MAP_ROW),
                 available_map: MapRowLocator::new(map, AVAILABLE_MAP_ROW),
-                row_count: 0,
+                row_count: self.initial_row_count,
                 long_value_maps: &long_value_maps,
             },
             output,
@@ -240,7 +286,9 @@ impl<'a> PlannedCreate<'a> {
     /// Builds the map page with the rows the definition names.
     fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
         let empty = inline_map_row(&[], budget)?;
-        let mut rows: Vec<[u8; 133]> = vec![empty, empty];
+        let data_pages = self.initial_data.as_ref().map(|_| self.page_count() - 1);
+        let data_map = inline_map_row(data_pages.as_slice(), budget)?;
+        let mut rows: Vec<[u8; 133]> = vec![data_map, data_map];
         for (root, _) in self.plan.index_placements() {
             rows.push(inline_map_row(&[root.get()], budget)?);
         }

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -22,12 +22,14 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use crate::atomic::atomic_create;
-use crate::bootstrap_composer::{ComposeError, compose_database};
+use crate::bootstrap_composer::{
+    ComposeError, compose_database, compose_database_with_rows, initial_row_layout,
+};
 use crate::page_append_plan::PlannedPage;
 use crate::{
     CatalogError, CatalogObjectClass, ColumnStorageClass, ColumnStorageKind, ColumnType,
     DatabaseOpenError, DatabaseReader, IndexDefinitionKind, IndexKind, PageNumber, PublishError,
-    ResourceBudget, TableDefinitionError, TableSpec,
+    ResourceBudget, RowError, RowValue, TableDefinitionError, TableSpec,
 };
 
 /// Structured failure of [`create_database`].
@@ -62,6 +64,10 @@ impl StdError for CreateDatabaseError {
 /// found when the candidate was reopened before publication.
 #[derive(Debug)]
 pub enum CandidateCheckError {
+    /// The candidate rows could not be read.
+    Rows(RowError),
+    /// Requested rows could not be encoded for comparison.
+    RowEncoding(ComposeError),
     /// The candidate could not be opened as a Jet 3 database.
     Open(DatabaseOpenError),
     /// The candidate's catalog could not be read.
@@ -78,6 +84,10 @@ pub enum CandidateCheckError {
 impl fmt::Display for CandidateCheckError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Rows(source) => write!(formatter, "candidate row scan failed: {source}"),
+            Self::RowEncoding(source) => {
+                write!(formatter, "candidate row comparison failed: {source}")
+            }
             Self::Open(source) => write!(formatter, "candidate did not open: {source}"),
             Self::Catalog(source) => write!(formatter, "candidate catalog failed: {source}"),
             Self::Definition(source) => {
@@ -93,6 +103,8 @@ impl fmt::Display for CandidateCheckError {
 impl StdError for CandidateCheckError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
+            Self::Rows(source) => Some(source),
+            Self::RowEncoding(source) => Some(source),
             Self::Open(source) => Some(source),
             Self::Catalog(source) => Some(source),
             Self::Definition(source) => Some(source),
@@ -135,6 +147,97 @@ pub fn create_database(
         |candidate| check_candidate(candidate, tables, page_count, budget),
     )
     .map_err(CreateDatabaseError::Publish)
+}
+
+/// Creates one unindexed table containing scalar initial rows in caller order.
+///
+/// All rows must fit one data page; the table definition must fit one page.
+/// AutoIncrement, Memo, and LongBinary columns are refused. Values use the
+/// same database-code-page and physical scalar representations as [`RowValue`].
+/// The existing-destination and atomic publication guarantees of
+/// [`create_database`] apply. Composition and the structural row comparison
+/// are charged to `budget`. Unsupported schemas and rows fail before writing.
+///
+/// This is an unvalidated candidate construction. No DAO differential has
+/// established compatibility for databases created with initial rows.
+pub fn create_database_with_rows(
+    path: impl AsRef<Path>,
+    table: &TableSpec<'_>,
+    rows: &[&[RowValue<'_>]],
+    budget: &mut ResourceBudget,
+) -> Result<(), CreateDatabaseError> {
+    let pages = compose_database_with_rows(table, rows, budget)
+        .map_err(CreateDatabaseError::Compose)?
+        .into_pages();
+    let page_count = pages.len() as u64;
+    budget
+        .charge_work_units(page_count.saturating_mul(crate::PAGE_BYTES as u64))
+        .map_err(|error| CreateDatabaseError::Compose(ComposeError::Encoding(error)))?;
+    atomic_create(
+        path,
+        |file| write_pages(file, &pages),
+        |candidate| {
+            check_candidate(candidate, std::slice::from_ref(table), page_count, budget)?;
+            check_initial_rows(candidate, table, rows, budget)
+        },
+    )
+    .map_err(CreateDatabaseError::Publish)
+}
+
+fn check_initial_rows(
+    candidate: &Path,
+    table: &TableSpec<'_>,
+    rows: &[&[RowValue<'_>]],
+    budget: &mut ResourceBudget,
+) -> Result<(), CandidateCheckError> {
+    let layout = initial_row_layout(table, budget).map_err(CandidateCheckError::RowEncoding)?;
+    let mut database =
+        DatabaseReader::open(candidate, budget).map_err(CandidateCheckError::Open)?;
+    // EXP-0065 Q2: first user table definition is page 20.
+    let definition = database
+        .table_definition(PageNumber::new(20), budget)
+        .map_err(CandidateCheckError::Definition)?;
+    let mut encoded = [0_u8; crate::PAGE_BYTES];
+    let mut ends = [0_usize; 256];
+    let mut used = 0;
+    for (index, row) in rows.iter().enumerate() {
+        let length = crate::encode_row(&layout, row, &mut encoded[used..], budget)
+            .map_err(|error| CandidateCheckError::RowEncoding(ComposeError::Row(error)))?
+            .get() as usize;
+        used += length;
+        let end = ends.get_mut(index).ok_or(CandidateCheckError::Mismatch {
+            detail: "initial row count",
+        })?;
+        *end = used;
+    }
+    let mut cursor = database
+        .rows(&definition, budget)
+        .map_err(CandidateCheckError::Rows)?;
+    let mut start = 0;
+    for end in ends.into_iter().take(rows.len()) {
+        let actual = cursor
+            .next_row()
+            .map_err(CandidateCheckError::Rows)?
+            .ok_or(CandidateCheckError::Mismatch {
+                detail: "initial row count",
+            })?;
+        if actual.raw_bytes() != &encoded[start..end] {
+            return Err(CandidateCheckError::Mismatch {
+                detail: "initial row value",
+            });
+        }
+        start = end;
+    }
+    if cursor
+        .next_row()
+        .map_err(CandidateCheckError::Rows)?
+        .is_some()
+    {
+        return Err(CandidateCheckError::Mismatch {
+            detail: "initial row count",
+        });
+    }
+    Ok(())
 }
 
 /// Writes every page in physical order and sets the exact final length.

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -151,7 +151,8 @@ pub fn create_database(
 
 /// Creates one unindexed table containing scalar initial rows in caller order.
 ///
-/// All rows must fit one data page; the table definition must fit one page.
+/// All rows must fit one data page, leaving a slot and room for one all-null
+/// row. The table definition must fit one page.
 /// AutoIncrement, Memo, and LongBinary columns are refused. Values use the
 /// same database-code-page and physical scalar representations as [`RowValue`].
 /// The existing-destination and atomic publication guarantees of
@@ -193,9 +194,15 @@ fn check_initial_rows(
     let layout = initial_row_layout(table, budget).map_err(CandidateCheckError::RowEncoding)?;
     let mut database =
         DatabaseReader::open(candidate, budget).map_err(CandidateCheckError::Open)?;
-    // EXP-0065 Q2: first user table definition is page 20.
+    let root = candidate_table_roots(&mut database, std::slice::from_ref(table), budget)?
+        .into_iter()
+        .next()
+        .flatten()
+        .ok_or(CandidateCheckError::Mismatch {
+            detail: "catalog row",
+        })?;
     let definition = database
-        .table_definition(PageNumber::new(20), budget)
+        .table_definition(root, budget)
         .map_err(CandidateCheckError::Definition)?;
     let mut encoded = [0_u8; crate::PAGE_BYTES];
     let mut ends = [0_usize; 256];
@@ -269,6 +276,20 @@ fn check_candidate(
     if database.geometry().page_count() != page_count {
         return Err(mismatch("page count"));
     }
+    let roots = candidate_table_roots(&mut database, tables, budget)?;
+    for (spec, root) in tables.iter().zip(roots) {
+        let root = root.ok_or(mismatch("catalog row"))?;
+        check_table(&mut database, spec, root, budget)?;
+    }
+    Ok(())
+}
+
+fn candidate_table_roots(
+    database: &mut DatabaseReader<crate::FileSource>,
+    tables: &[TableSpec<'_>],
+    budget: &mut ResourceBudget,
+) -> Result<Vec<Option<PageNumber>>, CandidateCheckError> {
+    let mismatch = |detail: &'static str| CandidateCheckError::Mismatch { detail };
     let mut roots: Vec<Option<PageNumber>> = vec![None; tables.len()];
     let mut user_rows = 0_usize;
     {
@@ -296,11 +317,7 @@ fn check_candidate(
     if user_rows != tables.len() {
         return Err(mismatch("catalog row"));
     }
-    for (spec, root) in tables.iter().zip(roots) {
-        let root = root.ok_or(mismatch("catalog row"))?;
-        check_table(&mut database, spec, root, budget)?;
-    }
-    Ok(())
+    Ok(roots)
 }
 
 /// Checks one table's definition at `root` against `spec`.

--- a/crates/jet3/src/create_initial_rows_tests.rs
+++ b/crates/jet3/src/create_initial_rows_tests.rs
@@ -1,0 +1,221 @@
+use super::*;
+use crate::{PageImageError, RowValue, RowWriteError, create_database_with_rows};
+
+fn scalar_table() -> TableSpec<'static> {
+    TableSpec {
+        name: b"Items",
+        columns: &[ID, CODE],
+        indexes: &[],
+    }
+}
+
+#[test]
+fn scalar_rows_publish_and_match_requested_values() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let target = directory.target();
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(1), RowValue::Text(b"one")],
+        &[RowValue::Long(-2), RowValue::Text(b"two")],
+        &[RowValue::Null, RowValue::Null],
+    ];
+    create_database_with_rows(&target, &scalar_table(), rows, &mut budget())?;
+    super::super::check_initial_rows(&target, &scalar_table(), rows, &mut budget())?;
+    let bytes = fs::read(&target)?;
+    assert_eq!(bytes.len(), 24 * crate::PAGE_BYTES);
+    assert_eq!(
+        &bytes[20 * crate::PAGE_BYTES + 12..20 * crate::PAGE_BYTES + 16],
+        &3_u32.to_le_bytes()
+    );
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn empty_initial_rows_do_not_allocate_a_data_page() -> TestResult {
+    let directory = TestDirectory::create()?;
+    create_database_with_rows(directory.target(), &scalar_table(), &[], &mut budget())?;
+    assert_eq!(
+        fs::metadata(directory.target())?.len(),
+        23 * crate::PAGE_BYTES as u64
+    );
+    Ok(())
+}
+
+#[test]
+fn rows_that_exceed_the_page_or_have_wrong_types_leave_no_file() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let row = [RowValue::Long(1), RowValue::Text(b"12345678")];
+    let rows = vec![row.as_slice(); 256];
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &scalar_table(), &rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::Page(
+            PageImageError::PageFull { .. }
+        )))
+    ));
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &scalar_table(),
+            &[&[RowValue::Byte(1), RowValue::Null]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::Row(
+            RowWriteError::TypeMismatch { ordinal: 0, .. }
+        )))
+    ));
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &scalar_table(), &[&[]], &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::Row(
+            RowWriteError::ValueCountMismatch { .. }
+        )))
+    ));
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn unsupported_initial_row_schemas_leave_no_file() -> TestResult {
+    let directory = TestDirectory::create()?;
+    for column_type in [
+        ColumnType::AutoIncrement,
+        ColumnType::Memo,
+        ColumnType::LongBinary,
+    ] {
+        let columns = [ColumnSpec::new(b"Value", column_type)];
+        let table = TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &[],
+        };
+        assert!(matches!(
+            create_database_with_rows(
+                directory.target(),
+                &table,
+                &[&[RowValue::Null]],
+                &mut budget()
+            ),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::UnsupportedInitialRowSchema
+            ))
+        ));
+    }
+    let indexes = [IndexSpec {
+        name: b"ById",
+        fields: &[IndexColumnSpec::ascending(b"Id")],
+        kind: IndexKind::Ordinary,
+    }];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::Long(1)]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::UnsupportedInitialRowSchema
+        ))
+    ));
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn initial_row_check_detects_wrong_values_and_counts() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let rows: &[&[RowValue<'_>]] = &[&[RowValue::Long(1), RowValue::Text(b"one")]];
+    create_database_with_rows(directory.target(), &scalar_table(), rows, &mut budget())?;
+    for (rows, detail) in [
+        (
+            &[&[RowValue::Long(2), RowValue::Text(b"one")][..]][..],
+            "initial row value",
+        ),
+        (&[][..], "initial row count"),
+        (&[rows[0], rows[0]][..], "initial row count"),
+    ] {
+        assert!(
+            matches!(super::super::check_initial_rows(&directory.target(), &scalar_table(), rows, &mut budget()),
+            Err(CandidateCheckError::Mismatch { detail: actual }) if actual == detail)
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn initial_rows_preserve_existing_destination_and_enforce_budget() -> TestResult {
+    let directory = TestDirectory::create()?;
+    fs::write(directory.target(), b"keep me")?;
+    let rows: &[&[RowValue<'_>]] = &[&[RowValue::Long(1), RowValue::Null]];
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &scalar_table(), rows, &mut budget()),
+        Err(CreateDatabaseError::Publish(_))
+    ));
+    assert_eq!(fs::read(directory.target())?, b"keep me");
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(0));
+    assert!(matches!(
+        create_database_with_rows(
+            directory.path.join("limited.mdb"),
+            &scalar_table(),
+            rows,
+            &mut limited
+        ),
+        Err(CreateDatabaseError::Compose(_))
+    ));
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn all_addressable_row_slots_are_supported_and_the_next_is_refused() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        name: b"Bits",
+        columns: &[ColumnSpec::new(b"Bit", ColumnType::Boolean)],
+        indexes: &[],
+    };
+    let row = [RowValue::Boolean(true)];
+    let rows = vec![row.as_slice(); 257];
+    create_database_with_rows(directory.target(), &table, &rows[..256], &mut budget())?;
+    assert!(matches!(
+        create_database_with_rows(
+            directory.path.join("overflow.mdb"),
+            &table,
+            &rows,
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::Page(
+            PageImageError::RowSlotsExhausted { maximum: 256 }
+        )))
+    ));
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn initial_rows_refuse_a_continued_definition() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let names = (0..70)
+        .map(|ordinal| format!("Field{ordinal:05}").into_bytes())
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name, ColumnType::Long))
+        .collect::<Vec<_>>();
+    let table = TableSpec {
+        name: b"Wide",
+        columns: &columns,
+        indexes: &[],
+    };
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &[], &mut budget()),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::UnsupportedInitialRowSchema
+        ))
+    ));
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}

--- a/crates/jet3/src/create_initial_rows_tests.rs
+++ b/crates/jet3/src/create_initial_rows_tests.rs
@@ -170,7 +170,7 @@ fn initial_rows_preserve_existing_destination_and_enforce_budget() -> TestResult
 }
 
 #[test]
-fn all_addressable_row_slots_are_supported_and_the_next_is_refused() -> TestResult {
+fn initial_rows_leave_one_available_row_slot() -> TestResult {
     let directory = TestDirectory::create()?;
     let table = TableSpec {
         name: b"Bits",
@@ -178,8 +178,8 @@ fn all_addressable_row_slots_are_supported_and_the_next_is_refused() -> TestResu
         indexes: &[],
     };
     let row = [RowValue::Boolean(true)];
-    let rows = vec![row.as_slice(); 257];
-    create_database_with_rows(directory.target(), &table, &rows[..256], &mut budget())?;
+    let rows = vec![row.as_slice(); 256];
+    create_database_with_rows(directory.target(), &table, &rows[..255], &mut budget())?;
     assert!(matches!(
         create_database_with_rows(
             directory.path.join("overflow.mdb"),
@@ -217,5 +217,31 @@ fn initial_rows_refuse_a_continued_definition() -> TestResult {
         ))
     ));
     assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn initial_rows_require_space_for_a_minimal_row() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        name: b"Numbers",
+        columns: &[ID],
+        indexes: &[],
+    };
+    let row = [RowValue::Long(1)];
+    let rows = vec![row.as_slice(); 254];
+    create_database_with_rows(directory.target(), &table, &rows[..253], &mut budget())?;
+    assert!(matches!(
+        create_database_with_rows(
+            directory.path.join("full.mdb"),
+            &table,
+            &rows,
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::Page(
+            PageImageError::PageFull { .. }
+        )))
+    ));
+    assert_eq!(directory.entries()?, ["created.mdb"]);
     Ok(())
 }

--- a/crates/jet3/src/create_tests.rs
+++ b/crates/jet3/src/create_tests.rs
@@ -353,3 +353,6 @@ fn two_tables_are_created_in_order_and_reopen() -> TestResult {
     assert_eq!(gamma.physical_indexes()[0].root(), PageNumber::new(25));
     Ok(())
 }
+
+#[path = "create_initial_rows_tests.rs"]
+mod initial_rows;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -128,7 +128,9 @@ pub use commit_state::{
     CommitSlotRole, CommitStateClass, SHARED_COMMIT_SLOT_COUNT, read_commit_region,
     read_commit_region_into,
 };
-pub use create::{CandidateCheckError, CreateDatabaseError, create_database};
+pub use create::{
+    CandidateCheckError, CreateDatabaseError, create_database, create_database_with_rows,
+};
 pub use database::{DatabaseOpenError, DatabasePageError, DatabaseReader};
 pub use database_header::{
     DATABASE_HEADER_PAGE_NUMBER, DatabaseFormatError, DatabaseHeaderPage, DatabaseHeaderPageError,


### PR DESCRIPTION
Database creation can now include scalar rows in one unindexed table. `create_database_with_rows` composes the rows, updates the table definition and allocation maps, and checks the written schema and row bytes before atomically publishing the destination.

This first slice requires the definition and initial rows to fit one page each, with capacity retained for an additional all-null row, and rejects AutoIncrement, Memo/OLE, and indexes. It adds focused boundary, refusal, corruption, and destination-preservation tests plus a deterministic candidate for a separately preregistered DAO experiment. It makes no interoperability claim.

Part of #100.

Validation: focused creation tests and scoped Clippy passed; `just ready` passed. Independent review findings were fixed and checked.
