### PR TITLE
docs: record accepted multi-page row creation result

### DIFF
--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -8,13 +8,9 @@
 //! pre-publication failure.
 //!
 //! The structural reopen is a publication prerequisite, not compatibility
-//! evidence. Only a recorded DAO differential can establish that Microsoft
-//! Access or DAO consume a created database; none has been run for schemas
-//! other than the exact `EXP-0091`, `EXP-0107`, `EXP-0110`, and `EXP-0112`
-//! constructions.
-//! `EXP-0110` observed DAO read one composed four-table image built from the
-//! `EXP-0087` later-create pattern; it does not establish other table counts,
-//! orders, names, or schemas.
+//! evidence. DAO observations in `docs/PROVENANCE.md` cover exact candidates;
+//! they do not establish arbitrary schemas, values, or general compatibility.
+//! Hosted differential results govern the support matrix.
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -162,10 +158,9 @@ pub fn create_database(
 /// [`create_database`] apply. Composition and the structural row comparison
 /// are charged to `budget`. Unsupported schemas and rows fail before writing.
 ///
-/// `EXP-0112` observed DAO read one exact `Rows(Id Long, Code Text 8)` image
-/// containing `(1, "one")`, `(-2, "two")`, and `(null, null)` unchanged in three
-/// local replicas. This establishes only that candidate, not other schemas or
-/// values, general compatibility, or hosted write-differential coverage.
+/// DAO observations cover only the exact candidates recorded in the provenance
+/// ledger. Construction bounds alone do not establish general compatibility or
+/// hosted write-differential coverage.
 pub fn create_database_with_rows(
     path: impl AsRef<Path>,
     table: &TableSpec<'_>,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10182,7 +10182,9 @@ Use `not applicable` explicitly rather than omitting a field.
   this result. The support matrix does not move.
 - Usage: issue `#100`; bounded multiple-data-page initial-row construction.
 - Rights: MDB bytes and provider binaries remain outside the repository.
-- Review: outcome implementation pass complete; independent review pending.
+- Review: independent report, input and retained-artifact identity, row
+  snapshot, additive-provenance, and evidence-boundary review completed
+  without findings.
 
 
 ## Fixtures and black-box results

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10133,6 +10133,58 @@ Use `not applicable` explicitly rather than omitting a field.
   tests and a PowerShell parser-only check pass.
 
 
+### EXP-0116 — Accepted multiple-data-page initial-row result
+
+- Recorded: 2026-09-04, OpenAI Codex (run timestamp is 2026-09-05 UTC)
+- Kind: validated SHA-256-pinned, development-only local DAO result
+- Question: does DAO read the exact `EXP-0115` candidate containing 509 Long
+  values across three data pages unchanged, matching fresh controls in all
+  three replicas?
+- Origin and binding: `EXP-0115` preregistration committed before acquisition
+  as `513b80e4dfd35124d80c4580c8c905717f7a5b83`; plan
+  `oracle/windows-dao/acquisition/multi-page-rows.plan.json`, SHA-256
+  `997070626c1b1c9f3e2daeae6c9a99333060c47916a2ac46c34e9c60073a50a2`.
+  Candidate source is `826b1318669071afc360659201fd8c012ff07bd0`.
+- Authorization and dispatch: user authorization covered single run
+  `20260905T032600Z-multi-page-rows`, dispatched once after the exact plan was
+  committed and reviewed. No retry occurred.
+- Environment: result records a 32-bit process, `DAO.DBEngine.36`, and
+  `Microsoft Windows NT 10.0.20348.0`.
+- Protocol and validation: the unchanged analyzer rechecked all preregistered
+  input pins, plan/result binding, candidate starting identities, retained
+  image identities, unchanged before/after sizes and hashes, expected control
+  schema and row multiset, and agreement across three replicas. Running it on
+  temporary copies of retained artifacts reproduced the canonical report byte
+  for byte; retained originals were read only.
+- Artifacts: local outbox `20260905T032600Z-multi-page-rows` retains
+  `result.json`, 745,900 bytes, SHA-256
+  `af1189cbe265c5b93871ef84e4570d5cd3804d619091bfb8e716dd515ca8632c`;
+  canonical `report.json`, 466 bytes, SHA-256
+  `c1bb6ac0e2294bccc36dd1c1f31daf7f88785996575333ff2fe914c491680f50`.
+- Retained candidates: each remained 53,248 bytes, SHA-256
+  `57498e634b9e4e7102efd4f4c2d673cccd42c344b51590177c7704232df675af`.
+  Controls also remained 53,248 bytes, with replica hashes respectively
+  `a515b61b4022f403809503051029c7692e77b6421ec466dbe1a9b612989e0fe3`,
+  `500ead2e707f9d1acdfbd1a40538b0e5c888c9dc0bbb1de3ddfb23d98efbe7fe`, and
+  `4bb744e1c1ee6687487c2414be9bf00b3d239a65571b9dc395b5fa09726ba9cf`.
+- Observation: canonical report records `observed_accepted`, three replicas,
+  `compatibility_claim=false`, and `support_movement=false`. All six images
+  completed schema and row endpoints: version `3.0`, exactly `Rows` plus the
+  four expected system tables, one `Id` Long field of size 4, no indexes, and
+  exactly one occurrence of each integer from -254 through 254.
+- Interpretation: DAO consumed unchanged the exact candidate whose three data
+  pages hold 254, 254, and 1 rows, with all three owned, only the final page
+  available, and the composed page-zero header retained. These are the pinned
+  candidate's construction choices; this result establishes no general DAO
+  availability threshold, header-update rule, or matching control layout.
+  Other schemas or values, indexed rows, long values, existing-database
+  mutation, general compatibility, and hosted support coverage remain outside
+  this result. The support matrix does not move.
+- Usage: issue `#100`; bounded multiple-data-page initial-row construction.
+- Rights: MDB bytes and provider binaries remain outside the repository.
+- Review: outcome implementation pass complete; independent review pending.
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -45,15 +45,15 @@ delivered in this order:
 
 Continue database creation under #100. The public API creates up to four empty
 user tables within its bounded schema restrictions. Initial-row creation now
-accepts one unindexed table with a one-page definition and scalar rows fitting
-one data page, with room left for another all-null row. AutoIncrement, Memo,
-and OLE values remain refused by that entry point.
+accepts one unindexed table with a one-page definition and scalar rows packed
+across data pages within the existing inline-map capacity. AutoIncrement,
+Memo, and OLE values remain refused by that entry point.
 
-`EXP-0110` observed DAO read the exact four-table candidate unchanged.
-`EXP-0112` now records three accepted local replicas of the exact
-`Rows(Id Long, Code Text 8)` candidate containing `(1, "one")`, `(-2, "two")`,
-and `(null, null)`. These observations establish only the pinned candidates;
-they do not establish general compatibility or move the support matrix.
+`EXP-0116` records three accepted local replicas of the exact 26-page
+`Rows(Id Long)` candidate containing integers -254 through 254 across three
+data pages. Earlier exact empty-table and one-page observations remain in the
+provenance ledger. These results establish only the pinned candidates, with no
+general allocation policy, compatibility claim, or support-matrix movement.
 
 Next, broaden initial-row creation in focused implementation and preregistered
 DAO experiment slices, including indexes and long values, and add relationships.


### PR DESCRIPTION
Record DAO acceptance of the exact Rust-created 509-row database spanning three data pages. All three controls and candidate replicas exposed the expected schema and values without changing file identities; EXP-0116 records the validated report and artifact identities.

The scope checkpoint now reflects multi-page scalar row creation. API documentation uses a stable provenance caveat instead of accumulating experiment history. No general allocation or interoperability claim is added, and consumed experiment inputs remain unchanged.

Validation: independent outcome/identity review, byte-identical report reproduction, rustdoc, formatting, and `just ready` passed.

Part of #100; stacked after #197.
