### PR TITLE
test: preregister multi-page initial-row DAO validation

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10093,6 +10093,46 @@ Use `not applicable` explicitly rather than omitting a field.
   additive-provenance, and evidence-boundary review completed without findings.
 
 
+### EXP-0115 — Multiple-data-page initial rows preregistration
+
+- Recorded: 2026-09-04, OpenAI Codex
+- Kind: SHA-256-pinned development-only local DAO experiment preregistration
+- Question: does DAO read the exact composed `Rows(Id Long)` image containing
+  every integer from -254 through 254 unchanged, with the same schema and row
+  multiset as fresh DAO controls in all three replicas?
+- Origin: project-authored `multi_page_row_candidate` example at reviewed source
+  commit `826b1318669071afc360659201fd8c012ff07bd0`. `EXP-0060`, `EXP-0065`,
+  and `EXP-0057` supply row, append, and map grammar; `EXP-0112` established
+  only the earlier exact one-page candidate. This candidate packs data pages
+  23, 24, and 25 with 254, 254, and 1 rows. All three are owned; only page 25
+  is marked available because the others lack physical room for an all-null
+  row. That availability policy and retaining the composed page-zero header
+  are experimental hypotheses, not established DAO policies.
+- Environment: private local Windows VM, x86 PowerShell, `DAO.DBEngine.36`.
+- Protocol: `oracle/windows-dao/acquisition/multi-page-rows.plan.json`, SHA-256
+  `997070626c1b1c9f3e2daeae6c9a99333060c47916a2ac46c34e9c60073a50a2`. Commit and review before one
+  dispatch. Host verifies all pins and committed plan; guest verifies producer
+  and prepares all three pinned candidate copies before the first control
+  creation. Controls insert the inclusive preregistered range. Read control
+  and candidate schema and rows read-only, require unchanged identities and
+  exact replicated semantics. The analyzer rechecks input pins before applying
+  the decision rule. Post-mutation failure requires a new human decision before
+  another dispatch.
+- Artifacts: exact candidate is 53,248 bytes, SHA-256
+  `57498e634b9e4e7102efd4f4c2d673cccd42c344b51590177c7704232df675af`. The plan pins
+  the producer, analyzer, imported transport, and Rust candidate example.
+- Observation: acquisition has not started; no DAO result recorded here.
+- Interpretation: exact-candidate schema/row endpoints only. No matching control
+  physical layout, general allocation policy, arbitrary schema or value support,
+  indexes, long values, existing-database mutation, compatibility claim, or
+  hosted support-matrix movement.
+- Usage: issue `#100`; separately validated multiple-data-page initial rows.
+- Rights: all MDB bytes and provider binaries remain outside the repository.
+- Review: independent harness review requested input revalidation during
+  analysis; that fix and a focused rejection test are implemented. Six analyzer
+  tests and a PowerShell parser-only check pass.
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/acquisition/multi-page-rows.plan.json
+++ b/oracle/windows-dao/acquisition/multi-page-rows.plan.json
@@ -1,0 +1,68 @@
+{
+  "document_type": "dao_row_candidate_plan",
+  "experiment_id": "multi-page-rows",
+  "issue": 100,
+  "development_only": true,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0060 provides row encoding and EXP-0065 allocation observations. EXP-0112 accepted the exact one-data-page Rows(Id Long, Code Text 8) candidate in three local replicas; it establishes no multiple-page or availability-threshold rule.",
+    "hypothesis": "DAO reads the composed Rows(Id Long) candidate containing 509 rows -254 through 254 unchanged. Rows occupy consecutive data pages 23, 24, and 25 with counts 254, 254, and 1. Owned-map bits name all three; only page 25 is available because pages 23 and 24 lack space for an all-null row. This physical-capacity availability policy and the unchanged composed page-zero header are exact-candidate hypotheses, not inferred DAO policies.",
+    "authorization": "User authorized DAO experiments and mutations on 2026-09-04. Commit and review the exact SHA-256-pinned plan before one dispatch. A failure after the first CreateDatabase is a scientific result; another dispatch requires a new human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/row_candidate.py": "203b23bd30365e61ca29948b78e0a71fc40ec23001d6342663b50dda0225f6f3",
+    "oracle/windows-dao/scripts/row_candidate.ps1": "89b408616de8778223b6bd40339468cc72cbc0a2e33b414242a23cc8131137a7",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/multi_page_row_candidate.rs": "a2910c2120f33c53a080f3f4abc7a621948d821bf90d43b736394eb3eb93228a"
+  },
+  "candidate": {
+    "size": 53248,
+    "sha256": "57498e634b9e4e7102efd4f4c2d673cccd42c344b51590177c7704232df675af"
+  },
+  "replicas": 3,
+  "expected_snapshot": {
+    "version": "3.0",
+    "tables": [
+      "MSysACEs",
+      "MSysObjects",
+      "MSysQueries",
+      "MSysRelationships",
+      "Rows"
+    ],
+    "fields": [
+      {
+        "name": "Id",
+        "type": 4,
+        "size": 4
+      }
+    ],
+    "index_count": 0
+  },
+  "execution": {
+    "environment": "Private local Windows VM, x86 PowerShell, DAO.DBEngine.36. This is development discovery, not hosted support-matrix evidence.",
+    "pre_mutation": "Host validates every input hash and committed plan; guest verifies its script hash and prepares three hash-checked candidate copies before any CreateDatabase.",
+    "per_replica": "Create and close a fresh DAO Jet 3 control with unindexed Rows(Id Long), insert every integer from row_range.first through row_range.last inclusive in ascending order. Read control and candidate read-only through the same schema/row endpoints; close and record unchanged identities. Compare row multisets without asserting physical row order or matching control page layout.",
+    "attempts": 1,
+    "command": "python3 oracle/windows-dao/scripts/row_candidate.py run /tmp/multi-page-rows.mdb --shared-root <VM shared directory> --run-id <UTC timestamp>-multi-page-rows",
+    "analysis": "python3 oracle/windows-dao/scripts/row_candidate.py analyze <shared directory>/outbox/<run id>",
+    "analysis_validation": "Before analysis, verify every preregistered input pin again; reject diagnostic producer/analyzer edits rather than emitting an outcome under the original plan."
+  },
+  "decision_rule": {
+    "observed_accepted": "All three controls and candidates have unchanged identities and exactly expected schema and row multiset, with identical replicated endpoint observations.",
+    "not_observed_accepted": "All three controls pass unchanged with expected semantics, all candidates unchanged and identically fail at one endpoint or yield the same semantic mismatch.",
+    "no_outcome": "Incomplete job, control failure, changed image, or disagreement between replicas.",
+    "validation_rejection": "Reject report for mismatched plan/result identity, invalid replica inventory, candidate starting pin mismatch, or retained image identity mismatch."
+  },
+  "evidence_boundary": "Only exact pinned image and schema/row endpoints. No arbitrary multiple-page schemas, availability-threshold or page-zero update rule, indexed rows, long values, existing-database mutations, general compatibility, or hosted support-matrix movement.",
+  "retention": "Retain result.json, canonical report.json, logs and all candidate/control MDBs locally. Never commit MDB bytes. Add one additive EXP outcome from validated report after acquisition.",
+  "candidate_generation": {
+    "source_commit": "826b1318669071afc360659201fd8c012ff07bd0",
+    "example": "crates/jet3/examples/multi_page_row_candidate.rs",
+    "command": "cargo run --locked -p jet3 --example multi_page_row_candidate -- /tmp/multi-page-rows.mdb"
+  },
+  "table_name": "Rows",
+  "row_range": {
+    "first": -254,
+    "last": 254
+  }
+}

