### PR TITLE
feat(jet3): create initial Memo and OLE payloads

### DIFF
--- a/crates/jet3/examples/initial_long_value_candidate.rs
+++ b/crates/jet3/examples/initial_long_value_candidate.rs
@@ -1,0 +1,64 @@
+//! Deterministic Memo/OLE initial-payload boundary candidates.
+use jet3::{
+    ColumnSpec, ColumnType, ResourceBudget, ResourceLimits, RowValue, TableSpec,
+    create_database_with_rows,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args_os().skip(1);
+    let path = args
+        .next()
+        .ok_or("usage: initial_long_value_candidate OUTPUT.mdb memo|ole")?;
+    let kind = match args.next().as_deref().and_then(|arg| arg.to_str()) {
+        Some("memo") => ColumnType::Memo,
+        Some("ole") => ColumnType::LongBinary,
+        _ => return Err("payload kind must be memo or ole".into()),
+    };
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Payload", kind),
+    ];
+    let table = TableSpec {
+        name: b"Rows",
+        columns: &columns,
+        indexes: &[],
+    };
+    let payloads = [1, 32, 33, 512, 2036, 2037, 2048, 4064, 4096]
+        .into_iter()
+        .enumerate()
+        .map(|(row, length)| {
+            (0..length)
+                .map(|offset| {
+                    if kind == ColumnType::Memo {
+                        b'A' + ((offset + row) % 26) as u8
+                    } else {
+                        ((offset + row) % 256) as u8
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut values = payloads
+        .iter()
+        .enumerate()
+        .map(|(row, payload)| {
+            [
+                RowValue::Long(row as i32 + 1),
+                if kind == ColumnType::Memo {
+                    RowValue::Memo(payload)
+                } else {
+                    RowValue::LongBinary(payload)
+                },
+            ]
+        })
+        .collect::<Vec<_>>();
+    values.push([RowValue::Long(10), RowValue::Null]);
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(
+        path,
+        &table,
+        &rows,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -17,8 +17,14 @@ pub enum ComposeError {
         /// Repeated Long value.
         value: i32,
     },
-    /// Initial rows require a single-page definition without
-    /// AutoIncrement or long-value columns.
+    /// An initial long value is outside the bounded payload construction.
+    InitialLongValue {
+        /// Zero-based input row.
+        row: usize,
+        /// The unsupported payload condition.
+        detail: &'static str,
+    },
+    /// Initial rows require a single-page definition without AutoIncrement.
     UnsupportedInitialRowSchema,
     /// A table definition could not be encoded.
     Definition(TableDefinitionWriteError),
@@ -93,6 +99,7 @@ impl std::error::Error for ComposeError {
             Self::NameKey(source) => Some(source),
             Self::Schema(source) => Some(source),
             Self::UnsupportedInitialRowSchema
+            | Self::InitialLongValue { .. }
             | Self::UnsupportedInitialIndexSchema
             | Self::NullInitialIndexKey { .. }
             | Self::DuplicateInitialIndexKey { .. }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -393,6 +393,11 @@ use definitions::{
     msys_relationships_definition,
 };
 
+#[path = "bootstrap_initial_long_values.rs"]
+mod initial_long_values;
+use initial_long_values::InitialLongValues;
+pub(crate) use initial_long_values::{encode_initial_row, initial_payload_start};
+
 #[path = "bootstrap_initial_index.rs"]
 mod initial_index;
 pub(crate) use initial_index::InitialLongIndex;

--- a/crates/jet3/src/bootstrap_initial_long_values.rs
+++ b/crates/jet3/src/bootstrap_initial_long_values.rs
@@ -1,0 +1,242 @@
+//! Initial Memo/OLE construction from EXP-0061 headers/fragments, EXP-0077
+//! column maps and EXP-0065 append placement. The inline cutoff (32 bytes),
+//! one fragment per page, and allocation before data pages are candidate
+//! policies, not inferred DAO allocation thresholds.
+
+use super::*;
+use crate::long_value_writer::{
+    HEADER_LEN, MAX_CHAINED_FRAGMENT, MAX_SINGLE_PAGE_PAYLOAD, chained_fragments,
+    encode_chained_row, encode_inline_long_value, external_long_value_header,
+};
+use crate::{ExternalLongValueStorage, RowLocator};
+
+const INLINE_LIMIT: usize = 32;
+
+#[derive(Debug, Clone)]
+pub(super) struct InitialLongValues {
+    first: u64,
+    pages: Vec<(PageImage, bool)>,
+}
+
+pub(crate) fn initial_payload_start(
+    table: &TableSpec<'_>,
+    root: PageNumber,
+) -> Result<u64, ComposeError> {
+    let plan = crate::table_schema_plan::plan_table_schema(table, root.get(), true)?;
+    Ok(root.get() + plan.appended_page_count())
+}
+
+fn refusal(row: usize, detail: &'static str) -> ComposeError {
+    ComposeError::InitialLongValue { row, detail }
+}
+
+fn external_shape(length: usize) -> (ExternalLongValueStorage, usize) {
+    if length <= MAX_SINGLE_PAGE_PAYLOAD {
+        (ExternalLongValueStorage::SinglePage, 1)
+    } else {
+        (
+            ExternalLongValueStorage::Chained,
+            length.div_ceil(MAX_CHAINED_FRAGMENT),
+        )
+    }
+}
+
+fn advance(next: &mut u64, count: usize) -> Result<(), ComposeError> {
+    // SRC-0020/EXP-0057 inline coverage; no indirect growth policy is assumed.
+    let limit = MAP_BITMAP_BYTES * 8;
+    if *next >= limit || count as u64 > limit - *next {
+        return Err(UsageMapWriteError::PageOutOfMap {
+            page: PageNumber::new(limit),
+            first: PageNumber::new(0),
+            page_count: limit,
+        }
+        .into());
+    }
+    *next += count as u64;
+    Ok(())
+}
+
+/// Lowers caller payloads to internally assigned headers before row encoding.
+/// The running page number also makes publication's expected headers deterministic.
+pub(crate) fn encode_initial_row(
+    layout: &[RowColumnLayout],
+    values: &[RowValue<'_>],
+    row: usize,
+    next: &mut u64,
+    output: &mut [u8],
+    budget: &mut ResourceBudget,
+) -> Result<ByteCount, ComposeError> {
+    if values.len() != layout.len() || values.len() > u8::MAX as usize {
+        return encode_row(layout, values, output, budget).map_err(Into::into);
+    }
+    budget.charge_work_units(2 * values.len() as u64)?;
+    let mut lowered = [RowValue::Null; u8::MAX as usize];
+    lowered[..values.len()].copy_from_slice(values);
+    let mut header = [0_u8; HEADER_LEN + INLINE_LIMIT];
+    if values
+        .iter()
+        .any(|value| matches!(value, RowValue::LongValue(_)))
+    {
+        return Err(refusal(row, "caller-supplied long-value header"));
+    }
+    for (ordinal, value) in values.iter().enumerate() {
+        budget.charge_items(1)?;
+        let (payload, expected) = match value {
+            RowValue::Memo(payload) => (*payload, ColumnPhysicalType::Memo),
+            RowValue::LongBinary(payload) => (*payload, ColumnPhysicalType::LongBinary),
+            _ => continue,
+        };
+        if layout[ordinal].physical_type() != expected {
+            return Err(RowWriteError::TypeMismatch {
+                ordinal: ordinal as u16,
+                physical_type: layout[ordinal].physical_type(),
+            }
+            .into());
+        }
+        if payload.is_empty() {
+            return Err(refusal(row, "empty payload"));
+        }
+        budget.check_decoded_value(ByteCount::new(payload.len() as u64))?;
+        budget.charge_work_units((HEADER_LEN + payload.len().min(INLINE_LIMIT)) as u64)?;
+        let length = if payload.len() <= INLINE_LIMIT {
+            encode_inline_long_value(payload, &mut header)
+                .map_err(|_| refusal(row, "inline payload encoding"))?
+        } else {
+            let (storage, count) = external_shape(payload.len());
+            let target = RowLocator::new(PageNumber::new(*next), 0);
+            let external = external_long_value_header(payload.len(), storage, target)
+                .map_err(|_| refusal(row, "external payload encoding bounds"))?;
+            advance(next, count)?;
+            header[..HEADER_LEN].copy_from_slice(&external);
+            HEADER_LEN
+        };
+        // The single-column schema restriction ensures this backing buffer is unique.
+        lowered[ordinal] = RowValue::LongValue(&header[..length]);
+        return encode_row(layout, &lowered[..values.len()], output, budget).map_err(Into::into);
+    }
+    encode_row(layout, values, output, budget).map_err(Into::into)
+}
+
+impl InitialLongValues {
+    pub(super) fn new(
+        first: u64,
+        rows: &[&[RowValue<'_>]],
+        budget: &mut ResourceBudget,
+    ) -> Result<Self, ComposeError> {
+        let mut result = Self {
+            first,
+            pages: Vec::new(),
+        };
+        for (row, values) in rows.iter().enumerate() {
+            for value in *values {
+                budget.charge_items(1)?;
+                let payload = match value {
+                    RowValue::Memo(payload) | RowValue::LongBinary(payload) => *payload,
+                    _ => continue,
+                };
+                if payload.len() <= INLINE_LIMIT {
+                    continue;
+                }
+                budget.check_decoded_value(ByteCount::new(payload.len() as u64))?;
+                let (storage, count) = external_shape(payload.len());
+                let start = result.first + result.pages.len() as u64;
+                external_long_value_header(
+                    payload.len(),
+                    storage,
+                    RowLocator::new(PageNumber::new(start), 0),
+                )
+                .map_err(|_| refusal(row, "external payload encoding bounds"))?;
+                let mut end = start;
+                advance(&mut end, count)?;
+                let needed = result.pages.len() + count;
+                if needed > result.pages.capacity() {
+                    let capacity = needed
+                        .max(result.pages.capacity() * 2)
+                        .min((MAP_BITMAP_BYTES * 8) as usize);
+                    budget.charge_allocation(ByteCount::new(
+                        ((capacity - result.pages.capacity()) * size_of::<(PageImage, bool)>())
+                            as u64,
+                    ))?;
+                    result
+                        .pages
+                        .try_reserve_exact(capacity - result.pages.len())
+                        .map_err(|_| Error::Io {
+                            operation: "reserve initial long-value pages",
+                            kind: std::io::ErrorKind::OutOfMemory,
+                        })?;
+                }
+                if storage == ExternalLongValueStorage::SinglePage {
+                    result.push(payload, budget)?;
+                } else {
+                    let mut bytes = [0_u8; PAGE_BYTES];
+                    for (offset, fragment) in chained_fragments(payload).enumerate() {
+                        let next = (offset + 1 < count).then(|| {
+                            RowLocator::new(PageNumber::new(start + offset as u64 + 1), 0)
+                        });
+                        budget.charge_work_units(fragment.len() as u64)?;
+                        let length = encode_chained_row(fragment, next, &mut bytes)
+                            .map_err(|_| refusal(row, "chained payload encoding"))?;
+                        result.push(&bytes[..length], budget)?;
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    fn push(&mut self, bytes: &[u8], budget: &mut ResourceBudget) -> Result<(), ComposeError> {
+        let mut builder = DataPageBuilder::new_long_value(budget)?;
+        builder.append_row(bytes, budget)?;
+        // Candidate policy: a page is available if another nonempty row fits.
+        let available = match builder.clone().append_row(&[0], budget) {
+            Ok(_) => true,
+            Err(PageImageError::PageFull { .. } | PageImageError::RowSlotsExhausted { .. }) => {
+                false
+            }
+            Err(error) => return Err(error.into()),
+        };
+        self.pages
+            .push((finish_data_builder(builder, budget)?, available));
+        Ok(())
+    }
+
+    pub(super) fn page_count(&self) -> u64 {
+        self.pages.len() as u64
+    }
+
+    pub(super) fn append_pages(
+        &self,
+        plan: &mut WholeFileImagePlan,
+        map: &mut InlineUsageMapEncoder,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), ComposeError> {
+        for (image, _) in &self.pages {
+            plan.append(image.clone(), map, budget)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn maps(&self, budget: &mut ResourceBudget) -> Result<[[u8; 133]; 2], ComposeError> {
+        let mut owned = InlineUsageMapEncoder::new(
+            PageNumber::new(0),
+            ByteCount::new(MAP_BITMAP_BYTES),
+            budget,
+        )?;
+        let mut available = InlineUsageMapEncoder::new(
+            PageNumber::new(0),
+            ByteCount::new(MAP_BITMAP_BYTES),
+            budget,
+        )?;
+        for (offset, (_, free)) in self.pages.iter().enumerate() {
+            let page = PageNumber::new(self.first + offset as u64);
+            owned.set_page(page)?;
+            if *free {
+                available.set_page(page)?;
+            }
+        }
+        let mut rows = [[0_u8; 133]; 2];
+        owned.encode_into(&mut rows[0], budget)?;
+        available.encode_into(&mut rows[1], budget)?;
+        Ok(rows)
+    }
+}

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -52,6 +52,7 @@ pub(super) struct PlannedCreate<'a> {
     /// map-page row and its available map the next.
     long_value: Option<u16>,
     initial_data: Vec<InitialDataPage>,
+    initial_long_values: Option<InitialLongValues>,
     initial_row_count: u32,
     initial_index: Option<InitialLongIndex>,
 }
@@ -86,12 +87,13 @@ impl<'a> PlannedCreate<'a> {
             plan,
             long_value,
             initial_data: Vec::new(),
+            initial_long_values: None,
             initial_row_count: 0,
             initial_index: None,
         })
     }
 
-    /// Packs scalar rows using EXP-0060 encoding and EXP-0065 append placement.
+    /// Packs rows using EXP-0060 encoding and EXP-0065 append placement.
     /// EXP-0057 supplies map roles; EXP-0073 supplies the definition row count.
     /// Multiple pages and their available-map membership remain a candidate
     /// hypothesis, with no generalized page-zero insertion transition.
@@ -101,10 +103,11 @@ impl<'a> PlannedCreate<'a> {
         budget: &mut ResourceBudget,
     ) -> Result<Self, ComposeError> {
         if self.plan.continuation_page().is_some()
-            || self.spec.columns.iter().any(|column| {
-                column.column_type().is_long_value()
-                    || column.column_type() == ColumnType::AutoIncrement
-            })
+            || self
+                .spec
+                .columns
+                .iter()
+                .any(|column| column.column_type() == ColumnType::AutoIncrement)
         {
             return Err(ComposeError::UnsupportedInitialRowSchema);
         }
@@ -118,6 +121,10 @@ impl<'a> PlannedCreate<'a> {
                 target: "u32",
             })?;
         let layout = initial_row_layout(self.spec, budget)?;
+        let mut next_payload = self.plan.definition_root().get() + self.plan.appended_page_count();
+        if self.long_value.is_some() {
+            self.initial_long_values = Some(InitialLongValues::new(next_payload, rows, budget)?);
+        }
         let mut minimum = [0_u8; PAGE_BYTES];
         // EXP-0060 bounds column count to 255; fixed fields retain their width.
         let nulls = [RowValue::Null; u8::MAX as usize];
@@ -126,8 +133,16 @@ impl<'a> PlannedCreate<'a> {
         let minimum = &minimum[..minimum_len];
         let mut builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
         let mut encoded = [0_u8; PAGE_BYTES];
-        for row in rows {
-            let length = encode_row(&layout, row, &mut encoded, budget)?.get() as usize;
+        for (ordinal, row) in rows.iter().enumerate() {
+            let length = encode_initial_row(
+                &layout,
+                row,
+                ordinal,
+                &mut next_payload,
+                &mut encoded,
+                budget,
+            )?
+            .get() as usize;
             let bytes = &encoded[..length];
             let slot = match builder.append_row(bytes, budget) {
                 Ok(slot) => slot,
@@ -209,6 +224,10 @@ impl<'a> PlannedCreate<'a> {
     pub(super) fn page_count(&self) -> u64 {
         self.plan.definition_root().get()
             + self.plan.appended_page_count()
+            + self
+                .initial_long_values
+                .as_ref()
+                .map_or(0, InitialLongValues::page_count)
             + self.initial_data.len() as u64
     }
 
@@ -260,6 +279,9 @@ impl<'a> PlannedCreate<'a> {
                 empty_index_page(owner, budget)?
             };
             plan.append(image, append_map, budget)?;
+        }
+        if let Some(values) = &self.initial_long_values {
+            values.append_pages(plan, append_map, budget)?;
         }
         for data in &self.initial_data {
             plan.append(data.image.clone(), append_map, budget)?;
@@ -384,7 +406,12 @@ impl<'a> PlannedCreate<'a> {
             ByteCount::new(MAP_BITMAP_BYTES),
             budget,
         )?;
-        let first = self.plan.definition_root().get() + self.plan.appended_page_count();
+        let first = self.plan.definition_root().get()
+            + self.plan.appended_page_count()
+            + self
+                .initial_long_values
+                .as_ref()
+                .map_or(0, InitialLongValues::page_count);
         for (offset, data) in self.initial_data.iter().enumerate() {
             let page = PageNumber::new(first + offset as u64);
             owned.set_page(page)?;
@@ -401,8 +428,11 @@ impl<'a> PlannedCreate<'a> {
             rows.push(inline_map_row(&[root.get()], budget)?);
         }
         if self.long_value.is_some() {
-            rows.push(empty);
-            rows.push(empty);
+            let maps = match &self.initial_long_values {
+                Some(values) => values.maps(budget)?,
+                None => [empty; 2],
+            };
+            rows.extend(maps);
         }
         let rows = rows.iter().map(<[u8; 133]>::as_slice).collect::<Vec<_>>();
         data_page(HEADER_PAGE, &rows, budget)

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use crate::atomic::atomic_create;
 use crate::bootstrap_composer::{
     ComposeError, InitialLongIndex, compose_database, compose_database_with_rows,
-    initial_row_layout,
+    encode_initial_row, initial_payload_start, initial_row_layout,
 };
 use crate::page_append_plan::PlannedPage;
 use crate::{
@@ -64,6 +64,10 @@ impl StdError for CreateDatabaseError {
 pub enum CandidateCheckError {
     /// The candidate index tree could not be read.
     Index(crate::IndexTreeError),
+    /// A candidate long-value field could not be decoded.
+    Value(crate::ValueError),
+    /// A candidate external payload could not be streamed.
+    LongValue(crate::LongValueError),
     /// The candidate rows could not be read.
     Rows(RowError),
     /// Requested rows could not be encoded for comparison.
@@ -85,6 +89,8 @@ impl fmt::Display for CandidateCheckError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Index(source) => write!(formatter, "candidate index scan failed: {source}"),
+            Self::Value(source) => write!(formatter, "candidate value failed: {source}"),
+            Self::LongValue(source) => write!(formatter, "candidate long value failed: {source}"),
             Self::Rows(source) => write!(formatter, "candidate row scan failed: {source}"),
             Self::RowEncoding(source) => {
                 write!(formatter, "candidate row comparison failed: {source}")
@@ -105,6 +111,8 @@ impl StdError for CandidateCheckError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Self::Index(source) => Some(source),
+            Self::Value(source) => Some(source),
+            Self::LongValue(source) => Some(source),
             Self::Rows(source) => Some(source),
             Self::RowEncoding(source) => Some(source),
             Self::Open(source) => Some(source),
@@ -151,7 +159,7 @@ pub fn create_database(
     .map_err(CreateDatabaseError::Publish)
 }
 
-/// Creates one table containing scalar initial rows in caller order.
+/// Creates one table containing initial rows in caller order.
 ///
 /// Rows are packed in caller order into data pages within the inline usage-map
 /// capacity. Each row and the table definition must fit one page. Pages with
@@ -161,8 +169,12 @@ pub fn create_database(
 /// 200 non-null keys in a single leaf. Primary and unique indexes reject
 /// duplicate keys; ordinary indexes retain duplicates. Null keys, descending
 /// indexes, and other key types are refused.
-/// AutoIncrement, Memo, and LongBinary columns are refused. Values use the
-/// same database-code-page and physical scalar representations as [`RowValue`].
+/// AutoIncrement is refused. One unindexed Memo or LongBinary column accepts
+/// nonempty typed payloads or null; raw `RowValue::LongValue` headers are refused.
+/// The candidate policy stores up to 32 bytes inline, up to 2,036 on one LVAL
+/// page, and larger payloads in 2,032-byte chained fragments, one per page.
+/// These are construction choices, not established DAO allocation thresholds.
+/// Values use the database-code-page and physical representations of [`RowValue`].
 /// The existing-destination and atomic publication guarantees of
 /// [`create_database`] apply. Composition and the structural row comparison
 /// are charged to `budget`. Unsupported schemas and rows fail before writing.
@@ -215,15 +227,24 @@ fn check_initial_rows(
         .map_err(CandidateCheckError::Definition)?;
     let mut expected_index = InitialLongIndex::new(table, rows.len(), budget)
         .map_err(CandidateCheckError::RowEncoding)?;
+    let mut next_payload =
+        initial_payload_start(table, root).map_err(CandidateCheckError::RowEncoding)?;
     let mut encoded = [0_u8; crate::PAGE_BYTES];
     let mut cursor = database
         .rows(&definition, budget)
         .map_err(CandidateCheckError::Rows)?;
-    for row in rows {
-        let length = crate::encode_row(&layout, row, &mut encoded, cursor.owned.budget_mut())
-            .map_err(|error| CandidateCheckError::RowEncoding(ComposeError::Row(error)))?
-            .get() as usize;
-        let actual = cursor
+    for (ordinal, row) in rows.iter().enumerate() {
+        let length = encode_initial_row(
+            &layout,
+            row,
+            ordinal,
+            &mut next_payload,
+            &mut encoded,
+            cursor.owned.budget_mut(),
+        )
+        .map_err(CandidateCheckError::RowEncoding)?
+        .get() as usize;
+        let mut actual = cursor
             .next_row()
             .map_err(CandidateCheckError::Rows)?
             .ok_or(CandidateCheckError::Mismatch {
@@ -235,6 +256,55 @@ fn check_initial_rows(
             });
         }
         let locator = actual.locator();
+        let mut external = None;
+        for (column, value) in row.iter().enumerate() {
+            let payload = match value {
+                RowValue::Memo(payload) | RowValue::LongBinary(payload) => *payload,
+                _ => continue,
+            };
+            let decoded = actual
+                .value(
+                    crate::ColumnOrdinal::new(column as u16),
+                    crate::TextCodePage::Windows1252,
+                )
+                .map_err(CandidateCheckError::Value)?;
+            if let Some(decoded) = decoded
+                && let crate::ValueKind::LongValue(crate::LongValue::External(reference)) =
+                    decoded.kind()
+            {
+                external = Some((*reference, payload));
+            }
+        }
+        if let Some((reference, expected)) = external {
+            cursor
+                .owned
+                .budget_mut()
+                .charge_work_units(expected.len() as u64)
+                .map_err(|error| CandidateCheckError::RowEncoding(ComposeError::Encoding(error)))?;
+            let mut stream = cursor
+                .long_value(reference)
+                .map_err(CandidateCheckError::LongValue)?;
+            let mut remaining = expected;
+            while let Some(chunk) = stream
+                .next_chunk()
+                .map_err(CandidateCheckError::LongValue)?
+            {
+                let bytes = match chunk.value() {
+                    crate::LongValueChunkValue::Text(text) => text.raw_bytes(),
+                    crate::LongValueChunkValue::Binary(bytes) => bytes,
+                };
+                remaining = remaining
+                    .strip_prefix(bytes)
+                    .ok_or(CandidateCheckError::Mismatch {
+                        detail: "initial long-value payload",
+                    })?;
+            }
+            if !remaining.is_empty() {
+                return Err(CandidateCheckError::Mismatch {
+                    detail: "initial long-value length",
+                });
+            }
+        }
         if let Some(index) = &mut expected_index {
             index
                 .push(row, locator, cursor.owned.budget_mut())

--- a/crates/jet3/src/create_initial_long_values_tests.rs
+++ b/crates/jet3/src/create_initial_long_values_tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+fn payload_value(kind: ColumnType, payload: &[u8]) -> RowValue<'_> {
+    if kind == ColumnType::Memo {
+        RowValue::Memo(payload)
+    } else {
+        RowValue::LongBinary(payload)
+    }
+}
+
+#[test]
+fn payload_boundaries_round_trip_with_separate_column_maps() -> TestResult {
+    for kind in [ColumnType::Memo, ColumnType::LongBinary] {
+        for (length, pages, available_last) in [
+            (1, 0, false),
+            (32, 0, false),
+            (33, 1, true),
+            (512, 1, true),
+            (2036, 1, false),
+            (2037, 2, true),
+            (2048, 2, true),
+            (4064, 2, false),
+            (4096, 3, true),
+        ] {
+            let directory = TestDirectory::create()?;
+            let columns = [ID, ColumnSpec::new(b"Payload", kind)];
+            let table = TableSpec {
+                name: b"Items",
+                columns: &columns,
+                indexes: &[],
+            };
+            let payload = vec![b'a'; length];
+            let values = [RowValue::Long(1), payload_value(kind, &payload)];
+            let rows: &[&[RowValue<'_>]] = &[&values, &[RowValue::Long(2), RowValue::Null]];
+            create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+            let bytes = fs::read(directory.target())?;
+            assert_eq!(bytes.len(), (24 + pages) * crate::PAGE_BYTES);
+            assert_eq!(page_rows(&bytes, 23 + pages), 2);
+            for page in 23..23 + pages {
+                assert!(map_bit(&bytes, 21, 2, page as u64)?);
+                assert!(!map_bit(&bytes, 21, 0, page as u64)?);
+                assert_eq!(
+                    &bytes[page * crate::PAGE_BYTES + 4..page * crate::PAGE_BYTES + 8],
+                    b"LVAL"
+                );
+                assert_eq!(
+                    map_bit(&bytes, 21, 3, page as u64)?,
+                    page == 22 + pages && available_last
+                );
+            }
+            assert!(map_bit(&bytes, 21, 0, (23 + pages) as u64)?);
+            assert!(!map_bit(&bytes, 21, 2, (23 + pages) as u64)?);
+            assert!(!map_bit(&bytes, 21, 2, 22)?);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn multiple_payloads_and_data_pages_keep_distinct_references() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let columns = [ID, ColumnSpec::new(b"Payload", ColumnType::LongBinary)];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &[],
+    };
+    let payloads = (0_u8..100)
+        .map(|value| vec![value; 512])
+        .collect::<Vec<_>>();
+    let values = payloads
+        .iter()
+        .enumerate()
+        .map(|(id, bytes)| [RowValue::Long(id as i32), RowValue::LongBinary(bytes)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(bytes.len(), 125 * crate::PAGE_BYTES);
+    assert_eq!(page_rows(&bytes, 123) + page_rows(&bytes, 124), 100);
+    for page in 23..123 {
+        assert!(map_bit(&bytes, 21, 2, page as u64)?);
+    }
+    for page in 123..125 {
+        assert!(map_bit(&bytes, 21, 0, page as u64)?);
+    }
+    Ok(())
+}
+
+#[test]
+fn payload_refusals_and_resource_limits_preserve_destination() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let columns = [ColumnSpec::new(b"Payload", ColumnType::LongBinary)];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &[],
+    };
+    create_database_with_rows(
+        directory.target(),
+        &table,
+        &[&[RowValue::Null]],
+        &mut budget(),
+    )?;
+    let original = fs::read(directory.target())?;
+    for value in [RowValue::LongBinary(&[]), RowValue::LongValue(&[0; 12])] {
+        assert!(matches!(
+            create_database_with_rows(directory.target(), &table, &[&[value]], &mut budget()),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::InitialLongValue { .. }
+            ))
+        ));
+    }
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::Memo(b"a")]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::Row(
+            RowWriteError::TypeMismatch { .. }
+        )))
+    ));
+    let payload = vec![0; 2032 * 1002];
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::LongBinary(&payload)]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::UsageMap(
+            crate::UsageMapWriteError::PageOutOfMap { .. }
+        )))
+    ));
+    let mut limited = ResourceBudget::new(
+        ResourceLimits::default().with_max_allocation_bytes(crate::ByteCount::new(2048)),
+    );
+    assert!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::LongBinary(&payload[..4096])]],
+            &mut limited
+        )
+        .is_err()
+    );
+    assert_eq!(fs::read(directory.target())?, original);
+    assert_eq!(directory.entries()?, ["created.mdb"]);
+    Ok(())
+}
+
+#[test]
+fn candidate_check_rejects_long_value_owner_pointer_and_payload_corruption() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let columns = [ColumnSpec::new(b"Payload", ColumnType::LongBinary)];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &[],
+    };
+    let payload = [42; 2048];
+    let rows: &[&[RowValue<'_>]] = &[&[RowValue::LongBinary(&payload)]];
+    create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+    let original = fs::read(directory.target())?;
+    // First chained row fills page 23 from offset 12: pointer then payload.
+    for offset in [
+        23 * crate::PAGE_BYTES + 4,
+        23 * crate::PAGE_BYTES + 13,
+        23 * crate::PAGE_BYTES + 16,
+    ] {
+        let mut changed = original.clone();
+        changed[offset] ^= 1;
+        fs::write(directory.target(), changed)?;
+        assert!(
+            super::super::super::check_initial_rows(
+                &directory.target(),
+                &table,
+                rows,
+                &mut budget()
+            )
+            .is_err()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn long_value_allocation_leaves_room_for_the_final_data_page() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let columns = [ColumnSpec::new(b"Payload", ColumnType::LongBinary)];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &[],
+    };
+    let payload = vec![1; 2032 * 1001];
+    create_database_with_rows(
+        directory.target(),
+        &table,
+        &[&[RowValue::LongBinary(&payload[..2032 * 1000])]],
+        &mut budget(),
+    )?;
+    let original = fs::read(directory.target())?;
+    assert_eq!(original.len(), 1024 * crate::PAGE_BYTES);
+    assert!(map_bit(&original, 21, 2, 1022)?);
+    assert!(!map_bit(&original, 21, 2, 1023)?);
+    assert!(map_bit(&original, 21, 0, 1023)?);
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::LongBinary(&payload)]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(ComposeError::UsageMap(
+            crate::UsageMapWriteError::PageOutOfMap { .. }
+        )))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    Ok(())
+}

--- a/crates/jet3/src/create_initial_rows_tests.rs
+++ b/crates/jet3/src/create_initial_rows_tests.rs
@@ -68,12 +68,8 @@ fn rows_with_wrong_types_leave_no_file() -> TestResult {
 #[test]
 fn unsupported_initial_row_schemas_leave_no_file() -> TestResult {
     let directory = TestDirectory::create()?;
-    for column_type in [
-        ColumnType::AutoIncrement,
-        ColumnType::Memo,
-        ColumnType::LongBinary,
-    ] {
-        let columns = [ColumnSpec::new(b"Value", column_type)];
+    {
+        let columns = [ColumnSpec::new(b"Value", ColumnType::AutoIncrement)];
         let table = TableSpec {
             name: b"Items",
             columns: &columns,
@@ -372,3 +368,6 @@ fn oversized_rows_and_page_storage_budget_fail_before_publication() -> TestResul
 
 #[path = "create_initial_index_tests.rs"]
 mod indexes;
+
+#[path = "create_initial_long_values_tests.rs"]
+mod long_values;

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -106,7 +106,14 @@ pub enum RowValue<'a> {
     Text(&'a [u8]),
     /// Replication ID in conventional display-byte order.
     Guid([u8; 16]),
+    /// Memo payload in database-code-page bytes, for `create_database_with_rows`.
+    /// The standalone row encoder requires the lower-level `LongValue` form.
+    Memo(&'a [u8]),
+    /// OLE payload bytes, for `create_database_with_rows`.
+    /// The standalone row encoder requires the lower-level `LongValue` form.
+    LongBinary(&'a [u8]),
     /// Already-encoded Memo/OLE header plus inline payload.
+    /// Public database creation refuses this form; it assigns its own pointers.
     LongValue(&'a [u8]),
 }
 
@@ -634,9 +641,12 @@ fn write_scalar(writer: &mut BinaryWriter<'_, '_>, value: RowValue<'_>) -> Resul
             d[3], d[2], d[1], d[0], d[5], d[4], d[7], d[6], d[8], d[9], d[10], d[11], d[12], d[13],
             d[14], d[15],
         ]),
-        RowValue::Null | RowValue::Boolean(_) | RowValue::Binary(_) | RowValue::LongValue(_) => {
-            Ok(())
-        }
+        RowValue::Null
+        | RowValue::Boolean(_)
+        | RowValue::Binary(_)
+        | RowValue::LongValue(_)
+        | RowValue::Memo(_)
+        | RowValue::LongBinary(_) => Ok(()),
     }
 }
 


### PR DESCRIPTION
Initial-row creation accepts typed Memo and LongBinary payload bytes and allocates their storage internally. Nonempty values use bounded inline, single-page, or chained storage; nulls are preserved. Caller-supplied physical headers are refused.

The writer maintains separate long-column usage maps and streams external payloads during the pre-publication check. This first surface accepts one long-value column in one unindexed table within inline-map capacity. Its storage thresholds are candidate construction policies, pending the separate DAO matrix.

Validation: independent review found no issues; 25 initial-row tests, four low-level row-writer tests, all-target Clippy, deterministic boundary candidates, and final `just ready` passed. Tests cover storage/map limits, damaged payloads, refusals, budget failures, and destination preservation.

Part of #100.
