### PR TITLE
test: preregister retained multi-level tree reanalysis

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11210,6 +11210,34 @@ Copy this block under the appropriate section and remove this instruction:
   or hosted support claim. Retain all MDBs externally and record one validated
   additive outcome as `EXP-0128`.
 
+### EXP-0145 — Retained multi-level index secondary-analysis preregistration
+
+- Plan: `oracle/windows-dao/acquisition/multi-level-index-reanalysis.plan.json`,
+  SHA-256 `a27b80e7745ea2dca35f78053a1b43d29ebb73d4db56d84bd6bd5ab814c454e4`; outcome reserved as EXP-0146.
+- This is explicitly post-acquisition analysis of EXP-0139 run
+  `20260905T054000Z-multi-level-index`, with no DAO execution or new acquisition.
+  EXP-0140 and its original three `no_outcome` classifications remain unchanged.
+  The plan pins the original result/report, all eighteen retained MDB identities,
+  the original plan and consumed inputs, and the separate secondary analyzer.
+- Prior read-only diagnosis identified branch header byte 21 equal to 2 in
+  primary/composite control roots where the original decoder admitted only 1.
+  The secondary decoder admits branch values 1/2 and leaf value 0, retaining
+  existing graph, separator, sibling, locator, map, and full semantic checks.
+  It records each raw byte and independently derived subtree height. The finite
+  byte/height relation is reported separately from candidate acceptance; the
+  candidate's all-branches-1 policy is not rewritten to match controls.
+- All nine original controls must pass and all eighteen source identities remain
+  unchanged. Three agreeing candidate observations per arm classify the separate
+  secondary result. Complete metadata, rows, traversal and original finite Seek
+  probes remain required. Changed pins reject analysis; incomplete observations
+  yield `no_outcome`. The new report must be outside the original outbox and
+  cannot overwrite an existing file.
+- Four focused synthetic tests cover header values and independently computed
+  three-level heights, retained original outcomes and failed-control/error gates,
+  input drift, and refusal to write into the source directory. Independent review
+  is pending before execution. No secondary observation is recorded in this entry;
+  no parser fact, general compatibility, or support-matrix movement is claimed.
+
 ### EXP-0140 — Multi-level candidate run retained as no_outcome
 
 - Recorded: 2026-09-05, OpenAI Codex

