### PR TITLE
test: preregister remaining scalar and null index cases

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11524,3 +11524,42 @@ Copy this block under the appropriate section and remove this instruction:
   Retain all 37 raw images externally. Any secondary read-only interpretation
   needs a separately declared analysis; any new DAO acquisition requires a
   separately reviewed successor plan and the repository's human retry decision.
+
+## EXP-0147 — Remaining Date/Binary/null index discovery successor plan
+
+- Recorded: 2026-09-05, OpenAI Codex; unacquired development-only successor.
+  EXP-0143 inputs and EXP-0144 `no_outcome` remain unchanged. Standing user
+  authorization covers DAO experiments/mutations; root dispatches this distinct
+  plan once only after independent review and final checks.
+- Plan: `oracle/windows-dao/acquisition/scalar-index-remaining.plan.json`,
+  SHA-256 `c0378eca7d65ae58bd8d4a5b124b476ea1bc51989de75d579cfebd7a3d7555ae`.
+  New producer/analyzer files have separate input pins, checked before dispatch
+  and analysis; dispatch requires the exact committed plan. Existing original
+  catalog/leaf decoders and local one-dispatch transport stay unchanged.
+- Scope: exactly the fourteen remaining arms, three fresh controls each:
+  ascending/descending Date and four-byte Binary, plus ten nullable Long
+  ordinary/unique/Required/IgnoreNulls one/two-component arms. Each control
+  has at most twelve attempts. The 36 completed scalar captures from EXP-0143
+  are neither reacquired nor reinterpreted by this plan.
+- Corrections: values use plain CLR arrays instead of PowerShell's decorated
+  `New-Object` array wrapper. Date conversion is precomputed and assigned with
+  the explicit `[datetime]` cast used by the original read producer. Original
+  artifacts do not identify the precise failing cast; this change does not
+  prove DAO Date acceptance. Unexpected errors now retain endpoint and script
+  stack alongside the original error text and completed attempt records.
+- Gates: retain actual Update outcomes, null omissions, complete saved rows,
+  exact raw key-to-row-locator bindings, schema/flag/direction metadata and
+  full DAO traversal. Compare three replicas per arm without guessing nullable
+  uniqueness/omission policies or index transforms. All 42 captures must be
+  complete, unchanged and correlated for `answered`; otherwise preserve an
+  honest `no_outcome`. Binding/pin failures reject validation; no automatic retry.
+- Validation: four focused Python classifier/binding/pin tests and compilation
+  passed. Windows x86 PowerShell parsed the new producer and ran only extracted
+  helper functions against in-memory fake fields: all 120 declared Date/Binary/
+  nullable row conversions and JSON array roundtrips matched exact planned
+  values. The retained test is `tests/check_scalar_index_remaining.ps1` under
+  `oracle/windows-dao`; it instantiates no DAO and executes no acquisition.
+- Boundary: no scalar encoding promotion, completed-capture reanalysis, Text
+  collation, GUID/Memo/OLE indexes, arbitrary Binary lengths, existing-row
+  updates, candidate acceptance, general compatibility or hosted support claim.
+  Retain raw images/results externally and record one validated EXP-0148 outcome.

