### PR TITLE
feat(jet3): create tables with multiple pages of initial rows

### DIFF
--- a/crates/jet3/examples/multi_page_row_candidate.rs
+++ b/crates/jet3/examples/multi_page_row_candidate.rs
@@ -1,0 +1,29 @@
+//! Deterministic multiple-data-page candidate for a preregistered DAO run.
+use jet3::{
+    ColumnSpec, ColumnType, ResourceBudget, ResourceLimits, RowValue, TableSpec,
+    create_database_with_rows,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args_os()
+        .nth(1)
+        .ok_or("usage: multi_page_row_candidate OUTPUT.mdb")?;
+    let table = TableSpec {
+        name: b"Rows",
+        columns: &[ColumnSpec::new(b"Id", ColumnType::Long)],
+        indexes: &[],
+    };
+    // 509 Long rows pack into pages of 254, 254, and 1 rows. The two
+    // exhausted pages are owned but not marked available by this candidate.
+    let values = (0..509)
+        .map(|value| [RowValue::Long(value - 254)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(
+        path,
+        &table,
+        &rows,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -174,7 +174,7 @@ fn compose_planned_creates(
     Ok(plan)
 }
 
-/// Composes one unindexed table with a single page of scalar initial rows.
+/// Composes one unindexed table with scalar initial rows in inline-mapped pages.
 pub(crate) fn compose_database_with_rows(
     spec: &TableSpec<'_>,
     rows: &[&[RowValue<'_>]],

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -51,8 +51,14 @@ pub(super) struct PlannedCreate<'a> {
     /// The long-value column's ordinal; its owned map takes the first free
     /// map-page row and its available map the next.
     long_value: Option<u16>,
-    initial_data: Option<PageImage>,
+    initial_data: Vec<InitialDataPage>,
     initial_row_count: u32,
+}
+
+#[derive(Debug, Clone)]
+struct InitialDataPage {
+    image: PageImage,
+    available: bool,
 }
 
 impl<'a> PlannedCreate<'a> {
@@ -78,15 +84,15 @@ impl<'a> PlannedCreate<'a> {
             spec,
             plan,
             long_value,
-            initial_data: None,
+            initial_data: Vec::new(),
             initial_row_count: 0,
         })
     }
 
-    /// Adds a single data page using EXP-0060/0061 row encoding and EXP-0065
-    /// Q2 append placement. EXP-0057 supplies the owned/available map roles;
-    /// EXP-0073 supplies the definition row count. This is a candidate
-    /// construction, without a generalized page-zero insertion transition.
+    /// Packs scalar rows using EXP-0060 encoding and EXP-0065 append placement.
+    /// EXP-0057 supplies map roles; EXP-0073 supplies the definition row count.
+    /// Multiple pages and their available-map membership remain a candidate
+    /// hypothesis, with no generalized page-zero insertion transition.
     pub(super) fn with_rows(
         mut self,
         rows: &[&[RowValue<'_>]],
@@ -104,29 +110,84 @@ impl<'a> PlannedCreate<'a> {
         if rows.is_empty() {
             return Ok(self);
         }
-        let layout = initial_row_layout(self.spec, budget)?;
-        let mut builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
-        let mut encoded = [0_u8; PAGE_BYTES];
-        for row in rows {
-            let length = encode_row(&layout, row, &mut encoded, budget)?.get() as usize;
-            builder.append_row(&encoded[..length], budget)?;
-        }
-        // EXP-0057 establishes available-page maps, but not the transition
-        // for exhausted pages. Refuse those candidates: the page must still
-        // have a slot and room for its smallest row, with every field null.
-        // This is a construction bound, not a DAO free-space threshold.
-        // EXP-0060 bounds the one-byte column count to 255.
-        let nulls = [RowValue::Null; u8::MAX as usize];
-        let minimum =
-            encode_row(&layout, &nulls[..layout.len()], &mut encoded, budget)?.get() as usize;
-        builder.clone().append_row(&encoded[..minimum], budget)?;
         self.initial_row_count =
             u32::try_from(rows.len()).map_err(|_| Error::IntegerConversion {
                 value: rows.len() as u128,
                 target: "u32",
             })?;
-        self.initial_data = Some(finish_data_builder(builder, budget)?);
+        let layout = initial_row_layout(self.spec, budget)?;
+        let mut minimum = [0_u8; PAGE_BYTES];
+        // EXP-0060 bounds column count to 255; fixed fields retain their width.
+        let nulls = [RowValue::Null; u8::MAX as usize];
+        let minimum_len =
+            encode_row(&layout, &nulls[..layout.len()], &mut minimum, budget)?.get() as usize;
+        let minimum = &minimum[..minimum_len];
+        let mut builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
+        let mut encoded = [0_u8; PAGE_BYTES];
+        for row in rows {
+            let length = encode_row(&layout, row, &mut encoded, budget)?.get() as usize;
+            let bytes = &encoded[..length];
+            match builder.append_row(bytes, budget) {
+                Ok(_) => {}
+                Err(PageImageError::PageFull { .. } | PageImageError::RowSlotsExhausted { .. })
+                    if builder.row_count() != 0 =>
+                {
+                    self.push_initial_page(builder, minimum, budget)?;
+                    builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
+                    builder.append_row(bytes, budget)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        self.push_initial_page(builder, minimum, budget)?;
         Ok(self)
+    }
+
+    fn push_initial_page(
+        &mut self,
+        builder: DataPageBuilder,
+        minimum_row: &[u8],
+        budget: &mut ResourceBudget,
+    ) -> Result<(), ComposeError> {
+        let page = PageNumber::new(self.page_count());
+        // The existing inline map covers this many pages (SRC-0020/EXP-0057).
+        // EXP-0065 observed indirect growth, but supplies no general policy.
+        let page_count = MAP_BITMAP_BYTES * 8;
+        if page.get() >= page_count {
+            return Err(UsageMapWriteError::PageOutOfMap {
+                page,
+                first: PageNumber::new(0),
+                page_count,
+            }
+            .into());
+        }
+        // Candidate policy: only physically exhausted pages are unavailable.
+        // This is not an inferred DAO free-space threshold (EXP-0057).
+        let available = match builder.clone().append_row(minimum_row, budget) {
+            Ok(_) => true,
+            Err(PageImageError::PageFull { .. } | PageImageError::RowSlotsExhausted { .. }) => {
+                false
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if self.initial_data.len() == self.initial_data.capacity() {
+            let capacity = self.initial_data.capacity();
+            let additional = capacity.max(1);
+            budget.charge_allocation(ByteCount::new(
+                (additional * size_of::<InitialDataPage>()) as u64,
+            ))?;
+            self.initial_data
+                .try_reserve_exact(additional)
+                .map_err(|_| Error::Io {
+                    operation: "reserve initial data pages",
+                    kind: std::io::ErrorKind::OutOfMemory,
+                })?;
+        }
+        self.initial_data.push(InitialDataPage {
+            image: finish_data_builder(builder, budget)?,
+            available,
+        });
+        Ok(())
     }
 
     /// Returns the page holding the catalog row's `LvProp` long value, present
@@ -139,7 +200,7 @@ impl<'a> PlannedCreate<'a> {
     pub(super) fn page_count(&self) -> u64 {
         self.plan.definition_root().get()
             + self.plan.appended_page_count()
-            + u64::from(self.initial_data.is_some())
+            + self.initial_data.len() as u64
     }
 
     /// Returns the catalog row the create adds (`EXP-0087`).
@@ -186,8 +247,8 @@ impl<'a> PlannedCreate<'a> {
         for _ in self.plan.index_placements() {
             plan.append(empty_index_page(owner, budget)?, append_map, budget)?;
         }
-        if let Some(image) = &self.initial_data {
-            plan.append(image.clone(), append_map, budget)?;
+        for data in &self.initial_data {
+            plan.append(data.image.clone(), append_map, budget)?;
         }
         Ok(())
     }
@@ -295,9 +356,29 @@ impl<'a> PlannedCreate<'a> {
     /// Builds the map page with the rows the definition names.
     fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
         let empty = inline_map_row(&[], budget)?;
-        let data_pages = self.initial_data.as_ref().map(|_| self.page_count() - 1);
-        let data_map = inline_map_row(data_pages.as_slice(), budget)?;
-        let mut rows: Vec<[u8; 133]> = vec![data_map, data_map];
+        let mut owned = InlineUsageMapEncoder::new(
+            PageNumber::new(0),
+            ByteCount::new(MAP_BITMAP_BYTES),
+            budget,
+        )?;
+        let mut available = InlineUsageMapEncoder::new(
+            PageNumber::new(0),
+            ByteCount::new(MAP_BITMAP_BYTES),
+            budget,
+        )?;
+        let first = self.plan.definition_root().get() + self.plan.appended_page_count();
+        for (offset, data) in self.initial_data.iter().enumerate() {
+            let page = PageNumber::new(first + offset as u64);
+            owned.set_page(page)?;
+            if data.available {
+                available.set_page(page)?;
+            }
+        }
+        let mut owned_row = [0_u8; 133];
+        let mut available_row = [0_u8; 133];
+        owned.encode_into(&mut owned_row, budget)?;
+        available.encode_into(&mut available_row, budget)?;
+        let mut rows: Vec<[u8; 133]> = vec![owned_row, available_row];
         for (root, _) in self.plan.index_placements() {
             rows.push(inline_map_row(&[root.get()], budget)?);
         }

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -152,8 +152,10 @@ pub fn create_database(
 
 /// Creates one unindexed table containing scalar initial rows in caller order.
 ///
-/// All rows must fit one data page, leaving a slot and room for one all-null
-/// row. The table definition must fit one page.
+/// Rows are packed in caller order into data pages within the inline usage-map
+/// capacity. Each row and the table definition must fit one page. Pages with
+/// a slot and room for an all-null row are marked available; this construction
+/// policy has not been established as DAO's allocation policy.
 /// AutoIncrement, Memo, and LongBinary columns are refused. Values use the
 /// same database-code-page and physical scalar representations as [`RowValue`].
 /// The existing-destination and atomic publication guarantees of
@@ -208,35 +210,24 @@ fn check_initial_rows(
         .table_definition(root, budget)
         .map_err(CandidateCheckError::Definition)?;
     let mut encoded = [0_u8; crate::PAGE_BYTES];
-    let mut ends = [0_usize; 256];
-    let mut used = 0;
-    for (index, row) in rows.iter().enumerate() {
-        let length = crate::encode_row(&layout, row, &mut encoded[used..], budget)
-            .map_err(|error| CandidateCheckError::RowEncoding(ComposeError::Row(error)))?
-            .get() as usize;
-        used += length;
-        let end = ends.get_mut(index).ok_or(CandidateCheckError::Mismatch {
-            detail: "initial row count",
-        })?;
-        *end = used;
-    }
     let mut cursor = database
         .rows(&definition, budget)
         .map_err(CandidateCheckError::Rows)?;
-    let mut start = 0;
-    for end in ends.into_iter().take(rows.len()) {
+    for row in rows {
+        let length = crate::encode_row(&layout, row, &mut encoded, cursor.owned.budget_mut())
+            .map_err(|error| CandidateCheckError::RowEncoding(ComposeError::Row(error)))?
+            .get() as usize;
         let actual = cursor
             .next_row()
             .map_err(CandidateCheckError::Rows)?
             .ok_or(CandidateCheckError::Mismatch {
                 detail: "initial row count",
             })?;
-        if actual.raw_bytes() != &encoded[start..end] {
+        if actual.raw_bytes() != &encoded[..length] {
             return Err(CandidateCheckError::Mismatch {
                 detail: "initial row value",
             });
         }
-        start = end;
     }
     if cursor
         .next_row()

--- a/crates/jet3/src/create_initial_rows_tests.rs
+++ b/crates/jet3/src/create_initial_rows_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{PageImageError, RowValue, RowWriteError, create_database_with_rows};
+use crate::{RowValue, RowWriteError, create_database_with_rows};
 
 fn scalar_table() -> TableSpec<'static> {
     TableSpec {
@@ -42,16 +42,8 @@ fn empty_initial_rows_do_not_allocate_a_data_page() -> TestResult {
 }
 
 #[test]
-fn rows_that_exceed_the_page_or_have_wrong_types_leave_no_file() -> TestResult {
+fn rows_with_wrong_types_leave_no_file() -> TestResult {
     let directory = TestDirectory::create()?;
-    let row = [RowValue::Long(1), RowValue::Text(b"12345678")];
-    let rows = vec![row.as_slice(); 256];
-    assert!(matches!(
-        create_database_with_rows(directory.target(), &scalar_table(), &rows, &mut budget()),
-        Err(CreateDatabaseError::Compose(ComposeError::Page(
-            PageImageError::PageFull { .. }
-        )))
-    ));
     assert!(matches!(
         create_database_with_rows(
             directory.target(),
@@ -169,8 +161,32 @@ fn initial_rows_preserve_existing_destination_and_enforce_budget() -> TestResult
     Ok(())
 }
 
+fn map_bit(
+    bytes: &[u8],
+    map_page: u64,
+    row: u8,
+    target: u64,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let start = map_page as usize * crate::PAGE_BYTES;
+    let raw = bytes[start..start + crate::PAGE_BYTES].try_into()?;
+    let classified = crate::classify_page(PageNumber::new(map_page), raw, &mut budget())?;
+    let record = crate::locate_usage_map(
+        classified,
+        crate::MapRowLocator::new(PageNumber::new(map_page), row),
+        &mut budget(),
+    )?;
+    let map = record.raw();
+    assert_eq!(&map[..5], &[0; 5]);
+    Ok(map[5 + target as usize / 8] & (1 << (target % 8)) != 0)
+}
+
+fn page_rows(bytes: &[u8], page: usize) -> u16 {
+    let offset = page * crate::PAGE_BYTES + 8;
+    u16::from_le_bytes([bytes[offset], bytes[offset + 1]])
+}
+
 #[test]
-fn initial_rows_leave_one_available_row_slot() -> TestResult {
+fn exhausted_row_slots_spill_to_the_next_page() -> TestResult {
     let directory = TestDirectory::create()?;
     let table = TableSpec {
         name: b"Bits",
@@ -178,20 +194,13 @@ fn initial_rows_leave_one_available_row_slot() -> TestResult {
         indexes: &[],
     };
     let row = [RowValue::Boolean(true)];
-    let rows = vec![row.as_slice(); 256];
-    create_database_with_rows(directory.target(), &table, &rows[..255], &mut budget())?;
-    assert!(matches!(
-        create_database_with_rows(
-            directory.path.join("overflow.mdb"),
-            &table,
-            &rows,
-            &mut budget()
-        ),
-        Err(CreateDatabaseError::Compose(ComposeError::Page(
-            PageImageError::RowSlotsExhausted { maximum: 256 }
-        )))
-    ));
-    assert_eq!(directory.entries()?, ["created.mdb"]);
+    let rows = vec![row.as_slice(); 257];
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(bytes.len(), 25 * crate::PAGE_BYTES);
+    assert_eq!((page_rows(&bytes, 23), page_rows(&bytes, 24)), (256, 1));
+    assert!(!map_bit(&bytes, 21, 1, 23)?);
+    assert!(map_bit(&bytes, 21, 1, 24)?);
     Ok(())
 }
 
@@ -221,7 +230,65 @@ fn initial_rows_refuse_a_continued_definition() -> TestResult {
 }
 
 #[test]
-fn initial_rows_require_space_for_a_minimal_row() -> TestResult {
+fn packed_pages_track_ownership_availability_and_total_rows() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        name: b"Numbers",
+        columns: &[ID],
+        indexes: &[],
+    };
+    let values = (0..509)
+        .map(|value| [RowValue::Long(value)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(bytes.len(), 26 * crate::PAGE_BYTES);
+    assert_eq!(
+        &bytes[20 * crate::PAGE_BYTES + 12..20 * crate::PAGE_BYTES + 16],
+        &509_u32.to_le_bytes()
+    );
+    assert_eq!(
+        [
+            page_rows(&bytes, 23),
+            page_rows(&bytes, 24),
+            page_rows(&bytes, 25)
+        ],
+        [254, 254, 1]
+    );
+    for page in 0..30 {
+        assert_eq!(map_bit(&bytes, 21, 0, page)?, (23..26).contains(&page));
+        assert_eq!(map_bit(&bytes, 21, 1, page)?, page == 25);
+        assert_eq!(map_bit(&bytes, 1, 0, page)?, page >= 26);
+    }
+    Ok(())
+}
+
+#[test]
+fn spilling_a_large_row_keeps_space_for_smaller_rows_available() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        name: b"TextRows",
+        columns: &[
+            ID,
+            ColumnSpec::new(b"Text", ColumnType::Text { max_len: nz(255) }),
+        ],
+        indexes: &[],
+    };
+    let text = [b'x'; 255];
+    let row = [RowValue::Long(1), RowValue::Text(&text)];
+    let rows = vec![row.as_slice(); 8];
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(bytes.len(), 25 * crate::PAGE_BYTES);
+    assert_eq!((page_rows(&bytes, 23), page_rows(&bytes, 24)), (7, 1));
+    assert!(map_bit(&bytes, 21, 1, 23)?);
+    assert!(map_bit(&bytes, 21, 1, 24)?);
+    Ok(())
+}
+
+#[test]
+fn later_page_corruption_and_missing_owned_pages_are_detected() -> TestResult {
     let directory = TestDirectory::create()?;
     let table = TableSpec {
         name: b"Numbers",
@@ -229,19 +296,97 @@ fn initial_rows_require_space_for_a_minimal_row() -> TestResult {
         indexes: &[],
     };
     let row = [RowValue::Long(1)];
-    let rows = vec![row.as_slice(); 254];
-    create_database_with_rows(directory.target(), &table, &rows[..253], &mut budget())?;
+    let rows = vec![row.as_slice(); 255];
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let original = fs::read(directory.target())?;
+    let mut changed = original.clone();
+    changed[24 * crate::PAGE_BYTES + 4] = 21;
+    fs::write(directory.target(), &changed)?;
+    assert!(matches!(
+        super::super::check_initial_rows(&directory.target(), &table, &rows, &mut budget()),
+        Err(CandidateCheckError::Rows(_))
+    ));
+    let mut changed = original;
+    let entry = 21 * crate::PAGE_BYTES + 10;
+    let start = u16::from_le_bytes([changed[entry], changed[entry + 1]]) as usize;
+    changed[21 * crate::PAGE_BYTES + start + 5 + 24 / 8] &= !1;
+    fs::write(directory.target(), &changed)?;
+    assert!(matches!(
+        super::super::check_initial_rows(&directory.target(), &table, &rows, &mut budget()),
+        Err(CandidateCheckError::Mismatch {
+            detail: "initial row count"
+        })
+    ));
+    Ok(())
+}
+
+#[test]
+fn inline_map_boundary_is_accepted_and_growth_past_it_preserves_destination() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let names = (0..70)
+        .map(|number| format!("F{number}"))
+        .collect::<Vec<_>>();
+    let columns = names
+        .iter()
+        .map(|name| ColumnSpec::new(name.as_bytes(), ColumnType::Double))
+        .collect::<Vec<_>>();
+    let table = TableSpec {
+        name: b"WideRows",
+        columns: &columns,
+        indexes: &[],
+    };
+    let row = [RowValue::Double(1.0); 70];
+    // Three 570-byte fixed-width rows per page, without wide variable offsets.
+    let rows = vec![row.as_slice(); 3004];
+    create_database_with_rows(directory.target(), &table, &rows[..3003], &mut budget())?;
+    let original = fs::read(directory.target())?;
+    assert_eq!(original.len(), 1024 * crate::PAGE_BYTES);
+    assert!(map_bit(&original, 21, 0, 1023)?);
+    assert!(!map_bit(&original, 1, 0, 1023)?);
+    assert!(
+        matches!(create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::UsageMap(crate::UsageMapWriteError::PageOutOfMap {
+            page, page_count: 1024, ..
+        }))) if page == PageNumber::new(1024))
+    );
+    assert_eq!(fs::read(directory.target())?, original);
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn oversized_rows_and_page_storage_budget_fail_before_publication() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let columns = [b"A", b"B", b"C", b"D", b"E", b"F", b"G", b"H", b"I"]
+        .map(|name| ColumnSpec::new(name, ColumnType::Text { max_len: nz(255) }));
+    let table = TableSpec {
+        name: b"WideRows",
+        columns: &columns,
+        indexes: &[],
+    };
+    let text = [b'x'; 255];
+    let row = [RowValue::Text(&text); 9];
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &[&row], &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::Row(_)))
+    ));
+    let mut limited = ResourceBudget::new(
+        ResourceLimits::default().with_max_allocation_bytes(crate::ByteCount::new(2000)),
+    );
     assert!(matches!(
         create_database_with_rows(
-            directory.path.join("full.mdb"),
-            &table,
-            &rows,
-            &mut budget()
+            directory.target(),
+            &scalar_table(),
+            &[&[RowValue::Long(1), RowValue::Null]],
+            &mut limited
         ),
-        Err(CreateDatabaseError::Compose(ComposeError::Page(
-            PageImageError::PageFull { .. }
+        Err(CreateDatabaseError::Compose(ComposeError::Encoding(
+            crate::Error::ResourceLimitExceeded {
+                kind: crate::ResourceLimitKind::AllocationBytes,
+                ..
+            }
         )))
     ));
-    assert_eq!(directory.entries()?, ["created.mdb"]);
+    assert!(directory.entries()?.is_empty());
     Ok(())
 }


### PR DESCRIPTION
Initial scalar rows can now span multiple data pages instead of failing at the first page boundary. The composer packs rows in caller order, updates the owned and available maps, bounds page growth by the existing inline map, and streams row comparisons before atomic publication.

This remains one unindexed table with a one-page definition, without AutoIncrement or Memo/OLE. Available-page selection is an explicit construction hypothesis pending its own DAO experiment. The earlier EXP-0112 candidate remains byte-identical.

Validation: independent review with no findings, 13 focused row tests and 19 composer tests, scoped Clippy, exact prior-candidate reproduction, and `just ready` passed. A deterministic 509-row/three-page candidate is included for separate preregistration.

Part of #100; stacked after #193.
