### PR TITLE
test: preregister AutoIncrement persisted-state discovery

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10992,6 +10992,47 @@ Copy this block under the appropriate section and remove this instruction:
   Report compatibility and support-matrix flags remain false.
 
 
+## EXP-0131 — AutoIncrement persisted-state discovery preregistration
+
+- Status: preregistered; no acquisition or outcome recorded by this entry.
+- Plan: `oracle/windows-dao/acquisition/autoincrement-layout.plan.json`, SHA-256
+  `c27de50741883f787a2280d0e92fde43089288ff284d77c4408f22dcc9f577f5`.
+  The plan pins its PowerShell acquisition script, Python analyzer, original
+  system-catalog decoder and VM transport. Dispatch requires the committed
+  plan; dispatch and standalone analysis verify these input hashes.
+- Question: identify persisted changes accompanying generated Long IDs and
+  observe the next generated ID after closing, reopening and deleting the
+  last generated row. EXP-0059 establishes AutoIncrement column metadata;
+  neither that evidence nor EXP-0065/A9 establishes persisted counter semantics.
+- Design: three replicas of two fresh unindexed tables, each named `Rows`
+  with Long `Id` and `Tag`. The AutoIncrement arm omits `Id` on every insert;
+  the ordinary Long control explicitly assigns `Id=Tag`. Each database has
+  six closed checkpoints: empty, Tag 1, Tags 1 through 255, append Tag 256,
+  delete Tag 256, then append Tag 257. Every checkpoint reopens the working
+  database; all 36 closed copies are observed read-only and hashed before
+  and after observation.
+- Capture: complete DAO column metadata and signed row values, original
+  decoder row locators/counts/maps/data pages, and complete raw page-zero,
+  user-TDEF and catalog-TDEF/data pages. Successive captures retain exact
+  changed byte ranges with both physical page locations. Replica comparison
+  requires matching question-bearing metadata, rows and TDEF `[12,35)`;
+  allocator addresses and catalog timestamps remain observations rather
+  than requirements for equality.
+- Hypotheses, not format facts: TDEF `[16,20)` contains the last generated
+  signed little-endian Long, remains unchanged after deletion, and stays
+  zero in the ordinary control; generated IDs equal the finite Tag sequence.
+  A stable disagreement is an answered observation. The actual ID generated
+  for Tag 257 is recorded without requiring it to equal 257.
+- Decision: all declared captures, unchanged identities, schema/row
+  correlations, surviving IDs and replica comparisons must pass. An
+  incomplete acquisition or failed observation yields `no_outcome`; invalid
+  input/result identities reject validation. No retry after the first DAO
+  mutation. Retain MDBs and reports externally; record one validated outcome
+  in EXP-0132.
+- Scope: local discovery only. No explicit AutoIncrement ID assignment,
+  high seed, signed overflow, indexed generation, Rust candidate acceptance,
+  general compatibility or hosted support claim.
+
 ## EXP-0128 — Descending/composite initial-index candidates accepted locally
 
 - Recorded: 2026-09-05, OpenAI Codex

