### PR TITLE
test: plan retained AutoIncrement secondary analysis

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10998,7 +10998,7 @@ Copy this block under the appropriate section and remove this instruction:
   not run. This is not a new preregistered acquisition. EXP-0132 remains an
   unchanged `no_outcome` from the original EXP-0131 experiment.
 - Plan: `oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json`,
-  SHA-256 `9b1e2247568356ba99725fa867c032b7632c9f8099d1daec18504a8f42624ed4`.
+  SHA-256 `13ab8dab2f129fa8a859545e896fa3376836cde938c14e673a842d1d87b5c96f`.
   It pins the original result/report and all 36 retained MDB captures from
   `20260905T044800Z-autoincrement-layout`, plus the new harness and unchanged
   original analyzer, decoder and acquisition plan.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10992,6 +10992,32 @@ Copy this block under the appropriate section and remove this instruction:
   Report compatibility and support-matrix flags remain false.
 
 
+## EXP-0135 — Retained AutoIncrement captures secondary-analysis plan
+
+- Status: post-acquisition secondary analysis planned; expanded analysis has
+  not run. This is not a new preregistered acquisition. EXP-0132 remains an
+  unchanged `no_outcome` from the original EXP-0131 experiment.
+- Plan: `oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json`,
+  SHA-256 `9b1e2247568356ba99725fa867c032b7632c9f8099d1daec18504a8f42624ed4`.
+  It pins the original result/report and all 36 retained MDB captures from
+  `20260905T044800Z-autoincrement-layout`, plus the new harness and unchanged
+  original analyzer, decoder and acquisition plan.
+- Known limitation motivating this analysis: the original helper rejected
+  24 captures containing a 169-slot page against its limit of 64. The sole
+  adjustment is `MAX_ROWS_PER_PAGE` from 64 to 256 in a private instance of
+  the original decoder. All structural checks and original schema, row,
+  identity, replica and classification rules remain in effect.
+- Commit and independent review precede expanded decoding. The harness
+  checks pinned artifacts before and after analysis and creates a separate
+  report outside the source outbox. That report identifies the original
+  `no_outcome`, all artifact identities and the exact analysis adjustment.
+  The original finite hypotheses remain hypotheses; stable disagreement is
+  an answered observation under the unchanged decision rule.
+- No DAO call, redispatch, new capture or source mutation is part of this
+  experiment. No additional decoder changes or automatic retry are allowed.
+  Record one validated secondary outcome as EXP-0136; neither this plan nor
+  a successful decode establishes general compatibility or hosted support.
+
 ## EXP-0132 — AutoIncrement discovery produced no outcome
 
 - Status: validated `no_outcome` from the single local EXP-0131 run

