### PR TITLE
feat(jet3): create populated tables with a relationship

### DIFF
--- a/crates/jet3/examples/relationship_row_candidate.rs
+++ b/crates/jet3/examples/relationship_row_candidate.rs
@@ -1,0 +1,86 @@
+//! Deterministic relationship candidate with repeated foreign keys across pages.
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexKind, IndexSpec, RelationshipColumn,
+    RelationshipSpec, ResourceBudget, ResourceLimits, RowValue, TableRef, TableRows, TableSpec,
+    create_database_with_relationship_rows,
+};
+use std::num::NonZeroU8;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args_os()
+        .nth(1)
+        .ok_or("usage: relationship_row_candidate OUTPUT.mdb")?;
+    let parent_columns = [
+        ColumnSpec::new(b"Code2", ColumnType::Long),
+        ColumnSpec::new(b"Key1", ColumnType::Long),
+    ];
+    let child_columns = [
+        ColumnSpec::new(
+            b"Label3",
+            ColumnType::Text {
+                max_len: NonZeroU8::new(255).ok_or("invalid width")?,
+            },
+        ),
+        ColumnSpec::new(b"Account4", ColumnType::Long),
+    ];
+    let indexes = [IndexSpec {
+        name: b"Primary9",
+        fields: &[IndexColumnSpec::ascending(b"Key1")],
+        kind: IndexKind::Primary,
+    }];
+    let parent = TableSpec {
+        name: b"Accounts7",
+        columns: &parent_columns,
+        indexes: &indexes,
+    };
+    let child = TableSpec {
+        name: b"Events9",
+        columns: &child_columns,
+        indexes: &[],
+    };
+    let relationship = RelationshipSpec {
+        name: b"Account7Events9",
+        parent: RelationshipColumn {
+            table: TableRef::Name(b"Accounts7"),
+            column: ColumnRef::Name(b"Key1"),
+        },
+        child: RelationshipColumn {
+            table: TableRef::Name(b"Events9"),
+            column: ColumnRef::Name(b"Account4"),
+        },
+    };
+    let payloads = (0..20)
+        .map(|position| [b'a' + position; 255])
+        .collect::<Vec<_>>();
+    let values = payloads
+        .iter()
+        .enumerate()
+        .map(|(position, text)| {
+            [
+                RowValue::Text(text),
+                RowValue::Long(1 + (position % 3) as i32),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let child_rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_relationship_rows(
+        path,
+        &[
+            TableRows {
+                table: parent,
+                rows: &[
+                    &[RowValue::Long(9), RowValue::Long(1)],
+                    &[RowValue::Long(8), RowValue::Long(2)],
+                    &[RowValue::Long(7), RowValue::Long(3)],
+                ],
+            },
+            TableRows {
+                table: child,
+                rows: &child_rows,
+            },
+        ],
+        &relationship,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -5,6 +5,13 @@ use super::*;
 /// Structured failure while composing a database image.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
+    /// A non-null child key has no matching initial parent row.
+    OrphanInitialRelationshipKey {
+        /// Zero-based child input row.
+        row: usize,
+        /// Unmatched Long key.
+        value: i32,
+    },
     /// The relationship request exceeds the supported schema or references.
     UnsupportedRelationship {
         /// Unsupported relationship constraint.
@@ -111,6 +118,7 @@ impl std::error::Error for ComposeError {
             Self::UnsupportedRelationship { .. }
             | Self::UnsupportedInitialRowSchema
             | Self::InitialLongValue { .. }
+            | Self::OrphanInitialRelationshipKey { .. }
             | Self::UnsupportedInitialIndexSchema
             | Self::NullInitialIndexKey { .. }
             | Self::DuplicateInitialIndexKey { .. }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -766,5 +766,5 @@ mod tests;
 #[path = "bootstrap_relationship_candidate.rs"]
 mod relationship_candidate;
 
-pub(crate) use relationship_candidate::compose_relationship;
 pub use relationship_candidate::{RelationshipColumn, RelationshipSpec, TableRef};
+pub(crate) use relationship_candidate::{compose_relationship, compose_relationship_with_rows};

--- a/crates/jet3/src/bootstrap_relationship_candidate.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate.rs
@@ -100,11 +100,23 @@ pub(crate) fn compose_relationship(
     budget: &mut ResourceBudget,
 ) -> Result<WholeFileImagePlan, ComposeError> {
     let relation = RelationshipPlan::new(tables, relationship)?;
-    let mut plan = compose_database(tables, budget)?;
+    let plan = compose_database(tables, budget)?;
     let creates = [
         PlannedCreate::new(&tables[0], relation.parent.definition_root().get(), true)?,
         PlannedCreate::new(&tables[1], relation.child.definition_root().get(), false)?,
     ];
+    assemble_relationship(&relation, &creates, plan, None, budget)
+}
+
+fn assemble_relationship(
+    relation: &RelationshipPlan<'_>,
+    creates: &[PlannedCreate<'_>],
+    mut plan: WholeFileImagePlan,
+    child_index: Option<&InitialLongIndex>,
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, ComposeError> {
+    let tables = relation.tables;
+    let relationship = relation.spec;
     let seed = CatalogSeed {
         name: relationship.name,
         ..RELATION
@@ -138,11 +150,11 @@ pub(crate) fn compose_relationship(
         ),
         (
             OBJECTS_PARENT_NAME_ROOT,
-            objects_parent_name_index(&creates, Some(seed), budget)?,
+            objects_parent_name_index(creates, Some(seed), budget)?,
         ),
         (
             OBJECTS_ID_ROOT,
-            objects_id_index(&creates, Some(seed), budget)?,
+            objects_id_index(creates, Some(seed), budget)?,
         ),
         (
             SHARED_MAP_PAGE,
@@ -150,15 +162,15 @@ pub(crate) fn compose_relationship(
         ),
         (
             ACES_OBJECT_ID_ROOT,
-            aces_index(&creates, &RELATION_ACES, budget)?,
+            aces_index(creates, &RELATION_ACES, budget)?,
         ),
         (
             MSYS_OBJECTS_DATA_PAGE,
-            objects_data_page(&creates, Some(seed), budget)?,
+            objects_data_page(creates, Some(seed), budget)?,
         ),
         (
             MSYS_ACES_DATA_PAGE,
-            aces_data_page(&creates, &RELATION_ACES, budget)?,
+            aces_data_page(creates, &RELATION_ACES, budget)?,
         ),
         (
             RELATIONSHIPS_NAME_ROOT,
@@ -174,15 +186,27 @@ pub(crate) fn compose_relationship(
         ),
         (
             relation.parent.definition_root().get(),
-            user_definition(&relation, true, budget)?,
+            user_definition(
+                relation,
+                true,
+                creates[0].row_count(),
+                creates[0].index_distinct_count(),
+                budget,
+            )?,
         ),
         (
             relation.child.definition_root().get(),
-            user_definition(&relation, false, budget)?,
+            user_definition(
+                relation,
+                false,
+                creates[1].row_count(),
+                child_index.map_or(0, InitialLongIndex::distinct_count),
+                budget,
+            )?,
         ),
         (
             relation.child.map_page().get(),
-            child_map(relation.index_page(), budget)?,
+            creates[1].map_page(Some(PageNumber::new(relation.index_page())), budget)?,
         ),
     ];
     for (page, image) in replacements {
@@ -190,12 +214,15 @@ pub(crate) fn compose_relationship(
     }
     let mut global_free = global_map(relation.data_page(), budget)?;
     plan.append(
-        relationship_data(&relation, budget)?,
+        relationship_data(relation, budget)?,
         &mut global_free,
         budget,
     )?;
     plan.append(
-        empty_index_page(relation.child.definition_root().get(), budget)?,
+        match child_index {
+            Some(index) => index.image(relation.child.definition_root(), budget)?,
+            None => empty_index_page(relation.child.definition_root().get(), budget)?,
+        },
         &mut global_free,
         budget,
     )?;
@@ -205,6 +232,8 @@ pub(crate) fn compose_relationship(
 fn user_definition(
     relation: &RelationshipPlan<'_>,
     parent: bool,
+    row_count: u32,
+    entry_count: u32,
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, ComposeError> {
     let child_fields = [IndexFieldSpec {
@@ -217,7 +246,7 @@ fn user_definition(
         usage_map_row: 2,
         root: PageNumber::new(relation.index_page()),
         flags: PhysicalIndexFlagsSpec::Ordinary,
-        entry_count: 0,
+        entry_count,
     }];
     let mut parent_physical = [child_physical[0]; 2];
     for (slot, (((root, row), index), fields)) in parent_physical.iter_mut().zip(
@@ -233,7 +262,7 @@ fn user_definition(
             usage_map_row: row,
             root,
             flags: index.kind.flags(),
-            entry_count: 0,
+            entry_count,
         };
     }
     let relationship_index = LogicalIndexSpec {
@@ -299,17 +328,11 @@ fn user_definition(
             indexes: &logical[..logical_count],
             owned_map: MapRowLocator::new(map, 0),
             available_map: MapRowLocator::new(map, 1),
-            row_count: 0,
+            row_count,
             long_value_maps: &[],
         },
         budget,
     )
-}
-
-fn child_map(index_page: u64, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
-    let empty = inline_map_row(&[], budget)?;
-    let index = inline_map_row(&[index_page], budget)?;
-    data_page(HEADER_PAGE, &[&empty, &empty, &index], budget)
 }
 
 fn relationship_data(
@@ -364,3 +387,7 @@ mod tests;
 #[cfg(test)]
 #[path = "bootstrap_relationship_parameterized_tests.rs"]
 mod parameterized_tests;
+
+#[path = "bootstrap_relationship_rows.rs"]
+mod initial_rows;
+pub(crate) use initial_rows::compose_relationship_with_rows;

--- a/crates/jet3/src/bootstrap_relationship_plan.rs
+++ b/crates/jet3/src/bootstrap_relationship_plan.rs
@@ -24,7 +24,7 @@ pub struct RelationshipColumn<'a> {
     pub column: ColumnRef<'a>,
 }
 
-/// One non-cascading relationship between two empty tables.
+/// One non-cascading relationship between two tables.
 ///
 /// Names are database-encoded bytes, subject to the bounded creation name
 /// encoder. See [`crate::create_database_with_relationship`] for schema limits.
@@ -63,6 +63,7 @@ pub(super) struct RelationshipPlan<'a> {
     pub(super) child_column: u16,
     pub(super) hidden_name: &'static [u8],
     pub(super) selector: u32,
+    pub(super) end_of_tables: u64,
 }
 
 fn invalid(detail: &'static str) -> ComposeError {
@@ -89,6 +90,12 @@ impl<'a> RelationshipPlan<'a> {
         let parent = plan_table_schema(&tables[0], EMPTY_DATABASE_PAGE_COUNT, true)?;
         let child_root = parent.definition_root().get() + parent.appended_page_count();
         let child = plan_table_schema(&tables[1], child_root, false)?;
+        if tables[0].name.eq_ignore_ascii_case(tables[1].name) {
+            return Err(ComposeError::DuplicateTableName {
+                first: 0,
+                second: 1,
+            });
+        }
         if parent.continuation_page().is_some() || child.continuation_page().is_some() {
             return Err(invalid("definition continuations are unsupported"));
         }
@@ -162,6 +169,7 @@ impl<'a> RelationshipPlan<'a> {
                 "additional parent index must be ascending unique on one Long column",
             ));
         }
+        let end_of_tables = child.definition_root().get() + child.appended_page_count();
         Ok(Self {
             tables,
             spec,
@@ -171,11 +179,12 @@ impl<'a> RelationshipPlan<'a> {
             child_column,
             hidden_name,
             selector,
+            end_of_tables,
         })
     }
 
     pub(super) fn data_page(&self) -> u64 {
-        self.child.definition_root().get() + self.child.appended_page_count()
+        self.end_of_tables
     }
     pub(super) fn index_page(&self) -> u64 {
         self.data_page() + 1

--- a/crates/jet3/src/bootstrap_relationship_rows.rs
+++ b/crates/jet3/src/bootstrap_relationship_rows.rs
@@ -1,0 +1,67 @@
+//! Populated relationship candidate using EXP-0114 reciprocal metadata,
+//! EXP-0062 leaf locators and EXP-0120 ordinary duplicate-key observations.
+//! Initial rows retain the bounded writer's maps/counts. Foreign keys are
+//! non-null Long values; no nullable-key grammar or insertion counter is guessed.
+
+use super::*;
+use crate::table_schema_plan::plan_table_schema;
+use crate::{ColumnRef, TableRows};
+
+pub(crate) fn compose_relationship_with_rows(
+    requests: &[TableRows<'_>],
+    relationship: &RelationshipSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<WholeFileImagePlan, ComposeError> {
+    let [parent, child] = requests else {
+        return Err(ComposeError::UnsupportedRelationship {
+            detail: "exactly two tables required",
+        });
+    };
+    let tables = [parent.table, child.table];
+    let mut relation = RelationshipPlan::new(&tables, relationship)?;
+    if tables[0].indexes.len() != 1 {
+        return Err(ComposeError::UnsupportedRelationship {
+            detail: "initial relationship rows require one parent primary index",
+        });
+    }
+    let parent_create =
+        PlannedCreate::new(&tables[0], relation.parent.definition_root().get(), true)?
+            .with_rows(parent.rows, budget)?;
+    relation.child = plan_table_schema(&tables[1], parent_create.page_count(), false)?;
+    let child_create =
+        PlannedCreate::new(&tables[1], relation.child.definition_root().get(), false)?
+            .with_rows(child.rows, budget)?;
+    relation.end_of_tables = child_create.page_count();
+    let fields = [IndexColumnSpec {
+        column: ColumnRef::Ordinal(relation.child_column),
+        direction: IndexDirection::Ascending,
+    }];
+    let indexes = [IndexSpec {
+        name: relationship.name,
+        fields: &fields,
+        kind: IndexKind::Ordinary,
+    }];
+    let indexed_child = TableSpec {
+        indexes: &indexes,
+        ..tables[1]
+    };
+    let mut foreign = InitialLongIndex::new(&indexed_child, child.rows.len(), budget)?
+        .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
+    for (row, locator) in child.rows.iter().zip(child_create.initial_row_locators()) {
+        foreign.push(row, locator, budget)?;
+    }
+    foreign.sort(budget)?;
+    // Both one-leaf index plans have already bounded row counts to at most 200.
+    budget.charge_work_units((parent.rows.len() * child.rows.len() * size_of::<i32>()) as u64)?;
+    for (row, values) in child.rows.iter().enumerate() {
+        let Some(RowValue::Long(value)) = values.get(usize::from(relation.child_column)) else {
+            return Err(ComposeError::NullInitialIndexKey { row });
+        };
+        if !parent.rows.iter().any(|values| matches!(values.get(usize::from(relation.parent_column)), Some(RowValue::Long(parent)) if parent == value)) {
+            return Err(ComposeError::OrphanInitialRelationshipKey { row, value: *value });
+        }
+    }
+    let creates = [parent_create, child_create];
+    let plan = compose_planned_creates(&creates, budget)?;
+    assemble_relationship(&relation, &creates, plan, Some(&foreign), budget)
+}

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -61,6 +61,7 @@ pub(super) struct PlannedCreate<'a> {
 struct InitialDataPage {
     image: PageImage,
     available: bool,
+    rows: u16,
 }
 
 impl<'a> PlannedCreate<'a> {
@@ -207,9 +208,11 @@ impl<'a> PlannedCreate<'a> {
                     kind: std::io::ErrorKind::OutOfMemory,
                 })?;
         }
+        let rows = builder.row_count();
         self.initial_data.push(InitialDataPage {
             image: finish_data_builder(builder, budget)?,
             available,
+            rows,
         });
         Ok(())
     }
@@ -229,6 +232,29 @@ impl<'a> PlannedCreate<'a> {
                 .as_ref()
                 .map_or(0, InitialLongValues::page_count)
             + self.initial_data.len() as u64
+    }
+
+    pub(super) const fn row_count(&self) -> u32 {
+        self.initial_row_count
+    }
+
+    pub(super) fn index_distinct_count(&self) -> u32 {
+        self.initial_index
+            .as_ref()
+            .map_or(0, InitialLongIndex::distinct_count)
+    }
+
+    /// Logical row locations in the same order used while packing initial data.
+    pub(super) fn initial_row_locators(&self) -> impl Iterator<Item = crate::RowLocator> + '_ {
+        let first = self.page_count() - self.initial_data.len() as u64;
+        self.initial_data
+            .iter()
+            .enumerate()
+            .flat_map(move |(page, data)| {
+                (0..data.rows).map(move |slot| {
+                    crate::RowLocator::new(PageNumber::new(first + page as u64), slot as u8)
+                })
+            })
     }
 
     /// Returns the catalog row the create adds (`EXP-0087`).
@@ -263,7 +289,7 @@ impl<'a> PlannedCreate<'a> {
     ) -> Result<(), ComposeError> {
         let (root, continuation) = self.definition_pages(budget)?;
         plan.append(root, append_map, budget)?;
-        plan.append(self.map_page(budget)?, append_map, budget)?;
+        plan.append(self.map_page(None, budget)?, append_map, budget)?;
         if self.plan.property_page().is_some() {
             let lval = DataPageBuilder::new_long_value(budget)?;
             plan.append(finish_data_builder(lval, budget)?, append_map, budget)?;
@@ -394,7 +420,14 @@ impl<'a> PlannedCreate<'a> {
     }
 
     /// Builds the map page with the rows the definition names.
-    fn map_page(&self, budget: &mut ResourceBudget) -> Result<PageImage, ComposeError> {
+    pub(super) fn map_page(
+        &self,
+        foreign_index: Option<PageNumber>,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, ComposeError> {
+        if foreign_index.is_some() && (!self.spec.indexes.is_empty() || self.long_value.is_some()) {
+            return Err(ComposeError::UnobservedMapRowLayout);
+        }
         let empty = inline_map_row(&[], budget)?;
         let mut owned = InlineUsageMapEncoder::new(
             PageNumber::new(0),
@@ -426,6 +459,9 @@ impl<'a> PlannedCreate<'a> {
         let mut rows: Vec<[u8; 133]> = vec![owned_row, available_row];
         for (root, _) in self.plan.index_placements() {
             rows.push(inline_map_row(&[root.get()], budget)?);
+        }
+        if let Some(index) = foreign_index {
+            rows.push(inline_map_row(&[index.get()], budget)?);
         }
         if self.long_value.is_some() {
             let maps = match &self.initial_long_values {

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -566,4 +566,4 @@ mod tests;
 
 #[path = "create_relationship.rs"]
 mod relationship;
-pub use relationship::create_database_with_relationship;
+pub use relationship::{create_database_with_relationship, create_database_with_relationship_rows};

--- a/crates/jet3/src/create_relationship.rs
+++ b/crates/jet3/src/create_relationship.rs
@@ -1,8 +1,11 @@
 //! Atomic publication of the bounded EXP-0118/0122 relationship construction.
 
 use super::*;
-use crate::bootstrap_composer::compose_relationship;
-use crate::{CatalogObjectKind, RelationshipSide, RelationshipSpec};
+use crate::bootstrap_composer::{compose_relationship, compose_relationship_with_rows};
+use crate::{
+    CatalogObjectKind, IndexColumnSpec, IndexDirection, IndexSpec, RelationshipSide,
+    RelationshipSpec,
+};
 
 /// Creates two empty tables with one non-cascading Long-to-Long relationship.
 ///
@@ -46,6 +49,57 @@ pub fn create_database_with_relationship(
     .map_err(CreateDatabaseError::Publish)
 }
 
+/// Creates two tables with initial rows and one non-cascading Long relationship.
+///
+/// Requests must contain parent then child. The parent has exactly one
+/// ascending Long primary index on its relationship column; the child starts
+/// unindexed and receives an ordinary foreign index. Both relationship keys
+/// must be non-null Long values, every child key must occur in the parent,
+/// and each table is limited to 200 rows by its single index leaf. Repeated
+/// child keys are allowed. Other scalar columns may span data pages under
+/// the existing row bounds. AutoIncrement and long-value columns are refused.
+///
+/// Existing destinations are preserved, and complete written pages,
+/// reciprocal relationship metadata, rows and both index trees are checked
+/// before atomic publication. This bounded candidate construction does not
+/// establish general DAO compatibility or subsequent integrity enforcement.
+pub fn create_database_with_relationship_rows(
+    path: impl AsRef<Path>,
+    requests: &[TableRows<'_>],
+    relationship: &RelationshipSpec<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<(), CreateDatabaseError> {
+    let [parent, child] = requests else {
+        return Err(CreateDatabaseError::Compose(
+            ComposeError::UnsupportedRelationship {
+                detail: "exactly two tables required",
+            },
+        ));
+    };
+    let tables = [parent.table, child.table];
+    let pages = compose_relationship_with_rows(requests, relationship, budget)
+        .map_err(CreateDatabaseError::Compose)?
+        .into_pages();
+    budget
+        .charge_work_units((pages.len() as u64).saturating_mul(crate::PAGE_BYTES as u64))
+        .map_err(|error| CreateDatabaseError::Compose(error.into()))?;
+    atomic_create(
+        path,
+        |file| write_pages(file, &pages),
+        |candidate| {
+            check_relationship_contents(
+                candidate,
+                &tables,
+                relationship,
+                &pages,
+                Some(requests),
+                budget,
+            )
+        },
+    )
+    .map_err(CreateDatabaseError::Publish)
+}
+
 fn check_relationship_candidate(
     candidate: &Path,
     tables: &[TableSpec<'_>],
@@ -53,10 +107,24 @@ fn check_relationship_candidate(
     pages: &[PlannedPage],
     budget: &mut ResourceBudget,
 ) -> Result<(), CandidateCheckError> {
+    check_relationship_contents(candidate, tables, relationship, pages, None, budget)
+}
+
+fn check_relationship_contents(
+    candidate: &Path,
+    tables: &[TableSpec<'_>],
+    relationship: &RelationshipSpec<'_>,
+    pages: &[PlannedPage],
+    requests: Option<&[TableRows<'_>]>,
+    budget: &mut ResourceBudget,
+) -> Result<(), CandidateCheckError> {
     let mismatch = |detail| CandidateCheckError::Mismatch { detail };
     let mut database =
         DatabaseReader::open(candidate, budget).map_err(CandidateCheckError::Open)?;
-    if tables.len() != 2 || database.geometry().page_count() != pages.len() as u64 {
+    if tables.len() != 2
+        || requests.is_some_and(|rows| rows.len() != 2)
+        || database.geometry().page_count() != pages.len() as u64
+    {
         return Err(mismatch("relationship geometry"));
     }
     let mut bytes = [0_u8; crate::PAGE_BYTES];
@@ -129,26 +197,47 @@ fn check_relationship_candidate(
         {
             return Err(mismatch("relationship endpoint"));
         }
-        for ordinal in 0..definition.physical_indexes().len() {
-            let ordinal =
-                u16::try_from(ordinal).map_err(|_| mismatch("relationship index count"))?;
-            if !database
-                .index_tree(&definition, ordinal, budget)
-                .map_err(CandidateCheckError::Index)?
-                .entries()
-                .is_empty()
-            {
-                return Err(mismatch("relationship index not empty"));
+        if let Some(requests) = requests {
+            let fields = [IndexColumnSpec {
+                column: relationship.child.column,
+                direction: IndexDirection::Ascending,
+            }];
+            let indexes = [IndexSpec {
+                name: relationship.name,
+                fields: &fields,
+                kind: IndexKind::Ordinary,
+            }];
+            let child = TableRows {
+                table: TableSpec {
+                    indexes: &indexes,
+                    ..requests[1].table
+                },
+                rows: requests[1].rows,
+            };
+            let request = if position == 0 { &requests[0] } else { &child };
+            check_initial_table_rows(&mut database, request, root, position == 0, budget)?;
+        } else {
+            for ordinal in 0..definition.physical_indexes().len() {
+                let ordinal =
+                    u16::try_from(ordinal).map_err(|_| mismatch("relationship index count"))?;
+                if !database
+                    .index_tree(&definition, ordinal, budget)
+                    .map_err(CandidateCheckError::Index)?
+                    .entries()
+                    .is_empty()
+                {
+                    return Err(mismatch("relationship index not empty"));
+                }
             }
-        }
-        if database
-            .rows(&definition, budget)
-            .map_err(CandidateCheckError::Rows)?
-            .next_row()
-            .map_err(CandidateCheckError::Rows)?
-            .is_some()
-        {
-            return Err(mismatch("relationship rows not empty"));
+            if database
+                .rows(&definition, budget)
+                .map_err(CandidateCheckError::Rows)?
+                .next_row()
+                .map_err(CandidateCheckError::Rows)?
+                .is_some()
+            {
+                return Err(mismatch("relationship rows not empty"));
+            }
         }
     }
     Ok(())

--- a/crates/jet3/src/create_relationship_rows_tests.rs
+++ b/crates/jet3/src/create_relationship_rows_tests.rs
@@ -1,0 +1,303 @@
+use super::*;
+use crate::{RowLocator, create_database_with_relationship_rows};
+
+fn parent_rows() -> &'static [&'static [RowValue<'static>]] {
+    &[
+        &[RowValue::Long(9), RowValue::Long(1)],
+        &[RowValue::Long(8), RowValue::Long(2)],
+        &[RowValue::Long(7), RowValue::Long(3)],
+    ]
+}
+
+fn map_bit(
+    bytes: &[u8],
+    page: u64,
+    row: u8,
+    target: u64,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let start = page as usize * crate::PAGE_BYTES;
+    let raw = bytes[start..start + crate::PAGE_BYTES].try_into()?;
+    let classified = crate::classify_page(PageNumber::new(page), raw, &mut budget())?;
+    let record = crate::locate_usage_map(
+        classified,
+        crate::MapRowLocator::new(PageNumber::new(page), row),
+        &mut budget(),
+    )?;
+    Ok(record.raw()[5 + target as usize / 8] & (1 << (target % 8)) != 0)
+}
+
+#[test]
+fn duplicate_child_keys_keep_payload_locators_maps_and_distinct_counts() -> TestResult {
+    let directory = Directory::new()?;
+    let (mut tables, relation) = schema(false);
+    let child_columns = [
+        ColumnSpec::new(
+            b"Label3",
+            ColumnType::Text {
+                max_len: crate::column_definition_writer::nz(255),
+            },
+        ),
+        tables[1].columns[1],
+    ];
+    tables[1].columns = &child_columns;
+    let payloads = (0..20)
+        .map(|position| [b'a' + position; 255])
+        .collect::<Vec<_>>();
+    let values = payloads
+        .iter()
+        .enumerate()
+        .map(|(position, payload)| {
+            [
+                RowValue::Text(payload),
+                RowValue::Long(1 + (position % 3) as i32),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let child_rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    let requests = [
+        TableRows {
+            table: tables[0],
+            rows: parent_rows(),
+        },
+        TableRows {
+            table: tables[1],
+            rows: &child_rows,
+        },
+    ];
+    create_database_with_relationship_rows(
+        directory.target(),
+        &requests,
+        &relation,
+        &mut budget(),
+    )?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(bytes.len(), 32 * crate::PAGE_BYTES);
+    assert_eq!(
+        &bytes[25 * crate::PAGE_BYTES + 12..25 * crate::PAGE_BYTES + 16],
+        &20_u32.to_le_bytes()
+    );
+    assert_eq!(
+        &bytes[25 * crate::PAGE_BYTES + 47..25 * crate::PAGE_BYTES + 51],
+        &3_u32.to_le_bytes()
+    );
+    for page in 27..30 {
+        assert!(map_bit(&bytes, 26, 0, page)?);
+        assert!(map_bit(&bytes, 26, 1, page)?);
+    }
+    assert!(map_bit(&bytes, 26, 2, 31)?);
+    assert!(!map_bit(&bytes, 26, 0, 31)?);
+    let mut operation = budget();
+    let mut database = DatabaseReader::open(directory.target(), &mut operation)?;
+    let child = database.table_definition(PageNumber::new(25), &mut operation)?;
+    let foreign = database.index_tree(&child, 0, &mut operation)?;
+    let mut positions = (0..20).collect::<Vec<_>>();
+    positions.sort_unstable_by_key(|position| (position % 3, *position));
+    assert_eq!(
+        foreign
+            .entries()
+            .iter()
+            .map(|entry| entry.row())
+            .collect::<Vec<_>>(),
+        positions
+            .iter()
+            .map(|position| RowLocator::new(
+                PageNumber::new(27 + position / 7),
+                (position % 7) as u8
+            ))
+            .collect::<Vec<_>>()
+    );
+    drop(database);
+    let pages = compose_relationship_with_rows(&requests, &relation, &mut budget())?.into_pages();
+    for offset in [
+        25 * crate::PAGE_BYTES + 47,
+        26 * crate::PAGE_BYTES + 5,
+        27 * crate::PAGE_BYTES + 2047,
+        31 * crate::PAGE_BYTES + 252,
+    ] {
+        let mut changed = bytes.clone();
+        changed[offset] ^= 1;
+        fs::write(directory.target(), changed)?;
+        assert!(
+            check_relationship_contents(
+                &directory.target(),
+                &tables,
+                &relation,
+                &pages,
+                Some(&requests),
+                &mut budget()
+            )
+            .is_err()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn orphan_null_duplicate_and_unsupported_parent_shapes_are_refused() -> TestResult {
+    let directory = Directory::new()?;
+    let (tables, relation) = schema(false);
+    type Rows<'a> = &'a [&'a [RowValue<'a>]];
+    let cases: &[(Rows<'_>, Rows<'_>, &str)] = &[
+        (
+            parent_rows(),
+            &[&[RowValue::Text(b"a"), RowValue::Long(99)]],
+            "orphan",
+        ),
+        (
+            parent_rows(),
+            &[&[RowValue::Text(b"a"), RowValue::Null]],
+            "null",
+        ),
+        (
+            &[
+                &[RowValue::Long(9), RowValue::Long(1)],
+                &[RowValue::Long(8), RowValue::Long(1)],
+            ],
+            &[],
+            "duplicate",
+        ),
+        (&[&[RowValue::Long(9), RowValue::Null]], &[], "null"),
+        (&[], &[&[RowValue::Text(b"a"), RowValue::Long(1)]], "orphan"),
+    ];
+    for &(parent, child, expected) in cases {
+        let requests = [
+            TableRows {
+                table: tables[0],
+                rows: parent,
+            },
+            TableRows {
+                table: tables[1],
+                rows: child,
+            },
+        ];
+        let error = create_database_with_relationship_rows(
+            directory.target(),
+            &requests,
+            &relation,
+            &mut budget(),
+        )
+        .err()
+        .ok_or("unexpected success")?;
+        assert!(matches!(
+            (expected, error),
+            (
+                "orphan",
+                CreateDatabaseError::Compose(ComposeError::OrphanInitialRelationshipKey { .. })
+            ) | (
+                "null",
+                CreateDatabaseError::Compose(ComposeError::NullInitialIndexKey { .. })
+            ) | (
+                "duplicate",
+                CreateDatabaseError::Compose(ComposeError::DuplicateInitialIndexKey { .. })
+            )
+        ));
+    }
+    let (two, relation) = schema(true);
+    assert!(matches!(
+        create_database_with_relationship_rows(
+            directory.target(),
+            &[
+                TableRows {
+                    table: two[0],
+                    rows: &[]
+                },
+                TableRows {
+                    table: two[1],
+                    rows: &[]
+                }
+            ],
+            &relation,
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::UnsupportedRelationship { .. }
+        ))
+    ));
+    assert!(directory.empty()?);
+    Ok(())
+}
+
+#[test]
+fn foreign_leaf_capacity_and_publication_budget_preserve_destination() -> TestResult {
+    let directory = Directory::new()?;
+    let (tables, relation) = schema(false);
+    let value = [RowValue::Text(b"a"), RowValue::Long(1)];
+    let child_rows = vec![value.as_slice(); 201];
+    let requests = [
+        TableRows {
+            table: tables[0],
+            rows: parent_rows(),
+        },
+        TableRows {
+            table: tables[1],
+            rows: &child_rows[..200],
+        },
+    ];
+    let mut composition = budget();
+    let plan = compose_relationship_with_rows(&requests, &relation, &mut composition)?;
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(
+        composition.total_work_units() + plan.pages().len() as u64 * crate::PAGE_BYTES as u64,
+    ));
+    assert!(matches!(
+        create_database_with_relationship_rows(
+            directory.target(),
+            &requests,
+            &relation,
+            &mut limited
+        ),
+        Err(CreateDatabaseError::Publish(_))
+    ));
+    assert!(directory.empty()?);
+    create_database_with_relationship_rows(
+        directory.target(),
+        &requests,
+        &relation,
+        &mut budget(),
+    )?;
+    let original = fs::read(directory.target())?;
+    let overflow = [
+        requests[0],
+        TableRows {
+            rows: &child_rows,
+            ..requests[1]
+        },
+    ];
+    assert!(matches!(
+        create_database_with_relationship_rows(
+            directory.target(),
+            &overflow,
+            &relation,
+            &mut budget()
+        ),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::IndexPageFull { .. }
+        ))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    assert_eq!(fs::read_dir(&directory.0)?.count(), 1);
+    Ok(())
+}
+
+#[test]
+fn empty_and_unreferenced_parent_rows_are_valid_inputs() -> TestResult {
+    let (tables, relation) = schema(false);
+    for parent in [&[], parent_rows()] {
+        let directory = Directory::new()?;
+        create_database_with_relationship_rows(
+            directory.target(),
+            &[
+                TableRows {
+                    table: tables[0],
+                    rows: parent,
+                },
+                TableRows {
+                    table: tables[1],
+                    rows: &[],
+                },
+            ],
+            &relation,
+            &mut budget(),
+        )?;
+    }
+    Ok(())
+}

--- a/crates/jet3/src/create_relationship_tests.rs
+++ b/crates/jet3/src/create_relationship_tests.rs
@@ -199,3 +199,6 @@ fn corrupted_written_page_and_wrong_endpoint_fail_publication_check() -> TestRes
     ));
     Ok(())
 }
+
+#[path = "create_relationship_rows_tests.rs"]
+mod initial_rows;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -130,7 +130,8 @@ pub use commit_state::{
 };
 pub use create::{
     CandidateCheckError, CreateDatabaseError, TableRows, create_database,
-    create_database_with_relationship, create_database_with_rows, create_database_with_table_rows,
+    create_database_with_relationship, create_database_with_relationship_rows,
+    create_database_with_rows, create_database_with_table_rows,
 };
 pub use database::{DatabaseOpenError, DatabasePageError, DatabaseReader};
 pub use database_header::{


### PR DESCRIPTION
Callers can create two populated scalar tables linked by one non-cascading Long relationship. The writer preserves sequential table/data allocation, builds the child foreign index from actual row locators, and rejects null keys, duplicate parent keys, and orphan children before publication.

The new TableRows entry point accepts one parent primary index and at most 200 rows per table. The empty relationship API retains its existing bounds. Publication verifies every written page, reciprocal metadata, rows, and parent/foreign index entries.

Validation: independent review found no issues; eight relationship tests, 33 initial-row tests, all-target Clippy, and final `just ready` passed. Tests cover multi-page duplicate children, map/count preservation, corruption, resource bounds, and destination preservation. DAO candidate validation follows separately.

Part of #100.