--- a/oracle/windows-dao/acquisition/multi-level-index-reanalysis.plan.json
+++ b/oracle/windows-dao/acquisition/multi-level-index-reanalysis.plan.json
@@ -1,0 +1,118 @@
+{
+  "experiment_id": "multi-level-index-reanalysis",
+  "provenance": "EXP-0145",
+  "outcome_provenance": "EXP-0146",
+  "development_only": true,
+  "compatibility_claim": false,
+  "support_movement": false,
+  "mode": "post-acquisition read-only reanalysis; no DAO execution or new acquisition",
+  "source_run": "20260905T054000Z-multi-level-index",
+  "original_plan_sha256": "7d0f368b31e2295b826118cea4e290b8ddc6661d108aea99eb870db84e13ccc2",
+  "original_outcome": "EXP-0140: all three arms no_outcome; preserved without amendment",
+  "source_commit": "5cd9e5a49888013059dfb88e8ab0a6ef942a91cd",
+  "replicas": 3,
+  "prior_information": "Read-only diagnosis after the original report found branch header byte 21 equal to 2 in primary/composite control roots; original decoder allowed only 1. Candidate writer emits 1 for every branch. This motivated the secondary analysis and is not a blind hypothesis.",
+  "hypothesis": "Retained DAO control branch header byte 21 may equal actual subtree height (leaves 0, branch heights 1 or 2). Record raw byte and independently derived height for every node; separately test exact candidate semantic acceptance under an expanded finite header decoder without requiring candidate bytes to equal control height classes.",
+  "decoder_policy": "Allow branch byte 21 only 1 or 2, leaf 0; all previous owner, compressed boundary, free-space, complete key/locator child-maximum separator, sibling, uniform leaf depth, map membership and row binding checks remain. Derive height recursively from children. No general arbitrary-height grammar or writer split policy inferred.",
+  "semantic_endpoints": "Reuse the pinned original complete schema/index/relationship metadata, full typed row multiset, full ordered traversal including duplicate payloads, and finite boundary/missing Seek queries. Keep semantic comparison independent of structural decoding failure; physical placement/compression need not match controls.",
+  "classification": "Exact nine-pair inventory and retained/input pins required. All nine controls must pass semantics and structure, original acquisition must have no error and mutation_started true, all eighteen original identities unchanged. Three agreeing candidate observations per arm yield observed_accepted or not_observed_accepted; disagreement or failed completeness/control gates gives no_outcome. Original outcomes are carried unchanged in the new report.",
+  "header_height_classification": "Report every node raw byte 21 and derived subtree height, with count summaries per index. For each arm and role all three replicas must agree on table names, class-height pair sets and equality relation (physical addresses and node counts may differ). All structures and acquisition/control gates must complete to answer this finite question. Candidate equality is not an acceptance gate; any observed candidate/control policy difference is retained.",
+  "retention": "Read the same eighteen retained MDBs and original result/report JSON. Verify all identities before and after analysis. Write one fresh secondary report outside the original outbox; refuse overwrite. Never edit original plan/scripts/results or redispatch DAO. Subsequent evidence-backed parser changes are a separate deliverable.",
+  "limits": {
+    "image_pages": 8192,
+    "rows_per_page": 1019,
+    "tree_depth": 32
+  },
+  "inputs": {
+    "oracle/windows-dao/scripts/multi_level_index.py": "a159a7630725f8d8a82dd781a07e551aee2840f07cc52887781d25bb106a3314",
+    "oracle/windows-dao/scripts/multi_level_index.ps1": "503d6f906bc9e1f58354d362246a8f66d1b15f343cee63f0b3de3e4d6d3b50ec",
+    "oracle/windows-dao/scripts/multi_level_index_structure.py": "a4291fd040cb6a90fb68dfbb5dfe75f9f5990caa1d3cec6893577b118191d928",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/examples/multi_level_index_candidate.rs": "e852d949354eb4ce694589a19d8dd3ef2114340522c694f89230fd5cfbc15eb4",
+    "oracle/windows-dao/acquisition/multi-level-index.plan.json": "7d0f368b31e2295b826118cea4e290b8ddc6661d108aea99eb870db84e13ccc2",
+    "oracle/windows-dao/scripts/multi_level_index_reanalysis.py": "1420a5af9bfa069ab299fa0bffc4b80875d586c2a95c740978b4f9c365aaa9c5"
+  },
+  "retained": {
+    "result.json": {
+      "size": 9682811,
+      "sha256": "4adee25ea2276ea8b080441ac6eadf293869a7d5cee881145d82ab602f612718"
+    },
+    "report.json": {
+      "size": 150657,
+      "sha256": "8c665dccb340155c3998022305cefbaa2b590c687167236abb2f18b2dcaf23cb"
+    },
+    "primary-candidate-r1.mdb": {
+      "size": 677888,
+      "sha256": "319337d779bfeceb7971ff133794ef738b5dcf44f3c55885d1c2591b5af15593"
+    },
+    "primary-candidate-r2.mdb": {
+      "size": 677888,
+      "sha256": "319337d779bfeceb7971ff133794ef738b5dcf44f3c55885d1c2591b5af15593"
+    },
+    "primary-candidate-r3.mdb": {
+      "size": 677888,
+      "sha256": "319337d779bfeceb7971ff133794ef738b5dcf44f3c55885d1c2591b5af15593"
+    },
+    "primary-control-r1.mdb": {
+      "size": 839680,
+      "sha256": "23828c3ebaf78bdf15f924ce069c246df2e1d54a864a3f972ed808b3316b6a89"
+    },
+    "primary-control-r2.mdb": {
+      "size": 839680,
+      "sha256": "6bdbd1d45fb084befa3711063bc17a53174f794ac128e2da87daa2e090d0d138"
+    },
+    "primary-control-r3.mdb": {
+      "size": 839680,
+      "sha256": "cf3131459fe08d6cd028da27932e5dba00588c1ef38211b88498f69c38f613f1"
+    },
+    "composite-candidate-r1.mdb": {
+      "size": 475136,
+      "sha256": "249529faf1161a6a7ceb255794fb65d6fd5080d66c0e8fefdae88a2eba2ae035"
+    },
+    "composite-candidate-r2.mdb": {
+      "size": 475136,
+      "sha256": "249529faf1161a6a7ceb255794fb65d6fd5080d66c0e8fefdae88a2eba2ae035"
+    },
+    "composite-candidate-r3.mdb": {
+      "size": 475136,
+      "sha256": "249529faf1161a6a7ceb255794fb65d6fd5080d66c0e8fefdae88a2eba2ae035"
+    },
+    "composite-control-r1.mdb": {
+      "size": 577536,
+      "sha256": "7ba5500bf8b8484472ae45e977cacbe3ffa7139f959207badedb3fea07710d26"
+    },
+    "composite-control-r2.mdb": {
+      "size": 577536,
+      "sha256": "9c48cc94f82ca93ee179e0bf4c4d01d346994e2264e33c799d7d0b066fe326ab"
+    },
+    "composite-control-r3.mdb": {
+      "size": 577536,
+      "sha256": "909f2dfb034c5d84637eaf0edbbf21f2b9249b9b213c507eade150b439ef96c1"
+    },
+    "relationship-candidate-r1.mdb": {
+      "size": 694272,
+      "sha256": "beec4f2af1e0a84396053ef39ac9b76b5465db822f759cc7c35c1d11a9342147"
+    },
+    "relationship-candidate-r2.mdb": {
+      "size": 694272,
+      "sha256": "beec4f2af1e0a84396053ef39ac9b76b5465db822f759cc7c35c1d11a9342147"
+    },
+    "relationship-candidate-r3.mdb": {
+      "size": 694272,
+      "sha256": "beec4f2af1e0a84396053ef39ac9b76b5465db822f759cc7c35c1d11a9342147"
+    },
+    "relationship-control-r1.mdb": {
+      "size": 481280,
+      "sha256": "5275c7c0a7b072e00c77860dd79d5d3b191629f15004625d521a3909c0d6c2a9"
+    },
+    "relationship-control-r2.mdb": {
+      "size": 481280,
+      "sha256": "caedbb7cfe2e7fa8855ef1f93972516957ddf0c966e5f545de2493caf7dfd22b"
+    },
+    "relationship-control-r3.mdb": {
+      "size": 481280,
+      "sha256": "5169e8a825568533c3d8319ea4a3cf1cc50d998ca5ee9354448bcb1c5d2cdea5"
+    }
+  }
+}