--- a/oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json
+++ b/oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json
@@ -1,0 +1,192 @@
+{
+  "document_type": "dao_autoincrement_secondary_plan",
+  "experiment_id": "autoincrement-reanalysis",
+  "entry": "EXP-0135",
+  "outcome_entry": "EXP-0136",
+  "development_only": true,
+  "classification": "Post-acquisition secondary analysis, committed and independently reviewed before expanded decoding. Not a new preregistered acquisition.",
+  "source": {
+    "run": "20260905T044800Z-autoincrement-layout",
+    "plan_entry": "EXP-0131",
+    "outcome_entry": "EXP-0132",
+    "outcome": "no_outcome",
+    "known_failure": "24 dense checkpoints rejected because 169 row slots exceeded analysis helper limit64; original hypotheses empty."
+  },
+  "change": "Load unchanged original analyzer and original decoder as private module instances; set only decoder MAX_ROWS_PER_PAGE from64 to256. Keep all original structural, schema, correlation, identity, replica and classification checks. No format grammar changes.",
+  "question": "Apply the original finite counter and sequence hypotheses to already acquired captures using the declared expanded row-directory limit. Stable hypothesis disagreement remains answered; no assumption about the actual next generated ID.",
+  "inputs": {
+    "oracle/windows-dao/scripts/autoincrement_reanalysis.py": "ca5c13dd9b0167cea189c57d84464cccb71399149808108150bc5bd8f93b8967",
+    "oracle/windows-dao/scripts/autoincrement_layout.py": "efdd6eccaa98900f9d79a14f4942aedf944ee62ad62f861e01405f605728da89",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/acquisition/autoincrement-layout.plan.json": "c27de50741883f787a2280d0e92fde43089288ff284d77c4408f22dcc9f577f5"
+  },
+  "artifacts": {
+    "result.json": {
+      "size": 1678940,
+      "sha256": "91f10571fd8885b860b2a7c58f5ee40bc3050d64c1b14e31886340a367600fcb"
+    },
+    "report.json": {
+      "size": 215446,
+      "sha256": "367f10da6f4966412dc3e02503d8e71cfa2f3d482db3edbab0b600e66319bb65"
+    },
+    "auto-r1-empty.mdb": {
+      "size": 47104,
+      "sha256": "bf6a85a82358218b54d8454caf54af91e108a8bb79d923d5b7601dfd37e8bfd3"
+    },
+    "auto-r1-one.mdb": {
+      "size": 49152,
+      "sha256": "4d8381654ec88436458b37f1b5a5d4b8c3288e554e1d85b381838edbf6dadf1d"
+    },
+    "auto-r1-n255.mdb": {
+      "size": 51200,
+      "sha256": "3a314f9e878fde67fd9da2b27a002e4139a11bcc03d3249446aa7ec80710252f"
+    },
+    "auto-r1-n256.mdb": {
+      "size": 51200,
+      "sha256": "2d60578edd16414ca37a79a8fbba7246e9cc5b889d295cca3cd85ff0bce93c73"
+    },
+    "auto-r1-deleted.mdb": {
+      "size": 51200,
+      "sha256": "34774d98f13a97095ab3dc11622da686998b5db17c2c17438ad88e16dbeffc96"
+    },
+    "auto-r1-next.mdb": {
+      "size": 51200,
+      "sha256": "242c3299d4b0e718a04af682f6ac5b3a84149f292eebfdbb99ffba042efcfd1e"
+    },
+    "long-r1-empty.mdb": {
+      "size": 47104,
+      "sha256": "311a1732285db3ea4ba6a93c9e5969156a545c561c4f3ec48b6d32c968e8c9e2"
+    },
+    "long-r1-one.mdb": {
+      "size": 49152,
+      "sha256": "80f14e06a319a5c53da429204a254513408c152cf87f77b83e6e46f41ecdefe7"
+    },
+    "long-r1-n255.mdb": {
+      "size": 51200,
+      "sha256": "325ee47f8b4cf946fc833c132b39f0d8d76e95962fad58ed1e7ce62b196f8ced"
+    },
+    "long-r1-n256.mdb": {
+      "size": 51200,
+      "sha256": "33a75e6b7335e5d3d926703523f3f8739ee12c5ea621bee4017232c850cf0d92"
+    },
+    "long-r1-deleted.mdb": {
+      "size": 51200,
+      "sha256": "b7c789c4df34237c3c557dc057fda6017588a4ab26d3554e452832b0088cc991"
+    },
+    "long-r1-next.mdb": {
+      "size": 51200,
+      "sha256": "a2bc5e7eb8a89072225af4111b5665c574f1c69eae5b3e0d686633fe46a7c9ad"
+    },
+    "auto-r2-empty.mdb": {
+      "size": 47104,
+      "sha256": "bab2beb2cd653fd5e63399a57ea2012fecb57c20d2c2be9d996bf96ad1b94603"
+    },
+    "auto-r2-one.mdb": {
+      "size": 49152,
+      "sha256": "1f94cf6f1a8079cf2778210722cec42fc9ad7bbc80c7c702360b6c8f52038907"
+    },
+    "auto-r2-n255.mdb": {
+      "size": 51200,
+      "sha256": "137068601a3911c679affc5248f3daf8795af4f1ab08e17600484a023e03b848"
+    },
+    "auto-r2-n256.mdb": {
+      "size": 51200,
+      "sha256": "d38a488f5efe8722ac11fe0731818f4bf89d123895c36833034b7fecfea8b04d"
+    },
+    "auto-r2-deleted.mdb": {
+      "size": 51200,
+      "sha256": "588f9c2df18e4c1f28674755e078bb582e501545d3b412c032a771f09926e491"
+    },
+    "auto-r2-next.mdb": {
+      "size": 51200,
+      "sha256": "fa33b3b5678253b9d58501016196645f7f49045eb15c3456942b5fc66c70d5c8"
+    },
+    "long-r2-empty.mdb": {
+      "size": 47104,
+      "sha256": "e9488f93f953f9c073134465103448f12ab191329b4700254616bac4c6d534d1"
+    },
+    "long-r2-one.mdb": {
+      "size": 49152,
+      "sha256": "2644860a0235c05beb42e2a9a3c4657c451e66c2cd7355012838ce02c6b056be"
+    },
+    "long-r2-n255.mdb": {
+      "size": 51200,
+      "sha256": "4b631ffa43e84f7b09afce1b0ca52e9c55fc37dbe578de01b6cbe25687e46074"
+    },
+    "long-r2-n256.mdb": {
+      "size": 51200,
+      "sha256": "8629c26f313f5abda7a575d51ccd8fa83b00723a293335e3758631dd65320440"
+    },
+    "long-r2-deleted.mdb": {
+      "size": 51200,
+      "sha256": "12e76b9fb17c50ac1dea73a203b944ed7573c18b7535ac89b3f564095ac10959"
+    },
+    "long-r2-next.mdb": {
+      "size": 51200,
+      "sha256": "c318edd089d8cc4228f141026f340338a6da8f57e1d78f68872c9bcc41d11c6f"
+    },
+    "auto-r3-empty.mdb": {
+      "size": 47104,
+      "sha256": "09da70e41405c5275d8aea3b0b2c320cad87350d8c7c8c74685a99e5fe402619"
+    },
+    "auto-r3-one.mdb": {
+      "size": 49152,
+      "sha256": "ee2fba78b8eadee786517c3b78f11b9aedb8bb5b221a2596b01e763f887652e1"
+    },
+    "auto-r3-n255.mdb": {
+      "size": 51200,
+      "sha256": "dde0d4c56d0ca802c092cf75a6ce5960f2d510a622e1b6619b5f291c8afc4aba"
+    },
+    "auto-r3-n256.mdb": {
+      "size": 51200,
+      "sha256": "1ab4af1fd65c8822e8094f64bf1c89fd0895e3af577ab72902979365945f94f0"
+    },
+    "auto-r3-deleted.mdb": {
+      "size": 51200,
+      "sha256": "a6e9a17aa59af6fb9708cb9a4c681e35d1b357fdcec4eeff37e1c1da87abaf23"
+    },
+    "auto-r3-next.mdb": {
+      "size": 51200,
+      "sha256": "b818ae094cb594c09c02ac2d6081ef7a86c9ca13d6ddd49dcc6fb46408e2e2c4"
+    },
+    "long-r3-empty.mdb": {
+      "size": 47104,
+      "sha256": "5e983938bf21162f5956c2f4a68828739459d1f149c34a8257d2ef6da9a7dfa7"
+    },
+    "long-r3-one.mdb": {
+      "size": 49152,
+      "sha256": "ac63f1d3fa201dd78af4fdd8ed5a87faaca7da7b5c0aeb457c1fb8cefe5084c2"
+    },
+    "long-r3-n255.mdb": {
+      "size": 51200,
+      "sha256": "a6e10ef022380693fcde9f01eb5c54e9f556a1bfac9d752be2896bd1996c721c"
+    },
+    "long-r3-n256.mdb": {
+      "size": 51200,
+      "sha256": "a934511971d028fd69cb027543cbf96a3ce57095e3e4351a54198170488cb5b1"
+    },
+    "long-r3-deleted.mdb": {
+      "size": 51200,
+      "sha256": "fafa467daed6e11f2de5ffa9594d9a8b43b6c95f8f4d6f7650bf13ea03461d43"
+    },
+    "long-r3-next.mdb": {
+      "size": 51200,
+      "sha256": "3821fc2f24bee00aceb7c10b06f240f616eb8afe1d8e03a4a8d0a80e8b826ca9"
+    }
+  },
+  "procedure": [
+    "Commit and independently review this plan and harness before expanded analysis.",
+    "Verify all input and artifact pins and the original no_outcome.",
+    "Apply the sole row-limit adjustment in a private decoder instance and call unchanged original build_report.",
+    "Recheck pins after analysis; exclusively create a new report outside source outbox identifying this plan, source no_outcome, all source identities and exact adjustment.",
+    "Record validated secondary result once as EXP-0136; preserve EXP-0132 and all original artifacts."
+  ],
+  "decision_rule": "Unchanged EXP-0131 build_report gates determine answered/no_outcome; input/artifact mismatch rejects secondary analysis. No outcome is inferred from successful raw DAO captures alone.",
+  "prohibitions": [
+    "No DAO invocation, redispatch, fresh captures, MDB generation or mutation.",
+    "No edits to consumed plans, scripts or source result/report.",
+    "No further analysis changes or automatic retry under this plan.",
+    "No general overflow/high-seed/indexed-generation or compatibility/support claim."
+  ],
+  "run": "python3 oracle/windows-dao/scripts/autoincrement_reanalysis.py analyze SOURCE_OUTBOX --output NEW_REPORT_OUTSIDE_SOURCE_OUTBOX"
+}

