### PR TITLE
feat(jet3): create descending and composite Long indexes

### DIFF
--- a/crates/jet3/examples/composite_index_candidate.rs
+++ b/crates/jet3/examples/composite_index_candidate.rs
@@ -1,0 +1,87 @@
+//! Deterministic EXP-0126-shaped candidates for subsequent DAO validation.
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
+    ResourceBudget, ResourceLimits, RowValue, TableSpec, create_database_with_rows,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args_os().skip(1);
+    let path = args
+        .next()
+        .ok_or("usage: composite_index_candidate OUTPUT.mdb ARM")?;
+    let arm = args.next().ok_or("ARM required")?;
+    let (directions, kind, input) = match arm.to_str() {
+        Some("descending-unique") => (
+            &[IndexDirection::Descending][..],
+            IndexKind::Unique,
+            [i32::MAX, i32::MIN, 0, -1, 1, -256, 255, 256, -65536, 65536]
+                .into_iter()
+                .enumerate()
+                .map(|(tag, a)| [a, 0, tag as i32])
+                .collect::<Vec<_>>(),
+        ),
+        Some("ascending-descending-unique") => (
+            &[IndexDirection::Ascending, IndexDirection::Descending][..],
+            IndexKind::Unique,
+            PAIRS[..12].to_vec(),
+        ),
+        Some("descending-ascending-ordinary") => (
+            &[IndexDirection::Descending, IndexDirection::Ascending][..],
+            IndexKind::Ordinary,
+            PAIRS.to_vec(),
+        ),
+        _ => return Err("unknown EXP-0126 arm".into()),
+    };
+    let columns = [
+        ColumnSpec::new(b"A", ColumnType::Long),
+        ColumnSpec::new(b"B", ColumnType::Long),
+        ColumnSpec::new(b"Tag", ColumnType::Long),
+    ];
+    let fields = directions
+        .iter()
+        .enumerate()
+        .map(|(ordinal, direction)| IndexColumnSpec {
+            column: ColumnRef::Ordinal(ordinal as u16),
+            direction: *direction,
+        })
+        .collect::<Vec<_>>();
+    let indexes = [IndexSpec {
+        name: b"ByKey",
+        fields: &fields,
+        kind,
+    }];
+    let table = TableSpec {
+        name: b"Rows",
+        columns: &columns,
+        indexes: &indexes,
+    };
+    let values = input
+        .iter()
+        .map(|row| row.map(RowValue::Long))
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(
+        path,
+        &table,
+        &rows,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}
+
+const PAIRS: [[i32; 3]; 14] = [
+    [0, 0, 0],
+    [i32::MIN, i32::MAX, 1],
+    [i32::MAX, i32::MIN, 2],
+    [-1, -1, 3],
+    [-1, 0, 4],
+    [-1, 1, 5],
+    [0, i32::MIN, 6],
+    [0, i32::MAX, 7],
+    [1, -256, 8],
+    [1, 255, 9],
+    [256, -65536, 10],
+    [-256, 65536, 11],
+    [0, 0, 12],
+    [-1, 0, 13],
+];

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -10,12 +10,17 @@ pub enum ComposeError {
         /// Unsupported relationship constraint.
         detail: &'static str,
     },
