### PR TITLE
feat(jet3): populate bounded Long indexes during creation

### DIFF
--- a/crates/jet3/examples/indexed_row_candidate.rs
+++ b/crates/jet3/examples/indexed_row_candidate.rs
@@ -1,0 +1,66 @@
+//! Deterministic primary, unique, and duplicate-key ordinary DAO candidates.
+use jet3::{
+    ColumnSpec, ColumnType, IndexColumnSpec, IndexKind, IndexSpec, ResourceBudget, ResourceLimits,
+    RowValue, TableSpec, create_database_with_rows,
+};
+use std::num::NonZeroU8;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args_os().skip(1);
+    let path = args
+        .next()
+        .ok_or("usage: indexed_row_candidate OUTPUT.mdb [primary|unique|ordinary]")?;
+    let kind = match args
+        .next()
+        .as_deref()
+        .and_then(|value| value.to_str())
+        .unwrap_or("primary")
+    {
+        "primary" => IndexKind::Primary,
+        "unique" => IndexKind::Unique,
+        "ordinary" => IndexKind::Ordinary,
+        _ => return Err("index kind must be primary, unique, or ordinary".into()),
+    };
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(
+            b"Payload",
+            ColumnType::Text {
+                max_len: NonZeroU8::new(255).ok_or("invalid length")?,
+            },
+        ),
+    ];
+    let indexes = [IndexSpec {
+        name: b"ById",
+        fields: &[IndexColumnSpec::ascending(b"Id")],
+        kind,
+    }];
+    let table = TableSpec {
+        name: b"Rows",
+        columns: &columns,
+        indexes: &indexes,
+    };
+    let payloads = (0_u8..20)
+        .map(|position| [b'a' + position; 255])
+        .collect::<Vec<_>>();
+    let values = payloads
+        .iter()
+        .enumerate()
+        .map(|(position, payload)| {
+            let key = if kind == IndexKind::Ordinary {
+                9 - (position % 10) as i32
+            } else {
+                9 - position as i32
+            };
+            [RowValue::Long(key), RowValue::Text(payload)]
+        })
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(
+        path,
+        &table,
+        &rows,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -5,7 +5,19 @@ use super::*;
 /// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
-    /// Initial rows require an unindexed, single-page definition without
+    /// Initial rows support at most one ascending, single-Long-column index.
+    UnsupportedInitialIndexSchema,
+    /// Null indexed keys are outside the bounded initial-index construction.
+    NullInitialIndexKey {
+        /// Zero-based input row.
+        row: usize,
+    },
+    /// A primary or unique initial index repeats a key.
+    DuplicateInitialIndexKey {
+        /// Repeated Long value.
+        value: i32,
+    },
+    /// Initial rows require a single-page definition without
     /// AutoIncrement or long-value columns.
     UnsupportedInitialRowSchema,
     /// A table definition could not be encoded.
@@ -81,6 +93,9 @@ impl std::error::Error for ComposeError {
             Self::NameKey(source) => Some(source),
             Self::Schema(source) => Some(source),
             Self::UnsupportedInitialRowSchema
+            | Self::UnsupportedInitialIndexSchema
+            | Self::NullInitialIndexKey { .. }
+            | Self::DuplicateInitialIndexKey { .. }
             | Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
             | Self::UnobservedLongValueColumnCount { .. }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -389,6 +389,10 @@ use definitions::{
     msys_relationships_definition,
 };
 
+#[path = "bootstrap_initial_index.rs"]
+mod initial_index;
+pub(crate) use initial_index::InitialLongIndex;
+
 #[path = "bootstrap_table_create.rs"]
 mod table_create;
 use table_create::PlannedCreate;

--- a/crates/jet3/src/bootstrap_initial_index.rs
+++ b/crates/jet3/src/bootstrap_initial_index.rs
@@ -1,0 +1,178 @@
+//! One uncompressed ascending Long leaf: EXP-0062 key and locator grammar,
+//! matching the existing catalog Long encoder; EXP-0073 distinct-key counts.
+
+use super::*;
+use crate::{IndexKind, IndexTree, RowLocator};
+
+const KEY_BYTES: usize = 5;
+const ENTRY_BYTES: usize = KEY_BYTES + 4;
+const MAX_ENTRIES: usize = INDEX_ENTRY_AREA_LEN / ENTRY_BYTES;
+
+#[derive(Debug, Clone)]
+pub(crate) struct InitialLongIndex {
+    column: usize,
+    unique: bool,
+    entries: Vec<[u8; ENTRY_BYTES]>,
+    distinct: u32,
+}
+
+impl InitialLongIndex {
+    pub(crate) fn new(
+        spec: &TableSpec<'_>,
+        row_count: usize,
+        budget: &mut ResourceBudget,
+    ) -> Result<Option<Self>, ComposeError> {
+        let [index] = spec.indexes else {
+            return if spec.indexes.is_empty() {
+                Ok(None)
+            } else {
+                Err(ComposeError::UnsupportedInitialIndexSchema)
+            };
+        };
+        let [field] = index.fields else {
+            return Err(ComposeError::UnsupportedInitialIndexSchema);
+        };
+        let column = field
+            .column
+            .resolve(spec.columns)
+            .map(usize::from)
+            .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
+        if field.direction != IndexDirection::Ascending
+            || spec
+                .columns
+                .get(column)
+                .is_none_or(|column| column.column_type() != ColumnType::Long)
+        {
+            return Err(ComposeError::UnsupportedInitialIndexSchema);
+        }
+        if row_count > MAX_ENTRIES {
+            return Err(ComposeError::IndexPageFull {
+                needed: row_count.saturating_mul(ENTRY_BYTES),
+                available: INDEX_ENTRY_AREA_LEN,
+            });
+        }
+        budget.charge_allocation(ByteCount::new((row_count * ENTRY_BYTES) as u64))?;
+        let mut entries = Vec::new();
+        entries
+            .try_reserve_exact(row_count)
+            .map_err(|_| Error::Io {
+                operation: "reserve initial Long index entries",
+                kind: std::io::ErrorKind::OutOfMemory,
+            })?;
+        Ok(Some(Self {
+            column,
+            unique: index.kind != IndexKind::Ordinary,
+            entries,
+            distinct: 0,
+        }))
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        values: &[RowValue<'_>],
+        locator: RowLocator,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), ComposeError> {
+        let Some(RowValue::Long(value)) = values.get(self.column) else {
+            return Err(ComposeError::NullInitialIndexKey {
+                row: self.entries.len(),
+            });
+        };
+        budget.charge_items(1)?;
+        let page = u32::try_from(locator.page().get()).map_err(|_| Error::IntegerConversion {
+            value: locator.page().get() as u128,
+            target: "24-bit index row page",
+        })?;
+        if page > 0x00ff_ffff {
+            return Err(Error::IntegerConversion {
+                value: page as u128,
+                target: "24-bit index row page",
+            }
+            .into());
+        }
+        let mut entry = [0_u8; ENTRY_BYTES];
+        entry[0] = 0x7f;
+        entry[1..KEY_BYTES].copy_from_slice(&value.to_be_bytes());
+        entry[1] ^= 0x80;
+        entry[KEY_BYTES..KEY_BYTES + 3].copy_from_slice(&page.to_be_bytes()[1..]);
+        entry[ENTRY_BYTES - 1] = locator.slot();
+        self.entries.push(entry);
+        Ok(())
+    }
+
+    pub(crate) fn sort(&mut self, budget: &mut ResourceBudget) -> Result<(), ComposeError> {
+        // At most 200 entries; charge a conservative quadratic byte-comparison bound.
+        let count = self.entries.len() as u64;
+        budget.charge_work_units(count * count * ENTRY_BYTES as u64)?;
+        self.entries.sort_unstable();
+        self.distinct = u32::from(!self.entries.is_empty());
+        for pair in self.entries.windows(2) {
+            if pair[0][..KEY_BYTES] == pair[1][..KEY_BYTES] {
+                if self.unique {
+                    let mut raw: [u8; 4] =
+                        pair[1][1..KEY_BYTES]
+                            .try_into()
+                            .map_err(|_| Error::Arithmetic {
+                                operation: "decode duplicate Long index key",
+                            })?;
+                    raw[0] ^= 0x80;
+                    return Err(ComposeError::DuplicateInitialIndexKey {
+                        value: i32::from_be_bytes(raw),
+                    });
+                }
+            } else {
+                self.distinct += 1;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) const fn distinct_count(&self) -> u32 {
+        self.distinct
+    }
+
+    pub(super) fn image(
+        &self,
+        owner: PageNumber,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, ComposeError> {
+        let mut bytes = [0_u8; PAGE_BYTES];
+        bytes[0] = 4;
+        bytes[1] = 1;
+        let used = self.entries.len() * ENTRY_BYTES;
+        bytes[2..4].copy_from_slice(&((INDEX_ENTRY_AREA_LEN - used) as u16).to_le_bytes());
+        let owner = u32::try_from(owner.get()).map_err(|_| Error::IntegerConversion {
+            value: owner.get() as u128,
+            target: "u32 index owner",
+        })?;
+        bytes[4..8].copy_from_slice(&owner.to_le_bytes());
+        for (position, entry) in self.entries.iter().enumerate() {
+            let start = INDEX_ENTRY_AREA_OFFSET + position * ENTRY_BYTES;
+            bytes[start..start + ENTRY_BYTES].copy_from_slice(entry);
+            let end = (position + 1) * ENTRY_BYTES;
+            bytes[INDEX_BOUNDARY_BITMAP_OFFSET + end / 8] |= 1 << (end % 8);
+        }
+        let mut image = PageImage::new(PageKind::LeafIndex);
+        image.write_at(PageOffset::new(0), &bytes, budget)?;
+        Ok(image)
+    }
+
+    pub(crate) fn matches(&self, tree: &IndexTree) -> bool {
+        self.entries.len() == tree.entries().len()
+            && self
+                .entries
+                .iter()
+                .zip(tree.entries())
+                .all(|(expected, actual)| {
+                    actual.key().raw_bytes() == &expected[..KEY_BYTES]
+                        && actual.row().page().get()
+                            == u64::from(u32::from_be_bytes([
+                                0,
+                                expected[5],
+                                expected[6],
+                                expected[7],
+                            ]))
+                        && actual.row().slot() == expected[8]
+                })
+    }
+}

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -53,6 +53,7 @@ pub(super) struct PlannedCreate<'a> {
     long_value: Option<u16>,
     initial_data: Vec<InitialDataPage>,
     initial_row_count: u32,
+    initial_index: Option<InitialLongIndex>,
 }
 
 #[derive(Debug, Clone)]
@@ -86,6 +87,7 @@ impl<'a> PlannedCreate<'a> {
             long_value,
             initial_data: Vec::new(),
             initial_row_count: 0,
+            initial_index: None,
         })
     }
 
@@ -98,8 +100,7 @@ impl<'a> PlannedCreate<'a> {
         rows: &[&[RowValue<'_>]],
         budget: &mut ResourceBudget,
     ) -> Result<Self, ComposeError> {
-        if !self.spec.indexes.is_empty()
-            || self.plan.continuation_page().is_some()
+        if self.plan.continuation_page().is_some()
             || self.spec.columns.iter().any(|column| {
                 column.column_type().is_long_value()
                     || column.column_type() == ColumnType::AutoIncrement
@@ -107,6 +108,7 @@ impl<'a> PlannedCreate<'a> {
         {
             return Err(ComposeError::UnsupportedInitialRowSchema);
         }
+        self.initial_index = InitialLongIndex::new(self.spec, rows.len(), budget)?;
         if rows.is_empty() {
             return Ok(self);
         }
@@ -127,17 +129,24 @@ impl<'a> PlannedCreate<'a> {
         for row in rows {
             let length = encode_row(&layout, row, &mut encoded, budget)?.get() as usize;
             let bytes = &encoded[..length];
-            match builder.append_row(bytes, budget) {
-                Ok(_) => {}
+            let slot = match builder.append_row(bytes, budget) {
+                Ok(slot) => slot,
                 Err(PageImageError::PageFull { .. } | PageImageError::RowSlotsExhausted { .. })
                     if builder.row_count() != 0 =>
                 {
                     self.push_initial_page(builder, minimum, budget)?;
                     builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
-                    builder.append_row(bytes, budget)?;
+                    builder.append_row(bytes, budget)?
                 }
                 Err(error) => return Err(error.into()),
+            };
+            let locator = crate::RowLocator::new(PageNumber::new(self.page_count()), slot);
+            if let Some(index) = &mut self.initial_index {
+                index.push(row, locator, budget)?;
             }
+        }
+        if let Some(index) = &mut self.initial_index {
+            index.sort(budget)?;
         }
         self.push_initial_page(builder, minimum, budget)?;
         Ok(self)
@@ -245,7 +254,12 @@ impl<'a> PlannedCreate<'a> {
         }
         let owner = self.plan.definition_root().get();
         for _ in self.plan.index_placements() {
-            plan.append(empty_index_page(owner, budget)?, append_map, budget)?;
+            let image = if let Some(index) = &self.initial_index {
+                index.image(self.plan.definition_root(), budget)?
+            } else {
+                empty_index_page(owner, budget)?
+            };
+            plan.append(image, append_map, budget)?;
         }
         for data in &self.initial_data {
             plan.append(data.image.clone(), append_map, budget)?;
@@ -307,7 +321,11 @@ impl<'a> PlannedCreate<'a> {
                 usage_map_row: row,
                 root,
                 flags: index.kind.flags(),
-                entry_count: 0,
+                // EXP-0073: the prefix counts distinct keys, not leaf entries.
+                entry_count: self
+                    .initial_index
+                    .as_ref()
+                    .map_or(0, InitialLongIndex::distinct_count),
             })
             .collect::<Vec<_>>();
         let logical = logical_index_order(spec.indexes)

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -20,7 +20,8 @@ use std::path::Path;
 
 use crate::atomic::atomic_create;
 use crate::bootstrap_composer::{
-    ComposeError, compose_database, compose_database_with_rows, initial_row_layout,
+    ComposeError, InitialLongIndex, compose_database, compose_database_with_rows,
+    initial_row_layout,
 };
 use crate::page_append_plan::PlannedPage;
 use crate::{
@@ -61,6 +62,8 @@ impl StdError for CreateDatabaseError {
 /// found when the candidate was reopened before publication.
 #[derive(Debug)]
 pub enum CandidateCheckError {
+    /// The candidate index tree could not be read.
+    Index(crate::IndexTreeError),
     /// The candidate rows could not be read.
     Rows(RowError),
     /// Requested rows could not be encoded for comparison.
@@ -81,6 +84,7 @@ pub enum CandidateCheckError {
 impl fmt::Display for CandidateCheckError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Index(source) => write!(formatter, "candidate index scan failed: {source}"),
             Self::Rows(source) => write!(formatter, "candidate row scan failed: {source}"),
             Self::RowEncoding(source) => {
                 write!(formatter, "candidate row comparison failed: {source}")
@@ -100,6 +104,7 @@ impl fmt::Display for CandidateCheckError {
 impl StdError for CandidateCheckError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
+            Self::Index(source) => Some(source),
             Self::Rows(source) => Some(source),
             Self::RowEncoding(source) => Some(source),
             Self::Open(source) => Some(source),
@@ -146,12 +151,16 @@ pub fn create_database(
     .map_err(CreateDatabaseError::Publish)
 }
 
-/// Creates one unindexed table containing scalar initial rows in caller order.
+/// Creates one table containing scalar initial rows in caller order.
 ///
 /// Rows are packed in caller order into data pages within the inline usage-map
 /// capacity. Each row and the table definition must fit one page. Pages with
 /// a slot and room for an all-null row are marked available; this construction
 /// policy has not been established as DAO's allocation policy.
+/// At most one ascending index on one Long column is accepted, with at most
+/// 200 non-null keys in a single leaf. Primary and unique indexes reject
+/// duplicate keys; ordinary indexes retain duplicates. Null keys, descending
+/// indexes, and other key types are refused.
 /// AutoIncrement, Memo, and LongBinary columns are refused. Values use the
 /// same database-code-page and physical scalar representations as [`RowValue`].
 /// The existing-destination and atomic publication guarantees of
@@ -204,6 +213,8 @@ fn check_initial_rows(
     let definition = database
         .table_definition(root, budget)
         .map_err(CandidateCheckError::Definition)?;
+    let mut expected_index = InitialLongIndex::new(table, rows.len(), budget)
+        .map_err(CandidateCheckError::RowEncoding)?;
     let mut encoded = [0_u8; crate::PAGE_BYTES];
     let mut cursor = database
         .rows(&definition, budget)
@@ -223,6 +234,12 @@ fn check_initial_rows(
                 detail: "initial row value",
             });
         }
+        let locator = actual.locator();
+        if let Some(index) = &mut expected_index {
+            index
+                .push(row, locator, cursor.owned.budget_mut())
+                .map_err(CandidateCheckError::RowEncoding)?;
+        }
     }
     if cursor
         .next_row()
@@ -232,6 +249,20 @@ fn check_initial_rows(
         return Err(CandidateCheckError::Mismatch {
             detail: "initial row count",
         });
+    }
+    drop(cursor);
+    if let Some(mut expected) = expected_index {
+        expected
+            .sort(budget)
+            .map_err(CandidateCheckError::RowEncoding)?;
+        let actual = database
+            .index_tree(&definition, 0, budget)
+            .map_err(CandidateCheckError::Index)?;
+        if !expected.matches(&actual) {
+            return Err(CandidateCheckError::Mismatch {
+                detail: "initial index entries",
+            });
+        }
     }
     Ok(())
 }

--- a/crates/jet3/src/create_initial_index_tests.rs
+++ b/crates/jet3/src/create_initial_index_tests.rs
@@ -1,0 +1,293 @@
+use super::*;
+
+const ID_FIELD: [IndexColumnSpec<'static>; 1] = [field(0, IndexDirection::Ascending)];
+
+fn one_index(kind: IndexKind) -> [IndexSpec<'static>; 1] {
+    [IndexSpec {
+        name: b"ById",
+        fields: &ID_FIELD,
+        kind,
+    }]
+}
+
+fn tree(path: &std::path::Path) -> Result<crate::IndexTree, Box<dyn std::error::Error>> {
+    let mut budget = budget();
+    let mut database = DatabaseReader::open(path, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(20), &mut budget)?;
+    Ok(database.index_tree(&definition, 0, &mut budget)?)
+}
+
+#[test]
+fn ascending_long_keys_sort_signed_extremes_and_retain_row_locators() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Primary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(i32::MAX)],
+        &[RowValue::Long(i32::MIN)],
+        &[RowValue::Long(0)],
+        &[RowValue::Long(-1)],
+    ];
+    create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+    let index = tree(&directory.target())?;
+    let expected = [
+        ([0x7f, 0, 0, 0, 0], 1),
+        ([0x7f, 0x7f, 0xff, 0xff, 0xff], 3),
+        ([0x7f, 0x80, 0, 0, 0], 2),
+        ([0x7f, 0xff, 0xff, 0xff, 0xff], 0),
+    ];
+    for (entry, (key, slot)) in index.entries().iter().zip(expected) {
+        assert_eq!(entry.key().raw_bytes(), key);
+        assert_eq!(
+            entry.row(),
+            crate::RowLocator::new(PageNumber::new(24), slot)
+        );
+    }
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(
+        &bytes[20 * crate::PAGE_BYTES + 47..20 * crate::PAGE_BYTES + 51],
+        &4_u32.to_le_bytes()
+    );
+    assert!(map_bit(&bytes, 21, 2, 23)?);
+    assert!(!map_bit(&bytes, 21, 0, 23)?);
+    assert!(map_bit(&bytes, 21, 0, 24)?);
+    Ok(())
+}
+
+#[test]
+fn duplicate_keys_are_distinct_counted_for_ordinary_and_rejected_for_unique() -> TestResult {
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(2)],
+        &[RowValue::Long(1)],
+        &[RowValue::Long(2)],
+    ];
+    for kind in [IndexKind::Primary, IndexKind::Unique, IndexKind::Ordinary] {
+        let directory = TestDirectory::create()?;
+        let indexes = one_index(kind);
+        let table = TableSpec {
+            name: b"Items",
+            columns: &[ID],
+            indexes: &indexes,
+        };
+        let result = create_database_with_rows(directory.target(), &table, rows, &mut budget());
+        if kind == IndexKind::Ordinary {
+            result?;
+            let bytes = fs::read(directory.target())?;
+            assert_eq!(
+                &bytes[20 * crate::PAGE_BYTES + 47..20 * crate::PAGE_BYTES + 51],
+                &2_u32.to_le_bytes()
+            );
+            let index = tree(&directory.target())?;
+            assert_eq!(
+                index
+                    .entries()
+                    .iter()
+                    .map(|entry| entry.row().slot())
+                    .collect::<Vec<_>>(),
+                [1, 0, 2]
+            );
+        } else {
+            assert!(matches!(
+                result,
+                Err(CreateDatabaseError::Compose(
+                    ComposeError::DuplicateInitialIndexKey { value: 2 }
+                ))
+            ));
+            assert!(directory.entries()?.is_empty());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn indexed_payload_rows_can_reference_multiple_data_pages() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let columns = [
+        ID,
+        ColumnSpec::new(b"Payload", ColumnType::Text { max_len: nz(255) }),
+    ];
+    let indexes = one_index(IndexKind::Unique);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &indexes,
+    };
+    let text = [b'x'; 255];
+    let values = (0..20)
+        .map(|value| [RowValue::Long(19 - value), RowValue::Text(&text)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    for (key, entry) in tree(&directory.target())?.entries().iter().enumerate() {
+        let ordinal = 19 - key;
+        assert_eq!(
+            entry.row(),
+            crate::RowLocator::new(
+                PageNumber::new(24 + ordinal as u64 / 7),
+                (ordinal % 7) as u8
+            )
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn leaf_capacity_is_exact_and_overflow_preserves_destination() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Primary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let values = (0..201)
+        .map(|value| [RowValue::Long(value)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(directory.target(), &table, &rows[..200], &mut budget())?;
+    let original = fs::read(directory.target())?;
+    assert_eq!(tree(&directory.target())?.entries().len(), 200);
+    assert_eq!(
+        &original[23 * crate::PAGE_BYTES + 2..23 * crate::PAGE_BYTES + 4],
+        &[0, 0]
+    );
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::IndexPageFull {
+            needed: 1809,
+            available: 1800
+        }))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn null_keys_and_unsupported_key_schemas_fail_before_publication() -> TestResult {
+    let directory = TestDirectory::create()?;
+    for kind in [IndexKind::Primary, IndexKind::Unique, IndexKind::Ordinary] {
+        let indexes = one_index(kind);
+        let table = TableSpec {
+            name: b"Items",
+            columns: &[ID],
+            indexes: &indexes,
+        };
+        assert!(matches!(
+            create_database_with_rows(
+                directory.target(),
+                &table,
+                &[&[RowValue::Null]],
+                &mut budget()
+            ),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::NullInitialIndexKey { row: 0 }
+            ))
+        ));
+    }
+    let multiple = [
+        one_index(IndexKind::Ordinary)[0],
+        IndexSpec {
+            name: b"Other",
+            ..one_index(IndexKind::Ordinary)[0]
+        },
+    ];
+    let descending = [IndexSpec {
+        fields: &[field(0, IndexDirection::Descending)],
+        ..one_index(IndexKind::Ordinary)[0]
+    }];
+    let composite = [IndexSpec {
+        fields: &[
+            field(0, IndexDirection::Ascending),
+            field(1, IndexDirection::Ascending),
+        ],
+        ..one_index(IndexKind::Ordinary)[0]
+    }];
+    let text = [IndexSpec {
+        fields: &[IndexColumnSpec::ascending(b"Code")],
+        ..one_index(IndexKind::Ordinary)[0]
+    }];
+    for indexes in [&multiple[..], &descending, &composite, &text] {
+        let table = TableSpec {
+            name: b"Items",
+            columns: &[ID, CODE],
+            indexes,
+        };
+        assert!(matches!(
+            create_database_with_rows(directory.target(), &table, &[], &mut budget()),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::UnsupportedInitialIndexSchema
+            ))
+        ));
+    }
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn candidate_check_rejects_index_owner_and_key_corruption() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Primary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let rows: &[&[RowValue<'_>]] = &[&[RowValue::Long(1)], &[RowValue::Long(2)]];
+    create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+    let original = fs::read(directory.target())?;
+    let mut changed = original.clone();
+    changed[23 * crate::PAGE_BYTES + 4] = 19;
+    fs::write(directory.target(), &changed)?;
+    assert!(matches!(
+        super::super::super::check_initial_rows(&directory.target(), &table, rows, &mut budget()),
+        Err(CandidateCheckError::Index(_))
+    ));
+    let mut changed = original;
+    changed[23 * crate::PAGE_BYTES + 248 + 4] = 0;
+    fs::write(directory.target(), &changed)?;
+    assert!(matches!(
+        super::super::super::check_initial_rows(&directory.target(), &table, rows, &mut budget()),
+        Err(CandidateCheckError::Mismatch {
+            detail: "initial index entries"
+        })
+    ));
+    Ok(())
+}
+
+#[test]
+fn index_storage_budget_and_empty_index_are_handled() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Primary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    create_database_with_rows(directory.target(), &table, &[], &mut budget())?;
+    assert!(tree(&directory.target())?.entries().is_empty());
+    let original = fs::read(directory.target())?;
+    let mut limited = ResourceBudget::new(
+        ResourceLimits::default().with_max_allocation_bytes(crate::ByteCount::new(8)),
+    );
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::Long(1)]],
+            &mut limited
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::Encoding(
+            crate::Error::ResourceLimitExceeded {
+                kind: crate::ResourceLimitKind::AllocationBytes,
+                ..
+            }
+        )))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    Ok(())
+}

--- a/crates/jet3/src/create_initial_rows_tests.rs
+++ b/crates/jet3/src/create_initial_rows_tests.rs
@@ -91,27 +91,6 @@ fn unsupported_initial_row_schemas_leave_no_file() -> TestResult {
             ))
         ));
     }
-    let indexes = [IndexSpec {
-        name: b"ById",
-        fields: &[IndexColumnSpec::ascending(b"Id")],
-        kind: IndexKind::Ordinary,
-    }];
-    let table = TableSpec {
-        name: b"Items",
-        columns: &[ID],
-        indexes: &indexes,
-    };
-    assert!(matches!(
-        create_database_with_rows(
-            directory.target(),
-            &table,
-            &[&[RowValue::Long(1)]],
-            &mut budget()
-        ),
-        Err(CreateDatabaseError::Compose(
-            ComposeError::UnsupportedInitialRowSchema
-        ))
-    ));
     assert!(directory.entries()?.is_empty());
     Ok(())
 }
@@ -390,3 +369,6 @@ fn oversized_rows_and_page_storage_budget_fail_before_publication() -> TestResul
     assert!(directory.entries()?.is_empty());
     Ok(())
 }
+
+#[path = "create_initial_index_tests.rs"]
+mod indexes;


### PR DESCRIPTION
Initial scalar rows can now populate one ascending Long index. The composer sorts keys with their actual row locations, rejects duplicate primary/unique keys, retains ordinary duplicates, and records distinct-key counts while checking both rows and index traversal before publication.

The first slice is bounded to one non-null Long key and one leaf page (200 entries); descending, composite, nullable, and larger indexes fail with structured errors. Scalar payload rows may still span data pages. Candidate examples cover primary, unique, and ordinary duplicate indexes for separate DAO validation.

Validation: independent parser review with no findings, 20 focused creation tests, scoped Clippy, formatting, and `just ready` passed. No interoperability claim is added.

Part of #100.
