### PR TITLE
test: preregister populated relationship acceptance and integrity

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11083,6 +11083,52 @@ Copy this block under the appropriate section and remove this instruction:
   or hosted support claim. Retain all MDBs externally and record one validated
   additive outcome as `EXP-0128`.
 
+### EXP-0133 — Populated relationship and integrity preregistration
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: committed development-only DAO preregistration; acquisition has not
+  started and no outcome or support movement is asserted.
+- Plan: `oracle/windows-dao/acquisition/relationship-rows.plan.json`, SHA-256
+  `ddeb3bdc88edc4c57163366fb77dfbf60eb5ed422d9a7943c78617be52ace5d2`. Input pins cover the producer, analyzer,
+  low-level transport and Rust example. Dispatch and analysis verify the
+  same pins; acquisition requires this committed plan and independent review.
+- Generator: `relationship_row_candidate` at reviewed source
+  `77269833fb21b4fdb77c4fab9b6e7d8ec23ac314`. Candidate is
+  65,536 bytes, SHA-256
+  `5a0bbe9329896ce19a46096d2b2a36bfc8dd2a2b16b8215dd377ff56fb05ab5b`.
+- Candidate: Accounts7 has three Long-key parent rows. Events9 has twenty
+  repeated child keys with distinct 255-character payloads across three
+  data pages. Account7Events9 links Accounts7.Key1 to Events9.Account4;
+  the child foreign leaf carries twenty entries and three distinct keys.
+  The plan fixes complete schemas, relation/index flags and every row value.
+- Read-only endpoint: three fresh matched DAO controls and three unchanged
+  candidate replicas; complete table/schema/index/relation metadata and all
+  row payloads, plus full parent/child index traversal and Seek1,2,3.
+  Duplicate traversal tie order and which valid duplicate Seek selects are
+  unspecified; every complete expected row must still occur in traversal.
+- Integrity endpoints: separate fresh writable candidate/control copies for
+  each replica and each operation. Insert valid child ('valid',2); attempt
+  orphan child ('orphan',999); attempt duplicate parent (Code2=6,Key1=1).
+  Require the valid insert to add exactly one child and the rejected inserts
+  to leave complete logical state unchanged. Capture actual native rejection
+  numbers/HRESULT and compare matched candidate/control identities without
+  guessed numeric gates. Read both indexes and every full row after each probe.
+  Six originals remain unchanged; retain those and eighteen probe files.
+- Classification: read-only acceptance and each integrity endpoint have
+  separate outcomes. Integrity requires accepted originals, complete probe
+  inventory and all matched controls passing. Three agreeing candidate
+  observations produce `observed_accepted` or `not_observed_accepted`;
+  incomplete jobs, failed controls, changed originals or disagreement give
+  `no_outcome`. Pin/binding/retention failures reject validation. Expected
+  Update rejections are recorded endpoints; unexpected post-mutation failure
+  remains a scientific result, never a redispatch or retry.
+- Preflight: eight focused classifier tests and VM PowerShell
+  `Parser.ParseFile` passed. The parser check executed no producer or DAO.
+- Boundary: this exact image and three finite DAO insert probes only; no
+  nullable/composite relationship keys, cascades, general allocation or
+  enforcement policy, Rust update implementation, general compatibility or
+  hosted support claim. Record one validated outcome as EXP-0134.
+
 ### EXP-0130 — Multi-table initial-row candidates accepted locally
 
 - Recorded: 2026-09-05, OpenAI Codex

