### PR TITLE
feat: create multi-level Long indexes

### DIFF
--- a/crates/jet3/examples/multi_level_index_candidate.rs
+++ b/crates/jet3/examples/multi_level_index_candidate.rs
@@ -1,0 +1,141 @@
+//! Deterministic multi-level Long index candidates for separate DAO validation.
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
+    RelationshipColumn, RelationshipSpec, ResourceBudget, ResourceLimits, RowValue, TableRef,
+    TableRows, TableSpec, create_database_with_relationship_rows, create_database_with_table_rows,
+};
+use std::path::Path;
+
+const COLUMNS: [ColumnSpec<'static>; 2] = [
+    ColumnSpec::new(b"Id", ColumnType::Long),
+    ColumnSpec::new(b"Payload", ColumnType::Long),
+];
+const PRIMARY: [IndexSpec<'static>; 1] = [IndexSpec {
+    name: b"ById",
+    fields: &[IndexColumnSpec {
+        column: ColumnRef::Ordinal(0),
+        direction: IndexDirection::Ascending,
+    }],
+    kind: IndexKind::Primary,
+}];
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn references<'a>(rows: &'a [[RowValue<'a>; 2]]) -> Vec<&'a [RowValue<'a>]> {
+    rows.iter().map(|row| row.as_slice()).collect()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = std::env::args_os()
+        .nth(1)
+        .ok_or("usage: multi_level_index_candidate OUTPUT_DIRECTORY")?;
+    let directory = Path::new(&directory);
+    std::fs::create_dir_all(directory)?;
+    let rows = (0..27801)
+        .map(|position| [RowValue::Long(27800 - position), RowValue::Long(position)])
+        .collect::<Vec<_>>();
+    create_database_with_table_rows(
+        directory.join("primary.mdb"),
+        &[TableRows {
+            table: TableSpec {
+                name: b"Rows",
+                columns: &COLUMNS,
+                indexes: &PRIMARY,
+            },
+            rows: &references(&rows),
+        }],
+        &mut budget(),
+    )?;
+
+    let columns = [
+        ColumnSpec::new(b"A", ColumnType::Long),
+        ColumnSpec::new(b"B", ColumnType::Long),
+        COLUMNS[1],
+    ];
+    let indexes = [IndexSpec {
+        name: b"ByKey",
+        fields: &[
+            IndexColumnSpec {
+                column: ColumnRef::Ordinal(1),
+                direction: IndexDirection::Descending,
+            },
+            IndexColumnSpec::ascending(b"A"),
+        ],
+        kind: IndexKind::Ordinary,
+    }];
+    let rows = (0..12929)
+        .map(|position| {
+            [
+                RowValue::Long(position / 400),
+                RowValue::Long(position / 800 - 9),
+                RowValue::Long(position),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let references = rows.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_table_rows(
+        directory.join("composite.mdb"),
+        &[
+            TableRows {
+                table: TableSpec {
+                    name: b"Empty",
+                    columns: &COLUMNS,
+                    indexes: &[],
+                },
+                rows: &[],
+            },
+            TableRows {
+                table: TableSpec {
+                    name: b"Rows",
+                    columns: &columns,
+                    indexes: &indexes,
+                },
+                rows: &references,
+            },
+        ],
+        &mut budget(),
+    )?;
+
+    let parent = (-100..=100)
+        .map(|id| [RowValue::Long(id), RowValue::Long(id + 100)])
+        .collect::<Vec<_>>();
+    let child = (0..27801)
+        .map(|position| [RowValue::Long(position % 3 - 1), RowValue::Long(position)])
+        .collect::<Vec<_>>();
+    let parent_rows = parent.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    let child_rows = child.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    create_database_with_relationship_rows(
+        directory.join("relationship.mdb"),
+        &[
+            TableRows {
+                table: TableSpec {
+                    name: b"Parents",
+                    columns: &COLUMNS,
+                    indexes: &PRIMARY,
+                },
+                rows: &parent_rows,
+            },
+            TableRows {
+                table: TableSpec {
+                    name: b"Children",
+                    columns: &COLUMNS,
+                    indexes: &[],
+                },
+                rows: &child_rows,
+            },
+        ],
+        &RelationshipSpec {
+            name: b"ParentChildren",
+            parent: RelationshipColumn {
+                table: TableRef::Ordinal(0),
+                column: ColumnRef::Ordinal(0),
+            },
+            child: RelationshipColumn {
+                table: TableRef::Ordinal(1),
+                column: ColumnRef::Ordinal(0),
+            },
+        },
+        &mut budget(),
+    )?;
+    Ok(())
+}

--- a/crates/jet3/src/bootstrap_initial_index.rs
+++ b/crates/jet3/src/bootstrap_initial_index.rs
@@ -203,7 +203,7 @@ impl InitialLongIndex {
         budget: &mut ResourceBudget,
     ) -> Result<bool, ComposeError> {
         budget.charge_work_units(
-            u64::from((self.entries.len().max(1) as u64).ilog2() + 1) * COMPONENT_BYTES as u64,
+            u64::from((self.entries.len().max(1) as u64).ilog2() + 2) * COMPONENT_BYTES as u64,
         )?;
         let mut key = [0x7f, 0, 0, 0, 0];
         key[1..].copy_from_slice(&value.to_be_bytes());
@@ -232,5 +232,42 @@ impl InitialLongIndex {
                             ]))
                         && actual.row().slot() == expected[key_bytes + 3]
                 })
+    }
+}
+
+#[cfg(test)]
+mod lookup_tests {
+    use super::*;
+
+    #[test]
+    fn odd_length_lookup_charges_the_final_comparison() -> Result<(), ComposeError> {
+        let table = TableSpec {
+            name: b"Keys",
+            columns: &[ColumnSpec::new(b"Id", ColumnType::Long)],
+            indexes: &[crate::IndexSpec {
+                name: b"ById",
+                kind: IndexKind::Primary,
+                fields: &[crate::IndexColumnSpec::ascending(b"Id")],
+            }],
+        };
+        let mut budget = ResourceBudget::new(crate::ResourceLimits::default());
+        let mut index = InitialLongIndex::new(&table, 3, &mut budget)?
+            .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
+        for slot in 0..3 {
+            index.push(
+                &[RowValue::Long(i32::from(slot))],
+                RowLocator::new(PageNumber::new(24), slot),
+                &mut budget,
+            )?;
+        }
+        index.sort(&mut budget)?;
+        let mut insufficient =
+            ResourceBudget::new(crate::ResourceLimits::default().with_max_total_work_units(14));
+        assert!(index.contains_single_long(1, &mut insufficient).is_err());
+        let mut sufficient =
+            ResourceBudget::new(crate::ResourceLimits::default().with_max_total_work_units(15));
+        assert!(index.contains_single_long(1, &mut sufficient)?);
+        assert_eq!(sufficient.total_work_units(), 15);
+        Ok(())
     }
 }

