### PR TITLE
test: preregister renamed relationship candidate matrix

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10512,3 +10512,37 @@ Copy this block under the appropriate section and remove this instruction:
 - Review: independent outcome review verified input and retained-image
   identities, byte-identical report reconstruction, all recorded metadata
   claims, and the exact-candidate evidence boundary; no findings.
+
+## EXP-0121 — Preregistered renamed relationship candidate matrix
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: preregistered local development DAO differential; no acquisition yet
+- Plan: `oracle/windows-dao/acquisition/parameterized-relationships.plan.json`,
+  SHA-256 `f4168b5e575303cc52247756d64da072a898e997c84cc7f9253d1f16db8bfe5f`.
+  Pins the new host/analyzer and PowerShell scripts, transport, private
+  composer/plan/export source, and both exact candidate identities.
+- Candidates: reviewed source `6058627` exports one-index `Accounts7` /
+  `Events9` / `Account7Events9` (57,344 bytes, SHA-256
+  `9d6d850ae06b4a4317f2640e468b0afae7ac248808c8c0ac2fbb211f2ce87927`)
+  and two-index `Owners2` / `Details4` / `Owner2_Details4` (59,392 bytes,
+  SHA-256 `25472960e097ac3539a1da8cf7d3d10e588637b209c991a578e095b74c629fd9`).
+  Parent columns are `Code2 Long`, `Key1 Long`, with primary `Primary9` on
+  `Key1` and, in the second arm, unique `Unique8` on `Code2`. Child columns
+  are `Label3 Text(8)`, `Account4 Long`; the relation binds `Key1` to
+  `Account4` with attributes zero. Both user tables are empty.
+- Question: do both exact renamed candidates match fresh DAO controls at
+  every captured table/column/index flag and binding, relation endpoint and
+  option, and empty-row snapshot? Bounded `.rB`/`.rC` placements derive from
+  `EXP-0059`/`EXP-0114`; applying `EXP-0087` standalone name weights remains
+  an explicit candidate hypothesis. `EXP-0118` accepted only the original
+  fixed-name candidate.
+- Protocol: prepare all six hash-checked candidate copies before mutation;
+  acquire three fresh controls and read-only candidate observations per
+  arm, in finite plan order. Require unchanged file identities and exact
+  within-arm replica/control agreement; no cross-arm or control-byte
+  equality. Host analysis rechecks pins and retained identities. Failure
+  after first mutation is an outcome, never an automatic retry.
+- Boundary: commit and review before one acquisition. No public API,
+  generalized relationship grammar, integrity-enforcement mutation,
+  cascade, populated relation, update, or hosted support claim. Record one
+  validated additive outcome as `EXP-0122`; retain MDBs externally.

