### PR TITLE
feat(jet3): compose a private relationship database candidate

### DIFF
--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -235,21 +235,21 @@ fn compose_existing_pages(
         msys_objects_definition(object_count, budget)?,
         msys_aces_definition(ace_count, object_count, budget)?,
         msys_queries_definition(budget)?,
-        msys_relationships_definition(budget)?,
+        msys_relationships_definition(0, [0; 3], budget)?,
         objects_map_page(creates, budget)?,
         single_map_page(&[], budget)?,
         single_map_page(&[OBJECTS_PARENT_NAME_ROOT], budget)?,
-        objects_parent_name_index(creates, budget)?,
+        objects_parent_name_index(creates, None, budget)?,
         single_map_page(&[OBJECTS_ID_ROOT], budget)?,
-        objects_id_index(creates, budget)?,
-        shared_map_page(budget)?,
-        aces_index(creates, budget)?,
+        objects_id_index(creates, None, budget)?,
+        shared_map_page(&[], budget)?,
+        aces_index(creates, &[], budget)?,
         empty_index_page(MSYS_QUERIES_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
         empty_index_page(MSYS_RELATIONSHIPS_ROOT, budget)?,
-        objects_data_page(creates, budget)?,
-        aces_data_page(creates, budget)?,
+        objects_data_page(creates, None, budget)?,
+        aces_data_page(creates, &[], budget)?,
     ])
 }
 
@@ -327,12 +327,16 @@ fn objects_map_page(
     data_page(HEADER_PAGE, &rows, budget)
 }
 