--- a/oracle/windows-dao/scripts/row_candidate.ps1
+++ b/oracle/windows-dao/scripts/row_candidate.ps1
@@ -1,0 +1,112 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function New-Control([string]$Path) {
+    $engine = $workspace = $db = $table = $id = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $table = $db.CreateTableDef([string]$plan.table_name)
+        $id = $table.CreateField('Id', 4)
+        $table.Fields.Append($id)
+        $db.TableDefs.Append($table)
+        $rs = $db.OpenRecordset([string]$plan.table_name, 2)
+        foreach ($value in ([int]$plan.row_range.first)..([int]$plan.row_range.last)) {
+            $rs.AddNew()
+            $rs.Fields.Item('Id').Value = [int]$value
+            $rs.Update()
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $id; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Observe([string]$Path) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item([string]$plan.table_name)
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.index_count = [int]$table.Indexes.Count
+        $endpoint = 'rows'
+        $rs = $db.OpenRecordset([string]$plan.table_name, 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            $id = $rs.Fields.Item('Id').Value
+            if ($null -eq $id -or [Convert]::IsDBNull($id)) { $id = $null } else { $id = [int]$id }
+            [void]$rows.Add(@{id=$id})
+            $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'row-candidate.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/row_candidate.ps1') { throw 'Script pin mismatch' }
+$candidate = Join-Path $env:JET3_WORK 'candidate.mdb'
+foreach ($replica in 1..3) {
+    $path = Join-Path $env:JET3_WORK "candidate-r$replica.mdb"
+    Copy-Item -LiteralPath $candidate -Destination $path
+    $identity = Identity $path
+    if ($identity.size -ne $plan.candidate.size -or $identity.sha256 -cne $plan.candidate.sha256) { throw 'Candidate pin mismatch' }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_row_candidate_result'; development_only=$true; experiment_id=[string]$plan.experiment_id
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($replica in 1..3) {
+        $control = Join-Path $env:JET3_WORK "control-r$replica.mdb"
+        New-Control $control
+        $result.replicas += @{replica=$replica; control=(Observe $control); candidate=(Observe (Join-Path $env:JET3_WORK "candidate-r$replica.mdb"))}
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/row_candidate.py
+++ b/oracle/windows-dao/scripts/row_candidate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Preregistered scalar-row DAO candidate experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/multi-page-rows.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/row_candidate.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+def preflight(candidate):
+    plan = json.loads(PLAN.read_text())
+    if plan['replicas'] != 3 or plan['row_range']['first'] > plan['row_range']['last']:
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    if identity(candidate) != plan['candidate']:
+        raise ValueError('Candidate identity mismatch')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def normalized(snapshot):
+    result = dict(snapshot)
+    if 'rows' in result:
+        result['rows'] = sorted(result['rows'], key=canonical)
+    return result
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    if (result['document_type'] != 'dao_row_candidate_result'
+            or result['experiment_id'] != plan['experiment_id']
+            or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32):
+        raise ValueError('Result identity/environment mismatch')
+    expected = normalized({**plan['expected_snapshot'],
+                           'rows': [{'id': value} for value in range(
+                               plan['row_range']['first'], plan['row_range']['last'] + 1)]})
+    replicas = result['replicas']
+    outcome = 'no_outcome'
+    observations = []
+    controls_ok = True
+    for number, replica in enumerate(replicas, 1):
+        if replica['replica'] != number or number > 3:
+            raise ValueError('Unexpected replica inventory')
+        for role in ('candidate', 'control'):
+            observation = replica[role]
+            retained = outbox / f'{role}-r{number}.mdb'
+            if identity(retained) != observation['after']:
+                raise ValueError(f'Retained identity mismatch: {retained.name}')
+            if role == 'candidate' and observation['before'] != plan['candidate']:
+                raise ValueError('Candidate did not start with pinned identity')
+            if observation['before'] != observation['after']:
+                controls_ok = False
+        control = replica['control']
+        controls_ok &= (control['status'] == 'pass' and control['endpoint'] == 'complete'
+                        and normalized(control['snapshot']) == expected)
+        candidate = dict(replica['candidate'])
+        candidate.pop('before')
+        candidate.pop('after')
+        candidate['snapshot'] = normalized(candidate['snapshot'])
+        observations.append(candidate)
+    if (result['mutation_started'] is True and result['error'] is None
+            and len(replicas) == 3 and controls_ok
+            and all(item == observations[0] for item in observations)):
+        accepted = (observations[0]['status'] == 'pass'
+                    and observations[0]['endpoint'] == 'complete'
+                    and observations[0]['snapshot'] == expected)
+        outcome = 'observed_accepted' if accepted else 'not_observed_accepted'
+    report = {'document_type': 'dao_row_candidate_report', 'development_only': True,
+              'experiment_id': plan['experiment_id'], 'compatibility_claim': False,
+              'support_movement': False,
+              'plan_sha256': digest(PLAN), 'result_sha256': digest(outbox / 'result.json'),
+              'outcome': outcome, 'replicas': len(replicas), 'candidate': plan['candidate']}
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report))
+
+
+def dispatch(args):
+    preflight(args.candidate)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'row-candidate.plan.json')
+    shutil.copyfile(args.candidate, inbox / 'candidate.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_row_candidate.py
+++ b/oracle/windows-dao/tests/test_row_candidate.py
@@ -1,0 +1,85 @@
+"""Focused classification checks for the scalar-row candidate experiment."""
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('row_candidate', Path(__file__).parents[1] / 'scripts/row_candidate.py')
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RowCandidateReportTests(unittest.TestCase):
+    def classify(self, change=lambda result: None, tamper=False, tamper_input=False):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            image = b'candidate bytes'
+            candidate = root / 'source.mdb'
+            candidate.write_bytes(image)
+            expected = {'version': '3.0', 'rows': [{'id': -1}, {'id': 0}, {'id': 1}]}
+            source = root / 'producer.ps1'
+            source.write_text('pinned producer')
+            plan = root / 'plan.json'
+            plan.write_text(json.dumps({'experiment_id': 'test-rows', 'candidate': MODULE.identity(candidate),
+                                        'inputs': {str(source): MODULE.digest(source)},
+                                        'expected_snapshot': {'version': '3.0'},
+                                        'row_range': {'first': -1, 'last': 1}}))
+            result = {'document_type': 'dao_row_candidate_result', 'experiment_id': 'test-rows', 'development_only': True,
+                      'plan_sha256': MODULE.digest(plan), 'environment': {'process_bits': 32},
+                      'mutation_started': True, 'error': None, 'replicas': []}
+            for number in range(1, 4):
+                replica = {'replica': number}
+                for role in ('candidate', 'control'):
+                    target = root / f'{role}-r{number}.mdb'
+                    target.write_bytes(image)
+                    replica[role] = {'before': MODULE.identity(target), 'after': MODULE.identity(target),
+                                     'status': 'pass', 'endpoint': 'complete', 'error': None,
+                                     'snapshot': json.loads(json.dumps(expected))}
+                result['replicas'].append(replica)
+            change(result)
+            (root / 'result.json').write_text(json.dumps(result))
+            if tamper_input:
+                source.write_text('diagnostic edit')
+            if tamper:
+                (root / 'candidate-r1.mdb').write_bytes(b'changed')
+            with patch.object(MODULE, 'PLAN', plan), patch('builtins.print'):
+                MODULE.analyze(root)
+            return json.loads((root / 'report.json').read_text())['outcome']
+
+    def test_accepts_row_multiset(self):
+        def change(result):
+            result['replicas'][0]['candidate']['snapshot']['rows'].reverse()
+        self.assertEqual(self.classify(change), 'observed_accepted')
+
+    def test_repeated_candidate_mismatch_is_negative_result(self):
+        def change(result):
+            for replica in result['replicas']:
+                replica['candidate']['snapshot']['rows'] = []
+        self.assertEqual(self.classify(change), 'not_observed_accepted')
+
+    def test_control_failure_or_replica_disagreement_has_no_outcome(self):
+        for role in ('control', 'candidate'):
+            def change(result):
+                result['replicas'][0][role]['snapshot']['rows'] = []
+            with self.subTest(role=role):
+                self.assertEqual(self.classify(change), 'no_outcome')
+
+    def test_post_mutation_incomplete_job_has_no_outcome(self):
+        def change(result):
+            result['replicas'] = []
+            result['error'] = 'CreateDatabase failed after mutation began'
+        self.assertEqual(self.classify(change), 'no_outcome')
+
+    def test_modified_producer_rejected_before_analysis(self):
+        with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+            self.classify(tamper_input=True)
+
+    def test_retained_image_tampering_rejected(self):
+        with self.assertRaisesRegex(ValueError, 'Retained identity mismatch'):
+            self.classify(tamper=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Preregister a local DAO validation of the exact 509-row, three-data-page candidate produced by #195. Three fresh DAO controls and three pinned candidate copies must expose the same schema and complete Long value multiset while remaining unchanged through read-only access.

The runner verifies the committed plan before dispatch and the analyzer checks input pins before reporting an outcome. This tests one bounded construction; it does not establish a general allocation policy or move the hosted support matrix. The single authorized run completed as `observed_accepted` in all three replicas; its additive outcome is being recorded separately.

Validation: independent harness review and fix verification, six focused analyzer tests, PowerShell syntax check, candidate/committed-plan preflight, and `just ready` passed.

Part of #100; stacked after #195.
