### PR TITLE
test: preregister relationship candidate DAO validation

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10417,3 +10417,43 @@ Copy this block under the appropriate section and remove this instruction:
 - Review: independent outcome review checked the retained JSON, input and
   artifact hashes, byte-identical report reconstruction, raw record fields,
   catalog values, index keys/maps, and scope boundaries; no findings.
+
+
+### EXP-0117 — Preregistered first-relationship candidate DAO validation
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: SHA-256-pinned local development preregistration; no acquisition
+  or acceptance observation has occurred under this plan
+- Question: Does DAO read the exact composed first `ParentChild` candidate
+  with the same table/field/index metadata, relation fields/options, and
+  empty user rows as three fresh same-schema DAO controls, without changing
+  either image during read-only opens?
+- Basis: `EXP-0114` supplies the exact relationship records, map placements,
+  IDs/ACEs, and index keys; the candidate retains the existing null-`LvProp`
+  bootstrap construction. This combination has no prior DAO acceptance.
+- Candidate: 59,392 bytes, SHA-256
+  `9afa3647fc3619cad95002eebdddf0dd14a9fe067a9621dcd0a3635b3582609d`,
+  exported from reviewed composer commit `1afb82de04dbe343dd55c14b974997b72ac364e3`
+  by the ignored `export_relationship_candidate` test. MDB bytes remain
+  outside the repository.
+- Plan: `oracle/windows-dao/acquisition/relationship-candidate.plan.json`,
+  SHA-256 `01357b430a038a450f88fef8e88e1c8477e99979d52f603eceb4763378af41f0`. The plan pins
+  acquisition/analyzer/transport inputs and the bounded candidate module
+  and exporter; the image hash itself binds the acquisition candidate.
+- Protocol: three fresh controls, each with `Parent(Id Long, Alternate Long)`
+  and primary `ById`, unique `ByAlternate`, then `Child(ParentId Long,
+  Alternate Long)` and zero-attribute `ParentChild` from `Id` to `ParentId`.
+  Read each control and candidate separately read-only; capture user-table
+  and field attributes, every index's flags and ordered field bindings,
+  relation fields/options, and complete empty-row snapshots. Rehash after
+  closing; no physical-byte equality with the controls is required.
+- Decision: unchanged complete candidate/control agreement across all three
+  replicas is `observed_accepted`; identical candidate failures/differences
+  with valid unchanged controls are `not_observed_accepted`; incomplete
+  acquisition, changed bytes, control failure, or replica disagreement is
+  `no_outcome`. Invalid identities reject validation. Standalone analysis
+  verifies input pins. No redispatch after first mutation without another
+  human decision.
+- Boundary: only this exact image and read-only endpoints; no generalized
+  relationship API, second relation, populated tables, cascades, integrity
+  enforcement, existing-database updates, or hosted support-matrix claim.

