### PR TITLE
test: preregister descending and composite Long key discovery

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10735,3 +10735,47 @@ Copy this block under the appropriate section and remove this instruction:
   integrity mutation, cascade, populated relation, existing-database update,
   general compatibility, or hosted support claim. All report compatibility
   and support-matrix flags remain false.
+
+## EXP-0125 — Preregistered descending and composite Long key discovery
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: preregistered local development DAO format observation; no acquisition
+- Plan: `oracle/windows-dao/acquisition/long-key-layout.plan.json`, SHA-256
+  `a5b107359cc713ecb613826745fea1118084d9c6f0cc482a527cdc6f4a0a9f4a`.
+  Pins the new acquisition/analyzer scripts, existing original
+  `system_catalog.py` row/definition decoder, `relationship_create.py` leaf
+  decoder, and SSH transport. The plan contains every input row.
+- Question: which exact raw index keys bind to non-null descending Long and
+  two-Long mixed-direction values, including repeated full ordinary keys?
+  `EXP-0062` supplies bounded leaf framing and locators, but its retained
+  summary JSON contains no raw key-to-row bindings and its composite case
+  mixed Text, Integer, and Long. Those outputs inform design only here.
+- Arms: fresh `Rows(A Long, B Long, Tag Long)` with `ByKey`; ten distinct
+  descending `A` keys in a unique index; twelve distinct ascending `A` /
+  descending `B` pairs in a unique index; fourteen descending `A` / ascending
+  `B` rows in an ordinary index, with two repeated full pairs and distinct
+  Tag payloads. Inputs include both signed extremes, values around zero and
+  byte boundaries, and repeated leading components. No nulls or intentional
+  failing insertions are included.
+- Hypothesis: ascending Long components use `7f` plus big-endian sign-bit-
+  flipped values; descending complements every component byte, and composite
+  keys concatenate components in declared order. This is an explicit test
+  hypothesis; stable differing bytes still answer the observation question.
+- Protocol: three fresh controls per arm; close after insertion, hash, open
+  read-only for declared metadata, full snapshots and ordered index scans,
+  close and rehash. Recover exact raw keys through the established single-
+  leaf decoder, bind every page/slot to decoded values, and require complete
+  one-to-one row coverage and directed DAO/decoded semantic ordering. Compare
+  raw key/value bindings, physical key fields/flags/counts, and captured DAO
+  metadata within each arm. Retain locators and prefix/map/root observations
+  without requiring allocator locations or duplicate payload order to match.
+- Decision: all nine captures must complete unchanged with matching
+  question-bearing observations. Record hypothesis agreement separately.
+  Incomplete acquisition, changed bytes, or correlation disagreement is
+  `no_outcome`; bad pins/result or retained identities reject validation.
+  Commit and independently review before one acquisition. Failure after
+  first mutation never triggers an automatic retry.
+- Boundary: these finite non-null Long cases only; no other key types,
+  arbitrary component counts, general branch/allocation policy, candidate
+  acceptance, updates, compatibility, or hosted support claim. Retain all
+  MDBs externally and record one validated additive outcome as `EXP-0126`.

