### PR TITLE
test: preregister descending and composite index candidates

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10889,3 +10889,46 @@ Copy this block under the appropriate section and remove this instruction:
   more components, arbitrary branches, allocator policy, candidate
   compatibility, updates, and hosted support remain outside this result.
   Report compatibility and support-matrix flags remain false.
+
+
+## EXP-0127 — Preregistered descending/composite initial-index candidates
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: preregistered local development DAO candidate differential; no acquisition
+- Plan: `oracle/windows-dao/acquisition/composite-index.plan.json`, SHA-256
+  `3ee36358cb911f6fb008c591ebb0d061650854bb4d089bb87f1e11c12a9a8b92`.
+  Pins the new host/analyzer and PowerShell scripts, existing transport,
+  reviewed Long index encoder, deterministic example, and all three images.
+- Candidates: reviewed source `caf60a5`, `composite_index_candidate` example;
+  each image is 51,200 bytes. Descending unique SHA-256
+  `43ebc902fd654a238ff5abf52671eb79ac37b9083c102cf315d74c72a4dc71f3`;
+  ascending/descending unique
+  `b1fe69cd81f6895bdee726d44d848236bf11192d6807e77eb09e8c1c3f6ccf55`;
+  descending/ascending ordinary
+  `50fde5c49bd1c5ca84d033887b1db0423d60a4af5b31fe4bb2637a6488bfb12c`.
+  All use `Rows(A Long,B Long,Tag Long)`, `ByKey`, and the exact 10/12/14-row
+  inputs of `EXP-0125`. `EXP-0126` established the observed component bytes;
+  it did not establish candidate acceptance.
+- Question: do the exact candidates match fresh DAO controls at every
+  captured table/field/index flag and ordered binding, full row snapshot,
+  directed index traversal, and Seek for every distinct full key, without
+  modifying either image?
+- Protocol: verify all nine candidate copies before first mutation. Acquire
+  three fresh controls and read-only candidate observations per arm. Require
+  all nine pairs complete, every control to satisfy the declared semantics,
+  and all eighteen files unchanged before classifying an arm. Compare full
+  normalized observations across each arm's three replicas and between
+  candidate/control. Ordinary duplicate payload tie order is unspecified;
+  traversal must contain every complete row. Seek may return either duplicate
+  only after checking the returned complete row and every queried component.
+- Decision: agreeing complete candidate/control semantics are
+  `observed_accepted`; stable candidate rejection/difference after the full
+  control/identity gate is `not_observed_accepted`; incomplete acquisition,
+  failed control, changed bytes, or replica disagreement is `no_outcome`.
+  Analysis rechecks input and retained-image pins; invalid binding rejects
+  validation. Commit and review before one acquisition; no automatic retry
+  after first mutation.
+- Boundary: only these three one-leaf images. No null/other-type/additional-
+  component grammar, branch/allocation policy, general compatibility, updates,
+  or hosted support claim. Retain all MDBs externally and record one validated
+  additive outcome as `EXP-0128`.

