### PR TITLE
test: preregister indexed-row DAO validation matrix

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10187,6 +10187,50 @@ Use `not applicable` explicitly rather than omitting a field.
   without findings.
 
 
+### EXP-0119 — Indexed initial-row candidate preregistration
+
+- Recorded: 2026-09-04, OpenAI Codex
+- Kind: SHA-256-pinned development-only local DAO experiment preregistration
+- Question: does DAO read the exact primary, unique, and ordinary-duplicate
+  initial-row candidates unchanged, including full index traversal and Seek?
+- Origin: reviewed `indexed_row_candidate` example at
+  `54d7d22b930b824c48d7afb0d44591f48c5b485d`. `EXP-0062` supplies
+  Long-key and leaf framing; `EXP-0073` supplies distinct-key counts. `EXP-0116`
+  established only an exact unindexed candidate. Each indexed arm creates
+  `Rows(Id Long, Payload Text 255)` with ascending `ById`, 20 rows in caller
+  order, and distinct payloads `a` through `t`, each repeated 255 times.
+  Primary and unique keys are 9 through -10; ordinary keys are 9 through 0
+  twice. The ordinary leaf has 20 entries and a definition distinct count of
+  10; the other arms have 20 distinct keys. All use leaf page 23 and data
+  pages 24--26 with 7, 7, and 6 rows.
+- Environment: private local Windows VM, x86 PowerShell, `DAO.DBEngine.36`.
+- Protocol: `oracle/windows-dao/acquisition/indexed-rows.plan.json`, SHA-256
+  `5d78e83ad3b00f1a460610580d2da42aae793c9f7c143f423525e9cb0a5b812c`. Commit and independently
+  review before one dispatch. Verify input pins on dispatch and analysis;
+  prepare and verify all nine candidate copies before the first control
+  creation. Each arm has three fresh DAO controls and three read-only candidate
+  observations. Verify full schema/index metadata, snapshot row multiset,
+  ordered index traversal containing every Id/payload pair, and Seek for every
+  distinct key. Duplicate traversal tie order is unspecified; ordinary Seek
+  may select either matching payload, while full traversal must contain both.
+  Require every control to pass and all 18 images to remain unchanged before
+  classifying candidate agreement per arm. Post-mutation failure requires a
+  new human decision before another dispatch.
+- Artifacts: each candidate is 55,296 bytes, with SHA-256 values:
+  primary `79b5e6c1a03418a0c6c9a99170cd6c67660b0d57eb56142354c5cbccc63cfa11`;
+  unique `cc4bd47bac0c57d7daa763b4675cb6dbe19dc886be733abf27edeebe7346b3c2`;
+  ordinary `9f517c410f65a3d5ec3ebd7829f7203dffb9594e95846413ef980290c03c5cd9`.
+  The plan pins producer, analyzer, imported transport, and Rust example.
+- Observation: acquisition has not started; no DAO outcome recorded here.
+- Interpretation: these three exact candidates only. No null/descending/
+  composite-key rule, general B-tree allocation, DAO free-space or page-zero
+  policy, update correctness, general compatibility, or hosted support claim.
+- Usage: issue `#100`; bounded indexed initial-row construction.
+- Rights: all MDB bytes and provider binaries remain outside the repository.
+- Review: independent harness review completed without findings; six focused
+  classifier tests and a PowerShell parser-only preflight passed.
+
+
 ## Fixtures and black-box results
 
 ### FIX-0001 — January 2026 controller backup

