### PR TITLE
test: preregister multi-level index DAO validation

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11210,6 +11210,82 @@ Copy this block under the appropriate section and remove this instruction:
   or hosted support claim. Retain all MDBs externally and record one validated
   additive outcome as `EXP-0128`.
 
+### EXP-0139 — Multi-level Long index candidate preregistration
+
+- Recorded: 2026-09-05, OpenAI Codex
+- Kind: committed development-only DAO preregistration; acquisition has not
+  started and no outcome or support movement is asserted.
+- Plan: `oracle/windows-dao/acquisition/multi-level-index.plan.json`, SHA-256
+  `7d0f368b31e2295b826118cea4e290b8ddc6661d108aea99eb870db84e13ccc2`. Pins cover producer, analyzer, dedicated structure decoder,
+  reused catalog decoder, low-level transport and Rust example. Dispatch and
+  analysis validate the same inputs; the exact plan must be committed before
+  acquisition. Independent harness review is required before dispatch.
+- Generator: `multi_level_index_candidate` at reviewed source
+  `5cd9e5a49888013059dfb88e8ab0a6ef942a91cd`. The implementation passed
+  independent review and `just ready`; the lookup-accounting review fix
+  changes no candidate bytes. No MDB bytes are committed.
+- Hypothesis: DAO accepts the writer's uncompressed balanced multi-level
+  construction, retaining its original root and appending non-contiguous
+  descendants after data. EXP-0062 supplies branch/leaf headers, complete
+  maximum-child key/row-locator separators, tail children and sibling links;
+  EXP-0126 supplies Long direction/composition, EXP-0073 distinct-key counts,
+  and EXP-0057/0065 map roles. The construction is not a DAO split or allocation
+  policy inference.
+- Three arms, each with three unchanged candidate replicas and three fresh
+  matched DAO controls. `primary` has Rows(Id Long, Payload Long), primary
+  ById ascending: position 0..27800 gives [27800-position, position].
+  `composite` has an empty first table and later Rows(A Long, B Long, Payload
+  Long), ordinary ByKey(B descending, A ascending): position 0..12928 gives
+  [floor(position/400), floor(position/800)-9, position]. `relationship` has
+  Parents(Id Long, Payload Long), primary ById, with [position-100, position]
+  for 0..200; Children has the same fields with [position%3-1, position] for
+  0..27800. ParentChildren links their Id columns and creates the child
+  ordinary foreign index. Parent keys include unused values; duplicate child
+  and composite runs cross leaf boundaries. Controls use the same insertion
+  order, one transaction per table, then relationship creation; no compaction.
+- Candidate identities:
+
+| Arm | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `primary` | 677,888 | `319337d779bfeceb7971ff133794ef738b5dcf44f3c55885d1c2591b5af15593` |
+| `composite` | 475,136 | `249529faf1161a6a7ceb255794fb65d6fd5080d66c0e8fefdae88a2eba2ae035` |
+| `relationship` | 694,272 | `beec4f2af1e0a84396053ef39ac9b76b5465db822f759cc7c35c1d11a9342147` |
+
+- Endpoints: complete DAO database/table/field/index/relation metadata, full
+  typed row multisets and full ordered index traversal returning every
+  payload. Seek is limited to the explicit matching/missing boundary keys
+  in the plan: seven primary queries, four composite queries, seven parent
+  and six child queries. Any duplicate selected by Seek must be a complete
+  matching row; duplicate tie order is unspecified. These finite probes do
+  not establish arbitrary Seek or update behavior.
+- Structural preflight and analysis: derive roots through the catalog, decode
+  all rows, bind every leaf locator exactly once, compare keys with row values,
+  and check every complete separator, tail, sibling chain and uniform leaf
+  depth. Report actual index/data/available maps and descendant membership.
+  Candidate main trees must have three levels (143/105/143 nodes respectively);
+  the relationship parent has two levels and three nodes. Control depths,
+  compression and page locations are observations, not equality gates.
+  Control map membership may include unused index pages; candidates may not.
+  The decoder explicitly allows 8,192 image pages, 1,019 directory slots and
+  32 tree levels, and handles inline and indirect control maps using existing
+  grammar. No consumed decoder is changed.
+- Classification: all nine controls must pass, all read-only identities remain
+  unchanged, and the complete inventory must have no job error. Three agreeing
+  candidate observations yield `observed_accepted` or `not_observed_accepted`
+  per arm; disagreement, incomplete jobs, changed files or failed controls
+  yield `no_outcome`. Pin and retained-identity mismatches reject validation.
+  Retain all eighteen MDBs and complete result/report JSON. SSH timeout is
+  3,600 seconds; interruption or unexpected failure after mutation is a
+  scientific result, with no automatic retries or redispatch.
+- Preflight: focused semantic/classifier/structure tests and a VM PowerShell
+  `Parser.ParseFile` check passed. The latter executed no producer or DAO.
+  Candidate raw decoding validated all planned depths and complete bindings;
+  generation after AutoIncrement integration reproduced identical bytes.
+- Boundary: exact pinned images and declared read-only probes only. No new
+  scalar/Text/Binary/null key grammar, indirect writer allocation, general
+  B-tree update policy, compatibility or hosted support claim. Record the
+  single validated outcome as EXP-0140.
+
 ### EXP-0134 — Populated relationship and bounded integrity probes accepted locally
 
 - Recorded: 2026-09-05, OpenAI Codex

