### PR TITLE
feat(jet3): expose typed relationship creation

### DIFF
--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -5,7 +5,7 @@ use super::*;
 /// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
-    /// The private relationship request exceeds the supported schema or references.
+    /// The relationship request exceeds the supported schema or references.
     UnsupportedRelationship {
         /// Unsupported relationship constraint.
         detail: &'static str,

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -770,3 +770,6 @@ mod tests;
 
 #[path = "bootstrap_relationship_candidate.rs"]
 mod relationship_candidate;
+
+pub(crate) use relationship_candidate::compose_relationship;
+pub use relationship_candidate::{RelationshipColumn, RelationshipSpec, TableRef};

--- a/crates/jet3/src/bootstrap_relationship_candidate.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate.rs
@@ -1,21 +1,18 @@
-//! Private bounded relationship composition with caller-supplied schemas.
+//! Bounded relationship composition with caller-supplied schemas.
 //!
-//! EXP-0118 accepted only the original fixed candidate. Renamed constructions
-//! remain candidates: applying EXP-0087 catalog text weights to standalone
-//! relationship keys is an explicit hypothesis, not an established general
-//! encoding. EXP-0059/0114 supply two bounded hidden-name/selector cases.
+//! EXP-0118 and EXP-0122 accepted three exact constructions, including the
+//! two renamed one/two-parent-index cases. EXP-0087 supplies name-key weights;
+//! no general name grammar or integrity-enforcement behavior is established.
 
-#![allow(
-    dead_code,
-    reason = "private relationship candidate awaiting DAO validation"
-)]
+#![allow(dead_code, reason = "retained deterministic relationship fixtures")]
 
 use super::*;
 use crate::{IndexColumnSpec, IndexFieldSpec, IndexKind, IndexSpec, RelationshipSide};
 
 #[path = "bootstrap_relationship_plan.rs"]
 mod planning;
-use planning::{RelationshipColumn, RelationshipPlan, RelationshipSpec, TableRef};
+use planning::RelationshipPlan;
+pub use planning::{RelationshipColumn, RelationshipSpec, TableRef};
 
 // EXP-0114 base and first checkpoints.
 const PARENT_ROOT: u64 = 20;
@@ -97,7 +94,7 @@ fn compose_parent_child(budget: &mut ResourceBudget) -> Result<WholeFileImagePla
     )
 }
 