--- a/oracle/windows-dao/acquisition/autoincrement-layout.plan.json
+++ b/oracle/windows-dao/acquisition/autoincrement-layout.plan.json
@@ -1,0 +1,71 @@
+{
+  "document_type": "dao_autoincrement_layout_plan",
+  "experiment_id": "autoincrement-layout",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0059 establishes AutoIncrement Long column class7 and DAO attribute16. TDEF [16,20) remains uninterpreted; EXP-0065/A9 supplies row-count/allocation observations, not generated-number state. Existing original system_catalog decoding supplies roots/columns/maps/rows.",
+    "question": "Which persisted TDEF/header/catalog changes accompany generated numbers, and what number does DAO generate after closing/reopening and deleting the last generated row?",
+    "hypotheses": [
+      "TDEF bytes[16,20) encode the last assigned generated Id as signed little-endian Long, including after deletion; ordinary Long controls leave that slot zero.",
+      "Auto-generated Id matches Tag for the finite inputs1..256 and next Tag257; these are tested hypotheses, not assumptions. Record the actual generated ID even if the hypothesis fails."
+    ],
+    "authorization": "User authorized DAO experiments/mutations. Commit and independently review pinned plan before one acquisition. Failure after first CreateDatabase is a scientific result; never automatically retry or redispatch."
+  },
+  "arms": {
+    "auto": "Rows(Id Long with DAO dbAutoIncrField16, Tag Long), no indexes; never assign Id during insertion.",
+    "long": "Same unindexed schema with ordinary Long Id, explicitly assign Id=Tag for every inserted row."
+  },
+  "checkpoints": [
+    {
+      "name": "empty",
+      "mutation": "Create and close fresh table, no rows."
+    },
+    {
+      "name": "one",
+      "mutation": "Reopen; append Tag1; ordinary control sets Id1, Auto omits Id; close."
+    },
+    {
+      "name": "n255",
+      "mutation": "Reopen; append Tag2..255 in order with the same assignment rule; close."
+    },
+    {
+      "name": "n256",
+      "mutation": "Reopen; append Tag256; close."
+    },
+    {
+      "name": "deleted",
+      "mutation": "Reopen; delete the row found by Tag=256, without assuming its generated Id; close."
+    },
+    {
+      "name": "next",
+      "mutation": "Reopen; append Tag257, ordinary control sets Id257, Auto omits Id; close and record actual generated Id."
+    }
+  ],
+  "execution": {
+    "environment": "Local private Windows VM, x86 PowerShell, DAO.DBEngine.36, dbVersion30 creation options32, ;LANGID=0x0409;CP=1252;COUNTRY=0.",
+    "order": "Replica1..3, each auto then long, six checkpoints in listed order. Six fresh working databases,36 closed captures. No explicit Auto Id insertion, rollback, compact, indexed table, reseed or overflow probe.",
+    "capture": "After each closed mutation, copy working MDB to checkpoint path. Hash copy; open read-only for version/table inventory/table attributes, fields/type/size/raw attributes, index count and every signed Id/Tag row; close and rehash. Continue mutations only in working MDB, reopening for each checkpoint.",
+    "decode": "Verify result and retained identities; use pinned original system_catalog decoder for complete schema, active rows with page/slot, table row count, maps, data-page ownership and global free-page observations. Require snapshot/decoded agreement and exact Tag inventory; ordinary Id equals Tag and surviving Id/Tag pairs remain unchanged across checkpoints.",
+    "raw_bytes": "Retain complete page-zero/user-TDEF/catalog-TDEF/catalog-data page hex per capture and exact coalesced changed ranges for each successive available capture. Retain both physical page numbers in each range. Candidate counter interpretation is isolated to raw TDEF[16,20); TDEF[12,16) comes from the existing row-count decoder. No guessed meanings for other changed bytes, including catalog timestamps or allocation fields.",
+    "replica_comparison": "Compare complete DAO metadata and Id/Tag row multisets, physical column records represented by the decoder, row count and exact TDEF[12,35) state/header bytes for every same arm/checkpoint. Retain raw locator/map/page-zero/catalog bytes and changed ranges, but do not require allocator addresses or timestamp bytes equal across replicas. Paired ordinary controls and header observations isolate candidate state from generic row-count/allocation changes; record hypotheses separately.",
+    "attempts": 1,
+    "run": "python3 oracle/windows-dao/scripts/autoincrement_layout.py run --shared-root VM_SHARED_ROOT --run-id UTC-autoincrement-layout",
+    "analysis": "python3 oracle/windows-dao/scripts/autoincrement_layout.py analyze OUTBOX; rechecks pinned inputs."
+  },
+  "decision_rule": {
+    "answered": "All36 captures complete unchanged; declared schemas/Tag inventories/row correlations pass and question-bearing observations agree across3replicas. Counter/sequence hypothesis false is still an answered observation; actual next-after-delete Id is always recorded.",
+    "no_outcome": "Incomplete/failed acquisition, changed read-only image, decode/schema/row/surviving-ID inconsistency, or replica disagreement. Retain completed snapshots/ranges and errors; no automatic retry.",
+    "rejection": "Bad plan/result/environment identity, changed pinned input, unexpected checkpoint inventory/order, or retained image identity mismatch rejects validation."
+  },
+  "boundary": "Only finite positive-generation/reopen/deletion cases on fresh unindexed one-AutoIncrement tables. No high seed, explicit Auto ID assignment, negative generation, signed overflow, multiple Auto columns, indexed generation, Rust candidate acceptance, general compatibility, updates or hosted support claim.",
+  "retention": "Retain all working/captured MDBs, result/report and logs externally; no MDB/provider bytes committed. Add one validated EXP-0132 outcome.",
+  "inputs": {
+    "oracle/windows-dao/scripts/autoincrement_layout.py": "efdd6eccaa98900f9d79a14f4942aedf944ee62ad62f861e01405f605728da89",
+    "oracle/windows-dao/scripts/autoincrement_layout.ps1": "36ed4a921622c01f581638320f98264406db265034fac52cd90614bfda1626fb",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  }
+}

