### PR TITLE
test: preregister multi-table initial-row DAO validation

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10990,3 +10990,44 @@ Copy this block under the appropriate section and remove this instruction:
   more components, arbitrary branches, allocator policy, candidate
   compatibility, updates, and hosted support remain outside this result.
   Report compatibility and support-matrix flags remain false.
+
+### EXP-0129 — Multi-table initial-row candidate preregistration
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: committed development-only DAO preregistration. Acquisition has not
+  started; this entry asserts no outcome or support movement.
+- Plan: `oracle/windows-dao/acquisition/multi-table-rows.plan.json`, SHA-256
+  `95f5711c27f45fdadef43fd242ae8b06afc75ebf7ad8c2f9fe665ee22eb459f9`. Input pins cover the
+  producer, analyzer, low-level SSH transport and deterministic Rust example.
+  Dispatch and analysis share input-pin verification; the plan must be committed.
+- Generator: `multi_table_row_candidate` at reviewed source
+  `4c4f2b34f3037b5b17c7027b629d4e396c9790ef`.
+- Candidate identities:
+  - mixed: 77824 bytes, SHA-256
+    `86a8e79ad23c0610d1c9c1cc70603efbd3186db1dfb6f42295fe857fc16ae17b`.
+  - empty-first: 57344 bytes, SHA-256
+    `fda4ae1e0775762daae9df21e78f36729c550f2c2fcbd700694399af3cf5abca`.
+- Hypothesis: the exact four-table mixed and two-table empty-first candidates
+  expose their complete declared schemas and initial rows unchanged. Mixed
+  combines 509 Numbers rows, three primary-indexed Keys rows, a 4096-character
+  Memo plus null in Notes, and an empty table. Empty-first precedes a chained
+  2048-byte OLE row with an empty table. The plan fixes every payload byte and
+  every field/index flag; Keys traversal and Seek validate the later table's
+  indexed row references. EXP-0087/0065 supply layout roles and EXP-0116/0120/
+  0124 provide individual-writer observations, not combination acceptance.
+- Acquisition: one job, three fresh matched DAO controls and three candidate
+  replicas per arm. Read all images read-only, compare every table's complete
+  schema and row multiset, Memo strings/OLE bytes, Keys traversal and Seek,
+  and unchanged before/after identities. Retain all twelve files externally.
+- Decision: accept an arm only after a complete six-pair job, all controls
+  pass, all images remain unchanged, and its three candidate observations
+  agree. Identical candidate failures yield `not_observed_accepted`; control
+  failure, changed images, incomplete jobs or replica disagreement yield
+  `no_outcome`. Binding/pin/retention errors reject validation. Failures after
+  the first mutation are scientific results, never automatic retries.
+- Preflight: seven classifier tests passed; VM `Parser.ParseFile` accepted
+  the PowerShell producer without executing it or DAO. Independent experiment
+  review precedes root's single authorized acquisition.
+- Boundary: exact candidates only; no general allocation, schema/index,
+  relationship, AutoIncrement, empty-payload, update, compatibility or hosted
+  support claim. Record the validated outcome once as EXP-0130.