-fn compose_relationship(
+pub(crate) fn compose_relationship(
     tables: &[TableSpec<'_>],
     relationship: &RelationshipSpec<'_>,
     budget: &mut ResourceBudget,
@@ -350,8 +347,8 @@ fn relation_index_name(
     row_page: u64,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
-    // Candidate hypothesis: the EXP-0087 text component also serves these
-    // standalone keys. EXP-0114's three original keys reproduce exactly.
+    // EXP-0118/0122 accepted the original and two renamed constructions
+    // using the EXP-0087 text component as these standalone keys.
     let mut entry = OwnedIndexEntry::EMPTY;
     let length = encode_catalog_name_key(0, name, &mut entry.key)?;
     let prefix = crate::catalog_name_key::LONG_COMPONENT_LEN;

--- a/crates/jet3/src/bootstrap_relationship_plan.rs
+++ b/crates/jet3/src/bootstrap_relationship_plan.rs
@@ -1,4 +1,4 @@
-//! Typed, bounded inputs for private relationship composition. Schema and
+//! Typed, bounded inputs for relationship composition. Schema and
 //! placement use the existing EXP-0059/0087/0093 planners; only the two hidden
 //! selector/name cases recorded by EXP-0059 and EXP-0114 are admitted.
 
@@ -6,23 +6,52 @@ use super::*;
 use crate::ColumnRef;
 use crate::table_schema_plan::{TableSchemaPlan, plan_table_schema};
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum TableRef<'a> {
+/// A table in the ordered input to [`crate::create_database_with_relationship`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableRef<'a> {
+    /// Zero-based position in the supplied table slice.
     Ordinal(usize),
+    /// Exact database-encoded table name; matching is case-sensitive.
     Name(&'a [u8]),
 }
 
+/// A table and column forming one endpoint of a relationship.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct RelationshipColumn<'a> {
-    pub(crate) table: TableRef<'a>,
-    pub(crate) column: ColumnRef<'a>,
+pub struct RelationshipColumn<'a> {
+    /// Table containing the column.
+    pub table: TableRef<'a>,
+    /// Column name or ordinal within that table.
+    pub column: ColumnRef<'a>,
 }
 
+/// One non-cascading relationship between two empty tables.
+///
+/// Names are database-encoded bytes, subject to the bounded creation name
+/// encoder. See [`crate::create_database_with_relationship`] for schema limits.
+///
+/// ```
+/// use jet3::{ColumnRef, RelationshipColumn, RelationshipSpec, TableRef};
+///
+/// let relationship = RelationshipSpec {
+///     name: b"AccountsEvents",
+///     parent: RelationshipColumn {
+///         table: TableRef::Name(b"Accounts"),
+///         column: ColumnRef::Name(b"Id"),
+///     },
+///     child: RelationshipColumn {
+///         table: TableRef::Name(b"Events"),
+///         column: ColumnRef::Name(b"AccountId"),
+///     },
+/// };
+/// ```
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct RelationshipSpec<'a> {
-    pub(crate) name: &'a [u8],
-    pub(crate) parent: RelationshipColumn<'a>,
-    pub(crate) child: RelationshipColumn<'a>,
+pub struct RelationshipSpec<'a> {
+    /// Caller-chosen relationship and child foreign-index name.
+    pub name: &'a [u8],
+    /// Referenced primary-key column in the first table.
+    pub parent: RelationshipColumn<'a>,
+    /// Referencing Long column in the second table.
+    pub child: RelationshipColumn<'a>,
 }
 
 pub(super) struct RelationshipPlan<'a> {

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -62,6 +62,8 @@ impl StdError for CreateDatabaseError {
 /// found when the candidate was reopened before publication.
 #[derive(Debug)]
 pub enum CandidateCheckError {
+    /// Reading a candidate page or charging comparison work failed.
+    Read(crate::Error),
     /// The candidate index tree could not be read.
     Index(crate::IndexTreeError),
     /// The candidate rows could not be read.
@@ -84,6 +86,7 @@ pub enum CandidateCheckError {
 impl fmt::Display for CandidateCheckError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Read(source) => write!(formatter, "candidate page comparison failed: {source}"),
             Self::Index(source) => write!(formatter, "candidate index scan failed: {source}"),
             Self::Rows(source) => write!(formatter, "candidate row scan failed: {source}"),
             Self::RowEncoding(source) => {
@@ -104,6 +107,7 @@ impl fmt::Display for CandidateCheckError {
 impl StdError for CandidateCheckError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
+            Self::Read(source) => Some(source),
             Self::Index(source) => Some(source),
             Self::Rows(source) => Some(source),
             Self::RowEncoding(source) => Some(source),
@@ -411,3 +415,7 @@ fn check_table(
 #[cfg(all(test, unix))]
 #[path = "create_tests.rs"]
 mod tests;
+
+#[path = "create_relationship.rs"]
+mod relationship;
+pub use relationship::create_database_with_relationship;

--- a/crates/jet3/src/create_relationship.rs
+++ b/crates/jet3/src/create_relationship.rs
@@ -1,0 +1,159 @@
+//! Atomic publication of the bounded EXP-0118/0122 relationship construction.
+
+use super::*;
+use crate::bootstrap_composer::compose_relationship;
+use crate::{CatalogObjectKind, RelationshipSide, RelationshipSpec};
+
+/// Creates two empty tables with one non-cascading Long-to-Long relationship.
+///
+/// The parent must be the first table and the child the second. The parent's
+/// first index must be an ascending, single-column primary index on the
+/// referenced Long column. It may have one further ascending, single-Long
+/// unique index. The child must initially have no indexes; creation adds its
+/// foreign index, named by `relationship.name`. Table and column references
+/// may use names or zero-based ordinals.
+///
+/// AutoIncrement, Memo, LongBinary, continued definitions, and unsupported
+/// name bytes are refused with [`CreateDatabaseError::Compose`] before writing.
+/// The name and scalar-column bounds of [`create_database`] also apply.
+/// The atomic publication and existing-destination guarantees are the same:
+/// the written pages, catalog, user definitions, reciprocal relationships,
+/// empty rows, and empty index trees are checked before publication. All
+/// composition, writing, and checking is charged to `budget`.
+///
+/// `EXP-0118` and `EXP-0122` observed DAO accept three exact original/renamed
+/// images with these one/two-parent-index shapes. Other names and schemas
+/// compose from the same bounded encoders; they have no individual DAO
+/// result. Referential-integrity mutations, cascades, and hosted write
+/// support were not established by those read-only experiments.
+pub fn create_database_with_relationship(
+    path: impl AsRef<Path>,
+    tables: &[TableSpec<'_>],
+    relationship: &RelationshipSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<(), CreateDatabaseError> {
+    let pages = compose_relationship(tables, relationship, budget)
+        .map_err(CreateDatabaseError::Compose)?
+        .into_pages();
+    budget
+        .charge_work_units((pages.len() as u64).saturating_mul(crate::PAGE_BYTES as u64))
+        .map_err(|error| CreateDatabaseError::Compose(ComposeError::Encoding(error)))?;
+    atomic_create(
+        path,
+        |file| write_pages(file, &pages),
+        |candidate| check_relationship_candidate(candidate, tables, relationship, &pages, budget),
+    )
+    .map_err(CreateDatabaseError::Publish)
+}
+
+fn check_relationship_candidate(
+    candidate: &Path,
+    tables: &[TableSpec<'_>],
+    relationship: &RelationshipSpec<'_>,
+    pages: &[PlannedPage],
+    budget: &mut ResourceBudget,
+) -> Result<(), CandidateCheckError> {
+    let mismatch = |detail| CandidateCheckError::Mismatch { detail };
+    let mut database =
+        DatabaseReader::open(candidate, budget).map_err(CandidateCheckError::Open)?;
+    if tables.len() != 2 || database.geometry().page_count() != pages.len() as u64 {
+        return Err(mismatch("relationship geometry"));
+    }
+    let mut bytes = [0_u8; crate::PAGE_BYTES];
+    for page in pages {
+        database
+            .read_raw_page(page.number(), &mut bytes, budget)
+            .map_err(CandidateCheckError::Read)?;
+        budget
+            .charge_work_units(crate::PAGE_BYTES as u64)
+            .map_err(CandidateCheckError::Read)?;
+        if &bytes != page.image().as_bytes() {
+            return Err(mismatch("relationship written page"));
+        }
+    }
+    let mut roots = [None; 2];
+    {
+        let mut catalog = database
+            .catalog(budget)
+            .map_err(CandidateCheckError::Catalog)?;
+        while let Some(record) = catalog
+            .next_record()
+            .map_err(CandidateCheckError::Catalog)?
+        {
+            if record.class() != CatalogObjectClass::User
+                || record.kind() != CatalogObjectKind::Table
+            {
+                continue;
+            }
+            let position = tables
+                .iter()
+                .position(|table| table.name == record.name().raw_bytes())
+                .ok_or(mismatch("relationship catalog table"))?;
+            if roots[position].is_some() {
+                return Err(mismatch("relationship duplicate table"));
+            }
+            roots[position] = record.table_definition();
+        }
+    }
+    for (position, table) in tables.iter().enumerate() {
+        let root = roots[position].ok_or(mismatch("relationship catalog table"))?;
+        let other = roots[1 - position].ok_or(mismatch("relationship catalog table"))?;
+        let definition = database
+            .table_definition(root, budget)
+            .map_err(CandidateCheckError::Definition)?;
+        let mut relations = definition.relationships();
+        let relation = relations.next().ok_or(mismatch("relationship record"))?;
+        let endpoint = if position == 0 {
+            relationship.parent
+        } else {
+            relationship.child
+        };
+        let fields = definition
+            .physical_indexes()
+            .get(usize::from(relation.physical_index()))
+            .ok_or(mismatch("relationship physical index"))?
+            .fields();
+        if relations.next().is_some()
+            || relation.related_table() != other
+            || relation.side()
+                != if position == 0 {
+                    RelationshipSide::PrimaryTable
+                } else {
+                    RelationshipSide::ForeignTable
+                }
+            || relation.cascade_updates()
+            || relation.cascade_deletes()
+            || (position == 1 && relation.name().raw_bytes() != relationship.name)
+            || fields.len() != 1
+            || endpoint.column.resolve(table.columns) != Some(fields[0].column().get())
+        {
+            return Err(mismatch("relationship endpoint"));
+        }
+        for ordinal in 0..definition.physical_indexes().len() {
+            let ordinal =
+                u16::try_from(ordinal).map_err(|_| mismatch("relationship index count"))?;
+            if !database
+                .index_tree(&definition, ordinal, budget)
+                .map_err(CandidateCheckError::Index)?
+                .entries()
+                .is_empty()
+            {
+                return Err(mismatch("relationship index not empty"));
+            }
+        }
+        if database
+            .rows(&definition, budget)
+            .map_err(CandidateCheckError::Rows)?
+            .next_row()
+            .map_err(CandidateCheckError::Rows)?
+            .is_some()
+        {
+            return Err(mismatch("relationship rows not empty"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+#[path = "create_relationship_tests.rs"]
+mod tests;

--- a/crates/jet3/src/create_relationship_tests.rs
+++ b/crates/jet3/src/create_relationship_tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+use crate::{
+    ColumnRef, ColumnSpec, IndexColumnSpec, IndexSpec, RelationshipColumn, ResourceLimits, TableRef,
+};
+use std::fs;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+static NEXT: AtomicU64 = AtomicU64::new(0);
+struct Directory(std::path::PathBuf);
+impl Directory {
+    fn new() -> Result<Self, io::Error> {
+        let path = std::env::temp_dir().join(format!(
+            "jet3-create-relation-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&path)?;
+        Ok(Self(path))
+    }
+    fn target(&self) -> std::path::PathBuf {
+        self.0.join("created.mdb")
+    }
+    fn empty(&self) -> Result<bool, io::Error> {
+        Ok(fs::read_dir(&self.0)?.next().is_none())
+    }
+}
+impl Drop for Directory {
+    fn drop(&mut self) {
+        let _result = fs::remove_dir_all(&self.0);
+    }
+}
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn schema(two: bool) -> ([TableSpec<'static>; 2], RelationshipSpec<'static>) {
+    const PARENT_COLUMNS: &[ColumnSpec<'static>] = &[
+        ColumnSpec::new(b"Code2", ColumnType::Long),
+        ColumnSpec::new(b"Key1", ColumnType::Long),
+    ];
+    const CHILD_COLUMNS: &[ColumnSpec<'static>] = &[
+        ColumnSpec::new(
+            b"Label3",
+            ColumnType::Text {
+                max_len: crate::column_definition_writer::nz(8),
+            },
+        ),
+        ColumnSpec::new(b"Account4", ColumnType::Long),
+    ];
+    const INDEXES: &[IndexSpec<'static>] = &[
+        IndexSpec {
+            name: b"Primary9",
+            fields: &[IndexColumnSpec {
+                column: ColumnRef::Name(b"Key1"),
+                direction: crate::IndexDirection::Ascending,
+            }],
+            kind: IndexKind::Primary,
+        },
+        IndexSpec {
+            name: b"Unique8",
+            fields: &[IndexColumnSpec {
+                column: ColumnRef::Name(b"Code2"),
+                direction: crate::IndexDirection::Ascending,
+            }],
+            kind: IndexKind::Unique,
+        },
+    ];
+    (
+        [
+            TableSpec {
+                name: b"Accounts7",
+                columns: PARENT_COLUMNS,
+                indexes: &INDEXES[..if two { 2 } else { 1 }],
+            },
+            TableSpec {
+                name: b"Events9",
+                columns: CHILD_COLUMNS,
+                indexes: &[],
+            },
+        ],
+        RelationshipSpec {
+            name: b"Account7Events9",
+            parent: RelationshipColumn {
+                table: TableRef::Name(b"Accounts7"),
+                column: ColumnRef::Name(b"Key1"),
+            },
+            child: RelationshipColumn {
+                table: TableRef::Ordinal(1),
+                column: ColumnRef::Ordinal(1),
+            },
+        },
+    )
+}
+
+#[test]
+fn public_relationship_creation_publishes_both_index_shapes() -> TestResult {
+    for two in [false, true] {
+        let directory = Directory::new()?;
+        let (tables, spec) = schema(two);
+        crate::create_database_with_relationship(
+            directory.target(),
+            &tables,
+            &spec,
+            &mut budget(),
+        )?;
+        let pages = compose_relationship(&tables, &spec, &mut budget())?.into_pages();
+        check_relationship_candidate(&directory.target(), &tables, &spec, &pages, &mut budget())?;
+        assert_eq!(fs::read_dir(&directory.0)?.count(), 1);
+    }
+    Ok(())
+}
+
+#[test]
+fn unsupported_references_and_schema_leave_no_destination() -> TestResult {
+    let directory = Directory::new()?;
+    let (mut tables, mut spec) = schema(false);
+    for reference in [TableRef::Ordinal(2), TableRef::Name(b"accounts7")] {
+        spec.parent.table = reference;
+        assert!(matches!(
+            crate::create_database_with_relationship(
+                directory.target(),
+                &tables,
+                &spec,
+                &mut budget()
+            ),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::UnsupportedRelationship { .. }
+            ))
+        ));
+    }
+    spec.parent.table = TableRef::Ordinal(0);
+    tables[1].indexes = tables[0].indexes;
+    assert!(
+        crate::create_database_with_relationship(directory.target(), &tables, &spec, &mut budget())
+            .is_err()
+    );
+    assert!(directory.empty()?);
+    Ok(())
+}
+
+#[test]
+fn existing_destination_and_exhausted_budget_are_preserved() -> TestResult {
+    let directory = Directory::new()?;
+    let (tables, spec) = schema(false);
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(0));
+    assert!(matches!(
+        crate::create_database_with_relationship(directory.target(), &tables, &spec, &mut limited),
+        Err(CreateDatabaseError::Compose(_))
+    ));
+    assert!(directory.empty()?);
+    let mut composition = budget();
+    let plan = compose_relationship(&tables, &spec, &mut composition)?;
+    let work_before_check =
+        composition.total_work_units() + plan.pages().len() as u64 * crate::PAGE_BYTES as u64;
+    let mut check_limited =
+        ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(work_before_check));
+    assert!(matches!(
+        crate::create_database_with_relationship(
+            directory.target(),
+            &tables,
+            &spec,
+            &mut check_limited
+        ),
+        Err(CreateDatabaseError::Publish(_))
+    ));
+    assert!(directory.empty()?);
+    fs::write(directory.target(), b"keep me")?;
+    assert!(matches!(
+        crate::create_database_with_relationship(directory.target(), &tables, &spec, &mut budget()),
+        Err(CreateDatabaseError::Publish(_))
+    ));
+    assert_eq!(fs::read(directory.target())?, b"keep me");
+    assert_eq!(fs::read_dir(&directory.0)?.count(), 1);
+    Ok(())
+}
+
+#[test]
+fn corrupted_written_page_and_wrong_endpoint_fail_publication_check() -> TestResult {
+    let directory = Directory::new()?;
+    let (tables, mut spec) = schema(false);
+    let pages = compose_relationship(&tables, &spec, &mut budget())?.into_pages();
+    crate::create_database_with_relationship(directory.target(), &tables, &spec, &mut budget())?;
+    spec.child.column = ColumnRef::Ordinal(0);
+    assert!(matches!(
+        check_relationship_candidate(&directory.target(), &tables, &spec, &pages, &mut budget()),
+        Err(CandidateCheckError::Mismatch {
+            detail: "relationship endpoint"
+        })
+    ));
+    let mut bytes = fs::read(directory.target())?;
+    let last = bytes.last_mut().ok_or("empty file")?;
+    *last ^= 1;
+    fs::write(directory.target(), bytes)?;
+    assert!(matches!(
+        check_relationship_candidate(&directory.target(), &tables, &spec, &pages, &mut budget()),
+        Err(CandidateCheckError::Mismatch {
+            detail: "relationship written page"
+        })
+    ));
+    Ok(())
+}

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -105,7 +105,7 @@ pub use atomic::{
 };
 pub use binary::BinaryCursor;
 pub use binary_writer::BinaryWriter;
-pub use bootstrap_composer::ComposeError;
+pub use bootstrap_composer::{ComposeError, RelationshipColumn, RelationshipSpec, TableRef};
 pub use candidate::{CandidateError, RawJet3Candidate};
 pub use catalog::{CatalogCursor, CatalogError};
 pub use catalog_name_key::CatalogNameKeyError;
@@ -129,7 +129,8 @@ pub use commit_state::{
     read_commit_region_into,
 };
 pub use create::{
-    CandidateCheckError, CreateDatabaseError, create_database, create_database_with_rows,
+    CandidateCheckError, CreateDatabaseError, create_database, create_database_with_relationship,
+    create_database_with_rows,
 };
 pub use database::{DatabaseOpenError, DatabasePageError, DatabaseReader};
 pub use database_header::{

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10684,3 +10684,54 @@ Copy this block under the appropriate section and remove this instruction:
   generalized relationship grammar, integrity-enforcement mutation,
   cascade, populated relation, update, or hosted support claim. Record one
   validated additive outcome as `EXP-0122`; retain MDBs externally.
+
+## EXP-0122 — Accepted two renamed relationship constructions
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: validated local development DAO differential under `EXP-0121`
+- Plan: `oracle/windows-dao/acquisition/parameterized-relationships.plan.json`,
+  SHA-256 `f4168b5e575303cc52247756d64da072a898e997c84cc7f9253d1f16db8bfe5f`.
+  Acquisition used the committed, reviewed plan and pinned inputs. Outcome
+  validation preceded subsequent public-API source changes; the consumed
+  plan, acquisition script, and analyzer remain unchanged.
+- Artifacts: run `20260905T035000Z-parameterized-relations`, external
+  `result.json` SHA-256
+  `4d7b99001f3829a6fe9d421ab15641e7ab490f968fa4fe0b35f6a54149f23981`,
+  `report.json` SHA-256
+  `8b2527103cb4dc633bb5c82579c3ee40d9ea1da16d90cda2f33e666796a555e9`.
+  Pinned-input analysis of temporary artifact copies verified every retained
+  identity and reproduced the report byte-identically. MDBs remain external.
+- Result: x86 `DAO.DBEngine.36`, Windows NT `10.0.20348.0`; both arms and
+  the matrix report `observed_accepted`, with no reasons. All three fresh
+  controls and three candidate replicas per arm reached `complete` with
+  status `pass`, no errors, and unchanged hashes. Every captured metadata
+  and row observation agreed within each arm and between candidate/control.
+- Exact images: one-index `Accounts7` / `Events9` / `Account7Events9`,
+  57,344 bytes, SHA-256
+  `9d6d850ae06b4a4317f2640e468b0afae7ac248808c8c0ac2fbb211f2ce87927`;
+  two-index `Owners2` / `Details4` / `Owner2_Details4`, 59,392 bytes,
+  SHA-256 `25472960e097ac3539a1da8cf7d3d10e588637b209c991a578e095b74c629fd9`.
+- Common metadata: DAO version `3.0`, exactly the two declared user tables
+  plus `MSysACEs`, `MSysObjects`, `MSysQueries`, `MSysRelationships`. User
+  table Attributes are zero. Parent columns, in order, are `Code2`, `Key1`,
+  each Type 4, Size 4, Attributes 1. Child columns are `Label3` (Type 10,
+  Size 8, Attributes 2), then `Account4` (Type 4, Size 4, Attributes 1).
+  All user row snapshots are empty.
+- Index metadata: parent `Primary9` on ascending `Key1` is primary, unique,
+  and required. The second arm additionally exposes `Unique8` on ascending
+  `Code2`, unique, nonprimary, and not required. Both parent indexes have
+  Foreign and IgnoreNulls false. The child exposes its relationship-named
+  index on ascending `Account4`, Foreign true, with Primary, Unique,
+  Required, and IgnoreNulls false. Every index field has Attributes zero.
+- Relation metadata: exactly the declared named relation in each arm,
+  pointing from its parent table's `Key1` to its child table's `Account4`,
+  Attributes zero. This observes both bounded one/two-parent-index shapes
+  with reordered linked columns and digit-bearing names (including the
+  second relation name's underscore), using the candidate's standalone
+  `EXP-0087` text-key composition. It does not establish all possible name
+  weights, selector formulas, or schema combinations.
+- Boundary: these exact candidates at read-only metadata and empty-row
+  endpoints only. No physical byte equality with controls, referential
+  integrity mutation, cascade, populated relation, existing-database update,
+  general compatibility, or hosted support claim. All report compatibility
+  and support-matrix flags remain false.

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -55,8 +55,14 @@ data pages. Earlier exact empty-table and one-page observations remain in the
 provenance ledger. These results establish only the pinned candidates, with no
 general allocation policy, compatibility claim, or support-matrix movement.
 
+`create_database_with_relationship` creates two empty tables with one
+Long-to-Long relationship, a parent primary index and optional additional
+unique Long index, and an initially unindexed child. `EXP-0118` and `EXP-0122`
+record exact local original/renamed candidate acceptance; cascades and
+referential-integrity mutations remain unvalidated.
+
 Next, broaden initial-row creation in focused implementation and preregistered
-DAO experiment slices, including indexes and long values, and add relationships.
+DAO experiment slices, including indexes and long values.
 After creation is complete, run the hosted write differential (#102), implement
 updates that preserve unrelated data (#112), then run the hosted update
 differential (#113). Keep module cleanup (#182) until the creation API settles.


### PR DESCRIPTION
Callers can create two empty tables with a typed, non-cascading Long-to-Long relationship through `create_database_with_relationship`. Table and column references accept names or ordinals; the parent uses its first primary index, optionally has another unique index, and the child receives the foreign index.

Creation preserves existing destinations on failure and checks every written page, catalog tables, reciprocal endpoints, empty indexes, and rows before publication. Unsupported schemas fail before writing.

EXP-0122 records all six accepted renamed-candidate DAO comparisons from EXP-0121. This is bounded local evidence, with no hosted support-matrix change.

Validation: independent review found no issues; four public tests, eight existing relationship tests, a doctest, Clippy, exact candidate hashes, reproduced outcome report, and final `just ready` passed.

Part of #100.