--- a/oracle/windows-dao/scripts/autoincrement_layout.ps1
+++ b/oracle/windows-dao/scripts/autoincrement_layout.ps1
@@ -1,0 +1,134 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function New-Control([string]$Path, [string]$Arm) {
+    $engine = $workspace = $db = $table = $field = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $table = $db.CreateTableDef('Rows')
+        foreach ($name in @('Id', 'Tag')) {
+            $field = $table.CreateField($name, 4)
+            if ($Arm -eq 'auto' -and $name -eq 'Id') { $field.Attributes = 16 }
+            $table.Fields.Append($field)
+            Release $field; $field = $null
+        }
+        $db.TableDefs.Append($table)
+    }
+    finally {
+        Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Mutate([string]$Path, [string]$Arm, [string]$Checkpoint) {
+    $engine = $db = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path)
+        $rs = $db.OpenRecordset('Rows', 2)
+        if ($Checkpoint -eq 'deleted') {
+            $rs.FindFirst('Tag = 256')
+            if ($rs.NoMatch) { throw 'Missing row Tag256 for planned deletion' }
+            $rs.Delete()
+        }
+        else {
+            $tags = switch ($Checkpoint) {
+                'one' { @(1) }
+                'n255' { @(2..255) }
+                'n256' { @(256) }
+                'next' { @(257) }
+                default { throw 'Unexpected mutation checkpoint' }
+            }
+            foreach ($tag in $tags) {
+                $rs.AddNew()
+                if ($Arm -eq 'long') { $rs.Fields.Item('Id').Value = [int]$tag }
+                $rs.Fields.Item('Tag').Value = [int]$tag
+                $rs.Update()
+            }
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+    }
+}
+function Observe([string]$Path) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $snapshot = [ordered]@{}
+    $status = 'pass'; $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item('Rows')
+        $snapshot.table_attributes = [int]$table.Attributes
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes} })
+        $snapshot.index_count = [int]$table.Indexes.Count
+        $rs = $db.OpenRecordset('Rows', 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$rows.Add(@([int]$rs.Fields.Item('Id').Value, [int]$rs.Fields.Item('Tag').Value))
+            $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+    }
+    catch { $status = 'fail'; $errorDetail = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'autoincrement-layout.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/autoincrement_layout.ps1') { throw 'Script pin mismatch' }
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_autoincrement_layout_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}
+    checkpoints=@(); error=$null
+}
+try {
+    foreach ($replica in 1..3) {
+        foreach ($arm in @('auto', 'long')) {
+            $working = Join-Path $env:JET3_WORK "$arm-r$replica-working.mdb"
+            New-Control $working $arm
+            foreach ($checkpoint in @('empty', 'one', 'n255', 'n256', 'deleted', 'next')) {
+                if ($checkpoint -ne 'empty') { Mutate $working $arm $checkpoint }
+                $name = "$arm-r$replica-$checkpoint.mdb"
+                $path = Join-Path $env:JET3_WORK $name
+                Copy-Item -LiteralPath $working -Destination $path
+                $observation = Observe $path
+                $observation.replica = $replica; $observation.arm = $arm
+                $observation.checkpoint = $checkpoint; $observation.file = $name
+                $result.checkpoints += $observation
+            }
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    [IO.File]::WriteAllText((Join-Path $env:JET3_OUTBOX 'result.json'), (($result | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*-*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/autoincrement_layout.py
+++ b/oracle/windows-dao/scripts/autoincrement_layout.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Pinned local AutoIncrement state observations; preflight, acquire once, and analyze."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/autoincrement-layout.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/autoincrement_layout.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'autoincrement-layout' or plan['replicas'] != 3:
+        raise ValueError('Unexpected experiment plan')
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+CHECKPOINTS = ('empty', 'one', 'n255', 'n256', 'deleted', 'next')
+ARMS = ('auto', 'long')
+
+
+def expected_tags(checkpoint):
+    if checkpoint == 'empty':
+        return []
+    if checkpoint == 'one':
+        return [1]
+    if checkpoint == 'n255' or checkpoint == 'deleted':
+        return list(range(1, 256))
+    if checkpoint == 'n256':
+        return list(range(1, 257))
+    return list(range(1, 256)) + [257]
+
+
+def observe(data):
+    analysis = catalog.analyze_checkpoint(data)
+    named = {table['name']: table for table in analysis['tables'].values()}
+    table = named['Rows']
+    definition = table['definition']
+    rows = catalog._table_rows(data, definition, table['data_pages'])
+    header = catalog._page(data, definition['root'], 'Rows definition')
+    pages = {'header': {'page': 0, 'hex': data[:catalog.PAGE_BYTES].hex()},
+             'user_definition': {'page': definition['root'], 'hex': header.hex()}}
+    objects = named['MSysObjects']
+    for label, numbers in [('catalog_definition', objects['definition']['pages']), ('catalog_data', objects['data_pages'])]:
+        for ordinal, page in enumerate(numbers):
+            pages[f'{label}:{ordinal}'] = {'page': page, 'hex': catalog._page(data, page, label).hex()}
+    return {'definition_root': definition['root'], 'row_count': definition['row_count'],
+            'columns': definition['columns'], 'rows': rows,
+            'state_header_hex': header[12:35].hex(),
+            'candidate_state_hex': header[16:20].hex(),
+            'candidate_state_i32': int.from_bytes(header[16:20], 'little', signed=True),
+            'maps': {kind: {'locator': locator, 'pages': sorted(catalog._locator_pages(data, locator, kind))}
+                     for kind, locator in definition['maps'].items()},
+            'data_pages': table['data_pages'], 'page_count': len(data) // catalog.PAGE_BYTES,
+            'global_free_pages': analysis['free_pages'], 'pages': pages}
+
+
+def changed_ranges(before, after):
+    result = []
+    for role in sorted(set(before['pages']) | set(after['pages'])):
+        old, new = before['pages'].get(role), after['pages'].get(role)
+        left, right = bytes.fromhex(old['hex']) if old else b'', bytes.fromhex(new['hex']) if new else b''
+        offsets = [offset for offset in range(max(len(left), len(right)))
+                   if left[offset:offset + 1] != right[offset:offset + 1]]
+        for start, end in catalog._coalesce(offsets):
+            result.append({'role': role, 'page_before': old['page'] if old else None,
+                'page_after': new['page'] if new else None, 'start': start, 'end': end,
+                'before_hex': left[start:end].hex(), 'after_hex': right[start:end].hex()})
+    return result
+
+
+def correlate(snapshot, decoded, arm, checkpoint):
+    fields = snapshot.get('fields', [])
+    if (snapshot.get('version') != '3.0' or snapshot.get('table_attributes') != 0
+            or snapshot.get('tables') != ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows']
+            or snapshot.get('index_count') != 0 or len(fields) != 2):
+        return False
+    for ordinal, name in enumerate(('Id', 'Tag')):
+        field = fields[ordinal]
+        if (field['name'] != name or field['type'] != 4 or field['size'] != 4
+                or bool(field['attributes'] & 16) != (arm == 'auto' and ordinal == 0)):
+            return False
+    rows = snapshot.get('rows', [])
+    if (sorted(rows) != sorted(row['values'] for row in decoded['rows'])
+            or sorted(row[1] for row in rows) != expected_tags(checkpoint)
+            or decoded['row_count'] != len(rows)):
+        return False
+    if any(type(value) is not int or not -(1 << 31) <= value < (1 << 31) for row in rows for value in row):
+        return False
+    return arm == 'auto' or all(row[0] == row[1] for row in rows)
+
+
+def comparable(entry):
+    decoded = entry['decoded']
+    snapshot = dict(entry['snapshot'], rows=sorted(entry['snapshot']['rows']))
+    return {'snapshot': snapshot, 'state_header_hex': decoded['state_header_hex'],
+            'columns': decoded['columns'], 'row_count': decoded['row_count']}
+
+
+def build_report(result, outbox, plan):
+    if (result['document_type'] != 'dao_autoincrement_layout_result'
+            or result['plan_sha256'] != digest(PLAN) or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    expected = [(replica, arm, checkpoint) for replica in range(1, 4) for arm in ARMS for checkpoint in CHECKPOINTS]
+    actual = [(entry['replica'], entry['arm'], entry['checkpoint']) for entry in result['checkpoints']]
+    if actual != expected[:len(actual)]:
+        raise ValueError('Unexpected checkpoint inventory')
+    observations, reasons, previous = [], [], {}
+    for entry in result['checkpoints']:
+        replica, arm, checkpoint = entry['replica'], entry['arm'], entry['checkpoint']
+        label = f'{arm}-r{replica}-{checkpoint}'
+        if entry['file'] != label + '.mdb' or identity(outbox / entry['file']) != entry['after']:
+            raise ValueError('Retained image identity mismatch')
+        if entry['before'] != entry['after']:
+            reasons.append(label + ': read-only bytes changed')
+        try:
+            if entry['status'] != 'pass' or entry['error'] is not None:
+                raise ValueError('DAO observation failed: ' + str(entry['error']))
+            decoded = observe((outbox / entry['file']).read_bytes())
+            if not correlate(entry['snapshot'], decoded, arm, checkpoint):
+                raise ValueError('DAO/decoded schema or row correlation failed')
+            prior = previous.get((replica, arm))
+            if prior:
+                old_ids = {row['values'][1]: row['values'][0] for row in prior[0]['rows']}
+                if any(row['values'][1] in old_ids and row['values'][0] != old_ids[row['values'][1]] for row in decoded['rows']):
+                    raise ValueError('Surviving row ID changed across checkpoints')
+            item = {'replica': replica, 'arm': arm, 'checkpoint': checkpoint,
+                    'snapshot': entry['snapshot'], 'decoded': decoded,
+                    'previous_checkpoint': prior[1] if prior else None,
+                    'changed_ranges': changed_ranges(prior[0], decoded) if prior else []}
+            previous[(replica, arm)] = (decoded, checkpoint)
+            observations.append(item)
+        except (catalog.DecodeError, KeyError, ValueError) as error:
+            reasons.append(label + ': ' + str(error))
+    if len(observations) != len(expected) or result['error'] is not None or result['mutation_started'] is not True:
+        reasons.append('Acquisition incomplete or failed: ' + str(result['error']))
+    for arm in ARMS:
+        for checkpoint in CHECKPOINTS:
+            group = [comparable(item) for item in observations if item['arm'] == arm and item['checkpoint'] == checkpoint]
+            if group and any(item != group[0] for item in group):
+                reasons.append(f'{arm}/{checkpoint}: question-bearing values differ across replicas')
+    hypotheses = []
+    if len(observations) == len(expected):
+        for replica in range(1, 4):
+            auto = {item['checkpoint']: item['decoded'] for item in observations if item['replica'] == replica and item['arm'] == 'auto'}
+            long = {item['checkpoint']: item['decoded'] for item in observations if item['replica'] == replica and item['arm'] == 'long'}
+            latest = {checkpoint: max((row['values'] for row in auto[checkpoint]['rows']), key=lambda row: row[1], default=[0, 0])[0] for checkpoint in CHECKPOINTS}
+            latest['deleted'] = latest['n256']
+            hypotheses.append({'replica': replica,
+                'state_matches_last_generated': all(auto[c]['candidate_state_i32'] == latest[c] for c in CHECKPOINTS),
+                'ordinary_state_stays_zero': all(long[c]['candidate_state_i32'] == 0 for c in CHECKPOINTS),
+                'generated_ids_match_tags': all(row['values'][0] == row['values'][1] for c in CHECKPOINTS for row in auto[c]['rows']),
+                'next_after_delete': next(row['values'][0] for row in auto['next']['rows'] if row['values'][1] == 257)})
+    return {'document_type': 'dao_autoincrement_layout_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'answered' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'hypotheses': hypotheses,
+            'compatibility_claim': False, 'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    output = outbox / 'report.json'
+    output.write_text(canonical(report) + '\n')
+    print(output)
+    print(report['outcome'])
+
+
+def dispatch(args):
+    preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    inbox, outbox = (args.shared_root.resolve() / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / PLAN.name)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight')
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        preflight()
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_autoincrement_layout.py
+++ b/oracle/windows-dao/tests/test_autoincrement_layout.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location('autoincrement_layout', SCRIPTS / 'autoincrement_layout.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class AutoIncrementLayoutTests(unittest.TestCase):
+    def fixture(self, outbox):
+        result = {'document_type': 'dao_autoincrement_layout_result', 'development_only': True,
+                  'plan_sha256': experiment.digest(experiment.PLAN), 'mutation_started': True,
+                  'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'checkpoints': [], 'error': None}
+        for replica in range(1, 4):
+            for arm in experiment.ARMS:
+                for checkpoint in experiment.CHECKPOINTS:
+                    tags = experiment.expected_tags(checkpoint)
+                    # A stable next ID of300 must remain a valid observation, not be forced to257.
+                    rows = [[300 if arm == 'auto' and tag == 257 else tag, tag] for tag in tags]
+                    state = (256 if checkpoint == 'deleted' else rows[-1][0] if rows else 0) if arm == 'auto' else 0
+                    header = len(rows).to_bytes(4, 'little') + state.to_bytes(4, 'little')
+                    decoded = {'rows': [{'page': 20 + replica, 'row': n, 'values': row} for n, row in enumerate(rows)],
+                               'row_count': len(rows), 'columns': [], 'candidate_state_i32': state,
+                               'state_header_hex': header.hex(), 'pages': {'user_definition': {'page': 20, 'hex': header.hex()}}}
+                    name = f'{arm}-r{replica}-{checkpoint}.mdb'
+                    (outbox / name).write_text(json.dumps(decoded))
+                    identity = experiment.identity(outbox / name)
+                    snapshot = {'version': '3.0', 'table_attributes': 0,
+                        'tables': ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows'],
+                        'index_count': 0, 'fields': [
+                            {'name': 'Id', 'type': 4, 'size': 4, 'attributes': 17 if arm == 'auto' else 1},
+                            {'name': 'Tag', 'type': 4, 'size': 4, 'attributes': 1}], 'rows': rows}
+                    result['checkpoints'].append({'replica': replica, 'arm': arm, 'checkpoint': checkpoint,
+                        'file': name, 'before': identity, 'after': identity, 'status': 'pass', 'error': None, 'snapshot': snapshot})
+        return result
+
+    def test_counter_refutation_and_unexpected_next_id_are_reported_as_observations(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=json.loads):
+            outbox = Path(temporary)
+            result = self.fixture(outbox)
+            report = experiment.build_report(result, outbox, {})
+            self.assertEqual(report['outcome'], 'answered')
+            self.assertTrue(all(item['next_after_delete'] == 300 for item in report['hypotheses']))
+            self.assertTrue(all(item['state_matches_last_generated'] for item in report['hypotheses']))
+            self.assertTrue(all(not item['generated_ids_match_tags'] for item in report['hypotheses']))
+            def alternate(data):
+                decoded = json.loads(data)
+                decoded['candidate_state_i32'] = -99
+                return decoded
+            with patch.object(experiment, 'observe', side_effect=alternate):
+                report = experiment.build_report(result, outbox, {})
+                self.assertEqual(report['outcome'], 'answered')
+                self.assertTrue(all(not item['state_matches_last_generated'] for item in report['hypotheses']))
+
+    def test_raw_ranges_retain_exact_bytes_and_locations(self):
+        before = {'pages': {'header': {'page': 0, 'hex': '000102'}}}
+        after = {'pages': {'header': {'page': 0, 'hex': '00ff02'}}}
+        self.assertEqual(experiment.changed_ranges(before, after), [{'role': 'header', 'page_before': 0,
+            'page_after': 0, 'start': 1, 'end': 2, 'before_hex': '01', 'after_hex': 'ff'}])
+
+    def test_incomplete_rows_identity_drift_and_modified_inputs_cannot_promote(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=json.loads):
+            outbox = Path(temporary)
+            result = self.fixture(outbox)
+            result['checkpoints'][3]['snapshot']['rows'][0][0] = 999
+            self.assertEqual(experiment.build_report(result, outbox, {})['outcome'], 'no_outcome')
+            result = self.fixture(outbox)
+            result['checkpoints'].pop()
+            result['error'] = 'DAO failed after mutation'
+            self.assertEqual(experiment.build_report(result, outbox, {})['outcome'], 'no_outcome')
+            result = self.fixture(outbox)
+            result['checkpoints'][0]['before'] = {'size': 0, 'sha256': 'changed'}
+            self.assertEqual(experiment.build_report(result, outbox, {})['outcome'], 'no_outcome')
+            (outbox / result['checkpoints'][0]['file']).write_text('changed')
+            with self.assertRaisesRegex(ValueError, 'identity mismatch'):
+                experiment.build_report(result, outbox, {})
+        with patch.object(experiment, 'verify_inputs', side_effect=ValueError('Input pin mismatch')):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                experiment.analyze(Path('unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EXP-0131 preregisters paired AutoIncrement and ordinary Long controls to identify persisted generation state. Three replicas capture empty, 1/255/256-row, delete-last, and next-insert checkpoints, reopening the database between mutations.

The report binds actual generated IDs to tags and records raw header, table-definition, and catalog changes. Stable disagreement with the counter hypothesis is retained as an observation. This is one finite acquisition with no automatic retry after mutation.

Validation: independent review found no issues; three focused tests, Python compilation, Windows PowerShell parser check, committed-input preflight, and `just ready` passed.