--- a/oracle/windows-dao/acquisition/multi-table-rows.plan.json
+++ b/oracle/windows-dao/acquisition/multi-table-rows.plan.json
@@ -1,0 +1,56 @@
+{
+  "document_type": "dao_multi_table_rows_plan",
+  "experiment_id": "multi-table-rows",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0087 supplies later-create page roles; EXP-0065 supplies row append placement. EXP-0116, EXP-0120 and EXP-0124 accepted exact individual scalar/indexed/long-value candidates. Their combination across tables remains a candidate hypothesis.",
+    "hypothesis": "DAO reads both exact multi-table initial-row candidates unchanged, exposing every declared table, field and index flag and exact row/payload multisets. Keys traversal and Seek resolve the later indexed table correctly. Mixed has Numbers definition20/data23..25, Keys definition26/index28/data29, Notes definition30/LVAL32..34/data35 and Empty definition36/map37. Empty-first has Empty definition20/map21/property22 and Binary definition23/map24/LVAL25..26/data27. Later creates omit catalog-property pages as in the existing bounded composer. Page zero follows existing table-only composition without introducing an initial-row transition. These layouts are writer choices, not generalized DAO allocation policies.",
+    "authorization": "User authorized DAO experiments/mutations on 2026-09-04. Commit and independently review this pinned plan before one dispatch. A failure after the first CreateDatabase begins is a scientific result; another dispatch requires a new human decision."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/multi_table_rows.py": "fa1531a8d94ef5729e224b3ac46e50263a251248d45133f1c6359311c3b8c3b1",
+    "oracle/windows-dao/scripts/multi_table_rows.ps1": "7e7fa2681727e0754e7cc6704409c3f948c2f2421eb792744bf30deba3ee2ab7",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/multi_table_row_candidate.rs": "f4d3c3d891b75352670c37d6cf4b69c5ac128298731ee3e40d55b9c3b9706fbb"
+  },
+  "candidates": {
+    "mixed": {
+      "size": 77824,
+      "sha256": "86a8e79ad23c0610d1c9c1cc70603efbd3186db1dfb6f42295fe857fc16ae17b"
+    },
+    "empty-first": {
+      "size": 57344,
+      "sha256": "fda4ae1e0775762daae9df21e78f36729c550f2c2fcbd700694399af3cf5abca"
+    }
+  },
+  "scenarios": {
+    "mixed": "Create in order Numbers(Id Long), Keys(Id Long, primary ascending ById), Notes(Payload Memo), Empty(Id Long). Numbers rows are -254..254 in order. Keys rows are 3,-1,2. Notes has a 4096-character ASCII string A+(offset mod26), then null. Empty has no rows.",
+    "empty-first": "Create Empty(Id Long) without rows, then Binary(Payload OLE) with one 2048-byte payload byte=(offset mod256).",
+    "schema": "DAO version3.0; exactly four system tables plus requested user tables. Id fields type4 size4; Memo Payload type12 size0; OLE Payload type11 size0. Only Keys has an index: ById Primary/Unique/Required true, Foreign/IgnoreNulls false, one Id field with Attributes0 and descendingfalse. All other index inventories empty."
+  },
+  "execution": {
+    "environment": "Private Windows VM, x86 PowerShell, DAO.DBEngine.36; development-only.",
+    "pre_mutation": "Host verifies all input/candidate pins and committed plan; guest verifies producer and all six candidate replicas before first control creation.",
+    "per_replica": "For mixed then empty-first, replicas1..3: create and close one fresh same-schema DAO control, defining and populating each table in declared order. Read control and candidate read-only; capture full table inventory, every user-table field/index schema, every row and complete Memo string/OLE bytes. Keys also has complete ascending traversal and Seek queries -1,2,3. Close objects, compare before/after identities, retain every file.",
+    "attempts": 1,
+    "command": "python3 oracle/windows-dao/scripts/multi_table_rows.py run <directory containing mixed.mdb empty-first.mdb> --shared-root <VM shared directory> --run-id <UTC timestamp>-multi-table-rows",
+    "analysis": "python3 oracle/windows-dao/scripts/multi_table_rows.py analyze <shared directory>/outbox/<run id>"
+  },
+  "decision_rule": {
+    "observed_accepted": "Complete six-pair job; every matched control passes expected semantics, all twelve images unchanged, and three agreeing accepted candidate observations for the arm.",
+    "not_observed_accepted": "Same complete-job/control/unchanged gate but the arm candidates identically fail an endpoint or return the same semantic mismatch.",
+    "no_outcome": "Incomplete job, any changed image, any control failure or candidate replica disagreement for the arm.",
+    "semantic_normalization": "Only snapshot row order is ignored, independently within each table. Complete table and schema inventories, all payload characters/bytes, null versus empty, and exact ascending traversal/Seek inventories remain required. Seek results must match each query exactly.",
+    "validation_rejection": "Input-pin drift during dispatch or analysis, malformed result binding/inventory, candidate starting-pin mismatch or retained-file identity mismatch rejects validation."
+  },
+  "evidence_boundary": "Only these two exact candidates. No general allocator, table-count, row-count, schema, composite/descending index, relationship, AutoIncrement, empty-payload, update, compatibility or hosted support claim.",
+  "retention": "Retain result.json, canonical report.json, logs and all twelve candidate/control files locally. Never commit MDB bytes/provider binaries. Record one validated additive EXP-0130 outcome.",
+  "candidate_generation": {
+    "source_commit": "4c4f2b34f3037b5b17c7027b629d4e396c9790ef",
+    "example": "crates/jet3/examples/multi_table_row_candidate.rs",
+    "command": "cargo run --locked -p jet3 --example multi_table_row_candidate -- <directory>/<arm>.mdb <arm>"
+  }
+}

