### PR TITLE
feat(jet3): parameterize private relationship composition

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -5,6 +5,11 @@ use super::*;
 /// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
+    /// The private relationship request exceeds the supported schema or references.
+    UnsupportedRelationship {
+        /// Unsupported relationship constraint.
+        detail: &'static str,
+    },
     /// Initial rows require an unindexed, single-page definition without
     /// AutoIncrement or long-value columns.
     UnsupportedInitialRowSchema,
@@ -80,7 +85,8 @@ impl std::error::Error for ComposeError {
             Self::Encoding(source) => Some(source),
             Self::NameKey(source) => Some(source),
             Self::Schema(source) => Some(source),
-            Self::UnsupportedInitialRowSchema
+            Self::UnsupportedRelationship { .. }
+            | Self::UnsupportedInitialRowSchema
             | Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
             | Self::UnobservedLongValueColumnCount { .. }

--- a/crates/jet3/src/bootstrap_relationship_candidate.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate.rs
@@ -1,10 +1,9 @@
-//! Private candidate for exactly EXP-0114's first ParentChild relationship.
+//! Private bounded relationship composition with caller-supplied schemas.
 //!
-//! All schemas, names, selectors, map placements, catalog IDs/ACEs, and
-//! logical-record fields are bounded to that observation. Bootstrap null
-//! LvProp construction still follows EXP-0091/0110; no DAO result establishes
-//! acceptance of this combined image. No generalized relationship API lives
-//! here, and the second relationship is not composed.
+//! EXP-0118 accepted only the original fixed candidate. Renamed constructions
+//! remain candidates: applying EXP-0087 catalog text weights to standalone
+//! relationship keys is an explicit hypothesis, not an established general
+//! encoding. EXP-0059/0114 supply two bounded hidden-name/selector cases.
 
 #![allow(
     dead_code,
@@ -13,6 +12,10 @@
 
 use super::*;
 use crate::{IndexColumnSpec, IndexFieldSpec, IndexKind, IndexSpec, RelationshipSide};
+
+#[path = "bootstrap_relationship_plan.rs"]
+mod planning;
+use planning::{RelationshipColumn, RelationshipPlan, RelationshipSpec, TableRef};
 
 // EXP-0114 base and first checkpoints.
 const PARENT_ROOT: u64 = 20;
@@ -77,11 +80,38 @@ const RELATION_ACES: [AceSeed; 2] = [
 ];
 
 fn compose_parent_child(budget: &mut ResourceBudget) -> Result<WholeFileImagePlan, ComposeError> {
-    let mut plan = compose_database(&TABLES, budget)?;
+    compose_relationship(
+        &TABLES,
+        &RelationshipSpec {
+            name: RELATION.name,
+            parent: RelationshipColumn {
+                table: TableRef::Ordinal(0),
+                column: crate::ColumnRef::Ordinal(0),
+            },
+            child: RelationshipColumn {
+                table: TableRef::Ordinal(1),
+                column: crate::ColumnRef::Ordinal(0),
+            },
+        },
+        budget,
+    )
+}
+
+fn compose_relationship(
+    tables: &[TableSpec<'_>],
+    relationship: &RelationshipSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, ComposeError> {
+    let relation = RelationshipPlan::new(tables, relationship)?;
+    let mut plan = compose_database(tables, budget)?;
     let creates = [
-        PlannedCreate::new(&TABLES[0], PARENT_ROOT, true)?,
-        PlannedCreate::new(&TABLES[1], CHILD_ROOT, false)?,
+        PlannedCreate::new(&tables[0], relation.parent.definition_root().get(), true)?,
+        PlannedCreate::new(&tables[1], relation.child.definition_root().get(), false)?,
     ];
+    let seed = CatalogSeed {
+        name: relationship.name,
+        ..RELATION
+    };
     let object_count = (SYSTEM_OBJECT_COUNT + TABLES.len() + 1) as u32;
     let ace_count = (SYSTEM_ACE_COUNT + 2 * TABLES.len() + RELATION_ACES.len()) as u32;
     let mut header = header_page(TABLES.len(), budget)?;
@@ -95,7 +125,7 @@ fn compose_parent_child(budget: &mut ResourceBudget) -> Result<WholeFileImagePla
         (HEADER_PAGE, header),
         (
             GLOBAL_MAP_PAGE,
-            global_map_page(CHILD_INDEX_ROOT + 1, budget)?,
+            global_map_page(relation.index_page() + 1, budget)?,
         ),
         (
             MSYS_OBJECTS_ROOT,
@@ -111,20 +141,23 @@ fn compose_parent_child(budget: &mut ResourceBudget) -> Result<WholeFileImagePla
         ),
         (
             OBJECTS_PARENT_NAME_ROOT,
-            objects_parent_name_index(&creates, Some(RELATION), budget)?,
+            objects_parent_name_index(&creates, Some(seed), budget)?,
         ),
         (
             OBJECTS_ID_ROOT,
-            objects_id_index(&creates, Some(RELATION), budget)?,
+            objects_id_index(&creates, Some(seed), budget)?,
         ),
-        (SHARED_MAP_PAGE, shared_map_page(&[RELATION_DATA], budget)?),
+        (
+            SHARED_MAP_PAGE,
+            shared_map_page(&[relation.data_page()], budget)?,
+        ),
         (
             ACES_OBJECT_ID_ROOT,
             aces_index(&creates, &RELATION_ACES, budget)?,
         ),
         (
             MSYS_OBJECTS_DATA_PAGE,
-            objects_data_page(&creates, Some(RELATION), budget)?,
+            objects_data_page(&creates, Some(seed), budget)?,
         ),
         (
             MSYS_ACES_DATA_PAGE,
@@ -132,126 +165,143 @@ fn compose_parent_child(budget: &mut ResourceBudget) -> Result<WholeFileImagePla
         ),
         (
             RELATIONSHIPS_NAME_ROOT,
-            relation_index(
-                b"\x7f\x73\x60\x75\x66\x70\x77\x62\x69\x6a\x6d\x64\x00",
-                budget,
-            )?,
+            relation_index_name(relationship.name, relation.data_page(), budget)?,
         ),
         (
             RELATIONSHIPS_OBJECT_ROOT,
-            relation_index(b"\x7f\x62\x69\x6a\x6d\x64\x00", budget)?,
+            relation_index_name(tables[1].name, relation.data_page(), budget)?,
         ),
         (
             RELATIONSHIPS_REFERENCED_ROOT,
-            relation_index(b"\x7f\x73\x60\x75\x66\x70\x77\x00", budget)?,
+            relation_index_name(tables[0].name, relation.data_page(), budget)?,
         ),
-        (PARENT_ROOT, user_definition(true, budget)?),
-        (CHILD_ROOT, user_definition(false, budget)?),
-        (CHILD_MAP, child_map(budget)?),
+        (
+            relation.parent.definition_root().get(),
+            user_definition(&relation, true, budget)?,
+        ),
+        (
+            relation.child.definition_root().get(),
+            user_definition(&relation, false, budget)?,
+        ),
+        (
+            relation.child.map_page().get(),
+            child_map(relation.index_page(), budget)?,
+        ),
     ];
     for (page, image) in replacements {
         plan.replace(PageNumber::new(page), image)?;
     }
-    let mut global_free = global_map(RELATION_DATA, budget)?;
-    plan.append(relationship_data(budget)?, &mut global_free, budget)?;
+    let mut global_free = global_map(relation.data_page(), budget)?;
     plan.append(
-        empty_index_page(CHILD_ROOT, budget)?,
+        relationship_data(&relation, budget)?,
+        &mut global_free,
+        budget,
+    )?;
+    plan.append(
+        empty_index_page(relation.child.definition_root().get(), budget)?,
         &mut global_free,
         budget,
     )?;
     Ok(plan)
 }
 
-fn user_definition(parent: bool, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
-    let id = [IndexFieldSpec {
-        column: 0,
+fn user_definition(
+    relation: &RelationshipPlan<'_>,
+    parent: bool,
+    budget: &mut ResourceBudget,
+) -> Result<PageImage, ComposeError> {
+    let child_fields = [IndexFieldSpec {
+        column: relation.child_column,
         direction: IndexDirection::Ascending,
     }];
-    let alternate = [IndexFieldSpec {
-        column: 1,
-        direction: IndexDirection::Ascending,
+    let child_physical = [PhysicalIndexSpec {
+        fields: &child_fields,
+        usage_map_page: relation.child.map_page(),
+        usage_map_row: 2,
+        root: PageNumber::new(relation.index_page()),
+        flags: PhysicalIndexFlagsSpec::Ordinary,
+        entry_count: 0,
     }];
-    let parent_physical = [
-        physical(
-            &id,
-            PARENT_MAP,
-            2,
-            PARENT_ID_ROOT,
-            PhysicalIndexFlagsSpec::UniqueRequired,
-        ),
-        physical(
-            &alternate,
-            PARENT_MAP,
-            3,
-            PARENT_ALTERNATE_ROOT,
-            PhysicalIndexFlagsSpec::Unique,
-        ),
-    ];
-    let child_physical = [physical(
-        &id,
-        CHILD_MAP,
-        2,
-        CHILD_INDEX_ROOT,
-        PhysicalIndexFlagsSpec::Ordinary,
-    )];
-    let parent_logical = [
-        LogicalIndexSpec {
-            name: b".rC",
-            physical_index: 0,
-            kind: LogicalIndexKindSpec::Relationship {
-                side: RelationshipSide::PrimaryTable,
-                related_table: PageNumber::new(CHILD_ROOT),
-                raw_selector: 2,
-                relation_ordinal: 0,
-                cascade_updates: false,
-                cascade_deletes: false,
-            },
+    let mut parent_physical = [child_physical[0]; 2];
+    for (slot, (((root, row), index), fields)) in parent_physical.iter_mut().zip(
+        relation
+            .parent
+            .index_placements()
+            .zip(relation.tables[0].indexes)
+            .zip(relation.parent.index_fields()),
+    ) {
+        *slot = PhysicalIndexSpec {
+            fields,
+            usage_map_page: relation.parent.map_page(),
+            usage_map_row: row,
+            root,
+            flags: index.kind.flags(),
+            entry_count: 0,
+        };
+    }
+    let relationship_index = LogicalIndexSpec {
+        name: if parent {
+            relation.hidden_name
+        } else {
+            relation.spec.name
         },
-        LogicalIndexSpec {
-            name: b"ByAlternate",
-            physical_index: 1,
-            kind: LogicalIndexKindSpec::Ordinary,
-        },
-        LogicalIndexSpec {
-            name: b"ById",
-            physical_index: 0,
-            kind: LogicalIndexKindSpec::Primary,
-        },
-    ];
-    let child_logical = [LogicalIndexSpec {
-        name: b"ParentChild",
         physical_index: 0,
         kind: LogicalIndexKindSpec::Relationship {
-            side: RelationshipSide::ForeignTable,
-            related_table: PageNumber::new(PARENT_ROOT),
-            raw_selector: 0,
-            relation_ordinal: 2,
+            side: if parent {
+                RelationshipSide::PrimaryTable
+            } else {
+                RelationshipSide::ForeignTable
+            },
+            related_table: if parent {
+                relation.child.definition_root()
+            } else {
+                relation.parent.definition_root()
+            },
+            raw_selector: if parent { relation.selector } else { 0 },
+            relation_ordinal: if parent { 0 } else { relation.selector },
             cascade_updates: false,
             cascade_deletes: false,
         },
-    }];
-    let map = if parent { PARENT_MAP } else { CHILD_MAP };
+    };
+    let mut logical = [relationship_index; 3];
+    let logical_count = if parent {
+        relation.tables[0].indexes.len() + 1
+    } else {
+        1
+    };
+    if parent {
+        for (ordinal, index) in relation.tables[0].indexes.iter().enumerate() {
+            logical[ordinal + 1] = LogicalIndexSpec {
+                name: index.name,
+                physical_index: ordinal as u16,
+                kind: index.kind.logical_kind(),
+            };
+        }
+        logical[..logical_count].sort_unstable_by(|left, right| left.name.cmp(right.name));
+    }
+    let table = if parent {
+        &relation.tables[0]
+    } else {
+        &relation.tables[1]
+    };
+    let map = if parent {
+        relation.parent.map_page()
+    } else {
+        relation.child.map_page()
+    };
     definition_page(
         &TableDefinitionSpec {
             kind: TableDefinitionKind::User,
-            columns: if parent {
-                &PARENT_COLUMNS
-            } else {
-                &CHILD_COLUMNS
-            },
+            columns: table.columns,
             system_column_classes: &[],
             physical_indexes: if parent {
-                &parent_physical
+                &parent_physical[..relation.tables[0].indexes.len()]
             } else {
                 &child_physical
             },
-            indexes: if parent {
-                &parent_logical
-            } else {
-                &child_logical
-            },
-            owned_map: MapRowLocator::new(PageNumber::new(map), 0),
-            available_map: MapRowLocator::new(PageNumber::new(map), 1),
+            indexes: &logical[..logical_count],
+            owned_map: MapRowLocator::new(map, 0),
+            available_map: MapRowLocator::new(map, 1),
             row_count: 0,
             long_value_maps: &[],
         },
@@ -259,30 +309,16 @@ fn user_definition(parent: bool, budget: &mut ResourceBudget) -> Result<PageImag
     )
 }
 
-fn physical<'a>(
-    fields: &'a [IndexFieldSpec],
-    map: u64,
-    row: u8,
-    root: u64,
-    flags: PhysicalIndexFlagsSpec,
-) -> PhysicalIndexSpec<'a> {
-    PhysicalIndexSpec {
-        fields,
-        usage_map_page: PageNumber::new(map),
-        usage_map_row: row,
-        root: PageNumber::new(root),
-        flags,
-        entry_count: 0,
-    }
-}
-
-fn child_map(budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+fn child_map(index_page: u64, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
     let empty = inline_map_row(&[], budget)?;
-    let index = inline_map_row(&[CHILD_INDEX_ROOT], budget)?;
+    let index = inline_map_row(&[index_page], budget)?;
     data_page(HEADER_PAGE, &[&empty, &empty, &index], budget)
 }
 
-fn relationship_data(budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+fn relationship_data(
+    relation: &RelationshipPlan<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<PageImage, ComposeError> {
     // EXP-0073 column layout; EXP-0114 first relationship's exact values.
     let layout = [
         variable(ColumnPhysicalType::Text, 0, 255),
@@ -295,36 +331,39 @@ fn relationship_data(budget: &mut ResourceBudget) -> Result<PageImage, ComposeEr
         variable(ColumnPhysicalType::Text, 4, 255),
     ];
     let values = [
-        RowValue::Text(b"ParentChild"),
+        RowValue::Text(relation.spec.name),
         RowValue::Long(0),
         RowValue::Long(1),
         RowValue::Long(0),
-        RowValue::Text(b"Child"),
-        RowValue::Text(b"ParentId"),
-        RowValue::Text(b"Parent"),
-        RowValue::Text(b"Id"),
+        RowValue::Text(relation.tables[1].name),
+        RowValue::Text(relation.tables[1].columns[usize::from(relation.child_column)].name()),
+        RowValue::Text(relation.tables[0].name),
+        RowValue::Text(relation.tables[0].columns[usize::from(relation.parent_column)].name()),
     ];
     let mut row = [0_u8; PAGE_BYTES];
     let length = encode_row(&layout, &values, &mut row, budget)?.get() as usize;
     data_page(MSYS_RELATIONSHIPS_ROOT, &[&row[..length]], budget)
 }
 
-fn relation_index(key: &[u8], budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
-    // Only the three exact EXP-0114 keys above are supplied; no text grammar.
+fn relation_index_name(
+    name: &[u8],
+    row_page: u64,
+    budget: &mut ResourceBudget,
+) -> Result<PageImage, ComposeError> {
+    // Candidate hypothesis: the EXP-0087 text component also serves these
+    // standalone keys. EXP-0114's three original keys reproduce exactly.
     let mut entry = OwnedIndexEntry::EMPTY;
-    let available = entry.key.len();
-    entry
-        .key
-        .get_mut(..key.len())
-        .ok_or(ComposeError::IndexPageFull {
-            needed: key.len(),
-            available,
-        })?
-        .copy_from_slice(key);
-    entry.len = key.len();
-    index_page(MSYS_RELATIONSHIPS_ROOT, RELATION_DATA, &[entry], budget)
+    let length = encode_catalog_name_key(0, name, &mut entry.key)?;
+    let prefix = crate::catalog_name_key::LONG_COMPONENT_LEN;
+    entry.key.copy_within(prefix..length, 0);
+    entry.len = length - prefix;
+    index_page(MSYS_RELATIONSHIPS_ROOT, row_page, &[entry], budget)
 }
 
 #[cfg(test)]
 #[path = "bootstrap_relationship_candidate_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "bootstrap_relationship_parameterized_tests.rs"]
+mod parameterized_tests;

--- a/crates/jet3/src/bootstrap_relationship_candidate_tests.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate_tests.rs
@@ -193,8 +193,12 @@ fn candidate_budget_exhaustion_and_oversized_key_are_structured() {
     let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(0));
     assert!(compose_parent_child(&mut limited).is_err());
     assert!(matches!(
-        relation_index(&[0; INDEX_KEY_CAPACITY + 1], &mut budget()),
-        Err(ComposeError::IndexPageFull { .. })
+        relation_index_name(
+            &[b'A'; INDEX_KEY_CAPACITY + 1],
+            RELATION_DATA,
+            &mut budget()
+        ),
+        Err(ComposeError::NameKey(_))
     ));
 }
 

--- a/crates/jet3/src/bootstrap_relationship_parameterized_tests.rs
+++ b/crates/jet3/src/bootstrap_relationship_parameterized_tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+use crate::column_definition_writer::nz;
+use crate::{ColumnRef, DatabaseReader, ResourceLimits, SliceSource};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+
+const RENAMED_PARENT_COLUMNS: [ColumnSpec<'static>; 2] = [
+    ColumnSpec::new(b"Code2", ColumnType::Long),
+    ColumnSpec::new(b"Key1", ColumnType::Long),
+];
+const RENAMED_CHILD_COLUMNS: [ColumnSpec<'static>; 2] = [
+    ColumnSpec::new(b"Label3", ColumnType::Text { max_len: nz(8) }),
+    ColumnSpec::new(b"Account4", ColumnType::Long),
+];
+
+fn renamed(two: bool) -> ([TableSpec<'static>; 2], RelationshipSpec<'static>) {
+    let parent_name: &[u8] = if two { b"Owners2" } else { b"Accounts7" };
+    let child_name: &[u8] = if two { b"Details4" } else { b"Events9" };
+    let indexes: &[IndexSpec<'static>] = &[
+        IndexSpec {
+            name: b"Primary9",
+            fields: &[IndexColumnSpec {
+                column: ColumnRef::Ordinal(1),
+                direction: IndexDirection::Ascending,
+            }],
+            kind: IndexKind::Primary,
+        },
+        IndexSpec {
+            name: b"Unique8",
+            fields: &[IndexColumnSpec {
+                column: ColumnRef::Ordinal(0),
+                direction: IndexDirection::Ascending,
+            }],
+            kind: IndexKind::Unique,
+        },
+    ];
+    (
+        [
+            TableSpec {
+                name: parent_name,
+                columns: &RENAMED_PARENT_COLUMNS,
+                indexes: &indexes[..if two { 2 } else { 1 }],
+            },
+            TableSpec {
+                name: child_name,
+                columns: &RENAMED_CHILD_COLUMNS,
+                indexes: &[],
+            },
+        ],
+        RelationshipSpec {
+            name: if two {
+                b"Owner2_Details4"
+            } else {
+                b"Account7Events9"
+            },
+            parent: RelationshipColumn {
+                table: TableRef::Name(parent_name),
+                column: ColumnRef::Name(b"Key1"),
+            },
+            child: RelationshipColumn {
+                table: TableRef::Name(child_name),
+                column: ColumnRef::Name(b"Account4"),
+            },
+        },
+    )
+}
+
+#[test]
+fn caller_names_columns_and_both_selector_cases_reopen() -> TestResult {
+    for two in [false, true] {
+        let (tables, spec) = renamed(two);
+        let plan = compose_relationship(&tables, &spec, &mut budget())?;
+        let bytes = plan
+            .pages()
+            .iter()
+            .flat_map(|page| page.image().as_bytes().iter().copied())
+            .collect::<Vec<_>>();
+        assert_eq!(bytes.len(), (if two { 29 } else { 28 }) * PAGE_BYTES);
+        let mut budget = budget();
+        let mut database = DatabaseReader::from_source(
+            SliceSource::new(&bytes, budget.read_budget())?,
+            &mut budget,
+        )?;
+        let parent = database.table_definition(PageNumber::new(20), &mut budget)?;
+        let relation = parent
+            .relationships()
+            .next()
+            .ok_or("missing parent relationship")?;
+        assert_eq!(
+            relation.name().raw_bytes(),
+            if two { b".rC" } else { b".rB" }
+        );
+        assert_eq!(relation.raw_selector(), if two { 2 } else { 1 });
+        assert_eq!(parent.physical_indexes()[0].fields()[0].column().get(), 1);
+        let child = database.table_definition(relation.related_table(), &mut budget)?;
+        assert_eq!(
+            child
+                .relationships()
+                .next()
+                .ok_or("missing child relationship")?
+                .name()
+                .raw_bytes(),
+            spec.name
+        );
+        assert_eq!(child.physical_indexes()[0].fields()[0].column().get(), 1);
+    }
+    Ok(())
+}
+
+#[test]
+fn missing_references_wrong_types_and_unsupported_indexes_are_refused() {
+    let (tables, spec) = renamed(false);
+    let mut wrong = spec;
+    wrong.parent.table = TableRef::Ordinal(9);
+    assert!(matches!(
+        compose_relationship(&tables, &wrong, &mut budget()),
+        Err(ComposeError::UnsupportedRelationship { .. })
+    ));
+    wrong = spec;
+    wrong.child.column = ColumnRef::Name(b"Missing");
+    assert!(matches!(
+        compose_relationship(&tables, &wrong, &mut budget()),
+        Err(ComposeError::UnsupportedRelationship {
+            detail: "child column reference"
+        })
+    ));
+    wrong.child.column = ColumnRef::Ordinal(0);
+    assert!(matches!(
+        compose_relationship(&tables, &wrong, &mut budget()),
+        Err(ComposeError::UnsupportedRelationship {
+            detail: "relationship columns must both be Long"
+        })
+    ));
+    wrong = spec;
+    wrong.parent.column = ColumnRef::Ordinal(0);
+    assert!(matches!(
+        compose_relationship(&tables, &wrong, &mut budget()),
+        Err(ComposeError::UnsupportedRelationship { .. })
+    ));
+    let mut indexed_child = tables;
+    indexed_child[1].indexes = &[IndexSpec {
+        name: b"Extra",
+        fields: &[IndexColumnSpec {
+            column: ColumnRef::Ordinal(1),
+            direction: IndexDirection::Ascending,
+        }],
+        kind: IndexKind::Ordinary,
+    }];
+    assert!(matches!(
+        compose_relationship(&indexed_child, &spec, &mut budget()),
+        Err(ComposeError::UnsupportedRelationship {
+            detail: "child must initially be unindexed"
+        })
+    ));
+}
+
+#[test]
+fn name_collisions_and_unsupported_name_bytes_are_refused() {
+    let (mut tables, mut spec) = renamed(false);
+    spec.name = b"Link\xff";
+    assert!(matches!(
+        compose_relationship(&tables, &spec, &mut budget()),
+        Err(ComposeError::NameKey(_))
+    ));
+    spec.name = b"";
+    assert!(matches!(
+        compose_relationship(&tables, &spec, &mut budget()),
+        Err(ComposeError::NameKey(_))
+    ));
+    spec.name = b"Link";
+    tables[1].name = b"ACCOUNTS7";
+    spec.parent.table = TableRef::Ordinal(0);
+    spec.child.table = TableRef::Ordinal(1);
+    assert!(matches!(
+        compose_relationship(&tables, &spec, &mut budget()),
+        Err(ComposeError::DuplicateTableName { .. })
+    ));
+}
+
+#[test]
+fn long_value_columns_and_allocation_exhaustion_are_refused() {
+    let (mut tables, spec) = renamed(false);
+    let mut limited =
+        ResourceBudget::new(ResourceLimits::default().with_max_allocation_bytes(ByteCount::new(0)));
+    assert!(compose_relationship(&tables, &spec, &mut limited).is_err());
+    let columns = [
+        ColumnSpec::new(b"Note", ColumnType::Memo),
+        ColumnSpec::new(b"Account4", ColumnType::Long),
+    ];
+    tables[1].columns = &columns;
+    assert!(matches!(
+        compose_relationship(&tables, &spec, &mut budget()),
+        Err(ComposeError::UnsupportedRelationship { .. })
+    ));
+}
+
+#[test]
+#[ignore = "exports two renamed candidates for separately preregistered validation"]
+fn export_parameterized_relationship_candidates() -> TestResult {
+    use std::io::Write;
+    let root = std::path::PathBuf::from(
+        std::env::var_os("JET3_RELATIONSHIP_CANDIDATE_DIR")
+            .ok_or("JET3_RELATIONSHIP_CANDIDATE_DIR required")?,
+    );
+    for (two, name) in [
+        (false, "relationship-one-index.mdb"),
+        (true, "relationship-two-index.mdb"),
+    ] {
+        let (tables, spec) = renamed(two);
+        let plan = compose_relationship(&tables, &spec, &mut budget())?;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(root.join(name))?;
+        for page in plan.pages() {
+            file.write_all(page.image().as_bytes())?;
+        }
+    }
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_relationship_plan.rs
+++ b/crates/jet3/src/bootstrap_relationship_plan.rs
@@ -1,0 +1,154 @@
+//! Typed, bounded inputs for private relationship composition. Schema and
+//! placement use the existing EXP-0059/0087/0093 planners; only the two hidden
+//! selector/name cases recorded by EXP-0059 and EXP-0114 are admitted.
+
+use super::*;
+use crate::ColumnRef;
+use crate::table_schema_plan::{TableSchemaPlan, plan_table_schema};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TableRef<'a> {
+    Ordinal(usize),
+    Name(&'a [u8]),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RelationshipColumn<'a> {
+    pub(crate) table: TableRef<'a>,
+    pub(crate) column: ColumnRef<'a>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RelationshipSpec<'a> {
+    pub(crate) name: &'a [u8],
+    pub(crate) parent: RelationshipColumn<'a>,
+    pub(crate) child: RelationshipColumn<'a>,
+}
+
+pub(super) struct RelationshipPlan<'a> {
+    pub(super) tables: &'a [TableSpec<'a>],
+    pub(super) spec: &'a RelationshipSpec<'a>,
+    pub(super) parent: TableSchemaPlan,
+    pub(super) child: TableSchemaPlan,
+    pub(super) parent_column: u16,
+    pub(super) child_column: u16,
+    pub(super) hidden_name: &'static [u8],
+    pub(super) selector: u32,
+}
+
+fn invalid(detail: &'static str) -> ComposeError {
+    ComposeError::UnsupportedRelationship { detail }
+}
+
+impl<'a> RelationshipPlan<'a> {
+    pub(super) fn new(
+        tables: &'a [TableSpec<'a>],
+        spec: &'a RelationshipSpec<'a>,
+    ) -> Result<Self, ComposeError> {
+        if tables.len() != 2 {
+            return Err(invalid("exactly two tables required"));
+        }
+        // EXP-0060 bounds the one-byte column count before reference scans.
+        if tables
+            .iter()
+            .any(|table| table.columns.len() > u8::MAX as usize)
+        {
+            return Err(invalid("at most 255 columns per table"));
+        }
+        let mut key = [0_u8; INDEX_KEY_CAPACITY];
+        encode_catalog_name_key(RELATIONSHIPS_ID, spec.name, &mut key)?;
+        let parent = plan_table_schema(&tables[0], EMPTY_DATABASE_PAGE_COUNT, true)?;
+        let child_root = parent.definition_root().get() + parent.appended_page_count();
+        let child = plan_table_schema(&tables[1], child_root, false)?;
+        if parent.continuation_page().is_some() || child.continuation_page().is_some() {
+            return Err(invalid("definition continuations are unsupported"));
+        }
+        let resolve_table = |reference| match reference {
+            TableRef::Ordinal(position) => (position < tables.len()).then_some(position),
+            TableRef::Name(name) => tables.iter().position(|table| table.name == name),
+        };
+        if resolve_table(spec.parent.table) != Some(0) || resolve_table(spec.child.table) != Some(1)
+        {
+            return Err(invalid(
+                "parent must reference first table and child second table",
+            ));
+        }
+        let parent_column = spec
+            .parent
+            .column
+            .resolve(tables[0].columns)
+            .ok_or(invalid("parent column reference"))?;
+        let child_column = spec
+            .child
+            .column
+            .resolve(tables[1].columns)
+            .ok_or(invalid("child column reference"))?;
+        if tables[0].columns[usize::from(parent_column)].column_type() != ColumnType::Long
+            || tables[1].columns[usize::from(child_column)].column_type() != ColumnType::Long
+        {
+            return Err(invalid("relationship columns must both be Long"));
+        }
+        if tables.iter().flat_map(|table| table.columns).any(|column| {
+            column.column_type().is_long_value()
+                || column.column_type() == ColumnType::AutoIncrement
+        }) {
+            return Err(invalid(
+                "AutoIncrement and long-value columns are unsupported",
+            ));
+        }
+        if !tables[1].indexes.is_empty() {
+            return Err(invalid("child must initially be unindexed"));
+        }
+        let (hidden_name, selector) = match tables[0].indexes.len() {
+            1 => (b".rB".as_slice(), 1), // EXP-0059.
+            2 => (b".rC".as_slice(), 2), // EXP-0114.
+            _ => {
+                return Err(invalid(
+                    "parent needs one primary and at most one additional unique index",
+                ));
+            }
+        };
+        let primary = &tables[0].indexes[0];
+        if primary.kind != IndexKind::Primary
+            || primary.fields.len() != 1
+            || primary.fields[0].column.resolve(tables[0].columns) != Some(parent_column)
+            || primary.fields[0].direction != IndexDirection::Ascending
+        {
+            return Err(invalid(
+                "first parent index must be ascending primary on the referenced column",
+            ));
+        }
+        if let Some(extra) = tables[0].indexes.get(1)
+            && (extra.kind != IndexKind::Unique
+                || extra.fields.len() != 1
+                || extra.fields[0].direction != IndexDirection::Ascending
+                || extra.fields[0]
+                    .column
+                    .resolve(tables[0].columns)
+                    .is_none_or(|ordinal| {
+                        tables[0].columns[usize::from(ordinal)].column_type() != ColumnType::Long
+                    }))
+        {
+            return Err(invalid(
+                "additional parent index must be ascending unique on one Long column",
+            ));
+        }
+        Ok(Self {
+            tables,
+            spec,
+            parent,
+            child,
+            parent_column,
+            child_column,
+            hidden_name,
+            selector,
+        })
+    }
+
+    pub(super) fn data_page(&self) -> u64 {
+        self.child.definition_root().get() + self.child.appended_page_count()
+    }
+    pub(super) fn index_page(&self) -> u64 {
+        self.data_page() + 1
+    }
+}

--- a/crates/jet3/src/catalog_name_key.rs
+++ b/crates/jet3/src/catalog_name_key.rs
@@ -44,7 +44,7 @@ const PRIMARY_WEIGHTS: [u8; 95] = [
 /// Marker `EXP-0062` observed before each non-null key component.
 const COMPONENT_MARKER: u8 = 0x7f;
 /// Encoded length of the leading non-null Long `ParentId` component.
-const LONG_COMPONENT_LEN: usize = 5;
+pub(crate) const LONG_COMPONENT_LEN: usize = 5;
 /// The text component's marker plus its terminating nibble-stream byte.
 const TEXT_COMPONENT_OVERHEAD: usize = 2;
 


### PR DESCRIPTION
The private relationship composer accepts typed table/column references and caller-provided names. It validates the bounded one-relation layout, supports one or two parent indexes and nonzero linked-column positions, and plans the catalog, relationship, index, and map pages.

Cascades, long-value columns, continued definitions, and broader layouts remain refused. The earlier accepted candidate stays byte-identical. Public exposure follows in a separate change with the renamed-candidate DAO result.

Validation: independent parser review, eight focused tests, both deterministic exporters, prior-candidate identity check, scoped Clippy, and `just ready` passed. Integration with indexed-row creation was separately reviewed; eight relationship and twenty initial-row/index tests plus final `just ready` passed.

Part of #100.