--- a/oracle/windows-dao/acquisition/long-key-layout.plan.json
+++ b/oracle/windows-dao/acquisition/long-key-layout.plan.json
@@ -1,0 +1,120 @@
+{
+  "document_type": "dao_long_key_layout_plan",
+  "experiment_id": "long-key-layout",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0062 supplies leaf framing, row locators and fixed Long component length; EXP-0073 supplies row/layout and distinct-key count observations. Existing retained composite inputs mixed Text/Integer/Long and do not establish the planned two-Long construction.",
+    "question": "What exact raw keys correspond to the planned non-null descending Long and mixed-direction two-Long values, including repeated full ordinary keys?",
+    "hypothesis": "Each ascending Long component is marker 7f then big-endian signed Long with sign bit flipped. Descending complements every component byte, including its marker. Composite keys concatenate components in declared field order. This is a test hypothesis, not a known format rule; a stable different encoding still answers the observation question.",
+    "authorization": "User authorized DAO experiments/mutations. Commit and independently review pinned plan before one acquisition. After first CreateDatabase a failure is a scientific result; no retry or redispatch without another human decision."
+  },
+  "arms": [
+    {
+      "name": "descending-unique",
+      "unique": true,
+      "fields": [
+        {
+          "name": "A",
+          "descending": true
+        }
+      ],
+      "rows": [
+        [2147483647, 0, 0],
+        [-2147483648, 0, 1],
+        [0, 0, 2],
+        [-1, 0, 3],
+        [1, 0, 4],
+        [-256, 0, 5],
+        [255, 0, 6],
+        [256, 0, 7],
+        [-65536, 0, 8],
+        [65536, 0, 9]
+      ]
+    },
+    {
+      "name": "ascending-descending-unique",
+      "unique": true,
+      "fields": [
+        {
+          "name": "A",
+          "descending": false
+        },
+        {
+          "name": "B",
+          "descending": true
+        }
+      ],
+      "rows": [
+        [0, 0, 0],
+        [-2147483648, 2147483647, 1],
+        [2147483647, -2147483648, 2],
+        [-1, -1, 3],
+        [-1, 0, 4],
+        [-1, 1, 5],
+        [0, -2147483648, 6],
+        [0, 2147483647, 7],
+        [1, -256, 8],
+        [1, 255, 9],
+        [256, -65536, 10],
+        [-256, 65536, 11]
+      ]
+    },
+    {
+      "name": "descending-ascending-ordinary",
+      "unique": false,
+      "fields": [
+        {
+          "name": "A",
+          "descending": true
+        },
+        {
+          "name": "B",
+          "descending": false
+        }
+      ],
+      "rows": [
+        [0, 0, 0],
+        [-2147483648, 2147483647, 1],
+        [2147483647, -2147483648, 2],
+        [-1, -1, 3],
+        [-1, 0, 4],
+        [-1, 1, 5],
+        [0, -2147483648, 6],
+        [0, 2147483647, 7],
+        [1, -256, 8],
+        [1, 255, 9],
+        [256, -65536, 10],
+        [-256, 65536, 11],
+        [0, 0, 12],
+        [-1, 0, 13]
+      ]
+    }
+  ],
+  "execution": {
+    "environment": "Private local Windows VM, x86 PowerShell, DAO.DBEngine.36, Jet3 creation options32 and ;LANGID=0x0409;CP=1252;COUNTRY=0; development discovery only.",
+    "per_replica": "In arm order create fresh Rows(A Long,B Long,Tag Long), append ByKey with declared field order/directions and uniqueness, insert exactly plan rows in listed order, then close. Unique arms contain distinct full keys; ordinary arm intentionally repeats two full keys with distinct Tag payloads. No intentional failing insertion or inferred rejection error code.",
+    "capture": "Hash closed image, open read-only and record version/table inventory/field types+sizes, index primary/unique/required/field direction metadata, full snapshot and ordered index traversal. Close, rehash, retain image/result. No compaction or update to retained image.",
+    "analysis": "Verify pinned inputs and result identity, retained after hashes and unchanged before/after. Use existing original system_catalog decoder to discover user root and decode every row with page/slot and values. Use existing original relationship_create leaf decoder to recover prefix-compressed raw keys and locators. Require one owner-correct leaf, one index, declared columns/rows, each locator resolving once and covering all rows. Correlate every key binding to planned and DAO rows and directed semantic order, allowing arbitrary payload order for equal full keys.",
+    "comparison": "Compare exact raw key/value bindings, physical key field records/flags/distinct count and all captured DAO metadata across three replicas per arm. Preserve raw locators, root/map/prefix/record observations but do not require allocator addresses or common-prefix choices to be equal across replicas. No comparison of whole MDB hashes across fresh controls.",
+    "attempts": 1,
+    "run": "python3 oracle/windows-dao/scripts/long_key_layout.py run --shared-root VM_SHARED_ROOT --run-id UTC-long-key-layout",
+    "analysis_command": "python3 oracle/windows-dao/scripts/long_key_layout.py analyze OUTBOX; pinned inputs are rechecked before report publication."
+  },
+  "decision_rule": {
+    "answered": "All nine captures complete unchanged; all decoded rows, exact row-locator/key bindings and DAO order/metadata checks pass; each arm has matching question-bearing observations in three replicas. Record hypothesis_matches separately; false does not invalidate a stable observation.",
+    "no_outcome": "Any incomplete or failed acquisition, changed read-only image, decoder/metadata/row correlation failure, unsupported non-leaf shape, or within-arm question-bearing disagreement. Preserve completed observations/errors without another dispatch.",
+    "rejection": "Mismatched plan/environment/result identity, unexpected arm/replica order, changed pinned input, or retained image mismatch rejects validation."
+  },
+  "boundary": "Only exact non-null Long inputs/directions/index shapes observed. No null keys, other types, arbitrary component counts, generalized branch or allocation policy, candidate acceptance, existing-database updates, or hosted support claim.",
+  "retention": "Retain result/report and all MDBs externally; no MDB or provider bytes committed. Record one additive EXP-0126 outcome from validated report JSON.",
+  "inputs": {
+    "oracle/windows-dao/scripts/long_key_layout.py": "336dbd41446d745aba5604238c1631ec7905ba9ab9ff5ab8b0b6f9c6860a0fa4",
+    "oracle/windows-dao/scripts/long_key_layout.ps1": "0ccc6fe88bf66f9c050d9166a948009e68324f51cb47bee4cf47d50f03c25f10",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/scripts/relationship_create.py": "aa267ca957815ecf49abc155bd081dfb7d02d609b414e0efa68600161f3f7740",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  }
+}