--- a/oracle/windows-dao/scripts/multi_level_index_reanalysis.py
+++ b/oracle/windows-dao/scripts/multi_level_index_reanalysis.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""EXP-0145: separately pinned read-only analysis of the retained EXP-0139 run.
+
+The consumed analysis remains unchanged. This finite decoder admits branch
+header byte 21 values 1 or 2, records that byte and subtree height separately,
+and keeps all existing key/locator/separator/map and semantic checks.
+"""
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import subprocess
+
+import multi_level_index as original
+from multi_level_index_structure import catalog, require
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/multi-level-index-reanalysis.plan.json'
+
+
+def tree(data, root, owner):
+    nodes, seen, leaf_entries = [], set(), []
+    def visit(number, depth):
+        require(depth <= 32 and number not in seen, 'Repeated page or excessive index depth')
+        seen.add(number)
+        page = catalog._page(data, number, 'index node')
+        branch = page[0] == 3
+        require(page[0] in (3, 4) and page[1] == 1 and page[21] in ((1, 2) if branch else (0,)), 'Index node header')
+        require(int.from_bytes(page[4:8], 'little') == owner, 'Index owner mismatch')
+        prefix = page[20]
+        previous, following, tail = [int.from_bytes(page[offset:offset + 4], 'little') for offset in (8, 12, 16)]
+        require(bool(tail) == branch, 'Index tail child mismatch')
+        area = page[248:]
+        boundaries = [position * 8 + bit for position, byte in enumerate(page[22:248]) for bit in range(8) if byte & (1 << bit)]
+        require(all(prefix < end <= 1800 for end in boundaries), 'Index boundary outside entry area')
+        require(int.from_bytes(page[2:4], 'little') == 1800 - (boundaries[-1] if boundaries else 0), 'Index free space mismatch')
+        require(bool(boundaries) or (not branch and prefix == 0), 'Empty branch or unmatched prefix')
+        node = dict(page=number, depth=depth, previous=previous, next=following, tail=tail, prefix=prefix, entries=len(boundaries), children=[], header_class=page[21])
+        nodes.append(node)
+        start, entries = prefix, []
+        for end in boundaries:
+            entry = area[:prefix] + area[start:end]
+            require(len(entry) >= (8 if branch else 4), 'Short index entry')
+            entries.append(entry)
+            start = end
+        require(entries == sorted(entries), 'Unsorted complete index entries')
+        if not branch:
+            leaf_entries.extend(entries)
+            node['subtree_height'] = 0
+            return (entries[-1] if entries else None), 0
+        child_heights = []
+        for entry in entries:
+            child = int.from_bytes(entry[-4:], 'big')
+            node['children'].append(child)
+            maximum, height = visit(child, depth + 1)
+            child_heights.append(height)
+            require(maximum == entry[:-4], 'Branch separator is not child maximum key and locator')
+        node['children'].append(tail)
+        maximum, height = visit(tail, depth + 1)
+        require(all(child == height for child in child_heights), 'Unequal child subtree heights')
+        node['subtree_height'] = height + 1
+        return maximum, height + 1
+    visit(root, 1)
+    for depth in sorted({node['depth'] for node in nodes}):
+        level = [node for node in nodes if node['depth'] == depth]
+        for position, node in enumerate(level):
+            require(node['previous'] == (level[position - 1]['page'] if position else 0)
+                    and node['next'] == (level[position + 1]['page'] if position + 1 < len(level) else 0), 'Index sibling chain mismatch')
+    require(len({node['depth'] for node in nodes if not node['children']}) == 1, 'Unequal leaf depth')
+    require(leaf_entries == sorted(leaf_entries), 'Index traversal is not sorted')
+    return nodes, leaf_entries
+
+
+def verify(source, committed=True):
+    plan = json.loads(PLAN.read_text())
+    for name, identity in plan['inputs'].items():
+        if original.digest(ROOT / name) != identity:
+            raise ValueError('Secondary-analysis input pin mismatch: ' + name)
+    initial = json.loads(original.PLAN.read_text())
+    original.verify_inputs(initial)
+    for name, identity in plan['retained'].items():
+        if original.identity(source / name) != identity:
+            raise ValueError('Retained source pin mismatch: ' + name)
+    if committed:
+        saved = subprocess.run(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT, check=True, capture_output=True).stdout
+        if saved != PLAN.read_bytes():
+            raise ValueError('Secondary-analysis plan must be committed')
+    return plan, initial
+
+
+def height_summary(tables):
+    result = []
+    for table in tables:
+        for index in table['indexes']:
+            counts = Counter((node['header_class'], node['subtree_height']) for node in index['nodes'])
+            result.append(dict(table=table['name'], root=index['root'], depth=index['depth'],
+                header_height_counts=[dict(header_class=key[0], subtree_height=key[1], nodes=count) for key, count in sorted(counts.items())],
+                all_classes_equal_height=all(a == b for a, b in counts)))
+    return result
+
+
+def build_report(source, plan, initial):
+    result = json.loads((source / 'result.json').read_text())
+    old = json.loads((source / 'report.json').read_text())
+    if (result['document_type'] != 'dao_multi_level_index_result' or result['plan_sha256'] != original.digest(original.PLAN)
+            or result['environment']['process_bits'] != 32 or result['environment']['provider'] != 'DAO.DBEngine.36'
+            or result['development_only'] is not True or old['outcomes'] != {arm: 'no_outcome' for arm in original.ARMS}):
+        raise ValueError('Original result/report binding mismatch')
+    expected = [(arm, replica) for arm in original.ARMS for replica in range(1, 4)]
+    actual = [(pair['arm'], pair['replica']) for pair in result['replicas']]
+    if actual != expected:
+        raise ValueError('Retained inventory differs from declared single run')
+    observations, groups = [], {arm: [] for arm in original.ARMS}
+    controls_ok, unchanged = True, True
+    saved_tree = original.structure.tree
+    try:
+        # The isolated secondary decoder replaces only the tree function in memory.
+        original.structure.tree = tree
+        for pair in result['replicas']:
+            arm, replica = pair['arm'], pair['replica']
+            tables = initial['arms'][arm]
+            expected_snapshot = original.normalize(original.expected_snapshot(arm, tables), tables)[1]
+            for role in ('control', 'candidate'):
+                observation = pair[role]
+                path = source / f'{arm}-{role}-r{replica}.mdb'
+                if original.identity(path) != observation['after']:
+                    raise ValueError('Retained identity mismatch')
+                if role == 'candidate' and observation['before'] != initial['candidates'][arm]:
+                    raise ValueError('Original candidate binding mismatch')
+                unchanged &= observation['before'] == observation['after']
+                semantic_ok, structure_ok, details, reason = False, False, None, None
+                try:
+                    valid, snapshot = original.normalize(observation['snapshot'], tables)
+                    semantic_ok = (valid and snapshot == expected_snapshot and observation['status'] == 'pass'
+                                   and observation['endpoint'] == 'complete' and observation['error'] is None)
+                    details = original.structure.observe(path.read_bytes(), tables,
+                        {table['name']: original.rows_for(arm, table['name']) for table in tables}, role == 'candidate')
+                    structure_ok = True
+                except (ValueError, KeyError, TypeError, IndexError) as error:
+                    reason = str(error)
+                passed = semantic_ok and structure_ok
+                summary = dict(arm=arm, replica=replica, role=role, semantic_match=semantic_ok,
+                    structural_match=structure_ok, passed=passed, reason=reason, tables=details,
+                    header_height=height_summary(details) if details is not None else None)
+                observations.append(summary)
+                if role == 'control':
+                    controls_ok &= passed
+                else:
+                    groups[arm].append((passed, semantic_ok, structure_ok, reason))
+    finally:
+        original.structure.tree = saved_tree
+    outcomes = {arm: 'no_outcome' for arm in original.ARMS}
+    complete = result['error'] is None and result['mutation_started'] is True and unchanged and controls_ok
+    if complete:
+        for arm, group in groups.items():
+            if all(item == group[0] for item in group):
+                outcomes[arm] = 'observed_accepted' if group[0][0] else 'not_observed_accepted'
+    relation_complete = all(observation['header_height'] is not None for observation in observations)
+    relations = []
+    for arm in original.ARMS:
+        for role in ('candidate', 'control'):
+            selected = [o for o in observations if o['arm'] == arm and o['role'] == role]
+            values = [[dict(table=t['table'], all_classes_equal_height=t['all_classes_equal_height'],
+                            class_height_pairs=[(x['header_class'], x['subtree_height']) for x in t['header_height_counts']])
+                       for t in o['header_height']] for o in selected if o['header_height'] is not None]
+            agrees = len(values) == 3 and all(value == values[0] for value in values)
+            relation_complete &= agrees
+            relations.append(dict(arm=arm, role=role, agrees=agrees, tables=values[0] if agrees else None))
+    return dict(document_type='dao_multi_level_index_reanalysis_report', development_only=True,
+        compatibility_claim=False, support_movement=False, plan_sha256=original.digest(PLAN),
+        original_plan_sha256=original.digest(original.PLAN), original_result=plan['retained']['result.json'],
+        original_report=plan['retained']['report.json'], original_outcomes=old['outcomes'], outcomes=outcomes,
+        header_height_outcome='answered' if relation_complete and complete else 'no_outcome',
+        header_height_relations=relations, observations=observations)
+
+
+def analyze(source, output):
+    plan, initial = verify(source)
+    if output.exists() or output.resolve().is_relative_to(source.resolve()):
+        raise ValueError('Secondary report must be new and outside the retained source directory')
+    report = build_report(source, plan, initial)
+    # Detect accidental changes to any retained source before publishing a new report.
+    verify(source)
+    with output.open('x') as target:
+        target.write(original.canonical(report) + '\n')
+    print(output)
+    print(original.canonical(report['outcomes']))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=['preflight', 'analyze'])
+    parser.add_argument('source', type=Path)
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    if args.command == 'preflight':
+        verify(args.source)
+        print('Committed secondary plan, inputs and retained identities match.')
+    else:
+        if args.output is None:
+            parser.error('analyze requires --output')
+        analyze(args.source, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/oracle/windows-dao/tests/test_multi_level_index_reanalysis.py
+++ b/oracle/windows-dao/tests/test_multi_level_index_reanalysis.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import multi_level_index_reanalysis as secondary
+import test_multi_level_index as original_tests
+
+
+class ReanalysisTests(unittest.TestCase):
+    def test_class_two_is_recorded_without_forcing_height_equality(self):
+        image, entries = original_tests.MultiLevelIndexTests().tree_image()
+        image[2048 + 21] = 2
+        nodes, actual = secondary.tree(image, 1, 20)
+        self.assertEqual(actual, entries)
+        root = nodes[0]
+        self.assertEqual((root['header_class'], root['subtree_height']), (2, 1))
+        summary = secondary.height_summary([{'name': 'Rows', 'indexes': [{'root': 1, 'depth': 2, 'nodes': nodes}]}])
+        self.assertFalse(summary[0]['all_classes_equal_height'])
+        for offset, value in [(2048 + 21, 3), (2 * 2048 + 21, 1), (2048 + 248 + 4, 0)]:
+            corrupt = bytearray(image); corrupt[offset] = value
+            with self.assertRaises(secondary.catalog.DecodeError):
+                secondary.tree(corrupt, 1, 20)
+
+    def test_three_levels_derive_height_from_children(self):
+        image, entries = original_tests.MultiLevelIndexTests().tree_image()
+        image.extend(bytes(3 * 2048))
+        image[4 * 2048:5 * 2048] = image[2048:2 * 2048]
+        image[5 * 2048:7 * 2048] = image[2 * 2048:4 * 2048]
+        image[4 * 2048 + 16:4 * 2048 + 20] = (6).to_bytes(4, 'little')
+        image[4 * 2048 + 257:4 * 2048 + 261] = (5).to_bytes(4, 'big')
+        image[5 * 2048 + 12:5 * 2048 + 16] = (6).to_bytes(4, 'little')
+        image[6 * 2048 + 8:6 * 2048 + 12] = (5).to_bytes(4, 'little')
+        # Reuse the two-subtree shape with distinct greater right-hand keys.
+        for page in [4, 5, 6]:
+            image[page * 2048 + 248] = 0x80
+        image[2 * 2048 + 12:2 * 2048 + 16] = (3).to_bytes(4, 'little')
+        image[3 * 2048 + 12:3 * 2048 + 16] = (5).to_bytes(4, 'little')
+        image[5 * 2048 + 8:5 * 2048 + 12] = (3).to_bytes(4, 'little')
+        image[4 * 2048 + 8:4 * 2048 + 12] = (1).to_bytes(4, 'little')
+        image[2048 + 12:2048 + 16] = (4).to_bytes(4, 'little')
+        new = bytearray(2048); new[:2] = b'\x03\x01'; new[21] = 2
+        new[4:8] = (20).to_bytes(4, 'little'); new[16:20] = (4).to_bytes(4, 'little')
+        separator = entries[-1] + (1).to_bytes(4, 'big')
+        new[248:261] = separator; new[22 + 13 // 8] = 1 << (13 % 8)
+        new[2:4] = (1800 - 13).to_bytes(2, 'little')
+        image.extend(new)
+        nodes, _ = secondary.tree(image, 7, 20)
+        self.assertEqual(nodes[0]['subtree_height'], 2)
+        self.assertTrue(all(node['header_class'] == node['subtree_height'] for node in nodes))
+
+    def test_secondary_outcome_preserves_original_and_gates_on_controls(self):
+        original_tests.MultiLevelIndexTests.setUpClass()
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory)
+            initial_path, result = original_tests.MultiLevelIndexTests().fixture(source)
+            initial = json.loads(initial_path.read_text())
+            old = {'outcomes': {arm: 'no_outcome' for arm in secondary.original.ARMS}}
+            (source / 'report.json').write_text(json.dumps(old))
+            plan = {'retained': {'result.json': {}, 'report.json': {}}}
+            def analyze():
+                (source / 'result.json').write_text(json.dumps(result))
+                with patch.object(secondary.original, 'PLAN', initial_path), patch.object(secondary, 'PLAN', initial_path), patch.object(secondary.original.structure, 'observe', return_value=[]):
+                    return secondary.build_report(source, plan, initial)
+            report = analyze()
+            self.assertEqual(report['original_outcomes'], old['outcomes'])
+            self.assertEqual(set(report['outcomes'].values()), {'observed_accepted'})
+            result['replicas'][0]['control']['status'] = 'fail'
+            self.assertEqual(set(analyze()['outcomes'].values()), {'no_outcome'})
+            result['replicas'][0]['control']['status'] = 'pass'
+            result['error'] = 'unexpected original acquisition failure'
+            self.assertEqual(set(analyze()['outcomes'].values()), {'no_outcome'})
+
+    def test_input_drift_rejected_and_original_directory_cannot_receive_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory); source = root / 'source'; source.mkdir()
+            (root / 'input.py').write_text('changed')
+            plan = root / 'plan.json'
+            plan.write_text(json.dumps({'inputs': {'input.py': '0' * 64}}))
+            with patch.object(secondary, 'ROOT', root), patch.object(secondary, 'PLAN', plan):
+                with self.assertRaisesRegex(ValueError, 'input pin mismatch'):
+                    secondary.verify(source)
+            with patch.object(secondary, 'verify', return_value=({}, {})):
+                with self.assertRaisesRegex(ValueError, 'outside'):
+                    secondary.analyze(source, source / 'secondary-report.json')
+            self.assertEqual(list(source.iterdir()), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The original multi-level report rejected six validly acquired control trees because its branch-header gate only admitted byte21=1. Preregister a post-acquisition read-only analysis of the same pinned 18 images and original JSON, allowing the observed branch values1/2 and recording raw class values beside derived subtree heights. Preserve full separator, sibling, locator, map and semantic checks.

The original no-outcome and consumed inputs remain untouched; output must be a fresh file outside the source outbox. Independent review, four focused tests, retained-input preflight and `just ready` pass. No expanded analysis or DAO acquisition has run. EXP-0146 is reserved for the secondary result; no hosted claim follows. Advances #100.