-    /// Initial rows support at most one ascending, single-Long-column index.
+    /// Initial rows support at most one index on one or two Long columns.
     UnsupportedInitialIndexSchema,
     /// Null indexed keys are outside the bounded initial-index construction.
     NullInitialIndexKey {
         /// Zero-based input row.
         row: usize,
+    },
+    /// A primary or unique initial index repeats a two-Long key.
+    DuplicateInitialCompositeIndexKey {
+        /// Repeated values in declared index-field order.
+        values: [i32; 2],
     },
     /// A primary or unique initial index repeats a key.
     DuplicateInitialIndexKey {
@@ -109,6 +114,7 @@ impl std::error::Error for ComposeError {
             | Self::UnsupportedInitialIndexSchema
             | Self::NullInitialIndexKey { .. }
             | Self::DuplicateInitialIndexKey { .. }
+            | Self::DuplicateInitialCompositeIndexKey { .. }
             | Self::IndexPageFull { .. }
             | Self::UnobservedMapRowLayout
             | Self::UnobservedLongValueColumnCount { .. }

--- a/crates/jet3/src/bootstrap_initial_index.rs
+++ b/crates/jet3/src/bootstrap_initial_index.rs
@@ -1,18 +1,26 @@
-//! One uncompressed ascending Long leaf: EXP-0062 key and locator grammar,
-//! matching the existing catalog Long encoder; EXP-0073 distinct-key counts.
+//! One uncompressed leaf of one/two Long components: EXP-0062 leaf/locator
+//! grammar, EXP-0126 direction/composition and full-key distinct counts.
 
 use super::*;
 use crate::{IndexKind, IndexTree, RowLocator};
 
-const KEY_BYTES: usize = 5;
-const ENTRY_BYTES: usize = KEY_BYTES + 4;
-const MAX_ENTRIES: usize = INDEX_ENTRY_AREA_LEN / ENTRY_BYTES;
+const COMPONENT_BYTES: usize = 5;
+const MAX_FIELDS: usize = 2;
+const LOCATOR_BYTES: usize = 4;
+const ENTRY_CAPACITY: usize = MAX_FIELDS * COMPONENT_BYTES + LOCATOR_BYTES;
+
+#[derive(Debug, Clone, Copy)]
+struct LongField {
+    column: usize,
+    direction: IndexDirection,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct InitialLongIndex {
-    column: usize,
+    fields: [LongField; MAX_FIELDS],
+    field_count: usize,
     unique: bool,
-    entries: Vec<[u8; ENTRY_BYTES]>,
+    entries: Vec<[u8; ENTRY_CAPACITY]>,
     distinct: u32,
 }
 
@@ -29,29 +37,39 @@ impl InitialLongIndex {
                 Err(ComposeError::UnsupportedInitialIndexSchema)
             };
         };
-        let [field] = index.fields else {
+        if !(1..=MAX_FIELDS).contains(&index.fields.len()) {
             return Err(ComposeError::UnsupportedInitialIndexSchema);
-        };
-        let column = field
-            .column
-            .resolve(spec.columns)
-            .map(usize::from)
-            .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
-        if field.direction != IndexDirection::Ascending
-            || spec
+        }
+        let mut fields = [LongField {
+            column: 0,
+            direction: IndexDirection::Ascending,
+        }; MAX_FIELDS];
+        for (slot, field) in fields.iter_mut().zip(index.fields) {
+            let column = field
+                .column
+                .resolve(spec.columns)
+                .map(usize::from)
+                .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
+            if spec
                 .columns
                 .get(column)
                 .is_none_or(|column| column.column_type() != ColumnType::Long)
-        {
-            return Err(ComposeError::UnsupportedInitialIndexSchema);
+            {
+                return Err(ComposeError::UnsupportedInitialIndexSchema);
+            }
+            *slot = LongField {
+                column,
+                direction: field.direction,
+            };
         }
-        if row_count > MAX_ENTRIES {
+        let entry_bytes = index.fields.len() * COMPONENT_BYTES + LOCATOR_BYTES;
+        if row_count > INDEX_ENTRY_AREA_LEN / entry_bytes {
             return Err(ComposeError::IndexPageFull {
-                needed: row_count.saturating_mul(ENTRY_BYTES),
+                needed: row_count.saturating_mul(entry_bytes),
                 available: INDEX_ENTRY_AREA_LEN,
             });
         }
-        budget.charge_allocation(ByteCount::new((row_count * ENTRY_BYTES) as u64))?;
+        budget.charge_allocation(ByteCount::new((row_count * ENTRY_CAPACITY) as u64))?;
         let mut entries = Vec::new();
         entries
             .try_reserve_exact(row_count)
@@ -60,7 +78,8 @@ impl InitialLongIndex {
                 kind: std::io::ErrorKind::OutOfMemory,
             })?;
         Ok(Some(Self {
-            column,
+            fields,
+            field_count: index.fields.len(),
             unique: index.kind != IndexKind::Ordinary,
             entries,
             distinct: 0,
@@ -73,11 +92,6 @@ impl InitialLongIndex {
         locator: RowLocator,
         budget: &mut ResourceBudget,
     ) -> Result<(), ComposeError> {
-        let Some(RowValue::Long(value)) = values.get(self.column) else {
-            return Err(ComposeError::NullInitialIndexKey {
-                row: self.entries.len(),
-            });
-        };
         budget.charge_items(1)?;
         let page = u32::try_from(locator.page().get()).map_err(|_| Error::IntegerConversion {
             value: locator.page().get() as u128,
@@ -90,12 +104,27 @@ impl InitialLongIndex {
             }
             .into());
         }
-        let mut entry = [0_u8; ENTRY_BYTES];
-        entry[0] = 0x7f;
-        entry[1..KEY_BYTES].copy_from_slice(&value.to_be_bytes());
-        entry[1] ^= 0x80;
-        entry[KEY_BYTES..KEY_BYTES + 3].copy_from_slice(&page.to_be_bytes()[1..]);
-        entry[ENTRY_BYTES - 1] = locator.slot();
+        let mut entry = [0_u8; ENTRY_CAPACITY];
+        for (position, field) in self.fields[..self.field_count].iter().enumerate() {
+            let Some(RowValue::Long(value)) = values.get(field.column) else {
+                return Err(ComposeError::NullInitialIndexKey {
+                    row: self.entries.len(),
+                });
+            };
+            let component =
+                &mut entry[position * COMPONENT_BYTES..(position + 1) * COMPONENT_BYTES];
+            component[0] = 0x7f;
+            component[1..].copy_from_slice(&value.to_be_bytes());
+            component[1] ^= 0x80;
+            if field.direction == IndexDirection::Descending {
+                for byte in component {
+                    *byte ^= 0xff;
+                }
+            }
+        }
+        let key_bytes = self.key_bytes();
+        entry[key_bytes..key_bytes + 3].copy_from_slice(&page.to_be_bytes()[1..]);
+        entry[key_bytes + LOCATOR_BYTES - 1] = locator.slot();
         self.entries.push(entry);
         Ok(())
     }
@@ -103,21 +132,34 @@ impl InitialLongIndex {
     pub(crate) fn sort(&mut self, budget: &mut ResourceBudget) -> Result<(), ComposeError> {
         // At most 200 entries; charge a conservative quadratic byte-comparison bound.
         let count = self.entries.len() as u64;
-        budget.charge_work_units(count * count * ENTRY_BYTES as u64)?;
+        budget.charge_work_units(count * count * ENTRY_CAPACITY as u64)?;
         self.entries.sort_unstable();
         self.distinct = u32::from(!self.entries.is_empty());
+        let key_bytes = self.key_bytes();
         for pair in self.entries.windows(2) {
-            if pair[0][..KEY_BYTES] == pair[1][..KEY_BYTES] {
+            if pair[0][..key_bytes] == pair[1][..key_bytes] {
                 if self.unique {
-                    let mut raw: [u8; 4] =
-                        pair[1][1..KEY_BYTES]
-                            .try_into()
-                            .map_err(|_| Error::Arithmetic {
-                                operation: "decode duplicate Long index key",
+                    let mut values = [0_i32; MAX_FIELDS];
+                    for (position, value) in values.iter_mut().enumerate().take(self.field_count) {
+                        let start = position * COMPONENT_BYTES + 1;
+                        let mut raw: [u8; 4] =
+                            pair[1][start..start + 4].try_into().map_err(|_| {
+                                Error::Arithmetic {
+                                    operation: "decode duplicate Long index component",
+                                }
                             })?;
-                    raw[0] ^= 0x80;
-                    return Err(ComposeError::DuplicateInitialIndexKey {
-                        value: i32::from_be_bytes(raw),
+                        if self.fields[position].direction == IndexDirection::Descending {
+                            for byte in &mut raw {
+                                *byte ^= 0xff;
+                            }
+                        }
+                        raw[0] ^= 0x80;
+                        *value = i32::from_be_bytes(raw);
+                    }
+                    return Err(if self.field_count == 1 {
+                        ComposeError::DuplicateInitialIndexKey { value: values[0] }
+                    } else {
+                        ComposeError::DuplicateInitialCompositeIndexKey { values }
                     });
                 }
             } else {
@@ -125,6 +167,10 @@ impl InitialLongIndex {
             }
         }
         Ok(())
+    }
+
+    const fn key_bytes(&self) -> usize {
+        self.field_count * COMPONENT_BYTES
     }
 
     pub(crate) const fn distinct_count(&self) -> u32 {
@@ -139,7 +185,8 @@ impl InitialLongIndex {
         let mut bytes = [0_u8; PAGE_BYTES];
         bytes[0] = 4;
         bytes[1] = 1;
-        let used = self.entries.len() * ENTRY_BYTES;
+        let entry_bytes = self.key_bytes() + LOCATOR_BYTES;
+        let used = self.entries.len() * entry_bytes;
         bytes[2..4].copy_from_slice(&((INDEX_ENTRY_AREA_LEN - used) as u16).to_le_bytes());
         let owner = u32::try_from(owner.get()).map_err(|_| Error::IntegerConversion {
             value: owner.get() as u128,
@@ -147,9 +194,9 @@ impl InitialLongIndex {
         })?;
         bytes[4..8].copy_from_slice(&owner.to_le_bytes());
         for (position, entry) in self.entries.iter().enumerate() {
-            let start = INDEX_ENTRY_AREA_OFFSET + position * ENTRY_BYTES;
-            bytes[start..start + ENTRY_BYTES].copy_from_slice(entry);
-            let end = (position + 1) * ENTRY_BYTES;
+            let start = INDEX_ENTRY_AREA_OFFSET + position * entry_bytes;
+            bytes[start..start + entry_bytes].copy_from_slice(&entry[..entry_bytes]);
+            let end = (position + 1) * entry_bytes;
             bytes[INDEX_BOUNDARY_BITMAP_OFFSET + end / 8] |= 1 << (end % 8);
         }
         let mut image = PageImage::new(PageKind::LeafIndex);
@@ -158,21 +205,22 @@ impl InitialLongIndex {
     }
 
     pub(crate) fn matches(&self, tree: &IndexTree) -> bool {
+        let key_bytes = self.key_bytes();
         self.entries.len() == tree.entries().len()
             && self
                 .entries
                 .iter()
                 .zip(tree.entries())
                 .all(|(expected, actual)| {
-                    actual.key().raw_bytes() == &expected[..KEY_BYTES]
+                    actual.key().raw_bytes() == &expected[..key_bytes]
                         && actual.row().page().get()
                             == u64::from(u32::from_be_bytes([
                                 0,
-                                expected[5],
-                                expected[6],
-                                expected[7],
+                                expected[key_bytes],
+                                expected[key_bytes + 1],
+                                expected[key_bytes + 2],
                             ]))
-                        && actual.row().slot() == expected[8]
+                        && actual.row().slot() == expected[key_bytes + 3]
                 })
     }
 }

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -169,10 +169,13 @@ pub fn create_database(
 /// capacity. Each row and the table definition must fit one page. Pages with
 /// a slot and room for an all-null row are marked available; this construction
 /// policy has not been established as DAO's allocation policy.
-/// At most one ascending index on one Long column is accepted, with at most
-/// 200 non-null keys in a single leaf. Primary and unique indexes reject
-/// duplicate keys; ordinary indexes retain duplicates. Null keys, descending
-/// indexes, and other key types are refused.
+/// At most one index on one or two Long columns is accepted, with each field
+/// ascending or descending. One leaf holds at most 200 single-column or 128
+/// two-column entries. Primary and unique indexes reject duplicate full keys;
+/// ordinary indexes retain duplicates. Null components and other key types
+/// are refused. `EXP-0126` records the component encoding on exact fresh DAO
+/// controls; composite/descending Rust-created candidates await their own
+/// DAO differential.
 /// AutoIncrement is refused. One unindexed Memo or LongBinary column accepts
 /// nonempty typed payloads or null; raw `RowValue::LongValue` headers are refused.
 /// The candidate policy stores up to 32 bytes inline, up to 2,036 on one LVAL

--- a/crates/jet3/src/create_composite_index_tests.rs
+++ b/crates/jet3/src/create_composite_index_tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+#[test]
+fn descending_signed_boundaries_encode_and_sort_with_original_locators() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = [IndexSpec {
+        fields: &[field(0, IndexDirection::Descending)],
+        ..one_index(IndexKind::Unique)[0]
+    }];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(i32::MIN)],
+        &[RowValue::Long(-1)],
+        &[RowValue::Long(0)],
+        &[RowValue::Long(i32::MAX)],
+    ];
+    create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+    let index = tree(&directory.target())?;
+    for (entry, (key, slot)) in index.entries().iter().zip([
+        ([0x80, 0, 0, 0, 0], 3),
+        ([0x80, 0x7f, 0xff, 0xff, 0xff], 2),
+        ([0x80, 0x80, 0, 0, 0], 1),
+        ([0x80, 0xff, 0xff, 0xff, 0xff], 0),
+    ]) {
+        assert_eq!(entry.key().raw_bytes(), key);
+        assert_eq!(
+            entry.row(),
+            crate::RowLocator::new(PageNumber::new(24), slot)
+        );
+    }
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[rows[0], rows[0]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::DuplicateInitialIndexKey { value: i32::MIN }
+        ))
+    ));
+    Ok(())
+}
+
+#[test]
+fn mixed_components_respect_declared_order_and_count_complete_duplicate_keys() -> TestResult {
+    for directions in [
+        [IndexDirection::Ascending, IndexDirection::Descending],
+        [IndexDirection::Descending, IndexDirection::Ascending],
+    ] {
+        let directory = TestDirectory::create()?;
+        let indexes = [IndexSpec {
+            fields: &[field(1, directions[0]), field(0, directions[1])],
+            ..one_index(IndexKind::Ordinary)[0]
+        }];
+        let table = TableSpec {
+            name: b"Items",
+            columns: &[ID, SEQUENCE],
+            indexes: &indexes,
+        };
+        let rows: &[&[RowValue<'_>]] = &[
+            &[RowValue::Long(i32::MIN), RowValue::Long(i32::MAX)],
+            &[RowValue::Long(i32::MAX), RowValue::Long(i32::MIN)],
+            &[RowValue::Long(0), RowValue::Long(-1)],
+            &[RowValue::Long(1), RowValue::Long(-1)],
+            &[RowValue::Long(0), RowValue::Long(-1)],
+        ];
+        create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+        let index = tree(&directory.target())?;
+        let (slots, first_key) = if directions[0] == IndexDirection::Ascending {
+            ([1, 3, 2, 4, 0], [0x7f, 0, 0, 0, 0, 0x80, 0, 0, 0, 0])
+        } else {
+            ([0, 2, 4, 3, 1], [0x80, 0, 0, 0, 0, 0x7f, 0, 0, 0, 0])
+        };
+        assert_eq!(index.entries()[0].key().raw_bytes(), first_key);
+        assert_eq!(
+            index
+                .entries()
+                .iter()
+                .map(|entry| entry.row().slot())
+                .collect::<Vec<_>>(),
+            slots
+        );
+        let bytes = fs::read(directory.target())?;
+        assert_eq!(
+            &bytes[20 * crate::PAGE_BYTES + 47..20 * crate::PAGE_BYTES + 51],
+            &4_u32.to_le_bytes()
+        );
+        for kind in [IndexKind::Primary, IndexKind::Unique] {
+            let indexes = [IndexSpec { kind, ..indexes[0] }];
+            let table = TableSpec {
+                indexes: &indexes,
+                ..table
+            };
+            assert!(matches!(
+                create_database_with_rows(directory.target(), &table, rows, &mut budget()),
+                Err(CreateDatabaseError::Compose(
+                    ComposeError::DuplicateInitialCompositeIndexKey { values: [-1, 0] }
+                ))
+            ));
+            assert_eq!(fs::read(directory.target())?, bytes);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn composite_capacity_and_multiple_row_pages_preserve_locators_and_destination() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = [IndexSpec {
+        fields: &[
+            field(0, IndexDirection::Ascending),
+            field(1, IndexDirection::Descending),
+        ],
+        ..one_index(IndexKind::Unique)[0]
+    }];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[
+            ID,
+            SEQUENCE,
+            ColumnSpec::new(b"Payload", ColumnType::Text { max_len: nz(255) }),
+        ],
+        indexes: &indexes,
+    };
+    let payload = [b'x'; 255];
+    let values = (0..129)
+        .map(|value| {
+            [
+                RowValue::Long(value),
+                RowValue::Long(-value),
+                RowValue::Text(&payload),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_rows(directory.target(), &table, &rows[..128], &mut budget())?;
+    let index = tree(&directory.target())?;
+    assert_eq!(index.entries().len(), 128);
+    for (ordinal, entry) in index.entries().iter().enumerate() {
+        assert_eq!(
+            entry.row(),
+            crate::RowLocator::new(
+                PageNumber::new(24 + ordinal as u64 / 7),
+                (ordinal % 7) as u8
+            )
+        );
+    }
+    let original = fs::read(directory.target())?;
+    assert_eq!(
+        &original[23 * crate::PAGE_BYTES + 2..23 * crate::PAGE_BYTES + 4],
+        &8_u16.to_le_bytes()
+    );
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::IndexPageFull {
+            needed: 1806,
+            available: 1800
+        }))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    let mut changed = original;
+    changed[23 * crate::PAGE_BYTES + 248 + 9] ^= 1;
+    fs::write(directory.target(), changed)?;
+    assert!(
+        crate::create::check_initial_rows(&directory.target(), &table, &rows[..128], &mut budget())
+            .is_err()
+    );
+    Ok(())
+}
+
+#[test]
+fn null_second_component_and_three_fields_are_refused_without_publication() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = [IndexSpec {
+        fields: &[
+            field(0, IndexDirection::Ascending),
+            field(1, IndexDirection::Descending),
+        ],
+        ..one_index(IndexKind::Ordinary)[0]
+    }];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID, SEQUENCE],
+        indexes: &indexes,
+    };
+    assert!(matches!(
+        create_database_with_rows(
+            directory.target(),
+            &table,
+            &[&[RowValue::Long(0), RowValue::Null]],
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::NullInitialIndexKey { row: 0 }
+        ))
+    ));
+    let indexes = [IndexSpec {
+        fields: &[
+            field(0, IndexDirection::Ascending),
+            field(1, IndexDirection::Descending),
+            field(2, IndexDirection::Ascending),
+        ],
+        ..indexes[0]
+    }];
+    let table = TableSpec {
+        columns: &[ID, SEQUENCE, ColumnSpec::new(b"Third", ColumnType::Long)],
+        indexes: &indexes,
+        ..table
+    };
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &[], &mut budget()),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::UnsupportedInitialIndexSchema
+        ))
+    ));
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}

--- a/crates/jet3/src/create_initial_index_tests.rs
+++ b/crates/jet3/src/create_initial_index_tests.rs
@@ -196,10 +196,6 @@ fn null_keys_and_unsupported_key_schemas_fail_before_publication() -> TestResult
             ..one_index(IndexKind::Ordinary)[0]
         },
     ];
-    let descending = [IndexSpec {
-        fields: &[field(0, IndexDirection::Descending)],
-        ..one_index(IndexKind::Ordinary)[0]
-    }];
     let composite = [IndexSpec {
         fields: &[
             field(0, IndexDirection::Ascending),
@@ -211,7 +207,7 @@ fn null_keys_and_unsupported_key_schemas_fail_before_publication() -> TestResult
         fields: &[IndexColumnSpec::ascending(b"Code")],
         ..one_index(IndexKind::Ordinary)[0]
     }];
-    for indexes in [&multiple[..], &descending, &composite, &text] {
+    for indexes in [&multiple[..], &composite, &text] {
         let table = TableSpec {
             name: b"Items",
             columns: &[ID, CODE],
@@ -291,3 +287,6 @@ fn index_storage_budget_and_empty_index_are_handled() -> TestResult {
     assert_eq!(fs::read(directory.target())?, original);
     Ok(())
 }
+
+#[path = "create_composite_index_tests.rs"]
+mod composite;

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10843,3 +10843,49 @@ Copy this block under the appropriate section and remove this instruction:
   arbitrary component counts, general branch/allocation policy, candidate
   acceptance, updates, compatibility, or hosted support claim. Retain all
   MDBs externally and record one validated additive outcome as `EXP-0126`.
+
+## EXP-0126 — Descending and two-component Long index key bindings
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: validated local development DAO observation under `EXP-0125`
+- Plan: `oracle/windows-dao/acquisition/long-key-layout.plan.json`, SHA-256
+  `a5b107359cc713ecb613826745fea1118084d9c6f0cc482a527cdc6f4a0a9f4a`.
+  Consumed acquisition, analyzer, decoder, transport, and plan inputs remain
+  unchanged. Acquisition ran once from the committed reviewed plan.
+- Artifacts: run `20260905T041200Z-long-key-layout`; external `result.json`
+  SHA-256 `74173d65d5d70cfdc78b717d9ae2dda748f36de790dace6065ee673934b20828`;
+  23,965-byte `report.json` SHA-256
+  `5b74ed896e9c4bf116dd9a52f4bcd39fc3fc6e6494464788dff61e68a9aeedf7`.
+  Analysis of temporary copies verified pinned inputs and every retained
+  identity and reproduced the report byte-identically. MDBs remain external.
+- Result: `answered`, no reasons, all nine captures complete and unchanged.
+  Three fresh replicas per arm agreed on every question-bearing value;
+  every key locator resolved once to a planned row and all rows were covered.
+  DAO snapshot and index traversal agreed with decoded rows and directed
+  semantic order. All nine `hypothesis_matches` values are true. This is
+  format observation, not acceptance of a Rust-created candidate.
+- Observed keys: each non-null ascending Long component is `7f` followed by
+  the four big-endian value bytes with the sign bit flipped. Descending
+  complements all five bytes, including the marker (`80`). Both tested
+  two-Long mixed-direction keys concatenate the components in declared field
+  order. For example, descending `2147483647` is `8000000000`;
+  ascending/descending `(-2147483648,2147483647)` is
+  `7f000000008000000000`; descending/ascending
+  `(2147483647,-2147483648)` is `80000000007f00000000`.
+  Every recorded signed boundary and repeated-leading-component binding in
+  the finite `EXP-0125` input matrix agrees with this construction.
+- Index/row observations: `Rows(A Long,B Long,Tag Long)` has root 20, leaf
+  root 23, data page 24, and index map page 21 row 2 in all captures. Leaf
+  common-prefix length is zero. The descending unique arm has ten rows and
+  ten physical distinct-key entries; the ascending/descending unique arm has
+  twelve of each. The descending/ascending ordinary arm has fourteen rows,
+  fourteen leaf entries, and physical distinct-key count twelve: `(0,0)` and
+  `(-1,0)` each have two entries with different Tag payloads/row locators.
+  Unique physical flags are 1, ordinary flags 0; recorded direction bytes
+  are 0 for descending and 1 for ascending. Locators are retained evidence,
+  not a general allocation rule or duplicate tie-order guarantee.
+- Boundary: these exact non-null one/two-Long cases establish the recorded
+  component construction and full-key distinct counting. Nulls, other types,
+  more components, arbitrary branches, allocator policy, candidate
+  compatibility, updates, and hosted support remain outside this result.
+  Report compatibility and support-matrix flags remain false.


### PR DESCRIPTION
Initial-row creation accepts one index on one or two non-null Long columns, each ascending or descending. Duplicate checks use the full key, ordinary indexes retain duplicate rows, and the one-leaf limits are 200 single-column or 128 two-column entries.

EXP-0126 records the preregistered DAO observations establishing component encodings, direction transforms, and composite distinct-key counts before the writer uses them. Publication checks compare the complete encoded keys and row locators. Rust-created candidate validation remains a separate experiment.

Validation: independent implementation and outcome review found no issues; eleven index tests, five integrated long-value tests, scoped Clippy, exact report reproduction, and `just ready` passed. Tests cover signed endpoints, field order, second-component corruption, duplicates, capacity limits, and destination preservation.

Part of #100.