--- a/oracle/windows-dao/scripts/multi_table_rows.ps1
+++ b/oracle/windows-dao/scripts/multi_table_rows.ps1
@@ -1,0 +1,209 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function Table-Names([string]$Arm) {
+    if ($Arm -ceq 'mixed') { return @('Numbers', 'Keys', 'Notes', 'Empty') }
+    return @('Empty', 'Binary')
+}
+function Add-Table($Database, [string]$Name) {
+    $table = $field = $index = $key = $null
+    try {
+        $table = $Database.CreateTableDef($Name)
+        $type = if ($Name -ceq 'Notes') { 12 } elseif ($Name -ceq 'Binary') { 11 } else { 4 }
+        $fieldName = if ($type -eq 4) { 'Id' } else { 'Payload' }
+        $field = $table.CreateField($fieldName, $type)
+        $table.Fields.Append($field)
+        if ($Name -ceq 'Keys') {
+            $index = $table.CreateIndex('ById')
+            $index.Primary = $true
+            $index.Unique = $true
+            $key = $index.CreateField('Id')
+            $index.Fields.Append($key)
+            $table.Indexes.Append($index)
+        }
+        $Database.TableDefs.Append($table)
+    }
+    finally { Release $key; Release $index; Release $field; Release $table }
+}
+function Add-Rows($Database, [string]$Name) {
+    if ($Name -ceq 'Empty') { return }
+    $rs = $field = $null
+    try {
+        $rs = $Database.OpenRecordset($Name, 2)
+        if ($Name -ceq 'Numbers' -or $Name -ceq 'Keys') {
+            $values = if ($Name -ceq 'Numbers') { -254..254 } else { @(3, -1, 2) }
+            foreach ($value in $values) {
+                $rs.AddNew()
+                $rs.Fields.Item('Id').Value = [int]$value
+                $rs.Update()
+            }
+        }
+        else {
+            $field = $rs.Fields.Item('Payload')
+            $rs.AddNew()
+            if ($Name -ceq 'Notes') {
+                $text = -join (0..4095 | ForEach-Object { [char](65 + ($_ % 26)) })
+                $field.AppendChunk([string]$text)
+            }
+            else {
+                $bytes = [byte[]](0..2047 | ForEach-Object { [byte]($_ % 256) })
+                $field.AppendChunk([byte[]]$bytes)
+            }
+            $rs.Update()
+            if ($Name -ceq 'Notes') {
+                $rs.AddNew()
+                $field.Value = [DBNull]::Value
+                $rs.Update()
+            }
+        }
+    }
+    finally {
+        Release $field
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs
+    }
+}
+function New-Control([string]$Path, [string]$Arm) {
+    $engine = $workspace = $db = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($name in (Table-Names $Arm)) {
+            Add-Table $db $name
+            Add-Rows $db $name
+        }
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset, [string]$Name) {
+    if ($Name -ceq 'Notes' -or $Name -ceq 'Binary') {
+        $value = $Recordset.Fields.Item('Payload').Value
+        if ($null -eq $value -or [Convert]::IsDBNull($value)) { $value = $null }
+        elseif ($Name -ceq 'Notes') { $value = [string]$value }
+        else { $value = [BitConverter]::ToString([byte[]]$value).Replace('-', '').ToLowerInvariant() }
+        return @{payload=$value}
+    }
+    $value = $Recordset.Fields.Item('Id').Value
+    if ($null -eq $value -or [Convert]::IsDBNull($value)) { $value = $null } else { $value = [int]$value }
+    return @{id=$value}
+}
+function Read-Table($Database, [string]$Name) {
+    $table = $rs = $null
+    try {
+        $table = $Database.TableDefs.Item($Name)
+        $snapshot = [ordered]@{name=$Name}
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required;
+              foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0); attributes=[int]$_.Attributes} })}
+        })
+        $rs = $Database.OpenRecordset($Name, 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) { [void]$rows.Add((Read-Row $rs $Name)); $rs.MoveNext() }
+        $snapshot.rows = @($rows)
+        if ($Name -ceq 'Keys') {
+            $rs.Close(); Release $rs; $rs = $null
+            $rs = $Database.OpenRecordset($Name, 1)
+            $rs.Index = 'ById'
+            $rs.MoveFirst()
+            $traversal = New-Object Collections.ArrayList
+            while (-not $rs.EOF) { [void]$traversal.Add((Read-Row $rs $Name)); $rs.MoveNext() }
+            $snapshot.traversal = @($traversal)
+            $seeks = New-Object Collections.ArrayList
+            foreach ($value in @(-1, 2, 3)) {
+                $rs.Seek('=', [int]$value)
+                $row = if ($rs.NoMatch) { $null } else { Read-Row $rs $Name }
+                [void]$seeks.Add(@{query=$value; row=$row})
+            }
+            $snapshot.seek = @($seeks)
+        }
+        return $snapshot
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+    }
+}
+function Observe([string]$Path, [string]$Arm) {
+    $before = Identity $Path
+    $engine = $db = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $endpoint = 'user_tables'
+        $snapshot.user_tables = @(foreach ($name in (Table-Names $Arm)) { Read-Table $db $name })
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'multi-table-rows.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/multi_table_rows.ps1') { throw 'Script pin mismatch' }
+$arms = @('mixed', 'empty-first')
+foreach ($arm in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$arm.mdb") -Destination $path
+        $identity = Identity $path
+        $expected = $plan.candidates.$arm
+        if ($identity.size -ne $expected.size -or $identity.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_multi_table_rows_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($arm in $arms) {
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$arm-control-r$replica.mdb"
+            New-Control $control $arm
+            $candidate = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+            $result.replicas += @{arm=$arm; replica=$replica; control=(Observe $control $arm); candidate=(Observe $candidate $arm)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/multi_table_rows.py
+++ b/oracle/windows-dao/scripts/multi_table_rows.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Preregistered multi-table initial-row DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/multi-table-rows.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/multi_table_rows.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+ARMS = ('mixed', 'empty-first')
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['replicas'] != 3 or list(plan['candidates']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        if identity(candidate_directory / f'{arm}.mdb') != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def expected_snapshot(arm):
+    id_field = [{'name': 'Id', 'type': 4, 'size': 4}]
+    tables = [{'name': 'Empty', 'fields': id_field, 'indexes': [], 'rows': []}]
+    if arm == 'mixed':
+        keys = [{'id': key} for key in (-1, 2, 3)]
+        tables = [
+            {'name': 'Numbers', 'fields': id_field, 'indexes': [],
+             'rows': [{'id': number} for number in range(-254, 255)]},
+            {'name': 'Keys', 'fields': id_field,
+             'indexes': [{'name': 'ById', 'primary': True, 'unique': True, 'required': True,
+                          'foreign': False, 'ignore_nulls': False,
+                          'fields': [{'name': 'Id', 'descending': False, 'attributes': 0}]}],
+             'rows': keys, 'traversal': [dict(row) for row in keys],
+             'seek': [{'query': key, 'row': {'id': key}} for key in (-1, 2, 3)]},
+            {'name': 'Notes', 'fields': [{'name': 'Payload', 'type': 12, 'size': 0}],
+             'indexes': [], 'rows': [{'payload': ''.join(chr(65 + offset % 26) for offset in range(4096))},
+                                    {'payload': None}]},
+            *tables]
+    else:
+        tables.append({'name': 'Binary', 'fields': [{'name': 'Payload', 'type': 11, 'size': 0}],
+                       'indexes': [], 'rows': [{'payload': bytes(offset % 256 for offset in range(2048)).hex()}]})
+    return {'version': '3.0', 'tables': sorted(['MSysACEs', 'MSysObjects', 'MSysQueries',
+            'MSysRelationships'] + [table['name'] for table in tables]), 'user_tables': tables}
+
+
+def normalize(snapshot):
+    result = json.loads(json.dumps(snapshot))
+    for table in result.get('user_tables', []):
+        if 'rows' in table:
+            table['rows'] = sorted(table['rows'], key=canonical)
+    return result
+
+
+def semantics(plan, arm, observation):
+    snapshot = normalize(observation['snapshot'])
+    passed = (observation['status'] == 'pass' and observation['endpoint'] == 'complete'
+              and observation['error'] is None and snapshot == normalize(expected_snapshot(arm)))
+    return passed, {**{key: observation[key] for key in ('status', 'endpoint', 'error')},
+                    'snapshot': snapshot}
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    if (result['document_type'] != 'dao_multi_table_rows_result'
+            or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32):
+        raise ValueError('Result identity/environment mismatch')
+    expected_inventory = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual_inventory = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual_inventory != expected_inventory[:len(actual_inventory)]:
+        raise ValueError('Unexpected replica inventory')
+    grouped = {arm: [] for arm in ARMS}
+    unchanged = True
+    controls_ok = True
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        for role in ('candidate', 'control'):
+            observation = item[role]
+            retained = outbox / f'{arm}-{role}-r{replica}.mdb'
+            if identity(retained) != observation['after']:
+                raise ValueError(f'Retained identity mismatch: {retained.name}')
+            if role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                raise ValueError('Candidate did not start with pinned identity')
+            unchanged &= observation['before'] == observation['after']
+        controls_ok &= semantics(plan, arm, item['control'])[0]
+        grouped[arm].append(semantics(plan, arm, item['candidate']))
+    outcomes = {arm: 'no_outcome' for arm in ARMS}
+    if (result['mutation_started'] is True and result['error'] is None
+            and actual_inventory == expected_inventory and controls_ok and unchanged):
+        for arm, observations in grouped.items():
+            if all(item == observations[0] for item in observations):
+                outcomes[arm] = 'observed_accepted' if observations[0][0] else 'not_observed_accepted'
+    report = {'document_type': 'dao_multi_table_rows_report', 'development_only': True,
+              'compatibility_claim': False, 'support_movement': False,
+              'plan_sha256': digest(PLAN), 'result_sha256': digest(outbox / 'result.json'),
+              'outcomes': outcomes, 'replicas': len(result['replicas']), 'candidates': plan['candidates']}
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report))
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'multi-table-rows.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_multi_table_rows.py
+++ b/oracle/windows-dao/tests/test_multi_table_rows.py
@@ -1,0 +1,108 @@
+"""Classify complete multi-table schema, payloads and later index traversal."""
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('multi_table_rows', Path(__file__).parents[1] / 'scripts/multi_table_rows.py')
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MultiTableRowsReportTests(unittest.TestCase):
+    def classify(self, change=lambda result: None, tamper=None):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / 'producer.ps1'
+            source.write_text('pinned producer')
+            plan = {'inputs': {str(source): MODULE.digest(source)}, 'schema': {'version': '3.0'}, 'candidates': {}}
+            for arm in MODULE.ARMS:
+                path = root / f'{arm}.mdb'
+                path.write_bytes(arm.encode())
+                plan['candidates'][arm] = MODULE.identity(path)
+            plan_path = root / 'plan.json'
+            plan_path.write_text(json.dumps(plan))
+            result = {'document_type': 'dao_multi_table_rows_result', 'development_only': True,
+                      'plan_sha256': MODULE.digest(plan_path), 'environment': {'process_bits': 32},
+                      'mutation_started': True, 'error': None, 'replicas': []}
+            for arm in MODULE.ARMS:
+                snapshot = MODULE.expected_snapshot(arm)
+                for number in range(1, 4):
+                    replica = {'arm': arm, 'replica': number}
+                    for role in ('candidate', 'control'):
+                        path = root / f'{arm}-{role}-r{number}.mdb'
+                        path.write_bytes(arm.encode())
+                        replica[role] = {'before': MODULE.identity(path), 'after': MODULE.identity(path),
+                                         'status': 'pass', 'endpoint': 'complete', 'error': None,
+                                         'snapshot': copy.deepcopy(snapshot)}
+                    result['replicas'].append(replica)
+            change(result)
+            (root / 'result.json').write_text(json.dumps(result))
+            if tamper == 'input':
+                source.write_text('diagnostic edit')
+            elif tamper == 'retained':
+                (root / 'mixed-candidate-r1.mdb').write_bytes(b'changed')
+            with patch.object(MODULE, 'PLAN', plan_path), patch('builtins.print'):
+                MODULE.analyze(root)
+            return json.loads((root / 'report.json').read_text())['outcomes']
+
+    def test_all_tables_allow_only_snapshot_row_order_differences(self):
+        def change(result):
+            for table in result['replicas'][0]['candidate']['snapshot']['user_tables']:
+                table['rows'].reverse()
+        self.assertTrue(all(value == 'observed_accepted' for value in self.classify(change).values()))
+
+    def test_later_table_payload_and_null_mismatches_are_negative(self):
+        def change(result):
+            for replica in result['replicas'][:3]:
+                replica['candidate']['snapshot']['user_tables'][2]['rows'][1]['payload'] = ''
+            for replica in result['replicas'][3:]:
+                replica['candidate']['snapshot']['user_tables'][1]['rows'][0]['payload'] = '00'
+        self.assertTrue(all(value == 'not_observed_accepted' for value in self.classify(change).values()))
+
+    def test_table_inventory_and_index_flags_are_checked(self):
+        for field in ('user_tables', 'tables'):
+            def change(result):
+                for replica in result['replicas'][:3]:
+                    replica['candidate']['snapshot'][field].pop()
+            self.assertEqual(self.classify(change)['mixed'], 'not_observed_accepted')
+        def flags(result):
+            for replica in result['replicas'][:3]:
+                replica['candidate']['snapshot']['user_tables'][1]['indexes'][0]['foreign'] = True
+        self.assertEqual(self.classify(flags)['mixed'], 'not_observed_accepted')
+
+    def test_later_index_traversal_and_seek_must_match_complete_rows(self):
+        for endpoint in ('traversal', 'seek'):
+            def change(result):
+                for replica in result['replicas'][:3]:
+                    replica['candidate']['snapshot']['user_tables'][1][endpoint].reverse()
+            self.assertEqual(self.classify(change)['mixed'], 'not_observed_accepted')
+
+    def test_disagreement_control_failure_and_mutation_have_no_outcome(self):
+        def disagreement(result):
+            result['replicas'][0]['candidate']['snapshot']['user_tables'].pop()
+        self.assertEqual(self.classify(disagreement)['mixed'], 'no_outcome')
+        def control_failure(result):
+            result['replicas'][0]['control']['snapshot']['user_tables'] = []
+        def changed_image(result):
+            result['replicas'][0]['control']['before']['sha256'] = '0' * 64
+        for change in (control_failure, changed_image):
+            self.assertTrue(all(value == 'no_outcome' for value in self.classify(change).values()))
+
+    def test_incomplete_scientific_job_has_no_outcome(self):
+        def change(result):
+            result['replicas'].pop()
+            result['error'] = 'CreateDatabase failed'
+        self.assertTrue(all(value == 'no_outcome' for value in self.classify(change).values()))
+
+    def test_modified_inputs_and_retained_files_are_rejected(self):
+        for tamper in ('input', 'retained'):
+            with self.subTest(tamper=tamper), self.assertRaises(ValueError):
+                self.classify(tamper=tamper)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EXP-0129 pins two Rust-created databases to validate initial rows across multiple tables: a four-table mixed case with later indexes and Memo payloads, and an empty-first-table case with chained OLE data.

Three fresh controls per arm compare every table, field, index flag, row, and payload, plus the indexed table's traversal and Seek results. Candidate identities must remain unchanged, and dispatch and analysis verify committed inputs. Acquisition runs once without automatic retries after mutation.

Validation: independent review found no issues; seven classifier tests, committed candidate preflight, Windows PowerShell parser validation, and `just ready` passed.

The single authorized acquisition subsequently accepted both arms in all six matched comparisons, with complete data and unchanged file identities. EXP-0130 will record the result separately.