--- a/oracle/windows-dao/acquisition/parameterized-relationships.plan.json
+++ b/oracle/windows-dao/acquisition/parameterized-relationships.plan.json
@@ -1,0 +1,191 @@
+{
+  "document_type": "dao_parameterized_relationships_plan",
+  "experiment_id": "parameterized-relationships",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0118 accepted the exact original ParentChild candidate. EXP-0059/0114 inform bounded one/two parent index selector placements; applying EXP-0087 standalone name weights to renamed relationship keys remains a candidate hypothesis.",
+    "hypothesis": "Both exact pinned renamed, digit-bearing candidates match their own fresh DAO controls at every captured schema/index/relation/empty-row endpoint without changing either file.",
+    "authorization": "User authorized DAO experiments/mutations in this session. Commit and review this pinned plan before one acquisition. A failure after first CreateDatabase is a scientific result; no redispatch without another human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/parameterized_relationships.py": "6cac2cbb053f7891bdc6399d67956cbee97678c22462fb5914c5053846c1e21a",
+    "oracle/windows-dao/scripts/parameterized_relationships.ps1": "8cbe15ce1ad8bb8de48e43c5e6c8bdc7d383c00788936b92d46cdea84e8a331d",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/src/bootstrap_relationship_candidate.rs": "63fe60b85a0b16f33b6a7d207049213ee936213c402b509f9b8564c02edc919d",
+    "crates/jet3/src/bootstrap_relationship_plan.rs": "467ef3bba64351f7263bbbc56eb1be4b906e797bc36af472cf1aa0fee10e6f57",
+    "crates/jet3/src/bootstrap_relationship_parameterized_tests.rs": "c8ea1cb0b2f746cde66291caa16528d22d3e03948eae1a9f3b7af8faf7d4f43a"
+  },
+  "candidate_generation": {
+    "source_commit": "605862779cb9a7cb51bd20bf4256e75f4abf4b19",
+    "command": "JET3_RELATIONSHIP_CANDIDATE_DIR=/absolute/existing/dir cargo test --locked -p jet3 --lib export_parameterized_relationship_candidates -- --ignored",
+    "notes": "Exact exported image hashes are acquisition inputs; no source-attestation or equivalence to other builds is claimed."
+  },
+  "execution": {
+    "environment": "Local private Windows VM, x86 PowerShell, DAO.DBEngine.36; development discovery only.",
+    "pre_mutation": "Verify host pins and committed plan; guest verifies its script and prepares all six hash-checked candidate replicas before first CreateDatabase.",
+    "per_replica": "In plan arm order, create parent columns Code2 Long then Key1 Long, Primary9 ascending primary on Key1, optionally Unique8 ascending unique on Code2; child Label3 Text(8) then Account4 Long with no indexes. Append named relation Key1 to Account4 with attributes zero. Close. Observe each control and candidate separately read-only, capturing table inventory, user-table/field attributes and types/sizes, every user index flag/ordered binding, all relations/options/bindings and full user rows. Close and rehash.",
+    "comparison": "Within each arm preserve column/index-field order; sort index inventories and relations by name. Compare all captured status/endpoint/error/snapshot values across three replicas and between candidate/control. No comparison across arms or physical-byte equality with controls.",
+    "control_anchor": "Require arm expected_control tables/version/columns/relations, zero user-table attributes, empty rows and specified parent index primary/unique/ascending field bindings. All remaining captured index/field metadata comes from differential controls.",
+    "attempts": 1,
+    "run": "python3 oracle/windows-dao/scripts/parameterized_relationships.py run CANDIDATE_DIRECTORY --shared-root VM_SHARED_ROOT --run-id UTC-parameterized-relations",
+    "analysis": "python3 oracle/windows-dao/scripts/parameterized_relationships.py analyze OUTBOX; rechecks input pins."
+  },
+  "decision_rule": {
+    "observed_accepted": "Per arm, all three controls satisfy anchor, six files unchanged, replicas agree, complete candidate/control observations identical. Overall accepted only when both arms accepted.",
+    "not_observed_accepted": "All controls satisfy the anchor unchanged; all candidates unchanged and identically fail at an endpoint or return the same metadata/rows difference.",
+    "no_outcome": "Incomplete/failed acquisition, control failure, changed image or within-arm disagreement. Overall no_outcome if either arm no_outcome, otherwise not_observed_accepted if either differs.",
+    "rejection": "Plan/result identity mismatch, unexpected replica inventory, candidate starting mismatch, or retained image identity mismatch rejects validation."
+  },
+  "boundary": "Only these two exact empty-table images and read-only metadata/rows endpoints. No general name grammar, public API, cascade, populated relation, integrity enforcement mutation, update or hosted support claim.",
+  "retention": "Retain JSON result/report, logs, and control/candidate MDBs externally. Never commit MDB bytes or provider binaries. Record one additive EXP-0122 outcome from the validated report.",
+  "arms": [
+    {
+      "name": "one-index",
+      "parent": "Accounts7",
+      "child": "Events9",
+      "relation": "Account7Events9",
+      "filename": "relationship-one-index.mdb",
+      "candidate": {
+        "size": 57344,
+        "sha256": "9d6d850ae06b4a4317f2640e468b0afae7ac248808c8c0ac2fbb211f2ce87927"
+      },
+      "expected_control": {
+        "version": "3.0",
+        "tables": [
+          "Accounts7",
+          "Events9",
+          "MSysACEs",
+          "MSysObjects",
+          "MSysQueries",
+          "MSysRelationships"
+        ],
+        "relations": [
+          {
+            "name": "Account7Events9",
+            "table": "Accounts7",
+            "foreign_table": "Events9",
+            "attributes": 0,
+            "fields": [
+              {
+                "name": "Key1",
+                "foreign_name": "Account4"
+              }
+            ]
+          }
+        ],
+        "columns": {
+          "Accounts7": [
+            {
+              "name": "Code2",
+              "type": 4,
+              "size": 4
+            },
+            {
+              "name": "Key1",
+              "type": 4,
+              "size": 4
+            }
+          ],
+          "Events9": [
+            {
+              "name": "Label3",
+              "type": 10,
+              "size": 8
+            },
+            {
+              "name": "Account4",
+              "type": 4,
+              "size": 4
+            }
+          ]
+        },
+        "parent": "Accounts7",
+        "parent_indexes": [
+          [
+            "Primary9",
+            "Key1",
+            true
+          ]
+        ]
+      }
+    },
+    {
+      "name": "two-index",
+      "parent": "Owners2",
+      "child": "Details4",
+      "relation": "Owner2_Details4",
+      "filename": "relationship-two-index.mdb",
+      "candidate": {
+        "size": 59392,
+        "sha256": "25472960e097ac3539a1da8cf7d3d10e588637b209c991a578e095b74c629fd9"
+      },
+      "expected_control": {
+        "version": "3.0",
+        "tables": [
+          "Details4",
+          "MSysACEs",
+          "MSysObjects",
+          "MSysQueries",
+          "MSysRelationships",
+          "Owners2"
+        ],
+        "relations": [
+          {
+            "name": "Owner2_Details4",
+            "table": "Owners2",
+            "foreign_table": "Details4",
+            "attributes": 0,
+            "fields": [
+              {
+                "name": "Key1",
+                "foreign_name": "Account4"
+              }
+            ]
+          }
+        ],
+        "columns": {
+          "Owners2": [
+            {
+              "name": "Code2",
+              "type": 4,
+              "size": 4
+            },
+            {
+              "name": "Key1",
+              "type": 4,
+              "size": 4
+            }
+          ],
+          "Details4": [
+            {
+              "name": "Label3",
+              "type": 10,
+              "size": 8
+            },
+            {
+              "name": "Account4",
+              "type": 4,
+              "size": 4
+            }
+          ]
+        },
+        "parent": "Owners2",
+        "parent_indexes": [
+          [
+            "Primary9",
+            "Key1",
+            true
+          ],
+          [
+            "Unique8",
+            "Code2",
+            false
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/oracle/windows-dao/scripts/parameterized_relationships.ps1
+++ b/oracle/windows-dao/scripts/parameterized_relationships.ps1
@@ -1,0 +1,166 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function New-Tables([string]$Path, $Arm) {
+    $engine = $workspace = $db = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($name in @($Arm.parent, $Arm.child)) {
+            $table = $field = $index = $key = $null
+            try {
+                $table = $db.CreateTableDef($name)
+                $columns = if ($name -eq $Arm.parent) { @('Code2', 'Key1') } else { @('Label3', 'Account4') }
+                foreach ($column in $columns) {
+                    $field = if ($column -eq 'Label3') { $table.CreateField($column, 10, 8) } else { $table.CreateField($column, 4) }
+                    $table.Fields.Append($field)
+                    Release $field; $field = $null
+                }
+                if ($name -eq $Arm.parent) {
+                    foreach ($definition in $Arm.expected_control.parent_indexes) {
+                        $index = $table.CreateIndex([string]$definition[0])
+                        $index.Unique = $true
+                        $index.Primary = [bool]$definition[2]
+                        $key = $index.CreateField([string]$definition[1])
+                        $index.Fields.Append($key)
+                        $table.Indexes.Append($index)
+                        Release $key; $key = $null
+                        Release $index; $index = $null
+                    }
+                }
+                $db.TableDefs.Append($table)
+            }
+            finally { Release $key; Release $index; Release $field; Release $table }
+        }
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Add-Relation([string]$Path, $Arm) {
+    $engine = $db = $relation = $field = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path)
+        $relation = $db.CreateRelation($Arm.relation, $Arm.parent, $Arm.child, 0)
+        $field = $relation.CreateField('Key1')
+        $field.ForeignName = 'Account4'
+        $relation.Fields.Append($field)
+        $db.Relations.Append($relation)
+    }
+    finally {
+        Release $field; Release $relation
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+    }
+}
+function Observe([string]$Path, $Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $snapshot = [ordered]@{}
+    $status = 'pass'; $endpoint = 'open_database'; $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.schema = @{}
+        foreach ($name in @($Arm.parent, $Arm.child)) {
+            $table = $db.TableDefs.Item($name)
+            $fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes} })
+            $indexes = @()
+            foreach ($index in $table.Indexes) {
+                try {
+                    $keys = @($index.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })
+                    $indexes += @{name=[string]$index.Name; primary=[bool]$index.Primary; unique=[bool]$index.Unique; foreign=[bool]$index.Foreign; required=[bool]$index.Required; ignore_nulls=[bool]$index.IgnoreNulls; fields=$keys}
+                }
+                finally { Release $index }
+            }
+            $snapshot.schema[$name] = @{attributes=[int]$table.Attributes; fields=$fields; indexes=$indexes; rows=@()}
+            Release $table; $table = $null
+        }
+        $endpoint = 'relations'
+        $snapshot.relations = @()
+        foreach ($relation in $db.Relations) {
+            try {
+                $fields = @($relation.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })
+                $snapshot.relations += @{name=[string]$relation.Name; table=[string]$relation.Table; foreign_table=[string]$relation.ForeignTable; attributes=[int]$relation.Attributes; fields=$fields}
+            }
+            finally { Release $relation }
+        }
+        $endpoint = 'rows'
+        foreach ($name in @($Arm.parent, $Arm.child)) {
+            $rs = $db.OpenRecordset($name, 4)
+            while (-not $rs.EOF) {
+                $values = @($rs.Fields | ForEach-Object {
+                    $value = $_.Value
+                    if ($null -eq $value -or [Convert]::IsDBNull($value)) { $null } else { $value }
+                })
+                $snapshot.schema[$name].rows += ,$values
+                $rs.MoveNext()
+            }
+            $rs.Close(); Release $rs; $rs = $null
+        }
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'parameterized-relationships.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/parameterized_relationships.ps1') { throw 'Script pin mismatch' }
+foreach ($arm in $plan.arms) {
+    $candidate = Join-Path $env:JET3_WORK $arm.filename
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$($arm.name)-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath $candidate -Destination $path
+        $identity = Identity $path
+        if ($identity.size -ne $arm.candidate.size -or $identity.sha256 -cne $arm.candidate.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_parameterized_relationships_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$($arm.name)-control-r$replica.mdb"
+            New-Tables $control $arm
+            Add-Relation $control $arm
+            $result.replicas += @{arm=$arm.name; replica=$replica; control=(Observe $control $arm); candidate=(Observe (Join-Path $env:JET3_WORK "$($arm.name)-candidate-r$replica.mdb") $arm)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    [IO.File]::WriteAllText((Join-Path $env:JET3_OUTBOX 'result.json'), (($result | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/parameterized_relationships.py
+++ b/oracle/windows-dao/scripts/parameterized_relationships.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Preregistered relationship candidate DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/parameterized-relationships.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/parameterized_relationships.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'parameterized-relationships' or plan['replicas'] != 3:
+        raise ValueError('Unexpected experiment plan')
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+    return plan
+
+
+def preflight(candidate):
+    plan = verify_inputs()
+    for arm in plan['arms']:
+        if identity(candidate / arm['filename']) != arm['candidate']:
+            raise ValueError('Candidate identity mismatch: ' + arm['name'])
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def normalized(snapshot):
+    result = json.loads(canonical(snapshot))
+    if 'schema' in result:
+        for table in result['schema'].values():
+            table['indexes'] = sorted(table['indexes'], key=lambda index: index['name'])
+    if 'relations' in result:
+        result['relations'] = sorted(result['relations'], key=lambda relation: relation['name'])
+    return result
+
+
+def control_matches(snapshot, expected):
+    if any(snapshot.get(key) != expected[key] for key in ('version', 'tables', 'relations')):
+        return False
+    schema = snapshot.get('schema', {})
+    if set(schema) != set(expected['columns']):
+        return False
+    for name, columns in expected['columns'].items():
+        table = schema[name]
+        fields = [{key: field[key] for key in ('name', 'type', 'size')} for field in table['fields']]
+        if table['attributes'] != 0 or fields != columns or table['rows'] != []:
+            return False
+    # DAO exposes all other index metadata as the differential control.
+    parent = {index['name']: index for index in schema[expected['parent']]['indexes']}
+    for name, column, primary in expected['parent_indexes']:
+        index = parent.get(name)
+        if not index or index['primary'] is not primary or index['unique'] is not True or index['fields'] != [{'name': column, 'attributes': 0}]:
+            return False
+    return True
+
+
+def arm_report(result, outbox, plan, arm):
+    if (result['document_type'] != 'dao_parameterized_relationships_result'
+            or result['plan_sha256'] != digest(PLAN) or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    observations, reasons = [], []
+    for number, replica in enumerate(result['replicas'], 1):
+        if replica['replica'] != number or number > 3:
+            raise ValueError('Unexpected replica inventory')
+        pair = {}
+        for role in ('control', 'candidate'):
+            observation = replica[role]
+            if identity(outbox / f"{arm['name']}-{role}-r{number}.mdb") != observation['after']:
+                raise ValueError('Retained image identity mismatch')
+            if role == 'candidate' and observation['before'] != arm['candidate']:
+                raise ValueError('Candidate starting identity mismatch')
+            if observation['before'] != observation['after']:
+                reasons.append(f'{role} replica {number}: read-only bytes changed')
+            pair[role] = {key: observation[key] for key in ('status', 'endpoint', 'error')}
+            pair[role]['snapshot'] = normalized(observation['snapshot'])
+        control = pair['control']
+        if (control['status'] != 'pass' or control['endpoint'] != 'complete'
+                or not control_matches(control['snapshot'], arm['expected_control'])):
+            reasons.append(f'Control replica {number} did not satisfy declared schema/relation/rows')
+        observations.append(pair)
+    if len(observations) != 3 or result['error'] is not None or result['mutation_started'] is not True:
+        reasons.append('Acquisition incomplete or failed: ' + str(result['error']))
+    if observations and any(pair != observations[0] for pair in observations):
+        reasons.append('Replicas disagree on endpoint observations')
+    outcome = 'no_outcome'
+    if not reasons:
+        outcome = 'observed_accepted' if observations[0]['candidate'] == observations[0]['control'] else 'not_observed_accepted'
+    return {'document_type': 'dao_parameterized_relationships_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'candidate': arm['candidate'], 'outcome': outcome,
+            'reasons': reasons, 'observations': observations, 'compatibility_claim': False,
+            'support_matrix_movement': False}
+
+
+def build_report(result, outbox, plan):
+    expected = [(arm['name'], replica) for arm in plan['arms'] for replica in range(1, 4)]
+    actual = [(entry['arm'], entry['replica']) for entry in result['replicas']]
+    if actual != expected[:len(actual)]:
+        raise ValueError('Unexpected arm/replica inventory')
+    reports = {}
+    for arm in plan['arms']:
+        subset = dict(result, replicas=[entry for entry in result['replicas'] if entry['arm'] == arm['name']])
+        reports[arm['name']] = arm_report(subset, outbox, plan, arm)
+    outcomes = [report['outcome'] for report in reports.values()]
+    outcome = ('no_outcome' if 'no_outcome' in outcomes else
+               'not_observed_accepted' if 'not_observed_accepted' in outcomes else 'observed_accepted')
+    return {'document_type': 'dao_parameterized_relationships_matrix_report',
+            'development_only': True, 'plan_sha256': digest(PLAN), 'outcome': outcome,
+            'arms': reports, 'compatibility_claim': False, 'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    output = outbox / 'report.json'
+    output.write_text(canonical(report) + '\n')
+    print(output)
+    print(report['outcome'])
+
+
+def dispatch(args):
+    plan = preflight(args.candidate)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / PLAN.name)
+    for arm in plan['arms']:
+        shutil.copyfile(args.candidate / arm['filename'], inbox / arm['filename'])
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        preflight(args.candidate)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_parameterized_relationships.py
+++ b/oracle/windows-dao/tests/test_parameterized_relationships.py
@@ -1,0 +1,89 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+spec = importlib.util.spec_from_file_location('parameterized_relationships', SCRIPTS / 'parameterized_relationships.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class ParameterizedRelationshipsTests(unittest.TestCase):
+    def fixture(self, outbox):
+        plan = json.loads(experiment.PLAN.read_text())
+        result = {'document_type': 'dao_parameterized_relationships_result', 'development_only': True,
+                  'plan_sha256': experiment.digest(experiment.PLAN), 'mutation_started': True,
+                  'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'replicas': [], 'error': None}
+        for arm in plan['arms']:
+            expected = arm['expected_control']
+            snapshot = {key: copy.deepcopy(expected[key]) for key in ('version', 'tables', 'relations')}
+            snapshot['schema'] = {name: {'attributes': 0, 'fields': copy.deepcopy(fields), 'rows': [], 'indexes': []}
+                                  for name, fields in expected['columns'].items()}
+            snapshot['schema'][arm['parent']]['indexes'] = [
+                {'name': name, 'primary': primary, 'unique': True, 'foreign': False,
+                 'required': False, 'ignore_nulls': False, 'fields': [{'name': column, 'attributes': 0}]}
+                for name, column, primary in expected['parent_indexes']]
+            image = arm['name'].encode()
+            arm['candidate'] = {'size': len(image), 'sha256': experiment.hashlib.sha256(image).hexdigest()}
+            observation = {'before': arm['candidate'], 'after': arm['candidate'], 'status': 'pass',
+                           'endpoint': 'complete', 'error': None, 'snapshot': snapshot}
+            for number in range(1, 4):
+                result['replicas'].append({'arm': arm['name'], 'replica': number,
+                                          'control': copy.deepcopy(observation), 'candidate': copy.deepcopy(observation)})
+                for role in ('control', 'candidate'):
+                    (outbox / f"{arm['name']}-{role}-r{number}.mdb").write_bytes(image)
+        return plan, result
+
+    def test_each_arm_requires_all_metadata_and_relation_bindings(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'observed_accepted')
+            for replica in result['replicas'][3:]:
+                replica['candidate']['snapshot']['relations'][0]['fields'][0]['foreign_name'] = 'Label3'
+            report = experiment.build_report(result, outbox, plan)
+            self.assertEqual(report['outcome'], 'not_observed_accepted')
+            self.assertEqual(report['arms']['one-index']['outcome'], 'observed_accepted')
+            self.assertEqual(report['arms']['two-index']['outcome'], 'not_observed_accepted')
+            result['replicas'][3]['candidate']['snapshot']['schema']['Owners2']['indexes'][0]['required'] = True
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+
+    def test_incomplete_controls_or_changed_files_cannot_be_accepted(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            for replica in result['replicas'][:3]:
+                replica['control']['snapshot']['schema']['Accounts7']['rows'] = [[1, 2]]
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+            plan, result = self.fixture(outbox)
+            result['replicas'].pop()
+            result['error'] = 'Mutation failed'
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+            result['replicas'][0]['control']['before'] = {'size': 0, 'sha256': 'changed'}
+            self.assertIn('read-only bytes changed', experiment.build_report(result, outbox, plan)['arms']['one-index']['reasons'][0])
+            result['replicas'][0]['candidate']['before'] = {'size': 0, 'sha256': 'wrong'}
+            with self.assertRaisesRegex(ValueError, 'starting identity'):
+                experiment.build_report(result, outbox, plan)
+            plan, result = self.fixture(outbox)
+            (outbox / 'one-index-candidate-r1.mdb').write_bytes(b'changed')
+            with self.assertRaisesRegex(ValueError, 'Retained image'):
+                experiment.build_report(result, outbox, plan)
+
+    def test_inventory_and_standalone_pins_are_required(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            result['replicas'][0]['arm'] = 'two-index'
+            with self.assertRaisesRegex(ValueError, 'inventory'):
+                experiment.build_report(result, outbox, plan)
+        with patch.object(experiment, 'verify_inputs', side_effect=ValueError('Input pin mismatch')):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                experiment.analyze(Path('unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The private relationship composer needs DAO evidence for caller-selected names and linked-column positions before public exposure. EXP-0121 pins two renamed candidates with one or two parent indexes and compares three fresh DAO controls per arm against complete schema, indexes, relationships, and empty rows.

The committed plan and every input are verified before acquisition and analysis. This is development evidence only; it makes no support-matrix or compatibility claim.

Validation: independent review found no issues; three classifier tests, Windows PowerShell parser check, candidate preflight, and `just ready` passed.

The single authorized acquisition subsequently accepted both arms in all six comparisons. EXP-0122 will record the result with public API exposure. Parent integration was independently reviewed and passed focused checks plus `just ready`.