--- a/oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json
+++ b/oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json
@@ -15,7 +15,7 @@
   "change": "Load unchanged original analyzer and original decoder as private module instances; set only decoder MAX_ROWS_PER_PAGE from64 to256. Keep all original structural, schema, correlation, identity, replica and classification checks. No format grammar changes.",
   "question": "Apply the original finite counter and sequence hypotheses to already acquired captures using the declared expanded row-directory limit. Stable hypothesis disagreement remains answered; no assumption about the actual next generated ID.",
   "inputs": {
-    "oracle/windows-dao/scripts/autoincrement_reanalysis.py": "ca5c13dd9b0167cea189c57d84464cccb71399149808108150bc5bd8f93b8967",
+    "oracle/windows-dao/scripts/autoincrement_reanalysis.py": "9eaab464db61340ad6f9a536d1f6141ce677ecb7254df64d63f5fc4c26f4f9b6",
     "oracle/windows-dao/scripts/autoincrement_layout.py": "efdd6eccaa98900f9d79a14f4942aedf944ee62ad62f861e01405f605728da89",
     "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
     "oracle/windows-dao/acquisition/autoincrement-layout.plan.json": "c27de50741883f787a2280d0e92fde43089288ff284d77c4408f22dcc9f577f5"

--- a/oracle/windows-dao/scripts/autoincrement_reanalysis.py
+++ b/oracle/windows-dao/scripts/autoincrement_reanalysis.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Secondary analysis of pinned EXP-0131 captures; never invokes DAO."""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+import autoincrement_layout as original
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/autoincrement-reanalysis.plan.json'
+
+
+def load_private(name, filename):
+    spec = importlib.util.spec_from_file_location(name, ROOT / 'oracle/windows-dao/scripts' / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def analyzer():
+    module = load_private('secondary_autoincrement', 'autoincrement_layout.py')
+    decoder = load_private('secondary_catalog', 'system_catalog.py')
+    if decoder.MAX_ROWS_PER_PAGE != 64:
+        raise ValueError('Original row limit changed')
+    decoder.MAX_ROWS_PER_PAGE = 256
+    module.catalog = decoder
+    return module
+
+
+def verify(outbox):
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'autoincrement-reanalysis':
+        raise ValueError('Unexpected secondary plan')
+    for name, expected in plan['inputs'].items():
+        if original.digest(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    original.verify_inputs()
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Secondary plan must be committed')
+    for name, expected in plan['artifacts'].items():
+        if original.identity(outbox / name) != expected:
+            raise ValueError('Artifact pin mismatch: ' + name)
+    source = json.loads((outbox / 'report.json').read_text())
+    if source['outcome'] != 'no_outcome':
+        raise ValueError('Source report must remain no_outcome')
+    return plan
+
+
+def analyze(outbox, output):
+    plan = verify(outbox)
+    # Never replace a source artifact or an existing report.
+    if output.resolve().parent == outbox.resolve():
+        raise ValueError('Output must be outside the source outbox')
+    if output.exists():
+        raise ValueError('Output already exists')
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    module = analyzer()
+    report = module.build_report(result, outbox, original.verify_inputs())
+    report['document_type'] = 'dao_autoincrement_secondary_report'
+    report['source'] = {'experiment': 'EXP-0131', 'outcome_entry': 'EXP-0132',
+                        'outcome': 'no_outcome', 'artifacts': plan['artifacts']}
+    report['secondary_plan_sha256'] = original.digest(PLAN)
+    report['analysis_change'] = {'module': 'system_catalog', 'constant': 'MAX_ROWS_PER_PAGE',
+                                 'original': 64, 'secondary': 256}
+    verify(outbox)
+    with output.open('x') as destination:
+        destination.write(original.canonical(report) + '\n')
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=('preflight', 'analyze'))
+    parser.add_argument('outbox', type=Path)
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        verify(args.outbox)
+        print('Committed secondary plan, inputs and retained artifacts match.')
+    else:
+        if args.output is None:
+            parser.error('analyze requires --output outside source outbox')
+        print(analyze(args.outbox, args.output)['outcome'])
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/scripts/autoincrement_reanalysis.py
+++ b/oracle/windows-dao/scripts/autoincrement_reanalysis.py
@@ -53,7 +53,7 @@ def verify(outbox):
 def analyze(outbox, output):
     plan = verify(outbox)
     # Never replace a source artifact or an existing report.
-    if output.resolve().parent == outbox.resolve():
+    if output.resolve().is_relative_to(outbox.resolve()):
         raise ValueError('Output must be outside the source outbox')
     if output.exists():
         raise ValueError('Output already exists')

--- a/oracle/windows-dao/tests/test_autoincrement_reanalysis.py
+++ b/oracle/windows-dao/tests/test_autoincrement_reanalysis.py
@@ -58,6 +58,11 @@ class SecondaryTests(unittest.TestCase):
             original.write_text('original no_outcome')
             with self.assertRaisesRegex(ValueError, 'outside'):
                 secondary.analyze(outbox, original)
+            nested = outbox / 'nested'
+            nested.mkdir()
+            with self.assertRaisesRegex(ValueError, 'outside'):
+                secondary.analyze(outbox, nested / 'report.json')
+            self.assertFalse((nested / 'report.json').exists())
             self.assertEqual(original.read_text(), 'original no_outcome')
 
 

--- a/oracle/windows-dao/tests/test_autoincrement_reanalysis.py
+++ b/oracle/windows-dao/tests/test_autoincrement_reanalysis.py
@@ -12,9 +12,10 @@ import autoincrement_reanalysis as secondary
 class SecondaryTests(unittest.TestCase):
     def test_limit_is_private_and_other_decoder_checks_remain(self):
         module = secondary.analyzer()
-        self.assertEqual(secondary.original.catalog.MAX_ROWS_PER_PAGE, 64)
+        baseline = secondary.load_private('baseline_catalog', 'system_catalog.py')
+        self.assertEqual(baseline.MAX_ROWS_PER_PAGE, 64)
         constants = lambda m: {k: v for k, v in vars(m).items() if k.isupper() and isinstance(v, (str, int))}
-        expected = constants(secondary.original.catalog)
+        expected = constants(baseline)
         expected['MAX_ROWS_PER_PAGE'] = 256
         self.assertEqual(constants(module.catalog), expected)
         self.assertIsNot(module.catalog, secondary.original.catalog)
@@ -22,8 +23,8 @@ class SecondaryTests(unittest.TestCase):
         data = bytearray(2048)
         data[0] = 1
         data[8:10] = (169).to_bytes(2, 'little')
-        with self.assertRaisesRegex(secondary.original.catalog.DecodeError, 'bound of 64'):
-            secondary.original.catalog._row_directory(bytes(data), 0)
+        with self.assertRaisesRegex(baseline.DecodeError, 'bound of 64'):
+            baseline._row_directory(bytes(data), 0)
         with self.assertRaises(module.catalog.DecodeError) as error:
             module.catalog._row_directory(bytes(data), 0)
         self.assertNotIn('bound of 64', str(error.exception))

--- a/oracle/windows-dao/tests/test_autoincrement_reanalysis.py
+++ b/oracle/windows-dao/tests/test_autoincrement_reanalysis.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import autoincrement_reanalysis as secondary
+
+
+class SecondaryTests(unittest.TestCase):
+    def test_limit_is_private_and_other_decoder_checks_remain(self):
+        module = secondary.analyzer()
+        self.assertEqual(secondary.original.catalog.MAX_ROWS_PER_PAGE, 64)
+        constants = lambda m: {k: v for k, v in vars(m).items() if k.isupper() and isinstance(v, (str, int))}
+        expected = constants(secondary.original.catalog)
+        expected['MAX_ROWS_PER_PAGE'] = 256
+        self.assertEqual(constants(module.catalog), expected)
+        self.assertIsNot(module.catalog, secondary.original.catalog)
+        # Synthetic row directory: the old count gate differs, but invalid offsets still fail.
+        data = bytearray(2048)
+        data[0] = 1
+        data[8:10] = (169).to_bytes(2, 'little')
+        with self.assertRaisesRegex(secondary.original.catalog.DecodeError, 'bound of 64'):
+            secondary.original.catalog._row_directory(bytes(data), 0)
+        with self.assertRaises(module.catalog.DecodeError) as error:
+            module.catalog._row_directory(bytes(data), 0)
+        self.assertNotIn('bound of 64', str(error.exception))
+
+    def test_pins_refuse_changed_input_or_artifact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plan = root / 'plan.json'
+            source = root / 'source.py'
+            source.write_text('original')
+            report = root / 'report.json'
+            report.write_text('{"outcome":"no_outcome"}')
+            document = {'experiment_id': 'autoincrement-reanalysis',
+                        'inputs': {'source.py': secondary.original.digest(source)},
+                        'artifacts': {'report.json': secondary.original.identity(report)}}
+            plan.write_text(json.dumps(document))
+            with patch.object(secondary, 'ROOT', root), patch.object(secondary, 'PLAN', plan), \
+                    patch.object(secondary.original, 'verify_inputs'), patch.object(secondary.subprocess, 'run') as run:
+                run.return_value.stdout = plan.read_bytes()
+                secondary.verify(root)
+                report.write_text('changed')
+                with self.assertRaisesRegex(ValueError, 'Artifact pin mismatch'):
+                    secondary.verify(root)
+                source.write_text('changed')
+                with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                    secondary.verify(root)
+
+    def test_output_cannot_overwrite_originals(self):
+        with tempfile.TemporaryDirectory() as directory, patch.object(secondary, 'verify', return_value={}):
+            outbox = Path(directory)
+            original = outbox / 'report.json'
+            original.write_text('original no_outcome')
+            with self.assertRaisesRegex(ValueError, 'outside'):
+                secondary.analyze(outbox, original)
+            self.assertEqual(original.read_text(), 'original no_outcome')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EXP-0135 defines a separate post-acquisition analysis of EXP-0131's retained artifacts. It pins the original result, no-outcome report, and all 36 MDB identities, then uses a private decoder instance with only its analysis row limit raised from 64 to 256.

The original classifier and structural checks are preserved. Original files remain read-only, the new report must be created outside the source outbox, and no DAO code is called. The original no-outcome remains unchanged.

Validation: independent review verified the limit-only change; a nested-output containment issue was fixed and independently verified. Three focused tests, committed artifact preflight, and final `just ready` passed. The subsequently executed secondary analysis returned `answered`; the original no-outcome remains intact and its new result will be recorded as EXP-0136.