--- a/oracle/windows-dao/acquisition/indexed-rows.plan.json
+++ b/oracle/windows-dao/acquisition/indexed-rows.plan.json
@@ -1,0 +1,83 @@
+{
+  "document_type": "dao_indexed_rows_plan",
+  "experiment_id": "indexed-rows",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0062 supplies Long key and leaf framing, EXP-0073 supplies distinct-key prefix counts, EXP-0116 accepted one exact unindexed multi-page candidate. No indexed initial-row candidate is assumed accepted.",
+    "hypothesis": "DAO reads the exact primary, unique, and ordinary-duplicate candidates unchanged, with expected schema/index flags, full rows, ordered index traversal and successful Seek for every distinct key. The ordinary candidate has 20 leaf entries but 10 distinct keys in its definition prefix. The primary/unique candidates each have 20 distinct keys. Each has one leaf at page 23 and three data pages 24..26 with 7, 7, 6 rows; availability and page-zero retention remain exact-candidate hypotheses.",
+    "authorization": "User authorized DAO acquisition/mutations on 2026-09-04. Commit and independently review the SHA256-pinned plan before one dispatch. Once the first CreateDatabase starts, failures are scientific results; another dispatch requires a new human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/indexed_rows.py": "b98185431b43a5eaf9421a15c73084f8323e5c3e1c3aa6901612ac0bf7331753",
+    "oracle/windows-dao/scripts/indexed_rows.ps1": "10e48dca70a5b6b0658ec802baba41fbfd6ef6b6b9dcc8d6a051fd2f4c333c14",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/indexed_row_candidate.rs": "4d514c4a5e8a2ab670fe7a7b7ef11e0d61ff27df4d27ea9511c4fe8456f3dc29"
+  },
+  "candidates": {
+    "primary": {
+      "size": 55296,
+      "sha256": "79b5e6c1a03418a0c6c9a99170cd6c67660b0d57eb56142354c5cbccc63cfa11"
+    },
+    "unique": {
+      "size": 55296,
+      "sha256": "cc4bd47bac0c57d7daa763b4675cb6dbe19dc886be733abf27edeebe7346b3c2"
+    },
+    "ordinary": {
+      "size": 55296,
+      "sha256": "9f517c410f65a3d5ec3ebd7829f7203dffb9594e95846413ef980290c03c5cd9"
+    }
+  },
+  "schema": {
+    "version": "3.0",
+    "tables": [
+      "MSysACEs",
+      "MSysObjects",
+      "MSysQueries",
+      "MSysRelationships",
+      "Rows"
+    ],
+    "fields": [
+      {
+        "name": "Id",
+        "type": 4,
+        "size": 4
+      },
+      {
+        "name": "Payload",
+        "type": 10,
+        "size": 255
+      }
+    ]
+  },
+  "scenarios": {
+    "common": "Rows(Id Long, Payload Text255), one ascending ById index. Insert 20 rows in position order 0..19, payload ASCII character a+position repeated 255 times.",
+    "primary": "Primary=true, Unique=true, Required=true; Id=9-position.",
+    "unique": "Primary=false, Unique=true, Required=false; Id=9-position.",
+    "ordinary": "Primary=false, Unique=false, Required=false; Id=9-(position mod10), so each key 0..9 appears twice with different payloads."
+  },
+  "execution": {
+    "environment": "Private Windows VM, x86 PowerShell, DAO.DBEngine.36; development-only.",
+    "pre_mutation": "Host verifies all input/candidate pins and committed plan; guest verifies producer and all 9 candidate replicas before first control creation.",
+    "per_replica": "For each arm in primary,unique,ordinary order and replicas 1..3, create and close a fresh same-schema DAO control, then read control and candidate read-only. Record schema/index metadata, snapshot rows, ordered ById traversal, and Seek result for every distinct key; close and compare before/after identities.",
+    "attempts": 1,
+    "command": "python3 oracle/windows-dao/scripts/indexed_rows.py run <candidate directory containing primary.mdb unique.mdb ordinary.mdb> --shared-root <VM shared directory> --run-id <UTC timestamp>-indexed-rows",
+    "analysis": "python3 oracle/windows-dao/scripts/indexed_rows.py analyze <shared directory>/outbox/<run id>"
+  },
+  "decision_rule": {
+    "observed_accepted": "Complete 9-pair job with all controls passing expected semantics, all 18 images unchanged, and three agreeing accepted candidate observations for that arm.",
+    "not_observed_accepted": "Same complete-job/control/unchanged gate, but the arm candidates identically fail at one endpoint or produce the same semantic mismatch.",
+    "no_outcome": "Incomplete job, any control failure, any changed image, or disagreement between candidate replicas for the arm.",
+    "semantic_normalization": "Snapshot rows are a multiset. Index traversal must be ascending by Id and contain every expected Id/payload pair exactly once; duplicate tie order is unspecified. Seek queries must be the complete ascending distinct-key inventory; each result must match query Id and one expected payload. Ordinary Seek may return either duplicate; the full traversal must still contain both.",
+    "validation_rejection": "Reject for input-pin drift during preflight or analysis, malformed binding/inventory, candidate starting-pin mismatch or retained-image mismatch."
+  },
+  "evidence_boundary": "Exact three candidates only. No general index/null/descending/composite/key-type rules, B-tree allocation, update correctness, DAO allocation or page-zero policy, general compatibility or hosted support movement.",
+  "retention": "Retain result.json, canonical report.json, logs and all 18 candidate/control MDBs locally; no MDB bytes/provider binaries in git. Add one EXP0120 outcome from validated report.",
+  "candidate_generation": {
+    "source_commit": "54d7d22b930b824c48d7afb0d44591f48c5b485d",
+    "example": "crates/jet3/examples/indexed_row_candidate.rs",
+    "command": "cargo run --locked -p jet3 --example indexed_row_candidate -- <directory>/<arm>.mdb <arm>"
+  }
+}

