### PR TITLE
test: add hosted DAO write differential pipeline

### DIFF
--- a/.github/workflows/windows-dao-write.yml
+++ b/.github/workflows/windows-dao-write.yml
@@ -1,0 +1,107 @@
+name: Windows DAO write differential
+on:
+  workflow_dispatch:
+    inputs:
+      run_acquisition:
+        description: Run the reviewed single write acquisition
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the committed EXP-0141 write plan
+        type: string
+        required: false
+permissions:
+  contents: read
+concurrency:
+  group: windows-dao-write-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  generate:
+    if: inputs.run_acquisition
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          python3 oracle/windows-dao/scripts/dao_write_diff.py plan "$PLAN_SHA256"
+      - name: Build public fixture and snapshot producers
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-write-fixture
+      - name: Create requested fixtures on supported publication platform
+        run: python3 oracle/windows-dao/scripts/dao_write_diff.py prepare artifacts/dao-write-v1_2 target/release/jet3-write-fixture target/release/jet3-cli "$GITHUB_SHA"
+      - name: Retain exact generated files and preparation diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-write-${{ github.sha }}
+          path: artifacts/dao-write-v1_2
+          if-no-files-found: warn
+          retention-days: 14
+  write-differential:
+    needs: generate
+    if: always() && (needs.generate.result == 'success' || !inputs.run_acquisition)
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          if ($env:GITHUB_RUN_ATTEMPT -ne '1') { throw 'No automatic acquisition retry' }
+          python oracle/windows-dao/scripts/dao_write_diff.py plan $env:PLAN_SHA256
+          if ($LASTEXITCODE -ne 0) { throw 'Reviewed write plan verification failed' }
+      - name: Probe stock x86 provider
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/probe-provider.ps1 -ProtocolVersion 1.2.0 -OutputPath artifacts/environment.json
+          if ($LASTEXITCODE -ne 0) { throw 'Stock provider unavailable; retained probe explains missing prerequisite' }
+      - name: Download the exact Unix-generated candidates
+        if: inputs.run_acquisition
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: generated-write-${{ github.sha }}
+          path: artifacts/dao-write-v1_2
+      - name: Build the read-only Rust snapshot producer
+        if: inputs.run_acquisition
+        shell: powershell
+        run: cargo build --locked --release -p jet3-cli
+      - name: Verify downloads and snapshot them on Windows
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_write_diff.py snapshot artifacts/dao-write-v1_2 target/release/jet3-cli.exe $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'Downloaded fixture snapshot failed' }
+      - name: Observe Rust files read-only with DAO
+        id: dao
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/Invoke-DaoWriteV12.ps1 -InventoryPath oracle/windows-dao/protocol/v1_2/write-scenarios.json -EnvironmentPath artifacts/environment.json -OutputRoot artifacts/dao-write-v1_2 -SourceRevision $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'DAO write observation failed' }
+      - name: Compare protocol snapshots and recipe semantics
+        if: always() && inputs.run_acquisition && steps.dao.outcome != 'skipped'
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_write_diff.py evaluate artifacts/dao-write-v1_2
+          if ($LASTEXITCODE -ne 0) { throw 'Write differential failed' }
+      - name: Retain diagnostics including failed files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-write-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/crates/jet3-cli/src/snapshot.rs
+++ b/crates/jet3-cli/src/snapshot.rs
@@ -6,12 +6,12 @@ use std::path::PathBuf;
 
 use jet3::TextCodePage;
 use jet3_testkit::{
-    PROTOCOL_SCENARIOS, Producer, SnapshotOptions, SnapshotOutcome, canonical_json, coverage,
-    parse_scenarios, snapshot_bytes,
+    PROTOCOL_SCENARIOS, Producer, SnapshotOptions, SnapshotOutcome, WRITE_SCENARIOS,
+    canonical_json, coverage, parse_scenarios, snapshot_bytes,
 };
 
 pub(crate) const HELP: &str = "\
-  jet3-cli snapshot <file> --out <dir> --scenario <DAO-READ-...> \
+  jet3-cli snapshot <file> --out <dir> --scenario <DAO-READ-...|DAO-WRITE-...> \
     [--source-revision <text>] [--code-page 1252|1251]
 
 snapshot reads the whole database with the jet3 reader and writes
