### PR TITLE
test: preregister initial Memo and OLE DAO matrix

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10799,3 +10799,46 @@ Copy this block under the appropriate section and remove this instruction:
   integrity mutation, cascade, populated relation, existing-database update,
   general compatibility, or hosted support claim. All report compatibility
   and support-matrix flags remain false.
+
+### EXP-0123 — Initial Memo/OLE payload candidate preregistration
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: committed preregistration for a development-only DAO validation;
+  acquisition has not started and no outcome is asserted.
+- Question: Does DAO accept both exact writer-policy candidates with the
+  expected complete schema, Memo strings/OLE bytes, and null rows while
+  leaving every candidate unchanged?
+- Plan: `oracle/windows-dao/acquisition/long-value-rows.plan.json`, SHA-256
+  `d30fa45eee7ec8abf163538680bd5b5818b8fa05a15941422ad55bfd5b45c128`. Its input pins cover the producer, analyzer,
+  low-level SSH transport and deterministic Rust example. Both dispatch and
+  analysis verify the same input pins; acquisition requires this committed plan.
+- Generator: `initial_long_value_candidate` from reviewed source
+  `2d3adf2e985e28c81f21cf1d9b07fdf52849341f`.
+- Candidate identities:
+  - Memo: 73728 bytes, SHA-256
+    `9302db2b9364aad2cf1fe8bf5b6d1ecb161e3f0b29d838990dc9dd2b695e98e5`.
+  - OLE: 73728 bytes, SHA-256
+    `8b13bd5cb99a8415fc90dc9c123cfdfcf673b14257affd384e0ed2f56c727d8c`.
+- Both candidates contain unindexed `Rows(Id Long, Payload Memo/OLE)` and
+  ten rows: Id1..9 carry lengths 1, 32, 33, 512, 2036, 2037, 2048, 4064 and
+  4096; Id10 carries null. The plan fixes every payload character/byte.
+  This tests inline/single/chained construction with twelve LVAL pages
+  before one data page and retained composed page-zero bytes. EXP-0061,
+  EXP-0077 and EXP-0065 supply the cited primitive grammar; the cutoffs and
+  placement are candidate choices, not inferred DAO storage thresholds.
+- Acquisition design: one job, three fresh same-schema DAO controls and
+  three unchanged candidate replicas per type. Read complete schema and
+  exact Id/payload multisets. Compare complete Memo strings and lowercase
+  OLE hex, including null versus empty; retain all twelve files and identities.
+- Decision: accept an arm only after the complete six-pair job, every control
+  passes, all twelve images remain unchanged, and its three observations
+  agree. Identical candidate failures yield `not_observed_accepted`; an
+  incomplete job, changed image, control failure or replica disagreement
+  yields `no_outcome`. Binding/pin/retention inconsistencies reject validation.
+  A failure after the first mutation is a result, never an automatic retry.
+- Preflight: six classifier tests passed; x86 VM PowerShell `Parser.ParseFile`
+  accepted the producer without executing it or DAO. Independent experiment
+  review precedes acquisition. Root owns the single authorized dispatch.
+- Boundary: development-only, no support-matrix movement or general
+  compatibility, storage-cutoff, empty-payload, multi-long-column, indexed
+  long-value or mutation claim. Add the validated outcome once as EXP-0124.

