### PR TITLE
feat: preserve existing files when updating Long fields

### DIFF
--- a/crates/jet3/src/atomic.rs
+++ b/crates/jet3/src/atomic.rs
@@ -173,7 +173,7 @@ impl StdError for PublishError {
 ///
 /// `mutate` receives the private file positioned at byte zero. `validate`
 /// receives the private path and must independently reopen or inspect it
-/// without modifying it. Copy work is charged to the caller-owned operation
+/// without modifying it. Copy reads and work are charged to the caller-owned operation
 /// budget before each chunk. The original file's standard-library permissions
 /// are applied to the private copy after mutation and before validation.
 ///
@@ -210,11 +210,35 @@ pub fn atomic_update_with_hook<M, V, H, ME, VE, HE>(
     budget: &mut ResourceBudget,
     mutate: M,
     validate: V,
-    mut before_stage: H,
+    before_stage: H,
 ) -> Result<(), PublishError>
 where
     M: FnOnce(&mut File) -> Result<(), ME>,
     V: FnOnce(&Path) -> Result<(), VE>,
+    H: FnMut(PublishStage) -> Result<(), HE>,
+    ME: StdError + Send + Sync + 'static,
+    VE: StdError + Send + Sync + 'static,
+    HE: StdError + Send + Sync + 'static,
+{
+    atomic_update_budgeted(
+        target,
+        budget,
+        |file, _| mutate(file),
+        |path, _| validate(path),
+        before_stage,
+    )
+}
+
+pub(crate) fn atomic_update_budgeted<M, V, H, ME, VE, HE>(
+    target: impl AsRef<Path>,
+    budget: &mut ResourceBudget,
+    mutate: M,
+    validate: V,
+    mut before_stage: H,
+) -> Result<(), PublishError>
+where
+    M: FnOnce(&mut File, &mut ResourceBudget) -> Result<(), ME>,
+    V: FnOnce(&Path, &mut ResourceBudget) -> Result<(), VE>,
     H: FnMut(PublishStage) -> Result<(), HE>,
     ME: StdError + Send + Sync + 'static,
     VE: StdError + Send + Sync + 'static,
@@ -246,14 +270,15 @@ where
         private_file
             .seek(SeekFrom::Start(0))
             .map_err(|error| PublishError::new(PublishStage::Mutation, error))?;
-        mutate(private_file).map_err(|error| PublishError::new(PublishStage::Mutation, error))?;
+        mutate(private_file, budget)
+            .map_err(|error| PublishError::new(PublishStage::Mutation, error))?;
 
         call_hook(&mut before_stage, PublishStage::Metadata)?;
         fs::set_permissions(private.path(), metadata.permissions())
             .map_err(|error| PublishError::new(PublishStage::Metadata, error))?;
 
         call_hook(&mut before_stage, PublishStage::Validation)?;
-        validate(private.path())
+        validate(private.path(), budget)
             .map_err(|error| PublishError::new(PublishStage::Validation, error))?;
 
         call_hook(&mut before_stage, PublishStage::FileSync)?;
@@ -433,6 +458,10 @@ fn copy_original(
                 },
             )
         })?;
+        budget
+            .read_budget()
+            .charge_read_attempt(crate::ByteCount::new(chunk_u64))
+            .map_err(|error| PublishError::new(PublishStage::Copy, error))?;
         source
             .read_exact(bytes)
             .map_err(|error| PublishError::new(PublishStage::Copy, error))?;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -85,6 +85,7 @@ mod table_definition_layout;
 pub mod table_definition_writer;
 mod table_schema_plan;
 pub mod text;
+pub mod update;
 pub mod usage_map;
 pub mod usage_map_writer;
 pub mod value;
@@ -179,6 +180,7 @@ pub use table_schema_plan::{
     ColumnRef, IndexColumnSpec, IndexKind, IndexSpec, TableSchemaPlanError, TableSpec,
 };
 pub use text::{DecodedText, TextCodePage, TextError};
+pub use update::{FieldUpdate, UpdateError, update_field};
 pub use usage_map::{UsageMapError, UsageMapRecord, locate_usage_map};
 pub use usage_map_writer::{
     EXTENDED_BITMAP_BITS, ExtendedUsageMapEncoder, InlineUsageMapEncoder, UsageMapWriteError,

--- a/crates/jet3/src/row.rs
+++ b/crates/jet3/src/row.rs
@@ -99,6 +99,18 @@ impl<'row> RowView<'row, '_> {
         Some(RawField::Bytes(&self.raw[range]))
     }
 