--- a/oracle/windows-dao/scripts/long_key_layout.ps1
+++ b/oracle/windows-dao/scripts/long_key_layout.ps1
@@ -1,0 +1,142 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function New-Control([string]$Path, $Arm) {
+    $engine = $workspace = $db = $table = $field = $index = $key = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $table = $db.CreateTableDef('Rows')
+        foreach ($name in @('A', 'B', 'Tag')) {
+            $field = $table.CreateField($name, 4)
+            $table.Fields.Append($field)
+            Release $field; $field = $null
+        }
+        $index = $table.CreateIndex('ByKey')
+        $index.Primary = $false
+        $index.Unique = [bool]$Arm.unique
+        foreach ($definition in $Arm.fields) {
+            $key = $index.CreateField([string]$definition.name)
+            if ($definition.descending) { $key.Attributes = 1 }
+            $index.Fields.Append($key)
+            Release $key; $key = $null
+        }
+        $table.Indexes.Append($index)
+        $db.TableDefs.Append($table)
+        $rs = $db.OpenRecordset('Rows', 2)
+        foreach ($row in $Arm.rows) {
+            $rs.AddNew()
+            $rs.Fields.Item('A').Value = [int]$row[0]
+            $rs.Fields.Item('B').Value = [int]$row[1]
+            $rs.Fields.Item('Tag').Value = [int]$row[2]
+            $rs.Update()
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $key; Release $index; Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset) {
+    return ,@([int]$Recordset.Fields.Item('A').Value, [int]$Recordset.Fields.Item('B').Value, [int]$Recordset.Fields.Item('Tag').Value)
+}
+function Observe([string]$Path) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item('Rows')
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0)} })}
+        })
+        $endpoint = 'rows'
+        $rs = $db.OpenRecordset('Rows', 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$rows.Add((Read-Row $rs))
+            $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+        $rs.Close(); Release $rs; $rs = $null
+        $endpoint = 'index_traversal'
+        $rs = $db.OpenRecordset('Rows', 1)
+        $rs.Index = 'ByKey'
+        $rs.MoveFirst()
+        $traversal = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$traversal.Add((Read-Row $rs))
+            $rs.MoveNext()
+        }
+        $snapshot.traversal = @($traversal)
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'long-key-layout.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/long_key_layout.ps1') { throw 'Script pin mismatch' }
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_long_key_layout_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $name = "$($arm.name)-r$replica.mdb"
+            $control = Join-Path $env:JET3_WORK $name
+            New-Control $control $arm
+            $observation = Observe $control
+            $observation.arm = $arm.name
+            $observation.replica = $replica
+            $observation.file = $name
+            $result.replicas += $observation
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/long_key_layout.py
+++ b/oracle/windows-dao/scripts/long_key_layout.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Pinned local Long index-key observations; preflight, acquire once, and analyze."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+from relationship_create import leaf_entries
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/long-key-layout.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/long_key_layout.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'long-key-layout' or plan['replicas'] != 3:
+        raise ValueError('Unexpected experiment plan')
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def hypothesized_key(values, arm):
+    """Test hypothesis only: marked, sign-flipped BE Long components; descending complement."""
+    key = b''
+    for field in arm['fields']:
+        value = values[['A', 'B', 'Tag'].index(field['name'])]
+        component = b'\x7f' + (value ^ -(1 << 31)).to_bytes(4, 'big', signed=True)
+        key += bytes(byte ^ 255 for byte in component) if field['descending'] else component
+    return key.hex()
+
+
+def observe(data, arm):
+    # The named user root is derived through the typed catalog decoder.
+    catalog_definition, _, objects = catalog._discover_catalog(data)
+    name = catalog._ordinal(catalog_definition, 'Name')
+    kind = catalog._ordinal(catalog_definition, 'Type')
+    ident = catalog._ordinal(catalog_definition, 'Id')
+    roots = [row['values'][ident] for row in objects
+             if row['values'][name] == 'Rows' and row['values'][kind] == 1]
+    if len(roots) != 1:
+        raise catalog.DecodeError('Expected one Rows table')
+    definition = catalog._definition(data, roots[0])
+    if ([(column['name'], column['type'], column['size']) for column in definition['columns']]
+            != [(name, 'Long', 4) for name in ('A', 'B', 'Tag')]
+            or len(definition['physical_indexes']) != 1 or len(definition['logical_indexes']) != 1):
+        raise catalog.DecodeError('Unexpected physical schema/index inventory')
+    pages, long_values = catalog._table_pages(data, definition)
+    if long_values:
+        raise catalog.DecodeError('Unexpected long-value pages')
+    rows = catalog._table_rows(data, definition, pages)
+    if sorted(row['values'] for row in rows) != sorted(arm['rows']) or definition['row_count'] != len(rows):
+        raise catalog.DecodeError('Decoded rows disagree with planned inputs')
+    index = definition['physical_indexes'][0]
+    leaf = leaf_entries(data, index['root'])
+    raw_page = catalog._page(data, index['root'], 'Long key leaf')
+    if int.from_bytes(raw_page[4:8], 'little') != definition['root']:
+        raise catalog.DecodeError('Index owner mismatch')
+    bindings = bind_rows(rows, leaf['entries'], arm)
+    return {'definition_root': definition['root'], 'row_count': definition['row_count'],
+            'physical_index': index, 'logical_indexes': definition['logical_indexes'],
+            'data_pages': pages, 'index_pages': sorted(catalog._locator_pages(data, index['map'], 'Long index')),
+            'prefix_hex': leaf['prefix_hex'], 'bindings': bindings,
+            'hypothesis_matches': all(row['key_hex'] == row['hypothesis_key_hex'] for row in bindings)}
+
+
+def bind_rows(rows, entries, arm):
+    by_locator = {(row['page'], row['row']): row['values'] for row in rows}
+    bindings, seen = [], set()
+    for entry in entries:
+        locator = (entry['row_page'], entry['row'])
+        if locator not in by_locator or locator in seen:
+            raise catalog.DecodeError('Index row locator missing or repeated')
+        seen.add(locator)
+        values = by_locator[locator]
+        bindings.append(dict(entry, values=values, hypothesis_key_hex=hypothesized_key(values, arm)))
+    if seen != set(by_locator):
+        raise catalog.DecodeError('Index does not cover every row')
+    return bindings
+
+
+def key_values(row, arm):
+    return tuple(row[['A', 'B', 'Tag'].index(field['name'])] * (-1 if field['descending'] else 1)
+                 for field in arm['fields'])
+
+
+def correlate(snapshot, decoded, arm):
+    expected_fields = [{'name': name, 'type': 4, 'size': 4} for name in ('A', 'B', 'Tag')]
+    indexes = snapshot.get('indexes', [])
+    if (snapshot.get('version') != '3.0' or snapshot.get('fields') != expected_fields
+            or snapshot.get('tables') != ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows']
+            or len(indexes) != 1):
+        return False
+    index = indexes[0]
+    if (index['name'] != 'ByKey' or index['primary'] is not False
+            or index['unique'] != arm['unique'] or index['fields'] != arm['fields']):
+        return False
+    rows, traversal = snapshot.get('rows', []), snapshot.get('traversal', [])
+    if sorted(rows) != sorted(arm['rows']) or sorted(traversal) != sorted(rows):
+        return False
+    wanted_order = sorted(key_values(row, arm) for row in rows)
+    # Equal full keys may appear in either payload order in DAO traversal.
+    return ([key_values(row, arm) for row in traversal] == wanted_order
+            and [key_values(entry['values'], arm) for entry in decoded['bindings']] == wanted_order)
+
+
+def comparable(observation):
+    decoded = observation['decoded']
+    # Page/slot identities are retained, but allocator locations and equal-key
+    # payload order are not the question-bearing comparison across replicas.
+    return {'snapshot': dict(observation['snapshot'],
+                rows=sorted(observation['snapshot']['rows']),
+                traversal=sorted(observation['snapshot']['traversal'])),
+            'bindings': sorted([(entry['values'], entry['key_hex']) for entry in decoded['bindings']]),
+            'entry_count': decoded['physical_index']['entry_count'],
+            'flags': decoded['physical_index']['flags'], 'keys': decoded['physical_index']['keys'],
+            'hypothesis_matches': decoded['hypothesis_matches']}
+
+
+def build_report(result, outbox, plan):
+    if (result['document_type'] != 'dao_long_key_layout_result'
+            or result['plan_sha256'] != digest(PLAN) or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    expected = [(arm['name'], replica) for arm in plan['arms'] for replica in range(1, 4)]
+    actual = [(entry['arm'], entry['replica']) for entry in result['replicas']]
+    if actual != expected[:len(actual)]:
+        raise ValueError('Unexpected arm/replica inventory')
+    observations, reasons = [], []
+    arms = {arm['name']: arm for arm in plan['arms']}
+    for entry in result['replicas']:
+        label = f"{entry['arm']}-r{entry['replica']}"
+        if entry['file'] != label + '.mdb' or identity(outbox / entry['file']) != entry['after']:
+            raise ValueError('Retained image identity mismatch')
+        if entry['before'] != entry['after']:
+            reasons.append(label + ': read-only bytes changed')
+        try:
+            if entry['status'] != 'pass' or entry['endpoint'] != 'complete' or entry['error'] is not None:
+                raise ValueError('DAO observation did not complete: ' + str(entry['error']))
+            decoded = observe((outbox / entry['file']).read_bytes(), arms[entry['arm']])
+            if not correlate(entry['snapshot'], decoded, arms[entry['arm']]):
+                raise ValueError('DAO/decoded row or metadata correlation failed')
+            observations.append({'arm': entry['arm'], 'replica': entry['replica'],
+                                 'snapshot': entry['snapshot'], 'decoded': decoded})
+        except (catalog.DecodeError, KeyError, ValueError) as error:
+            reasons.append(label + ': ' + str(error))
+    if len(observations) != len(expected) or result['error'] is not None or result['mutation_started'] is not True:
+        reasons.append('Acquisition incomplete or failed: ' + str(result['error']))
+    for arm in arms:
+        group = [comparable(item) for item in observations if item['arm'] == arm]
+        if group and any(item != group[0] for item in group):
+            reasons.append(arm + ': question-bearing observations differ across replicas')
+    return {'document_type': 'dao_long_key_layout_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'answered' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'compatibility_claim': False,
+            'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    output = outbox / 'report.json'
+    output.write_text(canonical(report) + '\n')
+    print(output)
+    print(report['outcome'])
+
+
+def dispatch(args):
+    preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    inbox, outbox = (args.shared_root.resolve() / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / PLAN.name)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight')
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        preflight()
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_long_key_layout.py
+++ b/oracle/windows-dao/tests/test_long_key_layout.py
@@ -1,0 +1,92 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location('long_key_layout', SCRIPTS / 'long_key_layout.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class LongKeyLayoutTests(unittest.TestCase):
+    def plan(self):
+        return json.loads(experiment.PLAN.read_text())
+
+    def test_hypothesis_is_explicit_and_locators_resolve_exactly_once(self):
+        arm = self.plan()['arms'][0]
+        self.assertEqual(experiment.hypothesized_key([-2147483648, 0, 0], arm), '80ffffffff')
+        self.assertEqual(experiment.hypothesized_key([2147483647, 0, 0], arm), '8000000000')
+        rows = [{'page': 23, 'row': 0, 'values': [0, 0, 0]}]
+        entries = [{'row_page': 23, 'row': 0, 'key_hex': 'deadbeef'}]
+        bindings = experiment.bind_rows(rows, entries, arm)
+        self.assertEqual(bindings[0]['key_hex'], 'deadbeef')  # Unknown bytes remain observable.
+        for broken in [[], entries * 2, [dict(entries[0], row=1)]]:
+            with self.assertRaises(experiment.catalog.DecodeError):
+                experiment.bind_rows(rows, broken, arm)
+
+    def fixture(self, outbox):
+        plan = self.plan()
+        result = {'document_type': 'dao_long_key_layout_result', 'development_only': True,
+                  'plan_sha256': experiment.digest(experiment.PLAN), 'mutation_started': True,
+                  'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'replicas': [], 'error': None}
+        for arm in plan['arms']:
+            snapshot = {'version': '3.0', 'tables': ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows'],
+                        'fields': [{'name': name, 'type': 4, 'size': 4} for name in ('A', 'B', 'Tag')],
+                        'indexes': [{'name': 'ByKey', 'primary': False, 'unique': arm['unique'],
+                                     'required': False, 'fields': arm['fields']}], 'rows': arm['rows'],
+                        'traversal': sorted(arm['rows'], key=lambda row: experiment.key_values(row, arm))}
+            for replica in range(1, 4):
+                name = f"{arm['name']}-r{replica}.mdb"
+                (outbox / name).write_bytes(b'synthetic')
+                identity = experiment.identity(outbox / name)
+                result['replicas'].append({'arm': arm['name'], 'replica': replica, 'file': name,
+                                          'before': identity, 'after': identity, 'status': 'pass',
+                                          'endpoint': 'complete', 'error': None, 'snapshot': copy.deepcopy(snapshot)})
+        return plan, result
+
+    @staticmethod
+    def decoded(_data, arm):
+        rows = sorted(arm['rows'], key=lambda row: experiment.key_values(row, arm))
+        return {'bindings': [{'row_page': 23, 'row': n, 'values': row, 'key_hex': 'abcdef'}
+                             for n, row in enumerate(rows)], 'hypothesis_matches': False,
+                'physical_index': {'entry_count': len(rows), 'flags': 1, 'keys': arm['fields']}}
+
+    def test_stable_hypothesis_refutation_answers_but_order_and_replica_failures_do_not(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=self.decoded):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'answered')
+            result['replicas'][0]['snapshot']['traversal'].reverse()
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+            plan, result = self.fixture(outbox)
+            result['replicas'][0]['snapshot']['indexes'][0]['required'] = True
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+            result['replicas'].pop()
+            result['error'] = 'DAO failed after mutation'
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+
+    def test_identities_inventory_and_standalone_pins_are_required(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=self.decoded):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            result['replicas'][0]['before'] = {'size': 0, 'sha256': 'changed'}
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+            (outbox / result['replicas'][0]['file']).write_bytes(b'changed')
+            with self.assertRaisesRegex(ValueError, 'identity mismatch'):
+                experiment.build_report(result, outbox, plan)
+            result['replicas'][0]['replica'] = 3
+            with self.assertRaisesRegex(ValueError, 'inventory'):
+                experiment.build_report(result, outbox, plan)
+        with patch.object(experiment, 'verify_inputs', side_effect=ValueError('Input pin mismatch')):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                experiment.analyze(Path('unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Populated descending and composite Long indexes need raw key-to-row evidence before the writer can encode them. EXP-0125 preregisters three finite DAO cases: a descending unique key, an ascending/descending unique pair, and a descending/ascending ordinary pair with duplicate full keys.

Each case captures three replicas and binds every leaf locator to the planned values and DAO traversal. Hypothesized byte transformations are checked separately from stable observations; unexpected bytes remain valid findings. Acquisition runs once with no automatic retry after mutation.

Validation: independent review found no issues; three focused tests, committed-pin preflight, Python compilation, Windows PowerShell parser check, and `just ready` passed.
