### PR TITLE
test: preregister AutoIncrement candidate continuation checks

### DIFF
--- a/crates/jet3/examples/autoincrement_validation_candidate.rs
+++ b/crates/jet3/examples/autoincrement_validation_candidate.rs
@@ -1,0 +1,63 @@
+//! Deterministic AutoIncrement candidates; no DAO acceptance is asserted.
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
+    ResourceBudget, ResourceLimits, RowValue, TableRows, TableSpec,
+    create_database_with_table_rows,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() != 3 {
+        return Err(
+            "usage: autoincrement_validation_candidate OUTPUT.mdb unindexed|indexed|multi".into(),
+        );
+    }
+    let count = match args[2].as_str() {
+        "unindexed" | "multi" => 300,
+        "indexed" => 10,
+        _ => return Err("unknown arm".into()),
+    };
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::AutoIncrement),
+        ColumnSpec::new(b"Tag", ColumnType::Long),
+    ];
+    let fields = [IndexColumnSpec {
+        column: ColumnRef::Ordinal(0),
+        direction: IndexDirection::Ascending,
+    }];
+    let indexes = [IndexSpec {
+        name: b"PrimaryKey",
+        fields: &fields,
+        kind: IndexKind::Primary,
+    }];
+    let values = (1..=count)
+        .map(|tag| [RowValue::AutoIncrement, RowValue::Long(tag)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    let second = [RowValue::AutoIncrement, RowValue::Long(-1)];
+    let second_rows = [second.as_slice()];
+    let mut requests = vec![TableRows {
+        table: TableSpec {
+            name: b"Rows",
+            columns: &columns,
+            indexes: if args[2] == "indexed" { &indexes } else { &[] },
+        },
+        rows: &rows,
+    }];
+    if args[2] == "multi" {
+        requests.push(TableRows {
+            table: TableSpec {
+                name: b"Later",
+                columns: &columns,
+                indexes: &indexes,
+            },
+            rows: &second_rows,
+        });
+    }
+    create_database_with_table_rows(
+        &args[1],
+        &requests,
+        &mut ResourceBudget::new(ResourceLimits::default()),
+    )?;
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -10992,6 +10992,43 @@ Copy this block under the appropriate section and remove this instruction:
   Report compatibility and support-matrix flags remain false.
 
 
+## EXP-0137 — Generated AutoIncrement candidate preregistration
+
+- Status: preregistered; no acquisition recorded here. Plan:
+  `oracle/windows-dao/acquisition/autoincrement-candidate.plan.json`, SHA-256
+  `503fc74b9179c3ea8c33a6f9606e5fdbf7d737c04b6dd9fbe3d9bd7594550cca`.
+  Inputs pin the dedicated exporter, acquisition/analyzer scripts, original
+  system-catalog decoder and transport. Candidate identities are pinned in
+  the plan; source library commit `d106f83` has completed review and checks.
+- Three arms: 300 generated unindexed rows; 10 generated rows with an
+  ascending AutoIncrement primary index; and two tables with independent
+  counters (300 unindexed rows and one indexed row). All tables have
+  `Id AutoIncrement` and `Tag Long`. The dedicated exporter preserves earlier
+  experiment candidates and uses the reviewed public generation API.
+- Three fresh DAO controls per arm match the complete declared schema and
+  insertion order. Observe each control and pinned candidate read-only with
+  unchanged identities, then independently copy each closed file and insert
+  once per table while omitting `Id`. Record its actual generated ID, close,
+  and observe the post-insert copy read-only. Expected successors are 301,
+  11 and, in the two-table arm, independently 301 and 2.
+- Compare complete table/column/index metadata, every row, complete ascending
+  traversal and Seek for every indexed ID, exact last-generated state and
+  row count before and after insertion. Original decoding uses a private
+  instance with its declared row-directory limit raised from 64 to 256;
+  other structural checks remain unchanged. No analysis limit is retrofitted
+  after acquisition. Ordinary row order and allocator locations are excluded
+  from equality; no row, index entry or state is omitted.
+- Require all nine complete pairs, valid controls, unchanged read-only
+  identities, correct copy-start identities and three matching replicas.
+  Repeatable candidate mismatch is `not_observed_accepted`; incomplete or
+  invalid controls, acquisition error or disagreement yields `no_outcome`.
+  Input/result or retained-identity mismatches reject validation. One attempt,
+  no automatic retry after the first mutation; retain all 36 files externally.
+- EXP-0136 supplies the state observation; EXP-0132 remains `no_outcome`.
+  Record one EXP-0138 outcome. This tests only the declared generated starts
+  and one subsequent insert, without explicit Auto ID assignment, high seeds,
+  deletion, overflow, relationships, LVAL or general compatibility/support.
+
 ## EXP-0136 — Retained AutoIncrement state observations
 
 - Status: validated `answered` secondary analysis under EXP-0135, not a new

--- a/oracle/windows-dao/acquisition/autoincrement-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/autoincrement-candidate.plan.json
@@ -1,0 +1,87 @@
+{
+  "document_type": "dao_autoincrement_candidate_plan",
+  "experiment_id": "autoincrement-candidate",
+  "entry": "EXP-0137",
+  "outcome_entry": "EXP-0138",
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "question": "Do exact generated AutoIncrement candidates match fresh DAO controls, and does one generated insertion on an independent writable copy continue each persisted sequence?",
+    "authorization": "Commit and independently review this pinned plan before acquisition. User authorizes DAO; one dispatch only. Post-first-mutation failure is a scientific result, never automatic retry."
+  },
+  "source": {
+    "reviewed_library_commit": "d106f83",
+    "implementation_commit": "9e4fbf7",
+    "state_evidence": "EXP-0136 secondary analysis; original EXP-0132 no_outcome remains preserved. Typed last-generated Long slot at user TDEF[16,20).",
+    "export": "cargo run -p jet3 --example autoincrement_validation_candidate -- OUTPUT.mdb ARM",
+    "exporter": "Dedicated experiment exporter; prior consumed candidates unchanged."
+  },
+  "arms": {
+    "unindexed": [
+      {
+        "name": "Rows",
+        "count": 300,
+        "indexed": false
+      }
+    ],
+    "indexed": [
+      {
+        "name": "Rows",
+        "count": 10,
+        "indexed": true
+      }
+    ],
+    "multi": [
+      {
+        "name": "Rows",
+        "count": 300,
+        "indexed": false
+      },
+      {
+        "name": "Later",
+        "count": 1,
+        "indexed": true
+      }
+    ]
+  },
+  "schema": "Every table has Id AutoIncrement Long then Tag ordinary Long. Indexed tables have ascending PrimaryKey(Id), primary/unique/required, not foreign or IgnoreNulls.",
+  "rows": "Rows inserts Tag1..count in order while omitting Id. Later inserts Tag-1 with generated Id1. Every table receives exactly one further generated insert with Tag1001 on each independent writable copy; expected Id=count+1.",
+  "candidates": {
+    "unindexed": {
+      "size": 51200,
+      "sha256": "2d7e3910f86587a428eab82c0f9f8c46e4d97478bd7b9949a3da7aed7bdd65dc"
+    },
+    "indexed": {
+      "size": 51200,
+      "sha256": "d101881cf90ba1f71906b84b7cbab2473818fbad8551e522e9d868bb2a7ab2d2"
+    },
+    "multi": {
+      "size": 59392,
+      "sha256": "df823f4c3e40b442dc9220303e2ff81c0e669af55a280547c3c720b35dc9b0b2"
+    }
+  },
+  "execution": {
+    "environment": "Local private Windows VM, x86 PowerShell, DAO.DBEngine.36, version3.0, CP1252 creation options32.",
+    "order": "Arms unindexed,indexed,multi; replicas1..3. Prepare and pin all9 candidate copies before first control creation. For each pair create fresh matching control; observe control then candidate read-only, each with before/after hash; copy each closed original to a distinct writable post file; open writable, insert once per table without assigning Id, capture LastModified Id, close; observe post file read-only and hash before/after. Retain all36 originals/post files. No equality required between physical layouts of control/candidate.",
+    "capture": "Complete version/table inventory/table attributes/column name,type,size,raw attributes/all index flags and field bindings; every Id/Tag row, full ascending indexed traversal, Seek every full Id key, exact returned rows and next generated Id for each table.",
+    "decode": "Load original system_catalog in a private instance with declared MAX_ROWS_PER_PAGE256 (original64), sufficient for any one-byte row slot; all other checks unchanged. Decode all retained files and correlate complete rows and TDEF row counts with DAO; read signed little-endian TDEF[16,20) state. Original helper limits otherwise apply. No retrospective bound changes.",
+    "normalization": "Ignore only physical page addresses and ordinary row snapshot order. Preserve exact metadata, complete row/traversal/Seek inventories, per-table counts and state. No reliance on equal allocator locations.",
+    "attempts": 1,
+    "run": "python3 oracle/windows-dao/scripts/autoincrement_candidate.py run CANDIDATE_DIRECTORY --shared-root VM_SHARED_ROOT --run-id UTC-autoincrement-candidate"
+  },
+  "decision_rule": {
+    "accepted": "All9 complete pairs, controls pass all initial/post/insert checks, read-only identities unchanged, writable-copy starting identities equal their observed initial source. Each arm repeats exact normalized observations3times and candidate equals control in full checked metadata,rows,index traversal/Seek,last state and actual inserted IDs.",
+    "not_observed_accepted": "Complete valid controls and unchanged identities, repeatable candidate mismatch or candidate failure.",
+    "no_outcome": "Incomplete result, acquisition error, controls fail, changed read-only files or replica disagreement. Retain failure; no retries.",
+    "rejected": "Bad environment/result identity, modified pinned inputs, unexpected inventory or retained identity mismatch."
+  },
+  "limits": "Only exact named/scalar/index/count arms and one follow-on insert per table. No explicit Auto ID assignment, high seed, deletion, rollback, overflow, relationships, LVAL, arbitrary schema or hosted support claim. One additive EXP-0138 outcome; MDB/provider bytes retained externally only.",
+  "inputs": {
+    "oracle/windows-dao/scripts/autoincrement_candidate.py": "1aede4abbe201ee5fa00cf9f6fe2de680d504f596c547efd0c93e393396f251f",
+    "oracle/windows-dao/scripts/autoincrement_candidate.ps1": "2bd4bada82f531b568e2b16dda8563b7d2911485d059ad0132016525d758a78c",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/autoincrement_validation_candidate.rs": "985ca7f8ea84685b5c253994c02e8df92c7704906d8280f6cbceeb6cf9cc95c7"
+  }
+}

--- a/oracle/windows-dao/scripts/autoincrement_candidate.ps1
+++ b/oracle/windows-dao/scripts/autoincrement_candidate.ps1
@@ -1,0 +1,161 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, (($Value | ConvertTo-Json -Depth 20) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function New-Control([string]$Path, $Tables) {
+    $engine = $workspace = $db = $table = $field = $index = $key = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($spec in $Tables) {
+            $table = $db.CreateTableDef([string]$spec.name)
+            foreach ($name in @('Id', 'Tag')) {
+                $field = $table.CreateField($name, 4)
+                if ($name -eq 'Id') { $field.Attributes = 16 }
+                $table.Fields.Append($field)
+                Release $field; $field = $null
+            }
+            if ($spec.indexed) {
+                $index = $table.CreateIndex('PrimaryKey'); $index.Primary = $true
+                $key = $index.CreateField('Id'); $index.Fields.Append($key)
+                $table.Indexes.Append($index)
+                Release $key; $key = $null; Release $index; $index = $null
+            }
+            $db.TableDefs.Append($table)
+            $rs = $db.OpenRecordset([string]$spec.name, 2)
+            foreach ($n in 1..([int]$spec.count)) {
+                $rs.AddNew()
+                $rs.Fields.Item('Tag').Value = if ($spec.name -eq 'Later') { -1 } else { $n }
+                $rs.Update()
+            }
+            $rs.Close(); Release $rs; $rs = $null; Release $table; $table = $null
+        }
+    } finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs; Release $key; Release $index; Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset) { return ,@([int]$Recordset.Fields.Item('Id').Value, [int]$Recordset.Fields.Item('Tag').Value) }
+function Observe([string]$Path, $Tables, [bool]$Post) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'; $status = 'pass'; $errorDetail = $null; $snapshot = [ordered]@{}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.user_tables = @()
+        foreach ($spec in $Tables) {
+            $endpoint = 'schema'
+            $table = $db.TableDefs.Item([string]$spec.name)
+            $item = [ordered]@{name=[string]$table.Name; attributes=[int]$table.Attributes}
+            $item.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes} })
+            $item.indexes = @($table.Indexes | ForEach-Object {
+                @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls;
+                  fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes; descending=(([int]$_.Attributes -band 1) -ne 0)} })}
+            })
+            $endpoint = 'rows'; $rs = $db.OpenRecordset([string]$spec.name, 4)
+            $rows = New-Object Collections.ArrayList
+            while (-not $rs.EOF) { [void]$rows.Add((Read-Row $rs)); $rs.MoveNext() }
+            $item.rows = @($rows); $rs.Close(); Release $rs; $rs = $null
+            $item.traversal = @(); $item.seek = @()
+            if ($spec.indexed) {
+                $endpoint = 'index_traversal'; $rs = $db.OpenRecordset([string]$spec.name, 1); $rs.Index = 'PrimaryKey'
+                $rs.MoveFirst(); $traversal = New-Object Collections.ArrayList
+                while (-not $rs.EOF) { [void]$traversal.Add((Read-Row $rs)); $rs.MoveNext() }
+                $item.traversal = @($traversal); $endpoint = 'seek'; $seeks = New-Object Collections.ArrayList
+                $count = [int]$spec.count + [int]$Post
+                foreach ($n in 1..$count) {
+                    $rs.Seek('=', [int]$n)
+                    $row = if ($rs.NoMatch) { $null } else { Read-Row $rs }
+                    [void]$seeks.Add(@{query=$n; row=$row})
+                }
+                $item.seek = @($seeks); $rs.Close(); Release $rs; $rs = $null
+            }
+            $snapshot.user_tables += $item
+            Release $table; $table = $null
+        }
+        $endpoint = 'complete'
+    } catch { $status = 'fail'; $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>') }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+function Insert-One([string]$Path, $Tables) {
+    $engine = $db = $rs = $null
+    $result = @{status='pass'; error=$null; ids=@()}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $false)
+        foreach ($spec in $Tables) {
+            $rs = $db.OpenRecordset([string]$spec.name, 2)
+            $rs.AddNew(); $rs.Fields.Item('Tag').Value = 1001; $rs.Update()
+            $rs.Bookmark = $rs.LastModified
+            $result.ids += [int]$rs.Fields.Item('Id').Value
+            $rs.Close(); Release $rs; $rs = $null
+        }
+    } catch { $result.status = 'fail'; $result.error = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>') }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $engine
+    }
+    return $result
+}
+$planPath = Join-Path $env:JET3_WORK 'autoincrement-candidate.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/autoincrement_candidate.ps1') { throw 'Script pin mismatch' }
+$arms = @('unindexed', 'indexed', 'multi')
+foreach ($name in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$name-candidate-r$replica-initial.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$name.mdb") -Destination $path
+        $actual = Identity $path; $expected = $plan.candidates.$name
+        if ($actual.size -ne $expected.size -or $actual.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{document_type='dao_autoincrement_candidate_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=32; os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null}
+try {
+    foreach ($name in $arms) {
+        foreach ($replica in 1..3) {
+            $tables = $plan.arms.$name
+            New-Control (Join-Path $env:JET3_WORK "$name-control-r$replica-initial.mdb") $tables
+            $pair = @{arm=$name; replica=$replica}
+            foreach ($role in @('control', 'candidate')) {
+                $initial = Join-Path $env:JET3_WORK "$name-$role-r$replica-initial.mdb"
+                $post = Join-Path $env:JET3_WORK "$name-$role-r$replica-post.mdb"
+                $observation = Observe $initial $tables $false
+                Copy-Item -LiteralPath $initial -Destination $post
+                $copyBefore = Identity $post
+                $insert = Insert-One $post $tables
+                $pair[$role] = @{initial=$observation; copy_before=$copyBefore; insert=$insert; post=(Observe $post $tables $true)}
+            }
+            $result.replicas += $pair
+        }
+    }
+} catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/autoincrement_candidate.py
+++ b/oracle/windows-dao/scripts/autoincrement_candidate.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Preregistered descending/composite candidate DAO experiment: preflight, dispatch once, analyze.
+
+Uses only the low-level SSH transport helpers from windows-dao-ps.py. Its
+ad-hoc discovery entry point is never used. Local results do not move the
+hosted support matrix.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/autoincrement-candidate.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/autoincrement_candidate.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError(f'Input pin mismatch: {name}')
+
+
+ARMS = ('unindexed', 'indexed', 'multi')
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'autoincrement-candidate' or plan['replicas'] != 3 or list(plan['candidates']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        if identity(candidate_directory / f'{arm}.mdb') != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+    # The exact plan must already exist in a commit before acquisition.
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def decoder():
+    spec = importlib.util.spec_from_file_location('auto_candidate_catalog', ROOT / 'oracle/windows-dao/scripts/system_catalog.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if module.MAX_ROWS_PER_PAGE != 64:
+        raise ValueError('Unexpected original decoder bound')
+    module.MAX_ROWS_PER_PAGE = 256
+    return module
+
+
+def expected_rows(table, post):
+    rows = [[n, n] for n in range(1, table['count'] + 1)]
+    if table['name'] == 'Later':
+        rows = [[1, -1]]
+    if post:
+        rows.append([table['count'] + 1, 1001])
+    return rows
+
+
+def semantics(observation, tables, post, path):
+    if observation['status'] != 'pass' or observation['endpoint'] != 'complete' or observation['error'] is not None:
+        return False, {'status': observation['status'], 'error': observation['error']}
+    snapshot = observation['snapshot']
+    expected = {'version': '3.0', 'tables': sorted(['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships'] + [t['name'] for t in tables]), 'user_tables': []}
+    for table in tables:
+        rows = expected_rows(table, post)
+        indexes = []
+        if table['indexed']:
+            indexes = [{'name': 'PrimaryKey', 'primary': True, 'unique': True, 'required': True,
+                'foreign': False, 'ignore_nulls': False, 'fields': [{'name': 'Id', 'attributes': 0, 'descending': False}]}]
+        expected['user_tables'].append({'name': table['name'], 'attributes': 0,
+            'fields': [{'name': 'Id', 'type': 4, 'size': 4, 'attributes': 17}, {'name': 'Tag', 'type': 4, 'size': 4, 'attributes': 1}],
+            'indexes': indexes, 'rows': rows,
+            'traversal': rows if table['indexed'] else [],
+            'seek': [{'query': row[0], 'row': row} for row in rows] if table['indexed'] else []})
+    normalized = json.loads(json.dumps(snapshot))
+    for table in normalized.get('user_tables', []):
+        table['rows'] = sorted(table['rows'])
+    module = decoder()
+    try:
+        data = path.read_bytes()
+        decoded = module.analyze_checkpoint(data)
+        named = {t['name']: t for t in decoded['tables'].values()}
+        states = []
+        good = normalized == expected
+        for table in tables:
+            definition = named[table['name']]['definition']
+            root = definition['root']
+            raw = module._page(data, root, 'user TDEF')
+            state = int.from_bytes(raw[16:20], 'little', signed=True)
+            rows = module._table_rows(data, definition, named[table['name']]['data_pages'])
+            wanted = expected_rows(table, post)
+            good &= (state == table['count'] + int(post) and definition['row_count'] == len(wanted)
+                     and sorted(row['values'] for row in rows) == wanted)
+            states.append({'name': table['name'], 'last_generated': state, 'row_count': definition['row_count']})
+        return good, {'snapshot': normalized, 'states': states}
+    except (module.DecodeError, KeyError, ValueError) as error:
+        return False, {'snapshot': normalized, 'decode_error': str(error)}
+
+
+def build_report(result, outbox, plan):
+    if (result['document_type'] != 'dao_autoincrement_candidate_result'
+            or result['plan_sha256'] != digest(PLAN) or result['development_only'] is not True
+            or result['environment']['process_bits'] != 32 or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    expected = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual != expected[:len(actual)]:
+        raise ValueError('Unexpected replica inventory')
+    compared, grouped = [], {arm: [] for arm in ARMS}
+    unchanged, controls_ok = True, True
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        roles = {}
+        for role in ('control', 'candidate'):
+            stages = {}
+            for post in (False, True):
+                stage = 'post' if post else 'initial'
+                observation = item[role][stage]
+                path = outbox / f'{arm}-{role}-r{replica}-{stage}.mdb'
+                if identity(path) != observation['after']:
+                    raise ValueError('Retained image identity mismatch')
+                unchanged &= observation['before'] == observation['after']
+                if not post and role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                    raise ValueError('Initial candidate pin mismatch')
+                stages[stage] = semantics(observation, plan['arms'][arm], post, path)
+            if item[role]['copy_before'] != item[role]['initial']['after']:
+                raise ValueError('Writable copy did not start from observed source')
+            insertion = item[role]['insert']
+            inserted = insertion['status'] == 'pass' and insertion['error'] is None and insertion['ids'] == [t['count'] + 1 for t in plan['arms'][arm]]
+            roles[role] = {'initial': stages['initial'], 'post': stages['post'], 'insert': insertion,
+                           'passed': inserted and all(s[0] for s in stages.values())}
+        controls_ok &= roles['control']['passed']
+        grouped[arm].append(roles)
+        compared.append({'arm': arm, 'replica': replica, **roles})
+    outcomes = dict.fromkeys(ARMS, 'no_outcome')
+    if actual == expected and result['error'] is None and result['mutation_started'] is True and unchanged and controls_ok:
+        for arm, observations in grouped.items():
+            if all(item == observations[0] for item in observations):
+                pair = observations[0]
+                outcomes[arm] = 'observed_accepted' if pair['candidate']['passed'] and pair['control'] == pair['candidate'] else 'not_observed_accepted'
+    return {'document_type': 'dao_autoincrement_candidate_report', 'plan_sha256': digest(PLAN),
+        'development_only': True, 'compatibility_claim': False, 'support_movement': False,
+        'outcomes': outcomes, 'observations': compared, 'unchanged': unchanged, 'controls_ok': controls_ok,
+        'acquisition_error': result['error'], 'mutation_started': result['mutation_started']}
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(report['outcomes']))
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'autoincrement-candidate.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_autoincrement_candidate.py
+++ b/oracle/windows-dao/tests/test_autoincrement_candidate.py
@@ -1,0 +1,84 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import autoincrement_candidate as experiment
+
+
+class CandidateTests(unittest.TestCase):
+    def fixture(self, outbox):
+        plan = {'arms': {arm: [{'name': 'Rows', 'count': 1, 'indexed': False}] for arm in experiment.ARMS}, 'candidates': {}}
+        result = {'document_type': 'dao_autoincrement_candidate_result', 'development_only': True,
+                  'plan_sha256': experiment.digest(experiment.PLAN), 'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'},
+                  'mutation_started': True, 'error': None, 'replicas': []}
+        for arm in experiment.ARMS:
+            for replica in range(1, 4):
+                item = {'arm': arm, 'replica': replica}
+                for role in ('control', 'candidate'):
+                    stages = {}
+                    for stage in ('initial', 'post'):
+                        path = outbox / f'{arm}-{role}-r{replica}-{stage}.mdb'
+                        path.write_bytes(stage.encode())
+                        identity = experiment.identity(path)
+                        stages[stage] = {'before': identity, 'after': identity, 'status': 'pass', 'endpoint': 'complete', 'error': None}
+                    stages['copy_before'] = stages['initial']['after']
+                    stages['insert'] = {'status': 'pass', 'error': None, 'ids': [2]}
+                    item[role] = stages
+                plan['candidates'][arm] = item['candidate']['initial']['before']
+                result['replicas'].append(item)
+        return plan, result
+
+    def test_complete_controls_identity_and_insert_gates(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'semantics', return_value=(True, {'complete': True})):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            self.assertEqual(set(experiment.build_report(result, outbox, plan)['outcomes'].values()), {'observed_accepted'})
+            altered = copy.deepcopy(result)
+            for pair in altered['replicas']:
+                pair['candidate']['insert']['ids'] = [1]
+            self.assertEqual(set(experiment.build_report(altered, outbox, plan)['outcomes'].values()), {'not_observed_accepted'})
+            for field, value in [('error', 'post-mutation failure'), ('mutation_started', False)]:
+                altered = copy.deepcopy(result); altered[field] = value
+                self.assertEqual(set(experiment.build_report(altered, outbox, plan)['outcomes'].values()), {'no_outcome'})
+            altered = copy.deepcopy(result); altered['replicas'].pop()
+            self.assertEqual(set(experiment.build_report(altered, outbox, plan)['outcomes'].values()), {'no_outcome'})
+            altered = copy.deepcopy(result); altered['replicas'][0]['control']['post']['before'] = {}
+            self.assertFalse(experiment.build_report(altered, outbox, plan)['unchanged'])
+            (outbox / 'unindexed-candidate-r1-initial.mdb').write_bytes(b'changed')
+            with self.assertRaisesRegex(ValueError, 'identity mismatch'):
+                experiment.build_report(result, outbox, plan)
+
+    def test_rows_and_persisted_state_must_both_match(self):
+        table = {'name': 'Rows', 'count': 1, 'indexed': False}
+        snapshot = {'version': '3.0', 'tables': ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows'],
+            'user_tables': [{'name': 'Rows', 'attributes': 0, 'fields': [
+                {'name': 'Id', 'type': 4, 'size': 4, 'attributes': 17}, {'name': 'Tag', 'type': 4, 'size': 4, 'attributes': 1}],
+                'indexes': [], 'rows': [[1, 1]], 'traversal': [], 'seek': []}]}
+        observation = {'status': 'pass', 'endpoint': 'complete', 'error': None, 'snapshot': snapshot}
+        raw = bytearray(2048); raw[16] = 1
+        decoder = types.SimpleNamespace(DecodeError=ValueError,
+            analyze_checkpoint=lambda data: {'tables': {20: {'name': 'Rows', 'definition': {'root': 20, 'row_count': 1}, 'data_pages': [23]}}},
+            _page=lambda *args: raw, _table_rows=lambda *args: [{'values': [1, 1]}])
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'decoder', return_value=decoder):
+            path = Path(temporary) / 'test.mdb'; path.write_bytes(b'fixture')
+            self.assertTrue(experiment.semantics(observation, [table], False, path)[0])
+            raw[16] = 0
+            self.assertFalse(experiment.semantics(observation, [table], False, path)[0])
+            raw[16] = 1; snapshot['user_tables'][0]['rows'] = [[2, 1]]
+            self.assertFalse(experiment.semantics(observation, [table], False, path)[0])
+
+    def test_analysis_checks_pins_and_private_decoder_has_planned_bound(self):
+        self.assertEqual(experiment.decoder().MAX_ROWS_PER_PAGE, 256)
+        with patch.object(experiment, 'verify_inputs', side_effect=ValueError('Input pin mismatch')):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                experiment.analyze(Path('unused'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Rust-created AutoIncrement tables need DAO confirmation that persisted counters continue correctly. Preregister EXP-0137 for three matched candidate/control arms: 300 generated rows, an indexed counter, and independent counters in two tables. Read-only observations compare complete schema, rows, traversal/Seek and counter state; separate writable copies each receive one generated insert.

The committed plan pins candidates and acquisition inputs and permits one dispatch. Independent review, three classifier tests, PowerShell parser checks, candidate generation, pinned-input verification and `just ready` pass. Local evidence only; no hosted support movement. Advances #100.