--- a/oracle/windows-dao/acquisition/long-value-rows.plan.json
+++ b/oracle/windows-dao/acquisition/long-value-rows.plan.json
@@ -1,0 +1,68 @@
+{
+  "document_type": "dao_long_value_rows_plan",
+  "experiment_id": "long-value-rows",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0061 supplies Memo/OLE headers, inline bytes, single rows and chained fragments; EXP-0077 supplies long-column map pairs; EXP-0065 supplies append placement. Those observations do not establish acceptance of this writer policy.",
+    "hypothesis": "DAO reads both exact ten-row candidates unchanged with complete expected schema and per-row payloads. The candidate policy stores lengths 1 and 32 inline, 33/512/2036 in one external row each, and 2037/2048/4064/4096 in 2032-byte chained fragments, one fragment per page. Twelve LVAL pages 23..34 precede data page 35; column owned maps name all twelve, column availability names 23,24,27,29,34, and table maps name 35. Page zero retains the composed empty-database header without insertion-counter transitions. This tests writer-policy acceptance, not DAO storage thresholds.",
+    "authorization": "User authorized DAO experiments/mutations on 2026-09-04. Commit and independently review the SHA256-pinned plan before one dispatch. A failure after the first CreateDatabase begins is a scientific result; another dispatch requires a new human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/long_value_rows.py": "313e35454f2420b31daa9b6de70549a9f3d35f422064226ddec4a63d44ba04f7",
+    "oracle/windows-dao/scripts/long_value_rows.ps1": "e6d4ec4f18ba75e8f93687d3c45b7ced4014092585ba77917c10a14e93e7c6da",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/initial_long_value_candidate.rs": "9c248ef25b92c00e5321c312940d06332becb3b61cb038b35f23e52729509bd8"
+  },
+  "candidates": {
+    "memo": {
+      "size": 73728,
+      "sha256": "9302db2b9364aad2cf1fe8bf5b6d1ecb161e3f0b29d838990dc9dd2b695e98e5"
+    },
+    "ole": {
+      "size": 73728,
+      "sha256": "8b13bd5cb99a8415fc90dc9c123cfdfcf673b14257affd384e0ed2f56c727d8c"
+    }
+  },
+  "schema": {
+    "version": "3.0",
+    "tables": [
+      "MSysACEs",
+      "MSysObjects",
+      "MSysQueries",
+      "MSysRelationships",
+      "Rows"
+    ],
+    "indexes": []
+  },
+  "scenarios": {
+    "common": "Rows(Id Long, Payload Memo or OLE), no index. Id 1..9 correspond to payload lengths [1,32,33,512,2036,2037,2048,4064,4096]; Id10 has null payload. Exact field metadata: Id type4 size4, Payload type12 for Memo or type11 for OLE, size0.",
+    "memo": "At zero-based row position r=0..8 and byte offset p, character ASCII A+((p+r) mod26). Compare complete DAO string, preserving case and every character.",
+    "ole": "At zero-based row position r=0..8 and byte offset p, byte (p+r) mod256. Compare complete DAO byte array serialized as lowercase hex.",
+    "empty": "Empty payloads remain an explicit implementation refusal and are not an acquisition arm; null is present in both arms."
+  },
+  "execution": {
+    "environment": "Private Windows VM, x86 PowerShell, DAO.DBEngine.36; development-only.",
+    "pre_mutation": "Host verifies all input/candidate pins and committed plan; guest verifies producer and all six copied candidate replicas before first control creation.",
+    "per_replica": "For memo then ole, replicas1..3: create/close a fresh same-schema DAO control using AppendChunk at type-specific call sites and a null tenth payload. Read control and candidate read-only, capture complete table/field/index metadata and every Id/payload pair, close and compare before/after identities.",
+    "attempts": 1,
+    "command": "python3 oracle/windows-dao/scripts/long_value_rows.py run <directory containing memo.mdb ole.mdb> --shared-root <VM shared directory> --run-id <UTC timestamp>-long-value-rows",
+    "analysis": "python3 oracle/windows-dao/scripts/long_value_rows.py analyze <shared directory>/outbox/<run id>"
+  },
+  "decision_rule": {
+    "observed_accepted": "Complete six-pair job, all controls match exact expected semantics, all twelve images unchanged, and three agreeing accepted candidate observations for that arm.",
+    "not_observed_accepted": "Same complete-job/control/unchanged gate, but all three candidates for the arm identically fail an endpoint or produce the same semantic mismatch.",
+    "no_outcome": "Incomplete job, any control failure, any changed image, or candidate replica disagreement for the arm.",
+    "semantic_normalization": "Rows are an exact Id/payload multiset, preserving null versus empty and every Memo character/OLE byte. No prefix, length-only or hash-only payload acceptance.",
+    "validation_rejection": "Input-pin drift at preflight or analysis, malformed result binding/inventory, candidate starting identity mismatch, or retained-file mismatch rejects validation."
+  },
+  "evidence_boundary": "Only these two exact ten-row candidates. No general storage cutoff, indirect allocation, empty-payload, multiple-long-column, long-column-index, insert/update, page-zero, compatibility or hosted support claim.",
+  "retention": "Retain result.json, canonical report.json, logs and all twelve MDBs locally. Never commit MDB bytes/provider binaries. Append EXP-0124 once from the validated report.",
+  "candidate_generation": {
+    "source_commit": "2d3adf2e985e28c81f21cf1d9b07fdf52849341f",
+    "example": "crates/jet3/examples/initial_long_value_candidate.rs",
+    "command": "cargo run --locked -p jet3 --example initial_long_value_candidate -- <directory>/<arm>.mdb <arm>"
+  }
+}