+    pub(crate) fn present_fixed_field_range(&self, ordinal: ColumnOrdinal) -> Option<Range<usize>> {
+        let column = self.definition.columns().get(usize::from(ordinal.get()))?;
+        let ColumnStorageClass::Fixed { offset } = column.storage() else {
+            return None;
+        };
+        if !self.layout.present(self.raw, ordinal) {
+            return None;
+        }
+        let start = 1 + usize::from(offset);
+        Some(start..start + usize::from(column.size()))
+    }
+
     /// Decodes one field with an explicitly selected text code page.
     ///
     /// The same operation-wide budget used by the row cursor is charged before

--- a/crates/jet3/src/update.rs
+++ b/crates/jet3/src/update.rs
@@ -1,0 +1,274 @@
+//! Preservation-aware field updates using `EXP-0059` schema, `SRC-0020`/
+//! `EXP-0060` row spans, and the signed Long encoding from `EXP-0061`.
+
+use std::convert::Infallible;
+use std::error::Error as StdError;
+use std::fmt;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+use crate::atomic::atomic_update_budgeted;
+use crate::row_directory::RowDirectory;
+use crate::{
+    ByteOffset, CatalogObjectClass, ColumnOrdinal, ColumnPhysicalType, DatabaseReader, FileSource,
+    PAGE_BYTES, PageImage, PageOffset, PublishStage, ReadAt, ResourceBudget, RowLocator, RowValue,
+    TableDefinitionKind,
+};
+
+/// One existing field to replace. Obtain the ordinal and locator from the reader.
+#[derive(Debug, Clone, Copy)]
+pub struct FieldUpdate<'a> {
+    /// Exact database-encoded user table name.
+    pub table: &'a [u8],
+    /// Logical row locator from that table's row cursor.
+    pub row: RowLocator,
+    /// Column ordinal from that table's definition.
+    pub column: ColumnOrdinal,
+    /// Replacement value; currently only an ordinary, present Long is supported.
+    pub value: RowValue<'a>,
+}
+
+/// A rejected request, malformed source, exhausted resource policy, or publication failure.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum UpdateError {
+    /// The named user table, row, or column was not found.
+    NotFound(&'static str),
+    /// The request needs an unimplemented update capability.
+    Unsupported(&'static str),
+    /// Source or private bytes did not match the planned update.
+    Mismatch(&'static str),
+    /// Resource policy or raw input failure.
+    Resource(crate::Error),
+    /// File operation failed.
+    Io(std::io::Error),
+    /// Database header failure.
+    Open(crate::DatabaseOpenError),
+    /// Catalog failure.
+    Catalog(crate::CatalogError),
+    /// Table definition failure.
+    Definition(crate::TableDefinitionError),
+    /// Row traversal failure.
+    Rows(crate::RowError),
+    /// Row directory failure.
+    Directory(crate::RowDirectoryError),
+    /// Atomic publication failed; its stage indicates whether publication occurred.
+    Publish(crate::PublishError),
+}
+
+impl fmt::Display for UpdateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "field update failed: {self:?}")
+    }
+}
+impl StdError for UpdateError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Resource(source) => Some(source),
+            Self::Io(source) => Some(source),
+            Self::Open(source) => Some(source),
+            Self::Catalog(source) => Some(source),
+            Self::Definition(source) => Some(source),
+            Self::Rows(source) => Some(source),
+            Self::Directory(source) => Some(source),
+            Self::Publish(source) => Some(source),
+            Self::NotFound(_) | Self::Unsupported(_) | Self::Mismatch(_) => None,
+        }
+    }
+}
+
+macro_rules! conversion {
+    ($source:ty, $variant:ident) => {
+        impl From<$source> for UpdateError {
+            fn from(source: $source) -> Self {
+                Self::$variant(source)
+            }
+        }
+    };
+}
+conversion!(crate::Error, Resource);
+conversion!(std::io::Error, Io);
+conversion!(crate::DatabaseOpenError, Open);
+conversion!(crate::CatalogError, Catalog);
+conversion!(crate::TableDefinitionError, Definition);
+conversion!(crate::RowError, Rows);
+conversion!(crate::RowDirectoryError, Directory);
+conversion!(crate::PublishError, Publish);
+
+/// Replaces one present Long field in an unindexed, relationship-free user table.
+///
+/// Null transitions, AutoIncrement columns, hidden/overflow rows and other value
+/// types are unsupported. The exact requested field bytes are the only bytes
+/// changed, including when the database contains opaque pages or unused space.
+/// Locators remain valid only while the source is unchanged: callers must exclude
+/// external writers for this entire operation, as required by [`crate::atomic_update`].
+/// Publication is Unix-only. Any pre-publication failure preserves the original;
+/// a post-publication sync failure is distinguished by the publication error stage.
+/// The same budget covers planning, copying, patching and streaming verification.
+/// Structural verification is not a DAO compatibility claim.
+pub fn update_field(
+    path: impl AsRef<Path>,
+    request: FieldUpdate<'_>,
+    budget: &mut ResourceBudget,
+) -> Result<(), UpdateError> {
+    update_with_hook(path.as_ref(), request, budget, |_| Ok::<(), Infallible>(()))
+}
+
+fn update_with_hook<H, HE>(
+    path: &Path,
+    request: FieldUpdate<'_>,
+    budget: &mut ResourceBudget,
+    hook: H,
+) -> Result<(), UpdateError>
+where
+    H: FnMut(PublishStage) -> Result<(), HE>,
+    HE: StdError + Send + Sync + 'static,
+{
+    let RowValue::Long(value) = request.value else {
+        return Err(UpdateError::Unsupported("replacement must be Long"));
+    };
+    let mut database = DatabaseReader::open(path, budget)?;
+    let mut root = None;
+    {
+        let mut catalog = database.catalog(budget)?;
+        while let Some(record) = catalog.next_record()? {
+            if record.class() == CatalogObjectClass::User
+                && record.name().raw_bytes() == request.table
+            {
+                if root.is_some() {
+                    return Err(UpdateError::Mismatch("ambiguous table name"));
+                }
+                root = record.table_definition();
+            }
+        }
+    }
+    let definition =
+        database.table_definition(root.ok_or(UpdateError::NotFound("table"))?, budget)?;
+    if definition.kind() != TableDefinitionKind::User
+        || !definition.indexes().is_empty()
+        || !definition.physical_indexes().is_empty()
+    {
+        return Err(UpdateError::Unsupported(
+            "table has indexes or relationships",
+        ));
+    }
+    let column = definition
+        .columns()
+        .get(usize::from(request.column.get()))
+        .ok_or(UpdateError::NotFound("column"))?;
+    if column.physical_type() != ColumnPhysicalType::Long || column.auto_increment() {
+        return Err(UpdateError::Unsupported("column must be ordinary Long"));
+    }
+    let mut original_page = [0; PAGE_BYTES];
+    database.read_raw_page(request.row.page(), &mut original_page, budget)?;
+    let directory = RowDirectory::validate(
+        request.row.page(),
+        definition.root(),
+        &original_page,
+        budget,
+    )?;
+    let entry = directory.entry(&original_page, request.row.slot())?;
+    if entry.hidden() || entry.overflow() {
+        return Err(UpdateError::Unsupported("hidden or overflow row"));
+    }
+    let (relative, before) = {
+        let mut rows = database.rows(&definition, budget)?;
+        let mut found = None;
+        while let Some(row) = rows.next_row()? {
+            if row.locator() != request.row {
+                continue;
+            }
+            if row.storage_locator() != request.row {
+                return Err(UpdateError::Unsupported("overflow row"));
+            }
+            let range = row
+                .present_fixed_field_range(request.column)
+                .ok_or(UpdateError::Unsupported("null or variable field"))?;
+            let bytes: [u8; 4] = row
+                .field(request.column)
+                .and_then(|field| field.raw_bytes())
+                .and_then(|bytes| bytes.try_into().ok())
+                .ok_or(UpdateError::Mismatch("Long width"))?;
+            found = Some((range, bytes));
+            break;
+        }
+        found.ok_or(UpdateError::NotFound("row"))?
+    };
+    let row_range = entry.range();
+    if relative.end > row_range.len() {
+        return Err(UpdateError::Mismatch("field outside row"));
+    }
+    let start = row_range
+        .start
+        .checked_add(relative.start)
+        .ok_or(UpdateError::Mismatch("field offset"))?;
+    let end = start
+        .checked_add(before.len())
+        .ok_or(UpdateError::Mismatch("field end"))?;
+    if original_page.get(start..end) != Some(before.as_slice()) {
+        return Err(UpdateError::Mismatch("source changed during planning"));
+    }
+    let mut patched = PageImage::from_bytes(original_page);
+    patched.write_at(PageOffset::new(start as u64), &value.to_le_bytes(), budget)?;
+    let page_offset = request
+        .row
+        .page()
+        .get()
+        .checked_mul(PAGE_BYTES as u64)
+        .ok_or(UpdateError::Mismatch("page offset"))?;
+    let offset = page_offset
+        .checked_add(start as u64)
+        .ok_or(UpdateError::Mismatch("file offset"))?;
+    let mut original = database.into_source();
+    let length = original.len();
+    atomic_update_budgeted(
+        path,
+        budget,
+        |file, budget| -> Result<(), UpdateError> {
+            budget.charge_work_units(before.len() as u64)?;
+            file.seek(SeekFrom::Start(offset))?;
+            file.write_all(&patched.as_bytes()[start..end])?;
+            Ok(())
+        },
+        |private, budget| -> Result<(), UpdateError> {
+            let mut candidate = FileSource::open(private, budget.read_budget())?;
+            if candidate.len() != length {
+                return Err(UpdateError::Mismatch("file length"));
+            }
+            let mut expected = [0; PAGE_BYTES];
+            let mut actual = [0; PAGE_BYTES];
+            let mut position = 0;
+            while position < length.get() {
+                let count = (length.get() - position).min(PAGE_BYTES as u64) as usize;
+                original.read_exact_at(
+                    ByteOffset::new(position),
+                    &mut expected[..count],
+                    budget.read_budget(),
+                )?;
+                candidate.read_exact_at(
+                    ByteOffset::new(position),
+                    &mut actual[..count],
+                    budget.read_budget(),
+                )?;
+                if position == page_offset {
+                    if expected != original_page {
+                        return Err(UpdateError::Mismatch("original page changed"));
+                    }
+                    expected = *patched.as_bytes();
+                }
+                budget.charge_work_units(count as u64)?;
+                if expected[..count] != actual[..count] {
+                    return Err(UpdateError::Mismatch("unrelated or requested bytes"));
+                }
+                position += count as u64;
+            }
+            Ok(())
+        },
+        hook,
+    )?;
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+#[path = "update_tests.rs"]
+mod tests;

--- a/crates/jet3/src/update.rs
+++ b/crates/jet3/src/update.rs
@@ -1,5 +1,6 @@
 //! Preservation-aware field updates using `EXP-0059` schema, `SRC-0020`/
-//! `EXP-0060` row spans, and the signed Long encoding from `EXP-0061`.
+//! `EXP-0060` row spans, the signed Long encoding from `EXP-0061`, and
+//! `EXP-0073`/`EXP-0114` relationship catalog endpoints.
 
 use std::convert::Infallible;
 use std::error::Error as StdError;
@@ -98,7 +99,9 @@ conversion!(crate::PublishError, Publish);
 /// Replaces one present Long field in an unindexed, relationship-free user table.
 ///
 /// Null transitions, AutoIncrement columns, hidden/overflow rows and other value
-/// types are unsupported. The exact requested field bytes are the only bytes
+/// types are unsupported. A missing or unreadable relationship catalog and
+/// unresolved non-ASCII relationship endpoint names are also refused.
+/// The exact requested field bytes are the only bytes
 /// changed, including when the database contains opaque pages or unused space.
 /// Locators remain valid only while the source is unchanged: callers must exclude
 /// external writers for this entire operation, as required by [`crate::atomic_update`].
@@ -129,9 +132,18 @@ where
     };
     let mut database = DatabaseReader::open(path, budget)?;
     let mut root = None;