--- a/oracle/windows-dao/acquisition/scalar-index-remaining.plan.json
+++ b/oracle/windows-dao/acquisition/scalar-index-remaining.plan.json
@@ -1,0 +1,180 @@
+{
+  "document_type": "dao_scalar_index_remaining_plan",
+  "experiment_id": "scalar-index-remaining",
+  "issue": 100,
+  "development_only": true,
+  "replicas": 3,
+  "preregistration": {
+    "acquisition_started": false,
+    "question": "What raw ascending/descending Date and four-byte Binary keys bind to the declared saved values, and how do nullable Long ordinary/unique one/two-component indexes encode or omit nulls and accept/reject duplicate nulls under Required and IgnoreNulls?",
+    "prior_evidence": "EXP-0062 supplies leaf framing and locators; EXP-0073 supplies fixed row/layout and index count observations; EXP-0126 supplies non-null Long direction/composition observations. No non-Long transform or nullable uniqueness/omission policy is presumed. EXP-0144 is the preserved no_outcome:36 completed scalar controls failed array-wrapper correlation; acquisition stopped during first Date attempt with an unlocalized InvalidCastException. This successor covers only the remaining Date/Binary/null arms, not the completed36.",
+    "authorization": "Standing user authorization covers any DAO experiments/mutations, including this distinct successor. Commit and independently review this new pinned plan before root dispatches once. Do not redispatch consumed EXP-0143 or edit its inputs/results. Each tag is attempted once; declared Update rejection is recorded/cancelled before the next tag."
+  },
+  "arms": [
+    {
+      "name": "date-ascending",
+      "family": "scalar",
+      "fields": [{"name": "A","type": 8,"size": 8}],
+      "directions": [false],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [["000000000088c3c0"],["000000000000f0bf"],["0000000000000000"],["000000000000f03f"],["00000000c0d5e140"],["0000008040924641"]]
+    },
+    {
+      "name": "date-descending",
+      "family": "scalar",
+      "fields": [{"name": "A","type": 8,"size": 8}],
+      "directions": [true],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [["000000000088c3c0"],["000000000000f0bf"],["0000000000000000"],["000000000000f03f"],["00000000c0d5e140"],["0000008040924641"]]
+    },
+    {
+      "name": "binary-ascending",
+      "family": "scalar",
+      "fields": [{"name": "A","type": 9,"size": 4}],
+      "directions": [false],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [["ffffffff"],["00000000"],["00000001"],["01000000"],["7fffffff"],["80000000"]]
+    },
+    {
+      "name": "binary-descending",
+      "family": "scalar",
+      "fields": [{"name": "A","type": 9,"size": 4}],
+      "directions": [true],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [["ffffffff"],["00000000"],["00000001"],["01000000"],["7fffffff"],["80000000"]]
+    },
+    {
+      "name": "null-ordinary",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4}],
+      "directions": [false],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [[null],["00000000"],["ffffffff"],["01000000"],[null],["00000000"],["ffffff7f"],["00000080"]]
+    },
+    {
+      "name": "null-descending",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4}],
+      "directions": [true],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [[null],["00000000"],["ffffffff"],["01000000"],[null],["00000000"],["ffffff7f"],["00000080"]]
+    },
+    {
+      "name": "null-unique",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4}],
+      "directions": [false],
+      "unique": true,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [[null],["00000000"],["ffffffff"],["01000000"],[null],["00000000"],["ffffff7f"],["00000080"]]
+    },
+    {
+      "name": "null-unique-ignore",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4}],
+      "directions": [false],
+      "unique": true,
+      "required": false,
+      "ignore_nulls": true,
+      "rows": [[null],["00000000"],["ffffffff"],["01000000"],[null],["00000000"],["ffffff7f"],["00000080"]]
+    },
+    {
+      "name": "null-ignore",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4}],
+      "directions": [false],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": true,
+      "rows": [[null],["00000000"],["ffffffff"],["01000000"],[null],["00000000"],["ffffff7f"],["00000080"]]
+    },
+    {
+      "name": "null-required",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4}],
+      "directions": [false],
+      "unique": false,
+      "required": true,
+      "ignore_nulls": false,
+      "rows": [[null],["00000000"],["ffffffff"],["01000000"],[null],["00000000"],["ffffff7f"],["00000080"]]
+    },
+    {
+      "name": "composite-null-ordinary",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4},{"name": "B","type": 4,"size": 4}],
+      "directions": [false,true],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],["ffffffff","01000000"],["01000000","ffffffff"],["00000080","ffffff7f"],["ffffff7f","00000080"]]
+    },
+    {
+      "name": "composite-null-unique",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4},{"name": "B","type": 4,"size": 4}],
+      "directions": [false,true],
+      "unique": true,
+      "required": false,
+      "ignore_nulls": false,
+      "rows": [[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],["ffffffff","01000000"],["01000000","ffffffff"],["00000080","ffffff7f"],["ffffff7f","00000080"]]
+    },
+    {
+      "name": "composite-null-ignore",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4},{"name": "B","type": 4,"size": 4}],
+      "directions": [false,true],
+      "unique": false,
+      "required": false,
+      "ignore_nulls": true,
+      "rows": [[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],["ffffffff","01000000"],["01000000","ffffffff"],["00000080","ffffff7f"],["ffffff7f","00000080"]]
+    },
+    {
+      "name": "composite-null-required",
+      "family": "nullable-long",
+      "fields": [{"name": "A","type": 4,"size": 4},{"name": "B","type": 4,"size": 4}],
+      "directions": [false,true],
+      "unique": false,
+      "required": true,
+      "ignore_nulls": false,
+      "rows": [[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],[null,null],[null,"01000000"],["01000000",null],["01000000","01000000"],["ffffffff","01000000"],["01000000","ffffffff"],["00000080","ffffff7f"],["ffffff7f","00000080"]]
+    }
+  ],
+  "execution": {
+    "environment": "Private local VM, x86 PowerShell, DAO.DBEngine.36, Jet3 options32, LANGID0x0409/CP1252; development discovery only.",
+    "per_replica": "Create fresh Rows with declared typed fields plus Long Tag, then declared ByKey. Assign each listed row once and record Update success or actual DAO error numbers/HRESULT. Assignment/setup/cleanup failures abort the run. Close and reopen read-only for complete rows, schema/index flags and ordered traversal; retain original closed MDB and result. Use plain CLR object[] arrays for values JSON. Date assignment explicitly casts a precomputed DateTime, matching the existing original read producer. Record operation endpoint and PowerShell stack for unexpected failure; the original Date fault location was not captured, so the correction makes no proven DAO Date acceptance claim.",
+    "values": "Values are little-endian physical value hex or null. Date uses finite integer OA day doubles; Binary is exactly four bytes; Long includes signed endpoints and repeated null/full keys. Each attempt has Tag=one-based position. Readback is normalized to physical value bytes, never a guessed index encoding. requested_payloads_match separately exposes provider value normalization; stable normalization remains an observation.",
+    "analysis": "Verify inputs, retained identities and unchanged read-only bytes. Decode original rows and prefix-expanded leaf keys using pinned existing original decoders; resolve each key locator exactly once. Correlate all saved rows with successful attempts and DAO readback and every bound key with DAO traversal. Non-null rows cannot be omitted. Null omissions and duplicate-null Update rejection codes are observations, not assumed flags policy. Check scalar semantic direction (Boolean True=-1 and False=0, consistent with retained EXP-0062 ascending leaf order); compare exact saved value/raw-key bindings, omitted rows, index key records/flags/counts, operation statuses/native codes/HRESULT and metadata across three replicas. Keep raw addresses/prefix and diagnostic fields without requiring allocator addresses equal.",
+    "decoder_bounds": "Unmodified shared decoder limits:64 rows per page,64 columns/items,64-page TDEF chain bound. Each arm has at most12 attempted rows,3 fields,one index andone leaf; unsupported layouts produce no_outcome, with raw MDB retained. No Text collation, GUID, Memo/OLE indexes or multilevel construction in this slice.",
+    "attempts": 1,
+    "run": "python3 oracle/windows-dao/scripts/scalar_index_remaining.py run --shared-root VM_SHARED_ROOT --run-id UTC-scalar-index-remaining",
+    "analysis_command": "python3 oracle/windows-dao/scripts/scalar_index_remaining.py analyze OUTBOX",
+    "host_language_preflight": "Before committing pins, execute only extracted helper functions against in-memory fake fields: every declared Date conversion and every row including Binary/nulls roundtrips through ConvertTo-Json/ConvertFrom-Json with exact array shape and bytes. ParseFile validates the producer separately. Neither check instantiates DAO or executes acquisition."
+  },
+  "decision_rule": {
+    "answered": "All42 closed captures are unchanged and completely decoded/correlated, all declared attempts recorded, and each arm repeats question-bearing observations three times. Stable Update rejection or provider normalization is answered only for its actual saved values/errors; it supplies no key bytes for rejected values.",
+    "no_outcome": "Any unexpected setup/assignment/cleanup/capture failure, incomplete capture, changed image, unsupported decoder shape, metadata/row/traversal mismatch, or within-arm disagreement. Preserve partial operations and images; no redispatch.",
+    "rejection": "Plan/environment/inventory/input-pin or retained identity mismatch rejects validation."
+  },
+  "boundary": "Finite discovery only: no transform promotion, candidate acceptance, general null/flag policy, arbitrary Binary lengths, float NaN/infinity, Text/GUID/Memo/OLE index grammar, existing-row updates, or hosted support movement.",
+  "retention": "Keep result/report and all MDBs externally; commit no MDB/provider bytes. Record one additive EXP-0148 outcome derived from validated report JSON.",
+  "inputs": {
+    "oracle/windows-dao/scripts/scalar_index_remaining.py": "abadc28e64e1641150e18c198e9ba0b993b34516529fa4aba0c5cabc185d4933",
+    "oracle/windows-dao/scripts/scalar_index_remaining.ps1": "059264fc87653cb838c82486d3ee16b4e98be155d00e8f37657a7e8d251db2e2",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/scripts/relationship_create.py": "aa267ca957815ecf49abc155bd081dfb7d02d609b414e0efa68600161f3f7740",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  }
+}

