### PR TITLE
feat(jet3): generate initial AutoIncrement IDs

### DIFF
--- a/crates/jet3/examples/autoincrement_candidate.rs
+++ b/crates/jet3/examples/autoincrement_candidate.rs
@@ -1,0 +1,61 @@
+//! Deterministic AutoIncrement candidates; no DAO acceptance is asserted.
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
+    ResourceBudget, ResourceLimits, RowValue, TableRows, TableSpec,
+    create_database_with_table_rows,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() != 3 {
+        return Err("usage: autoincrement_candidate OUTPUT.mdb unindexed|indexed|multi".into());
+    }
+    let count = match args[2].as_str() {
+        "unindexed" | "multi" => 256,
+        "indexed" => 10,
+        _ => return Err("unknown arm".into()),
+    };
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::AutoIncrement),
+        ColumnSpec::new(b"Tag", ColumnType::Long),
+    ];
+    let fields = [IndexColumnSpec {
+        column: ColumnRef::Ordinal(0),
+        direction: IndexDirection::Ascending,
+    }];
+    let indexes = [IndexSpec {
+        name: b"PrimaryKey",
+        fields: &fields,
+        kind: IndexKind::Primary,
+    }];
+    let values = (1..=count)
+        .map(|tag| [RowValue::AutoIncrement, RowValue::Long(tag)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    let second = [RowValue::AutoIncrement, RowValue::Long(-1)];
+    let second_rows = [second.as_slice()];
+    let mut requests = vec![TableRows {
+        table: TableSpec {
+            name: b"Rows",
+            columns: &columns,
+            indexes: if args[2] == "indexed" { &indexes } else { &[] },
+        },
+        rows: &rows,
+    }];
+    if args[2] == "multi" {
+        requests.push(TableRows {
+            table: TableSpec {
+                name: b"Later",
+                columns: &columns,
+                indexes: &indexes,
+            },
+            rows: &second_rows,
+        });
+    }
+    create_database_with_table_rows(
+        &args[1],
+        &requests,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_autoincrement.rs
+++ b/crates/jet3/src/bootstrap_autoincrement.rs
@@ -1,0 +1,125 @@
+//! Initial generated Long values and persisted last-generated state (EXP-0136).
+//! DAO observations cover 0..=256 and a subsequent generated 257 after deletion;
+//! larger positive counts use the same checked scalar encoding as a candidate.
+
+use super::*;
+use crate::{BinaryWriter, ByteOffset};
+
+/// EXP-0136: signed little-endian last-generated Long in the user TDEF root.
+const STATE_OFFSET: usize = 16;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InitialAutoIncrement {
+    column: usize,
+    last: i32,
+}
+
+impl InitialAutoIncrement {
+    pub(crate) fn new(table: &TableSpec<'_>, rows: usize) -> Result<Option<Self>, ComposeError> {
+        let mut columns = table
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| column.column_type() == ColumnType::AutoIncrement);
+        let Some((column, _)) = columns.next() else {
+            return Ok(None);
+        };
+        if columns.next().is_some() {
+            return Err(Self::refusal("multiple AutoIncrement columns"));
+        }
+        // Leave a representable positive successor; no overflow behavior is inferred.
+        let last = i32::try_from(rows)
+            .ok()
+            .filter(|last| *last < i32::MAX)
+            .ok_or_else(|| Self::refusal("generated count reaches the signed Long boundary"))?;
+        Ok(Some(Self { column, last }))
+    }
+
+    fn refusal(detail: &'static str) -> ComposeError {
+        ComposeError::InitialAutoIncrement { detail }
+    }
+
+    pub(crate) fn lower<'a>(
+        self,
+        values: &[RowValue<'a>],
+        ordinal: usize,
+        lowered: &mut [RowValue<'a>; u8::MAX as usize],
+        budget: &mut ResourceBudget,
+    ) -> Result<(), ComposeError> {
+        if values.len() > lowered.len() || self.column >= values.len() {
+            return Err(Self::refusal("missing generation request"));
+        }
+        if !matches!(values[self.column], RowValue::AutoIncrement) {
+            return Err(Self::refusal(
+                "AutoIncrement requires an explicit generation request",
+            ));
+        }
+        let generated = i32::try_from(ordinal)
+            .ok()
+            .and_then(|n| n.checked_add(1))
+            .filter(|n| *n <= self.last)
+            .ok_or_else(|| Self::refusal("generated row ordinal exceeds planned state"))?;
+        budget.charge_work_units(values.len() as u64)?;
+        lowered[..values.len()].copy_from_slice(values);
+        lowered[self.column] = RowValue::Long(generated);
+        Ok(())
+    }
+
+    pub(crate) fn write(
+        self,
+        root: &mut [u8; PAGE_BYTES],
+        budget: &mut ResourceBudget,
+    ) -> Result<(), ComposeError> {
+        let mut writer = BinaryWriter::new(root, budget)?;
+        writer.seek(ByteOffset::new(STATE_OFFSET as u64))?;
+        writer.write_i32_le(self.last)?;
+        Ok(())
+    }
+
+    pub(crate) fn matches(self, root: &[u8; PAGE_BYTES]) -> bool {
+        root[STATE_OFFSET..STATE_OFFSET + size_of::<i32>()] == self.last.to_le_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_counter_boundary_and_exact_state_preservation()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let table = TableSpec {
+            name: b"T",
+            columns: &[crate::ColumnSpec::new(b"Id", ColumnType::AutoIncrement)],
+            indexes: &[],
+        };
+        assert!(InitialAutoIncrement::new(&table, i32::MAX as usize).is_err());
+        let generated =
+            InitialAutoIncrement::new(&table, i32::MAX as usize - 1)?.ok_or("no generator")?;
+        let mut bytes = [0xa5; PAGE_BYTES];
+        let mut budget = ResourceBudget::new(crate::ResourceLimits::default());
+        generated.write(&mut bytes, &mut budget)?;
+        assert!(generated.matches(&bytes));
+        assert_eq!(&bytes[..16], &[0xa5; 16]);
+        assert_eq!(&bytes[20..], &[0xa5; PAGE_BYTES - 20]);
+        let mut lowered = [RowValue::Null; u8::MAX as usize];
+        generated.lower(
+            &[RowValue::AutoIncrement],
+            i32::MAX as usize - 2,
+            &mut lowered,
+            &mut budget,
+        )?;
+        assert_eq!(lowered[0], RowValue::Long(i32::MAX - 1));
+        assert!(
+            generated
+                .lower(
+                    &[RowValue::AutoIncrement],
+                    i32::MAX as usize - 1,
+                    &mut lowered,
+                    &mut budget
+                )
+                .is_err()
+        );
+        Ok(())
+    }
+}

--- a/crates/jet3/src/bootstrap_compose_error.rs
+++ b/crates/jet3/src/bootstrap_compose_error.rs
@@ -41,7 +41,12 @@ pub enum ComposeError {
         /// The unsupported payload condition.
         detail: &'static str,
     },
-    /// Initial rows require a single-page definition without AutoIncrement.
+    /// Initial generated IDs exceed the supported construction.
+    InitialAutoIncrement {
+        /// Unsupported generation request or counter boundary.
+        detail: &'static str,
+    },
+    /// Initial rows require a single-page definition.
     UnsupportedInitialRowSchema,
     /// A table definition could not be encoded.
     Definition(TableDefinitionWriteError),
@@ -118,6 +123,7 @@ impl std::error::Error for ComposeError {
             Self::UnsupportedRelationship { .. }
             | Self::UnsupportedInitialRowSchema
             | Self::InitialLongValue { .. }
+            | Self::InitialAutoIncrement { .. }
             | Self::OrphanInitialRelationshipKey { .. }
             | Self::UnsupportedInitialIndexSchema
             | Self::NullInitialIndexKey { .. }

--- a/crates/jet3/src/bootstrap_composer.rs
+++ b/crates/jet3/src/bootstrap_composer.rs
@@ -768,3 +768,7 @@ mod relationship_candidate;
 
 pub use relationship_candidate::{RelationshipColumn, RelationshipSpec, TableRef};
 pub(crate) use relationship_candidate::{compose_relationship, compose_relationship_with_rows};
+
+#[path = "bootstrap_autoincrement.rs"]
+mod autoincrement;
+pub(crate) use autoincrement::InitialAutoIncrement;

--- a/crates/jet3/src/bootstrap_initial_index.rs
+++ b/crates/jet3/src/bootstrap_initial_index.rs
@@ -50,11 +50,12 @@ impl InitialLongIndex {
                 .resolve(spec.columns)
                 .map(usize::from)
                 .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
-            if spec
-                .columns
-                .get(column)
-                .is_none_or(|column| column.column_type() != ColumnType::Long)
-            {
+            if spec.columns.get(column).is_none_or(|column| {
+                !matches!(
+                    column.column_type(),
+                    ColumnType::Long | ColumnType::AutoIncrement
+                )
+            }) {
                 return Err(ComposeError::UnsupportedInitialIndexSchema);
             }
             *slot = LongField {

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -55,6 +55,7 @@ pub(super) struct PlannedCreate<'a> {
     initial_long_values: Option<InitialLongValues>,
     initial_row_count: u32,
     initial_index: Option<InitialLongIndex>,
+    initial_autoincrement: Option<InitialAutoIncrement>,
 }
 
 #[derive(Debug, Clone)]
@@ -91,6 +92,7 @@ impl<'a> PlannedCreate<'a> {
             initial_long_values: None,
             initial_row_count: 0,
             initial_index: None,
+            initial_autoincrement: None,
         })
     }
 
@@ -103,15 +105,11 @@ impl<'a> PlannedCreate<'a> {
         rows: &[&[RowValue<'_>]],
         budget: &mut ResourceBudget,
     ) -> Result<Self, ComposeError> {
-        if self.plan.continuation_page().is_some()
-            || self
-                .spec
-                .columns
-                .iter()
-                .any(|column| column.column_type() == ColumnType::AutoIncrement)
-        {
+        if self.plan.continuation_page().is_some() {
             return Err(ComposeError::UnsupportedInitialRowSchema);
         }
+        let generated = InitialAutoIncrement::new(self.spec, rows.len())?;
+        self.initial_autoincrement = generated;
         self.initial_index = InitialLongIndex::new(self.spec, rows.len(), budget)?;
         if rows.is_empty() {
             return Ok(self);
@@ -135,6 +133,13 @@ impl<'a> PlannedCreate<'a> {
         let mut builder = DataPageBuilder::new(self.plan.definition_root(), budget)?;
         let mut encoded = [0_u8; PAGE_BYTES];
         for (ordinal, row) in rows.iter().enumerate() {
+            let mut lowered = [RowValue::Null; u8::MAX as usize];
+            let row = if let Some(generated) = generated {
+                generated.lower(row, ordinal, &mut lowered, budget)?;
+                &lowered[..row.len()]
+            } else {
+                *row
+            };
             let length = encode_initial_row(
                 &layout,
                 row,
@@ -331,6 +336,9 @@ impl<'a> PlannedCreate<'a> {
         }
         let mut root = [0_u8; PAGE_BYTES];
         root.copy_from_slice(&logical[..PAGE_BYTES]);
+        if let Some(generated) = self.initial_autoincrement {
+            generated.write(&mut root, budget)?;
+        }
         let Some(continuation_page) = self.plan.continuation_page() else {
             return Ok((PageImage::from_bytes(root), None));
         };

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -20,8 +20,9 @@ use std::path::Path;
 
 use crate::atomic::atomic_create;
 use crate::bootstrap_composer::{
-    ComposeError, InitialLongIndex, compose_database, compose_database_with_table_rows,
-    encode_initial_row, initial_payload_start, initial_row_layout,
+    ComposeError, InitialAutoIncrement, InitialLongIndex, compose_database,
+    compose_database_with_table_rows, encode_initial_row, initial_payload_start,
+    initial_row_layout,
 };
 use crate::page_append_plan::PlannedPage;
 use crate::{
@@ -178,14 +179,20 @@ pub fn create_database(
 /// capacity. Each row and the table definition must fit one page. Pages with
 /// a slot and room for an all-null row are marked available; this construction
 /// policy has not been established as DAO's allocation policy.
-/// At most one index on one or two Long columns is accepted, with each field
+/// At most one index on one or two Long columns (including a generated
+/// AutoIncrement column) is accepted, with each field
 /// ascending or descending. One leaf holds at most 200 single-column or 128
 /// two-column entries. Primary and unique indexes reject duplicate full keys;
 /// ordinary indexes retain duplicates. Null components and other key types
 /// are refused. `EXP-0126` records the component encoding on exact fresh DAO
 /// controls; composite/descending Rust-created candidates await their own
 /// DAO differential.
-/// AutoIncrement is refused. One unindexed Memo or LongBinary column accepts
+/// One AutoIncrement column requires [`RowValue::AutoIncrement`] in every row;
+/// IDs start at 1 independently per table and the last generated ID is persisted.
+/// Null and explicit IDs are refused, as are counts reaching the signed Long
+/// boundary. DAO state observations cover 256 initial rows and a subsequent 257;
+/// larger counts and this composed generation await candidate validation.
+/// One unindexed Memo or LongBinary column accepts
 /// nonempty typed payloads or null; raw `RowValue::LongValue` headers are refused.
 /// The candidate policy stores up to 32 bytes inline, up to 2,036 on one LVAL
 /// page, and larger payloads in 2,032-byte chained fragments, one per page.
@@ -307,6 +314,19 @@ fn check_initial_table_rows(
     let definition = database
         .table_definition(root, budget)
         .map_err(CandidateCheckError::Definition)?;
+    let generated =
+        InitialAutoIncrement::new(table, rows.len()).map_err(CandidateCheckError::RowEncoding)?;
+    if let Some(generated) = generated {
+        let mut raw = [0_u8; crate::PAGE_BYTES];
+        database
+            .read_raw_page(root, &mut raw, budget)
+            .map_err(|error| CandidateCheckError::RowEncoding(ComposeError::Encoding(error)))?;
+        if !generated.matches(&raw) {
+            return Err(CandidateCheckError::Mismatch {
+                detail: "initial AutoIncrement state",
+            });
+        }
+    }
     let mut expected_index = InitialLongIndex::new(table, rows.len(), budget)
         .map_err(CandidateCheckError::RowEncoding)?;
     let mut next_payload = initial_payload_start(table, root, first_create)
@@ -316,6 +336,15 @@ fn check_initial_table_rows(
         .rows(&definition, budget)
         .map_err(CandidateCheckError::Rows)?;
     for (ordinal, row) in rows.iter().enumerate() {
+        let mut lowered = [RowValue::Null; u8::MAX as usize];
+        let row = if let Some(generated) = generated {
+            generated
+                .lower(row, ordinal, &mut lowered, cursor.owned.budget_mut())
+                .map_err(CandidateCheckError::RowEncoding)?;
+            &lowered[..row.len()]
+        } else {
+            *row
+        };
         let length = encode_initial_row(
             &layout,
             row,

--- a/crates/jet3/src/create_autoincrement_tests.rs
+++ b/crates/jet3/src/create_autoincrement_tests.rs
@@ -1,0 +1,177 @@
+use super::*;
+use crate::{TableRows, create_database_with_table_rows};
+
+const AUTO: ColumnSpec<'static> = ColumnSpec::new(b"Id", ColumnType::AutoIncrement);
+
+const TAG: ColumnSpec<'static> = ColumnSpec::new(b"Tag", ColumnType::Long);
+
+fn auto_table() -> TableSpec<'static> {
+    TableSpec {
+        name: b"Generated",
+        columns: &[AUTO, TAG],
+        indexes: &[],
+    }
+}
+
+#[test]
+fn autoincrement_generates_rows_and_detects_state_or_row_corruption() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let values = (1..=256)
+        .map(|tag| [RowValue::AutoIncrement, RowValue::Long(tag)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    let table = auto_table();
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let original = fs::read(directory.target())?;
+    assert_eq!(
+        &original[20 * crate::PAGE_BYTES + 16..20 * crate::PAGE_BYTES + 20],
+        &256_i32.to_le_bytes()
+    );
+    let mut changed = original.clone();
+    changed[20 * crate::PAGE_BYTES + 16] = 1;
+    fs::write(directory.target(), changed)?;
+    assert!(matches!(
+        crate::create::check_initial_rows(&directory.target(), &table, &rows, &mut budget()),
+        Err(CandidateCheckError::Mismatch {
+            detail: "initial AutoIncrement state"
+        })
+    ));
+    fs::write(directory.target(), original)?;
+    let mut changed_values = values.clone();
+    changed_values[0][1] = RowValue::Long(-1);
+    let changed_rows = changed_values
+        .iter()
+        .map(|row| row.as_slice())
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        crate::create::check_initial_rows(
+            &directory.target(),
+            &table,
+            &changed_rows,
+            &mut budget()
+        ),
+        Err(CandidateCheckError::Mismatch {
+            detail: "initial row value"
+        })
+    ));
+    Ok(())
+}
+
+#[test]
+fn autoincrement_invalid_values_and_types_leave_no_file() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        columns: &[AUTO],
+        ..auto_table()
+    };
+    for value in [RowValue::Null, RowValue::Long(1), RowValue::Text(b"1")] {
+        assert!(matches!(
+            create_database_with_rows(directory.target(), &table, &[&[value]], &mut budget()),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::InitialAutoIncrement { .. }
+            ))
+        ));
+    }
+    assert!(
+        create_database_with_rows(
+            directory.target(),
+            &scalar_table(),
+            &[&[RowValue::AutoIncrement, RowValue::Null]],
+            &mut budget()
+        )
+        .is_err()
+    );
+    assert!(create_database_with_rows(directory.target(), &table, &[&[]], &mut budget()).is_err());
+    let multiple = TableSpec {
+        columns: &[AUTO, ColumnSpec::new(b"Other", ColumnType::AutoIncrement)],
+        ..auto_table()
+    };
+    assert!(create_database_with_rows(directory.target(), &multiple, &[], &mut budget()).is_err());
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn autoincrement_multi_table_indexed_and_empty_counters_are_independent() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = [IndexSpec {
+        name: b"PrimaryKey",
+        fields: &[field(0, IndexDirection::Ascending)],
+        kind: IndexKind::Primary,
+    }];
+    let requests = [
+        TableRows {
+            table: TableSpec {
+                name: b"First",
+                columns: &[AUTO],
+                indexes: &indexes,
+            },
+            rows: &[&[RowValue::AutoIncrement], &[RowValue::AutoIncrement]],
+        },
+        TableRows {
+            table: TableSpec {
+                name: b"Second",
+                columns: &[AUTO],
+                indexes: &[],
+            },
+            rows: &[&[RowValue::AutoIncrement]],
+        },
+        TableRows {
+            table: TableSpec {
+                name: b"Empty",
+                columns: &[AUTO],
+                indexes: &[],
+            },
+            rows: &[],
+        },
+    ];
+    create_database_with_table_rows(directory.target(), &requests, &mut budget())?;
+    let mut operation = budget();
+    let mut database = DatabaseReader::open(directory.target(), &mut operation)?;
+    let tables = requests.map(|r| r.table);
+    let roots = crate::create::candidate_table_roots(&mut database, &tables, &mut operation)?;
+    for (root, count) in roots.into_iter().zip([2_i32, 1, 0]) {
+        let mut bytes = [0_u8; crate::PAGE_BYTES];
+        database.read_raw_page(root.ok_or("missing root")?, &mut bytes, &mut operation)?;
+        assert_eq!(&bytes[16..20], &count.to_le_bytes());
+    }
+    Ok(())
+}
+
+#[test]
+fn autoincrement_budget_and_existing_destination_are_preserved() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        columns: &[AUTO],
+        ..auto_table()
+    };
+    let rows: &[&[RowValue<'_>]] = &[&[RowValue::AutoIncrement]];
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(0));
+    assert!(create_database_with_rows(directory.target(), &table, rows, &mut limited).is_err());
+    assert!(directory.entries()?.is_empty());
+    fs::write(directory.target(), b"original")?;
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, rows, &mut budget()),
+        Err(CreateDatabaseError::Publish(_))
+    ));
+    assert_eq!(fs::read(directory.target())?, b"original");
+    Ok(())
+}
+
+#[test]
+fn autoincrement_positive_counts_are_not_limited_to_the_observed_sample() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let table = TableSpec {
+        columns: &[AUTO],
+        ..auto_table()
+    };
+    let row = [RowValue::AutoIncrement];
+    let rows = vec![row.as_slice(); 257];
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(
+        &bytes[20 * crate::PAGE_BYTES + 16..20 * crate::PAGE_BYTES + 20],
+        &257_i32.to_le_bytes()
+    );
+    Ok(())
+}

--- a/crates/jet3/src/create_initial_rows_tests.rs
+++ b/crates/jet3/src/create_initial_rows_tests.rs
@@ -83,7 +83,7 @@ fn unsupported_initial_row_schemas_leave_no_file() -> TestResult {
                 &mut budget()
             ),
             Err(CreateDatabaseError::Compose(
-                ComposeError::UnsupportedInitialRowSchema
+                ComposeError::InitialAutoIncrement { .. }
             ))
         ));
     }
@@ -374,3 +374,6 @@ mod long_values;
 
 #[path = "create_multi_table_rows_tests.rs"]
 mod multi_table;
+
+#[path = "create_autoincrement_tests.rs"]
+mod autoincrement;

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -78,6 +78,9 @@ impl From<&ColumnDefinition> for RowColumnLayout {
 pub enum RowValue<'a> {
     /// Absent value; for Boolean columns equivalent to `false`.
     Null,
+    /// Generate the next positive ID during initial database creation.
+    /// Required for AutoIncrement columns; standalone row encoding refuses it.
+    AutoIncrement,
     /// Boolean stored as the presence bit.
     Boolean(bool),
     /// Unsigned eight-bit integer.
@@ -642,6 +645,7 @@ fn write_scalar(writer: &mut BinaryWriter<'_, '_>, value: RowValue<'_>) -> Resul
             d[14], d[15],
         ]),
         RowValue::Null
+        | RowValue::AutoIncrement
         | RowValue::Boolean(_)
         | RowValue::Binary(_)
         | RowValue::LongValue(_)

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10992,6 +10992,38 @@ Copy this block under the appropriate section and remove this instruction:
   Report compatibility and support-matrix flags remain false.
 
 
+## EXP-0136 — Retained AutoIncrement state observations
+
+- Status: validated `answered` secondary analysis under EXP-0135, not a new
+  acquisition or a revision of EXP-0132's preserved `no_outcome`.
+  Plan SHA-256:
+  `13ab8dab2f129fa8a859545e896fa3376836cde938c14e673a842d1d87b5c96f`.
+- External report: `20260905T045600Z-autoincrement-secondary/report.json`,
+  1,080,091 bytes, SHA-256
+  `670cc25e591afb33a987e6a8c6e26852e0543ab5a24939b903c25e876dfe01e6`.
+  Reproduced byte-identically from temporary copies of the pinned original
+  result/report and all 36 captures; originals remain unchanged. The only
+  decoder adjustment was its private row-directory limit from 64 to 256.
+- All three replicas passed the original correlations and all three finite
+  hypotheses. In the AutoIncrement arm, TDEF `[16,20)` held signed
+  little-endian values 0, 1, 255, 256, 256 and 257 at the empty, one, n255,
+  n256, deleted and next checkpoints respectively. Row counts were 0, 1,
+  255, 256, 255 and 256. Generated IDs matched insertion Tags; the next
+  insertion after deleting Tag 256 generated ID 257 in every replica.
+- Paired ordinary Long controls held zero throughout TDEF `[16,20)` with
+  the same row counts and explicit ID/Tag values. User-definition changes
+  in both arms were confined to existing row-count bytes `[12,16)` and,
+  only for generated inserts in the AutoIncrement arm, `[16,20)`. Deletion
+  changed row count but retained the last generated number. Thus this slot
+  records last-generated state for these finite positive cases, rather than
+  current row count or the largest surviving ID.
+- This supports a bounded initial construction that generates IDs 1 through
+  at most 256 and persists that last generated value. The state observed at
+  257 followed deletion/reopening; no arbitrary high seed, explicit Auto ID,
+  overflow, indexed generation or generalized update grammar was tested.
+  Rust candidate acceptance and subsequent DAO insertion remain separate
+  validation work. No compatibility or hosted support claim follows.
+
 ## EXP-0135 — Retained AutoIncrement captures secondary-analysis plan
 
 - Status: post-acquisition secondary analysis planned; expanded analysis has

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -46,8 +46,11 @@ delivered in this order:
 Continue database creation under #100. Initial-row creation now accepts up to
 four tables with scalar rows across data pages, bounded Long indexes, and
 one unindexed Memo/OLE column per table. Existing schema, single-leaf and
-inline-map bounds still apply. AutoIncrement values and empty long payloads
-remain refused.
+inline-map bounds still apply. One AutoIncrement column per table accepts
+explicit generation requests and persists its last generated ID, including
+when indexed; explicit IDs and empty long payloads remain refused. EXP-0136
+records secondary analysis of DAO state observations. Generated Rust candidates
+and subsequent DAO insertion still need validation.
 
 `EXP-0130` records exact local mixed-table and empty-first candidate acceptance,
 including later-table index traversal and Memo/OLE payloads. Earlier exact
@@ -61,8 +64,8 @@ unique Long index, and an initially unindexed child. Populated relationships
 and referential-integrity mutations remain unvalidated.
 
 Next, combine relationships with initial rows, including the child foreign
-index and initial referential checks. AutoIncrement state needs separate
-observation. After creation is complete, run the hosted write differential
+index and initial referential checks. AutoIncrement creation needs candidate and follow-on insertion
+validation. After creation is complete, run the hosted write differential
 (#102), implement updates preserving unrelated data (#112), then run the
 hosted update differential (#113). Keep module cleanup (#182) until the
 creation API settles.


### PR DESCRIPTION
`RowValue::AutoIncrement` requests generated positive Long IDs during creation. IDs and persisted last-generated state are tracked independently per table, lowered before row/index encoding, and verified before atomic publication. Existing indexes can use the generated column.

Explicit/null IDs, multiple generated columns per table, and unsupported signed-counter boundaries fail structurally. Existing schema, index-leaf, and allocation bounds apply; the API has no arbitrary 256-row cap.

EXP-0136 records the separate retained-artifact analysis establishing the observed state encoding and delete/reopen behavior, while preserving EXP-0132's original no-outcome. Larger and indexed Rust candidates remain subject to separate DAO validation.

Validation: independent implementation/outcome review found no issues; six AutoIncrement tests, initial-row and relationship integration tests, scoped Clippy, exact secondary-report reproduction, and final `just ready` passed.

Part of #100.