+    let mut relationship_root = None;
     {
         let mut catalog = database.catalog(budget)?;
         while let Some(record) = catalog.next_record()? {
+            if record.class() == CatalogObjectClass::System
+                && record.name().raw_bytes() == b"MSysRelationships"
+            {
+                if relationship_root.is_some() {
+                    return Err(UpdateError::Mismatch("ambiguous relationship catalog"));
+                }
+                relationship_root = record.table_definition();
+            }
             if record.class() == CatalogObjectClass::User
                 && record.name().raw_bytes() == request.table
             {
@@ -152,6 +164,12 @@ where
             "table has indexes or relationships",
         ));
     }
+    reject_catalog_relationships(
+        &mut database,
+        relationship_root.ok_or(UpdateError::Unsupported("missing relationship catalog"))?,
+        request.table,
+        budget,
+    )?;
     let column = definition
         .columns()
         .get(usize::from(request.column.get()))
@@ -266,6 +284,58 @@ where
         },
         hook,
     )?;
+    Ok(())
+}
+
+// EXP-0073/0114 source these endpoint columns independently of user indexes.
+fn reject_catalog_relationships(
+    database: &mut DatabaseReader<FileSource>,
+    root: crate::PageNumber,
+    table: &[u8],
+    budget: &mut ResourceBudget,
+) -> Result<(), UpdateError> {
+    let definition = database.table_definition(root, budget)?;
+    if definition.kind() != TableDefinitionKind::System {
+        return Err(UpdateError::Unsupported("relationship catalog kind"));
+    }
+    let mut endpoints = [None; 2];
+    for (position, name) in [b"szObject".as_slice(), b"szReferencedObject".as_slice()]
+        .iter()
+        .enumerate()
+    {
+        for column in definition
+            .columns()
+            .iter()
+            .filter(|column| column.name().raw_bytes() == *name)
+        {
+            if endpoints[position].is_some() || column.physical_type() != ColumnPhysicalType::Text {
+                return Err(UpdateError::Unsupported("relationship endpoint schema"));
+            }
+            endpoints[position] = Some(column.ordinal());
+        }
+    }
+    let [Some(object), Some(referenced)] = endpoints else {
+        return Err(UpdateError::Unsupported("missing relationship endpoint"));
+    };
+    let mut rows = database.rows(&definition, budget)?;
+    while let Some(row) = rows.next_row()? {
+        for ordinal in [object, referenced] {
+            let name = row
+                .field(ordinal)
+                .and_then(|field| field.raw_bytes())
+                .ok_or(UpdateError::Unsupported("null relationship endpoint"))?;
+            if name.is_empty() || !name.is_ascii() || !table.is_ascii() {
+                return Err(UpdateError::Unsupported(
+                    "unresolved relationship endpoint name",
+                ));
+            }
+            if name.eq_ignore_ascii_case(table) {
+                return Err(UpdateError::Unsupported(
+                    "table appears in relationship catalog",
+                ));
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/jet3/src/update_tests.rs
+++ b/crates/jet3/src/update_tests.rs
@@ -1,0 +1,420 @@
+use super::*;
+use crate::{
+    ByteCount, ColumnSpec, ColumnType, ResourceLimits, TableSpec, create_database_with_rows,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+type TestResult = Result<(), Box<dyn StdError>>;
+static NEXT: AtomicU64 = AtomicU64::new(0);
+struct Fixture(PathBuf);
+impl Fixture {
+    fn new(
+        columns: &[ColumnSpec<'_>],
+        values: &[&[RowValue<'_>]],
+    ) -> Result<Self, Box<dyn StdError>> {
+        let directory = std::env::temp_dir().join(format!(
+            "jet3-field-update-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&directory)?;
+        let fixture = Self(directory);
+        create_database_with_rows(
+            fixture.path(),
+            &TableSpec {
+                name: b"Items",
+                columns,
+                indexes: &[],
+            },
+            values,
+            &mut budget(),
+        )?;
+        Ok(fixture)
+    }
+    fn path(&self) -> PathBuf {
+        self.0.join("source.mdb")
+    }
+    fn locator(&self, slot: u8) -> Result<RowLocator, Box<dyn StdError>> {
+        let mut budget = budget();
+        let mut database = DatabaseReader::open(self.path(), &mut budget)?;
+        let root = {
+            let mut catalog = database.catalog(&mut budget)?;
+            let mut found = None;
+            while let Some(record) = catalog.next_record()? {
+                if record.name().raw_bytes() == b"Items" {
+                    found = record.table_definition();
+                }
+            }
+            found.ok_or("table absent")?
+        };
+        let definition = database.table_definition(root, &mut budget)?;
+        let mut rows = database.rows(&definition, &mut budget)?;
+        while let Some(row) = rows.next_row()? {
+            if row.locator().slot() == slot {
+                return Ok(row.locator());
+            }
+        }
+        Err("row absent".into())
+    }
+    fn assert_only_original(&self) -> TestResult {
+        assert_eq!(fs::read_dir(&self.0)?.count(), 1);
+        Ok(())
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn request(row: RowLocator, value: RowValue<'_>) -> FieldUpdate<'_> {
+    FieldUpdate {
+        table: b"Items",
+        row,
+        column: ColumnOrdinal::new(0),
+        value,
+    }
+}
+fn simple() -> Result<Fixture, Box<dyn StdError>> {
+    Fixture::new(
+        &[
+            ColumnSpec::new(b"Id", ColumnType::Long),
+            ColumnSpec::new(b"Other", ColumnType::Long),
+        ],
+        &[
+            &[RowValue::Long(1), RowValue::Long(77)],
+            &[RowValue::Null, RowValue::Long(88)],
+        ],
+    )
+}
+
+#[test]
+fn four_byte_update_preserves_slack_opaque_pages_and_other_fields() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let mut original = fs::read(fixture.path())?;
+    original[row.page().get() as usize * PAGE_BYTES + 64] = 0xa7;
+    original.extend_from_slice(&[0xb6; PAGE_BYTES]);
+    fs::write(fixture.path(), &original)?;
+    for value in [i32::MIN, i32::MAX, -123, 0] {
+        update_field(
+            fixture.path(),
+            request(row, RowValue::Long(value)),
+            &mut budget(),
+        )?;
+        let after = fs::read(fixture.path())?;
+        let mut expected = original.clone();
+        let mut db = DatabaseReader::open(fixture.path(), &mut budget())?;
+        let mut b = budget();
+        let definition = db.table_definition(crate::PageNumber::new(20), &mut b)?;
+        let offset = {
+            let mut rows = db.rows(&definition, &mut b)?;
+            let view = rows.next_row()?.ok_or("row absent")?;
+            assert_eq!(
+                view.field(ColumnOrdinal::new(0))
+                    .and_then(|field| field.raw_bytes()),
+                Some(value.to_le_bytes().as_slice())
+            );
+            view.present_fixed_field_range(ColumnOrdinal::new(0))
+                .ok_or("field absent")?
+                .start
+        };
+        let mut page = [0; PAGE_BYTES];
+        db.read_raw_page(row.page(), &mut page, &mut b)?;
+        let directory = RowDirectory::validate(row.page(), definition.root(), &page, &mut b)?;
+        let start = row.page().get() as usize * PAGE_BYTES
+            + directory.entry(&page, row.slot())?.range().start
+            + offset;
+        expected[start..start + 4].copy_from_slice(&value.to_le_bytes());
+        assert_eq!(after, expected);
+    }
+    fixture.assert_only_original()
+}
+
+#[test]
+fn bad_requests_and_resource_failures_preserve_original() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    let invalid = [
+        FieldUpdate {
+            table: b"Missing",
+            ..request(row, RowValue::Long(2))
+        },
+        FieldUpdate {
+            column: ColumnOrdinal::new(99),
+            ..request(row, RowValue::Long(2))
+        },
+        request(RowLocator::new(row.page(), 200), RowValue::Long(2)),
+        request(
+            RowLocator::new(crate::PageNumber::new(1), 0),
+            RowValue::Long(2),
+        ),
+        request(row, RowValue::Null),
+        request(row, RowValue::Byte(2)),
+        request(fixture.locator(1)?, RowValue::Long(2)),
+    ];
+    for invalid in invalid {
+        assert!(update_field(fixture.path(), invalid, &mut budget()).is_err());
+        assert_eq!(fs::read(fixture.path())?, original);
+        fixture.assert_only_original()?;
+    }
+    for limits in [
+        ResourceLimits::default().with_max_allocation_bytes(ByteCount::new(0)),
+        ResourceLimits::default().with_max_encoded_bytes(ByteCount::new(3)),
+        ResourceLimits::default().with_max_total_work_units(1),
+    ] {
+        assert!(
+            update_field(
+                fixture.path(),
+                request(row, RowValue::Long(2)),
+                &mut ResourceBudget::new(limits)
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(fixture.path())?, original);
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn auto_and_non_long_columns_are_refused() -> TestResult {
+    for (kind, initial) in [
+        (ColumnType::AutoIncrement, RowValue::AutoIncrement),
+        (ColumnType::Byte, RowValue::Byte(1)),
+    ] {
+        let fixture = Fixture::new(&[ColumnSpec::new(b"Id", kind)], &[&[initial]])?;
+        let original = fs::read(fixture.path())?;
+        assert!(matches!(
+            update_field(
+                fixture.path(),
+                request(fixture.locator(0)?, RowValue::Long(2)),
+                &mut budget()
+            ),
+            Err(UpdateError::Unsupported(_))
+        ));
+        assert_eq!(fs::read(fixture.path())?, original);
+    }
+    Ok(())
+}
+
+#[test]
+fn faults_at_each_prepublication_stage_preserve_original() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    for stage in [
+        PublishStage::PrivateCopyCreation,
+        PublishStage::Copy,
+        PublishStage::Mutation,
+        PublishStage::Metadata,
+        PublishStage::Validation,
+        PublishStage::FileSync,
+        PublishStage::PrePublish,
+        PublishStage::Publish,
+    ] {
+        let result = update_with_hook(
+            &fixture.path(),
+            request(row, RowValue::Long(8)),
+            &mut budget(),
+            |current| {
+                if current == stage {
+                    Err(std::io::Error::other("injected"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+        assert!(matches!(result, Err(UpdateError::Publish(error)) if error.stage() == stage));
+        assert_eq!(fs::read(fixture.path())?, original);
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn private_byte_corruption_is_rejected_by_streaming_verification() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    for damage_target in [false, true] {
+        let result = update_with_hook(
+            &fixture.path(),
+            request(row, RowValue::Long(8)),
+            &mut budget(),
+            |stage| -> Result<(), std::io::Error> {
+                if stage == PublishStage::Validation {
+                    for entry in fs::read_dir(&fixture.0)? {
+                        let path = entry?.path();
+                        if path != fixture.path() {
+                            let mut bytes = fs::read(&path)?;
+                            if damage_target {
+                                bytes = original.clone();
+                            } else {
+                                bytes[64] ^= 1;
+                            }
+                            fs::write(path, bytes)?;
+                        }
+                    }
+                }
+                Ok(())
+            },
+        );
+        assert!(
+            matches!(result, Err(UpdateError::Publish(error)) if error.stage() == PublishStage::Validation)
+        );
+        assert_eq!(fs::read(fixture.path())?, original);
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn indexed_tables_are_refused_before_publication() -> TestResult {
+    let fixture = simple()?;
+    fs::remove_file(fixture.path())?;
+    let columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
+    let keys = [crate::IndexColumnSpec::ascending(0)];
+    let indexes = [crate::IndexSpec {
+        name: b"Pk",
+        kind: crate::IndexKind::Primary,
+        fields: &keys,
+    }];
+    create_database_with_rows(
+        fixture.path(),
+        &TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &indexes,
+        },
+        &[&[RowValue::Long(1)]],
+        &mut budget(),
+    )?;
+    let original = fs::read(fixture.path())?;
+    assert!(matches!(
+        update_field(
+            fixture.path(),
+            request(fixture.locator(0)?, RowValue::Long(3)),
+            &mut budget()
+        ),
+        Err(UpdateError::Unsupported(_))
+    ));
+    assert_eq!(fs::read(fixture.path())?, original);
+    fixture.assert_only_original()
+}
+
+#[test]
+fn malformed_hidden_and_overflow_slots_are_refused() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    let slot_offset = row.page().get() as usize * PAGE_BYTES + 10;
+    let raw = u16::from_le_bytes([original[slot_offset], original[slot_offset + 1]]);
+    for replacement in [0_u16, raw | 0x2000, raw | 0x8000, raw | 0x4000] {
+        let mut damaged = original.clone();
+        damaged[slot_offset..slot_offset + 2].copy_from_slice(&replacement.to_le_bytes());
+        fs::write(fixture.path(), &damaged)?;
+        assert!(
+            update_field(
+                fixture.path(),
+                request(row, RowValue::Long(3)),
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(fixture.path())?, damaged);
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn copy_and_verification_share_the_planning_read_budget() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    // Planning only reads pages. The copier's larger read is refused before I/O.
+    let limits = crate::ReadLimits::new(
+        ByteCount::new(1_000_000),
+        ByteCount::new(PAGE_BYTES as u64),
+        ByteCount::new(10_000_000),
+    );
+    let result = update_field(
+        fixture.path(),
+        request(row, RowValue::Long(3)),
+        &mut ResourceBudget::new(ResourceLimits::new(limits)),
+    );
+    assert!(
+        matches!(result, Err(UpdateError::Publish(error)) if error.stage() == PublishStage::Copy)
+    );
+    assert_eq!(fs::read(fixture.path())?, original);
+    let mut exact = budget();
+    update_field(fixture.path(), request(row, RowValue::Long(3)), &mut exact)?;
+    let total = exact.read_budget().total_read().get();
+    fs::write(fixture.path(), &original)?;
+    for maximum in [total - 1, total] {
+        let reads = crate::ReadLimits::new(
+            ByteCount::new(1_000_000),
+            ByteCount::new(1_000_000),
+            ByteCount::new(maximum),
+        );
+        let result = update_field(
+            fixture.path(),
+            request(row, RowValue::Long(3)),
+            &mut ResourceBudget::new(ResourceLimits::new(reads)),
+        );
+        if maximum < total {
+            assert!(
+                matches!(result, Err(UpdateError::Publish(error)) if error.stage() == PublishStage::Validation)
+            );
+            assert_eq!(fs::read(fixture.path())?, original);
+        } else {
+            result?;
+        }
+    }
+    fixture.assert_only_original()
+}
+
+#[test]
+fn a_valid_locator_from_another_table_is_rejected() -> TestResult {
+    let fixture = simple()?;
+    fs::remove_file(fixture.path())?;
+    let columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
+    let tables = [
+        crate::TableRows {
+            table: TableSpec {
+                name: b"Items",
+                columns: &columns,
+                indexes: &[],
+            },
+            rows: &[&[RowValue::Long(1)]],
+        },
+        crate::TableRows {
+            table: TableSpec {
+                name: b"Other",
+                columns: &columns,
+                indexes: &[],
+            },
+            rows: &[&[RowValue::Long(2)]],
+        },
+    ];
+    crate::create_database_with_table_rows(fixture.path(), &tables, &mut budget())?;
+    let original = fs::read(fixture.path())?;
+    let wrong = FieldUpdate {
+        table: b"Other",
+        ..request(fixture.locator(0)?, RowValue::Long(3))
+    };
+    assert!(matches!(
+        update_field(fixture.path(), wrong, &mut budget()),
+        Err(UpdateError::Directory(
+            crate::RowDirectoryError::UnexpectedOwner { .. }
+        ))
+    ));
+    assert_eq!(fs::read(fixture.path())?, original);
+    fixture.assert_only_original()
+}

--- a/crates/jet3/src/update_tests.rs
+++ b/crates/jet3/src/update_tests.rs
@@ -418,3 +418,90 @@ fn a_valid_locator_from_another_table_is_rejected() -> TestResult {
     assert_eq!(fs::read(fixture.path())?, original);
     fixture.assert_only_original()
 }
+
+#[test]
+fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
+    let fixture = simple()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    let mut b = budget();
+    let mut database = DatabaseReader::open(fixture.path(), &mut b)?;
+    let root = {
+        let mut catalog = database.catalog(&mut b)?;
+        let mut found = None;
+        while let Some(record) = catalog.next_record()? {
+            if record.name().raw_bytes() == b"MSysRelationships" {
+                found = record.table_definition();
+            }
+        }
+        found.ok_or("relationship catalog absent")?
+    };
+    let definition = database.table_definition(root, &mut b)?;
+    let columns: Vec<_> = definition
+        .columns()
+        .iter()
+        .map(crate::RowColumnLayout::from)
+        .collect();
+    let map = definition.maps().owned();
+    let mut map_page = [0; PAGE_BYTES];
+    database.read_raw_page(map.page(), &mut map_page, &mut b)?;
+    let directory = crate::data_page_directory::DataPageDirectory::validate(&map_page, &mut b)
+        .map_err(|_| "invalid fixture map directory")?;
+    let map_range = directory
+        .entry(&map_page, u16::from(map.row()))
+        .ok_or("map row absent")?
+        .range();
+    assert_eq!(&map_page[map_range.start..map_range.start + 5], &[0; 5]);
+    let page = crate::PageNumber::new((original.len() / PAGE_BYTES) as u64);
+    for (object, referenced, refused) in [
+        (Some(b"iTeMs".as_slice()), Some(b"Other".as_slice()), true),
+        (Some(b"Other".as_slice()), Some(b"Items".as_slice()), true),
+        (None, Some(b"Other".as_slice()), true),
+        (Some(b"\x80".as_slice()), Some(b"Other".as_slice()), true),
+        (
+            Some(b"Other".as_slice()),
+            Some(b"Elsewhere".as_slice()),
+            false,
+        ),
+    ] {
+        let mut raw = [0; 256];
+        let length = crate::encode_row(
+            &columns,
+            &[
+                RowValue::Text(b"MetadataOnly"),
+                RowValue::Long(0),
+                RowValue::Long(1),
+                RowValue::Long(0),
+                object.map_or(RowValue::Null, RowValue::Text),
+                RowValue::Text(b"Id"),
+                referenced.map_or(RowValue::Null, RowValue::Text),
+                RowValue::Text(b"Id"),
+            ],
+            &mut raw,
+            &mut b,
+        )?;
+        let mut data = crate::DataPageBuilder::new(root, &mut b)?;
+        data.append_row(&raw[..length.get() as usize], &mut b)?;
+        let mut input = original.clone();
+        input.extend_from_slice(data.finish().as_bytes());
+        let bit = page.get() as usize;
+        input[map.page().get() as usize * PAGE_BYTES + map_range.start + 5 + bit / 8] |=
+            1 << (bit % 8);
+        let count = root.get() as usize * PAGE_BYTES + 12;
+        input[count..count + 4].copy_from_slice(&1_u32.to_le_bytes());
+        fs::write(fixture.path(), &input)?;
+        let result = update_field(
+            fixture.path(),
+            request(row, RowValue::Long(3)),
+            &mut budget(),
+        );
+        if refused {
+            assert!(matches!(result, Err(UpdateError::Unsupported(_))));
+            assert_eq!(fs::read(fixture.path())?, input);
+        } else {
+            result?;
+        }
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Existing databases had no typed field update operation. Add atomic replacement of one present ordinary Long in an unindexed user table, validating the locator and preserving every byte outside the selected field. Unsupported shapes return structured errors; publication remains Unix-only.

Independent implementation review passed. Focused update/preservation tests, atomic tests, Clippy, and final `just ready` passed. DAO validation follows in a separately pinned experiment; this PR makes no compatibility claim.