--- a/oracle/windows-dao/scripts/scalar_index_remaining.ps1
+++ b/oracle/windows-dao/scripts/scalar_index_remaining.ps1
@@ -1,0 +1,211 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) {
+        [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value)
+    }
+}
+function From-Hex([string]$Text) {
+    $bytes = New-Object byte[] ($Text.Length / 2)
+    for ($i = 0; $i -lt $bytes.Length; $i++) { $bytes[$i] = [Convert]::ToByte($Text.Substring($i * 2, 2), 16) }
+    return ,$bytes
+}
+function To-Hex([byte[]]$Bytes) { return [BitConverter]::ToString($Bytes).Replace('-', '').ToLowerInvariant() }
+function Set-Value($Recordset, $Definition, $Value) {
+    $field = $Recordset.Fields.Item([string]$Definition.name)
+    try {
+        if ($null -eq $Value) { $field.Value = [DBNull]::Value; return }
+        if ($Definition.type -eq 1) { $field.Value = [bool]$Value; return }
+        $raw = From-Hex ([string]$Value)
+        switch ([int]$Definition.type) {
+            2 { $field.Value = [byte]$raw[0] }
+            3 { $field.Value = [int16][BitConverter]::ToInt16($raw, 0) }
+            4 { $field.Value = [int][BitConverter]::ToInt32($raw, 0) }
+            5 { $field.Value = ([decimal][BitConverter]::ToInt64($raw, 0) / [decimal]10000) }
+            6 { $field.Value = [single][BitConverter]::ToSingle($raw, 0) }
+            7 { $field.Value = [double][BitConverter]::ToDouble($raw, 0) }
+            8 {
+                $dateValue = [datetime]::FromOADate([BitConverter]::ToDouble($raw, 0))
+                $field.Value = [datetime]$dateValue
+            }
+            9 { $field.Value = [byte[]]$raw }
+            default { throw 'Undeclared field type' }
+        }
+    }
+    finally { Release $field }
+}
+function Read-Value($Recordset, $Definition) {
+    $field = $Recordset.Fields.Item([string]$Definition.name)
+    try {
+        $value = $field.Value
+        if ($null -eq $value -or $value -is [DBNull]) { return $null }
+        switch ([int]$Definition.type) {
+            1 { return [bool]$value }
+            2 { return To-Hex ([byte[]]@([byte]$value)) }
+            3 { return To-Hex ([BitConverter]::GetBytes([int16]$value)) }
+            4 { return To-Hex ([BitConverter]::GetBytes([int]$value)) }
+            5 { return To-Hex ([BitConverter]::GetBytes([long]([decimal]$value * [decimal]10000))) }
+            6 { return To-Hex ([BitConverter]::GetBytes([single]$value)) }
+            7 { return To-Hex ([BitConverter]::GetBytes([double]$value)) }
+            8 { return To-Hex ([BitConverter]::GetBytes(([datetime]$value).ToOADate())) }
+            9 { return To-Hex ([byte[]]$value) }
+            default { throw 'Undeclared field type' }
+        }
+    }
+    finally { Release $field }
+}
+function Read-Row($Recordset, $Arm) {
+    $values = [object[]]::new($Arm.fields.Count)
+    for ($i = 0; $i -lt $Arm.fields.Count; $i++) { $values[$i] = Read-Value $Recordset $Arm.fields[$i] }
+    return @{tag=[int]$Recordset.Fields.Item('Tag').Value; values=$values}
+}
+function New-Control([string]$Path, $Arm, $Operations) {
+    $engine = $workspace = $db = $table = $field = $index = $key = $rs = $null
+    try {
+        $script:endpoint = 'create_engine'
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $script:endpoint = 'create_database'
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        $script:endpoint = 'create_table_index'
+        $table = $db.CreateTableDef('Rows')
+        foreach ($definition in @($Arm.fields) + @(@{name='Tag'; type=4; size=4})) {
+            $field = $table.CreateField([string]$definition.name, [int]$definition.type, [int]$definition.size)
+            $table.Fields.Append($field)
+            Release $field; $field = $null
+        }
+        $index = $table.CreateIndex('ByKey')
+        $index.Primary = $false
+        $index.Unique = [bool]$Arm.unique
+        $index.Required = [bool]$Arm.required
+        $index.IgnoreNulls = [bool]$Arm.ignore_nulls
+        for ($i = 0; $i -lt $Arm.fields.Count; $i++) {
+            $key = $index.CreateField([string]$Arm.fields[$i].name)
+            if ($Arm.directions[$i]) { $key.Attributes = 1 }
+            $index.Fields.Append($key)
+            Release $key; $key = $null
+        }
+        $table.Indexes.Append($index)
+        $db.TableDefs.Append($table)
+        $rs = $db.OpenRecordset('Rows', 2)
+        $tag = 0
+        foreach ($row in $Arm.rows) {
+            $tag++
+            $script:endpoint = 'add_new_tag_' + $tag
+            $rs.AddNew()
+            for ($i = 0; $i -lt $Arm.fields.Count; $i++) {
+                $script:endpoint = 'assign_tag_' + $tag + '_field_' + $Arm.fields[$i].name
+                Set-Value $rs $Arm.fields[$i] $row[$i]
+            }
+            $script:endpoint = 'assign_tag_' + $tag + '_Tag'
+            $rs.Fields.Item('Tag').Value = [int]$tag
+            $operation = @{tag=$tag; status='updated'; endpoint='update'; native_codes=@(); hresult=$null; error=$null}
+            $script:endpoint = 'update_tag_' + $tag
+            try { $rs.Update() }
+            catch {
+                $operation.status = 'rejected'
+                $operation.native_codes = @($engine.Errors | ForEach-Object { [int]$_.Number })
+                $exception = $_.Exception
+                while ($null -ne $exception.InnerException) { $exception = $exception.InnerException }
+                $operation.hresult = [int]$exception.HResult
+                $operation.error = $_.Exception.Message
+                if ($rs.EditMode -ne 0) { $rs.CancelUpdate() }
+            }
+            [void]$Operations.Add($operation)
+        }
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $key; Release $index; Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $workspace; Release $engine
+    }
+}
+function Observe([string]$Path, $Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $endpoint = 'open_database'
+    $snapshot = [ordered]@{}
+    $status = 'pass'; $errorDetail = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $endpoint = 'schema'
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $table = $db.TableDefs.Item('Rows')
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object {
+            @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; ignore_nulls=[bool]$_.IgnoreNulls;
+              fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; descending=(([int]$_.Attributes -band 1) -ne 0); attributes=[int]$_.Attributes} })}
+        })
+        $endpoint = 'rows'
+        $rs = $db.OpenRecordset('Rows', 4)
+        $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) { [void]$rows.Add((Read-Row $rs $Arm)); $rs.MoveNext() }
+        $snapshot.rows = @($rows)
+        $rs.Close(); Release $rs; $rs = $null
+        $endpoint = 'index_traversal'
+        $rs = $db.OpenRecordset('Rows', 1)
+        $rs.Index = 'ByKey'
+        $traversal = New-Object Collections.ArrayList
+        if (-not ($rs.BOF -and $rs.EOF)) { $rs.MoveFirst() }
+        while (-not $rs.EOF) { [void]$traversal.Add((Read-Row $rs $Arm)); $rs.MoveNext() }
+        $snapshot.traversal = @($traversal)
+        $endpoint = 'complete'
+    }
+    catch {
+        $status = 'fail'
+        $errorDetail = ($_.Exception.GetType().FullName + ': ' + $_.Exception.Message).Replace($Path, '<DATABASE>')
+    }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }
+        Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }
+        Release $db; Release $engine
+        [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'scalar-index-remaining.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/scalar_index_remaining.ps1') { throw 'Script pin mismatch' }
+$mutationStarted = $false
+$endpoint = 'initial'
+$result = [ordered]@{
+    document_type='dao_scalar_index_remaining_result'; development_only=$true
+    plan_sha256=(Identity $planPath).sha256; mutation_started=$false
+    environment=@{process_bits=([IntPtr]::Size * 8); os=[Environment]::OSVersion.VersionString; provider='DAO.DBEngine.36'}
+    replicas=@(); attempts=@(); error=$null; failure_endpoint=$null; failure_stack=$null
+}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $name = "$($arm.name)-r$replica.mdb"
+            $control = Join-Path $env:JET3_WORK $name
+            $operations = New-Object Collections.ArrayList
+            $result.attempts += @{arm=$arm.name; replica=$replica; operations=$operations}
+            New-Control $control $arm $operations
+            $observation = Observe $control $arm
+            $observation.arm = $arm.name; $observation.replica = $replica; $observation.file = $name
+            $observation.operations = @($operations)
+            $result.replicas += $observation
+        }
+    }
+}
+catch {
+    $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message
+    $result.failure_endpoint = $endpoint
+    $result.failure_stack = $_.ScriptStackTrace
+}
+finally {
+    $result.mutation_started = $mutationStarted
+    [IO.File]::WriteAllText((Join-Path $env:JET3_OUTBOX 'result.json'), (($result | ConvertTo-Json -Depth 30) + "`n"), (New-Object Text.UTF8Encoding($false)))
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/scalar_index_remaining.py
+++ b/oracle/windows-dao/scripts/scalar_index_remaining.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Pinned finite scalar/null index observations; no key transform is assumed."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import struct
+import subprocess
+
+import system_catalog as catalog
+from relationship_create import leaf_entries
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/scalar-index-remaining.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/scalar_index_remaining.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    if plan['experiment_id'] != 'scalar-index-remaining' or plan['replicas'] != 3:
+        raise ValueError('Unexpected plan')
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    committed = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT,
+                               check=True, capture_output=True).stdout
+    if committed != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def physical(value, field):
+    """Normalize existing row decoding to physical value bytes, never index bytes."""
+    kind = field['type']
+    if value is None or kind == 1:
+        return value
+    if kind in (2, 3, 4):
+        return value.to_bytes(field['size'], 'little', signed=kind != 2).hex()
+    if kind == 8:
+        return struct.pack('<d', value).hex()
+    return value if kind == 9 else value['raw_hex']
+
+
+def semantic_key(row, arm):
+    values = []
+    for value, field, direction in zip(row['values'], arm['fields'], arm['directions']):
+        if field['type'] == 1:
+            # EXP-0062 retained Boolean leaf: True precedes False ascending.
+            number = -int(value)
+        else:
+            raw = bytes.fromhex(value)
+            if field['type'] in (6, 7, 8):
+                number = struct.unpack('<f' if field['type'] == 6 else '<d', raw)[0]
+            elif field['type'] == 9:
+                number = int.from_bytes(raw, 'big')
+            else:
+                number = int.from_bytes(raw, 'little', signed=field['type'] != 2)
+        values.append(-number if direction else number)
+    return tuple(values)
+
+
+def observe(data, arm):
+    definition, _, objects = catalog._discover_catalog(data)
+    names, kinds, ids = [catalog._ordinal(definition, name) for name in ('Name', 'Type', 'Id')]
+    roots = [row['values'][ids] for row in objects
+             if row['values'][names] == 'Rows' and row['values'][kinds] == 1]
+    if len(roots) != 1:
+        raise catalog.DecodeError('Expected one Rows table')
+    definition = catalog._definition(data, roots[0])
+    if len(definition['physical_indexes']) != 1 or len(definition['logical_indexes']) != 1:
+        raise catalog.DecodeError('Expected one physical/logical index')
+    pages, long_values = catalog._table_pages(data, definition)
+    if long_values:
+        raise catalog.DecodeError('Unexpected long values')
+    rows = catalog._table_rows(data, definition, pages)
+    fields = arm['fields'] + [{'name': 'Tag', 'type': 4, 'size': 4}]
+    expected_types = {1: 'Boolean', 2: 'Byte', 3: 'Integer', 4: 'Long', 5: 'Currency',
+                      6: 'Single', 7: 'Double', 8: 'Date', 9: 'Binary'}
+    if [(c['name'], c['type'], c['size']) for c in definition['columns']] != [
+            (f['name'], expected_types[f['type']], f['size']) for f in fields]:
+        raise catalog.DecodeError('Decoded schema differs')
+    by_locator = {(row['page'], row['row']): {'tag': row['values'][-1],
+                  'values': [physical(value, field) for value, field in zip(row['values'], arm['fields'])]}
+                  for row in rows}
+    index = definition['physical_indexes'][0]
+    leaf = leaf_entries(data, index['root'])
+    raw = catalog._page(data, index['root'], 'scalar leaf')
+    if int.from_bytes(raw[4:8], 'little') != definition['root']:
+        raise catalog.DecodeError('Index owner differs')
+    bindings, seen = [], set()
+    for entry in leaf['entries']:
+        locator = (entry['row_page'], entry['row'])
+        if locator not in by_locator or locator in seen:
+            raise catalog.DecodeError('Missing or repeated index row locator')
+        seen.add(locator)
+        bindings.append({**entry, **by_locator[locator]})
+    omitted = [row for locator, row in by_locator.items() if locator not in seen]
+    if any(None not in row['values'] for row in omitted):
+        raise catalog.DecodeError('Index omitted a non-null row')
+    return {'definition_root': definition['root'], 'row_count': definition['row_count'],
+            'physical_index': index, 'logical_indexes': definition['logical_indexes'],
+            'data_pages': pages, 'index_pages': sorted(catalog._locator_pages(data, index['map'], 'index')),
+            'rows': sorted(by_locator.values(), key=lambda row: row['tag']), 'bindings': bindings,
+            'omitted_rows': sorted(omitted, key=lambda row: row['tag']), 'prefix_hex': leaf['prefix_hex']}
+
+
+def correlate(entry, decoded, arm):
+    snapshot = entry['snapshot']
+    fields = arm['fields'] + [{'name': 'Tag', 'type': 4, 'size': 4}]
+    expected_index = {'name': 'ByKey', 'primary': False, 'unique': arm['unique'],
+                      'required': arm['required'], 'ignore_nulls': arm['ignore_nulls'],
+                      'fields': [{'name': f['name'], 'descending': d, 'attributes': int(d)}
+                                 for f, d in zip(arm['fields'], arm['directions'])]}
+    if (snapshot['version'] != '3.0' or snapshot['fields'] != fields
+            or snapshot['indexes'] != [expected_index]
+            or snapshot['tables'] != ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows']):
+        raise ValueError('DAO schema differs from declared control')
+    operations = entry['operations']
+    if [op['tag'] for op in operations] != list(range(1, len(arm['rows']) + 1)):
+        raise ValueError('Incomplete insertion attempts')
+    if any(op['status'] not in ('updated', 'rejected') or op['endpoint'] != 'update' for op in operations):
+        raise ValueError('Unexpected operation result')
+    accepted = [op['tag'] for op in operations if op['status'] == 'updated']
+    rows = sorted(snapshot['rows'], key=lambda row: row['tag'])
+    if ([row['tag'] for row in rows] != accepted or rows != decoded['rows']
+            or decoded['row_count'] != len(rows)):
+        raise ValueError('Saved rows do not match accepted attempts/decoded rows')
+    traversal = snapshot['traversal']
+    bound = [{'tag': b['tag'], 'values': b['values']} for b in decoded['bindings']]
+    if sorted(traversal, key=lambda row: row['tag']) != sorted(bound, key=lambda row: row['tag']):
+        raise ValueError('DAO traversal differs from raw key bindings')
+    # Equal full values may have different tag order; null ordering is a question.
+    if [row['values'] for row in traversal] != [row['values'] for row in bound]:
+        raise ValueError('DAO traversal value order differs from raw leaf')
+    if arm['family'] == 'scalar' and [semantic_key(row, arm) for row in traversal] != sorted(
+            semantic_key(row, arm) for row in traversal):
+        raise ValueError('Scalar traversal is not in declared direction')
+    return all(row['values'] == arm['rows'][row['tag'] - 1] for row in rows)
+
+
+def comparable(observation):
+    decoded = observation['decoded']
+    return {'operations': [{k: op[k] for k in ('tag', 'status', 'endpoint', 'native_codes', 'hresult')}
+                           for op in observation['operations']],
+            'snapshot': {k: v for k, v in observation['snapshot'].items() if k not in ('rows', 'traversal')},
+            'rows': decoded['rows'], 'bindings': sorted((b['tag'], b['values'], b['key_hex']) for b in decoded['bindings']),
+            'omitted_rows': decoded['omitted_rows'], 'keys': decoded['physical_index']['keys'],
+            'flags': decoded['physical_index']['flags'], 'entry_count': decoded['physical_index']['entry_count'],
+            'requested_payloads_match': observation['requested_payloads_match']}
+
+
+def build_report(result, outbox, plan):
+    if (result['document_type'] != 'dao_scalar_index_remaining_result' or result['plan_sha256'] != digest(PLAN)
+            or result['development_only'] is not True or result['environment']['process_bits'] != 32
+            or result['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Result binding/environment mismatch')
+    expected = [(arm['name'], replica) for arm in plan['arms'] for replica in range(1, 4)]
+    actual = [(e['arm'], e['replica']) for e in result['replicas']]
+    if actual != expected[:len(actual)]:
+        raise ValueError('Unexpected replica inventory')
+    arms = {arm['name']: arm for arm in plan['arms']}
+    observations, reasons = [], []
+    for entry in result['replicas']:
+        label = f"{entry['arm']}-r{entry['replica']}"
+        if entry['file'] != label + '.mdb' or identity(outbox / entry['file']) != entry['after']:
+            raise ValueError('Retained image identity mismatch')
+        if entry['before'] != entry['after']:
+            reasons.append(label + ': read-only bytes changed')
+        try:
+            if entry['status'] != 'pass' or entry['error'] is not None:
+                raise ValueError('DAO capture failed: ' + str(entry['error']))
+            decoded = observe((outbox / entry['file']).read_bytes(), arms[entry['arm']])
+            matching = correlate(entry, decoded, arms[entry['arm']])
+            observations.append({**{k: entry[k] for k in ('arm', 'replica', 'operations', 'snapshot')},
+                                 'decoded': decoded, 'requested_payloads_match': matching})
+        except (catalog.DecodeError, KeyError, ValueError) as error:
+            reasons.append(label + ': ' + str(error))
+    if len(observations) != len(expected) or result['error'] is not None or result['mutation_started'] is not True:
+        reasons.append('Acquisition incomplete or failed: ' + str(result['error']))
+    for arm in arms:
+        group = [comparable(o) for o in observations if o['arm'] == arm]
+        if group and any(o != group[0] for o in group):
+            reasons.append(arm + ': question-bearing replica disagreement')
+    return {'document_type': 'dao_scalar_index_remaining_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'answered' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'compatibility_claim': False,
+            'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    output = outbox / 'report.json'
+    output.write_text(canonical(report) + '\n')
+    print(output)
+    print(report['outcome'])
+
+
+def dispatch(args):
+    preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9][a-z0-9-]{0,31}', args.run_id):
+        raise ValueError('Invalid run id')
+    inbox, outbox = (args.shared_root.resolve() / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists():
+        raise ValueError('Run id already used; never redispatch a scientific run')
+    inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1')
+    shutil.copyfile(PLAN, inbox / PLAN.name)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15',
+               '-o', 'IdentitiesOnly=yes', '-i', args.identity, f'{args.user}@{args.host}',
+               'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    print(f'Dispatching one run {args.run_id}; no automatic retries.', flush=True)
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if (outbox / 'log.txt').exists():
+        print(transport.read_log(outbox / 'log.txt'))
+    if not (outbox / 'result.json').exists():
+        raise RuntimeError(f'No scientific result (SSH exit {completed.returncode}); inspect run, do not retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight')
+    report = commands.add_parser('analyze')
+    report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run')
+    run.add_argument('--run-id', required=True)
+    run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'),
+                          ('identity', str(Path.home() / '.ssh/jet3-dao')),
+                          ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=os.environ.get('JET3_WINDOWS_' + name.upper().replace('-', '_'), default))
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        preflight()
+        print('Pinned inputs and committed plan match.')
+    elif args.command == 'analyze':
+        analyze(args.outbox)
+    else:
+        dispatch(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/check_scalar_index_remaining.ps1
+++ b/oracle/windows-dao/tests/check_scalar_index_remaining.ps1
@@ -1,0 +1,28 @@
+param([string]$Root)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'Host-language check requires acquisition x86 runtime' }
+$scriptPath = Join-Path $Root 'script.ps1'
+$tokens=$null; $errors=$null
+$ast=[System.Management.Automation.Language.Parser]::ParseFile($scriptPath,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw ($errors | Out-String)}
+foreach($name in @('Release','From-Hex','To-Hex','Set-Value','Read-Value','Read-Row')) {
+    $definition=@($ast.FindAll({param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name},$false))
+    if($definition.Count -ne 1){throw "Missing helper $name"}
+    Invoke-Expression $definition[0].Extent.Text
+}
+$plan=Get-Content (Join-Path $Root 'plan.json') -Raw | ConvertFrom-Json
+$output=New-Object Collections.ArrayList
+foreach($arm in $plan.arms){
+    $fields=[pscustomobject]@{Storage=@{}}
+    $fields | Add-Member -MemberType ScriptMethod -Name Item -Value {param($Name) return $this.Storage[$Name]}
+    foreach($definition in $arm.fields){$fields.Storage[$definition.name]=[pscustomobject]@{Value=$null}}
+    $fields.Storage.Tag=[pscustomobject]@{Value=1}
+    $rs=[pscustomobject]@{Fields=$fields}
+    foreach($row in $arm.rows){
+        for($i=0;$i -lt $arm.fields.Count;$i++){Set-Value $rs $arm.fields[$i] $row[$i]}
+        $read=Read-Row $rs $arm
+        [void]$output.Add(@{arm=$arm.name; row=$read.values})
+    }
+}
+ConvertTo-Json -InputObject @($output) -Depth 10 -Compress

--- a/oracle/windows-dao/tests/test_scalar_index_remaining.py
+++ b/oracle/windows-dao/tests/test_scalar_index_remaining.py
@@ -1,0 +1,135 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location('scalar_index_remaining', SCRIPTS / 'scalar_index_remaining.py')
+experiment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(experiment)
+
+
+class ScalarIndexRemainingTests(unittest.TestCase):
+    def plan(self):
+        return json.loads(experiment.PLAN.read_text())
+
+    @staticmethod
+    def decoded(_data, arm):
+        rows = [{'tag': i + 1, 'values': value} for i, value in enumerate(arm['rows'])]
+        if arm['required']:
+            rows = [row for row in rows if None not in row['values']]
+        omitted = [row for row in rows if arm['ignore_nulls'] and None in row['values']]
+        bound = [row for row in rows if row not in omitted]
+        if arm['family'] == 'scalar':
+            bound.sort(key=lambda row: experiment.semantic_key(row, arm))
+        return {'rows': rows, 'row_count': len(rows), 'omitted_rows': omitted,
+                'bindings': [dict(row, row_page=23, row=i, key_hex='deadbeef') for i, row in enumerate(bound)],
+                'physical_index': {'entry_count': len(bound), 'flags': 1, 'keys': arm['fields']}}
+
+    def fixture(self, outbox):
+        plan = self.plan()
+        result = {'document_type': 'dao_scalar_index_remaining_result', 'development_only': True,
+                  'plan_sha256': experiment.digest(experiment.PLAN), 'mutation_started': True,
+                  'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'replicas': [], 'error': None}
+        for arm in plan['arms']:
+            decoded = self.decoded(None, arm)
+            saved = {row['tag'] for row in decoded['rows']}
+            operations = [{'tag': i + 1, 'status': 'updated' if i + 1 in saved else 'rejected',
+                           'endpoint': 'update', 'native_codes': [] if i + 1 in saved else [9999],
+                           'hresult': None if i + 1 in saved else -123} for i in range(len(arm['rows']))]
+            snapshot = {'version': '3.0', 'tables': ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows'],
+                        'fields': arm['fields'] + [{'name': 'Tag', 'type': 4, 'size': 4}],
+                        'indexes': [{'name': 'ByKey', 'primary': False, 'unique': arm['unique'],
+                                     'required': arm['required'], 'ignore_nulls': arm['ignore_nulls'],
+                                     'fields': [{'name': f['name'], 'descending': d, 'attributes': int(d)}
+                                                for f, d in zip(arm['fields'], arm['directions'])]}],
+                        'rows': decoded['rows'], 'traversal': [{'tag': b['tag'], 'values': b['values']}
+                                                            for b in decoded['bindings']]}
+            for replica in range(1, 4):
+                name = f"{arm['name']}-r{replica}.mdb"
+                (outbox / name).write_bytes(b'synthetic')
+                identity = experiment.identity(outbox / name)
+                result['replicas'].append({'arm': arm['name'], 'replica': replica, 'file': name,
+                                          'before': identity, 'after': identity, 'status': 'pass',
+                                          'endpoint': 'complete', 'error': None,
+                                          'operations': copy.deepcopy(operations), 'snapshot': copy.deepcopy(snapshot)})
+        return plan, result
+
+    def test_raw_bindings_reject_wrong_locator_and_nonnull_omission(self):
+        arm = next(a for a in self.plan()['arms'] if a['name'] == 'null-ignore')
+        definition = {'root': 20, 'columns': [{'name': 'A', 'type': 'Long', 'size': 4},
+                                            {'name': 'Tag', 'type': 'Long', 'size': 4}],
+                      'physical_indexes': [{'root': 24, 'map': {}}], 'logical_indexes': [{}], 'row_count': 2}
+        rows = [{'page': 23, 'row': 0, 'values': [None, 1]}, {'page': 23, 'row': 1, 'values': [7, 2]}]
+        leaf = {'entries': [{'row_page': 23, 'row': 1, 'key_hex': 'aabb'}], 'prefix_hex': ''}
+        raw = bytearray(2048); raw[4:8] = (20).to_bytes(4, 'little')
+        with patch.object(experiment.catalog, '_discover_catalog', return_value=({}, None, [{'values': ['Rows', 1, 20]}])), \
+                patch.object(experiment.catalog, '_ordinal', side_effect=lambda _, name: ['Name', 'Type', 'Id'].index(name)), \
+                patch.object(experiment.catalog, '_definition', return_value=definition), \
+                patch.object(experiment.catalog, '_table_pages', return_value=([23], [])), \
+                patch.object(experiment.catalog, '_table_rows', return_value=rows), \
+                patch.object(experiment.catalog, '_page', return_value=raw), \
+                patch.object(experiment.catalog, '_locator_pages', return_value={24}), \
+                patch.object(experiment, 'leaf_entries', return_value=leaf):
+            observed = experiment.observe(b'', arm)
+            self.assertEqual(observed['bindings'][0]['values'], ['07000000'])
+            self.assertEqual(observed['bindings'][0]['key_hex'], 'aabb')
+            self.assertEqual(observed['omitted_rows'], [{'tag': 1, 'values': [None]}])
+            leaf['entries'][0]['row'] = 9
+            with self.assertRaisesRegex(experiment.catalog.DecodeError, 'locator'):
+                experiment.observe(b'', arm)
+            leaf['entries'] = []
+            with self.assertRaisesRegex(experiment.catalog.DecodeError, 'non-null'):
+                experiment.observe(b'', arm)
+
+    def test_actual_rejections_and_null_omissions_answer_without_guessed_policy(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=self.decoded):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'answered')
+            entry = next(e for e in result['replicas'] if e['arm'] == 'null-required')
+            entry['operations'][0]['native_codes'] = [8888]
+            self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+
+    def test_complete_rows_traversal_metadata_and_no_retry_failure_gates(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=self.decoded):
+            outbox = Path(temporary)
+            plan, original = self.fixture(outbox)
+            for change in ('rows', 'traversal', 'schema', 'partial', 'changed'):
+                result = copy.deepcopy(original)
+                entry = result['replicas'][0]
+                if change == 'rows': entry['snapshot']['rows'].pop()
+                elif change == 'traversal': entry['snapshot']['traversal'].reverse()
+                elif change == 'schema': entry['snapshot']['indexes'][0]['ignore_nulls'] = True
+                elif change == 'partial': result['replicas'].pop(); result['error'] = 'post-mutation failure'
+                else: entry['before'] = {'size': 0, 'sha256': 'changed'}
+                with self.subTest(change=change):
+                    self.assertEqual(experiment.build_report(result, outbox, plan)['outcome'], 'no_outcome')
+
+    def test_retained_identity_and_both_pin_paths(self):
+        with tempfile.TemporaryDirectory() as temporary, patch.object(experiment, 'observe', side_effect=self.decoded):
+            outbox = Path(temporary)
+            plan, result = self.fixture(outbox)
+            (outbox / result['replicas'][0]['file']).write_bytes(b'changed')
+            with self.assertRaisesRegex(ValueError, 'identity mismatch'):
+                experiment.build_report(result, outbox, plan)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            producer = root / 'producer.py'; producer.write_text('changed')
+            plan = root / 'plan.json'
+            plan.write_text(json.dumps({'experiment_id': 'scalar-index-remaining', 'replicas': 3,
+                                        'inputs': {'producer.py': '0' * 64}}))
+            with patch.object(experiment, 'ROOT', root), patch.object(experiment, 'PLAN', plan):
+                for operation in (experiment.preflight, lambda: experiment.analyze(root)):
+                    with self.assertRaisesRegex(ValueError, 'Input pin mismatch'):
+                        operation()
+            self.assertFalse((root / 'report.json').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The original scalar discovery stopped before Date, Binary and nullable Long captures. Preregister EXP-0147 for only those 14 remaining arms with three fresh controls each, preserving the failed run and its 36 completed captures. Use plain CLR arrays for saved-value JSON, explicit precomputed DateTime assignment, and retained failure endpoints/stacks.

Independent review, four focused Python tests, committed-input verification and `just ready` pass. Actual x86 PowerShell executed all 120 planned row conversion/JSON checks without DAO. The pinned successor uses the user’s standing DAO authorization; no old plan is edited or redispatched. Advances #100.