--- a/oracle/windows-dao/scripts/indexed_rows.ps1
+++ b/oracle/windows-dao/scripts/indexed_rows.ps1
@@ -1,0 +1,156 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function New-Control([string]$Path, [string]$Arm) {
+    $engine = $workspace = $db = $table = $id = $payload = $index = $key = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $table = $db.CreateTableDef('Rows')
+        $id = $table.CreateField('Id', 4)
+        $table.Fields.Append($id)
+        $payload = $table.CreateField('Payload', 10, 255)
+        $table.Fields.Append($payload)
+        $index = $table.CreateIndex('ById')
+        $index.Primary = ($Arm -ceq 'primary')
+        $index.Unique = ($Arm -cne 'ordinary')
+        $key = $index.CreateField('Id')
+        $index.Fields.Append($key)
+        $table.Indexes.Append($index)
+        $db.TableDefs.Append($table)
+        $rs = $db.OpenRecordset('Rows', 2)
+        foreach ($position in 0..19) {
+            $value = if ($Arm -ceq 'ordinary') { 9 - ($position % 10) } else { 9 - $position }
+            $rs.AddNew()
+            $rs.Fields.Item('Id').Value = [int]$value
+            $rs.Fields.Item('Payload').Value = ([string][char](97 + $position)) * 255
+            $rs.Update()
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $key; Release $index; Release $payload; Release $id; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset) {
+    $id = $Recordset.Fields.Item('Id').Value
+    $payload = $Recordset.Fields.Item('Payload').Value
+    if ($null -eq $id -or [Convert]::IsDBNull($id)) { $id = $null } else { $id = [int]$id }
+    if ($null -eq $payload -or [Convert]::IsDBNull($payload)) { $payload = $null } else { $payload = [string]$payload }
+    return @{id=$id; payload=$payload}
+}
+function Observe([string]$Path, [string]$Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item('Rows')
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0)} })}
+        })
+        $endpoint = 'rows'
+        $rs = $db.OpenRecordset('Rows', 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$rows.Add((Read-Row $rs))
+            $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+        $rs.Close(); Release $rs; $rs = $null
+        $endpoint = 'index_traversal'
+        $rs = $db.OpenRecordset('Rows', 1)
+        $rs.Index = 'ById'
+        $rs.MoveFirst()
+        $traversal = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$traversal.Add((Read-Row $rs))
+            $rs.MoveNext()
+        }
+        $snapshot.traversal = @($traversal)
+        $endpoint = 'seek'
+        $seeks = New-Object Collections.ArrayList
+        $first = if ($Arm -ceq 'ordinary') { 0 } else { -10 }
+        foreach ($value in $first..9) {
+            $rs.Seek('=', [int]$value)
+            $row = if ($rs.NoMatch) { $null } else { Read-Row $rs }
+            [void]$seeks.Add(@{query=$value; row=$row})
+        }
+        $snapshot.seek = @($seeks)
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'indexed-rows.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/indexed_rows.ps1') { throw 'Script pin mismatch' }
+$arms = @('primary', 'unique', 'ordinary')
+foreach ($arm in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$arm.mdb") -Destination $path
+        $identity = Identity $path
+        $expected = $plan.candidates.$arm
+        if ($identity.size -ne $expected.size -or $identity.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_indexed_rows_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($arm in $arms) {
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$arm-control-r$replica.mdb"
+            New-Control $control $arm
+            $candidate = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+            $result.replicas += @{arm=$arm; replica=$replica; control=(Observe $control $arm); candidate=(Observe $candidate $arm)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/indexed_rows.py
+++ b/oracle/windows-dao/scripts/indexed_rows.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Preregistered indexed initial-row DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/indexed-rows.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/indexed_rows.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+ARMS = ('primary', 'unique', 'ordinary')
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['replicas'] != 3 or list(plan['candidates']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        if identity(candidate_directory / f'{arm}.mdb') != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def expected_rows(arm):
+    return [{'id': 9 - (position % 10 if arm == 'ordinary' else position),
+             'payload': chr(ord('a') + position) * 255} for position in range(20)]
+
+
+def schema(plan, arm):
+    return {**plan['schema'], 'indexes': [{'name': 'ById', 'primary': arm == 'primary',
+            'unique': arm != 'ordinary', 'required': arm == 'primary',
+            'fields': [{'name': 'Id', 'descending': False}]}]}
+
+
+def semantics(plan, arm, observation):
+    snapshot = observation['snapshot']
+    expected = expected_rows(arm)
+    rowset = sorted(expected, key=canonical)
+    shape = {key: value for key, value in snapshot.items() if key not in ('rows', 'traversal', 'seek')}
+    traversal = snapshot.get('traversal', [])
+    keys = [row['id'] for row in traversal]
+    ordered = all(isinstance(key, int) for key in keys) and keys == sorted(keys)
+    seeks = snapshot.get('seek', [])
+    expected_queries = sorted({row['id'] for row in expected})
+    seek_ok = ([item['query'] for item in seeks] == expected_queries
+               and all(item['row'] in expected and item['row']['id'] == item['query'] for item in seeks))
+    passed = (observation['status'] == 'pass' and observation['endpoint'] == 'complete'
+              and shape == schema(plan, arm)
+              and sorted(snapshot.get('rows', []), key=canonical) == rowset
+              and ordered and sorted(traversal, key=canonical) == rowset and seek_ok)
+    normalized = dict(snapshot)
+    if 'rows' in normalized:
+        normalized['rows'] = sorted(normalized['rows'], key=canonical)
+    if ordered and 'traversal' in normalized:
+        normalized['traversal'] = sorted(traversal, key=canonical)
+    if seek_ok:
+        # Ordinary Seek may select either duplicate; both must occur in traversal.
+        normalized['seek'] = expected_queries
+    return passed, {**{key: observation[key] for key in ('status', 'endpoint', 'error')},
+                    'snapshot': normalized}
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    if (result['document_type'] != 'dao_indexed_rows_result'
+            or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32):
+        raise ValueError('Result identity/environment mismatch')
+    expected_inventory = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual_inventory = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual_inventory != expected_inventory[:len(actual_inventory)]:
+        raise ValueError('Unexpected replica inventory')
+    grouped = {arm: [] for arm in ARMS}
+    unchanged = True
+    controls_ok = True
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        for role in ('candidate', 'control'):
+            observation = item[role]
+            retained = outbox / f'{arm}-{role}-r{replica}.mdb'
+            if identity(retained) != observation['after']:
+                raise ValueError(f'Retained identity mismatch: {retained.name}')
+            if role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                raise ValueError('Candidate did not start with pinned identity')
+            unchanged &= observation['before'] == observation['after']
+        controls_ok &= semantics(plan, arm, item['control'])[0]
+        grouped[arm].append(semantics(plan, arm, item['candidate']))
+    outcomes = {arm: 'no_outcome' for arm in ARMS}
+    if (result['mutation_started'] is True and result['error'] is None
+            and actual_inventory == expected_inventory and controls_ok and unchanged):
+        for arm, observations in grouped.items():
+            if all(item == observations[0] for item in observations):
+                outcomes[arm] = 'observed_accepted' if observations[0][0] else 'not_observed_accepted'
+    report = {'document_type': 'dao_indexed_rows_report', 'development_only': True,
+              'compatibility_claim': False, 'support_movement': False,
+              'plan_sha256': digest(PLAN), 'result_sha256': digest(outbox / 'result.json'),
+              'outcomes': outcomes, 'replicas': len(result['replicas']), 'candidates': plan['candidates']}
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report))
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'indexed-rows.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_indexed_rows.py
+++ b/oracle/windows-dao/tests/test_indexed_rows.py
@@ -1,0 +1,99 @@
+"""Classify index traversal and Seek independently of producer pass flags."""
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('indexed_rows', Path(__file__).parents[1] / 'scripts/indexed_rows.py')
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class IndexedRowsReportTests(unittest.TestCase):
+    def classify(self, change=lambda result: None, tamper=None):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / 'producer.ps1'
+            source.write_text('pinned producer')
+            plan = {'inputs': {str(source): MODULE.digest(source)}, 'schema': {'version': '3.0'}, 'candidates': {}}
+            for arm in MODULE.ARMS:
+                path = root / f'{arm}.mdb'
+                path.write_bytes(arm.encode())
+                plan['candidates'][arm] = MODULE.identity(path)
+            plan_path = root / 'plan.json'
+            plan_path.write_text(json.dumps(plan))
+            result = {'document_type': 'dao_indexed_rows_result', 'development_only': True,
+                      'plan_sha256': MODULE.digest(plan_path), 'environment': {'process_bits': 32},
+                      'mutation_started': True, 'error': None, 'replicas': []}
+            for arm in MODULE.ARMS:
+                rows = MODULE.expected_rows(arm)
+                snapshot = {**MODULE.schema(plan, arm), 'rows': rows,
+                            'traversal': sorted(rows, key=lambda row: (row['id'], row['payload'])),
+                            'seek': [{'query': key, 'row': next(row for row in rows if row['id'] == key)}
+                                     for key in sorted({row['id'] for row in rows})]}
+                for number in range(1, 4):
+                    replica = {'arm': arm, 'replica': number}
+                    for role in ('candidate', 'control'):
+                        path = root / f'{arm}-{role}-r{number}.mdb'
+                        path.write_bytes(arm.encode())
+                        replica[role] = {'before': MODULE.identity(path), 'after': MODULE.identity(path),
+                                         'status': 'pass', 'endpoint': 'complete', 'error': None,
+                                         'snapshot': copy.deepcopy(snapshot)}
+                    result['replicas'].append(replica)
+            change(result)
+            (root / 'result.json').write_text(json.dumps(result))
+            if tamper == 'input':
+                source.write_text('diagnostic edit')
+            elif tamper == 'retained':
+                (root / 'primary-candidate-r1.mdb').write_bytes(b'changed')
+            with patch.object(MODULE, 'PLAN', plan_path), patch('builtins.print'):
+                MODULE.analyze(root)
+            return json.loads((root / 'report.json').read_text())['outcomes']
+
+    def test_duplicate_seek_may_choose_either_matching_payload(self):
+        def change(result):
+            replica = result['replicas'][6]
+            rows = MODULE.expected_rows('ordinary')
+            for item in replica['candidate']['snapshot']['seek']:
+                item['row'] = next(row for row in reversed(rows) if row['id'] == item['query'])
+        self.assertTrue(all(value == 'observed_accepted' for value in self.classify(change).values()))
+
+    def test_missing_duplicate_in_traversal_is_negative(self):
+        def change(result):
+            for replica in result['replicas'][6:]:
+                replica['candidate']['snapshot']['traversal'].pop()
+        outcomes = self.classify(change)
+        self.assertEqual(outcomes['ordinary'], 'not_observed_accepted')
+        self.assertEqual(outcomes['primary'], 'observed_accepted')
+
+    def test_wrong_seek_payload_is_negative(self):
+        def change(result):
+            for replica in result['replicas'][3:6]:
+                replica['candidate']['snapshot']['seek'][0]['row']['payload'] = 'wrong'
+        self.assertEqual(self.classify(change)['unique'], 'not_observed_accepted')
+
+    def test_traversal_disagreement_and_control_failure_have_no_outcome(self):
+        def disagreement(result):
+            result['replicas'][0]['candidate']['snapshot']['traversal'].reverse()
+        self.assertEqual(self.classify(disagreement)['primary'], 'no_outcome')
+        def control_failure(result):
+            result['replicas'][0]['control']['snapshot']['rows'] = []
+        self.assertTrue(all(value == 'no_outcome' for value in self.classify(control_failure).values()))
+
+    def test_incomplete_scientific_job_has_no_outcome(self):
+        def change(result):
+            result['replicas'].pop()
+            result['error'] = 'CreateDatabase failed'
+        self.assertTrue(all(value == 'no_outcome' for value in self.classify(change).values()))
+
+    def test_modified_inputs_and_retained_files_are_rejected(self):
+        for tamper in ('input', 'retained'):
+            with self.subTest(tamper=tamper), self.assertRaises(ValueError):
+                self.classify(tamper=tamper)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Preregister DAO validation for the exact primary, unique, and ordinary-duplicate initial-row candidates from #201. Each arm has three fresh controls and candidate replicas; comparisons cover full schema/index flags, every key/payload pair, ordered index traversal, and Seek results while requiring unchanged identities.

Ordinary duplicate tie order and Seek choice are normalized only after validating the complete expected pairs. Any incomplete run, failed control, or changed image makes the matrix no_outcome; no automatic retry exists. Input pins are enforced during dispatch and analysis. No acquisition has run.

Validation: independent harness review with no findings, six focused classifier tests, PowerShell syntax check, committed-plan/candidate preflight, and `just ready` passed.

Part of #100; stacked after #201.