--- a/oracle/windows-dao/acquisition/relationship-rows.plan.json
+++ b/oracle/windows-dao/acquisition/relationship-rows.plan.json
@@ -1,0 +1,80 @@
+{
+  "document_type": "dao_relationship_rows_plan",
+  "experiment_id": "relationship-rows",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "prior_evidence": "EXP-0114/0118/0122 supply exact empty relationship layout/acceptance; EXP-0120 supplies ordinary duplicate-key leaf observations; EXP-0130 accepted exact multi-table row/payload candidates. None establishes populated relationship enforcement.",
+    "hypothesis": "The exact populated candidate is readable unchanged with complete schema, relation metadata, all 23 rows, and both indexes traversable/searchable. On independent writable copies DAO accepts one valid child insert, rejects one orphan child insert, and rejects one duplicate parent key, matching fresh controls and exact expected post-state. These finite DAO operations are candidate acceptance/integrity observations, not implementation of a Rust updater.",
+    "authorization": "User authorized DAO experiments/mutations on2026-09-04. Commit and independently review this pinned plan before one dispatch. Unexpected failure after first mutation is a scientific result, never an automatic retry."
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/relationship_rows.py": "aaf732161c4db7e5c11dbd49e69ac5f0fe4f455bfdbffeeaf446d4b8be93904a",
+    "oracle/windows-dao/scripts/relationship_rows.ps1": "1573dc11738ad23cd41c6a3bc2d90478ebb86d33af0ceed659422fc8ced98531",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/relationship_row_candidate.rs": "0c256261068b30fbd39e8647d0bfaa4b41637171165c085bc4e9cf35f19b972d"
+  },
+  "candidates": {
+    "populated": {
+      "size": 65536,
+      "sha256": "5a0bbe9329896ce19a46096d2b2a36bfc8dd2a2b16b8215dd377ff56fb05ab5b"
+    }
+  },
+  "schema": {
+    "tables": [
+      "Accounts7",
+      "Events9",
+      "MSysACEs",
+      "MSysObjects",
+      "MSysQueries",
+      "MSysRelationships"
+    ],
+    "parent": "Accounts7(Code2 Long, Key1 Long), Primary9 ascending Key1; Primary/Unique/Required true, Foreign/IgnoreNulls false.",
+    "child": "Events9(Label3 Text255, Account4 Long), Account7Events9 ascending Account4; Foreign true, Primary/Unique/Required/IgnoreNulls false.",
+    "relation": "Account7Events9: Accounts7.Key1 -> Events9.Account4, Attributes0. Index field Attributes0/descendingfalse; DAO version3.0. Long fields type4 size4, Text type10 size255. Exact inventories contain no extra fields/indexes/relations."
+  },
+  "rows": {
+    "parent": "(Code2,Key1)=(9,1),(8,2),(7,3).",
+    "child": "For position0..19: Label3=(ASCII a+position) repeated255; Account4=1+(position mod3). Compare every complete pair and every payload character."
+  },
+  "candidate_layout": "32pages: parent definition20/map21/property22/primary23/data24; child definition25/map26/data27..29; relationship data30 and foreignleaf31. Foreignleaf has20 entries/3 distinct keys; existing table maps/counts retained. This construction asserts no general insertion/page-zero/allocation rule.",
+  "probes": {
+    "valid_child": {
+      "operation": "Insert Events9(Label3='valid',Account4=2)",
+      "expected": "Update succeeds; full post-state equals original plus exactly this child row, including both complete indexes."
+    },
+    "orphan_child": {
+      "operation": "Insert Events9(Label3='orphan',Account4=999)",
+      "expected": "Update rejects; full schema/relation/row/index semantics equal original. Record actual native DAO error numbers and deepest exception HRESULT; require agreement with matched control, without presupposing numeric error codes."
+    },
+    "duplicate_parent": {
+      "operation": "Insert Accounts7(Code2=6,Key1=1)",
+      "expected": "Update rejects; full schema/relation/row/index semantics equal original. Actual native rejection identity must match matched control; no guessed numeric gate."
+    }
+  },
+  "execution": {
+    "environment": "Private Windows VM, x86 PowerShell, DAO.DBEngine.36; development-only.",
+    "pre_mutation": "Host validates committed plan and every input/candidate pin; guest validates producer and all three copied candidates before any fresh control CreateDatabase.",
+    "base_replicas": "Create/close one fresh matched control per replica, defining both tables, inserting all rows, then appending the relation with Attributes0. Observe control and pinned candidate read-only: complete schema/relations/rows, both index traversals, and Seek queries 1, 2, 3. Record before/after identities.",
+    "integrity_order": "After all three base pairs, for replicas1..3 and probes valid_child,orphan_child,duplicate_parent: make separate fresh copies of that original control and candidate. Verify each copy starts with its source identity, open writable, AddNew/assign fields, attempt Update once, capture native rejection identity immediately on Update failure, cancel a remaining edit if necessary, close. Read complete post-state read-only. Never roll back or reuse a probe copy. Unexpected setup/assignment/cleanup errors abort the job; anticipated Update rejections remain recorded endpoints.",
+    "attempts": 1,
+    "command": "python3 oracle/windows-dao/scripts/relationship_rows.py run <directory containing populated.mdb> --shared-root <VM shared directory> --run-id <UTC timestamp>-relationship-rows",
+    "analysis": "python3 oracle/windows-dao/scripts/relationship_rows.py analyze <shared directory>/outbox/<run id>"
+  },
+  "decision_rule": {
+    "read_only": "Complete three-pair job with all controls passing, six originals unchanged and three agreeing candidate observations: observed_accepted for exact semantics, not_observed_accepted for identical failures/mismatches. Any job error, control failure, changed original or disagreement gives no_outcome.",
+    "integrity": "Requires accepted read-only originals, no job error, all nine probe pairs present, every matched probe control meeting expected operation and exact post-operation state, and all probe post-observations read-only. Classify each probe from three agreeing candidate results: observed_accepted if expected operation, full post-operation state and native rejection identity match controls, not_observed_accepted for consistent mismatch. Incomplete jobs, failed controls or candidate disagreement yield no_outcome.",
+    "normalization": "Only snapshot row order and duplicate traversal tie order are unspecified. Traversal must contain every expected full row and ascending relationship keys. Seek queries exactly 1, 2, 3 must return a matching complete row; foreign Seek may choose any matching duplicate. Normalize valid Seek responses to queries, retaining raw rows in result. Actual native codes/HRESULT are compared to controls; English error text is retained but not a semantic discriminator.",
+    "validation_rejection": "Input drift, malformed inventories/result binding, candidate starting-pin mismatch, writable copy/source mismatch, retained identity mismatch, or changed read-only post-probe observation rejects validation."
+  },
+  "native_error_capture_reference": "https://learn.microsoft.com/en-us/office/client-developer/access/desktop-database-reference/error-object-dao",
+  "evidence_boundary": "Exact candidate plus three finite DAO insert probes only. No nullable/composite relationship keys, cascades, deletes/updates, general integrity/allocator/schema policy, Rust existing-database writer correctness, general compatibility or hosted support movement.",
+  "retention": "Retain result.json, canonical report.json, logs, six unchanged original candidate/control MDBs and eighteen writable probe copies locally. No MDB/provider bytes in git. Append one validated EXP-0134 outcome.",
+  "candidate_generation": {
+    "source_commit": "77269833fb21b4fdb77c4fab9b6e7d8ec23ac314",
+    "example": "crates/jet3/examples/relationship_row_candidate.rs",
+    "command": "cargo run --locked -p jet3 --example relationship_row_candidate -- <directory>/populated.mdb"
+  }
+}