--- a/oracle/windows-dao/acquisition/composite-index.plan.json
+++ b/oracle/windows-dao/acquisition/composite-index.plan.json
@@ -1,0 +1,207 @@
+{
+  "document_type": "dao_composite_index_plan",
+  "experiment_id": "composite-index",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0126 observes exact non-null descending Long and mixed-direction two-Long key bindings/counts. The composed candidates use these source encoders; no DAO acceptance is assumed.",
+    "hypothesis": "DAO reads all three exact pinned candidates unchanged with the same full captured table/field/index metadata, complete rows, directed index traversal, and full-key Seek results as fresh matching DAO controls.",
+    "authorization": "User authorized DAO acquisition/mutations on 2026-09-04. Commit and independently review the SHA256-pinned plan before one dispatch. Once the first CreateDatabase starts, failures are scientific results; another dispatch requires a new human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/composite_index.py": "6caaff10cd2e7191589eb4aede3b4a79d7ac21b87506c9f1948f0ad309e09225",
+    "oracle/windows-dao/scripts/composite_index.ps1": "12741b1fa0d2f0c8634edc04f8aaff41a58d3155334c9b89d45f1d646066fe85",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/composite_index_candidate.rs": "3dfc1958f2edb1bc35368cdce62945ed5340dd09341934aaa70ce7489f51882e",
+    "crates/jet3/src/bootstrap_initial_index.rs": "6ca68b1f418a381799541a3388f3bf17b6c86f2b86a7b7fd12fdad5cd83cd735"
+  },
+  "candidates": {
+    "descending-unique": {
+      "size": 51200,
+      "sha256": "43ebc902fd654a238ff5abf52671eb79ac37b9083c102cf315d74c72a4dc71f3"
+    },
+    "ascending-descending-unique": {
+      "size": 51200,
+      "sha256": "b1fe69cd81f6895bdee726d44d848236bf11192d6807e77eb09e8c1c3f6ccf55"
+    },
+    "descending-ascending-ordinary": {
+      "size": 51200,
+      "sha256": "50fde5c49bd1c5ca84d033887b1db0423d60a4af5b31fe4bb2637a6488bfb12c"
+    }
+  },
+  "schema": {
+    "version": "3.0",
+    "tables": [
+      "MSysACEs",
+      "MSysObjects",
+      "MSysQueries",
+      "MSysRelationships",
+      "Rows"
+    ],
+    "table_attributes": 0,
+    "fields": [
+      {
+        "name": "A",
+        "type": 4,
+        "size": 4,
+        "attributes": 1
+      },
+      {
+        "name": "B",
+        "type": 4,
+        "size": 4,
+        "attributes": 1
+      },
+      {
+        "name": "Tag",
+        "type": 4,
+        "size": 4,
+        "attributes": 1
+      }
+    ]
+  },
+  "execution": {
+    "environment": "Private Windows VM, x86 PowerShell, DAO.DBEngine.36; development-only.",
+    "pre_mutation": "Host verifies all input/candidate pins and committed plan. Guest verifies producer and all nine candidate copies before first control CreateDatabase.",
+    "per_replica": "In plan arm order and replicas1..3, create fresh Rows(A Long,B Long,Tag Long), append ByKey with declared field order/directions/uniqueness, insert listed rows, close. Read control and candidate separately read-only; capture version/table inventory/table attributes, all user-field names/types/sizes/attributes, all indexes and primary/unique/required/foreign/ignoreNulls flags plus ordered field attributes/directions, complete row snapshots and directed index traversal. Seek every distinct full key in listed query order; close and rehash.",
+    "attempts": 1,
+    "command": "python3 oracle/windows-dao/scripts/composite_index.py run CANDIDATE_DIRECTORY --shared-root VM_SHARED_ROOT --run-id UTC-composite-index",
+    "analysis": "python3 oracle/windows-dao/scripts/composite_index.py analyze OUTBOX; verify input pins again before report publication."
+  },
+  "decision_rule": {
+    "observed_accepted": "Complete nine-pair job, all controls match exact declared semantics, all18 images unchanged, and each arm has three identical complete normalized candidate/control pairs with every candidate passing.",
+    "not_observed_accepted": "Same complete-job/control/unchanged gate, but one arm candidates identically fail at an endpoint or return a stable semantic mismatch.",
+    "no_outcome": "Incomplete job, any control failure or changed image, or disagreement between normalized replicas for an arm.",
+    "semantic_normalization": "Snapshot rows are a multiset. Traversal must contain every complete A/B/Tag row exactly once and follow declared key directions; only equal full-key payload tie order is unspecified. Normalize traversal in directed full-key order with row values as tie-breaker. Seek query inventory must exactly match all distinct full keys; every returned full row must belong to the expected rows and match every queried index component. Only after these checks normalize Seek to query inventory, allowing ordinary duplicates to return either valid Tag. Compare all captured metadata without dropping flags/field bindings.",
+    "validation_rejection": "Reject for input-pin drift during preflight or analysis, malformed binding/inventory, candidate starting-pin mismatch or retained-image mismatch."
+  },
+  "evidence_boundary": "Exact three51200-byte one-leaf candidates only. No null/other-type/more-component rule, arbitrary B-tree allocation, general compatibility, integrity mutation, update or hosted support claim.",
+  "retention": "Retain result/report/logs and all18 candidate/control MDBs externally. Never commit MDB or provider bytes. Record one additive EXP-0128 outcome from the validated report.",
+  "candidate_generation": {
+    "source_commit": "caf60a5ab94c6dac02ca88d1ed2058e512aadfab",
+    "example": "crates/jet3/examples/composite_index_candidate.rs",
+    "command": "cargo run --locked -p jet3 --example composite_index_candidate -- DIRECTORY/ARM.mdb ARM",
+    "notes": "Exact image hashes bind inputs. No source-attestation or equivalence to other builds is claimed."
+  },
+  "arms": {
+    "descending-unique": {
+      "unique": true,
+      "fields": [
+        {
+          "name": "A",
+          "descending": true
+        }
+      ],
+      "rows": [
+        [2147483647, 0, 0],
+        [-2147483648, 0, 1],
+        [0, 0, 2],
+        [-1, 0, 3],
+        [1, 0, 4],
+        [-256, 0, 5],
+        [255, 0, 6],
+        [256, 0, 7],
+        [-65536, 0, 8],
+        [65536, 0, 9]
+      ],
+      "queries": [
+        [-2147483648],
+        [-65536],
+        [-256],
+        [-1],
+        [0],
+        [1],
+        [255],
+        [256],
+        [65536],
+        [2147483647]
+      ]
+    },
+    "ascending-descending-unique": {
+      "unique": true,
+      "fields": [
+        {
+          "name": "A",
+          "descending": false
+        },
+        {
+          "name": "B",
+          "descending": true
+        }
+      ],
+      "rows": [
+        [0, 0, 0],
+        [-2147483648, 2147483647, 1],
+        [2147483647, -2147483648, 2],
+        [-1, -1, 3],
+        [-1, 0, 4],
+        [-1, 1, 5],
+        [0, -2147483648, 6],
+        [0, 2147483647, 7],
+        [1, -256, 8],
+        [1, 255, 9],
+        [256, -65536, 10],
+        [-256, 65536, 11]
+      ],
+      "queries": [
+        [-2147483648, 2147483647],
+        [-256, 65536],
+        [-1, -1],
+        [-1, 0],
+        [-1, 1],
+        [0, -2147483648],
+        [0, 0],
+        [0, 2147483647],
+        [1, -256],
+        [1, 255],
+        [256, -65536],
+        [2147483647, -2147483648]
+      ]
+    },
+    "descending-ascending-ordinary": {
+      "unique": false,
+      "fields": [
+        {
+          "name": "A",
+          "descending": true
+        },
+        {
+          "name": "B",
+          "descending": false
+        }
+      ],
+      "rows": [
+        [0, 0, 0],
+        [-2147483648, 2147483647, 1],
+        [2147483647, -2147483648, 2],
+        [-1, -1, 3],
+        [-1, 0, 4],
+        [-1, 1, 5],
+        [0, -2147483648, 6],
+        [0, 2147483647, 7],
+        [1, -256, 8],
+        [1, 255, 9],
+        [256, -65536, 10],
+        [-256, 65536, 11],
+        [0, 0, 12],
+        [-1, 0, 13]
+      ],
+      "queries": [
+        [-2147483648, 2147483647],
+        [-256, 65536],
+        [-1, -1],
+        [-1, 0],
+        [-1, 1],
+        [0, -2147483648],
+        [0, 0],
+        [0, 2147483647],
+        [1, -256],
+        [1, 255],
+        [256, -65536],
+        [2147483647, -2147483648]
+      ]
+    }
+  }
+}