--- a/crates/jet3/src/bootstrap_initial_index.rs
+++ b/crates/jet3/src/bootstrap_initial_index.rs
@@ -1,8 +1,12 @@
-//! One uncompressed leaf of one/two Long components: EXP-0062 leaf/locator
+//! Uncompressed trees of one/two Long components: EXP-0062 branch/leaf/locator
 //! grammar, EXP-0126 direction/composition and full-key distinct counts.
 
 use super::*;
 use crate::{IndexKind, IndexTree, RowLocator};
+
+#[path = "bootstrap_initial_index_pages.rs"]
+mod pages;
+use pages::IndexPages;
 
 const COMPONENT_BYTES: usize = 5;
 const MAX_FIELDS: usize = 2;
@@ -22,6 +26,7 @@ pub(crate) struct InitialLongIndex {
     unique: bool,
     entries: Vec<[u8; ENTRY_CAPACITY]>,
     distinct: u32,
+    pages: IndexPages,
 }
 
 impl InitialLongIndex {
@@ -63,12 +68,7 @@ impl InitialLongIndex {
             };
         }
         let entry_bytes = index.fields.len() * COMPONENT_BYTES + LOCATOR_BYTES;
-        if row_count > INDEX_ENTRY_AREA_LEN / entry_bytes {
-            return Err(ComposeError::IndexPageFull {
-                needed: row_count.saturating_mul(entry_bytes),
-                available: INDEX_ENTRY_AREA_LEN,
-            });
-        }
+        let pages = IndexPages::new(row_count, entry_bytes, budget)?;
         budget.charge_allocation(ByteCount::new((row_count * ENTRY_CAPACITY) as u64))?;
         let mut entries = Vec::new();
         entries
@@ -83,6 +83,7 @@ impl InitialLongIndex {
             unique: index.kind != IndexKind::Ordinary,
             entries,
             distinct: 0,
+            pages,
         }))
     }
 