--- a/oracle/windows-dao/acquisition/multi-level-index.plan.json
+++ b/oracle/windows-dao/acquisition/multi-level-index.plan.json
@@ -1,0 +1,320 @@
+{
+  "experiment_id": "multi-level-index",
+  "provenance": "EXP-0139",
+  "outcome_provenance": "EXP-0140",
+  "development_only": true,
+  "compatibility_claim": false,
+  "support_movement": false,
+  "replicas": 3,
+  "source_commit": "5cd9e5a49888013059dfb88e8ab0a6ef942a91cd",
+  "hypothesis": "DAO reads the exact uncompressed balanced multi-level Long index candidate policy: fixed root, appended non-contiguous descendants, maximum complete key+locator separators, sibling chains; no DAO split/allocation policy inferred.",
+  "source_facts": [
+    "EXP-0062 branch/leaf grammar",
+    "EXP-0126 Long direction/composition",
+    "EXP-0073 distinct counts",
+    "EXP-0057 and EXP-0065 allocation map roles"
+  ],
+  "controls": "Fresh matched DAO database per candidate replica; same field/index/relation metadata, row values and insertion order; one transaction per table, relation appended after rows. No compaction.",
+  "endpoints": [
+    "read-only full metadata and complete typed rows",
+    "complete ordered index traversal including all duplicate payloads",
+    "finite matching/missing Seek queries in each table spec",
+    "raw row binding, complete child-max separators, sibling chains at each depth, uniform leaf depth, actual index/data/available map membership"
+  ],
+  "classification": "All 9 controls must pass, original candidate/control images remain unchanged, complete inventory and no unexpected job error. Three agreeing candidate semantic/structural observations per arm give observed_accepted or not_observed_accepted; disagreement, incomplete job, failed control or changed read-only file gives no_outcome. Pin/identity mismatches reject report. Retain all 18 MDBs and JSON. No automatic retry after first mutation.",
+  "limits": {
+    "ssh_timeout_seconds": 3600,
+    "image_pages": 8192,
+    "rows_per_page": 1019,
+    "tree_depth": 32,
+    "output": "complete typed snapshots; report retains structural graph and identities, no raw MDBs in git"
+  },
+  "structural_comparison": "Candidate depths are fixed by each table spec (three levels in each main tree; two for Parents). Control depths/locations are observations, not equality gates. Every descendant must belong to its index map; candidates have no extra mapped index pages. Available data maps must be subsets of owned data pages. Indirect control maps decoded from existing grammar. Actual placement and compression are not required to match controls.",
+  "unknowns": "No new scalar/Text/Binary/null key encoding, indirect writer allocation, general B-tree update/split policy, hosted support or general compatibility claim.",
+  "arms": {
+    "primary": [
+      {
+        "name": "Rows",
+        "fields": [
+          {
+            "name": "Id",
+            "type": 4,
+            "size": 4
+          },
+          {
+            "name": "Payload",
+            "type": 4,
+            "size": 4
+          }
+        ],
+        "row_count": 27801,
+        "indexes": [
+          {
+            "name": "ById",
+            "fields": [
+              {
+                "name": "Id",
+                "descending": false,
+                "attributes": 0
+              }
+            ],
+            "primary": true,
+            "unique": true,
+            "required": true,
+            "foreign": false,
+            "ignore_nulls": false
+          }
+        ],
+        "queries": [
+          [
+            -1
+          ],
+          [
+            0
+          ],
+          [
+            199
+          ],
+          [
+            200
+          ],
+          [
+            27799
+          ],
+          [
+            27800
+          ],
+          [
+            27801
+          ]
+        ],
+        "candidate_depth": 3
+      }
+    ],
+    "composite": [
+      {
+        "name": "Empty",
+        "fields": [
+          {
+            "name": "Id",
+            "type": 4,
+            "size": 4
+          },
+          {
+            "name": "Payload",
+            "type": 4,
+            "size": 4
+          }
+        ],
+        "row_count": 0,
+        "indexes": [],
+        "queries": [],
+        "candidate_depth": 0
+      },
+      {
+        "name": "Rows",
+        "fields": [
+          {
+            "name": "A",
+            "type": 4,
+            "size": 4
+          },
+          {
+            "name": "B",
+            "type": 4,
+            "size": 4
+          },
+          {
+            "name": "Payload",
+            "type": 4,
+            "size": 4
+          }
+        ],
+        "row_count": 12929,
+        "indexes": [
+          {
+            "name": "ByKey",
+            "fields": [
+              {
+                "name": "B",
+                "descending": true,
+                "attributes": 1
+              },
+              {
+                "name": "A",
+                "descending": false,
+                "attributes": 0
+              }
+            ],
+            "primary": false,
+            "unique": false,
+            "required": false,
+            "foreign": false,
+            "ignore_nulls": false
+          }
+        ],
+        "queries": [
+          [
+            -9,
+            0
+          ],
+          [
+            -9,
+            1
+          ],
+          [
+            7,
+            32
+          ],
+          [
+            99,
+            99
+          ]
+        ],
+        "candidate_depth": 3
+      }
+    ],
+    "relationship": [
+      {
+        "name": "Parents",
+        "fields": [
+          {
+            "name": "Id",
+            "type": 4,
+            "size": 4
+          },
+          {
+            "name": "Payload",
+            "type": 4,
+            "size": 4
+          }
+        ],
+        "row_count": 201,
+        "indexes": [
+          {
+            "name": "ById",
+            "fields": [
+              {
+                "name": "Id",
+                "descending": false,
+                "attributes": 0
+              }
+            ],
+            "primary": true,
+            "unique": true,
+            "required": true,
+            "foreign": false,
+            "ignore_nulls": false
+          }
+        ],
+        "queries": [
+          [
+            -101
+          ],
+          [
+            -100
+          ],
+          [
+            -1
+          ],
+          [
+            0
+          ],
+          [
+            1
+          ],
+          [
+            100
+          ],
+          [
+            101
+          ]
+        ],
+        "candidate_depth": 2
+      },
+      {
+        "name": "Children",
+        "fields": [
+          {
+            "name": "Id",
+            "type": 4,
+            "size": 4
+          },
+          {
+            "name": "Payload",
+            "type": 4,
+            "size": 4
+          }
+        ],
+        "row_count": 27801,
+        "indexes": [
+          {
+            "name": "ParentChildren",
+            "fields": [
+              {
+                "name": "Id",
+                "descending": false,
+                "attributes": 0
+              }
+            ],
+            "primary": false,
+            "unique": false,
+            "required": false,
+            "foreign": true,
+            "ignore_nulls": false
+          }
+        ],
+        "queries": [
+          [
+            -100
+          ],
+          [
+            -1
+          ],
+          [
+            0
+          ],
+          [
+            1
+          ],
+          [
+            100
+          ],
+          [
+            101
+          ]
+        ],
+        "candidate_depth": 3
+      }
+    ]
+  },
+  "candidates": {
+    "primary": {
+      "size": 677888,
+      "sha256": "319337d779bfeceb7971ff133794ef738b5dcf44f3c55885d1c2591b5af15593"
+    },
+    "composite": {
+      "size": 475136,
+      "sha256": "249529faf1161a6a7ceb255794fb65d6fd5080d66c0e8fefdae88a2eba2ae035"
+    },
+    "relationship": {
+      "size": 694272,
+      "sha256": "beec4f2af1e0a84396053ef39ac9b76b5465db822f759cc7c35c1d11a9342147"
+    }
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/multi_level_index.py": "a159a7630725f8d8a82dd781a07e551aee2840f07cc52887781d25bb106a3314",
+    "oracle/windows-dao/scripts/multi_level_index.ps1": "503d6f906bc9e1f58354d362246a8f66d1b15f343cee63f0b3de3e4d6d3b50ec",
+    "oracle/windows-dao/scripts/multi_level_index_structure.py": "a4291fd040cb6a90fb68dfbb5dfe75f9f5990caa1d3cec6893577b118191d928",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/multi_level_index_candidate.rs": "e852d949354eb4ce694589a19d8dd3ef2114340522c694f89230fd5cfbc15eb4"
+  },
+  "row_formulas": {
+    "primary.Rows": "position0..27800: [27800-position, position]",
+    "composite.Empty": "no rows",
+    "composite.Rows": "position0..12928: [floor(position/400), floor(position/800)-9, position]",
+    "relationship.Parents": "position0..200: [position-100, position]",
+    "relationship.Children": "position0..27800: [position%3-1, position]"
+  }
+}