--- a/oracle/windows-dao/acquisition/relationship-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/relationship-candidate.plan.json
@@ -1,0 +1,98 @@
+{
+  "document_type": "dao_relationship_candidate_plan",
+  "experiment_id": "relationship-candidate",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0114 observed the exact first/second relationship creation records. This candidate implements only the first relation using the existing null-LvProp bootstrap construction; DAO acceptance is unestablished.",
+    "hypothesis": "DAO reads the exact pinned Parent/Child/ParentChild candidate with the same declared schema, all observed field/index metadata, relation fields/options, and empty user rows as a fresh DAO control, without modifying either file.",
+    "authorization": "User authorized DAO experiments/mutations in this session. Commit and review this pinned plan before one acquisition. A failure after first CreateDatabase is a scientific result; no redispatch without another human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/relationship_candidate.py": "9f1b1a1d1c35389d5e9f709cb3db3aed5dc25575a84e791e7b8119f3a3053c76",
+    "oracle/windows-dao/scripts/relationship_candidate.ps1": "dea3290e070f7a356f441734d1676d6e214f10c57cec7b921b0f7ca048ab1826",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/src/bootstrap_relationship_candidate.rs": "a31a7ecd14bb1cca232c4d8b8a34f79d61737c49ada01b0ad16bf65f5a30826d",
+    "crates/jet3/src/bootstrap_relationship_candidate_tests.rs": "2e2fd683184c0eaaf5cf709e489504b625451fee7a7600c76940f22db3ce6c31"
+  },
+  "candidate": {
+    "size": 59392,
+    "sha256": "9afa3647fc3619cad95002eebdddf0dd14a9fe067a9621dcd0a3635b3582609d"
+  },
+  "candidate_generation": {
+    "source_commit": "1afb82de04dbe343dd55c14b974997b72ac364e3",
+    "command": "JET3_RELATIONSHIP_CANDIDATE=/absolute/new/relationship-candidate.mdb cargo test --locked -p jet3 --lib export_relationship_candidate -- --ignored",
+    "notes": "Exact exported image hash is the acquisition input. No source-attestation or equivalence to other builds is claimed."
+  },
+  "expected_control": {
+    "version": "3.0",
+    "tables": [
+      "Child",
+      "MSysACEs",
+      "MSysObjects",
+      "MSysQueries",
+      "MSysRelationships",
+      "Parent"
+    ],
+    "relations": [
+      {
+        "name": "ParentChild",
+        "table": "Parent",
+        "foreign_table": "Child",
+        "attributes": 0,
+        "fields": [
+          {
+            "name": "Id",
+            "foreign_name": "ParentId"
+          }
+        ]
+      }
+    ],
+    "columns": {
+      "Parent": [
+        {
+          "name": "Id",
+          "type": 4,
+          "size": 4
+        },
+        {
+          "name": "Alternate",
+          "type": 4,
+          "size": 4
+        }
+      ],
+      "Child": [
+        {
+          "name": "ParentId",
+          "type": 4,
+          "size": 4
+        },
+        {
+          "name": "Alternate",
+          "type": 4,
+          "size": 4
+        }
+      ]
+    }
+  },
+  "execution": {
+    "environment": "Local private Windows VM, x86 PowerShell, DAO.DBEngine.36; development discovery only.",
+    "pre_mutation": "Host verifies inputs, candidate identity, and committed plan. Guest verifies script and prepares three exact hash-checked candidate copies before any CreateDatabase.",
+    "per_replica": "Create Parent(Id Long, Alternate Long), primary ById on Id then unique ByAlternate on Alternate; create Child(ParentId Long, Alternate Long) unindexed; append ParentChild relation Parent.Id to Child.ParentId with attributes zero. Close control. Read control and candidate separately read-only, enumerate all table names, user-table/field attributes and types/sizes, every user-table index and field binding, all relations/options/field pairs, and full user row snapshots. Close and rehash each image.",
+    "comparison": "Preserve column and index-field order. Sort index inventories and relations by name only. Compare complete endpoint/status/error and snapshots between replicas, and complete candidate snapshot to control; ignore no captured flags or bindings. Do not compare candidate bytes with control bytes.",
+    "control_anchor": "Require exactly declared tables/version/columns/relations, attributes zero on user tables, empty user rows, ById primary+unique on ascending Id and ByAlternate unique/nonprimary on ascending Alternate. Remaining DAO-exposed index metadata (including hidden-index visibility) is the differential control, not a guessed constant.",
+    "attempts": 1,
+    "run": "python3 oracle/windows-dao/scripts/relationship_candidate.py run CANDIDATE.mdb --shared-root VM_SHARED_ROOT --run-id UTC-relationship-candidate",
+    "analysis": "python3 oracle/windows-dao/scripts/relationship_candidate.py analyze OUTBOX; verifies pinned inputs again before emitting a report."
+  },
+  "decision_rule": {
+    "observed_accepted": "All three controls satisfy the declared anchor; all six files are unchanged by read-only opens; all replicated observations agree; candidate and control complete observations are identical.",
+    "not_observed_accepted": "All controls satisfy the anchor unchanged; all candidates unchanged and identically fail at an endpoint or return the same metadata/rows difference.",
+    "no_outcome": "Incomplete acquisition, control failure, changed image, or disagreement between replicas. Preserve errors and completed snapshots in the canonical report.",
+    "rejection": "Plan/result identity mismatch, unexpected replica inventory, candidate starting mismatch, or retained image identity mismatch rejects validation."
+  },
+  "boundary": "Only this exact 29-page image and metadata/empty-row endpoints. No general relationship composer/API, second relation, cascades, populated tables, integrity-enforcement mutations, existing-database updates, or hosted support claims.",
+  "retention": "Retain JSON result/report, logs, and control/candidate MDBs externally. Never commit MDB bytes or provider binaries. Record one additive EXP-0118 outcome from the validated report."
+}