--- a/oracle/windows-dao/scripts/long_value_rows.ps1
+++ b/oracle/windows-dao/scripts/long_value_rows.ps1
@@ -1,0 +1,145 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function New-Control([string]$Path, [string]$Arm) {
+    $engine = $workspace = $db = $table = $id = $payload = $field = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $table = $db.CreateTableDef('Rows')
+        $id = $table.CreateField('Id', 4)
+        $table.Fields.Append($id)
+        $type = if ($Arm -ceq 'memo') { 12 } else { 11 }
+        $payload = $table.CreateField('Payload', $type)
+        $table.Fields.Append($payload)
+        $db.TableDefs.Append($table)
+        $rs = $db.OpenRecordset('Rows', 2)
+        $lengths = @(1, 32, 33, 512, 2036, 2037, 2048, 4064, 4096)
+        foreach ($position in 0..9) {
+            $rs.AddNew()
+            $rs.Fields.Item('Id').Value = [int]($position + 1)
+            if ($position -lt 9) {
+                $field = $rs.Fields.Item('Payload')
+                $length = $lengths[$position]
+                if ($Arm -ceq 'memo') {
+                    $text = -join (0..($length - 1) | ForEach-Object { [char](65 + (($_ + $position) % 26)) })
+                    $field.AppendChunk([string]$text)
+                }
+                else {
+                    $bytes = [byte[]](0..($length - 1) | ForEach-Object { [byte](($_ + $position) % 256) })
+                    $field.AppendChunk([byte[]]$bytes)
+                }
+                Release $field; $field = $null
+            }
+            $rs.Update()
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $field; Release $rs; Release $payload; Release $id; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset, [string]$Arm) {
+    $id = $Recordset.Fields.Item('Id').Value
+    $payload = $Recordset.Fields.Item('Payload').Value
+    if ($null -eq $id -or [Convert]::IsDBNull($id)) { $id = $null } else { $id = [int]$id }
+    if ($null -eq $payload -or [Convert]::IsDBNull($payload)) { $payload = $null }
+    elseif ($Arm -ceq 'memo') { $payload = [string]$payload }
+    else { $payload = [BitConverter]::ToString([byte[]]$payload).Replace('-', '').ToLowerInvariant() }
+    return @{id=$id; payload=$payload}
+}
+function Observe([string]$Path, [string]$Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item('Rows')
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0)} })}
+        })
+        $endpoint = 'rows'
+        $rs = $db.OpenRecordset('Rows', 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$rows.Add((Read-Row $rs $Arm))
+            $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'long-value-rows.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/long_value_rows.ps1') { throw 'Script pin mismatch' }
+$arms = @('memo', 'ole')
+foreach ($arm in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$arm.mdb") -Destination $path
+        $identity = Identity $path
+        $expected = $plan.candidates.$arm
+        if ($identity.size -ne $expected.size -or $identity.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_long_value_rows_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($arm in $arms) {
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$arm-control-r$replica.mdb"
+            New-Control $control $arm
+            $candidate = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+            $result.replicas += @{arm=$arm; replica=$replica; control=(Observe $control $arm); candidate=(Observe $candidate $arm)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/long_value_rows.py
+++ b/oracle/windows-dao/scripts/long_value_rows.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Preregistered Memo/OLE initial-payload DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/long-value-rows.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/long_value_rows.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+ARMS = ('memo', 'ole')
+LENGTHS = (1, 32, 33, 512, 2036, 2037, 2048, 4064, 4096)
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['replicas'] != 3 or list(plan['candidates']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        if identity(candidate_directory / f'{arm}.mdb') != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def expected_rows(arm):
+    rows = []
+    for position, length in enumerate(LENGTHS):
+        payload = (''.join(chr(65 + (offset + position) % 26) for offset in range(length))
+                   if arm == 'memo' else bytes((offset + position) % 256 for offset in range(length)).hex())
+        rows.append({'id': position + 1, 'payload': payload})
+    return rows + [{'id': 10, 'payload': None}]
+
+
+def schema(plan, arm):
+    return {**plan['schema'], 'fields': [{'name': 'Id', 'type': 4, 'size': 4},
+            {'name': 'Payload', 'type': 12 if arm == 'memo' else 11, 'size': 0}]}
+
+
+def semantics(plan, arm, observation):
+    snapshot = observation['snapshot']
+    shape = {key: value for key, value in snapshot.items() if key != 'rows'}
+    rows = sorted(snapshot.get('rows', []), key=canonical)
+    passed = (observation['status'] == 'pass' and observation['endpoint'] == 'complete'
+              and shape == schema(plan, arm)
+              and rows == sorted(expected_rows(arm), key=canonical))
+    normalized = {**snapshot, 'rows': rows} if 'rows' in snapshot else snapshot
+    return passed, {**{key: observation[key] for key in ('status', 'endpoint', 'error')},
+                    'snapshot': normalized}
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    if (result['document_type'] != 'dao_long_value_rows_result'
+            or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32):
+        raise ValueError('Result identity/environment mismatch')
+    expected_inventory = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual_inventory = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual_inventory != expected_inventory[:len(actual_inventory)]:
+        raise ValueError('Unexpected replica inventory')
+    grouped = {arm: [] for arm in ARMS}
+    unchanged = True
+    controls_ok = True
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        for role in ('candidate', 'control'):
+            observation = item[role]
+            retained = outbox / f'{arm}-{role}-r{replica}.mdb'
+            if identity(retained) != observation['after']:
+                raise ValueError(f'Retained identity mismatch: {retained.name}')
+            if role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                raise ValueError('Candidate did not start with pinned identity')
+            unchanged &= observation['before'] == observation['after']
+        controls_ok &= semantics(plan, arm, item['control'])[0]
+        grouped[arm].append(semantics(plan, arm, item['candidate']))
+    outcomes = {arm: 'no_outcome' for arm in ARMS}
+    if (result['mutation_started'] is True and result['error'] is None
+            and actual_inventory == expected_inventory and controls_ok and unchanged):
+        for arm, observations in grouped.items():
+            if all(item == observations[0] for item in observations):
+                outcomes[arm] = 'observed_accepted' if observations[0][0] else 'not_observed_accepted'
+    report = {'document_type': 'dao_long_value_rows_report', 'development_only': True,
+              'compatibility_claim': False, 'support_movement': False,
+              'plan_sha256': digest(PLAN), 'result_sha256': digest(outbox / 'result.json'),
+              'outcomes': outcomes, 'replicas': len(result['replicas']), 'candidates': plan['candidates']}
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report))
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'long-value-rows.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_long_value_rows.py
+++ b/oracle/windows-dao/tests/test_long_value_rows.py
@@ -1,0 +1,95 @@
+"""Classify exact Memo strings and OLE bytes independently of producer pass flags."""
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('long_value_rows', Path(__file__).parents[1] / 'scripts/long_value_rows.py')
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class LongValueRowsReportTests(unittest.TestCase):
+    def classify(self, change=lambda result: None, tamper=None):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / 'producer.ps1'
+            source.write_text('pinned producer')
+            plan = {'inputs': {str(source): MODULE.digest(source)}, 'schema': {'version': '3.0'}, 'candidates': {}}
+            for arm in MODULE.ARMS:
+                path = root / f'{arm}.mdb'
+                path.write_bytes(arm.encode())
+                plan['candidates'][arm] = MODULE.identity(path)
+            plan_path = root / 'plan.json'
+            plan_path.write_text(json.dumps(plan))
+            result = {'document_type': 'dao_long_value_rows_result', 'development_only': True,
+                      'plan_sha256': MODULE.digest(plan_path), 'environment': {'process_bits': 32},
+                      'mutation_started': True, 'error': None, 'replicas': []}
+            for arm in MODULE.ARMS:
+                rows = MODULE.expected_rows(arm)
+                snapshot = {**MODULE.schema(plan, arm), 'rows': rows}
+                for number in range(1, 4):
+                    replica = {'arm': arm, 'replica': number}
+                    for role in ('candidate', 'control'):
+                        path = root / f'{arm}-{role}-r{number}.mdb'
+                        path.write_bytes(arm.encode())
+                        replica[role] = {'before': MODULE.identity(path), 'after': MODULE.identity(path),
+                                         'status': 'pass', 'endpoint': 'complete', 'error': None,
+                                         'snapshot': copy.deepcopy(snapshot)}
+                    result['replicas'].append(replica)
+            change(result)
+            (root / 'result.json').write_text(json.dumps(result))
+            if tamper == 'input':
+                source.write_text('diagnostic edit')
+            elif tamper == 'retained':
+                (root / 'memo-candidate-r1.mdb').write_bytes(b'changed')
+            with patch.object(MODULE, 'PLAN', plan_path), patch('builtins.print'):
+                MODULE.analyze(root)
+            return json.loads((root / 'report.json').read_text())['outcomes']
+
+    def test_exact_payloads_allow_row_order_differences(self):
+        def change(result):
+            result['replicas'][0]['candidate']['snapshot']['rows'].reverse()
+        self.assertTrue(all(value == 'observed_accepted' for value in self.classify(change).values()))
+
+    def test_payload_and_null_mismatches_are_negative(self):
+        for row, payload in [(0, ''), (8, 'wrong'), (9, '')]:
+            def change(result):
+                for replica in result['replicas'][3:]:
+                    replica['candidate']['snapshot']['rows'][row]['payload'] = payload
+            self.assertEqual(self.classify(change)['ole'], 'not_observed_accepted')
+
+    def test_schema_mismatch_is_negative(self):
+        def change(result):
+            for replica in result['replicas'][:3]:
+                replica['candidate']['snapshot']['fields'][1]['type'] = 10
+        self.assertEqual(self.classify(change)['memo'], 'not_observed_accepted')
+
+    def test_disagreement_control_failure_and_mutation_have_no_outcome(self):
+        def disagreement(result):
+            result['replicas'][0]['candidate']['snapshot']['rows'].pop()
+        self.assertEqual(self.classify(disagreement)['memo'], 'no_outcome')
+        def control_failure(result):
+            result['replicas'][0]['control']['snapshot']['rows'] = []
+        def changed_image(result):
+            result['replicas'][0]['control']['before']['sha256'] = '0' * 64
+        for change in (control_failure, changed_image):
+            self.assertTrue(all(value == 'no_outcome' for value in self.classify(change).values()))
+
+    def test_incomplete_scientific_job_has_no_outcome(self):
+        def change(result):
+            result['replicas'].pop()
+            result['error'] = 'CreateDatabase failed'
+        self.assertTrue(all(value == 'no_outcome' for value in self.classify(change).values()))
+
+    def test_modified_inputs_and_retained_files_are_rejected(self):
+        for tamper in ('input', 'retained'):
+            with self.subTest(tamper=tamper), self.assertRaises(ValueError):
+                self.classify(tamper=tamper)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EXP-0123 pins Memo and OLE candidates containing nulls and payload lengths spanning each chosen inline, single-page, and chained storage boundary. Three fresh controls per type compare complete schema and all payload contents, with unchanged candidate identities required.

Both dispatch and analysis verify committed inputs. The matrix permits one acquisition, with no automatic retry after mutation; results remain local development evidence.

Validation: independent review found no issues; six classifier tests, committed candidate/input preflight, Windows PowerShell parser validation, and `just ready` passed.

The subsequent single authorized acquisition accepted both types in all six control/candidate comparisons, including all payloads and unchanged identities. The result will be recorded separately as EXP-0124.