--- a/oracle/windows-dao/scripts/multi_level_index.ps1
+++ b/oracle/windows-dao/scripts/multi_level_index.ps1
@@ -1,0 +1,187 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function Values([string]$Arm, [string]$Name, [int]$Position) {
+    if ($Arm -ceq 'primary') { return ,@([int](27800 - $Position), $Position) }
+    if ($Arm -ceq 'composite') { return ,@([int][Math]::Floor($Position / 400), [int]([Math]::Floor($Position / 800) - 9), $Position) }
+    if ($Name -ceq 'Parents') { return ,@([int]($Position - 100), $Position) }
+    return ,@([int]($Position % 3 - 1), $Position)
+}
+function Add-Table($Database, $Spec) {
+    $table = $index = $field = $null
+    try {
+        $table = $Database.CreateTableDef([string]$Spec.name)
+        foreach ($column in $Spec.fields) {
+            $field = $table.CreateField([string]$column.name, 4)
+            $table.Fields.Append($field); Release $field; $field = $null
+        }
+        foreach ($definition in $Spec.indexes) {
+            if ($definition.foreign) { continue }
+            $index = $table.CreateIndex([string]$definition.name)
+            $index.Primary = [bool]$definition.primary; $index.Unique = [bool]$definition.unique
+            foreach ($key in $definition.fields) {
+                $field = $index.CreateField([string]$key.name)
+                $field.Attributes = [int]$key.attributes
+                $index.Fields.Append($field); Release $field; $field = $null
+            }
+            $table.Indexes.Append($index); Release $index; $index = $null
+        }
+        $Database.TableDefs.Append($table)
+    }
+    finally { Release $field; Release $index; Release $table }
+}
+function New-Control([string]$Path, [string]$Arm) {
+    $engine = $workspace = $db = $rs = $relation = $field = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($table in $plan.arms.$Arm) { Add-Table $db $table }
+        foreach ($table in $plan.arms.$Arm) {
+            $rs = $db.OpenRecordset([string]$table.name, 2)
+            $workspace.BeginTrans()
+            for ($position = 0; $position -lt [int]$table.row_count; $position++) {
+                $values = Values $Arm ([string]$table.name) $position
+                $rs.AddNew()
+                for ($column = 0; $column -lt $values.Count; $column++) { $rs.Fields.Item($column).Value = [int]$values[$column] }
+                $rs.Update()
+            }
+            $workspace.CommitTrans()
+            $rs.Close(); Release $rs; $rs = $null
+        }
+        if ($Arm -ceq 'relationship') {
+            $relation = $db.CreateRelation('ParentChildren', 'Parents', 'Children', 0)
+            $field = $relation.CreateField('Id'); $field.ForeignName = 'Id'
+            $relation.Fields.Append($field); $db.Relations.Append($relation)
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $field; Release $relation
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Read-Row($Recordset, [int]$Count) {
+    $values = @()
+    for ($column = 0; $column -lt $Count; $column++) {
+        $value = $Recordset.Fields.Item($column).Value
+        if ($null -eq $value -or [Convert]::IsDBNull($value)) { $values += $null }
+        else { $values += [int]$value }
+    }
+    return ,$values
+}
+function Read-Table($Database, $Spec) {
+    $table = $rs = $null
+    try {
+        $table = $Database.TableDefs.Item([string]$Spec.name)
+        $snapshot = [ordered]@{name=[string]$Spec.name}
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required;
+              foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0); attributes=[int]$_.Attributes} })}
+        })
+        $rs = $Database.OpenRecordset([string]$Spec.name, 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) { [void]$rows.Add((Read-Row $rs $Spec.fields.Count)); $rs.MoveNext() }
+        $snapshot.rows = @($rows)
+        if ($Spec.indexes.Count -gt 0) {
+            $rs.Close(); Release $rs; $rs = $null
+            $rs = $Database.OpenRecordset([string]$Spec.name, 1)
+            $rs.Index = [string]$Spec.indexes[0].name
+            $rs.MoveFirst()
+            $traversal = New-Object Collections.ArrayList
+            while (-not $rs.EOF) { [void]$traversal.Add((Read-Row $rs $Spec.fields.Count)); $rs.MoveNext() }
+            $snapshot.traversal = @($traversal)
+            $seeks = New-Object Collections.ArrayList
+            foreach ($query in $Spec.queries) {
+                if ($query.Count -eq 1) { $rs.Seek('=', [int]$query[0]) }
+                else { $rs.Seek('=', [int]$query[0], [int]$query[1]) }
+                $row = if ($rs.NoMatch) { $null } else { Read-Row $rs $Spec.fields.Count }
+                [void]$seeks.Add(@{query=@($query); row=$row})
+            }
+            $snapshot.seek = @($seeks)
+        }
+        return $snapshot
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+    }
+}
+function Observe([string]$Path, [string]$Arm) {
+    $before = Identity $Path
+    $engine = $db = $null
+    $endpoint = 'open_database'; $snapshot = [ordered]@{}; $status = 'pass'; $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @()
+        foreach ($relation in $db.Relations) {
+            try {
+                $fields = @($relation.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })
+                $snapshot.relations += @{name=[string]$relation.Name; table=[string]$relation.Table; foreign_table=[string]$relation.ForeignTable; attributes=[int]$relation.Attributes; fields=$fields}
+            }
+            finally { Release $relation }
+        }
+        $endpoint = 'user_tables'
+        $snapshot.user_tables = @(foreach ($spec in $plan.arms.$Arm) { Read-Table $db $spec })
+        $endpoint = 'complete'
+    }
+    catch { $status = 'fail'; $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>') }
+    finally {
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'multi-level-index.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/multi_level_index.ps1') { throw 'Script pin mismatch' }
+$arms = @('primary', 'composite', 'relationship')
+foreach ($arm in $arms) {
+    foreach ($replica in 1..3) {
+        $path = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+        Copy-Item -LiteralPath (Join-Path $env:JET3_WORK "$arm.mdb") -Destination $path
+        $identity = Identity $path; $expected = $plan.candidates.$arm
+        if ($identity.size -ne $expected.size -or $identity.sha256 -cne $expected.sha256) { throw 'Candidate pin mismatch' }
+    }
+}
+$mutationStarted = $false
+$result = [ordered]@{
+    document_type='dao_multi_level_index_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); error=$null
+}
+try {
+    foreach ($arm in $arms) {
+        foreach ($replica in 1..3) {
+            $control = Join-Path $env:JET3_WORK "$arm-control-r$replica.mdb"
+            New-Control $control $arm
+            $candidate = Join-Path $env:JET3_WORK "$arm-candidate-r$replica.mdb"
+            $result.replicas += @{arm=$arm; replica=$replica; control=(Observe $control $arm); candidate=(Observe $candidate $arm)}
+        }
+    }
+}
+catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    [IO.File]::WriteAllText((Join-Path $env:JET3_OUTBOX 'result.json'), (($result | ConvertTo-Json -Depth 20 -Compress) + "`n"), (New-Object Text.UTF8Encoding($false)))
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/multi_level_index.py
+++ b/oracle/windows-dao/scripts/multi_level_index.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Pinned finite multi-level Long index validation; one acquisition, no retries."""
+from __future__ import annotations
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import multi_level_index_structure as structure
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/multi-level-index.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/multi_level_index.ps1'
+ARMS = ('primary', 'composite', 'relationship')
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs(plan):
+    for path, expected in plan['inputs'].items():
+        if digest(ROOT / path) != expected:
+            raise ValueError(f'Input pin mismatch: {path}')
+
+
+def rows_for(arm, name):
+    if name == 'Empty':
+        return []
+    if arm == 'primary':
+        return [[27800 - position, position] for position in range(27801)]
+    if arm == 'composite':
+        return [[position // 400, position // 800 - 9, position] for position in range(12929)]
+    if name == 'Parents':
+        return [[value, value + 100] for value in range(-100, 101)]
+    return [[position % 3 - 1, position] for position in range(27801)]
+
+
+def order_key(row, table):
+    names = [field['name'] for field in table['fields']]
+    return tuple(row[names.index(field['name'])] * (-1 if field['descending'] else 1)
+                 for field in table['indexes'][0]['fields'])
+
+
+def query_key(row, table):
+    names = [field['name'] for field in table['fields']]
+    return tuple(row[names.index(field['name'])] for field in table['indexes'][0]['fields'])
+
+
+def expected_snapshot(arm, tables):
+    users = []
+    for table in tables:
+        rows = rows_for(arm, table['name'])
+        value = {key: table[key] for key in ('name', 'fields', 'indexes')}
+        value['rows'] = rows
+        if table['indexes']:
+            by_key = {query_key(row, table): row for row in rows}
+            value['traversal'] = sorted(rows, key=lambda row: order_key(row, table))
+            value['seek'] = [{'query': query, 'row': by_key.get(tuple(query))} for query in table['queries']]
+        users.append(value)
+    relations = []
+    if arm == 'relationship':
+        relations = [{'name': 'ParentChildren', 'table': 'Parents', 'foreign_table': 'Children', 'attributes': 0,
+                      'fields': [{'name': 'Id', 'foreign_name': 'Id'}]}]
+    return {'version': '3.0', 'tables': sorted(['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships'] + [table['name'] for table in tables]),
+            'user_tables': users, 'relations': relations}
+
+
+def normalize(snapshot, tables):
+    result = json.loads(json.dumps(snapshot))
+    specifications = {table['name']: table for table in tables}
+    valid = True
+    for table in result.get('user_tables', []):
+        spec = specifications[table['name']]
+        rows = table['rows']
+        valid &= all(len(row) == len(spec['fields']) and all(type(value) is int for value in row) for row in rows)
+        row_set = {tuple(row) for row in rows}
+        table['rows'] = sorted(rows)
+        if spec['indexes']:
+            traversal = table['traversal']
+            ordered = sorted(traversal) == sorted(rows) and [order_key(row, spec) for row in traversal] == sorted(order_key(row, spec) for row in rows)
+            valid &= ordered
+            if ordered:
+                table['traversal'] = sorted(traversal)
+            existing = {query_key(row, spec) for row in rows}
+            seeks = table['seek']
+            seek_ok = [item['query'] for item in seeks] == spec['queries']
+            for item in seeks:
+                row, query = item['row'], tuple(item['query'])
+                seek_ok &= ((row is None and query not in existing) or
+                            (row is not None and tuple(row) in row_set and query_key(row, spec) == query))
+            valid &= seek_ok
+            if seek_ok:
+                table['seek'] = [{'query': item['query'], 'found': item['row'] is not None} for item in seeks]
+    return valid, result
+
+
+def preflight(candidate_directory):
+    plan = json.loads(PLAN.read_text())
+    if plan['replicas'] != 3 or list(plan['arms']) != list(ARMS):
+        raise ValueError('Unexpected experiment plan')
+    verify_inputs(plan)
+    for arm in ARMS:
+        path = candidate_directory / f'{arm}.mdb'
+        if identity(path) != plan['candidates'][arm]:
+            raise ValueError(f'Candidate identity mismatch: {arm}')
+        structure.observe(path.read_bytes(), plan['arms'][arm],
+                          {table['name']: rows_for(arm, table['name']) for table in plan['arms'][arm]}, True)
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def analyze(outbox):
+    plan = json.loads(PLAN.read_text())
+    verify_inputs(plan)
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    if (result['document_type'] != 'dao_multi_level_index_result' or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result identity/environment mismatch')
+    expected_inventory = [(arm, replica) for arm in ARMS for replica in range(1, 4)]
+    actual_inventory = [(item['arm'], item['replica']) for item in result['replicas']]
+    if actual_inventory != expected_inventory[:len(actual_inventory)]:
+        raise ValueError('Unexpected replica inventory')
+    groups, decoded = {arm: [] for arm in ARMS}, []
+    controls_ok, unchanged = True, True
+    for item in result['replicas']:
+        arm, replica = item['arm'], item['replica']
+        tables = plan['arms'][arm]
+        expected = normalize(expected_snapshot(arm, tables), tables)[1]
+        roles = {}
+        for role in ('control', 'candidate'):
+            observation = item[role]
+            path = outbox / f'{arm}-{role}-r{replica}.mdb'
+            if identity(path) != observation['after']:
+                raise ValueError('Retained identity mismatch: ' + path.name)
+            if role == 'candidate' and observation['before'] != plan['candidates'][arm]:
+                raise ValueError('Candidate did not start with pinned identity')
+            unchanged &= observation['before'] == observation['after']
+            details, reason = None, None
+            try:
+                valid, normalized = normalize(observation['snapshot'], tables)
+                passed = valid and normalized == expected and observation['status'] == 'pass' and observation['endpoint'] == 'complete' and observation['error'] is None
+                details = structure.observe(path.read_bytes(), tables, {table['name']: rows_for(arm, table['name']) for table in tables}, role == 'candidate')
+            except (ValueError, KeyError, TypeError, IndexError) as error:
+                passed, normalized, reason = False, observation['snapshot'], str(error)
+            semantic_hash = hashlib.sha256(canonical(normalized).encode()).hexdigest()
+            roles[role] = (passed, semantic_hash, observation['status'], observation['endpoint'], observation['error'], reason)
+            decoded.append(dict(arm=arm, replica=replica, role=role, passed=passed, semantic_sha256=semantic_hash, reason=reason, tables=details))
+        controls_ok &= roles['control'][0]
+        groups[arm].append(roles['candidate'])
+    outcomes = {arm: 'no_outcome' for arm in ARMS}
+    if (result['mutation_started'] is True and result['error'] is None and unchanged and controls_ok and actual_inventory == expected_inventory):
+        for arm, observations in groups.items():
+            if all(value == observations[0] for value in observations):
+                outcomes[arm] = 'observed_accepted' if observations[0][0] else 'not_observed_accepted'
+    report = dict(document_type='dao_multi_level_index_report', development_only=True, compatibility_claim=False,
+                  support_movement=False, plan_sha256=digest(PLAN), result_sha256=digest(outbox / 'result.json'),
+                  outcomes=outcomes, replicas=len(result['replicas']), candidates=plan['candidates'], structures=decoded)
+    path = outbox / 'report.json'
+    path.write_text(canonical(report) + '\n')
+    print(path)
+    print(canonical(outcomes))
+    return report
+
+
+def dispatch(args):
+    preflight(args.candidate_directory)
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve()
+    inbox, outbox = (shared / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / 'multi-level-index.plan.json')
+    for arm in ARMS:
+        shutil.copyfile(args.candidate_directory / f'{arm}.mdb', inbox / f'{arm}.mdb')
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=3600)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    global PLAN
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--plan', type=Path, default=PLAN)
+    commands = parser.add_subparsers(dest='command', required=True)
+    check = commands.add_parser('preflight')
+    check.add_argument('candidate_directory', type=Path)
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('candidate_directory', type=Path)
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    PLAN = args.plan.resolve()
+    if args.command == 'preflight':
+        preflight(args.candidate_directory)
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/scripts/multi_level_index_structure.py
+++ b/oracle/windows-dao/scripts/multi_level_index_structure.py
@@ -1,0 +1,144 @@
+"""Finite index-tree/map/row decoding from EXP-0062, EXP-0057/0065 and EXP-0126.
+
+Reuses an isolated system-catalog decoder with explicit experiment limits.
+No consumed decoder file or other experiment's runtime instance is modified.
+"""
+import hashlib
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location('multi_level_catalog', Path(__file__).with_name('system_catalog.py'))
+catalog = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(catalog)
+catalog.MAX_PAGES = 8192
+catalog.MAX_ROWS_PER_PAGE = 1019  # complete 2048-byte page directory, not the old sample's 64 slots
+
+
+def require(condition, detail):
+    if not condition:
+        raise catalog.DecodeError(detail)
+
+
+def map_pages(data, locator, what):
+    raw = catalog._locator_row(data, locator, what)
+    if raw[0] == 0:
+        return catalog._map_pages(raw, len(data) // 2048, what, bounded=True)
+    require(raw[0] == 1 and (len(raw) - 1) % 4 == 0, 'Invalid indirect map')
+    pages = set()
+    for slot, offset in enumerate(range(1, len(raw), 4)):
+        reference = int.from_bytes(raw[offset:offset + 4], 'little')
+        if not reference:
+            continue
+        bitmap = catalog._page(data, reference, what)
+        require(bitmap[:4] == b'\x05\x01\x00\x00', 'Invalid extended bitmap header')
+        start = slot * 2044 * 8
+        for position, byte in enumerate(bitmap[4:]):
+            for bit in range(8):
+                if byte & (1 << bit):
+                    page = start + position * 8 + bit
+                    require(page < len(data) // 2048, 'Map member outside image')
+                    pages.add(page)
+    return pages
+
+
+catalog._locator_pages = map_pages
+
+
+def key_bytes(row, fields, columns):
+    key = b''
+    for field in fields:
+        value = row[columns.index(field['name'])]
+        component = b'\x7f' + (value + (1 << 31)).to_bytes(4, 'big')
+        key += bytes(byte ^ 255 for byte in component) if field['descending'] else component
+    return key
+
+
+def tree(data, root, owner):
+    nodes, seen, leaf_entries = [], set(), []
+    def visit(number, depth):
+        require(depth <= 32 and number not in seen, 'Repeated page or excessive index depth')
+        seen.add(number)
+        page = catalog._page(data, number, 'index node')
+        branch = page[0] == 3
+        require(page[0] in (3, 4) and page[1] == 1 and page[21] == int(branch), 'Index node header')
+        require(int.from_bytes(page[4:8], 'little') == owner, 'Index owner mismatch')
+        prefix = page[20]
+        previous, following, tail = [int.from_bytes(page[offset:offset + 4], 'little') for offset in (8, 12, 16)]
+        require(bool(tail) == branch, 'Index tail child mismatch')
+        area = page[248:]
+        boundaries = [position * 8 + bit for position, byte in enumerate(page[22:248]) for bit in range(8) if byte & (1 << bit)]
+        require(all(prefix < end <= 1800 for end in boundaries), 'Index boundary outside entry area')
+        require(int.from_bytes(page[2:4], 'little') == 1800 - (boundaries[-1] if boundaries else 0), 'Index free space mismatch')
+        require(bool(boundaries) or (not branch and prefix == 0), 'Empty branch or unmatched prefix')
+        node = dict(page=number, depth=depth, previous=previous, next=following, tail=tail, prefix=prefix, entries=len(boundaries), children=[])
+        nodes.append(node)
+        start, entries = prefix, []
+        for end in boundaries:
+            entry = area[:prefix] + area[start:end]
+            require(len(entry) >= (8 if branch else 4), 'Short index entry')
+            entries.append(entry)
+            start = end
+        require(entries == sorted(entries), 'Unsorted complete index entries')
+        if not branch:
+            leaf_entries.extend(entries)
+            return entries[-1] if entries else None
+        for entry in entries:
+            child = int.from_bytes(entry[-4:], 'big')
+            node['children'].append(child)
+            maximum = visit(child, depth + 1)
+            require(maximum == entry[:-4], 'Branch separator is not child maximum key and locator')
+        node['children'].append(tail)
+        return visit(tail, depth + 1)
+    visit(root, 1)
+    for depth in sorted({node['depth'] for node in nodes}):
+        level = [node for node in nodes if node['depth'] == depth]
+        for position, node in enumerate(level):
+            require(node['previous'] == (level[position - 1]['page'] if position else 0)
+                    and node['next'] == (level[position + 1]['page'] if position + 1 < len(level) else 0), 'Index sibling chain mismatch')
+    require(len({node['depth'] for node in nodes if not node['children']}) == 1, 'Unequal leaf depth')
+    require(leaf_entries == sorted(leaf_entries), 'Index traversal is not sorted')
+    return nodes, leaf_entries
+
+
+def observe(data, tables, expected_rows, candidate):
+    require(len(data) % 2048 == 0 and 20 <= len(data) // 2048 <= 8192, 'Image page bound')
+    definition, _, objects = catalog._discover_catalog(data)
+    name, kind, ident = [catalog._ordinal(definition, key) for key in ('Name', 'Type', 'Id')]
+    roots = {row['values'][name]: row['values'][ident] for row in objects if row['values'][kind] == 1}
+    observations = []
+    for table in tables:
+        definition = catalog._definition(data, roots[table['name']])
+        require([(column['name'], column['type'], column['size']) for column in definition['columns']]
+                == [(field['name'], 'Long', 4) for field in table['fields']], 'Physical schema mismatch')
+        pages, long_values = catalog._table_pages(data, definition)
+        rows = catalog._table_rows(data, definition, pages)
+        require(not long_values and sorted(row['values'] for row in rows) == sorted(expected_rows[table['name']])
+                and definition['row_count'] == len(rows), 'Physical row mismatch')
+        available = map_pages(data, definition['maps']['available'], 'available rows')
+        require(available <= set(pages), 'Available pages outside owned data pages')
+        require(len(definition['physical_indexes']) == len(table['indexes']), 'Physical index inventory mismatch')
+        result = dict(name=table['name'], root=definition['root'], row_count=len(rows), data_pages=pages, available_pages=sorted(available), indexes=[])
+        for physical, index in zip(definition['physical_indexes'], table['indexes']):
+            nodes, entries = tree(data, physical['root'], definition['root'])
+            mapped = map_pages(data, physical['map'], 'index map')
+            graph = {node['page'] for node in nodes}
+            require(graph <= mapped and not mapped.intersection(pages), 'Index map membership mismatch')
+            require(not candidate or graph == mapped, 'Candidate index map has unused members')
+            columns = [field['name'] for field in table['fields']]
+            by_locator = {(row['page'], row['row']): row['values'] for row in rows}
+            seen, keys = set(), []
+            for entry in entries:
+                locator = (int.from_bytes(entry[-4:-1], 'big'), entry[-1])
+                require(locator in by_locator and locator not in seen, 'Missing or repeated row locator')
+                seen.add(locator)
+                expected = key_bytes(by_locator[locator], index['fields'], columns)
+                require(entry[:-4] == expected, 'Index key and row values disagree')
+                keys.append(expected)
+            require(seen == set(by_locator) and physical['entry_count'] == len(set(keys)), 'Index coverage or distinct count mismatch')
+            depth = max(node['depth'] for node in nodes)
+            require(not candidate or depth == table['candidate_depth'], 'Candidate did not reach planned depth')
+            result['indexes'].append(dict(root=physical['root'], depth=depth, nodes=nodes, mapped_pages=sorted(mapped),
+                leaf_entries=len(entries), distinct_keys=physical['entry_count'], physical_flags=physical['flags'],
+                locator_key_sha256=hashlib.sha256(b''.join(entries)).hexdigest()))
+        observations.append(result)
+    return observations

--- a/oracle/windows-dao/tests/test_multi_level_index.py
+++ b/oracle/windows-dao/tests/test_multi_level_index.py
@@ -1,0 +1,155 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+import multi_level_index as experiment
+import multi_level_index_structure as structure
+
+
+class MultiLevelIndexTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.plan = json.loads(experiment.PLAN.read_text())
+
+    def test_complete_duplicate_traversal_and_seek_allow_only_matching_rows(self):
+        tables = self.plan['arms']['relationship']
+        snapshot = experiment.expected_snapshot('relationship', tables)
+        child = snapshot['user_tables'][1]
+        child['traversal'][0], child['traversal'][1] = child['traversal'][1], child['traversal'][0]
+        child['seek'][1]['row'] = child['traversal'][1]
+        self.assertTrue(experiment.normalize(snapshot, tables)[0])
+        child['seek'][1]['row'] = [999, 0]
+        self.assertFalse(experiment.normalize(snapshot, tables)[0])
+        snapshot = experiment.expected_snapshot('relationship', tables)
+        snapshot['user_tables'][1]['traversal'].pop()
+        self.assertFalse(experiment.normalize(snapshot, tables)[0])
+
+    def test_direction_payload_types_and_missing_seek_are_checked(self):
+        tables = self.plan['arms']['composite']
+        snapshot = experiment.expected_snapshot('composite', tables)
+        self.assertTrue(experiment.normalize(snapshot, tables)[0])
+        snapshot['user_tables'][1]['traversal'].reverse()
+        self.assertFalse(experiment.normalize(snapshot, tables)[0])
+        snapshot = experiment.expected_snapshot('composite', tables)
+        snapshot['user_tables'][1]['rows'][0][2] = True
+        self.assertFalse(experiment.normalize(snapshot, tables)[0])
+        snapshot = experiment.expected_snapshot('composite', tables)
+        snapshot['user_tables'][1]['seek'][-1]['row'] = snapshot['user_tables'][1]['rows'][0]
+        self.assertFalse(experiment.normalize(snapshot, tables)[0])
+
+    def test_analysis_and_preflight_share_input_pin_validation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'input.py').write_text('changed')
+            plan = root / 'plan.json'
+            plan.write_text(json.dumps(dict(self.plan, inputs={'input.py': '0' * 64})))
+            with patch.object(experiment, 'ROOT', root), patch.object(experiment, 'PLAN', plan):
+                with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                    experiment.preflight(root)
+                with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                    experiment.analyze(root)
+
+    def fixture(self, root):
+        plan = copy.deepcopy(self.plan)
+        plan['inputs'] = {}
+        result = dict(document_type='dao_multi_level_index_result', development_only=True,
+                      environment={'process_bits': 32, 'provider': 'DAO.DBEngine.36'},
+                      mutation_started=True, error=None, replicas=[])
+        for arm, tables in plan['arms'].items():
+            plan['candidates'][arm] = {'size': 1, 'sha256': experiment.hashlib.sha256(b'x').hexdigest()}
+            for replica in range(1, 4):
+                pair = dict(arm=arm, replica=replica)
+                for role in ('candidate', 'control'):
+                    (root / f'{arm}-{role}-r{replica}.mdb').write_bytes(b'x')
+                    pair[role] = dict(before=plan['candidates'][arm], after=plan['candidates'][arm], status='pass', endpoint='complete', error=None,
+                                      snapshot=experiment.expected_snapshot(arm, tables))
+                result['replicas'].append(pair)
+        plan_path = root / 'plan.json'
+        plan_path.write_text(json.dumps(plan))
+        result['plan_sha256'] = experiment.digest(plan_path)
+        return plan_path, result
+
+    def test_classifier_acceptance_failure_and_incomplete_control_gates(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plan, result = self.fixture(root)
+            def analyze():
+                (root / 'result.json').write_text(json.dumps(result))
+                with patch.object(experiment, 'PLAN', plan), patch.object(structure, 'observe', return_value=[]):
+                    return experiment.analyze(root)['outcomes']
+            self.assertEqual(set(analyze().values()), {'observed_accepted'})
+            result['error'] = 'unexpected mutation failure'
+            self.assertEqual(set(analyze().values()), {'no_outcome'})
+            result['error'] = None
+            result['replicas'][-1]['control']['status'] = 'fail'
+            self.assertEqual(set(analyze().values()), {'no_outcome'})
+            result['replicas'][-1]['control']['status'] = 'pass'
+            for pair in result['replicas'][:3]:
+                pair['candidate']['snapshot']['version'] = 'wrong'
+            self.assertEqual(analyze()['primary'], 'not_observed_accepted')
+            result['replicas'][0]['candidate']['snapshot']['version'] = '3.0'
+            self.assertEqual(analyze()['primary'], 'no_outcome')
+            (root / 'primary-candidate-r1.mdb').write_bytes(b'corrupt')
+            with self.assertRaisesRegex(ValueError, 'Retained identity mismatch'):
+                analyze()
+
+    def tree_image(self):
+        image = bytearray(4 * 2048)
+        entries = [b'\x7f\x80\x00\x00' + bytes([key]) + b'\x00\x00\x06' + bytes([key]) for key in (1, 2, 3)]
+        def page(number, records, branch=False, previous=0, following=0, tail=0, prefix=0):
+            raw = bytearray(2048)
+            raw[0:2] = bytes([3 if branch else 4, 1]); raw[21] = int(branch); raw[20] = prefix
+            for offset, value in [(4, 20), (8, previous), (12, following), (16, tail)]:
+                raw[offset:offset + 4] = value.to_bytes(4, 'little')
+            start = prefix
+            raw[248:248 + prefix] = records[0][:prefix]
+            for record in records:
+                suffix = record[prefix:]; end = start + len(suffix)
+                raw[248 + start:248 + end] = suffix
+                raw[22 + end // 8] |= 1 << (end % 8)
+                start = end
+            raw[2:4] = (1800 - start).to_bytes(2, 'little')
+            image[number * 2048:(number + 1) * 2048] = raw
+        page(2, entries[:2], following=3, prefix=3)
+        page(3, entries[2:], previous=2)
+        page(1, [entries[1] + (2).to_bytes(4, 'big')], branch=True, tail=3)
+        return image, entries
+
+    def test_tree_prefixes_full_separators_links_and_cycles(self):
+        image, entries = self.tree_image()
+        nodes, actual = structure.tree(image, 1, 20)
+        self.assertEqual(actual, entries)
+        self.assertEqual(len(nodes), 3)
+        for offset in [2048 + 248 + 4, 2 * 2048 + 12, 2048 + 16]:
+            changed = bytearray(image); changed[offset] ^= 1
+            with self.assertRaises(structure.catalog.DecodeError):
+                structure.tree(changed, 1, 20)
+
+    def test_indirect_control_maps_decode_members_and_reject_outside_bits(self):
+        data = bytearray(2 * 2048)
+        data[2048:2052] = b'\x05\x01\x00\x00'
+        data[2052] = 2
+        record = b'\x01' + (1).to_bytes(4, 'little')
+        with patch.object(structure.catalog, '_locator_row', return_value=record):
+            self.assertEqual(structure.map_pages(data, {}, 'test'), {1})
+            data[2052] = 4
+            with self.assertRaisesRegex(structure.catalog.DecodeError, 'outside image'):
+                structure.map_pages(data, {}, 'test')
+
+    def test_declared_directory_limit_accepts_more_than_64_rows(self):
+        image = bytearray(2048)
+        image[8:10] = (256).to_bytes(2, 'little')
+        for slot in range(256):
+            image[10 + 2 * slot:12 + 2 * slot] = (2048 - slot - 1).to_bytes(2, 'little')
+        self.assertEqual(len(structure.catalog._row_directory(image, 1)), 256)
+        self.assertEqual(structure.catalog.MAX_ROWS_PER_PAGE, 1019)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The new multi-level Long writer needs DAO validation beyond a single leaf. Preregister EXP-0139 for three candidate/control arms with 27,801 primary rows, 12,929 composite rows after an empty table, and 27,801 child rows referencing 201 parents. Each arm has three fresh controls and unchanged read-only observations.

Compare complete metadata, rows and index traversal, plus explicit boundary/missing Seek probes. Validate raw tree separators, sibling chains, row locators and maps without requiring DAO to use the same physical layout. Inputs and candidate hashes are pinned; the single-dispatch timeout is 3,600 seconds. Independent review, seven focused tests, committed preflight, PowerShell parser checks and `just ready` pass. Local evidence only; no hosted support claim. Advances #100.