--- a/oracle/windows-dao/scripts/relationship_candidate.ps1
+++ b/oracle/windows-dao/scripts/relationship_candidate.ps1
@@ -1,0 +1,162 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function New-Tables([string]$Path) {
+    $engine = $workspace = $db = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($name in @('Parent', 'Child')) {
+            $table = $field = $index = $key = $null
+            try {
+                $table = $db.CreateTableDef($name)
+                $first = if ($name -eq 'Parent') { 'Id' } else { 'ParentId' }
+                foreach ($column in @($first, 'Alternate')) {
+                    $field = $table.CreateField($column, 4)
+                    $table.Fields.Append($field)
+                    Release $field; $field = $null
+                }
+                if ($name -eq 'Parent') {
+                    foreach ($column in @('Id', 'Alternate')) {
+                        $index = $table.CreateIndex(('By' + $column))
+                        $index.Unique = $true
+                        $index.Primary = ($column -eq 'Id')
+                        $key = $index.CreateField($column)
+                        $index.Fields.Append($key)
+                        $table.Indexes.Append($index)
+                        Release $key; $key = $null
+                        Release $index; $index = $null
+                    }
+                }
+                $db.TableDefs.Append($table)
+            }
+            finally { Release $key; Release $index; Release $field; Release $table }
+        }
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Add-Relation([string]$Path, [string]$Name, [string]$ParentColumn, [string]$ChildColumn) {
+    $engine = $db = $relation = $field = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path)
+        $relation = $db.CreateRelation($Name, 'Parent', 'Child', 0)
+        $field = $relation.CreateField($ParentColumn)
+        $field.ForeignName = $ChildColumn
+        $relation.Fields.Append($field)
+        $db.Relations.Append($relation)
+    }
+    finally {
+        Release $field; Release $relation
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+    }
+}
+function Observe([string]$Path) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $snapshot = [ordered]@{}
+    $status = 'pass'; $endpoint = 'open_database'; $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.schema = @{}
+        foreach ($name in @('Parent', 'Child')) {
+            $table = $db.TableDefs.Item($name)
+            $fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes} })
+            $indexes = @()
+            foreach ($index in $table.Indexes) {
+                try {
+                    $keys = @($index.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })
+                    $indexes += @{name=[string]$index.Name; primary=[bool]$index.Primary; unique=[bool]$index.Unique; foreign=[bool]$index.Foreign; required=[bool]$index.Required; ignore_nulls=[bool]$index.IgnoreNulls; fields=$keys}
+                }
+                finally { Release $index }
+            }
+            $snapshot.schema[$name] = @{attributes=[int]$table.Attributes; fields=$fields; indexes=$indexes; rows=@()}
+            Release $table; $table = $null
+        }
+        $endpoint = 'relations'
+        $snapshot.relations = @()
+        foreach ($relation in $db.Relations) {
+            try {
+                $fields = @($relation.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })
+                $snapshot.relations += @{name=[string]$relation.Name; table=[string]$relation.Table; foreign_table=[string]$relation.ForeignTable; attributes=[int]$relation.Attributes; fields=$fields}
+            }
+            finally { Release $relation }
+        }
+        $endpoint = 'rows'
+        foreach ($name in @('Parent', 'Child')) {
+            $rs = $db.OpenRecordset($name, 4)
+            while (-not $rs.EOF) {
+                $values = @($rs.Fields | ForEach-Object {
+                    $value = $_.Value
+                    if ($null -eq $value -or [Convert]::IsDBNull($value)) { $null } else { [int]$value }
+                })
+                $snapshot.schema[$name].rows += ,$values
+                $rs.MoveNext()
+            }
+            $rs.Close(); Release $rs; $rs = $null
+        }
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'relationship-candidate.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/relationship_candidate.ps1') { throw 'Script pin mismatch' }
+$candidate = Join-Path $env:JET3_WORK 'relationship-candidate.mdb'
+foreach ($replica in 1..3) {
+    $path = Join-Path $env:JET3_WORK "candidate-r$replica.mdb"
+    Copy-Item -LiteralPath $candidate -Destination $path
+    $identity = Identity $path
+    if ($identity.size -ne $plan.candidate.size -or $identity.sha256 -cne $plan.candidate.sha256) { throw 'Candidate pin mismatch' }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_relationship_candidate_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($replica in 1..3) {
+        $control = Join-Path $env:JET3_WORK "control-r$replica.mdb"
+        New-Tables $control
+        Add-Relation $control 'ParentChild' 'Id' 'ParentId'
+        $result.replicas += @{replica=$replica; control=(Observe $control); candidate=(Observe (Join-Path $env:JET3_WORK "candidate-r$replica.mdb"))}
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    [IO.File]::WriteAllText((Join-Path $env:JET3_OUTBOX 'result.json'), (($result | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/relationship_candidate.py
+++ b/oracle/windows-dao/scripts/relationship_candidate.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Preregistered relationship candidate DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/relationship-candidate.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/relationship_candidate.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'relationship-candidate' or plan['replicas'] != 3:
+        raise ValueError('Unexpected experiment plan')
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+    return plan
+
+
+def preflight(candidate):
+    plan = verify_inputs()
+    if identity(candidate) != plan['candidate']:
+        raise ValueError('Candidate identity mismatch')
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def normalized(snapshot):
+    result = json.loads(canonical(snapshot))
+    if 'schema' in result:
+        for table in result['schema'].values():
+            table['indexes'] = sorted(table['indexes'], key=lambda index: index['name'])
+    if 'relations' in result:
+        result['relations'] = sorted(result['relations'], key=lambda relation: relation['name'])
+    return result
+
+
+def control_matches(snapshot, expected):
+    if any(snapshot.get(key) != expected[key] for key in ('version', 'tables', 'relations')):
+        return False
+    schema = snapshot.get('schema', {})
+    if set(schema) != set(expected['columns']):
+        return False
+    for name, columns in expected['columns'].items():
+        table = schema[name]
+        fields = [{key: field[key] for key in ('name', 'type', 'size')} for field in table['fields']]
+        if table['attributes'] != 0 or fields != columns or table['rows'] != []:
+            return False
+    # DAO exposes all other index metadata as the differential control.
+    parent = {index['name']: index for index in schema['Parent']['indexes']}
+    for name, column, primary in [('ById', 'Id', True), ('ByAlternate', 'Alternate', False)]:
+        index = parent.get(name)
+        if not index or index['primary'] is not primary or index['unique'] is not True or index['fields'] != [{'name': column, 'attributes': 0}]:
+            return False
+    return True
+
+
+def build_report(result, outbox, plan):
+    if (result['document_type'] != 'dao_relationship_candidate_result'
+            or result['plan_sha256'] != digest(PLAN) or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    observations, reasons = [], []
+    for number, replica in enumerate(result['replicas'], 1):
+        if replica['replica'] != number or number > 3:
+            raise ValueError('Unexpected replica inventory')
+        pair = {}
+        for role in ('control', 'candidate'):
+            observation = replica[role]
+            if identity(outbox / f'{role}-r{number}.mdb') != observation['after']:
+                raise ValueError('Retained image identity mismatch')
+            if role == 'candidate' and observation['before'] != plan['candidate']:
+                raise ValueError('Candidate starting identity mismatch')
+            if observation['before'] != observation['after']:
+                reasons.append(f'{role} replica {number}: read-only bytes changed')
+            pair[role] = {key: observation[key] for key in ('status', 'endpoint', 'error')}
+            pair[role]['snapshot'] = normalized(observation['snapshot'])
+        control = pair['control']
+        if (control['status'] != 'pass' or control['endpoint'] != 'complete'
+                or not control_matches(control['snapshot'], plan['expected_control'])):
+            reasons.append(f'Control replica {number} did not satisfy declared schema/relation/rows')
+        observations.append(pair)
+    if len(observations) != 3 or result['error'] is not None or result['mutation_started'] is not True:
+        reasons.append('Acquisition incomplete or failed: ' + str(result['error']))
+    if observations and any(pair != observations[0] for pair in observations):
+        reasons.append('Replicas disagree on endpoint observations')
+    outcome = 'no_outcome'
+    if not reasons:
+        outcome = 'observed_accepted' if observations[0]['candidate'] == observations[0]['control'] else 'not_observed_accepted'
+    return {'document_type': 'dao_relationship_candidate_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'candidate': plan['candidate'], 'outcome': outcome,
+            'reasons': reasons, 'observations': observations, 'compatibility_claim': False,
+            'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    output = outbox / 'report.json'
+    output.write_text(canonical(report) + '\n')
+    print(output)
+    print(report['outcome'])
+
+
+def dispatch(args):
+    preflight(args.candidate)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / PLAN.name)
+    shutil.copyfile(args.candidate, inbox / 'relationship-candidate.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        preflight(args.candidate)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_relationship_candidate.py
+++ b/oracle/windows-dao/tests/test_relationship_candidate.py
@@ -1,0 +1,70 @@
+import copy
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+spec = importlib.util.spec_from_file_location('relationship_candidate', SCRIPTS / 'relationship_candidate.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class RelationshipCandidateTests(unittest.TestCase):
+    def fixture(self, outbox):
+        plan = {'candidate': {'size': 9, 'sha256': experiment.hashlib.sha256(b'synthetic').hexdigest()},
+                'expected_control': {'version': '3.0', 'tables': ['Child', 'Parent'], 'relations': [],
+                                     'columns': {'Parent': [], 'Child': []}}}
+        snapshot = {'version': '3.0', 'tables': ['Child', 'Parent'], 'relations': [], 'schema': {
+            'Parent': {'attributes': 0, 'fields': [], 'rows': [], 'indexes': [
+                {'name': 'ById', 'primary': True, 'unique': True, 'fields': [{'name': 'Id', 'attributes': 0}]},
+                {'name': 'ByAlternate', 'primary': False, 'unique': True, 'fields': [{'name': 'Alternate', 'attributes': 0}]},
+            ]}, 'Child': {'attributes': 0, 'fields': [], 'rows': [], 'indexes': []}}}
+        observation = {'before': plan['candidate'], 'after': plan['candidate'], 'status': 'pass',
+                       'endpoint': 'complete', 'error': None, 'snapshot': snapshot}
+        result = {'document_type': 'dao_relationship_candidate_result', 'development_only': True,
+                  'plan_sha256': 'pinned-plan', 'mutation_started': True,
+                  'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'replicas': [], 'error': None}
+        for number in range(1, 4):
+            result['replicas'].append({'replica': number, 'control': copy.deepcopy(observation), 'candidate': copy.deepcopy(observation)})
+            for role in ('control', 'candidate'):
+                (outbox / f'{role}-r{number}.mdb').write_bytes(b'synthetic')
+        return plan, result
+
+    def test_acceptance_requires_matching_index_metadata_and_unchanged_images(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'digest', return_value='pinned-plan'):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            # Identity uses the real candidate digest while plan hashing is mocked.
+            with patch.object(experiment, 'identity', return_value=plan['candidate']):
+                self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'observed_accepted')
+                for replica in result['replicas']:
+                    replica['candidate']['snapshot']['schema']['Parent']['indexes'][0]['unique'] = False
+                self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'not_observed_accepted')
+                result['replicas'][1]['candidate']['endpoint'] = 'schema'
+                self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+                result['replicas'][0]['candidate']['before'] = {'size': 0, 'sha256': 'wrong'}
+                with self.assertRaisesRegex(ValueError, 'starting identity'):
+                    experiment.build_report(result, outbox, plan)
+
+    def test_control_failure_and_partial_acquisition_cannot_be_accepted(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'digest', return_value='pinned-plan'):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            with patch.object(experiment, 'identity', return_value=plan['candidate']):
+                result['replicas'].pop()
+                result['error'] = 'DAO mutation failed'
+                self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+            with patch.object(experiment, 'identity', return_value={'size': 0, 'sha256': 'changed'}):
+                with self.assertRaisesRegex(ValueError, 'Retained image'):
+                    experiment.build_report(result, outbox, plan)
+
+    def test_standalone_analysis_verifies_input_pins(self):
+        with patch.object(experiment, 'verify_inputs', side_effect=ValueError('Input pin mismatch')):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                experiment.analyze(Path('unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Preregister DAO validation of the exact private first-relationship image from #196. Three fresh controls and three pinned candidate replicas must expose matching tables, fields, every captured index flag/binding, the expected relation, and empty row snapshots, with unchanged file identities after read-only access.

The plan pins the candidate and experiment inputs; both dispatch and analysis enforce input hashes. Failure or disagreement remains a scientific result without retry. The single authorized run completed as `observed_accepted` in all three replicas; its additive outcome is being recorded separately. No general compatibility/support claim is added.

Validation: independent harness review with no findings, three focused analyzer tests, PowerShell syntax check, committed-plan/candidate preflight, and `just ready` passed.

Part of #100; stacked after #196.
