### PR TITLE
docs: record accepted initial-row DAO result

### DIFF
--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -1,4 +1,4 @@
-//! Creation of a fresh Jet 3 database holding empty user tables.
+//! Creation of a fresh Jet 3 database holding user tables.
 //!
 //! [`create_database`] composes the complete image in memory, writes every
 //! page in physical order to a private file beside the destination, reopens
@@ -10,7 +10,8 @@
 //! The structural reopen is a publication prerequisite, not compatibility
 //! evidence. Only a recorded DAO differential can establish that Microsoft
 //! Access or DAO consume a created database; none has been run for schemas
-//! other than the exact `EXP-0091`, `EXP-0107`, and `EXP-0110` constructions.
+//! other than the exact `EXP-0091`, `EXP-0107`, `EXP-0110`, and `EXP-0112`
+//! constructions.
 //! `EXP-0110` observed DAO read one composed four-table image built from the
 //! `EXP-0087` later-create pattern; it does not establish other table counts,
 //! orders, names, or schemas.
@@ -159,8 +160,10 @@ pub fn create_database(
 /// [`create_database`] apply. Composition and the structural row comparison
 /// are charged to `budget`. Unsupported schemas and rows fail before writing.
 ///
-/// This is an unvalidated candidate construction. No DAO differential has
-/// established compatibility for databases created with initial rows.
+/// `EXP-0112` observed DAO read one exact `Rows(Id Long, Code Text 8)` image
+/// containing `(1, "one")`, `(-2, "two")`, and `(null, null)` unchanged in three
+/// local replicas. This establishes only that candidate, not other schemas or
+/// values, general compatibility, or hosted write-differential coverage.
 pub fn create_database_with_rows(
     path: impl AsRef<Path>,
     table: &TableSpec<'_>,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10041,6 +10041,57 @@ Use `not applicable` explicitly rather than omitting a field.
   findings; five focused analyzer tests and PowerShell syntax check passed.
 
 
+### EXP-0112 — Accepted initial-row creation result
+
+- Recorded: 2026-09-04, OpenAI Codex (run timestamp is 2026-09-05 UTC)
+- Kind: validated SHA-256-pinned, development-only local DAO result
+- Question: does DAO read the exact `EXP-0111` initial-row candidate unchanged
+  with the expected schema and row multiset in all three replicas?
+- Origin and binding: `EXP-0111`, committed before acquisition as
+  `6778b9209b8e569a71ba265bc3f7e5129e6f6498`; plan
+  `oracle/windows-dao/acquisition/initial-rows.plan.json`, SHA-256
+  `0fb2a14ec8d4e73b881f72b543233599733ef57f2edc78deb12b74c4897be291`.
+  Candidate source commit is `df7c42e6e67803703d8814a27f71a9251f9fccd6`.
+  The plan pins the PowerShell producer, Python analyzer, imported transport,
+  and Rust candidate example; those inputs remain unchanged.
+- Authorization and dispatch: the user's standing authorization covered the
+  single local run `20260905T030500Z-initial-rows`. It was dispatched once,
+  after preregistration was committed and reviewed; no retry occurred.
+- Environment: result records a 32-bit process, `DAO.DBEngine.36`, and
+  `Microsoft Windows NT 10.0.20348.0`.
+- Protocol and validation: the analyzer validated the plan/result binding,
+  pinned candidate starting identities, retained image identities, unchanged
+  before/after sizes and hashes, control schema and rows, and agreement across
+  three replicas. Running the unchanged analyzer on temporary copies of the
+  retained artifacts reproduced `report.json` byte for byte without modifying
+  the originals.
+- Artifacts: retained under local outbox `20260905T030500Z-initial-rows`:
+  `result.json`, 24,291 bytes, SHA-256
+  `888e4dacdc3f161af330c0c87f976da94623512c3c9e299c0cc64e601c436812`;
+  canonical `report.json`, 378 bytes, SHA-256
+  `476645a252e22f6ef1e0d9ac2cef3581128326815f88874f3477623e6d7aef04`.
+- Retained candidates: all three remained 49,152 bytes, SHA-256
+  `5d1dc9148f58d5a3c19c75b86368d7ee9deacf6a95c0fa6746944f8cc3b322f4`.
+  Controls also remained 49,152 bytes, with replica hashes respectively
+  `073b0ad2cc21aea6201486e729c9ebbfd6719fd167129146f798b7690b7b26b8`,
+  `872d0f5d9c43681a9d03516152b1f52e4cc0051d4e9cc27994a5f3a1068f0b82`, and
+  `fe2a358cae1b52210c5ddc91051ef0934f91ba3b9466ee255872db66877062c9`.
+- Observation: the validated canonical report records `observed_accepted` for
+  three replicas. All candidates and controls completed the read-only schema
+  and row endpoints: version `3.0`, exactly `Rows` plus the four expected
+  system tables, ordered fields `Id` Long size 4 and `Code` Text size 8,
+  no indexes, and row multiset `(1, "one")`, `(-2, "two")`, `(null, null)`.
+- Interpretation: DAO consumed the exact composed one-table, one-data-page
+  image unchanged while it retained the composed page-zero header without
+  insertion counter updates. This establishes no general header-update rule,
+  other schemas or values, multiple data pages, indexed inserts, long values,
+  existing-database mutation, general compatibility, or hosted write
+  differential coverage. The support matrix does not move.
+- Usage: issue `#100`; `create_database_with_rows` exact-candidate caveat.
+- Rights: MDB bytes and provider binaries remain outside the repository.
+- Review: outcome implementation pass complete; independent review pending.
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10089,7 +10089,8 @@ Use `not applicable` explicitly rather than omitting a field.
   differential coverage. The support matrix does not move.
 - Usage: issue `#100`; `create_database_with_rows` exact-candidate caveat.
 - Rights: MDB bytes and provider binaries remain outside the repository.
-- Review: outcome implementation pass complete; independent review pending.
+- Review: independent outcome, report reproduction, artifact identity,
+  additive-provenance, and evidence-boundary review completed without findings.
 
 
 ## Fixtures and black-box results

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -43,111 +43,20 @@ delivered in this order:
 
 ## Current next step
 
-Finish the focused writer experiments before exposing the creation API. The
-typed table planner and one-table composer are merged: a described table is
-validated through the same table-definition and catalog encoders that write
-it, and its pages, catalog row, and access-control rows derive from `EXP-0087`.
-The composer still requires a caller-supplied `LvProp` payload in code because
-only its framing, not a general grammar, is established. `EXP-0091` now admits
-the exact null-`LvProp` plus retained-empty-page construction as the bounded
-replacement hypothesis for the next implementation slice.
+Continue database creation under #100. The public API creates up to four empty
+user tables within its bounded schema restrictions. Initial-row creation now
+accepts one unindexed table with a one-page definition and scalar rows fitting
+one data page, with room left for another all-null row. AutoIncrement, Memo,
+and OLE values remain refused by that entry point.
 
-`EXP-0091` observed DAO accept one exact composed Alpha image with a null
-catalog `LvProp` and an empty retained property page. That admits the bounded
-construction as the next implementation hypothesis; it does not establish the
-same result for arbitrary schemas or permit omitting the retained page. The
-remaining experiments and implementation slices proceed in small independently
-reviewed changes: multiple-index implementation, definition continuation
-placement, extended names, public creation, initial rows, relationships, and
-safe filesystem publication. `EXP-0093` records an accepted three-replica
-multiple-index result for the four exact first-create arms. It observes one map
-page at `root+1`, the catalog `LvProp` page at `root+2`, and one index root per
-physical ordinal at `root+3+i`. That overturns the composer's current deduced
-one-index order, which places the first root before `LvProp`.
+`EXP-0110` observed DAO read the exact four-table candidate unchanged.
+`EXP-0112` now records three accepted local replicas of the exact
+`Rows(Id Long, Code Text 8)` candidate containing `(1, "one")`, `(-2, "two")`,
+and `(null, null)`. These observations establish only the pinned candidates;
+they do not establish general compatibility or move the support matrix.
 
-The two format gaps that needed preregistered DAO validation before the planner
-could widen now have bounded evidence: definition-continuation placement
-(#151) and catalog name keys for bytes above `0x7E` (#152).
-`EXP-0094` contains the first SHA-256-pinned #151 preregistration. `EXP-0095` records its
-canonical `no_outcome`: every replica reached capture of the 69-field arm, but
-that arm failed the combined 2-KiB geometry/64-page bound and could not be
-retained. No continuation placement was observed, and the 70- and 140-field
-DAO table appends were not attempted. The SHA-256-pinned `EXP-0098` successor
-kept the exact scenarios and questions while raising completed checkpoints to
-256 pages. `EXP-0100` records its valid `no_outcome`: all three producers
-completed all four checkpoints without recovery, but the analyzer found one
-continuation page in the 2,046-byte `zero` control where the preregistration
-required zero. The diagnostic one-, one-, and two-continuation chains are not
-promotable under the all-or-`no_outcome` decision. `EXP-0102` preregisters the
-next successor with the established `Alpha(Id Long)` 66-byte, zero-continuation
-control and the unchanged 2,075- and 4,105-byte wide targets. `EXP-0103`
-records its single authorized run as a valid `no_outcome`: all three producers
-completed every checkpoint and baseline without recovery, but every analyzer
-replica reported `one appended page 22 is unattributed`. No continuation count
-or placement diagnostic is promoted. `EXP-0104` preregisters a successor with
-the exact same producer, schemas, counts, and bounds. It changes only the
-analysis rule: every appended page must still have a decoded page-role record,
-but a replica-stable explicit `unassigned` record is reported with its raw tag
-and decoded global-map free status instead of forcing `no_outcome` when the
-global map marks it free. An in-use `unassigned` page or globally-free definition
-page remains
-`no_outcome`. Every globally-free page's decoded role and owners describe only
-retained bytes and establish no current owner, purpose, reuse history, or
-semantic role. Every catalog `LvProp` referenced appended LVAL page must be
-globally in use; a decoder-labeled but unreferenced LVAL page may be globally
-free and remains a bounded retained-byte observation. A referenced globally
-free LVAL page is `no_outcome`. Page-zero and catalog-root correlation remains
-observational; the exact user-table/root resolution is already enforced. The `EXP-0103`
-diagnostic is design input only and promotes no page-role fact. `EXP-0105`
-records the exact merged successor run as accepted with all five questions
-answered identically across three complete replicas. The exact chains are
-`[20]`, `[20, 68]`, and `[20, 219, 218]`, with logical chunk lengths `[66]`,
-`[2048, 27]`, and `[2048, 2040, 17]`. All definition pages are globally in use.
-The wide arms also retain globally free `unassigned` tag-9 pages and globally
-free decoder-labeled LVAL ranges unreferenced by catalog `LvProp`; those labels
-establish no current owner, purpose, reuse history, or semantic role. Issue
-#151 is evidence-complete for the exact preregistered shapes; the result does
-not establish general placement, allocation policy, or chains longer than two
-continuation pages. #150 is evidence-complete. The bounded implementation now
-corrects the one-index page order, supports up to three physical and logical
-indexes, and refuses continuation placement because DAO's allocation policy is
-still underdetermined. `EXP-0107` records the exact #178 run as accepted: DAO
-read the indexed and compact one-continuation null-`LvProp` candidates unchanged
-with the same bounded schema observations as fresh same-schema controls in all
-three replicas. This establishes only those exact candidate identities. The
-compact page-23 continuation is available to a future bounded implementation,
-but is not a general placement rule. The composer now plans later creates from
-`EXP-0087`. `EXP-0110` records the exact `EXP-0109` run as accepted: DAO read
-the composed Alpha, Beta, Gamma, and Delta image unchanged with the same
-bounded schema observations as a fresh same-sequence control in all three
-replicas. This establishes only that exact candidate identity. Like the
-`EXP-0107` continuation result, it makes the observed later-create construction
-available to a separately reviewed bounded implementation, which must keep its
-`EXP-0087` refusals and claim no compatibility; it is not a general multi-table
-rule. #102 remains the separate hosted write differential after database
-creation is complete.
-
-`EXP-0096` is the first SHA-256-pinned #152 preregistration. `EXP-0097` records
-its canonical `no_outcome`: all 2,358 DAO name attempts reported creation and
-the bounded DAO metadata agreed, but every replica failed catalog-key decoding
-at the former `reject` checkpoint under the all-arm decoder. The successor
-renames that checkpoint `controls`. The defined arms cannot be promoted post hoc
-and establish no catalog-name mapping or weights.
-`EXP-0099` preregistered a successor that left the 41 defined-byte arms
-unchanged, validated U+007F and the five undefined-slot Unicode values only at
-the BSTR/DAO metadata boundary, and never decoded that controls arm. It also
-required exact non-ASCII JSON transport and compared exact question-bearing
-collation facts across replicas while retaining incidental locators separately.
-`EXP-0101` records the authorized successor as `accepted`: all 123 defined
-bytes and all six exact forms were observed, the exact primary and secondary
-nibble results and composition predicates agreed across three replicas, and all
-seven metadata-only controls were accepted at the Unicode BSTR/DAO metadata
-boundary. This resolves #152's bounded six-form evidence question, but does not
-unblock general planner widening. Only singleton positions, repeat, and each
-byte's registered adjacent defined neighbor were tested, and secondary
-observations were sometimes noncompositional. Any implementation derived now
-must retain the current blanket rejection or fail closed to exact evidenced
-contexts and contexts supported solely by a positive composition result for
-that tested byte or pair. Arbitrary names, more than two non-ASCII bytes, and
-untested pairs or contexts need more evidence. No general collation, writer
-correctness, public compatibility, or support-matrix movement is established.
+Next, broaden initial-row creation in focused implementation and preregistered
+DAO experiment slices, including indexes and long values, and add relationships.
+After creation is complete, run the hosted write differential (#102), implement
+updates that preserve unrelated data (#112), then run the hosted update
+differential (#113). Keep module cleanup (#182) until the creation API settles.


### PR DESCRIPTION
Record the accepted initial-row DAO result: all three fresh controls and exact Rust candidate replicas produced the expected schema and rows, with every read-only file identity unchanged. EXP-0112 records the validated report and artifact identities without claiming general write interoperability.

The creation API documentation now identifies that exact evidence, and the scope checkpoint reflects the merged scalar-row API and remaining writer work. Consumed experiment inputs and the support matrix are unchanged.

Validation: independent report/identity review, byte-identical analyzer reproduction, rustdoc, formatting, and `just ready` passed.

Part of #100; hosted write differential remains #102.