@@ -73,7 +73,12 @@ pub(crate) fn parse_args(
 
 /// Writes the artifact pair and returns a one-line JSON summary.
 pub(crate) fn run(command: &SnapshotCommand) -> Result<String, String> {
-    let scenarios = parse_scenarios(PROTOCOL_SCENARIOS).map_err(|error| error.to_string())?;
+    let scenarios = parse_scenarios(if command.scenario_id.starts_with("DAO-WRITE-") {
+        WRITE_SCENARIOS
+    } else {
+        PROTOCOL_SCENARIOS
+    })
+    .map_err(|error| error.to_string())?;
     if !scenarios
         .iter()
         .any(|scenario| scenario.id == command.scenario_id)

--- a/crates/jet3-cli/tests/snapshot.rs
+++ b/crates/jet3-cli/tests/snapshot.rs
@@ -153,3 +153,41 @@ fn rejected_header_writes_only_the_coverage_receipt() -> TestResult {
     validate_document(&out.join("coverage.json"))?;
     validate_pair(&out.join("coverage.json"), None)
 }
+
+#[test]
+#[cfg(unix)]
+fn write_snapshot_uses_separate_inventory_and_public_fixture_creation() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let database = directory.path().join("write.mdb");
+    jet3_testkit::write_fixture("DAO-WRITE-AUTO-PRIMARY", &database)?;
+    let output = directory.path().join("snapshot");
+    let run = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .args(["snapshot"])
+        .arg(&database)
+        .args(["--scenario", "DAO-WRITE-AUTO-PRIMARY", "--out"])
+        .arg(&output)
+        .output()?;
+    assert!(
+        run.status.success(),
+        "{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(output.join("coverage.json"))?)?;
+    assert_eq!(receipt["scenario_id"], "DAO-WRITE-AUTO-PRIMARY");
+    let scenarios = receipt["scenarios"].as_array().ok_or("missing scenarios")?;
+    assert!(scenarios.iter().all(|s| {
+        s["id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("DAO-WRITE-"))
+    }));
+    assert!(
+        scenarios
+            .iter()
+            .any(|s| s["id"] == "DAO-WRITE-AUTO-PRIMARY" && s["satisfied"] == true)
+    );
+    let absent = directory.path().join("unknown.mdb");
+    assert!(jet3_testkit::write_fixture("DAO-WRITE-UNKNOWN", &absent).is_err());
+    assert!(!absent.exists());
+    Ok(())
+}

--- a/crates/jet3-testkit/src/bin/jet3-write-fixture.rs
+++ b/crates/jet3-testkit/src/bin/jet3-write-fixture.rs
@@ -1,0 +1,8 @@
+//! Creates a declared protocol write fixture through the public API.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        return Err("usage: jet3-write-fixture SCENARIO OUTPUT.mdb".into());
+    }
+    jet3_testkit::write_fixture(&args[0], std::path::Path::new(&args[1]))
+}

--- a/crates/jet3-testkit/src/lib.rs
+++ b/crates/jet3-testkit/src/lib.rs
@@ -29,3 +29,6 @@ pub use semantic_snapshot::{
 pub const fn fixture_format_name() -> &'static str {
     jet3::FORMAT_NAME
 }
+
+mod write_fixture;
+pub use write_fixture::{WRITE_SCENARIOS, write_fixture};

--- a/crates/jet3-testkit/src/write_fixture.rs
+++ b/crates/jet3-testkit/src/write_fixture.rs
@@ -1,0 +1,297 @@
+//! Declarative fixtures built through the public creation API for the write leg.
+use std::{num::NonZeroU8, path::Path};
+
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
+    RelationshipColumn, RelationshipSpec, ResourceBudget, ResourceLimits, RowValue, TableRef,
+    TableRows, TableSpec, create_database_with_relationship_rows, create_database_with_table_rows,
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Separate write inventory; read inventory membership remains unchanged.
+pub const WRITE_SCENARIOS: &str =
+    include_str!("../../../oracle/windows-dao/protocol/v1_2/write-scenarios.json");
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Deserialize)]
+struct Inventory {
+    scenarios: Vec<Recipe>,
+}
+#[derive(Deserialize)]
+struct Recipe {
+    id: String,
+    tables: Vec<Table>,
+    relationship: Option<Relation>,
+}
+#[derive(Deserialize)]
+struct Table {
+    name: String,
+    columns: Vec<Column>,
+    indexes: Vec<Index>,
+    rows: Vec<Vec<Value>>,
+    repeat: Option<usize>,
+}
+#[derive(Deserialize)]
+struct Column {
+    name: String,
+    kind: String,
+    size: Option<u8>,
+}
+#[derive(Deserialize)]
+struct Index {
+    name: String,
+    kind: String,
+    fields: Vec<Field>,
+}
+#[derive(Deserialize)]
+struct Field {
+    column: u16,
+    descending: bool,
+}
+#[derive(Deserialize)]
+struct Relation {
+    name: String,
+    parent_table: u16,
+    parent_column: u16,
+    child_table: u16,
+    child_column: u16,
+}
+
+fn column_type(column: &Column) -> Result<ColumnType> {
+    Ok(match column.kind.as_str() {
+        "Boolean" => ColumnType::Boolean,
+        "Byte" => ColumnType::Byte,
+        "Integer" => ColumnType::Integer,
+        "Long" => ColumnType::Long,
+        "AutoIncrement" => ColumnType::AutoIncrement,
+        "Currency" => ColumnType::Currency,
+        "Single" => ColumnType::Single,
+        "Double" => ColumnType::Double,
+        "DateTime" => ColumnType::DateTime,
+        "Guid" => ColumnType::Guid,
+        "Memo" => ColumnType::Memo,
+        "LongBinary" => ColumnType::LongBinary,
+        "Text" => ColumnType::Text {
+            max_len: NonZeroU8::new(column.size.ok_or("missing size")?).ok_or("zero size")?,
+        },
+        "Binary" => ColumnType::Binary {
+            max_len: NonZeroU8::new(column.size.ok_or("missing size")?).ok_or("zero size")?,
+        },
+        _ => return Err("unknown recipe column type".into()),
+    })
+}
+
+fn expand(value: &Value, row: usize) -> Result<Value> {
+    if let Some(start) = value.get("sequence").and_then(Value::as_i64) {
+        return Ok(Value::from(
+            start
+                .checked_add(row.try_into()?)
+                .ok_or("sequence overflow")?,
+        ));
+    }
+    if let Some(text) = value.get("repeat_text").and_then(Value::as_str) {
+        return Ok(Value::String(
+            text.repeat(
+                value["count"]
+                    .as_u64()
+                    .ok_or("missing repeat count")?
+                    .try_into()?,
+            ),
+        ));
+    }
+    Ok(value.clone())
+}
+
+fn row_value<'a>(value: &'a Value, column: &Column) -> Result<RowValue<'a>> {
+    if value.is_null() {
+        return Ok(RowValue::Null);
+    }
+    let integer = || value.as_i64().ok_or("expected integer");
+    let number = || value.as_f64().ok_or("expected number");
+    let text = || value.as_str().ok_or("expected ASCII text");
+    Ok(match column.kind.as_str() {
+        "AutoIncrement" if value.get("auto").and_then(Value::as_bool) == Some(true) => {
+            RowValue::AutoIncrement
+        }
+        "Boolean" => RowValue::Boolean(value.as_bool().ok_or("expected boolean")?),
+        "Byte" => RowValue::Byte(integer()?.try_into()?),
+        "Integer" => RowValue::Integer(integer()?.try_into()?),
+        "Long" => RowValue::Long(integer()?.try_into()?),
+        "Currency" => RowValue::Currency { scaled: integer()? },
+        "Single" => RowValue::Single(number()? as f32),
+        "Double" => RowValue::Double(number()?),
+        "DateTime" => RowValue::DateTime { days: number()? },
+        "Text" | "Memo" | "Binary" | "LongBinary" => {
+            let bytes = text()?.as_bytes();
+            if !bytes.is_ascii() {
+                return Err("fixture strings must be ASCII".into());
+            }
+            match column.kind.as_str() {
+                "Text" => RowValue::Text(bytes),
+                "Memo" => RowValue::Memo(bytes),
+                "Binary" => RowValue::Binary(bytes),
+                _ => RowValue::LongBinary(bytes),
+            }
+        }
+        "Guid" => {
+            let bytes = value
+                .as_array()
+                .ok_or("expected GUID byte array")?
+                .iter()
+                .map(|byte| Ok(u8::try_from(byte.as_u64().ok_or("invalid GUID byte")?)?))
+                .collect::<Result<Vec<_>>>()?;
+            RowValue::Guid(bytes.try_into().map_err(|_| "GUID needs 16 bytes")?)
+        }
+        _ => return Err("invalid recipe value".into()),
+    })
+}
+
+/// Creates one inventory fixture with exactly one public creation call.
+pub fn write_fixture(id: &str, output: &Path) -> Result<()> {
+    let inventory: Inventory = serde_json::from_str(WRITE_SCENARIOS)?;
+    let recipe = inventory
+        .scenarios
+        .into_iter()
+        .find(|r| r.id == id)
+        .ok_or("unknown write scenario")?;
+    let columns = recipe
+        .tables
+        .iter()
+        .map(|table| {
+            table
+                .columns
+                .iter()
+                .map(|column| {
+                    Ok(ColumnSpec::new(
+                        column.name.as_bytes(),
+                        column_type(column)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let fields = recipe
+        .tables
+        .iter()
+        .map(|table| {
+            table
+                .indexes
+                .iter()
+                .map(|index| {
+                    index
+                        .fields
+                        .iter()
+                        .map(|field| IndexColumnSpec {
+                            column: ColumnRef::Ordinal(field.column),
+                            direction: if field.descending {
+                                IndexDirection::Descending
+                            } else {
+                                IndexDirection::Ascending
+                            },
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let indexes = recipe
+        .tables
+        .iter()
+        .zip(&fields)
+        .map(|(table, fields)| {
+            table
+                .indexes
+                .iter()
+                .zip(fields)
+                .map(|(index, fields)| {
+                    Ok(IndexSpec {
+                        name: index.name.as_bytes(),
+                        fields,
+                        kind: match index.kind.as_str() {
+                            "primary" => IndexKind::Primary,
+                            "unique" => IndexKind::Unique,
+                            "ordinary" => IndexKind::Ordinary,
+                            _ => return Err("invalid index kind".into()),
+                        },
+                    })
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let values = recipe
+        .tables
+        .iter()
+        .map(|table| {
+            (0..table.repeat.unwrap_or(table.rows.len()))
+                .map(|row| {
+                    let source = table
+                        .rows
+                        .get(if table.repeat.is_some() { 0 } else { row })
+                        .ok_or("missing row")?;
+                    source
+                        .iter()
+                        .map(|value| expand(value, row))
+                        .collect::<Result<Vec<_>>>()
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let rows = recipe
+        .tables
+        .iter()
+        .zip(&values)
+        .map(|(table, rows)| {
+            rows.iter()
+                .map(|row| {
+                    if row.len() != table.columns.len() {
+                        return Err("row width mismatch".into());
+                    }
+                    row.iter()
+                        .zip(&table.columns)
+                        .map(|(value, column)| row_value(value, column))
+                        .collect::<Result<Vec<_>>>()
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let slices = rows
+        .iter()
+        .map(|rows| rows.iter().map(Vec::as_slice).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let requests = recipe
+        .tables
+        .iter()
+        .enumerate()
+        .map(|(n, table)| TableRows {
+            table: TableSpec {
+                name: table.name.as_bytes(),
+                columns: &columns[n],
+                indexes: &indexes[n],
+            },
+            rows: &slices[n],
+        })
+        .collect::<Vec<_>>();
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    if let Some(relation) = recipe.relationship {
+        create_database_with_relationship_rows(
+            output,
+            &requests,
+            &RelationshipSpec {
+                name: relation.name.as_bytes(),
+                parent: RelationshipColumn {
+                    table: TableRef::Ordinal(usize::from(relation.parent_table)),
+                    column: ColumnRef::Ordinal(relation.parent_column),
+                },
+                child: RelationshipColumn {
+                    table: TableRef::Ordinal(usize::from(relation.child_table)),
+                    column: ColumnRef::Ordinal(relation.child_column),
+                },
+            },
+            &mut budget,
+        )?;
+    } else {
+        create_database_with_table_rows(output, &requests, &mut budget)?;
+    }
+    Ok(())
+}

--- a/oracle/windows-dao/protocol/v1_2/WRITE.md
+++ b/oracle/windows-dao/protocol/v1_2/WRITE.md
@@ -1,0 +1,28 @@
+# Write differential
+
+`write-scenarios.json` is a separate bounded inventory with operation mode
+`dao_open_rust`. It does not replace or relax the protocol 1.2 read inventory.
+Snapshots retain the existing canonical shape; write coverage receipts are
+validated against the write inventory by `dao_write_diff.py`.
+
+The Ubuntu job creates each recipe with one public creation call, validates a
+Rust snapshot against the recipe, and uploads the exact files. Publication is
+currently Unix-only. The Windows 2022 job downloads and verifies those files,
+produces a read-only Rust snapshot, probes the stock x86 DAO provider, and opens
+the same files read-only through DAO. It compares the complete protocol
+snapshots and independently checks the requested schema, typed rows and
+relationships. Every index also gets complete DAO traversal and full-key Seek;
+ordinary duplicate-key Seek may select any matching complete row.
+
+Local generation without DAO:
+
+```sh
+cargo build -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-write-fixture
+python3 oracle/windows-dao/scripts/dao_write_diff.py prepare OUT target/debug/jet3-write-fixture target/debug/jet3-cli SOURCE_REVISION
+```
+
+The workflow's acquisition gate requires the later reviewed EXP-0141 plan and
+its SHA-256. This scaffold does not contain that finalized plan and cannot run
+acquisition yet. EXP-0142 is reserved for the outcome. Probe and failure
+artifacts are retained; no runtime installer, automatic retry or support-matrix
+promotion is included. Inventory deferrals describe the remaining bounds.

--- a/oracle/windows-dao/protocol/v1_2/write-scenarios.json
+++ b/oracle/windows-dao/protocol/v1_2/write-scenarios.json
@@ -1,0 +1,786 @@
+{
+  "document_type": "dao_write_scenario_inventory",
+  "protocol_version": "1.2.0",
+  "scenarios": [
+    {
+      "id": "DAO-WRITE-EMPTY",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "empty database"
+      ],
+      "tables": [],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-SCALARS",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "scalar types",
+        "nulls",
+        "signed bounds",
+        "GUID"
+      ],
+      "tables": [
+        {
+          "name": "Scalars",
+          "columns": [
+            {
+              "name": "Boolean",
+              "kind": "Boolean"
+            },
+            {
+              "name": "Byte",
+              "kind": "Byte"
+            },
+            {
+              "name": "Integer",
+              "kind": "Integer"
+            },
+            {
+              "name": "Long",
+              "kind": "Long"
+            },
+            {
+              "name": "Currency",
+              "kind": "Currency"
+            },
+            {
+              "name": "Single",
+              "kind": "Single"
+            },
+            {
+              "name": "Double",
+              "kind": "Double"
+            },
+            {
+              "name": "DateTime",
+              "kind": "DateTime"
+            },
+            {
+              "name": "Guid",
+              "kind": "Guid"
+            },
+            {
+              "name": "Text",
+              "kind": "Text",
+              "size": 8
+            },
+            {
+              "name": "Binary",
+              "kind": "Binary",
+              "size": 8
+            }
+          ],
+          "rows": [
+            [
+              true,
+              255,
+              -32768,
+              -2147483648,
+              -12345,
+              1.5,
+              -2.25,
+              2.5,
+              [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ],
+              "text",
+              "bytes"
+            ],
+            [
+              false,
+              0,
+              32767,
+              2147483647,
+              0,
+              -1.5,
+              3.5,
+              0,
+              [
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+                26,
+                27,
+                28,
+                29,
+                30,
+                31
+              ],
+              "more",
+              "raw"
+            ],
+            [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ]
+          ],
+          "indexes": [],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-AUTO",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "AutoIncrement",
+        "multiple data pages"
+      ],
+      "tables": [
+        {
+          "name": "Generated",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "AutoIncrement"
+            },
+            {
+              "name": "Tag",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              {
+                "auto": true
+              },
+              {
+                "sequence": 1
+              }
+            ]
+          ],
+          "indexes": [],
+          "repeat": 300
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-INDEX-PRIMARY",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "index schema",
+        "complete traversal",
+        "full-key Seek"
+      ],
+      "tables": [
+        {
+          "name": "Keys",
+          "columns": [
+            {
+              "name": "A",
+              "kind": "Long"
+            },
+            {
+              "name": "B",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              9
+            ],
+            [
+              -1,
+              8
+            ],
+            [
+              0,
+              7
+            ]
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-INDEX-UNIQUE-DESC",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "index schema",
+        "complete traversal",
+        "full-key Seek"
+      ],
+      "tables": [
+        {
+          "name": "Keys",
+          "columns": [
+            {
+              "name": "A",
+              "kind": "Long"
+            },
+            {
+              "name": "B",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              9
+            ],
+            [
+              -1,
+              8
+            ],
+            [
+              0,
+              7
+            ]
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "unique",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": true
+                }
+              ]
+            }
+          ],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-INDEX-ORDINARY",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "index schema",
+        "complete traversal",
+        "full-key Seek"
+      ],
+      "tables": [
+        {
+          "name": "Keys",
+          "columns": [
+            {
+              "name": "A",
+              "kind": "Long"
+            },
+            {
+              "name": "B",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              9
+            ],
+            [
+              1,
+              8
+            ],
+            [
+              0,
+              7
+            ]
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "ordinary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-INDEX-COMPOSITE",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "index schema",
+        "complete traversal",
+        "full-key Seek"
+      ],
+      "tables": [
+        {
+          "name": "Keys",
+          "columns": [
+            {
+              "name": "A",
+              "kind": "Long"
+            },
+            {
+              "name": "B",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              9
+            ],
+            [
+              1,
+              8
+            ],
+            [
+              0,
+              7
+            ],
+            [
+              1,
+              9
+            ]
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "ordinary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": true
+                },
+                {
+                  "column": 1,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-AUTO-PRIMARY",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "indexed AutoIncrement"
+      ],
+      "tables": [
+        {
+          "name": "Generated",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "AutoIncrement"
+            },
+            {
+              "name": "Tag",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              {
+                "auto": true
+              },
+              {
+                "sequence": 1
+              }
+            ]
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": 10
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-MULTI",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "multiple tables",
+        "multiple data pages",
+        "independent table rows"
+      ],
+      "tables": [
+        {
+          "name": "First",
+          "columns": [
+            {
+              "name": "Value",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              {
+                "sequence": -150
+              }
+            ]
+          ],
+          "indexes": [],
+          "repeat": 300
+        },
+        {
+          "name": "Second",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "AutoIncrement"
+            }
+          ],
+          "rows": [
+            [
+              {
+                "auto": true
+              }
+            ]
+          ],
+          "indexes": [],
+          "repeat": 3
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-LVAL-MEMO",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "inline LVAL",
+        "single-page LVAL",
+        "chained LVAL",
+        "null LVAL"
+      ],
+      "tables": [
+        {
+          "name": "Payloads",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Memo"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              "short"
+            ],
+            [
+              2,
+              {
+                "repeat_text": "L",
+                "count": 512
+              }
+            ],
+            [
+              3,
+              {
+                "repeat_text": "X",
+                "count": 2040
+              }
+            ],
+            [
+              4,
+              null
+            ]
+          ],
+          "indexes": [],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-LVAL-LONGBINARY",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "inline LVAL",
+        "single-page LVAL",
+        "chained LVAL",
+        "null LVAL"
+      ],
+      "tables": [
+        {
+          "name": "Payloads",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "LongBinary"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              "short"
+            ],
+            [
+              2,
+              {
+                "repeat_text": "L",
+                "count": 512
+              }
+            ],
+            [
+              3,
+              {
+                "repeat_text": "X",
+                "count": 2040
+              }
+            ],
+            [
+              4,
+              null
+            ]
+          ],
+          "indexes": [],
+          "repeat": null
+        }
+      ],
+      "relationship": null
+    },
+    {
+      "id": "DAO-WRITE-RELATIONSHIP",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "populated relationship",
+        "foreign index",
+        "duplicate foreign keys"
+      ],
+      "tables": [
+        {
+          "name": "Parent",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              1
+            ],
+            [
+              2
+            ]
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null
+        },
+        {
+          "name": "Child",
+          "columns": [
+            {
+              "name": "ParentId",
+              "kind": "Long"
+            },
+            {
+              "name": "Tag",
+              "kind": "Long"
+            }
+          ],
+          "rows": [
+            [
+              1,
+              10
+            ],
+            [
+              1,
+              11
+            ],
+            [
+              2,
+              12
+            ]
+          ],
+          "indexes": [],
+          "repeat": null
+        }
+      ],
+      "relationship": {
+        "name": "ParentChild",
+        "parent_table": 0,
+        "parent_column": 0,
+        "child_table": 1,
+        "child_column": 0
+      }
+    }
+  ],
+  "deferred_requirements": [
+    "Multi-level initial index creation (implementation pending)",
+    "General null/composite foreign keys and cascades",
+    "Explicit AutoIncrement seeds, overflow and update semantics",
+    "Empty LVAL payloads and unsupported schema combinations",
+    "General allocation policy and arbitrary names/code pages"
+  ]
+}

--- a/oracle/windows-dao/protocol/v1_2/write-scenarios.json
+++ b/oracle/windows-dao/protocol/v1_2/write-scenarios.json
@@ -777,7 +777,7 @@
     }
   ],
   "deferred_requirements": [
-    "Multi-level initial index creation (implementation pending)",
+    "Multi-level index write-inventory boundary coverage",
     "General null/composite foreign keys and cascades",
     "Explicit AutoIncrement seeds, overflow and update semantics",
     "Empty LVAL payloads and unsupported schema combinations",

--- a/oracle/windows-dao/scripts/Invoke-DaoWriteV12.ps1
+++ b/oracle/windows-dao/scripts/Invoke-DaoWriteV12.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$InventoryPath,
+    [Parameter(Mandatory=$true)][string]$EnvironmentPath,
+    [Parameter(Mandatory=$true)][string]$OutputRoot,
+    [Parameter(Mandatory=$true)][string]$SourceRevision
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+# Reuse only named pure snapshot helpers; never execute the read acquisition.
+$helperPath = Join-Path $PSScriptRoot 'Invoke-DaoReadV12.ps1'
+$tokens = $null; $errors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile($helperPath, [ref]$tokens, [ref]$errors)
+if ($errors.Count) { throw 'Snapshot helper parse failure' }
+foreach ($name in @('Release-ComObject','Write-JsonDocument','Convert-ToLowerHex','Get-FileSha256','Get-DateText','Get-TypedValue','Get-NormalizedSize','Get-DaoSnapshot')) {
+    $definitions = @($ast.FindAll({param($node) $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name}, $false))
+    if ($definitions.Count -ne 1) { throw "Missing snapshot helper $name" }
+    Invoke-Expression $definitions[0].Extent.Text
+}
+$DaoTypeNames = @{1='dbBoolean';2='dbByte';3='dbInteger';4='dbLong';5='dbCurrency';6='dbSingle';7='dbDouble';8='dbDate';9='dbBinary';10='dbText';11='dbLongBinary';12='dbMemo';15='dbGUID'}
+$DbAutoIncrField = 16; $DbSystemObject = -2147483646; $DbDescending = 1
+$Utf8 = New-Object Text.UTF8Encoding($false)
+$CodePage = [Text.Encoding]::GetEncoding(1252, (New-Object Text.EncoderExceptionFallback), (New-Object Text.DecoderExceptionFallback))
+function Get-RowValues($Recordset, $Columns) {
+    $values = [ordered]@{}
+    foreach ($column in $Columns) {
+        $field = $null
+        try { $field = $Recordset.Fields.Item([string]$column.name); $values[[string]$column.name] = Get-TypedValue -Field $field }
+        finally { Release-ComObject $field }
+    }
+    return $values
+}
+function Get-IndexObservations($Database, $Snapshot) {
+    $observations = New-Object Collections.ArrayList
+    foreach ($table in $Snapshot.tables) {
+        foreach ($index in $table.indexes) {
+            $rs = $null
+            try {
+                $rs = $Database.OpenRecordset([string]$table.name, 1); $rs.Index = [string]$index.name
+                $rows = New-Object Collections.ArrayList; $seeks = New-Object Collections.ArrayList
+                if (-not $rs.EOF) { $rs.MoveFirst() }
+                while (-not $rs.EOF) { [void]$rows.Add((Get-RowValues $rs $table.columns)); $rs.MoveNext() }
+                $seen = @{}
+                foreach ($row in $rows) {
+                    $query = @($index.fields | ForEach-Object { [int]$row[[string]$_.name].value })
+                    $identity = $query -join ':'
+                    if ($seen.ContainsKey($identity)) { continue }; $seen[$identity] = $true
+                    if ($query.Count -eq 1) { $rs.Seek('=', $query[0]) }
+                    elseif ($query.Count -eq 2) { $rs.Seek('=', $query[0], $query[1]) }
+                    else { throw 'Write inventory only declares one/two Long index fields' }
+                    $found = if ($rs.NoMatch) { $null } else { Get-RowValues $rs $table.columns }
+                    [void]$seeks.Add(@{query=$query; row=$found})
+                }
+                [void]$observations.Add(@{table=[string]$table.name; index=[string]$index.name; rows=@($rows); seeks=@($seeks)})
+            } finally {
+                if ($null -ne $rs) { try { $rs.Close() } catch {} }; Release-ComObject $rs
+            }
+        }
+    }
+    return ,@($observations)
+}
+$inventory = Get-Content -LiteralPath $InventoryPath -Raw | ConvertFrom-Json
+$environment = Get-Content -LiteralPath $EnvironmentPath -Raw | ConvertFrom-Json
+$prepared = Get-Content -LiteralPath (Join-Path $OutputRoot 'preparation.json') -Raw | ConvertFrom-Json
+$inventoryHash = Get-FileSha256 $InventoryPath
+if ($inventory.document_type -cne 'dao_write_scenario_inventory' -or $prepared.inventory_sha256 -cne $inventoryHash) { throw 'Write inventory identity mismatch' }
+if ($environment.status -cne 'ready' -or $null -eq $environment.accepted_provider) { throw 'No accepted DAO provider' }
+if ($prepared.scenarios.Count -ne $inventory.scenarios.Count) { throw 'Incomplete Rust preparation' }
+$manifest = [ordered]@{document_type='dao_write_manifest'; protocol_version='1.2.0'; inventory_sha256=$inventoryHash; source_revision=$SourceRevision; scenarios=@()}
+try {
+    for ($n=0; $n -lt $inventory.scenarios.Count; $n++) {
+        $scenario = $inventory.scenarios[$n]; $initial = $prepared.scenarios[$n]
+        if ($scenario.operation.mode -cne 'dao_open_rust' -or $scenario.id -cne $initial.scenario_id -or $initial.status -cne 'prepared') { throw 'Invalid write preparation' }
+        $root = Join-Path $OutputRoot ([string]$scenario.id); $path = Join-Path $root 'database.mdb'
+        $before = Get-FileSha256 $path
+        if ($before -cne $initial.database_sha256) { throw 'Prepared MDB identity mismatch' }
+        $entry = [ordered]@{scenario_id=[string]$scenario.id; before=$before; after=$null; status='pass'; error=$null}
+        $engine = $db = $null
+        try {
+            $engine = New-Object -ComObject ([string]$environment.accepted_provider.prog_id)
+            $db = $engine.OpenDatabase($path, $false, $true)
+            $snapshot = Get-DaoSnapshot -Database $db -Scenario $scenario.id -Revision $SourceRevision -DatabaseHash $before
+            Write-JsonDocument -Path (Join-Path $root 'dao-snapshot.raw.json') -Document $snapshot
+            $indexes = Get-IndexObservations $db $snapshot
+            [IO.File]::WriteAllText((Join-Path $root 'dao-indexes.raw.json'), ((ConvertTo-Json -InputObject $indexes -Depth 32 -Compress) + "`n"), $Utf8)
+        } catch { $entry.status='fail'; $entry.error=$_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+        finally {
+            if ($null -ne $db) { try { $db.Close() } catch { $entry.status='fail'; $entry.error=$_.Exception.Message } }
+            Release-ComObject $db; Release-ComObject $engine
+            [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+            $entry.after = Get-FileSha256 $path
+            $manifest.scenarios += $entry
+        }
+    }
+} finally { Write-JsonDocument -Path (Join-Path $OutputRoot 'dao-manifest.raw.json') -Document $manifest }
+if (@($manifest.scenarios | Where-Object { $_.status -ne 'pass' -or $_.before -cne $_.after }).Count) { exit 1 }

--- a/oracle/windows-dao/scripts/dao_write_diff.py
+++ b/oracle/windows-dao/scripts/dao_write_diff.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Separate protocol 1.2 write inventory, generation and hosted evaluation."""
+import argparse
+import copy
+import datetime
+import hashlib
+import json
+import platform
+import re
+from pathlib import Path
+import struct
+import subprocess
+import uuid
+
+import dao_read_diff as common
+import validate_protocol_v1_2 as protocol
+from protocol_validation import ValidationError, load_json
+
+ROOT = Path(__file__).resolve().parents[3]
+INVENTORY = ROOT / 'oracle/windows-dao/protocol/v1_2/write-scenarios.json'
+PLAN = ROOT / 'oracle/windows-dao/acquisition/write-v1_2.plan.json'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def inventory(path=INVENTORY):
+    value = load_json(path)
+    if value['document_type'] != 'dao_write_scenario_inventory' or value['protocol_version'] != '1.2.0':
+        raise ValidationError('Expected separate protocol 1.2 write inventory')
+    ids = [s['id'] for s in value['scenarios']]
+    if len(set(ids)) != len(ids) or not ids:
+        raise ValidationError('Duplicate or empty write inventory')
+    for scenario in value['scenarios']:
+        if not re.fullmatch(r'DAO-WRITE-[A-Z0-9][A-Z0-9_-]{2,63}', scenario['id']) or scenario['operation'] != {'mode': 'dao_open_rust', 'expected_outcome': 'success', 'error_class': None}:
+            raise ValidationError('Wrong write scenario ID or operation mode')
+        if set(scenario['required_branches']) - protocol.load_branch_ids():
+            raise ValidationError('Unknown required branch')
+        if not scenario['coverage']:
+            raise ValidationError('Missing declared coverage')
+    if not value['deferred_requirements']:
+        raise ValidationError('Bounded first write leg must declare its deferrals')
+    return value
+
+
+def expand_rows(table):
+    rows = []
+    for n in range(table['repeat'] if table['repeat'] is not None else len(table['rows'])):
+        row = table['rows'][0 if table['repeat'] is not None else n]
+        if len(row) != len(table['columns']):
+            raise ValidationError('Recipe row width mismatch')
+        expanded = []
+        for value in row:
+            if isinstance(value, dict):
+                if 'sequence' in value: value = value['sequence'] + n
+                elif 'repeat_text' in value: value = value['repeat_text'] * value['count']
+                elif value == {'auto': True}: value = n + 1
+                else: raise ValidationError('Unknown recipe expression')
+            expanded.append(value)
+        rows.append(expanded)
+    return rows
+
+
+def typed(column, value):
+    kind = column['kind']
+    if kind == 'Boolean':
+        return {'kind': 'boolean', 'value': bool(value)}
+    if value is None:
+        return {'kind': 'null', 'value': None}
+    formats = {'Byte': ('byte', 'B'), 'Integer': ('integer', 'h'), 'Long': ('long', 'i'),
+        'AutoIncrement': ('long', 'i'), 'Single': ('single', 'f'), 'Double': ('double', 'd'), 'Currency': ('currency', 'q'), 'DateTime': ('datetime', 'd')}
+    if kind in formats:
+        name, fmt = formats[kind]
+        raw = struct.pack('<' + fmt, value)
+        if kind == 'Single': value = struct.unpack('<f', raw)[0]
+        elif kind == 'Currency':
+            sign = '-' if value < 0 else ''
+            value = f'{sign}{abs(value)//10000}.{abs(value)%10000:04d}'
+        elif kind == 'DateTime':
+            value = (datetime.datetime(1899, 12, 30) + datetime.timedelta(days=value)).isoformat()
+        return {'kind': name, 'value': value, 'raw_hex': raw.hex()}
+    if kind == 'Guid':
+        guid = uuid.UUID(bytes=bytes(value))
+        return {'kind': 'guid', 'value': str(guid), 'raw_hex': guid.bytes_le.hex()}
+    raw = value.encode('ascii')
+    if kind in ('Text', 'Memo'):
+        return {'kind': kind.lower(), 'value': value, 'raw_hex': raw.hex(), 'code_page': 1252}
+    return {'kind': 'binary' if kind == 'Binary' else 'ole', 'value': raw.hex(), 'raw_hex': raw.hex()}
+
+
+def expected_schema(scenario):
+    tables = []
+    sizes = {'Boolean': 1, 'Byte': 1, 'Integer': 2, 'Long': 4, 'AutoIncrement': 4, 'Currency': 8, 'Single': 4, 'Double': 8, 'DateTime': 8, 'Guid': 16, 'Memo': 0, 'LongBinary': 0}
+    dao = {'AutoIncrement': 'Long', 'DateTime': 'Date', 'Guid': 'GUID'}
+    for table in scenario['tables']:
+        columns = [{'name': c['name'], 'ordinal': n, 'dao_type': 'db' + dao.get(c['kind'], c['kind']),
+            'size': sizes.get(c['kind'], c.get('size')), 'auto_increment': c['kind'] == 'AutoIncrement',
+            'attributes': 17 if c['kind'] == 'AutoIncrement' else 2 if c['kind'] in ('Text', 'Binary', 'Memo', 'LongBinary') else 1, 'properties': {}}
+            for n, c in enumerate(table['columns'])]
+        indexes = [{'name': index['name'], 'fields': [{'name': columns[field['column']]['name'], 'descending': field['descending']} for field in index['fields']],
+            'primary': index['kind'] == 'primary', 'unique': index['kind'] != 'ordinary', 'required': index['kind'] == 'primary', 'properties': {}} for index in table['indexes']]
+        rows = [{'values': {column['name']: typed(column, value) for column, value in zip(table['columns'], row)}} for row in expand_rows(table)]
+        tables.append({'name': table['name'], 'kind': 'user', 'attributes': 0, 'properties': {}, 'columns': columns, 'indexes': indexes, 'rows': rows})
+    relationships = []
+    relation = scenario['relationship']
+    if relation:
+        parent, child = tables[relation['parent_table']], tables[relation['child_table']]
+        field = parent['columns'][relation['parent_column']]['name']
+        foreign = child['columns'][relation['child_column']]['name']
+        relationships.append({'name': relation['name'], 'table': parent['name'], 'foreign_table': child['name'],
+            'attributes': 0, 'fields': [{'field': field, 'foreign_field': foreign}], 'properties': {}})
+        child['indexes'].append({'name': relation['name'], 'fields': [{'name': foreign, 'descending': False}],
+            'primary': False, 'unique': False, 'required': False, 'properties': {}})
+    return tables, relationships
+
+
+def assert_recipe(snapshot, scenario):
+    expected = copy.deepcopy(snapshot)
+    expected['tables'], expected['relationships'] = expected_schema(scenario)
+    expected['database_properties'] = {}
+    expected['raw_preservation'] = []
+    expected = common.canonicalize_snapshot(expected)
+    if common.comparison_document(snapshot) != common.comparison_document(expected):
+        raise ValidationError('Snapshot differs from declared creation request')
+
+
+def validate_write_coverage(receipt, scenarios, snapshot):
+    protocol.SCHEMA_SET.validate(receipt)
+    ids = [s['id'] for s in scenarios]
+    if receipt['scenario_id'] not in ids or [s['id'] for s in receipt['scenarios']] != ids:
+        raise ValidationError('Write receipt inventory mismatch')
+    branches = receipt['branches']
+    if branches != sorted(set(branches)) or set(branches) - protocol.load_branch_ids():
+        raise ValidationError('Invalid write receipt branches')
+    if receipt['outcome'] != 'success' or receipt['error_class'] is not None or receipt['producer']['kind'] != 'rust':
+        raise ValidationError('Write snapshot did not succeed')
+    if receipt['database_sha256'] != snapshot['database_sha256'] or receipt['scenario_id'] != snapshot['scenario_id']:
+        raise ValidationError('Write receipt snapshot mismatch')
+    for declaration, actual in zip(scenarios, receipt['scenarios']):
+        missing = sorted(set(declaration['required_branches']) - set(branches))
+        forbidden = sorted(set((declaration['boundary'] or {}).get('forbidden_branches', [])) & set(branches))
+        if actual != {'id': declaration['id'], 'missing_branches': missing, 'forbidden_observed': forbidden, 'outcome_matches': True, 'satisfied': not missing and not forbidden}:
+            raise ValidationError('Write receipt verdict mismatch')
+    if not next(s['satisfied'] for s in receipt['scenarios'] if s['id'] == receipt['scenario_id']):
+        raise ValidationError('Write coverage unsatisfied')
+
+
+def assert_indexes(observations, snapshot):
+    expected = [(table, index) for table in snapshot['tables'] for index in table['indexes']]
+    if [(x['table'], x['index']) for x in observations] != [(t['name'], i['name']) for t, i in expected]:
+        raise ValidationError('Incomplete index observation inventory')
+    for observation, (table, index) in zip(observations, expected):
+        rows = [row['values'] for row in table['rows']]
+        key = lambda row: tuple(row[field['name']]['value'] for field in index['fields'])
+        directed = lambda row: tuple(v * (-1 if f['descending'] else 1) for v, f in zip(key(row), index['fields']))
+        canonical = lambda row: common.canonical_bytes(row)
+        traversal = observation['rows']
+        if sorted(map(canonical, traversal)) != sorted(map(canonical, rows)) or list(map(directed, traversal)) != sorted(map(directed, rows)):
+            raise ValidationError('Index traversal differs from complete requested rows')
+        queries = [tuple(s['query']) for s in observation['seeks']]
+        if len(queries) != len(set(queries)) or set(queries) != set(map(key, rows)):
+            raise ValidationError('Seek inventory incomplete')
+        for seek in observation['seeks']:
+            if seek['row'] not in rows or key(seek['row']) != tuple(seek['query']):
+                raise ValidationError('Seek returned wrong full row')
+
+
+def prepare(out, generator, reader, revision):
+    scenarios = inventory()['scenarios']
+    out.mkdir(parents=True, exist_ok=False)
+    manifest = {'document_type': 'dao_write_preparation', 'protocol_version': '1.2.0', 'source_revision': revision, 'producer_os': platform.system(), 'inventory_sha256': digest(INVENTORY), 'scenarios': []}
+    try:
+        for scenario in scenarios:
+            root = out / scenario['id']; root.mkdir()
+            entry = {'scenario_id': scenario['id'], 'status': 'failed', 'error': None}
+            manifest['scenarios'].append(entry)
+            try:
+                for label, command in [('generate', [str(generator), scenario['id'], str(root / 'database.mdb')]),
+                    ('snapshot', [str(reader), 'snapshot', str(root / 'database.mdb'), '--scenario', scenario['id'], '--out', str(root / 'rust'), '--source-revision', revision])]:
+                    run = subprocess.run(command, capture_output=True, text=True, timeout=120)
+                    (root / (label + '.stdout.log')).write_text(run.stdout)
+                    (root / (label + '.stderr.log')).write_text(run.stderr)
+                    if run.returncode: raise ValidationError(label + ' failed')
+                snapshot = load_json(root / 'rust/snapshot.json')
+                assert_recipe(snapshot, scenario)
+                validate_write_coverage(load_json(root / 'rust/coverage.json'), scenarios, snapshot)
+                entry.update(status='prepared', database_sha256=digest(root / 'database.mdb'))
+            except Exception as error:
+                entry['error'] = str(error)
+                raise
+    finally:
+        common.write_canonical(out / 'preparation.json', manifest)
+
+
+def resnapshot(out, reader, revision):
+    prepared = load_json(out / 'preparation.json')
+    if prepared['source_revision'] != revision or prepared['inventory_sha256'] != digest(INVENTORY):
+        raise ValidationError('Downloaded preparation identity mismatch')
+    for entry in prepared['scenarios']:
+        if entry['scenario_id'] not in [s['id'] for s in inventory()['scenarios']]:
+            raise ValidationError('Unknown downloaded scenario')
+        root = out / entry['scenario_id']
+        if entry['status'] != 'prepared' or digest(root / 'database.mdb') != entry['database_sha256']:
+            raise ValidationError('Downloaded database identity mismatch')
+        run = subprocess.run([str(reader), 'snapshot', str(root / 'database.mdb'), '--scenario', entry['scenario_id'],
+            '--out', str(root / 'rust'), '--source-revision', revision], capture_output=True, text=True, timeout=120)
+        (root / 'windows-snapshot.stdout.log').write_text(run.stdout)
+        (root / 'windows-snapshot.stderr.log').write_text(run.stderr)
+        if run.returncode: raise ValidationError('Windows Rust snapshot failed')
+    common.write_canonical(out / 'reader.json', {'source_revision': revision, 'reader_os': platform.system()})
+
+
+def evaluate_checked(out):
+    scenarios = inventory()['scenarios']; prepared = load_json(out / 'preparation.json'); manifest = load_json(out / 'dao-manifest.raw.json')
+    ids = [s['id'] for s in scenarios]
+    if manifest['source_revision'] != prepared['source_revision']:
+        raise ValidationError('Producer source revision mismatch')
+    if prepared['inventory_sha256'] != digest(INVENTORY) or manifest['inventory_sha256'] != digest(INVENTORY):
+        raise ValidationError('Inventory identity mismatch')
+    if [s['scenario_id'] for s in prepared['scenarios']] != ids or [s['scenario_id'] for s in manifest['scenarios']] != ids:
+        raise ValidationError('Incomplete write acquisition')
+    comparisons = []
+    for scenario, initial, observation in zip(scenarios, prepared['scenarios'], manifest['scenarios']):
+        root = out / scenario['id']; identity = digest(root / 'database.mdb')
+        if initial['status'] != 'prepared' or observation['status'] != 'pass' or observation['error'] is not None:
+            raise ValidationError('Write generation or DAO observation failed')
+        if not identity == initial['database_sha256'] == observation['before'] == observation['after']:
+            raise ValidationError('Read-only database identity changed')
+        rust = load_json(root / 'rust/snapshot.json'); dao = common.canonicalize_snapshot(load_json(root / 'dao-snapshot.raw.json'))
+        if rust['database_sha256'] != identity: raise ValidationError('Snapshot database mismatch')
+        validate_write_coverage(load_json(root / 'rust/coverage.json'), scenarios, rust)
+        assert_recipe(rust, scenario); assert_recipe(dao, scenario)
+        assert_indexes(load_json(root / 'dao-indexes.raw.json'), dao)
+        comparison = common.compare_snapshots(dao, rust); comparison['document_type'] = 'dao_write_comparison'; comparison['mode'] = 'dao_open_rust'
+        common.write_canonical(root / 'dao-snapshot.json', dao); common.write_canonical(root / 'comparison.json', comparison)
+        comparisons.append(comparison)
+    report = {'document_type': 'dao_write_report', 'protocol_version': '1.2.0', 'outcome': 'matched', 'mode': 'dao_open_rust',
+        'comparisons': comparisons, 'deferred_requirements': inventory()['deferred_requirements'], 'support_matrix_movement': False}
+    common.write_canonical(out / 'report.json', report)
+
+
+def evaluate(out):
+    try:
+        evaluate_checked(out)
+    except Exception as error:
+        common.write_canonical(out / 'report.json', {'document_type': 'dao_write_report', 'protocol_version': '1.2.0',
+            'outcome': 'no_outcome', 'mode': 'dao_open_rust', 'error': str(error), 'support_matrix_movement': False})
+        raise
+
+
+def validate_plan(expected):
+    if digest(PLAN) != expected: raise ValidationError('Plan digest mismatch')
+    plan = load_json(PLAN)
+    if plan['mode'] != 'dao_open_rust': raise ValidationError('Wrong plan mode')
+    for name, sha in plan['inputs'].items():
+        if digest(ROOT / name) != sha: raise ValidationError('Plan input mismatch: ' + name)
+    inventory()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__); commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('inventory')
+    plan = commands.add_parser('plan'); plan.add_argument('sha256')
+    prep = commands.add_parser('prepare'); prep.add_argument('out', type=Path); prep.add_argument('generator', type=Path); prep.add_argument('reader', type=Path); prep.add_argument('revision')
+    snap = commands.add_parser('snapshot'); snap.add_argument('out', type=Path); snap.add_argument('reader', type=Path); snap.add_argument('revision')
+    check = commands.add_parser('evaluate'); check.add_argument('out', type=Path)
+    args = parser.parse_args()
+    if args.command == 'inventory': inventory()
+    elif args.command == 'plan': validate_plan(args.sha256)
+    elif args.command == 'prepare': prepare(args.out, args.generator, args.reader, args.revision)
+    elif args.command == 'snapshot': resnapshot(args.out, args.reader, args.revision)
+    else: evaluate(args.out)
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/scripts/dao_write_diff.py
+++ b/oracle/windows-dao/scripts/dao_write_diff.py
@@ -135,7 +135,8 @@ def validate_write_coverage(receipt, scenarios, snapshot):
         raise ValidationError('Invalid write receipt branches')
     if receipt['outcome'] != 'success' or receipt['error_class'] is not None or receipt['producer']['kind'] != 'rust':
         raise ValidationError('Write snapshot did not succeed')
-    if receipt['database_sha256'] != snapshot['database_sha256'] or receipt['scenario_id'] != snapshot['scenario_id']:
+    if (receipt['database_sha256'] != snapshot['database_sha256'] or receipt['scenario_id'] != snapshot['scenario_id']
+            or receipt['producer'] != snapshot['producer']):
         raise ValidationError('Write receipt snapshot mismatch')
     for declaration, actual in zip(scenarios, receipt['scenarios']):
         missing = sorted(set(declaration['required_branches']) - set(branches))
@@ -166,6 +167,12 @@ def assert_indexes(observations, snapshot):
                 raise ValidationError('Seek returned wrong full row')
 
 
+def bind_snapshot(snapshot, scenario_id, revision, kind, identity):
+    if (snapshot['scenario_id'] != scenario_id or snapshot['producer'] != {'kind': kind, 'source_revision': revision}
+            or snapshot['database_sha256'] != identity):
+        raise ValidationError('Snapshot scenario, source or database identity mismatch')
+
+
 def prepare(out, generator, reader, revision):
     scenarios = inventory()['scenarios']
     out.mkdir(parents=True, exist_ok=False)
@@ -182,10 +189,15 @@ def prepare(out, generator, reader, revision):
                     (root / (label + '.stdout.log')).write_text(run.stdout)
                     (root / (label + '.stderr.log')).write_text(run.stderr)
                     if run.returncode: raise ValidationError(label + ' failed')
+                    if label == 'generate':
+                        entry['database_sha256'] = digest(root / 'database.mdb')
+                    elif digest(root / 'database.mdb') != entry['database_sha256']:
+                        raise ValidationError('Initial reader changed generated database')
                 snapshot = load_json(root / 'rust/snapshot.json')
+                bind_snapshot(snapshot, scenario['id'], revision, 'rust', entry['database_sha256'])
                 assert_recipe(snapshot, scenario)
                 validate_write_coverage(load_json(root / 'rust/coverage.json'), scenarios, snapshot)
-                entry.update(status='prepared', database_sha256=digest(root / 'database.mdb'))
+                entry['status'] = 'prepared'
             except Exception as error:
                 entry['error'] = str(error)
                 raise
@@ -214,6 +226,9 @@ def resnapshot(out, reader, revision):
 def evaluate_checked(out):
     scenarios = inventory()['scenarios']; prepared = load_json(out / 'preparation.json'); manifest = load_json(out / 'dao-manifest.raw.json')
     ids = [s['id'] for s in scenarios]
+    reader = load_json(out / 'reader.json')
+    if prepared['producer_os'] != 'Linux' or reader != {'source_revision': prepared['source_revision'], 'reader_os': 'Windows'}:
+        raise ValidationError('Producer/reader source or platform receipt mismatch')
     if manifest['source_revision'] != prepared['source_revision']:
         raise ValidationError('Producer source revision mismatch')
     if prepared['inventory_sha256'] != digest(INVENTORY) or manifest['inventory_sha256'] != digest(INVENTORY):
@@ -228,7 +243,8 @@ def evaluate_checked(out):
         if not identity == initial['database_sha256'] == observation['before'] == observation['after']:
             raise ValidationError('Read-only database identity changed')
         rust = load_json(root / 'rust/snapshot.json'); dao = common.canonicalize_snapshot(load_json(root / 'dao-snapshot.raw.json'))
-        if rust['database_sha256'] != identity: raise ValidationError('Snapshot database mismatch')
+        bind_snapshot(rust, scenario['id'], prepared['source_revision'], 'rust', identity)
+        bind_snapshot(dao, scenario['id'], prepared['source_revision'], 'dao', identity)
         validate_write_coverage(load_json(root / 'rust/coverage.json'), scenarios, rust)
         assert_recipe(rust, scenario); assert_recipe(dao, scenario)
         assert_indexes(load_json(root / 'dao-indexes.raw.json'), dao)

--- a/oracle/windows-dao/tests/test_dao_write_diff.py
+++ b/oracle/windows-dao/tests/test_dao_write_diff.py
@@ -1,0 +1,103 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+import dao_write_diff as write
+
+
+def requested_snapshot(scenario):
+    result = write.common.minimal_snapshot('rust')
+    result['scenario_id'] = scenario['id']
+    result['tables'], result['relationships'] = write.expected_schema(scenario)
+    return write.common.canonicalize_snapshot(result)
+
+
+class WriteTests(unittest.TestCase):
+    def test_separate_inventory_does_not_weaken_read_contract(self):
+        declared = write.inventory()
+        self.assertEqual(len(declared['scenarios']), 12)
+        self.assertTrue(all(s['operation']['mode'] == 'dao_open_rust' for s in declared['scenarios']))
+        with self.assertRaises(write.ValidationError):
+            write.protocol.validate_document(declared)
+        wrong = copy.deepcopy(declared); wrong['scenarios'][0]['operation']['mode'] = 'rust_read_dao'
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / 'inventory.json'; path.write_text(json.dumps(wrong))
+            with self.assertRaises(write.ValidationError): write.inventory(path)
+
+    def test_matching_producers_still_must_satisfy_the_requested_recipe(self):
+        scenario = next(s for s in write.inventory()['scenarios'] if s['id'] == 'DAO-WRITE-INDEX-COMPOSITE')
+        snapshot = requested_snapshot(scenario)
+        write.assert_recipe(snapshot, scenario)
+        snapshot['tables'][0]['rows'].pop()
+        snapshot = write.common.canonicalize_snapshot(snapshot)
+        with self.assertRaisesRegex(write.ValidationError, 'declared creation request'):
+            write.assert_recipe(snapshot, scenario)
+
+    def test_full_traversal_and_seek_reject_omissions_and_wrong_duplicate_rows(self):
+        scenario = next(s for s in write.inventory()['scenarios'] if s['id'] == 'DAO-WRITE-INDEX-ORDINARY')
+        snapshot = requested_snapshot(scenario); table = snapshot['tables'][0]
+        rows = sorted([r['values'] for r in table['rows']], key=lambda r: r['A']['value'])
+        seeks = [{'query': [n], 'row': next(row for row in rows if row['A']['value'] == n)} for n in (0, 1)]
+        observation = [{'table': 'Keys', 'index': 'ByKey', 'rows': rows, 'seeks': seeks}]
+        write.assert_indexes(observation, snapshot)
+        broken = copy.deepcopy(observation); broken[0]['rows'].pop()
+        with self.assertRaises(write.ValidationError): write.assert_indexes(broken, snapshot)
+        broken = copy.deepcopy(observation); broken[0]['seeks'].pop()
+        with self.assertRaises(write.ValidationError): write.assert_indexes(broken, snapshot)
+        broken = copy.deepcopy(observation); broken[0]['seeks'][1]['row']['B']['value'] = 123
+        with self.assertRaises(write.ValidationError): write.assert_indexes(broken, snapshot)
+
+    def test_scalar_and_relationship_requests_preserve_protocol_shapes(self):
+        for scenario in write.inventory()['scenarios']:
+            snapshot = requested_snapshot(scenario)
+            write.assert_recipe(snapshot, scenario)
+        scalar = write.typed({'kind': 'Currency'}, -12345)
+        self.assertEqual(scalar['value'], '-1.2345')
+        self.assertEqual(write.typed({'kind': 'Boolean'}, None), {'kind': 'boolean', 'value': False})
+
+    def test_complete_evaluation_retains_no_outcome_on_identity_drift(self):
+        with tempfile.TemporaryDirectory() as temp:
+            out = Path(temp)
+            scenarios = write.inventory()['scenarios']
+            prepared = {'source_revision': 'test', 'inventory_sha256': write.digest(write.INVENTORY), 'scenarios': []}
+            manifest = {'source_revision': 'test', 'inventory_sha256': write.digest(write.INVENTORY), 'scenarios': []}
+            for scenario in scenarios:
+                root = out / scenario['id']; (root / 'rust').mkdir(parents=True)
+                (root / 'database.mdb').write_bytes(b'synthetic test identity')
+                identity = write.digest(root / 'database.mdb')
+                snapshot = requested_snapshot(scenario); snapshot['database_sha256'] = identity
+                write.common.write_canonical(root / 'rust/snapshot.json', snapshot)
+                dao = copy.deepcopy(snapshot); dao['producer']['kind'] = 'dao'
+                write.common.write_canonical(root / 'dao-snapshot.raw.json', dao)
+                receipt = {'document_type': 'coverage_receipt', 'protocol_version': '1.2.0', 'scenario_id': scenario['id'],
+                    'database_sha256': identity, 'producer': snapshot['producer'], 'outcome': 'success', 'error_class': None,
+                    'branches': ['open.header_page'], 'scenarios': [{'id': s['id'], 'missing_branches': [], 'forbidden_observed': [], 'outcome_matches': True, 'satisfied': True} for s in scenarios]}
+                write.common.write_canonical(root / 'rust/coverage.json', receipt)
+                observations = []
+                for table in snapshot['tables']:
+                    for index in table['indexes']:
+                        key = lambda row: tuple(row[f['name']]['value'] for f in index['fields'])
+                        directed = lambda row: tuple(v * (-1 if f['descending'] else 1) for v, f in zip(key(row), index['fields']))
+                        rows = sorted([r['values'] for r in table['rows']], key=directed)
+                        queries = sorted(set(map(key, rows)))
+                        observations.append({'table': table['name'], 'index': index['name'], 'rows': rows,
+                            'seeks': [{'query': list(q), 'row': next(row for row in rows if key(row) == q)} for q in queries]})
+                write.common.write_canonical(root / 'dao-indexes.raw.json', observations)
+                prepared['scenarios'].append({'scenario_id': scenario['id'], 'status': 'prepared', 'database_sha256': identity})
+                manifest['scenarios'].append({'scenario_id': scenario['id'], 'status': 'pass', 'error': None, 'before': identity, 'after': identity})
+            write.common.write_canonical(out / 'preparation.json', prepared)
+            write.common.write_canonical(out / 'dao-manifest.raw.json', manifest)
+            write.evaluate(out)
+            self.assertEqual(write.load_json(out / 'report.json')['outcome'], 'matched')
+            (out / scenarios[0]['id'] / 'database.mdb').write_bytes(b'changed')
+            with self.assertRaisesRegex(write.ValidationError, 'identity changed'): write.evaluate(out)
+            self.assertEqual(write.load_json(out / 'report.json')['outcome'], 'no_outcome')
+
+
+if __name__ == '__main__': unittest.main()

--- a/oracle/windows-dao/tests/test_dao_write_diff.py
+++ b/oracle/windows-dao/tests/test_dao_write_diff.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
+import types
 
 SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
 sys.path.insert(0, str(SCRIPTS))
@@ -65,13 +67,13 @@ class WriteTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             out = Path(temp)
             scenarios = write.inventory()['scenarios']
-            prepared = {'source_revision': 'test', 'inventory_sha256': write.digest(write.INVENTORY), 'scenarios': []}
+            prepared = {'producer_os': 'Linux', 'source_revision': 'test', 'inventory_sha256': write.digest(write.INVENTORY), 'scenarios': []}
             manifest = {'source_revision': 'test', 'inventory_sha256': write.digest(write.INVENTORY), 'scenarios': []}
             for scenario in scenarios:
                 root = out / scenario['id']; (root / 'rust').mkdir(parents=True)
                 (root / 'database.mdb').write_bytes(b'synthetic test identity')
                 identity = write.digest(root / 'database.mdb')
-                snapshot = requested_snapshot(scenario); snapshot['database_sha256'] = identity
+                snapshot = requested_snapshot(scenario); snapshot['database_sha256'] = identity; snapshot['producer']['source_revision'] = 'test'
                 write.common.write_canonical(root / 'rust/snapshot.json', snapshot)
                 dao = copy.deepcopy(snapshot); dao['producer']['kind'] = 'dao'
                 write.common.write_canonical(root / 'dao-snapshot.raw.json', dao)
@@ -93,11 +95,45 @@ class WriteTests(unittest.TestCase):
                 manifest['scenarios'].append({'scenario_id': scenario['id'], 'status': 'pass', 'error': None, 'before': identity, 'after': identity})
             write.common.write_canonical(out / 'preparation.json', prepared)
             write.common.write_canonical(out / 'dao-manifest.raw.json', manifest)
+            write.common.write_canonical(out / 'reader.json', {'source_revision': 'test', 'reader_os': 'Windows'})
             write.evaluate(out)
             self.assertEqual(write.load_json(out / 'report.json')['outcome'], 'matched')
+            root = out / scenarios[0]['id']
+            for name, field, value in [('rust/snapshot.json', 'scenario_id', 'DAO-WRITE-SCALARS'),
+                    ('dao-snapshot.raw.json', 'scenario_id', 'DAO-WRITE-SCALARS'),
+                    ('rust/snapshot.json', 'producer', {'kind': 'rust', 'source_revision': 'unrelated'}),
+                    ('dao-snapshot.raw.json', 'producer', {'kind': 'dao', 'source_revision': 'unrelated'}),
+                    ('rust/coverage.json', 'producer', {'kind': 'rust', 'source_revision': 'unrelated'})]:
+                path = root / name; original = path.read_bytes(); document = json.loads(original)
+                document[field] = value; write.common.write_canonical(path, document)
+                with self.assertRaises(write.ValidationError): write.evaluate(out)
+                path.write_bytes(original)
+            reader = out / 'reader.json'; original = reader.read_bytes()
+            for document in [{'source_revision': 'other', 'reader_os': 'Windows'}, {'source_revision': 'test', 'reader_os': 'Linux'}]:
+                write.common.write_canonical(reader, document)
+                with self.assertRaises(write.ValidationError): write.evaluate(out)
+            reader.unlink()
+            with self.assertRaises(write.ValidationError): write.evaluate(out)
+            reader.write_bytes(original)
             (out / scenarios[0]['id'] / 'database.mdb').write_bytes(b'changed')
             with self.assertRaisesRegex(write.ValidationError, 'identity changed'): write.evaluate(out)
             self.assertEqual(write.load_json(out / 'report.json')['outcome'], 'no_outcome')
+
+    def test_first_reader_cannot_change_the_generated_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            out = Path(temporary) / 'output'
+            def run(command, **kwargs):
+                if command[0] == 'generator':
+                    Path(command[2]).write_bytes(b'generated')
+                else:
+                    Path(command[2]).write_bytes(b'reader mutation')
+                return types.SimpleNamespace(returncode=0, stdout='', stderr='')
+            with patch.object(write.subprocess, 'run', side_effect=run):
+                with self.assertRaisesRegex(write.ValidationError, 'reader changed'):
+                    write.prepare(out, Path('generator'), Path('reader'), 'test')
+            entry = write.load_json(out / 'preparation.json')['scenarios'][0]
+            self.assertEqual(entry['status'], 'failed')
+            self.assertEqual(entry['database_sha256'], write.hashlib.sha256(b'generated').hexdigest())
 
 
 if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Writer interoperability needs a hosted comparison between requested recipes, Rust snapshots and DAO observations. Add a separate 12-scenario write inventory and public-API fixture generator, with Unix file generation followed by Windows read-only Rust/DAO snapshots, complete index traversal and Seek. Existing read inventory and acquisition remain unchanged.

Evaluation binds every scenario, source revision and file identity, compares canonical protocol snapshots and independently checks the requested schema, rows and relationships. Before/after hashes detect changes during readback, and the workflow retains failure artifacts. A separately reviewed EXP-0141 plan is still required before acquisition; this scaffold makes no support-matrix changes.

Independent review found two identity gaps; the original author fixed both and fix review passed. Six Python tests, four CLI snapshot checks, Clippy, PowerShell parser checks, all 12 actual Linux recipe preparations and `just ready` pass. Advances #102.