--- a/oracle/windows-dao/scripts/relationship_rows.ps1
+++ b/oracle/windows-dao/scripts/relationship_rows.ps1
@@ -1,0 +1,250 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function Add-Table($Database, [bool]$Parent) {
+    $table = $first = $second = $index = $key = $null
+    try {
+        if ($Parent) {
+            $table = $Database.CreateTableDef('Accounts7')
+            $first = $table.CreateField('Code2', 4)
+            $second = $table.CreateField('Key1', 4)
+        }
+        else {
+            $table = $Database.CreateTableDef('Events9')
+            $first = $table.CreateField('Label3', 10, 255)
+            $second = $table.CreateField('Account4', 4)
+        }
+        $table.Fields.Append($first); $table.Fields.Append($second)
+        if ($Parent) {
+            $index = $table.CreateIndex('Primary9')
+            $index.Primary = $true; $index.Unique = $true
+            $key = $index.CreateField('Key1')
+            $index.Fields.Append($key)
+            $table.Indexes.Append($index)
+        }
+        $Database.TableDefs.Append($table)
+    }
+    finally { Release $key; Release $index; Release $second; Release $first; Release $table }
+}
+function New-Control([string]$Path, [string]$Arm) {
+    $engine = $workspace = $db = $rs = $relation = $field = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        Add-Table $db $true
+        Add-Table $db $false
+        $rs = $db.OpenRecordset('Accounts7', 2)
+        foreach ($position in 0..2) {
+            $rs.AddNew()
+            $rs.Fields.Item('Code2').Value = [int](9 - $position)
+            $rs.Fields.Item('Key1').Value = [int]($position + 1)
+            $rs.Update()
+        }
+        $rs.Close(); Release $rs; $rs = $null
+        $rs = $db.OpenRecordset('Events9', 2)
+        foreach ($position in 0..19) {
+            $rs.AddNew()
+            $rs.Fields.Item('Label3').Value = ([string][char](97 + $position)) * 255
+            $rs.Fields.Item('Account4').Value = [int](1 + $position % 3)
+            $rs.Update()
+        }
+        $rs.Close(); Release $rs; $rs = $null
+        $relation = $db.CreateRelation('Account7Events9', 'Accounts7', 'Events9', 0)
+        $field = $relation.CreateField('Key1')
+        $field.ForeignName = 'Account4'
+        $relation.Fields.Append($field)
+        $db.Relations.Append($relation)
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $field; Release $relation
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset, [string]$Name) {
+    $first = $Recordset.Fields.Item(0).Value
+    $second = $Recordset.Fields.Item(1).Value
+    if ($null -eq $first -or [Convert]::IsDBNull($first)) { $first = $null }
+    elseif ($Name -ceq 'Accounts7') { $first = [int]$first } else { $first = [string]$first }
+    if ($null -eq $second -or [Convert]::IsDBNull($second)) { $second = $null } else { $second = [int]$second }
+    if ($Name -ceq 'Accounts7') { return @{code2=$first; key1=$second} }
+    return @{label3=$first; account4=$second}
+}
+function Read-Table($Database, [string]$Name) {
+    $table = $rs = $null
+    try {
+        $table = $Database.TableDefs.Item($Name)
+        $snapshot = [ordered]@{name=$Name}
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required;
+              foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0); attributes=[int]$_.Attributes} })}
+        })
+        $rs = $Database.OpenRecordset($Name, 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) { [void]$rows.Add((Read-Row $rs $Name)); $rs.MoveNext() }
+        $snapshot.rows = @($rows)
+        if ($Name -ceq 'Accounts7' -or $Name -ceq 'Events9') {
+            $rs.Close(); Release $rs; $rs = $null
+            $rs = $Database.OpenRecordset($Name, 1)
+            $rs.Index = $(if ($Name -ceq 'Accounts7') { 'Primary9' } else { 'Account7Events9' })
+            $rs.MoveFirst()
+            $traversal = New-Object Collections.ArrayList
+            while (-not $rs.EOF) { [void]$traversal.Add((Read-Row $rs $Name)); $rs.MoveNext() }
+            $snapshot.traversal = @($traversal)
+            $seeks = New-Object Collections.ArrayList
+            foreach ($value in @(1, 2, 3)) {
+                $rs.Seek('=', [int]$value)
+                $row = if ($rs.NoMatch) { $null } else { Read-Row $rs $Name }
+                [void]$seeks.Add(@{query=$value; row=$row})
+            }
+            $snapshot.seek = @($seeks)
+        }
+        return $snapshot
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+    }
+}
+function Observe([string]$Path, [string]$Arm) {
+    $before = Identity $Path
+    $engine = $db = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'
+    $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @()
+        foreach ($relation in $db.Relations) {
+            try {
+                $fields = @($relation.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })
+                $snapshot.relations += @{name=[string]$relation.Name; table=[string]$relation.Table; foreign_table=[string]$relation.ForeignTable; attributes=[int]$relation.Attributes; fields=$fields}
+            }
+            finally { Release $relation }
+        }
+        $endpoint = 'user_tables'
+        $snapshot.user_tables = @(foreach ($name in @('Accounts7', 'Events9')) { Read-Table $db $name })
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+function Probe([string]$Source, [string]$Path, [string]$Kind) {
+    Copy-Item -LiteralPath $Source -Destination $Path
+    $before = Identity $Path
+    $sourceIdentity = Identity $Source
+    if ($before.sha256 -cne $sourceIdentity.sha256 -or $before.size -ne $sourceIdentity.size) { throw 'Writable copy mismatch' }
+    $engine = $db = $rs = $null
+    $operation = @{status='updated'; endpoint='update'; native_codes=@(); hresult=$null; error=$null}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $false)
+        $table = if ($Kind -ceq 'duplicate_parent') { 'Accounts7' } else { 'Events9' }
+        $rs = $db.OpenRecordset($table, 2)
+        $rs.AddNew()
+        if ($Kind -ceq 'duplicate_parent') {
+            $rs.Fields.Item('Code2').Value = [int]6
+            $rs.Fields.Item('Key1').Value = [int]1
+        }
+        else {
+            $label = if ($Kind -ceq 'valid_child') { 'valid' } else { 'orphan' }
+            $key = if ($Kind -ceq 'valid_child') { 2 } else { 999 }
+            $rs.Fields.Item('Label3').Value = [string]$label
+            $rs.Fields.Item('Account4').Value = [int]$key
+        }
+        try { $rs.Update() }
+        catch {
+            $exception = $_.Exception
+            while ($null -ne $exception.InnerException) { $exception = $exception.InnerException }
+            $operation.status = 'rejected'
+            $operation.hresult = [int]$exception.HResult
+            $operation.error = ($exception.GetType().FullName + ': ' + $exception.Message).Replace($Path, '<DATABASE>')
+            $operation.native_codes = @($engine.Errors | ForEach-Object { [int]$_.Number })
+            if ([int]$rs.EditMode -ne 0) { $rs.CancelUpdate() }
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; operation=$operation; observation=(Observe $Path 'populated')}
+}
+$planPath = Join-Path $env:JET3_WORK 'relationship-rows.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+$scriptHash = (Identity $PSCommandPath).sha256
+if ($scriptHash -cne $plan.inputs.'oracle/windows-dao/scripts/relationship_rows.ps1') { throw 'Script pin mismatch' }
+$arms = @('populated')
+foreach ($arm in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$arm.mdb") -Destination $path
+        $identity = Identity $path
+        $expected = $plan.candidates.$arm
+        if ($identity.size -ne $expected.size -or $identity.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_relationship_rows_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); probes=@(); error=$null
+}
+try {
+    foreach ($arm in $arms) {
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$arm-control-r$replica.mdb"
+            New-Control $control $arm
+            $candidate = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+            $result.replicas += @{arm=$arm; replica=$replica; control=(Observe $control $arm); candidate=(Observe $candidate $arm)}
+        }
+    }
+    foreach ($replica in 1..3) {
+        foreach ($probe in @('valid_child', 'orphan_child', 'duplicate_parent')) {
+            $control = Join-Path $env:JET3_WORK "populated-control-r$replica.mdb"
+            $candidate = Join-Path $env:JET3_WORK "populated-candidate-r$replica.mdb"
+            $controlCopy = Join-Path $env:JET3_WORK "populated-control-$probe-r$replica.mdb"
+            $candidateCopy = Join-Path $env:JET3_WORK "populated-candidate-$probe-r$replica.mdb"
+            $result.probes += @{replica=$replica; probe=$probe; control=(Probe $control $controlCopy $probe); candidate=(Probe $candidate $candidateCopy $probe)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/relationship_rows.py
+++ b/oracle/windows-dao/scripts/relationship_rows.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Preregistered populated relationship and integrity DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/relationship-rows.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/relationship_rows.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+ARMS = ('populated',)
+PROBES = ('valid_child', 'orphan_child', 'duplicate_parent')
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['replicas'] != 3 or list(plan['candidates']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        if identity(candidate_directory / f'{arm}.mdb') != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def expected_snapshot(arm, probe=None):
+    parent = [{'code2': 9 - position, 'key1': position + 1} for position in range(3)]
+    child = [{'label3': chr(97 + position) * 255, 'account4': 1 + position % 3} for position in range(20)]
+    if probe == 'valid_child':
+        child.append({'label3': 'valid', 'account4': 2})
+    tables = []
+    for name, rows, key, fields, index in [
+        ('Accounts7', parent, 'key1', [{'name': 'Code2', 'type': 4, 'size': 4}, {'name': 'Key1', 'type': 4, 'size': 4}], 'Primary9'),
+        ('Events9', child, 'account4', [{'name': 'Label3', 'type': 10, 'size': 255}, {'name': 'Account4', 'type': 4, 'size': 4}], 'Account7Events9')]:
+        primary = name == 'Accounts7'
+        tables.append({'name': name, 'fields': fields,
+                       'indexes': [{'name': index, 'primary': primary, 'unique': primary,
+                                    'required': primary, 'foreign': not primary, 'ignore_nulls': False,
+                                    'fields': [{'name': 'Key1' if primary else 'Account4', 'descending': False, 'attributes': 0}]}],
+                       'rows': rows, 'traversal': [dict(row) for row in sorted(rows, key=lambda row: row[key])],
+                       'seek': [{'query': value, 'row': dict(next(row for row in rows if row[key] == value))} for value in (1, 2, 3)]})
+    return {'version': '3.0', 'tables': ['Accounts7', 'Events9', 'MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships'],
+            'user_tables': tables, 'relations': [{'name': 'Account7Events9', 'table': 'Accounts7', 'foreign_table': 'Events9',
+                                               'attributes': 0, 'fields': [{'name': 'Key1', 'foreign_name': 'Account4'}]}]}
+
+
+def normalize(snapshot):
+    result = json.loads(json.dumps(snapshot))
+    valid = True
+    for table in result.get('user_tables', []):
+        key = {'Accounts7': 'key1', 'Events9': 'account4'}.get(table['name'])
+        rows = table.get('rows', [])
+        traversal = table.get('traversal', [])
+        keys = [row.get(key) for row in traversal]
+        ordered = (all(type(value) is int for value in keys) and keys == sorted(keys)
+                   and sorted(traversal, key=canonical) == sorted(rows, key=canonical))
+        seeks = table.get('seek', [])
+        seek_ok = ([item['query'] for item in seeks] == [1, 2, 3]
+                   and all(item['row'] in rows and item['row'][key] == item['query'] for item in seeks))
+        valid &= ordered and seek_ok
+        if 'rows' in table:
+            table['rows'] = sorted(rows, key=canonical)
+        if ordered and 'traversal' in table:
+            table['traversal'] = sorted(traversal, key=canonical)
+        if seek_ok:
+            table['seek'] = [1, 2, 3]
+    return valid, result
+
+
+def semantics(plan, arm, observation, probe=None):
+    valid, snapshot = normalize(observation['snapshot'])
+    passed = (valid and observation['status'] == 'pass' and observation['endpoint'] == 'complete'
+              and observation['error'] is None and snapshot == normalize(expected_snapshot(arm, probe))[1])
+    return passed, {**{key: observation[key] for key in ('status', 'endpoint', 'error')}, 'snapshot': snapshot}
+
+
+def probe_semantics(plan, probe, observation):
+    passed, snapshot = semantics(plan, 'populated', observation['observation'], probe)
+    operation = observation['operation']
+    expected = 'updated' if probe == 'valid_child' else 'rejected'
+    passed &= operation['status'] == expected and operation['endpoint'] == 'update'
+    normalized = {key: operation[key] for key in ('status', 'endpoint', 'native_codes', 'hresult')}
+    return passed, {'operation': normalized, 'observation': snapshot}
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    if (result['document_type'] != 'dao_relationship_rows_result'
+            or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32):
+        raise ValueError('Result identity/environment mismatch')
+    expected_inventory = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual_inventory = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual_inventory != expected_inventory[:len(actual_inventory)]:
+        raise ValueError('Unexpected replica inventory')
+    grouped = {arm: [] for arm in ARMS}
+    unchanged = True
+    controls_ok = True
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        for role in ('candidate', 'control'):
+            observation = item[role]
+            retained = outbox / f'{arm}-{role}-r{replica}.mdb'
+            if identity(retained) != observation['after']:
+                raise ValueError(f'Retained identity mismatch: {retained.name}')
+            if role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                raise ValueError('Candidate did not start with pinned identity')
+            unchanged &= observation['before'] == observation['after']
+        controls_ok &= semantics(plan, arm, item['control'])[0]
+        grouped[arm].append(semantics(plan, arm, item['candidate']))
+    outcomes = {arm: 'no_outcome' for arm in ARMS}
+    if (result['mutation_started'] is True and result['error'] is None
+            and actual_inventory == expected_inventory and controls_ok and unchanged):
+        for arm, observations in grouped.items():
+            if all(item == observations[0] for item in observations):
+                outcomes[arm] = 'observed_accepted' if observations[0][0] else 'not_observed_accepted'
+    expected_probes = [(replica, probe) for replica in range(1, 4) for probe in PROBES]
+    actual_probes = [(item['replica'], item['probe']) for item in result['probes']]
+    if actual_probes != expected_probes[:len(actual_probes)]:
+        raise ValueError('Unexpected integrity probe inventory')
+    grouped_probes = {probe: [] for probe in PROBES}
+    probe_codes = {probe: {'candidate': [], 'control': []} for probe in PROBES}
+    probe_controls_ok = True
+    for item in result['probes']:
+        probe, replica = item['probe'], item['replica']
+        for role in ('candidate', 'control'):
+            observed = item[role]
+            base = next(value for value in result['replicas'] if value['replica'] == replica)[role]
+            path = outbox / f'populated-{role}-{probe}-r{replica}.mdb'
+            if observed['before'] != base['after'] or identity(path) != observed['observation']['after']:
+                raise ValueError('Integrity copy identity mismatch')
+            if observed['observation']['before'] != observed['observation']['after']:
+                raise ValueError('Read-only post-probe observation changed image')
+            probe_codes[probe][role].append(observed['operation']['native_codes'])
+        control = probe_semantics(plan, probe, item['control'])
+        candidate = probe_semantics(plan, probe, item['candidate'])
+        probe_controls_ok &= control[0]
+        # Native rejection identities are observed and compared to matched controls,
+        # never guessed numeric acquisition gates.
+        same_error = (candidate[1]['operation']['native_codes'] == control[1]['operation']['native_codes']
+                      and candidate[1]['operation']['hresult'] == control[1]['operation']['hresult'])
+        grouped_probes[probe].append((candidate[0] and same_error, candidate[1]))
+    integrity = {probe: 'no_outcome' for probe in PROBES}
+    if (result['error'] is None and actual_probes == expected_probes and controls_ok
+            and actual_inventory == expected_inventory and unchanged and probe_controls_ok
+            and outcomes['populated'] == 'observed_accepted'):
+        for probe, observations in grouped_probes.items():
+            if all(item == observations[0] for item in observations):
+                integrity[probe] = 'observed_accepted' if observations[0][0] else 'not_observed_accepted'
+    report = {'document_type': 'dao_relationship_rows_report', 'development_only': True,
+              'compatibility_claim': False, 'support_movement': False,
+              'plan_sha256': digest(PLAN), 'result_sha256': digest(outbox / 'result.json'),
+              'outcomes': outcomes, 'integrity': integrity, 'probe_codes': probe_codes,
+              'replicas': len(result['replicas']), 'probes': len(result['probes']), 'candidates': plan['candidates']}
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report))
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'relationship-rows.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_relationship_rows.py
+++ b/oracle/windows-dao/tests/test_relationship_rows.py
@@ -1,0 +1,144 @@
+"""Classify populated relationships and independent writable-copy integrity probes."""
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location('relationship_rows', Path(__file__).parents[1] / 'scripts/relationship_rows.py')
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RelationshipRowsReportTests(unittest.TestCase):
+    def classify(self, change=lambda result: None, tamper=None):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / 'producer.ps1'
+            source.write_text('pinned producer')
+            plan = {'inputs': {str(source): MODULE.digest(source)}, 'schema': {'version': '3.0'}, 'candidates': {}}
+            for arm in MODULE.ARMS:
+                path = root / f'{arm}.mdb'
+                path.write_bytes(arm.encode())
+                plan['candidates'][arm] = MODULE.identity(path)
+            plan_path = root / 'plan.json'
+            plan_path.write_text(json.dumps(plan))
+            result = {'document_type': 'dao_relationship_rows_result', 'development_only': True,
+                      'plan_sha256': MODULE.digest(plan_path), 'environment': {'process_bits': 32},
+                      'mutation_started': True, 'error': None, 'replicas': [], 'probes': []}
+            for arm in MODULE.ARMS:
+                snapshot = MODULE.expected_snapshot(arm)
+                for number in range(1, 4):
+                    replica = {'arm': arm, 'replica': number}
+                    for role in ('candidate', 'control'):
+                        path = root / f'{arm}-{role}-r{number}.mdb'
+                        path.write_bytes(arm.encode())
+                        replica[role] = {'before': MODULE.identity(path), 'after': MODULE.identity(path),
+                                         'status': 'pass', 'endpoint': 'complete', 'error': None,
+                                         'snapshot': copy.deepcopy(snapshot)}
+                    result['replicas'].append(replica)
+            for replica in range(1, 4):
+                for probe in MODULE.PROBES:
+                    item = {'replica': replica, 'probe': probe}
+                    for role in ('candidate', 'control'):
+                        path = root / f'populated-{role}-{probe}-r{replica}.mdb'
+                        path.write_bytes(probe.encode())
+                        operation = {'status': 'updated' if probe == 'valid_child' else 'rejected',
+                                     'endpoint': 'update', 'native_codes': [] if probe == 'valid_child' else [3201 if probe == 'orphan_child' else 3022],
+                                     'hresult': None if probe == 'valid_child' else -1, 'error': None}
+                        item[role] = {'before': plan['candidates']['populated'], 'operation': operation,
+                                      'observation': {'before': MODULE.identity(path), 'after': MODULE.identity(path),
+                                                      'status': 'pass', 'endpoint': 'complete', 'error': None,
+                                                      'snapshot': MODULE.expected_snapshot('populated', probe)}}
+                    result['probes'].append(item)
+            change(result)
+            (root / 'result.json').write_text(json.dumps(result))
+            if tamper == 'input':
+                source.write_text('diagnostic edit')
+            elif tamper == 'probe_retained':
+                (root / 'populated-candidate-valid_child-r1.mdb').write_bytes(b'changed probe')
+            elif tamper == 'retained':
+                (root / 'populated-candidate-r1.mdb').write_bytes(b'changed')
+            with patch.object(MODULE, 'PLAN', plan_path), patch('builtins.print'):
+                MODULE.analyze(root)
+            return json.loads((root / 'report.json').read_text())
+
+    def test_complete_acceptance_and_all_three_integrity_endpoints(self):
+        report = self.classify()
+        self.assertEqual(report['outcomes']['populated'], 'observed_accepted')
+        self.assertTrue(all(value == 'observed_accepted' for value in report['integrity'].values()))
+
+    def test_duplicate_child_seek_and_tie_order_are_not_overconstrained(self):
+        def change(result):
+            child = result['replicas'][0]['candidate']['snapshot']['user_tables'][1]
+            child['rows'].reverse()
+            child['traversal'].sort(key=lambda row: (row['account4'], row['label3']), reverse=False)
+            for seek in child['seek']:
+                seek['row'] = next(row for row in child['rows'] if row['account4'] == seek['query'])
+        self.assertEqual(self.classify(change)['outcomes']['populated'], 'observed_accepted')
+
+    def test_relation_foreign_index_and_full_payload_mismatches_are_negative(self):
+        for field in ('relation', 'index', 'payload', 'traversal'):
+            def change(result):
+                for replica in result['replicas']:
+                    snapshot = replica['candidate']['snapshot']
+                    if field == 'relation':
+                        snapshot['relations'][0]['attributes'] = 256
+                    elif field == 'index':
+                        snapshot['user_tables'][1]['indexes'][0]['foreign'] = False
+                    elif field == 'payload':
+                        snapshot['user_tables'][1]['rows'][0]['label3'] = 'wrong'
+                    else:
+                        snapshot['user_tables'][1]['traversal'].pop()
+            self.assertEqual(self.classify(change)['outcomes']['populated'], 'not_observed_accepted')
+
+    def test_probe_requires_expected_operation_and_exact_post_state(self):
+        for field in ('operation', 'state'):
+            def change(result):
+                for item in result['probes']:
+                    if item['probe'] == 'orphan_child':
+                        if field == 'operation':
+                            item['candidate']['operation']['status'] = 'updated'
+                        else:
+                            item['candidate']['observation']['snapshot']['user_tables'][1]['rows'].pop()
+            self.assertEqual(self.classify(change)['integrity']['orphan_child'], 'not_observed_accepted')
+
+    def test_native_codes_are_matched_to_controls_not_guessed(self):
+        def different_native_code(result):
+            for item in result['probes']:
+                if item['probe'] == 'orphan_child':
+                    for role in ('candidate', 'control'):
+                        item[role]['operation']['native_codes'] = [9999]
+        self.assertEqual(self.classify(different_native_code)['integrity']['orphan_child'], 'observed_accepted')
+        def mismatch(result):
+            for item in result['probes']:
+                if item['probe'] == 'orphan_child':
+                    item['candidate']['operation']['native_codes'] = [9999]
+        self.assertEqual(self.classify(mismatch)['integrity']['orphan_child'], 'not_observed_accepted')
+
+    def test_disagreement_and_control_failure_have_no_outcome(self):
+        def disagreement(result):
+            result['probes'][0]['candidate']['observation']['snapshot']['user_tables'][1]['rows'].pop()
+        self.assertEqual(self.classify(disagreement)['integrity']['valid_child'], 'no_outcome')
+        def control_failure(result):
+            result['probes'][0]['control']['operation']['status'] = 'rejected'
+        self.assertTrue(all(value == 'no_outcome' for value in self.classify(control_failure)['integrity'].values()))
+
+    def test_incomplete_scientific_job_has_no_outcome(self):
+        def change(result):
+            result['probes'].pop()
+            result['error'] = 'Unexpected DAO failure'
+        report = self.classify(change)
+        self.assertEqual(report['outcomes']['populated'], 'no_outcome')
+        self.assertTrue(all(value == 'no_outcome' for value in report['integrity'].values()))
+
+    def test_modified_inputs_and_retained_files_are_rejected(self):
+        for tamper in ('input', 'retained', 'probe_retained'):
+            with self.subTest(tamper=tamper), self.assertRaises(ValueError):
+                self.classify(tamper=tamper)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
EXP-0133 validates the populated relationship candidate against three fresh DAO controls, comparing complete schema, relationship metadata, rows, and parent/foreign index traversal and Seek results.

Independent writable copies then test a valid child insert, orphan-child rejection, and duplicate-parent rejection, each with exact post-state checks. Rejection codes are compared to matched controls. Original candidates must remain unchanged; expected rejection endpoints are distinct from unexpected job failure, with no automatic redispatch.

Validation: independent review found no issues; eight classifier tests, committed candidate preflight, Windows PowerShell parser check, and `just ready` passed.
