### PR TITLE
fix: read observed three-level index root markers

### DIFF
--- a/crates/jet3/src/index_tree_marker_tests.rs
+++ b/crates/jet3/src/index_tree_marker_tests.rs
@@ -1,0 +1,89 @@
+use super::*;
+
+fn three_level_tree() -> Vec<u8> {
+    let mut bytes = database_bytes(4, 3, 4);
+    bytes.resize(11 * PAGE_BYTES, 0);
+    for (slot, page) in (7..=10).enumerate() {
+        let entry = leaf_entry(&[0x7f, 0x80, 0, 0, slot as u8], slot as u8);
+        write_node(
+            &mut bytes,
+            NodeSpec {
+                page,
+                tag: 4,
+                previous: if page == 7 { 0 } else { page - 1 },
+                next: if page == 10 { 0 } else { page + 1 },
+                tail_child: 0,
+                prefix: &[0x7f, 0x80, 0, 0],
+                entries: &[&entry],
+            },
+        );
+    }
+    for (page, previous, next, child, tail, slot) in [
+        (4, 0, 5, 7, 8, 0),
+        (5, 4, 0, 9, 10, 2),
+        (INDEX_ROOT, 0, 0, 4, 5, 1),
+    ] {
+        let entry = branch_entry(&[0x7f, 0x80, 0, 0, slot], slot, child);
+        write_node(
+            &mut bytes,
+            NodeSpec {
+                page,
+                tag: 3,
+                previous,
+                next,
+                tail_child: tail,
+                prefix: &[],
+                entries: &[&entry],
+            },
+        );
+    }
+    bytes
+}
+
+#[test]
+fn observed_root_classes_keep_three_level_traversal_and_depth_bounds()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut bytes = three_level_tree();
+    for marker in [1, 2] {
+        bytes[INDEX_ROOT * PAGE_BYTES + 21] = marker;
+        let (tree, _) = traverse_with_limits(&bytes, limits(&bytes).with_max_chain_depth(3))?;
+        assert_eq!(tree.nodes().len(), 7);
+        assert_eq!(tree.entries().len(), 4);
+        for (slot, entry) in tree.entries().iter().enumerate() {
+            assert_eq!(entry.key().raw_bytes(), &[0x7f, 0x80, 0, 0, slot as u8]);
+            assert_eq!(entry.row().slot(), slot as u8);
+        }
+        assert!(
+            tree.nodes()
+                .iter()
+                .filter(|node| node.kind() == IndexNodeKind::Leaf)
+                .all(|node| node.depth() == 3)
+        );
+        let error = traverse_with_limits(&bytes, limits(&bytes).with_max_chain_depth(2))
+            .err()
+            .ok_or("depth limit unexpectedly succeeded")?;
+        assert!(matches!(
+            error.downcast_ref::<IndexTreeError>(),
+            Some(IndexTreeError::Resource(Error::ResourceLimitExceeded {
+                kind: ResourceLimitKind::ChainDepth,
+                ..
+            }))
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn unknown_branch_and_nonzero_leaf_markers_remain_rejected() {
+    for (page, marker) in [(INDEX_ROOT, 0), (INDEX_ROOT, 3), (4, 255), (7, 1), (7, 2)] {
+        let mut bytes = three_level_tree();
+        bytes[INDEX_ROOT * PAGE_BYTES + 21] = 2;
+        bytes[page * PAGE_BYTES + 21] = marker;
+        let result = traverse_with_limits(&bytes, limits(&bytes));
+        assert!(
+            matches!(result, Err(error) if matches!(error.downcast_ref::<IndexTreeError>(),
+            Some(IndexTreeError::InvalidHeaderMarker { page: actual, offset: 21, raw })
+                if actual.get() == page as u64 && *raw == marker))
+        );
+    }
+}

--- a/crates/jet3/src/index_tree_page.rs
+++ b/crates/jet3/src/index_tree_page.rs
@@ -1,4 +1,4 @@
-//! Checked decoding of one physical index page from `EXP-0062`.
+//! Checked decoding of one physical index page from `EXP-0062` and `EXP-0146`.
 
 use crate::index_tree::{IndexNode, IndexNodeKind, IndexTreeError, PendingNode};
 use crate::{JET3_PAGE_SIZE, PageGeometry, PageKind, PageNumber, ResourceBudget};
@@ -9,7 +9,8 @@ const ENTRY_AREA_LEN: usize = PAGE_BYTES - ENTRY_AREA_OFFSET;
 const BOUNDARY_BITMAP_OFFSET: usize = 22;
 const HEADER_MARKER: u8 = 1;
 const LEAF_NODE_MARKER: u8 = 0;
-const INTERMEDIATE_NODE_MARKER: u8 = 1;
+// EXP-0146 admits both observed branch classes without treating them as depth.
+const INTERMEDIATE_NODE_MARKERS: [u8; 2] = [1, 2];
 
 #[derive(Debug)]
 pub(crate) struct ParsedNode {
@@ -88,11 +89,11 @@ pub(crate) fn parse_node(
         });
     }
     let marker = page[21];
-    let expected_marker = match node_kind {
-        IndexNodeKind::Intermediate => INTERMEDIATE_NODE_MARKER,
-        IndexNodeKind::Leaf => LEAF_NODE_MARKER,
+    let valid_marker = match node_kind {
+        IndexNodeKind::Intermediate => INTERMEDIATE_NODE_MARKERS.contains(&marker),
+        IndexNodeKind::Leaf => marker == LEAF_NODE_MARKER,
     };
-    if marker != expected_marker {
+    if !valid_marker {
         return Err(IndexTreeError::InvalidHeaderMarker {
             page: pending.page,
             offset: 21,

--- a/crates/jet3/src/index_tree_tests.rs
+++ b/crates/jet3/src/index_tree_tests.rs
@@ -752,3 +752,6 @@ fn invalid_row_reference_and_error_sources_remain_structured()
 
 #[path = "index_tree_key_inventory_tests.rs"]
 mod key_inventory;
+
+#[path = "index_tree_marker_tests.rs"]
+mod marker_tests;


### PR DESCRIPTION
The reader rejected a three-level DAO index root observed in EXP-0146. Accept its observed branch marker 2 alongside marker 1, retaining strict leaf and structural validation.

Independent review, focused traversal/corruption/depth tests, Clippy, and final `just ready` passed.