--- a/oracle/windows-dao/scripts/composite_index.ps1
+++ b/oracle/windows-dao/scripts/composite_index.ps1
@@ -1,0 +1,159 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function New-Control([string]$Path, $Arm) {
+    $engine = $workspace = $db = $table = $field = $index = $key = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $table = $db.CreateTableDef('Rows')
+        foreach ($name in @('A', 'B', 'Tag')) {
+            $field = $table.CreateField($name, 4)
+            $table.Fields.Append($field)
+            Release $field; $field = $null
+        }
+        $index = $table.CreateIndex('ByKey')
+        $index.Primary = $false
+        $index.Unique = [bool]$Arm.unique
+        foreach ($definition in $Arm.fields) {
+            $key = $index.CreateField([string]$definition.name)
+            if ($definition.descending) { $key.Attributes = 1 }
+            $index.Fields.Append($key)
+            Release $key; $key = $null
+        }
+        $table.Indexes.Append($index)
+        $db.TableDefs.Append($table)
+        $rs = $db.OpenRecordset('Rows', 2)
+        foreach ($row in $Arm.rows) {
+            $rs.AddNew()
+            $rs.Fields.Item('A').Value = [int]$row[0]
+            $rs.Fields.Item('B').Value = [int]$row[1]
+            $rs.Fields.Item('Tag').Value = [int]$row[2]
+            $rs.Update()
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $key; Release $index; Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset) {
+    return ,@([int]$Recordset.Fields.Item('A').Value, [int]$Recordset.Fields.Item('B').Value, [int]$Recordset.Fields.Item('Tag').Value)
+}
+function Observe([string]$Path, $Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item('Rows')
+        $snapshot.table_attributes = [int]$table.Attributes
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes; descending=(([int]$_.Attributes -band 1) -ne 0)} })}
+        })
+        $endpoint = 'rows'
+        $rs = $db.OpenRecordset('Rows', 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$rows.Add((Read-Row $rs))
+            $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+        $rs.Close(); Release $rs; $rs = $null
+        $endpoint = 'index_traversal'
+        $rs = $db.OpenRecordset('Rows', 1)
+        $rs.Index = 'ByKey'
+        $rs.MoveFirst()
+        $traversal = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$traversal.Add((Read-Row $rs))
+            $rs.MoveNext()
+        }
+        $snapshot.traversal = @($traversal)
+        $endpoint = 'seek'
+        $seeks = New-Object Collections.ArrayList
+        foreach ($query in $Arm.queries) {
+            if ($Arm.fields.Count -eq 1) { $rs.Seek('=', [int]$query[0]) }
+            else { $rs.Seek('=', [int]$query[0], [int]$query[1]) }
+            $row = if ($rs.NoMatch) { $null } else { Read-Row $rs }
+            [void]$seeks.Add(@{query=@($query); row=$row})
+        }
+        $snapshot.seek = @($seeks)
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'composite-index.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/composite_index.ps1') { throw 'Script pin mismatch' }
+$arms = @('descending-unique', 'ascending-descending-unique', 'descending-ascending-ordinary')
+foreach ($name in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$name-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$name.mdb") -Destination $path
+        $identity = Identity $path
+        $expected = $plan.candidates.$name
+        if ($identity.size -ne $expected.size -or $identity.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_composite_index_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($name in $arms) {
+        $arm = $plan.arms.$name
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$name-control-r$replica.mdb"
+            New-Control $control $arm
+            $candidate = Join-Path $env:JET3_WORK "$name-candidate-r$replica.mdb"
+            $result.replicas += @{arm=$name; replica=$replica; control=(Observe $control $arm); candidate=(Observe $candidate $arm)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/composite_index.py
+++ b/oracle/windows-dao/scripts/composite_index.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Preregistered descending/composite candidate DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/composite-index.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/composite_index.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+ARMS = ('descending-unique', 'ascending-descending-unique', 'descending-ascending-ordinary')
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'composite-index' or plan['replicas'] != 3 or list(plan['candidates']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        if identity(candidate_directory / f'{arm}.mdb') != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def key_values(row, arm):
+    return tuple(row[['A', 'B', 'Tag'].index(field['name'])] for field in arm['fields'])
+
+
+def ordered_key(row, arm):
+    return tuple(value * (-1 if field['descending'] else 1)
+                 for value, field in zip(key_values(row, arm), arm['fields']))
+
+
+def semantics(plan, name, observation):
+    arm = plan['arms'][name]
+    snapshot = observation['snapshot']
+    expected = arm['rows']
+    shape = {key: value for key, value in snapshot.items() if key not in ('rows', 'traversal', 'seek')}
+    expected_shape = {**plan['schema'], 'indexes': [{'name': 'ByKey', 'primary': False,
+        'unique': arm['unique'], 'foreign': False, 'required': False, 'ignore_nulls': False,
+        'fields': [{**field, 'attributes': int(field['descending'])} for field in arm['fields']]}]}
+    traversal = snapshot.get('traversal', [])
+    rowset_ok = sorted(snapshot.get('rows', [])) == sorted(expected)
+    traversal_ok = (sorted(traversal) == sorted(expected)
+        and [ordered_key(row, arm) for row in traversal] == sorted(ordered_key(row, arm) for row in expected))
+    seeks = snapshot.get('seek', [])
+    seek_ok = ([item['query'] for item in seeks] == arm['queries']
+        and all(item['row'] in expected and list(key_values(item['row'], arm)) == item['query'] for item in seeks))
+    passed = (observation['status'] == 'pass' and observation['endpoint'] == 'complete'
+        and observation['error'] is None and shape == expected_shape and rowset_ok and traversal_ok and seek_ok)
+    normalized = dict(snapshot)
+    if rowset_ok:
+        normalized['rows'] = sorted(expected)
+    if traversal_ok:
+        normalized['traversal'] = sorted(traversal, key=lambda row: (ordered_key(row, arm), row))
+    if seek_ok:
+        # Each returned full row was checked; ordinary Seek can choose either duplicate.
+        normalized['seek'] = arm['queries']
+    return passed, {**{key: observation[key] for key in ('status', 'endpoint', 'error')}, 'snapshot': normalized}
+
+
+def build_report(result, outbox, plan):
+    if (result['document_type'] != 'dao_composite_index_result'
+            or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    expected_inventory = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual_inventory = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual_inventory != expected_inventory[:len(actual_inventory)]:
+        raise ValueError('Unexpected replica inventory')
+    grouped = {arm: [] for arm in ARMS}
+    unchanged = True
+    controls_ok = True
+    compared = []
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        for role in ('candidate', 'control'):
+            observation = item[role]
+            retained = outbox / f'{arm}-{role}-r{replica}.mdb'
+            if identity(retained) != observation['after']:
+                raise ValueError(f'Retained identity mismatch: {retained.name}')
+            if role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                raise ValueError('Candidate did not start with pinned identity')
+            unchanged &= observation['before'] == observation['after']
+        control = semantics(plan, arm, item['control'])
+        candidate = semantics(plan, arm, item['candidate'])
+        controls_ok &= control[0]
+        grouped[arm].append((control, candidate))
+        compared.append({'arm': arm, 'replica': replica, 'control': control[1], 'candidate': candidate[1]})
+    outcomes = {arm: 'no_outcome' for arm in ARMS}
+    if (result['mutation_started'] is True and result['error'] is None
+            and actual_inventory == expected_inventory and controls_ok and unchanged):
+        for arm, observations in grouped.items():
+            if all(item == observations[0] for item in observations):
+                outcomes[arm] = ('observed_accepted' if observations[0][1][0]
+                    and observations[0][0][1] == observations[0][1][1] else 'not_observed_accepted')
+    report = {'document_type': 'dao_composite_index_report', 'development_only': True,
+              'compatibility_claim': False, 'support_movement': False,
+              'plan_sha256': digest(PLAN), 'observations': compared,
+              'controls_ok': controls_ok, 'unchanged': unchanged,
+              'acquisition_error': result['error'], 'mutation_started': result['mutation_started'],
+              'outcomes': outcomes, 'replicas': len(result['replicas']), 'candidates': plan['candidates']}
+    return report
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report['outcomes']))
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'composite-index.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_composite_index.py
+++ b/oracle/windows-dao/tests/test_composite_index.py
@@ -1,0 +1,98 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+spec = importlib.util.spec_from_file_location('composite_index', SCRIPTS / 'composite_index.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class CompositeIndexTests(unittest.TestCase):
+    def fixture(self, outbox):
+        plan = json.loads(experiment.PLAN.read_text())
+        result = {'document_type': 'dao_composite_index_result', 'development_only': True,
+                  'plan_sha256': experiment.digest(experiment.PLAN), 'mutation_started': True,
+                  'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'replicas': [], 'error': None}
+        for name, arm in plan['arms'].items():
+            snapshot = {**copy.deepcopy(plan['schema']), 'indexes': [{'name': 'ByKey', 'primary': False,
+                'unique': arm['unique'], 'foreign': False, 'required': False, 'ignore_nulls': False,
+                'fields': [{**field, 'attributes': int(field['descending'])} for field in arm['fields']]}], 'rows': copy.deepcopy(arm['rows']),
+                'traversal': sorted(arm['rows'], key=lambda row: experiment.ordered_key(row, arm)),
+                'seek': [{'query': query, 'row': next(row for row in arm['rows']
+                    if list(experiment.key_values(row, arm)) == query)} for query in arm['queries']]}
+            image = name.encode()
+            identity = {'size': len(image), 'sha256': experiment.hashlib.sha256(image).hexdigest()}
+            plan['candidates'][name] = identity
+            observation = {'before': identity, 'after': identity, 'status': 'pass', 'endpoint': 'complete', 'error': None,
+                           'snapshot': snapshot}
+            for replica in range(1, 4):
+                for role in ('control', 'candidate'):
+                    (outbox / f'{name}-{role}-r{replica}.mdb').write_bytes(image)
+                result['replicas'].append({'arm': name, 'replica': replica,
+                    'candidate': copy.deepcopy(observation), 'control': copy.deepcopy(observation)})
+        return plan, result
+
+    def test_duplicate_seek_may_choose_either_full_row_but_traversal_requires_both(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            ordinary = experiment.ARMS[-1]
+            self.assertTrue(all(value == 'observed_accepted' for value in experiment.build_report(result, outbox, plan)['outcomes'].values()))
+            for replica in result['replicas'][-3:]:
+                for seek in replica['candidate']['snapshot']['seek']:
+                    if seek['query'] == [0, 0]:
+                        seek['row'] = [0, 0, 12]
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcomes'][ordinary], 'observed_accepted')
+            for replica in result['replicas'][-3:]:
+                replica['candidate']['snapshot']['traversal'].remove([0, 0, 12])
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcomes'][ordinary], 'not_observed_accepted')
+
+    def test_full_seek_binding_and_direction_flags_cannot_be_ignored(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            name = experiment.ARMS[1]
+            for replica in result['replicas'][3:6]:
+                replica['candidate']['snapshot']['seek'][0]['query'] = [-2147483648]
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcomes'][name], 'not_observed_accepted')
+            plan, result = self.fixture(outbox)
+            for replica in result['replicas'][:3]:
+                replica['candidate']['snapshot']['indexes'][0]['fields'][0]['descending'] = False
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcomes'][experiment.ARMS[0]], 'not_observed_accepted')
+            result['replicas'][0]['candidate']['snapshot']['indexes'][0]['required'] = True
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcomes'][experiment.ARMS[0]], 'no_outcome')
+
+    def test_control_failure_incomplete_run_and_changed_identity_cannot_accept(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            result['replicas'][0]['control']['status'] = 'fail'
+            self.assertTrue(all(value == 'no_outcome' for value in experiment.build_report(result, outbox, plan)['outcomes'].values()))
+            plan, result = self.fixture(outbox)
+            result['replicas'].pop()
+            result['error'] = 'DAO failed after mutation'
+            self.assertTrue(all(value == 'no_outcome' for value in experiment.build_report(result, outbox, plan)['outcomes'].values()))
+            plan, result = self.fixture(outbox)
+            result['replicas'][0]['control']['before'] = {'size': 0, 'sha256': 'changed'}
+            self.assertFalse(experiment.build_report(result, outbox, plan)['unchanged'])
+            result['replicas'][0]['candidate']['before'] = {'size': 0, 'sha256': 'wrong'}
+            with self.assertRaisesRegex(ValueError, 'pinned identity'):
+                experiment.build_report(result, outbox, plan)
+            plan, result = self.fixture(outbox)
+            (outbox / f'{experiment.ARMS[0]}-candidate-r1.mdb').write_bytes(b'changed')
+            with self.assertRaisesRegex(ValueError, 'Retained identity'):
+                experiment.build_report(result, outbox, plan)
+
+    def test_analysis_checks_input_pins(self):
+        with patch.object(experiment, 'verify_inputs', side_effect=ValueError('Input pin mismatch')):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                experiment.analyze(Path('unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EXP-0127 pins Rust-created descending and mixed-direction composite Long index candidates for DAO validation. Three matched controls per arm compare complete schema, index attributes, all rows, directed traversal, and Seek for every distinct full key; ordinary duplicate choices are allowed only after complete row/key checks.

The runner verifies every candidate copy before mutation and enforces input pins during dispatch and analysis. It permits one acquisition with no automatic retry after mutation; evidence remains local and bounded.

Validation: independent review found no issues; four focused tests, candidate/input preflight, Python compilation, Windows PowerShell parser check, and `just ready` passed.

The single authorized acquisition subsequently accepted all three arms in all nine matched comparisons, with exact traversal/Seek results and unchanged files. EXP-0128 will record the result separately.