@@ -130,9 +131,11 @@ impl InitialLongIndex {
     }
 
     pub(crate) fn sort(&mut self, budget: &mut ResourceBudget) -> Result<(), ComposeError> {
-        // At most 200 entries; charge a conservative quadratic byte-comparison bound.
         let count = self.entries.len() as u64;
-        budget.charge_work_units(count * count * ENTRY_CAPACITY as u64)?;
+        // The unstable sort has O(n log n) worst-case work; charge byte comparisons.
+        budget.charge_work_units(
+            count * u64::from(count.max(1).ilog2() + 1) * 4 * ENTRY_CAPACITY as u64,
+        )?;
         self.entries.sort_unstable();
         self.distinct = u32::from(!self.entries.is_empty());
         let key_bytes = self.key_bytes();
@@ -177,31 +180,37 @@ impl InitialLongIndex {
         self.distinct
     }
 
+    pub(super) fn extra_page_count(&self) -> u64 {
+        self.pages.extra_count()
+    }
+
     pub(super) fn image(
         &self,
         owner: PageNumber,
+        root: PageNumber,
+        first_extra: u64,
+        ordinal: Option<usize>,
         budget: &mut ResourceBudget,
     ) -> Result<PageImage, ComposeError> {
-        let mut bytes = [0_u8; PAGE_BYTES];
-        bytes[0] = 4;
-        bytes[1] = 1;
-        let entry_bytes = self.key_bytes() + LOCATOR_BYTES;
-        let used = self.entries.len() * entry_bytes;
-        bytes[2..4].copy_from_slice(&((INDEX_ENTRY_AREA_LEN - used) as u16).to_le_bytes());
-        let owner = u32::try_from(owner.get()).map_err(|_| Error::IntegerConversion {
-            value: owner.get() as u128,
-            target: "u32 index owner",
-        })?;
-        bytes[4..8].copy_from_slice(&owner.to_le_bytes());
-        for (position, entry) in self.entries.iter().enumerate() {
-            let start = INDEX_ENTRY_AREA_OFFSET + position * entry_bytes;
-            bytes[start..start + entry_bytes].copy_from_slice(&entry[..entry_bytes]);
-            let end = (position + 1) * entry_bytes;
-            bytes[INDEX_BOUNDARY_BITMAP_OFFSET + end / 8] |= 1 << (end % 8);
-        }
-        let mut image = PageImage::new(PageKind::LeafIndex);
-        image.write_at(PageOffset::new(0), &bytes, budget)?;
-        Ok(image)
+        self.pages
+            .image(&self.entries, owner, root, first_extra, ordinal, budget)
+    }
+
+    pub(super) fn contains_single_long(
+        &self,
+        value: i32,
+        budget: &mut ResourceBudget,
+    ) -> Result<bool, ComposeError> {
+        budget.charge_work_units(
+            u64::from((self.entries.len().max(1) as u64).ilog2() + 1) * COMPONENT_BYTES as u64,
+        )?;
+        let mut key = [0x7f, 0, 0, 0, 0];
+        key[1..].copy_from_slice(&value.to_be_bytes());
+        key[1] ^= 0x80;
+        Ok(self
+            .entries
+            .binary_search_by(|entry| entry[..COMPONENT_BYTES].cmp(&key))
+            .is_ok())
     }
 
     pub(crate) fn matches(&self, tree: &IndexTree) -> bool {

--- a/crates/jet3/src/bootstrap_initial_index_pages.rs
+++ b/crates/jet3/src/bootstrap_initial_index_pages.rs
@@ -1,0 +1,177 @@
+//! Uncompressed bulk index trees using EXP-0062 branch separators and links.
+//! Children are balanced across each level; this is writer policy, not a DAO
+//! split threshold. The existing root stays fixed and other nodes append.
+
+use super::*;
+use std::ops::Range;
+
+const CHILD_BYTES: usize = 4;
+
+#[derive(Debug, Clone)]
+struct Node {
+    entries: Range<usize>,
+    children: Range<usize>,
+    siblings: Range<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct IndexPages {
+    nodes: Vec<Node>,
+    entry_bytes: usize,
+}
+
+impl IndexPages {
+    pub(super) fn new(
+        count: usize,
+        entry_bytes: usize,
+        budget: &mut ResourceBudget,
+    ) -> Result<Self, ComposeError> {
+        let leaf_capacity = INDEX_ENTRY_AREA_LEN / entry_bytes;
+        let fanout = INDEX_ENTRY_AREA_LEN / (entry_bytes + CHILD_BYTES) + 1;
+        let leaves = count.div_ceil(leaf_capacity).max(1);
+        let mut total = leaves;
+        let mut level = leaves;
+        while level > 1 {
+            level = level.div_ceil(fanout);
+            total = total.checked_add(level).ok_or(Error::Arithmetic {
+                operation: "count initial index pages",
+            })?;
+        }
+        // All creation maps currently use the established inline representation.
+        if total as u64 > MAP_BITMAP_BYTES * 8 {
+            return Err(UsageMapWriteError::PageOutOfMap {
+                page: PageNumber::new(total as u64 - 1),
+                first: PageNumber::new(0),
+                page_count: MAP_BITMAP_BYTES * 8,
+            }
+            .into());
+        }
+        budget.charge_allocation(ByteCount::new((total * size_of::<Node>()) as u64))?;
+        budget.charge_items(total as u64)?;
+        let mut nodes = Vec::new();
+        nodes.try_reserve_exact(total).map_err(|_| Error::Io {
+            operation: "reserve initial index nodes",
+            kind: std::io::ErrorKind::OutOfMemory,
+        })?;
+        for leaf in 0..leaves {
+            nodes.push(Node {
+                entries: leaf * leaf_capacity..((leaf + 1) * leaf_capacity).min(count),
+                children: 0..0,
+                siblings: 0..leaves,
+            });
+        }
+        let mut previous = 0..leaves;
+        while previous.len() > 1 {
+            let parents = previous.len().div_ceil(fanout);
+            let start = nodes.len();
+            for parent in 0..parents {
+                // Balanced groups avoid a non-root branch with only a tail child.
+                let first = previous.start + parent * previous.len() / parents;
+                let end = previous.start + (parent + 1) * previous.len() / parents;
+                nodes.push(Node {
+                    entries: nodes[first].entries.start..nodes[end - 1].entries.end,
+                    children: first..end,
+                    siblings: start..start + parents,
+                });
+            }
+            previous = start..nodes.len();
+        }
+        Ok(Self { nodes, entry_bytes })
+    }
+
+    pub(super) fn extra_count(&self) -> u64 {
+        self.nodes.len() as u64 - 1
+    }
+
+    fn page(&self, ordinal: usize, root: PageNumber, first_extra: u64) -> u64 {
+        if ordinal + 1 == self.nodes.len() {
+            root.get()
+        } else {
+            first_extra + ordinal as u64
+        }
+    }
+
+    pub(super) fn image(
+        &self,
+        entries: &[[u8; ENTRY_CAPACITY]],
+        owner: PageNumber,
+        root: PageNumber,
+        first_extra: u64,
+        ordinal: Option<usize>,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, ComposeError> {
+        let last = first_extra
+            .checked_add(self.extra_count())
+            .ok_or(Error::Arithmetic {
+                operation: "place initial index pages",
+            })?;
+        if last > MAP_BITMAP_BYTES * 8 {
+            return Err(UsageMapWriteError::PageOutOfMap {
+                page: PageNumber::new(last - 1),
+                first: PageNumber::new(0),
+                page_count: MAP_BITMAP_BYTES * 8,
+            }
+            .into());
+        }
+        let entry_bytes = self.entry_bytes;
+        let ordinal = ordinal.unwrap_or(self.nodes.len() - 1);
+        let node = &self.nodes[ordinal];
+        let branch = !node.children.is_empty();
+        let mut bytes = [0_u8; PAGE_BYTES];
+        bytes[0] = if branch { 3 } else { 4 };
+        bytes[1] = 1;
+        bytes[21] = u8::from(branch);
+        let owner = u32::try_from(owner.get()).map_err(|_| Error::IntegerConversion {
+            value: owner.get() as u128,
+            target: "u32 index owner",
+        })?;
+        bytes[4..8].copy_from_slice(&owner.to_le_bytes());
+        for (offset, neighbor) in [
+            (
+                8,
+                ordinal.checked_sub(1).filter(|n| *n >= node.siblings.start),
+            ),
+            (12, (ordinal + 1 < node.siblings.end).then_some(ordinal + 1)),
+        ] {
+            if let Some(neighbor) = neighbor {
+                bytes[offset..offset + 4].copy_from_slice(
+                    &(self.page(neighbor, root, first_extra) as u32).to_le_bytes(),
+                );
+            }
+        }
+        let count = if branch {
+            node.children.len() - 1
+        } else {
+            node.entries.len()
+        };
+        let width = entry_bytes + if branch { CHILD_BYTES } else { 0 };
+        bytes[2..4].copy_from_slice(&((INDEX_ENTRY_AREA_LEN - count * width) as u16).to_le_bytes());
+        if branch {
+            bytes[16..20].copy_from_slice(
+                &(self.page(node.children.end - 1, root, first_extra) as u32).to_le_bytes(),
+            );
+        }
+        for position in 0..count {
+            let source = if branch {
+                self.nodes[node.children.start + position].entries.end - 1
+            } else {
+                node.entries.start + position
+            };
+            let start = INDEX_ENTRY_AREA_OFFSET + position * width;
+            bytes[start..start + entry_bytes].copy_from_slice(&entries[source][..entry_bytes]);
+            if branch {
+                let child = self.page(node.children.start + position, root, first_extra) as u32;
+                bytes[start + entry_bytes..start + width].copy_from_slice(&child.to_be_bytes());
+            }
+            let end = (position + 1) * width;
+            bytes[INDEX_BOUNDARY_BITMAP_OFFSET + end / 8] |= 1 << (end % 8);
+        }
+        let mut image = PageImage::new(if branch {
+            PageKind::IntermediateIndex
+        } else {
+            PageKind::LeafIndex
+        });
+        image.write_at(PageOffset::new(0), &bytes, budget)?;
+        Ok(image)
+    }
+}

--- a/crates/jet3/src/bootstrap_relationship_candidate.rs
+++ b/crates/jet3/src/bootstrap_relationship_candidate.rs
@@ -134,7 +134,12 @@ fn assemble_relationship(
         (HEADER_PAGE, header),
         (
             GLOBAL_MAP_PAGE,
-            global_map_page(relation.index_page() + 1, budget)?,
+            global_map_page(
+                relation.index_page()
+                    + 1
+                    + child_index.map_or(0, InitialLongIndex::extra_page_count),
+                budget,
+            )?,
         ),
         (
             MSYS_OBJECTS_ROOT,
@@ -206,7 +211,13 @@ fn assemble_relationship(
         ),
         (
             relation.child.map_page().get(),
-            creates[1].map_page(Some(PageNumber::new(relation.index_page())), budget)?,
+            creates[1].map_page(
+                Some((
+                    PageNumber::new(relation.index_page()),
+                    child_index.map_or(0, InitialLongIndex::extra_page_count),
+                )),
+                budget,
+            )?,
         ),
     ];
     for (page, image) in replacements {
@@ -220,12 +231,33 @@ fn assemble_relationship(
     )?;
     plan.append(
         match child_index {
-            Some(index) => index.image(relation.child.definition_root(), budget)?,
+            Some(index) => index.image(
+                relation.child.definition_root(),
+                PageNumber::new(relation.index_page()),
+                relation.index_page() + 1,
+                None,
+                budget,
+            )?,
             None => empty_index_page(relation.child.definition_root().get(), budget)?,
         },
         &mut global_free,
         budget,
     )?;
+    if let Some(index) = child_index {
+        for ordinal in 0..index.extra_page_count() {
+            plan.append(
+                index.image(
+                    relation.child.definition_root(),
+                    PageNumber::new(relation.index_page()),
+                    relation.index_page() + 1,
+                    Some(ordinal as usize),
+                    budget,
+                )?,
+                &mut global_free,
+                budget,
+            )?;
+        }
+    }
     Ok(plan)
 }
 

--- a/crates/jet3/src/bootstrap_relationship_rows.rs
+++ b/crates/jet3/src/bootstrap_relationship_rows.rs
@@ -51,13 +51,11 @@ pub(crate) fn compose_relationship_with_rows(
         foreign.push(row, locator, budget)?;
     }
     foreign.sort(budget)?;
-    // Both one-leaf index plans have already bounded row counts to at most 200.
-    budget.charge_work_units((parent.rows.len() * child.rows.len() * size_of::<i32>()) as u64)?;
     for (row, values) in child.rows.iter().enumerate() {
         let Some(RowValue::Long(value)) = values.get(usize::from(relation.child_column)) else {
             return Err(ComposeError::NullInitialIndexKey { row });
         };
-        if !parent.rows.iter().any(|values| matches!(values.get(usize::from(relation.parent_column)), Some(RowValue::Long(parent)) if parent == value)) {
+        if !parent_create.contains_initial_long(*value, budget)? {
             return Err(ComposeError::OrphanInitialRelationshipKey { row, value: *value });
         }
     }

--- a/crates/jet3/src/bootstrap_table_create.rs
+++ b/crates/jet3/src/bootstrap_table_create.rs
@@ -156,7 +156,7 @@ impl<'a> PlannedCreate<'a> {
                 }
                 Err(error) => return Err(error.into()),
             };
-            let locator = crate::RowLocator::new(PageNumber::new(self.page_count()), slot);
+            let locator = crate::RowLocator::new(PageNumber::new(self.data_end()), slot);
             if let Some(index) = &mut self.initial_index {
                 index.push(row, locator, budget)?;
             }
@@ -174,7 +174,7 @@ impl<'a> PlannedCreate<'a> {
         minimum_row: &[u8],
         budget: &mut ResourceBudget,
     ) -> Result<(), ComposeError> {
-        let page = PageNumber::new(self.page_count());
+        let page = PageNumber::new(self.data_end());
         // The existing inline map covers this many pages (SRC-0020/EXP-0057).
         // EXP-0065 observed indirect growth, but supplies no general policy.
         let page_count = MAP_BITMAP_BYTES * 8;
@@ -225,6 +225,14 @@ impl<'a> PlannedCreate<'a> {
 
     /// Returns the page count once every appended page is in place.
     pub(super) fn page_count(&self) -> u64 {
+        self.data_end()
+            + self
+                .initial_index
+                .as_ref()
+                .map_or(0, InitialLongIndex::extra_page_count)
+    }
+
+    fn data_end(&self) -> u64 {
         self.plan.definition_root().get()
             + self.plan.appended_page_count()
             + self
@@ -246,7 +254,7 @@ impl<'a> PlannedCreate<'a> {
 
     /// Logical row locations in the same order used while packing initial data.
     pub(super) fn initial_row_locators(&self) -> impl Iterator<Item = crate::RowLocator> + '_ {
-        let first = self.page_count() - self.initial_data.len() as u64;
+        let first = self.data_end() - self.initial_data.len() as u64;
         self.initial_data
             .iter()
             .enumerate()
@@ -255,6 +263,17 @@ impl<'a> PlannedCreate<'a> {
                     crate::RowLocator::new(PageNumber::new(first + page as u64), slot as u8)
                 })
             })
+    }
+
+    pub(super) fn contains_initial_long(
+        &self,
+        value: i32,
+        budget: &mut ResourceBudget,
+    ) -> Result<bool, ComposeError> {
+        self.initial_index
+            .as_ref()
+            .ok_or(ComposeError::UnsupportedInitialIndexSchema)?
+            .contains_single_long(value, budget)
     }
 
     /// Returns the catalog row the create adds (`EXP-0087`).
@@ -298,9 +317,15 @@ impl<'a> PlannedCreate<'a> {
             plan.append(continuation, append_map, budget)?;
         }
         let owner = self.plan.definition_root().get();
-        for _ in self.plan.index_placements() {
+        for (root, _) in self.plan.index_placements() {
             let image = if let Some(index) = &self.initial_index {
-                index.image(self.plan.definition_root(), budget)?
+                index.image(
+                    self.plan.definition_root(),
+                    root,
+                    self.data_end(),
+                    None,
+                    budget,
+                )?
             } else {
                 empty_index_page(owner, budget)?
             };
@@ -311,6 +336,27 @@ impl<'a> PlannedCreate<'a> {
         }
         for data in &self.initial_data {
             plan.append(data.image.clone(), append_map, budget)?;
+        }
+        if let Some(index) = &self.initial_index {
+            let root = self
+                .plan
+                .index_placements()
+                .next()
+                .ok_or(ComposeError::UnsupportedInitialIndexSchema)?
+                .0;
+            for ordinal in 0..index.extra_page_count() {
+                plan.append(
+                    index.image(
+                        self.plan.definition_root(),
+                        root,
+                        self.data_end(),
+                        Some(ordinal as usize),
+                        budget,
+                    )?,
+                    append_map,
+                    budget,
+                )?;
+            }
         }
         Ok(())
     }
@@ -422,7 +468,7 @@ impl<'a> PlannedCreate<'a> {
     /// Builds the map page with the rows the definition names.
     pub(super) fn map_page(
         &self,
-        foreign_index: Option<PageNumber>,
+        foreign_index: Option<(PageNumber, u64)>,
         budget: &mut ResourceBudget,
     ) -> Result<PageImage, ComposeError> {
         if foreign_index.is_some() && (!self.spec.indexes.is_empty() || self.long_value.is_some()) {
@@ -458,10 +504,17 @@ impl<'a> PlannedCreate<'a> {
         available.encode_into(&mut available_row, budget)?;
         let mut rows: Vec<[u8; 133]> = vec![owned_row, available_row];
         for (root, _) in self.plan.index_placements() {
-            rows.push(inline_map_row(&[root.get()], budget)?);
+            rows.push(initial_index_map(
+                root,
+                self.data_end(),
+                self.initial_index
+                    .as_ref()
+                    .map_or(0, InitialLongIndex::extra_page_count),
+                budget,
+            )?);
         }
-        if let Some(index) = foreign_index {
-            rows.push(inline_map_row(&[index.get()], budget)?);
+        if let Some((root, extra)) = foreign_index {
+            rows.push(initial_index_map(root, root.get() + 1, extra, budget)?);
         }
         if self.long_value.is_some() {
             let maps = match &self.initial_long_values {
@@ -530,3 +583,20 @@ fn long_value_columns<'s>(spec: &'s TableSpec<'_>) -> impl Iterator<Item = u16> 
 #[cfg(test)]
 #[path = "bootstrap_table_create_tests.rs"]
 mod tests;
+
+fn initial_index_map(
+    root: PageNumber,
+    first_extra: u64,
+    extra_count: u64,
+    budget: &mut ResourceBudget,
+) -> Result<[u8; 133], ComposeError> {
+    let mut map =
+        InlineUsageMapEncoder::new(PageNumber::new(0), ByteCount::new(MAP_BITMAP_BYTES), budget)?;
+    map.set_page(root)?;
+    for page in first_extra..first_extra + extra_count {
+        map.set_page(PageNumber::new(page))?;
+    }
+    let mut row = [0_u8; 133];
+    map.encode_into(&mut row, budget)?;
+    Ok(row)
+}

--- a/crates/jet3/src/create.rs
+++ b/crates/jet3/src/create.rs
@@ -179,8 +179,8 @@ pub fn create_database(
 /// a slot and room for an all-null row are marked available; this construction
 /// policy has not been established as DAO's allocation policy.
 /// At most one index on one or two Long columns is accepted, with each field
-/// ascending or descending. One leaf holds at most 200 single-column or 128
-/// two-column entries. Primary and unique indexes reject duplicate full keys;
+/// ascending or descending. Uncompressed branch/leaf trees grow within the
+/// existing inline-map and resource limits. Primary and unique indexes reject duplicate full keys;
 /// ordinary indexes retain duplicates. Null components and other key types
 /// are refused. `EXP-0126` records the component encoding on exact fresh DAO
 /// controls; composite/descending Rust-created candidates await their own

--- a/crates/jet3/src/create_composite_index_tests.rs
+++ b/crates/jet3/src/create_composite_index_tests.rs
@@ -155,14 +155,10 @@ fn composite_capacity_and_multiple_row_pages_preserve_locators_and_destination()
         &original[23 * crate::PAGE_BYTES + 2..23 * crate::PAGE_BYTES + 4],
         &8_u16.to_le_bytes()
     );
-    assert!(matches!(
-        create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
-        Err(CreateDatabaseError::Compose(ComposeError::IndexPageFull {
-            needed: 1806,
-            available: 1800
-        }))
-    ));
-    assert_eq!(fs::read(directory.target())?, original);
+    let expanded = TestDirectory::create()?;
+    create_database_with_rows(expanded.target(), &table, &rows, &mut budget())?;
+    assert_eq!(tree(&expanded.target())?.nodes().len(), 3);
+    assert_eq!(tree(&expanded.target())?.entries().len(), 129);
     let mut changed = original;
     changed[23 * crate::PAGE_BYTES + 248 + 9] ^= 1;
     fs::write(directory.target(), changed)?;

--- a/crates/jet3/src/create_initial_index_tests.rs
+++ b/crates/jet3/src/create_initial_index_tests.rs
@@ -136,7 +136,7 @@ fn indexed_payload_rows_can_reference_multiple_data_pages() -> TestResult {
 }
 
 #[test]
-fn leaf_capacity_is_exact_and_overflow_preserves_destination() -> TestResult {
+fn leaf_capacity_spills_into_a_branch_root() -> TestResult {
     let directory = TestDirectory::create()?;
     let indexes = one_index(IndexKind::Primary);
     let table = TableSpec {
@@ -157,13 +157,16 @@ fn leaf_capacity_is_exact_and_overflow_preserves_destination() -> TestResult {
     );
     assert!(matches!(
         create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
-        Err(CreateDatabaseError::Compose(ComposeError::IndexPageFull {
-            needed: 1809,
-            available: 1800
-        }))
+        Err(CreateDatabaseError::Publish(_))
     ));
     assert_eq!(fs::read(directory.target())?, original);
-    assert_eq!(directory.entries()?, ["created.mdb"]);
+    let directory = TestDirectory::create()?;
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let expanded = tree(&directory.target())?;
+    assert_eq!(expanded.entries().len(), 201);
+    assert_eq!(expanded.nodes().len(), 3);
+    assert_eq!(expanded.nodes()[0].depth(), 1);
+    assert_eq!(fs::read(directory.target())?[23 * crate::PAGE_BYTES], 3);
     Ok(())
 }
 
@@ -290,3 +293,6 @@ fn index_storage_budget_and_empty_index_are_handled() -> TestResult {
 
 #[path = "create_composite_index_tests.rs"]
 mod composite;
+
+#[path = "create_multi_level_index_tests.rs"]
+mod multi_level;

--- a/crates/jet3/src/create_multi_level_index_tests.rs
+++ b/crates/jet3/src/create_multi_level_index_tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+use crate::{IndexNodeKind, TableRows, create_database_with_table_rows};
+
+#[test]
+fn branch_fanout_builds_another_level_and_preserves_complete_separators() -> TestResult {
+    let indexes = one_index(IndexKind::Primary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let values = (0..27801)
+        .rev()
+        .map(|id| [RowValue::Long(id)])
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    for (count, nodes, depth) in [(27800, 140, 2), (27801, 143, 3)] {
+        let directory = TestDirectory::create()?;
+        create_database_with_rows(directory.target(), &table, &rows[..count], &mut budget())?;
+        let index = tree(&directory.target())?;
+        assert_eq!(index.entries().len(), count);
+        assert_eq!(index.nodes().len(), nodes);
+        assert_eq!(
+            index.nodes().iter().map(|node| node.depth()).max(),
+            Some(depth)
+        );
+        let bytes = fs::read(directory.target())?;
+        for node in index.nodes() {
+            assert!(map_bit(&bytes, 21, 2, node.page().get())?);
+            assert!(!map_bit(&bytes, 21, 0, node.page().get())?);
+            if node.kind() != IndexNodeKind::Intermediate {
+                continue;
+            }
+            let offset = node.page().get() as usize * crate::PAGE_BYTES;
+            let raw = &bytes[offset..offset + crate::PAGE_BYTES];
+            let used = 1800 - usize::from(u16::from_le_bytes(raw[2..4].try_into()?));
+            for separator in raw[248..248 + used].chunks_exact(13) {
+                let child_page = u32::from_be_bytes(separator[9..13].try_into()?) as usize;
+                let child =
+                    &bytes[child_page * crate::PAGE_BYTES..(child_page + 1) * crate::PAGE_BYTES];
+                // Follow rightmost children to the referenced subtree's maximum leaf entry.
+                let mut leaf = child;
+                while leaf[0] == 3 {
+                    let page = u32::from_le_bytes(leaf[16..20].try_into()?) as usize;
+                    leaf = &bytes[page * crate::PAGE_BYTES..(page + 1) * crate::PAGE_BYTES];
+                }
+                let end = 2048 - usize::from(u16::from_le_bytes(leaf[2..4].try_into()?));
+                assert_eq!(&separator[..9], &leaf[end - 9..end]);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn composite_duplicates_cross_leaves_and_later_tables_keep_roots_and_locators() -> TestResult {
+    let indexes = [IndexSpec {
+        fields: &[
+            field(1, IndexDirection::Descending),
+            field(0, IndexDirection::Ascending),
+        ],
+        ..one_index(IndexKind::Ordinary)[0]
+    }];
+    let table = TableSpec {
+        name: b"First",
+        columns: &[ID, SEQUENCE],
+        indexes: &indexes,
+    };
+    let values = (0..12929)
+        .map(|position| {
+            [
+                RowValue::Long(position / 400),
+                RowValue::Long(position / 800),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let rows = values.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+    let requests = [
+        TableRows { table, rows: &rows },
+        TableRows {
+            table: TableSpec {
+                name: b"Later",
+                ..table
+            },
+            rows: &rows[..401],
+        },
+    ];
+    let directory = TestDirectory::create()?;
+    create_database_with_table_rows(directory.target(), &requests, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    let mut reader = DatabaseReader::open(directory.target(), &mut budget())?;
+    let first = reader.table_definition(PageNumber::new(20), &mut budget())?;
+    let first_tree = reader.index_tree(&first, 0, &mut budget())?;
+    assert_eq!(
+        first_tree.nodes().iter().map(|node| node.depth()).max(),
+        Some(3)
+    );
+    assert_eq!(first_tree.entries().len(), rows.len());
+    let later_root = first_tree
+        .nodes()
+        .iter()
+        .map(|node| node.page().get())
+        .max()
+        .ok_or("missing nodes")?
+        + 1;
+    let later = reader.table_definition(PageNumber::new(later_root), &mut budget())?;
+    let later_tree = reader.index_tree(&later, 0, &mut budget())?;
+    assert_eq!(later_tree.entries().len(), 401);
+    for node in later_tree.nodes() {
+        assert!(map_bit(&bytes, later_root + 1, 2, node.page().get())?);
+    }
+    for entry in later_tree.entries() {
+        assert!(entry.row().page().get() > later_root + 2);
+        assert!(map_bit(
+            &bytes,
+            later_root + 1,
+            0,
+            entry.row().page().get()
+        )?);
+    }
+    let distinct = u32::from_le_bytes(
+        bytes[20 * crate::PAGE_BYTES + 47..20 * crate::PAGE_BYTES + 51].try_into()?,
+    );
+    assert_eq!(distinct, 33);
+    assert!(
+        first_tree
+            .entries()
+            .windows(2)
+            .all(|pair| pair[0].key().raw_bytes() <= pair[1].key().raw_bytes())
+    );
+    Ok(())
+}
+
+#[test]
+fn branched_corruption_and_index_map_overflow_preserve_publication() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Ordinary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let value = [RowValue::Long(1)];
+    let rows = vec![value.as_slice(); 401];
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let original = fs::read(directory.target())?;
+    let index = tree(&directory.target())?;
+    let leaf = index
+        .nodes()
+        .iter()
+        .find(|node| node.kind() == IndexNodeKind::Leaf)
+        .ok_or("missing leaf")?
+        .page()
+        .get() as usize;
+    for offset in [
+        23 * crate::PAGE_BYTES + 16,
+        23 * crate::PAGE_BYTES + 248 + 12,
+        leaf * crate::PAGE_BYTES + 12,
+    ] {
+        let mut changed = original.clone();
+        changed[offset] = 0;
+        fs::write(directory.target(), changed)?;
+        assert!(
+            crate::create::check_initial_rows(&directory.target(), &table, &rows, &mut budget())
+                .is_err()
+        );
+    }
+    fs::write(directory.target(), &original)?;
+    let huge = vec![value.as_slice(); 204800];
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &huge, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::UsageMap(_)))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(100));
+    assert!(create_database_with_rows(directory.target(), &table, &rows, &mut limited).is_err());
+    assert_eq!(fs::read(directory.target())?, original);
+    Ok(())
+}
+
+#[test]
+fn data_and_all_index_levels_share_the_exact_inline_map_limit() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Ordinary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let value = [RowValue::Long(1)];
+    let rows = vec![value.as_slice(); 111253];
+    create_database_with_rows(directory.target(), &table, &rows[..111252], &mut budget())?;
+    let original = fs::read(directory.target())?;
+    assert_eq!(original.len(), 1024 * crate::PAGE_BYTES);
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::UsageMap(_)))
+    ));
+    assert_eq!(fs::read(directory.target())?, original);
+    Ok(())
+}

--- a/crates/jet3/src/create_multi_level_index_tests.rs
+++ b/crates/jet3/src/create_multi_level_index_tests.rs
@@ -199,3 +199,34 @@ fn data_and_all_index_levels_share_the_exact_inline_map_limit() -> TestResult {
     assert_eq!(fs::read(directory.target())?, original);
     Ok(())
 }
+
+#[test]
+fn generated_keys_keep_their_counter_and_locators_across_index_leaves() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = one_index(IndexKind::Primary);
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ColumnSpec::new(b"Id", ColumnType::AutoIncrement)],
+        indexes: &indexes,
+    };
+    let value = [RowValue::AutoIncrement];
+    let rows = vec![value.as_slice(); 401];
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    assert_eq!(
+        &bytes[20 * crate::PAGE_BYTES + 16..20 * crate::PAGE_BYTES + 20],
+        &401_i32.to_le_bytes()
+    );
+    let index = tree(&directory.target())?;
+    assert_eq!(index.nodes().len(), 4);
+    for (ordinal, entry) in index.entries().iter().enumerate() {
+        assert_eq!(
+            entry.row(),
+            crate::RowLocator::new(
+                PageNumber::new(24 + ordinal as u64 / 254),
+                (ordinal % 254) as u8
+            )
+        );
+    }
+    Ok(())
+}

--- a/crates/jet3/src/create_relationship.rs
+++ b/crates/jet3/src/create_relationship.rs
@@ -55,8 +55,8 @@ pub fn create_database_with_relationship(
 /// ascending Long primary index on its relationship column; the child starts
 /// unindexed and receives an ordinary foreign index. Both relationship keys
 /// must be non-null Long values, every child key must occur in the parent,
-/// and each table is limited to 200 rows by its single index leaf. Repeated
-/// child keys are allowed. Other scalar columns may span data pages under
+/// and both index trees grow within the existing inline-map and resource
+/// limits. Repeated child keys are allowed. Other scalar columns may span data pages under
 /// the existing row bounds. AutoIncrement and long-value columns are refused.
 ///
 /// Existing destinations are preserved, and complete written pages,

--- a/crates/jet3/src/create_relationship_rows_tests.rs
+++ b/crates/jet3/src/create_relationship_rows_tests.rs
@@ -218,7 +218,7 @@ fn orphan_null_duplicate_and_unsupported_parent_shapes_are_refused() -> TestResu
 }
 
 #[test]
-fn foreign_leaf_capacity_and_publication_budget_preserve_destination() -> TestResult {
+fn foreign_branch_growth_and_publication_budget_preserve_destination() -> TestResult {
     let directory = Directory::new()?;
     let (tables, relation) = schema(false);
     let value = [RowValue::Text(b"a"), RowValue::Long(1)];
@@ -254,25 +254,41 @@ fn foreign_leaf_capacity_and_publication_budget_preserve_destination() -> TestRe
         &relation,
         &mut budget(),
     )?;
-    let original = fs::read(directory.target())?;
-    let overflow = [
+    let expanded = [
         requests[0],
         TableRows {
             rows: &child_rows,
             ..requests[1]
         },
     ];
-    assert!(matches!(
+    let directory = Directory::new()?;
+    create_database_with_relationship_rows(
+        directory.target(),
+        &expanded,
+        &relation,
+        &mut budget(),
+    )?;
+    let original = fs::read(directory.target())?;
+    let mut reader = DatabaseReader::open(directory.target(), &mut budget())?;
+    let definition = reader.table_definition(PageNumber::new(25), &mut budget())?;
+    let tree = reader.index_tree(&definition, 0, &mut budget())?;
+    assert_eq!(tree.entries().len(), 201);
+    assert_eq!(tree.nodes().len(), 3);
+    for node in tree.nodes() {
+        assert!(map_bit(&original, 26, 2, node.page().get())?);
+        assert!(!map_bit(&original, 26, 0, node.page().get())?);
+    }
+    drop(reader);
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(1));
+    assert!(
         create_database_with_relationship_rows(
             directory.target(),
-            &overflow,
+            &expanded,
             &relation,
-            &mut budget()
-        ),
-        Err(CreateDatabaseError::Compose(
-            ComposeError::IndexPageFull { .. }
-        ))
-    ));
+            &mut limited
+        )
+        .is_err()
+    );
     assert_eq!(fs::read(directory.target())?, original);
     assert_eq!(fs::read_dir(&directory.0)?.count(), 1);
     Ok(())

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -45,8 +45,8 @@ delivered in this order:
 
 Continue database creation under #100. Initial-row creation accepts up to
 four tables with scalar rows across data pages, bounded Long indexes, and
-one unindexed Memo/OLE column per table. Existing schema, single-leaf and
-inline-map bounds still apply. One AutoIncrement column per table accepts
+one unindexed Memo/OLE column per table. Long indexes now grow through
+multiple branch/leaf levels; existing schema and inline-map bounds still apply. One AutoIncrement column per table accepts
 explicit generation requests and persists its last generated ID, including
 when indexed; explicit IDs and empty long payloads remain refused. EXP-0136
 records the underlying DAO state observations.
@@ -60,8 +60,8 @@ records the other bounded writer observations. These establish only the
 pinned candidates and finite probes, with no general compatibility claim
 or hosted support movement.
 
-Next, broaden creation index keys, null semantics and allocation beyond a
-single leaf. After creation is complete, run the hosted write differential
+Next, validate multi-level index candidates, then broaden creation index
+keys, null semantics and allocation beyond inline maps. After creation is complete, run the hosted write differential
 (#102), implement updates preserving unrelated data (#112), then run the
 hosted update differential (#113). Keep module cleanup (#182) until the
 creation API settles.


### PR DESCRIPTION
Initial indexed rows currently fail once a Long index exceeds one leaf (200 single-field or128 composite entries). Build multi-level Long indexes with stable roots, sorted separators, sibling links and mapped child pages, allowing creation up to the existing allocation and resource bounds. The same builder supports populated relationship foreign indexes and preserves later-table row locations.

Focused tests cover leaf and branch fanout transitions, duplicate runs, composite directions, generated keys, later tables, exact map capacity, corrupted links and failed-publication preservation. Independent review found and the author fixed a lookup work-accounting bound; fix review and `just ready` pass. Three deterministic candidates are ready for a separate preregistered DAO validation; this change makes no new compatibility claim. Advances #100.