-fn shared_map_page(budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+fn shared_map_page(
+    relationship_pages: &[u64],
+    budget: &mut ResourceBudget,
+) -> Result<PageImage, ComposeError> {
     let ace_owned = inline_map_row(&[MSYS_ACES_DATA_PAGE], budget)?;
     let ace_available = inline_map_row(&[MSYS_ACES_DATA_PAGE], budget)?;
     let ace_index = inline_map_row(&[ACES_OBJECT_ID_ROOT], budget)?;
     let empty = inline_map_row(&[], budget)?;
     let query_index = inline_map_row(&[QUERIES_INDEX_ROOT], budget)?;
+    let relation_data = inline_map_row(relationship_pages, budget)?;
     let relation_name = inline_map_row(&[RELATIONSHIPS_NAME_ROOT], budget)?;
     let relation_object = inline_map_row(&[RELATIONSHIPS_OBJECT_ROOT], budget)?;
     let relation_referenced = inline_map_row(&[RELATIONSHIPS_REFERENCED_ROOT], budget)?;
@@ -345,8 +349,8 @@ fn shared_map_page(budget: &mut ResourceBudget) -> Result<PageImage, ComposeErro
         &empty,
         &empty,
         &query_index,
-        &empty,
-        &empty,
+        &relation_data,
+        &relation_data,
         &relation_name,
         &relation_object,
         &relation_referenced,
@@ -506,10 +510,12 @@ const CATALOG_SEEDS: [CatalogSeed<'static>; 8] = [
 /// Returns the catalog rows the composed image holds, in stored row order.
 fn catalog_seeds<'a>(
     creates: &'a [PlannedCreate<'a>],
+    extra: Option<CatalogSeed<'a>>,
 ) -> impl Iterator<Item = CatalogSeed<'a>> + 'a {
     CATALOG_SEEDS
         .into_iter()
         .chain(creates.iter().map(PlannedCreate::catalog_seed))
+        .chain(extra)
 }
 
 /// Builds the catalog data page. Every `LvProp` is null: the system rows
@@ -518,11 +524,12 @@ fn catalog_seeds<'a>(
 /// any other created table the null form is an unvalidated candidate.
 fn objects_data_page(
     creates: &[PlannedCreate<'_>],
+    extra: Option<CatalogSeed<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_OBJECTS_ROOT), budget)?;
     let mut row = [0_u8; PAGE_BYTES];
-    for seed in catalog_seeds(creates) {
+    for seed in catalog_seeds(creates, extra) {
         let length = encode_catalog_row(seed, &mut row, budget)?;
         builder.append_row(&row[..length], budget)?;
     }
@@ -591,19 +598,24 @@ const fn ace(object: i32, sid: &'static [u8], acm: i32, inheritable: bool) -> Ac
 }
 
 /// Returns the access-control rows the composed image holds, in stored order.
-fn ace_seeds<'a>(creates: &'a [PlannedCreate<'a>]) -> impl Iterator<Item = AceSeed> + 'a {
+fn ace_seeds<'a>(
+    creates: &'a [PlannedCreate<'a>],
+    extra: &'a [AceSeed],
+) -> impl Iterator<Item = AceSeed> + 'a {
     ACE_SEEDS
         .into_iter()
         .chain(creates.iter().flat_map(PlannedCreate::ace_seeds))
+        .chain(extra.iter().copied())
 }
 
 fn aces_data_page(
     creates: &[PlannedCreate<'_>],
+    extra: &[AceSeed],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let mut builder = DataPageBuilder::new(PageNumber::new(MSYS_ACES_ROOT), budget)?;
     let mut row = [0_u8; 64];
-    for seed in ace_seeds(creates) {
+    for seed in ace_seeds(creates, extra) {
         let values = [
             RowValue::Long(seed.object),
             RowValue::Binary(seed.sid),
@@ -662,9 +674,10 @@ impl OwnedIndexEntry {
 
 fn objects_parent_name_index(
     creates: &[PlannedCreate<'_>],
+    extra: Option<CatalogSeed<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    let mut entries = catalog_seeds(creates)
+    let mut entries = catalog_seeds(creates, extra)
         .enumerate()
         .map(|(row, seed)| OwnedIndexEntry::name(seed.parent, seed.name, row as u8))
         .collect::<Result<Vec<_>, ComposeError>>()?;
@@ -673,9 +686,10 @@ fn objects_parent_name_index(
 }
 fn objects_id_index(
     creates: &[PlannedCreate<'_>],
+    extra: Option<CatalogSeed<'_>>,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    let mut entries = catalog_seeds(creates)
+    let mut entries = catalog_seeds(creates, extra)
         .enumerate()
         .map(|(row, seed)| OwnedIndexEntry::long(seed.id, row as u8))
         .collect::<Vec<_>>();
@@ -684,9 +698,10 @@ fn objects_id_index(
 }
 fn aces_index(
     creates: &[PlannedCreate<'_>],
+    extra: &[AceSeed],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    let mut entries = ace_seeds(creates)
+    let mut entries = ace_seeds(creates, extra)
         .enumerate()
         .map(|(row, seed)| OwnedIndexEntry::long(seed.object, row as u8))
         .collect::<Vec<_>>();
@@ -748,3 +763,6 @@ fn index_page(
 #[cfg(test)]
 #[path = "bootstrap_composer_tests.rs"]
 mod tests;
+
+#[path = "bootstrap_relationship_candidate.rs"]
+mod relationship_candidate;

--- a/crates/jet3/src/bootstrap_relationship_candidate.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate.rs
@@ -1,0 +1,330 @@
+//! Private candidate for exactly EXP-0114's first ParentChild relationship.
+//!
+//! All schemas, names, selectors, map placements, catalog IDs/ACEs, and
+//! logical-record fields are bounded to that observation. Bootstrap null
+//! LvProp construction still follows EXP-0091/0110; no DAO result establishes
+//! acceptance of this combined image. No generalized relationship API lives
+//! here, and the second relationship is not composed.
+
+#![allow(
+    dead_code,
+    reason = "private relationship candidate awaiting DAO validation"
+)]
+
+use super::*;
+use crate::{IndexColumnSpec, IndexFieldSpec, IndexKind, IndexSpec, RelationshipSide};
+
+// EXP-0114 base and first checkpoints.
+const PARENT_ROOT: u64 = 20;
+const PARENT_MAP: u64 = 21;
+const PARENT_ID_ROOT: u64 = 23;
+const PARENT_ALTERNATE_ROOT: u64 = 24;
+const CHILD_ROOT: u64 = 25;
+const CHILD_MAP: u64 = 26;
+const RELATION_DATA: u64 = 27;
+const CHILD_INDEX_ROOT: u64 = 28;
+const RELATION_ID: i32 = i32::MIN;
+const PAGE0_TRANSITION_OFFSET: u64 = 1538;
+const PAGE0_TRANSITION_BYTE: u8 = 2;
+const PARENT_COLUMNS: [ColumnSpec<'static>; 2] = [
+    ColumnSpec::new(b"Id", ColumnType::Long),
+    ColumnSpec::new(b"Alternate", ColumnType::Long),
+];
+const CHILD_COLUMNS: [ColumnSpec<'static>; 2] = [
+    ColumnSpec::new(b"ParentId", ColumnType::Long),
+    ColumnSpec::new(b"Alternate", ColumnType::Long),
+];
+const TABLES: [TableSpec<'static>; 2] = [
+    TableSpec {
+        name: b"Parent",
+        columns: &PARENT_COLUMNS,
+        indexes: &[
+            IndexSpec {
+                name: b"ById",
+                fields: &[IndexColumnSpec {
+                    column: crate::ColumnRef::Ordinal(0),
+                    direction: IndexDirection::Ascending,
+                }],
+                kind: IndexKind::Primary,
+            },
+            IndexSpec {
+                name: b"ByAlternate",
+                fields: &[IndexColumnSpec {
+                    column: crate::ColumnRef::Ordinal(1),
+                    direction: IndexDirection::Ascending,
+                }],
+                kind: IndexKind::Unique,
+            },
+        ],
+    },
+    TableSpec {
+        name: b"Child",
+        columns: &CHILD_COLUMNS,
+        indexes: &[],
+    },
+];
+const RELATION: CatalogSeed<'static> = CatalogSeed {
+    id: RELATION_ID,
+    parent: RELATIONSHIPS_ID,
+    name: b"ParentChild",
+    kind: 8,
+    owner: CATALOG_OWNER_0301,
+    flags: 0,
+};
+const RELATION_ACES: [AceSeed; 2] = [
+    ace(RELATION_ID, b"\x03\x01", 983294, false),
+    ace(RELATION_ID, b"\x02\x01", 1048575, false),
+];
+
+fn compose_parent_child(budget: &mut ResourceBudget) -> Result<WholeFileImagePlan, ComposeError> {
+    let mut plan = compose_database(&TABLES, budget)?;
+    let creates = [
+        PlannedCreate::new(&TABLES[0], PARENT_ROOT, true)?,
+        PlannedCreate::new(&TABLES[1], CHILD_ROOT, false)?,
+    ];
+    let object_count = (SYSTEM_OBJECT_COUNT + TABLES.len() + 1) as u32;
+    let ace_count = (SYSTEM_ACE_COUNT + 2 * TABLES.len() + RELATION_ACES.len()) as u32;
+    let mut header = header_page(TABLES.len(), budget)?;
+    // EXP-0114 observed this raw value; its meaning is not generalized.
+    header.write_at(
+        PageOffset::new(PAGE0_TRANSITION_OFFSET),
+        &[PAGE0_TRANSITION_BYTE],
+        budget,
+    )?;
+    let replacements = [
+        (HEADER_PAGE, header),
+        (
+            GLOBAL_MAP_PAGE,
+            global_map_page(CHILD_INDEX_ROOT + 1, budget)?,
+        ),
+        (
+            MSYS_OBJECTS_ROOT,
+            msys_objects_definition(object_count, budget)?,
+        ),
+        (
+            MSYS_ACES_ROOT,
+            msys_aces_definition(ace_count, object_count, budget)?,
+        ),
+        (
+            MSYS_RELATIONSHIPS_ROOT,
+            msys_relationships_definition(1, [1; 3], budget)?,
+        ),
+        (
+            OBJECTS_PARENT_NAME_ROOT,
+            objects_parent_name_index(&creates, Some(RELATION), budget)?,
+        ),
+        (
+            OBJECTS_ID_ROOT,
+            objects_id_index(&creates, Some(RELATION), budget)?,
+        ),
+        (SHARED_MAP_PAGE, shared_map_page(&[RELATION_DATA], budget)?),
+        (
+            ACES_OBJECT_ID_ROOT,
+            aces_index(&creates, &RELATION_ACES, budget)?,
+        ),
+        (
+            MSYS_OBJECTS_DATA_PAGE,
+            objects_data_page(&creates, Some(RELATION), budget)?,
+        ),
+        (
+            MSYS_ACES_DATA_PAGE,
+            aces_data_page(&creates, &RELATION_ACES, budget)?,
+        ),
+        (
+            RELATIONSHIPS_NAME_ROOT,
+            relation_index(
+                b"\x7f\x73\x60\x75\x66\x70\x77\x62\x69\x6a\x6d\x64\x00",
+                budget,
+            )?,
+        ),
+        (
+            RELATIONSHIPS_OBJECT_ROOT,
+            relation_index(b"\x7f\x62\x69\x6a\x6d\x64\x00", budget)?,
+        ),
+        (
+            RELATIONSHIPS_REFERENCED_ROOT,
+            relation_index(b"\x7f\x73\x60\x75\x66\x70\x77\x00", budget)?,
+        ),
+        (PARENT_ROOT, user_definition(true, budget)?),
+        (CHILD_ROOT, user_definition(false, budget)?),
+        (CHILD_MAP, child_map(budget)?),
+    ];
+    for (page, image) in replacements {
+        plan.replace(PageNumber::new(page), image)?;
+    }
+    let mut global_free = global_map(RELATION_DATA, budget)?;
+    plan.append(relationship_data(budget)?, &mut global_free, budget)?;
+    plan.append(
+        empty_index_page(CHILD_ROOT, budget)?,
+        &mut global_free,
+        budget,
+    )?;
+    Ok(plan)
+}
+
+fn user_definition(parent: bool, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+    let id = [IndexFieldSpec {
+        column: 0,
+        direction: IndexDirection::Ascending,
+    }];
+    let alternate = [IndexFieldSpec {
+        column: 1,
+        direction: IndexDirection::Ascending,
+    }];
+    let parent_physical = [
+        physical(
+            &id,
+            PARENT_MAP,
+            2,
+            PARENT_ID_ROOT,
+            PhysicalIndexFlagsSpec::UniqueRequired,
+        ),
+        physical(
+            &alternate,
+            PARENT_MAP,
+            3,
+            PARENT_ALTERNATE_ROOT,
+            PhysicalIndexFlagsSpec::Unique,
+        ),
+    ];
+    let child_physical = [physical(
+        &id,
+        CHILD_MAP,
+        2,
+        CHILD_INDEX_ROOT,
+        PhysicalIndexFlagsSpec::Ordinary,
+    )];
+    let parent_logical = [
+        LogicalIndexSpec {
+            name: b".rC",
+            physical_index: 0,
+            kind: LogicalIndexKindSpec::Relationship {
+                side: RelationshipSide::PrimaryTable,
+                related_table: PageNumber::new(CHILD_ROOT),
+                raw_selector: 2,
+                relation_ordinal: 0,
+                cascade_updates: false,
+                cascade_deletes: false,
+            },
+        },
+        LogicalIndexSpec {
+            name: b"ByAlternate",
+            physical_index: 1,
+            kind: LogicalIndexKindSpec::Ordinary,
+        },
+        LogicalIndexSpec {
+            name: b"ById",
+            physical_index: 0,
+            kind: LogicalIndexKindSpec::Primary,
+        },
+    ];
+    let child_logical = [LogicalIndexSpec {
+        name: b"ParentChild",
+        physical_index: 0,
+        kind: LogicalIndexKindSpec::Relationship {
+            side: RelationshipSide::ForeignTable,
+            related_table: PageNumber::new(PARENT_ROOT),
+            raw_selector: 0,
+            relation_ordinal: 2,
+            cascade_updates: false,
+            cascade_deletes: false,
+        },
+    }];
+    let map = if parent { PARENT_MAP } else { CHILD_MAP };
+    definition_page(
+        &TableDefinitionSpec {
+            kind: TableDefinitionKind::User,
+            columns: if parent {
+                &PARENT_COLUMNS
+            } else {
+                &CHILD_COLUMNS
+            },
+            system_column_classes: &[],
+            physical_indexes: if parent {
+                &parent_physical
+            } else {
+                &child_physical
+            },
+            indexes: if parent {
+                &parent_logical
+            } else {
+                &child_logical
+            },
+            owned_map: MapRowLocator::new(PageNumber::new(map), 0),
+            available_map: MapRowLocator::new(PageNumber::new(map), 1),
+            row_count: 0,
+            long_value_maps: &[],
+        },
+        budget,
+    )
+}
+
+fn physical<'a>(
+    fields: &'a [IndexFieldSpec],
+    map: u64,
+    row: u8,
+    root: u64,
+    flags: PhysicalIndexFlagsSpec,
+) -> PhysicalIndexSpec<'a> {
+    PhysicalIndexSpec {
+        fields,
+        usage_map_page: PageNumber::new(map),
+        usage_map_row: row,
+        root: PageNumber::new(root),
+        flags,
+        entry_count: 0,
+    }
+}
+
+fn child_map(budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+    let empty = inline_map_row(&[], budget)?;
+    let index = inline_map_row(&[CHILD_INDEX_ROOT], budget)?;
+    data_page(HEADER_PAGE, &[&empty, &empty, &index], budget)
+}
+
+fn relationship_data(budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+    // EXP-0073 column layout; EXP-0114 first relationship's exact values.
+    let layout = [
+        variable(ColumnPhysicalType::Text, 0, 255),
+        fixed(ColumnPhysicalType::Long, 0, 4),
+        fixed(ColumnPhysicalType::Long, 4, 4),
+        fixed(ColumnPhysicalType::Long, 8, 4),
+        variable(ColumnPhysicalType::Text, 1, 255),
+        variable(ColumnPhysicalType::Text, 2, 255),
+        variable(ColumnPhysicalType::Text, 3, 255),
+        variable(ColumnPhysicalType::Text, 4, 255),
+    ];
+    let values = [
+        RowValue::Text(b"ParentChild"),
+        RowValue::Long(0),
+        RowValue::Long(1),
+        RowValue::Long(0),
+        RowValue::Text(b"Child"),
+        RowValue::Text(b"ParentId"),
+        RowValue::Text(b"Parent"),
+        RowValue::Text(b"Id"),
+    ];
+    let mut row = [0_u8; PAGE_BYTES];
+    let length = encode_row(&layout, &values, &mut row, budget)?.get() as usize;
+    data_page(MSYS_RELATIONSHIPS_ROOT, &[&row[..length]], budget)
+}
+
+fn relation_index(key: &[u8], budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+    // Only the three exact EXP-0114 keys above are supplied; no text grammar.
+    let mut entry = OwnedIndexEntry::EMPTY;
+    let available = entry.key.len();
+    entry
+        .key
+        .get_mut(..key.len())
+        .ok_or(ComposeError::IndexPageFull {
+            needed: key.len(),
+            available,
+        })?
+        .copy_from_slice(key);
+    entry.len = key.len();
+    index_page(MSYS_RELATIONSHIPS_ROOT, RELATION_DATA, &[entry], budget)
+}
+
+#[cfg(test)]
+#[path = "bootstrap_relationship_candidate_tests.rs"]
+mod tests;

--- a/crates/jet3/src/bootstrap_relationship_candidate_tests.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate_tests.rs
@@ -1,0 +1,213 @@
+use super::super::tests::inline_map_bit;
+use super::*;
+use crate::{ColumnOrdinal, DatabaseReader, ResourceLimits, SliceSource};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn bytes() -> Result<Vec<u8>, ComposeError> {
+    Ok(compose_parent_child(&mut budget())?
+        .pages()
+        .iter()
+        .flat_map(|page| page.image().as_bytes().iter().copied())
+        .collect())
+}
+
+#[test]
+fn reciprocal_records_and_system_rows_match_the_first_observation() -> TestResult {
+    let bytes = bytes()?;
+    assert_eq!(bytes.len(), 29 * PAGE_BYTES);
+    let mut budget = budget();
+    let mut database =
+        DatabaseReader::from_source(SliceSource::new(&bytes, budget.read_budget())?, &mut budget)?;
+    for (root, name, selector, ordinal, other) in [
+        (20, b".rC".as_slice(), 2, 0, 25),
+        (25, b"ParentChild".as_slice(), 0, 2, 20),
+    ] {
+        let definition = database.table_definition(PageNumber::new(root), &mut budget)?;
+        let relations = definition.relationships().collect::<Vec<_>>();
+        assert_eq!(relations.len(), 1);
+        let relation = relations[0];
+        assert_eq!(relation.name().raw_bytes(), name);
+        assert_eq!(relation.physical_index(), 0);
+        assert_eq!(relation.raw_selector(), selector);
+        assert_eq!(relation.raw_relation_ordinal(), ordinal);
+        assert_eq!(relation.related_table(), PageNumber::new(other));
+        assert_eq!(relation.raw_context(), [0, 0]);
+        for index in 0..definition.physical_indexes().len() {
+            assert!(
+                database
+                    .index_tree(&definition, index as u16, &mut budget)?
+                    .entries()
+                    .is_empty()
+            );
+        }
+    }
+    let relations = database.table_definition(PageNumber::new(5), &mut budget)?;
+    let mut cursor = database.rows(&relations, &mut budget)?;
+    let row = cursor.next_row()?.ok_or("missing relationship row")?;
+    for (ordinal, value) in [
+        (0, b"ParentChild".as_slice()),
+        (4, b"Child"),
+        (5, b"ParentId"),
+        (6, b"Parent"),
+        (7, b"Id"),
+    ] {
+        assert_eq!(
+            row.field(ColumnOrdinal::new(ordinal))
+                .and_then(|field| field.raw_bytes()),
+            Some(value)
+        );
+    }
+    for (ordinal, value) in [(1, 0_i32), (2, 1), (3, 0)] {
+        assert_eq!(
+            row.field(ColumnOrdinal::new(ordinal))
+                .and_then(|field| field.raw_bytes()),
+            Some(value.to_le_bytes().as_slice())
+        );
+    }
+    assert!(cursor.next_row()?.is_none());
+    Ok(())
+}
+
+#[test]
+fn relationship_catalog_and_aces_match_recorded_ids_and_permissions() -> TestResult {
+    let bytes = bytes()?;
+    let mut budget = budget();
+    let mut database =
+        DatabaseReader::from_source(SliceSource::new(&bytes, budget.read_budget())?, &mut budget)?;
+    let objects = database.table_definition(PageNumber::new(2), &mut budget)?;
+    for index in 0..2 {
+        assert_eq!(
+            database
+                .index_tree(&objects, index, &mut budget)?
+                .entries()
+                .len(),
+            11
+        );
+    }
+    let mut cursor = database.rows(&objects, &mut budget)?;
+    let mut matches = 0;
+    while let Some(row) = cursor.next_row()? {
+        if row
+            .field(ColumnOrdinal::new(2))
+            .and_then(|field| field.raw_bytes())
+            == Some(b"ParentChild".as_slice())
+        {
+            matches += 1;
+            for (ordinal, wanted) in [
+                (0, i32::MIN.to_le_bytes()),
+                (1, 0x0f000003_i32.to_le_bytes()),
+                (7, 0_i32.to_le_bytes()),
+            ] {
+                assert_eq!(
+                    row.field(ColumnOrdinal::new(ordinal))
+                        .and_then(|field| field.raw_bytes()),
+                    Some(wanted.as_slice())
+                );
+            }
+            assert_eq!(
+                row.field(ColumnOrdinal::new(3))
+                    .and_then(|field| field.raw_bytes()),
+                Some(8_i16.to_le_bytes().as_slice())
+            );
+        }
+    }
+    assert_eq!(matches, 1);
+    drop(cursor);
+    let aces = database.table_definition(PageNumber::new(3), &mut budget)?;
+    assert_eq!(
+        database.index_tree(&aces, 0, &mut budget)?.entries().len(),
+        22
+    );
+    let mut cursor = database.rows(&aces, &mut budget)?;
+    let mut permissions = Vec::new();
+    while let Some(row) = cursor.next_row()? {
+        if row
+            .field(ColumnOrdinal::new(0))
+            .and_then(|field| field.raw_bytes())
+            == Some(i32::MIN.to_le_bytes().as_slice())
+        {
+            permissions.push((
+                row.field(ColumnOrdinal::new(1))
+                    .and_then(|field| field.raw_bytes())
+                    .ok_or("missing SID")?
+                    .to_vec(),
+                row.field(ColumnOrdinal::new(2))
+                    .and_then(|field| field.raw_bytes())
+                    .ok_or("missing ACM")?
+                    .to_vec(),
+            ));
+        }
+    }
+    assert_eq!(
+        permissions,
+        [
+            (vec![3, 1], 983294_i32.to_le_bytes().to_vec()),
+            (vec![2, 1], 1048575_i32.to_le_bytes().to_vec())
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn index_locators_maps_and_unrelated_generated_pages_are_preserved() -> TestResult {
+    let bytes = bytes()?;
+    let base = compose_database(&TABLES, &mut budget())?;
+    for page in [4, 6, 7, 8, 10, 14, 21, 22, 23, 24] {
+        assert_eq!(
+            &bytes[page * PAGE_BYTES..(page + 1) * PAGE_BYTES],
+            base.pages()[page].image().as_bytes()
+        );
+    }
+    for (map, row, owned) in [(12, 8, 27), (12, 9, 27), (26, 2, 28)] {
+        assert!(inline_map_bit(&bytes, map, row, owned)?);
+    }
+    for page in 0..29 {
+        assert!(!inline_map_bit(&bytes, 1, 0, page)?);
+    }
+    let mut budget = budget();
+    let mut database =
+        DatabaseReader::from_source(SliceSource::new(&bytes, budget.read_budget())?, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(5), &mut budget)?;
+    for (ordinal, wanted) in [
+        b"\x7f\x73\x60\x75\x66\x70\x77\x62\x69\x6a\x6d\x64\x00".as_slice(),
+        b"\x7f\x62\x69\x6a\x6d\x64\x00",
+        b"\x7f\x73\x60\x75\x66\x70\x77\x00",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let tree = database.index_tree(&definition, ordinal as u16, &mut budget)?;
+        assert_eq!(tree.entries().len(), 1);
+        assert_eq!(tree.entries()[0].key().raw_bytes(), wanted);
+        assert_eq!(tree.entries()[0].row().page(), PageNumber::new(27));
+        assert_eq!(tree.entries()[0].row().slot(), 0);
+    }
+    Ok(())
+}
+
+#[test]
+fn candidate_budget_exhaustion_and_oversized_key_are_structured() {
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(0));
+    assert!(compose_parent_child(&mut limited).is_err());
+    assert!(matches!(
+        relation_index(&[0; INDEX_KEY_CAPACITY + 1], &mut budget()),
+        Err(ComposeError::IndexPageFull { .. })
+    ));
+}
+
+#[test]
+#[ignore = "exports exact private candidate for a separately preregistered DAO run"]
+fn export_relationship_candidate() -> TestResult {
+    use std::io::Write;
+    let path = std::env::var_os("JET3_RELATIONSHIP_CANDIDATE")
+        .ok_or("JET3_RELATIONSHIP_CANDIDATE is required")?;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    file.write_all(&bytes()?)?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_system_definitions.rs
+++ b/crates/jet3/src/bootstrap_system_definitions.rs
@@ -282,6 +282,8 @@ const RELATIONSHIP_CLASSES: [SystemColumnClassSpec; 8] = {
 };
 
 pub(super) fn msys_relationships_definition(
+    row_count: u32,
+    entry_counts: [u32; 3],
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let name_fields = [field(0)];
@@ -294,7 +296,7 @@ pub(super) fn msys_relationships_definition(
             10,
             RELATIONSHIPS_NAME_ROOT,
             PhysicalIndexFlagsSpec::SystemUninterpreted,
-            0,
+            entry_counts[0],
         ),
         physical(
             &object_fields,
@@ -302,7 +304,7 @@ pub(super) fn msys_relationships_definition(
             11,
             RELATIONSHIPS_OBJECT_ROOT,
             PhysicalIndexFlagsSpec::SystemUninterpreted,
-            0,
+            entry_counts[1],
         ),
         physical(
             &referenced_fields,
@@ -310,7 +312,7 @@ pub(super) fn msys_relationships_definition(
             12,
             RELATIONSHIPS_REFERENCED_ROOT,
             PhysicalIndexFlagsSpec::SystemUninterpreted,
-            0,
+            entry_counts[2],
         ),
     ];
     let logical = [
@@ -339,7 +341,7 @@ pub(super) fn msys_relationships_definition(
             indexes: &logical,
             owned_map: locator(SHARED_MAP_PAGE, 8),
             available_map: locator(SHARED_MAP_PAGE, 9),
-            row_count: 0,
+            row_count,
             long_value_maps: &[],
         },
         budget,

--- a/crates/jet3/src/page_append_plan.rs
+++ b/crates/jet3/src/page_append_plan.rs
@@ -36,6 +36,11 @@ impl PlannedPage {
         &self.image
     }
 
+    /// Replaces this slot's complete image without changing its number.
+    pub(crate) fn replace_image(&mut self, image: PageImage) {
+        self.image = image;
+    }
+
     /// Splits the planned page into its number and complete image.
     pub(crate) fn into_parts(self) -> (PageNumber, PageImage) {
         (self.number, self.image)

--- a/crates/jet3/src/whole_file_plan.rs
+++ b/crates/jet3/src/whole_file_plan.rs
@@ -22,6 +22,11 @@ const EXISTING_PAGE_COUNT: usize = EMPTY_DATABASE_PAGE_COUNT as usize;
 /// Structured failure while aggregating a whole-file page plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WholeFilePlanError {
+    /// A requested replacement has no planned slot.
+    MissingPage {
+        /// Requested page number.
+        page: PageNumber,
+    },
     /// Resource accounting or allocation failed while retaining page plans.
     Resource(Error),
     /// A fresh image could not be appended.
@@ -31,6 +36,9 @@ pub enum WholeFilePlanError {
 impl fmt::Display for WholeFilePlanError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::MissingPage { page } => {
+                write!(formatter, "no planned page {} to replace", page.get())
+            }
             Self::Resource(source) => {
                 write!(formatter, "whole-file plan resource failure: {source}")
             }
@@ -42,6 +50,7 @@ impl fmt::Display for WholeFilePlanError {
 impl std::error::Error for WholeFilePlanError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::MissingPage { .. } => None,
             Self::Resource(source) => Some(source),
             Self::Append(source) => Some(source),
         }
@@ -120,6 +129,21 @@ impl WholeFileImagePlan {
         let number = planned.number();
         self.pages.push(planned);
         Ok(number)
+    }
+
+    /// Replaces one retained complete image without changing page numbering.
+    /// The caller remains responsible for references and allocation maps.
+    pub(crate) fn replace(
+        &mut self,
+        page: PageNumber,
+        image: PageImage,
+    ) -> Result<(), WholeFilePlanError> {
+        let slot = usize::try_from(page.get())
+            .ok()
+            .and_then(|slot| self.pages.get_mut(slot))
+            .ok_or(WholeFilePlanError::MissingPage { page })?;
+        slot.replace_image(image);
+        Ok(())
     }
 
     /// Consumes the aggregate and returns its ordered page plans.

--- a/crates/jet3/src/whole_file_plan_tests.rs
+++ b/crates/jet3/src/whole_file_plan_tests.rs
@@ -166,3 +166,33 @@ fn append_budget_rejection_preserves_plan_and_global_map() -> TestResult {
     assert_eq!(map, map_before);
     Ok(())
 }
+
+#[test]
+fn replacement_keeps_other_slots_and_refuses_missing_pages() -> TestResult {
+    let original = existing_images();
+    let mut plan = WholeFileImagePlan::from_existing_pages(original.clone(), &mut budget())?;
+    let replacement = PageImage::from_bytes([0x42; crate::PAGE_BYTES]);
+    plan.replace(PageNumber::new(7), replacement.clone())?;
+    for (index, page) in plan.pages().iter().enumerate() {
+        assert_eq!(page.number(), PageNumber::new(index as u64));
+        assert_eq!(
+            page.image(),
+            if index == 7 {
+                &replacement
+            } else {
+                &original[index]
+            }
+        );
+    }
+    for number in [20, u64::MAX] {
+        assert_eq!(
+            plan.replace(PageNumber::new(number), replacement.clone()),
+            Err(WholeFilePlanError::MissingPage {
+                page: PageNumber::new(number)
+            })
+        );
+    }
+    assert_eq!(plan.page_count(), 20);
+    assert_eq!(plan.pages()[7].image(), &replacement);
+    Ok(())
+}


### PR DESCRIPTION
Add a private composer for the exact first ParentChild relationship observed in EXP-0114. It builds the relationship catalog and access-control rows, reciprocal logical records, system index entries, and mapped data/index pages through the existing encoders while preserving unrelated generated pages.

The candidate is intentionally private and limited to the observed empty Parent/Child schema. An ignored deterministic export test supplies the image for a separate preregistered DAO validation; no public relationship API or interoperability claim is added.

Validation: independent parser review with no findings, focused composer/planner/preservation tests, scoped Clippy, and `just ready` passed.

Part of #100.
