### PR TITLE
test: preregister relationship creation observations

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10235,3 +10235,36 @@ Copy this block under the appropriate section and remove this instruction:
 - Rights:
 - Review:
 ```
+
+
+### EXP-0113 — Preregistered first and second relationship creation observations
+
+- Recorded: 2026-09-04, OpenAI Codex
+- Kind: SHA-256-pinned local development experiment preregistration; no DAO
+  acquisition or format observation has occurred under this plan
+- Question: Which exact reciprocal logical records, hidden names, physical
+  indexes/maps, relationship catalog IDs and rows, and standalone system
+  text-index keys result from creating the first and second relationship
+  between two fresh empty tables, without an intervening query?
+- Origin: original project-authored observation harness using only the
+  recorded `EXP-0057`, `EXP-0059`, `EXP-0060`, `EXP-0062`, and `EXP-0073`
+  grammar; no third-party MDB implementation was inspected
+- Protocol: three fresh CP1252 `dbVersion30` replicas, each creating
+  `Parent(Id Long, Alternate Long)` with primary `ById` and unique
+  `ByAlternate`, then `Child(ParentId Long, Alternate Long)`. Capture
+  closed `base`, then `first` after `ParentChild` (`Id` to `ParentId`), then
+  `second` after `AlternateLink` (`Alternate` to `Alternate`), both with
+  attributes zero. Capture read-only DAO Relations metadata and verify
+  unchanged bytes; retain MDBs externally.
+- Preregistration artifact:
+  `oracle/windows-dao/acquisition/relationship-create.plan.json`, SHA-256
+  `2a8e70e1eb34d5cf8019d7bc4840e2d8798da8ea7e44d5e73d9b23a0bb9a926e`. The plan pins the acquisition script,
+  analyzer, reused system-catalog decoder, and local transport helper.
+- Decision: complete matching question-bearing values across all three
+  replicas produce `answered`; scientific failures or disagreement produce
+  `no_outcome`. Preserve physical locators and raw records. Invalid retained
+  identities reject analysis. No retry after the first mutation without
+  another human decision.
+- Boundary: only these exact names, two relations, schemas and creation
+  order are tested. No automatic generalized hidden-name, selector, ID or
+  text-weight grammar, compatibility claim, or support-matrix movement.

--- a/oracle/windows-dao/acquisition/relationship-create.plan.json
+++ b/oracle/windows-dao/acquisition/relationship-create.plan.json
@@ -1,0 +1,57 @@
+{
+  "document_type": "dao_relationship_create_plan",
+  "experiment_id": "relationship-create",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "purpose": "Observe exact relationship creation metadata needed by the clean-room composer: first/second catalog IDs, reciprocal logical records and hidden names, physical index/map placement, and standalone system text-index keys.",
+  "preregistration": {
+    "acquisition_started": false,
+    "authorization": "One local acquisition after this pinned plan and its inputs are committed and reviewed; user authorized DAO experiments in the current session.",
+    "retry": "A failure after the first DAO mutation is a scientific outcome. Do not redispatch without a new human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/relationship_create.ps1": "a2456ae5038758828f684ca4ba413f3ec338a97d548513eb119e33adf62f4f6f",
+    "oracle/windows-dao/scripts/relationship_create.py": "aa267ca957815ecf49abc155bd081dfb7d02d609b414e0efa68600161f3f7740",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "scenario": [
+    "For each of three fresh dbVersion30 CP1252 databases, create Parent(Id Long, Alternate Long) with ById primary on Id and ByAlternate unique on Alternate, then Child(ParentId Long, Alternate Long) without indexes; close and capture base.",
+    "Append ParentChild from Parent.Id to Child.ParentId with attributes 0; close and capture first.",
+    "Append AlternateLink from Parent.Alternate to Child.Alternate with attributes 0; close and capture second.",
+    "At each checkpoint, reopen read-only to inventory DAO Relations and field pairs, close, rehash, and retain the exact MDB externally. Preserve partial results and the final working file on failure."
+  ],
+  "prior_evidence": [
+    "EXP-0057 table/index maps",
+    "EXP-0059 reciprocal logical records and definition grammar",
+    "EXP-0060 row layout",
+    "EXP-0062 leaf prefix/boundaries and relationship options",
+    "EXP-0073 system catalog/relationship rows"
+  ],
+  "questions": {
+    "Q1": "What exact logical index names and raw 20-byte reciprocal records, physical indexes and table/index map locators appear at base, first, and second? Do their related table references/selector ordinals correspond to the two DAO field pairs in these exact checkpoints?",
+    "Q2": "What Id, ParentId, Name, Type, Flags and Owner values identify the first and second relationships in MSysObjects when no query exists; what associated MSysACEs and MSysRelationships rows appear?",
+    "Q3": "What exact uncompressed key bytes and physical row locators appear in the three MSysRelationships single-leaf indexes, and what common prefix was stored?",
+    "Q4": "Are these values, page counts, global free-page lists, and the raw page-zero byte at1538 identical across the three replicas, with all physical locators retained?"
+  },
+  "analysis": {
+    "decoding": "Reuse the project-authored system_catalog.py typed decoder; reconstruct only EXP-0062 leaf prefix/boundary/trailer grammar. Record text keys uninterpreted; do not import catalog composite weight assumptions. Non-leaf or linked index pages produce no_outcome.",
+    "comparison": "Compare all emitted question-bearing observations exactly across replicas per checkpoint, including hidden names, raw logical records, physical selectors and page/row locators. Exclude only MSysObjects timestamps and unrelated system rows; do not mask differing question-bearing fields.",
+    "answered": "All nine checkpoints validate retained SHA-256 identities, unchanged read-only opens, exact expected DAO relation metadata, successful decoding, and replica equality. Emit one deterministic JSON report with complete decoded observations.",
+    "no_outcome": "Incomplete acquisition, any DAO failure, decode failure, metadata disagreement, changed read-only bytes, or replica disagreement yields one no_outcome report retaining completed observations and errors. Invalid identity/order rejects analysis.",
+    "limits": "Observations apply only to these two relations, names, empty schemas, indexes, creation order and zero cascade attributes. No generalized hidden-name, ordinal, ID or text-weight grammar is inferred automatically."
+  },
+  "publication": {
+    "compatibility_claim": false,
+    "support_matrix_movement": false,
+    "mdb_bytes_committed": false,
+    "provider_binaries_committed": false,
+    "outcome_entry": "EXP-0114"
+  },
+  "commands": {
+    "preflight": "python3 oracle/windows-dao/scripts/relationship_create.py preflight",
+    "run": "python3 oracle/windows-dao/scripts/relationship_create.py run --run-id UTC-relationship-create --shared-root LOCAL_SHARED_ROOT",
+    "analyze": "python3 oracle/windows-dao/scripts/relationship_create.py analyze OUTBOX"
+  }
+}

--- a/oracle/windows-dao/scripts/relationship_create.ps1
+++ b/oracle/windows-dao/scripts/relationship_create.ps1
@@ -1,0 +1,123 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function New-Tables([string]$Path) {
+    $engine = $workspace = $db = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($name in @('Parent', 'Child')) {
+            $table = $field = $index = $key = $null
+            try {
+                $table = $db.CreateTableDef($name)
+                $first = if ($name -eq 'Parent') { 'Id' } else { 'ParentId' }
+                foreach ($column in @($first, 'Alternate')) {
+                    $field = $table.CreateField($column, 4)
+                    $table.Fields.Append($field)
+                    Release $field; $field = $null
+                }
+                if ($name -eq 'Parent') {
+                    foreach ($column in @('Id', 'Alternate')) {
+                        $index = $table.CreateIndex(('By' + $column))
+                        $index.Unique = $true
+                        $index.Primary = ($column -eq 'Id')
+                        $key = $index.CreateField($column)
+                        $index.Fields.Append($key)
+                        $table.Indexes.Append($index)
+                        Release $key; $key = $null
+                        Release $index; $index = $null
+                    }
+                }
+                $db.TableDefs.Append($table)
+            }
+            finally { Release $key; Release $index; Release $field; Release $table }
+        }
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Add-Relation([string]$Path, [string]$Name, [string]$ParentColumn, [string]$ChildColumn) {
+    $engine = $db = $relation = $field = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path)
+        $relation = $db.CreateRelation($Name, 'Parent', 'Child', 0)
+        $field = $relation.CreateField($ParentColumn)
+        $field.ForeignName = $ChildColumn
+        $relation.Fields.Append($field)
+        $db.Relations.Append($relation)
+    }
+    finally {
+        Release $field; Release $relation
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+    }
+}
+function Capture([string]$Path, [int]$Replica, [string]$Checkpoint) {
+    $before = Identity $Path
+    $engine = $db = $null
+    $relations = @()
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        foreach ($relation in $db.Relations) {
+            try {
+                $fields = @()
+                foreach ($field in $relation.Fields) {
+                    try { $fields += @{name=[string]$field.Name; foreign_name=[string]$field.ForeignName} }
+                    finally { Release $field }
+                }
+                $relations += @{name=[string]$relation.Name; table=[string]$relation.Table; foreign_table=[string]$relation.ForeignTable; attributes=[int]$relation.Attributes; fields=$fields}
+            }
+            finally { Release $relation }
+        }
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    $filename = "relationship-r$Replica-$Checkpoint.mdb"
+    Copy-Item -LiteralPath $Path -Destination (Join-Path $env:JET3_OUTBOX $filename)
+    return @{replica=$Replica; checkpoint=$Checkpoint; file=$filename; before=$before; after=(Identity $Path); relations=$relations}
+}
+$planPath = Join-Path $env:JET3_WORK 'relationship-create.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/relationship_create.ps1') { throw 'Script pin mismatch' }
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_relationship_create_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}
+    checkpoints=@(); error=$null
+}
+try {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "working-r$replica.mdb"
+        New-Tables $path
+        $result.checkpoints += Capture $path $replica 'base'
+        Add-Relation $path 'ParentChild' 'Id' 'ParentId'
+        $result.checkpoints += Capture $path $replica 'first'
+        Add-Relation $path 'AlternateLink' 'Alternate' 'Alternate'
+        $result.checkpoints += Capture $path $replica 'second'
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    [IO.File]::WriteAllText((Join-Path $env:JET3_OUTBOX 'result.json'), (($result | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter 'working-*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/relationship_create.py
+++ b/oracle/windows-dao/scripts/relationship_create.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Pinned local relationship observations; preflight, acquire once, and analyze."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/relationship-create.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/relationship_create.ps1'
+CHECKPOINTS = ('base', 'first', 'second')
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'relationship-create' or plan['replicas'] != 3:
+        raise ValueError('Unexpected experiment plan')
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def leaf_entries(data, root):
+    """EXP-0062 leaf boundaries and shared prefix; keys remain uninterpreted."""
+    page = catalog._page(data, root, 'relationship index')
+    if page[0] != 4 or any(page[8:20]):
+        raise catalog.DecodeError('Expected a single leaf with no sibling/child links')
+    area = page[248:]
+    prefix_length = int.from_bytes(page[20:22], 'little')
+    ends = [bit for bit in range(len(area) + 1) if page[22 + bit // 8] & (1 << (bit % 8))]
+    used = ends[-1] if ends else 0
+    if prefix_length > used or int.from_bytes(page[2:4], 'little') != len(area) - used:
+        raise catalog.DecodeError('Leaf prefix/free-space mismatch')
+    entries = []
+    start = prefix_length
+    for end in ends:
+        if end <= start:
+            raise catalog.DecodeError('Leaf boundary order mismatch')
+        raw = area[:prefix_length] + area[start:end]
+        if end - start < 4 or len(raw) <= 4:
+            raise catalog.DecodeError('Leaf entry lacks a row locator')
+        entries.append({'key_hex': raw[:-4].hex(), 'row_page': int.from_bytes(raw[-4:-1], 'big'), 'row': raw[-1]})
+        start = end
+    return {'root': root, 'prefix_hex': area[:prefix_length].hex(), 'entries': entries}
+
+
+def observe(data):
+    analysis = catalog.analyze_checkpoint(data)
+    named = {table['name']: table for table in analysis['tables'].values()}
+    result = {'page_count': len(data) // catalog.PAGE_BYTES, 'global_free_pages': analysis['free_pages'],
+              'page0_transition_byte': data[1538], 'tables': {}, 'system_rows': {}}
+    for name in ('Parent', 'Child', 'MSysRelationships'):
+        definition = named[name]['definition']
+        physical = [{key: value for key, value in index.items() if key != 'entry_count_offset'}
+                    for index in definition['physical_indexes']]
+        for index in physical:
+            index['map_pages'] = sorted(catalog._locator_pages(data, index['map'], name + ' index'))
+        result['tables'][name] = {
+            'root': definition['root'], 'logical_indexes': definition['logical_indexes'],
+            'physical_indexes': physical, 'row_count': definition['row_count'],
+            'maps': {kind: {'locator': locator, 'pages': sorted(catalog._locator_pages(data, locator, name))}
+                     for kind, locator in definition['maps'].items()},
+            'index_leaves': [leaf_entries(data, index['root']) for index in physical],
+        }
+    for name in ('MSysObjects', 'MSysACEs', 'MSysRelationships'):
+        rows = catalog._generic_rows(analysis['system_rows'][name], analysis)
+        if name == 'MSysObjects':
+            rows = [{key: row[key] for key in ('Id', 'ParentId', 'Name', 'Type', 'Flags', 'Owner')}
+                    for row in rows if row['Type'] == 8]
+        elif name == 'MSysACEs':
+            ids = {row['Id'] for row in result['system_rows']['MSysObjects']}
+            rows = [row for row in rows if row['ObjectId'] in ids]
+        result['system_rows'][name] = rows
+    return result
+
+
+def correlate(observation, relations):
+    expected_rows = sorted(({
+        'szRelationship': relation['name'], 'grbit': 0, 'ccolumn': 1, 'icolumn': 0,
+        'szObject': relation['foreign_table'], 'szColumn': relation['fields'][0]['foreign_name'],
+        'szReferencedObject': relation['table'], 'szReferencedColumn': relation['fields'][0]['name'],
+    } for relation in relations), key=canonical)
+    rows = observation['system_rows']
+    if sorted(rows['MSysRelationships'], key=canonical) != expected_rows:
+        return 'MSysRelationships rows do not match DAO relation fields'
+    if sorted(row['Name'] for row in rows['MSysObjects']) != sorted(row['name'] for row in relations):
+        return 'Relationship catalog names do not match DAO relations'
+    for name, other, side in [('Parent', 'Child', 1), ('Child', 'Parent', 2)]:
+        indexes = observation['tables'][name]['logical_indexes']
+        related = [index for index in indexes if index['class'] == 2]
+        if len(related) != len(relations):
+            return 'Reciprocal logical-record count does not match DAO relations'
+        for index in related:
+            raw = bytes.fromhex(index['raw_hex'])
+            if raw[8] != side or int.from_bytes(raw[13:17], 'little') != observation['tables'][other]['root'] or raw[17:19] != b'\0\0':
+                return 'Reciprocal side/reference/cascade context does not match DAO relations'
+    return None
+
+
+def build_report(result, outbox):
+    if (result['document_type'] != 'dao_relationship_create_result'
+            or result['plan_sha256'] != digest(PLAN) or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    observations, reasons = [], []
+    expected = [(replica, checkpoint) for replica in range(1, 4) for checkpoint in CHECKPOINTS]
+    for position, checkpoint in enumerate(result['checkpoints']):
+        pair = (checkpoint['replica'], checkpoint['checkpoint'])
+        if position >= len(expected) or pair != expected[position]:
+            raise ValueError('Unexpected checkpoint inventory/order')
+        filename = f'relationship-r{pair[0]}-{pair[1]}.mdb'
+        if checkpoint['file'] != filename or identity(outbox / filename) != checkpoint['after']:
+            raise ValueError('Retained checkpoint identity mismatch')
+        if checkpoint['before'] != checkpoint['after']:
+            reasons.append(f'{pair}: read-only metadata open changed bytes')
+        try:
+            decoded = observe((outbox / filename).read_bytes())
+            relations = sorted(checkpoint['relations'], key=lambda row: row['name'])
+            wanted = []
+            for name, parent, child in [('ParentChild', 'Id', 'ParentId'), ('AlternateLink', 'Alternate', 'Alternate')][:CHECKPOINTS.index(pair[1])]:
+                wanted.append({'name': name, 'table': 'Parent', 'foreign_table': 'Child', 'attributes': 0,
+                               'fields': [{'name': parent, 'foreign_name': child}]})
+            if relations != sorted(wanted, key=lambda row: row['name']):
+                reasons.append(f'{pair}: DAO relationship metadata mismatch')
+            disagreement = correlate(decoded, relations)
+            if disagreement:
+                reasons.append(f'{pair}: {disagreement}')
+            decoded['dao_relations'] = relations
+            observations.append({'replica': pair[0], 'checkpoint': pair[1], 'observation': decoded})
+        except (catalog.DecodeError, KeyError, ValueError) as error:
+            reasons.append(f'{pair}: {error}')
+    if len(observations) != 9 or result['error'] is not None or result['mutation_started'] is not True:
+        reasons.append('Acquisition incomplete or failed: ' + str(result['error']))
+    if len(observations) == 9:
+        for index in range(3):
+            if any(observations[index]['observation'] != observations[index + offset]['observation'] for offset in (3, 6)):
+                reasons.append(f'{CHECKPOINTS[index]}: question-bearing values disagree across replicas')
+    return {'document_type': 'dao_relationship_create_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'answered' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'compatibility_claim': False,
+            'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    output = outbox / 'report.json'
+    output.write_text(canonical(report) + '\n')
+    print(output)
+    print(report['outcome'])
+
+
+def dispatch(args):
+    preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    inbox, outbox = (args.shared_root.resolve() / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / PLAN.name)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight')
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        preflight()
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_relationship_create.py
+++ b/oracle/windows-dao/tests/test_relationship_create.py
@@ -1,0 +1,88 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location('relationship_create', SCRIPTS / 'relationship_create.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class RelationshipCreateTests(unittest.TestCase):
+    def test_leaf_reconstructs_shared_prefix_and_row_locators(self):
+        page = bytearray(2048)
+        page[0] = 4
+        page[20] = 2
+        page[248:250] = b'\x7f\x60'
+        payloads = [b'\x61\x00\x00\x00\x17\x00', b'\x62\x00\x00\x00\x17\x01']
+        end = 2
+        for payload in payloads:
+            page[248 + end:248 + end + len(payload)] = payload
+            end += len(payload)
+            page[22 + end // 8] |= 1 << (end % 8)
+        page[2:4] = (1800 - end).to_bytes(2, 'little')
+        entries = experiment.leaf_entries(bytes(page), 0)['entries']
+        self.assertEqual(entries, [
+            {'key_hex': '7f606100', 'row_page': 23, 'row': 0},
+            {'key_hex': '7f606200', 'row_page': 23, 'row': 1},
+        ])
+        page[2] ^= 1
+        with self.assertRaises(experiment.catalog.DecodeError):
+            experiment.leaf_entries(bytes(page), 0)
+
+    def test_standalone_analysis_rejects_modified_inputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / 'decoder.py'
+            source.write_text('original')
+            plan = root / 'plan.json'
+            plan.write_text(json.dumps({'experiment_id': 'relationship-create', 'replicas': 3,
+                                        'inputs': {'decoder.py': experiment.digest(source)}}))
+            source.write_text('modified')
+            with patch.object(experiment, 'ROOT', root), patch.object(experiment, 'PLAN', plan):
+                with self.assertRaisesRegex(ValueError, 'Input pin mismatch: decoder.py'):
+                    experiment.analyze(root)
+
+    def result(self, outbox):
+        checkpoints = []
+        for replica in range(1, 4):
+            relations = []
+            for checkpoint in experiment.CHECKPOINTS:
+                if checkpoint != 'base':
+                    first = checkpoint == 'first'
+                    relations = relations + [{'name': 'ParentChild' if first else 'AlternateLink',
+                        'table': 'Parent', 'foreign_table': 'Child', 'attributes': 0,
+                        'fields': [{'name': 'Id' if first else 'Alternate', 'foreign_name': 'ParentId' if first else 'Alternate'}]}]
+                name = f'relationship-r{replica}-{checkpoint}.mdb'
+                (outbox / name).write_bytes(b'synthetic')
+                identity = experiment.identity(outbox / name)
+                checkpoints.append({'replica': replica, 'checkpoint': checkpoint, 'file': name,
+                                    'before': identity, 'after': identity, 'relations': relations})
+        return {'document_type': 'dao_relationship_create_result', 'development_only': True,
+                'plan_sha256': experiment.digest(experiment.PLAN), 'mutation_started': True,
+                'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'},
+                'checkpoints': checkpoints, 'error': None}
+
+    def test_report_requires_complete_matching_replicas_and_retained_bytes(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            result = self.result(outbox)
+            with patch.object(experiment, 'observe', return_value={}), patch.object(experiment, 'correlate', return_value=None):
+                self.assertEqual(experiment.build_report(result, outbox)['outcome'], 'answered')
+                with patch.object(experiment, 'observe', side_effect=[{}] * 8 + [{'raw_selector': 99}]):
+                    self.assertEqual(experiment.build_report(result, outbox)['outcome'], 'no_outcome')
+                result['checkpoints'].pop()
+                result['error'] = 'DAO mutation failed'
+                self.assertEqual(experiment.build_report(result, outbox)['outcome'], 'no_outcome')
+                (outbox / result['checkpoints'][0]['file']).write_bytes(b'changed')
+                with self.assertRaisesRegex(ValueError, 'identity mismatch'):
+                    experiment.build_report(result, outbox)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Relationship creation still lacks observed rules for the reciprocal logical records, relationship catalog IDs, and system index keys. This preregisters one local DAO acquisition capturing two successive relationships between the same empty tables in three fresh replicas, retaining exact raw observations without generalizing their meaning.

The analyzer reuses the existing clean-room decoder and rejects changed input pins before promoting results. A post-mutation failure is recorded without retry. The single authorized acquisition completed with all nine checkpoints validated and the report `answered`; its additive outcome is being recorded separately. No support status changes.

Part of #100. This PR is stacked after #191 solely to preserve additive provenance.

Validation: independent implementation review and fix verification, three focused analyzer tests, Windows PowerShell parser check, committed-plan preflight, and `just ready` passed.
