### PR TITLE
test: preregister existing field update preservation

### DIFF
--- a/crates/jet3/examples/field_update_candidate.rs
+++ b/crates/jet3/examples/field_update_candidate.rs
@@ -1,0 +1,84 @@
+//! Update a closed DAO-created copy through the public API for EXP-0151.
+use jet3::{
+    CatalogObjectClass, DatabaseReader, FieldUpdate, ResourceBudget, ResourceLimits, RowValue,
+    update_field,
+};
+use std::{env, fs, path::Path};
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = env::args().skip(1).collect();
+    let [source, destination, table, selected_id, column, replacement] = args.as_slice() else {
+        return Err(
+            "usage: field_update_candidate SOURCE DESTINATION TABLE ORIGINAL_ID COLUMN LONG".into(),
+        );
+    };
+    if Path::new(destination).exists() {
+        return Err("destination exists".into());
+    }
+    let selected_id: i32 = selected_id.parse()?;
+    let replacement: i32 = replacement.parse()?;
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let mut database = DatabaseReader::open(source, &mut budget)?;
+    let root = {
+        let mut catalog = database.catalog(&mut budget)?;
+        let mut roots = Vec::new();
+        while let Some(record) = catalog.next_record()? {
+            if record.class() == CatalogObjectClass::User
+                && record.name().raw_bytes() == table.as_bytes()
+            {
+                roots.push(record.table_definition().ok_or("not a table")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("table not unique".into());
+        }
+        roots[0]
+    };
+    let definition = database.table_definition(root, &mut budget)?;
+    let id = definition
+        .columns()
+        .iter()
+        .find(|c| c.name().raw_bytes() == b"Id")
+        .ok_or("Id absent")?
+        .ordinal();
+    let column = definition
+        .columns()
+        .iter()
+        .find(|c| c.name().raw_bytes() == column.as_bytes())
+        .ok_or("column absent")?
+        .ordinal();
+    let locator = {
+        let mut rows = database.rows(&definition, &mut budget)?;
+        let mut found = Vec::new();
+        while let Some(row) = rows.next_row()? {
+            if row.field(id).and_then(|field| field.raw_bytes())
+                == Some(selected_id.to_le_bytes().as_slice())
+            {
+                found.push(row.locator());
+            }
+        }
+        if found.len() != 1 {
+            return Err("selected Id not unique".into());
+        }
+        found[0]
+    };
+    drop(database);
+    fs::copy(source, destination)?;
+    update_field(
+        destination,
+        FieldUpdate {
+            table: table.as_bytes(),
+            row: locator,
+            column,
+            value: RowValue::Long(replacement),
+        },
+        &mut budget,
+    )?;
+    println!(
+        "{{\"root\":{},\"page\":{},\"slot\":{},\"column\":{}}}",
+        root.get(),
+        locator.page().get(),
+        locator.slot(),
+        column.get()
+    );
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11024,6 +11024,43 @@ Copy this block under the appropriate section and remove this instruction:
   Neither this plan nor self-validation establishes general compatibility,
   completion of #100 or support-matrix movement.
 
+## EXP-0151 — Existing-file Long field update validation preregistered
+
+- Recorded: 2026-09-05, OpenAI Codex; local development acquisition plan,
+  no acquisition or compatibility outcome yet. Plan
+  `oracle/windows-dao/acquisition/field-update.plan.json`, SHA-256
+  `26ae94929c64304a9cee320846fe441292d781108b982e683385cb4d125085ad`, pins the phased
+  producer/analyzer, transport, decoder, public exporter and relevant source
+  inputs. Reviewed field-update implementation is `7ee3b4a`.
+- One coordinated acquisition has three finite cases and three replicas each.
+  Windows DAO first creates nine originals, each with `Items` and `Later`
+  unindexed tables containing `Id`/`Value` Long and `Payload` Text(20), three
+  declared non-null rows each, plus stored `KeepQuery` SQL. It closes every
+  writable handle before read-only baseline capture and before guest exit.
+- Linux then preserves each original and invokes the public `update_field`
+  API once on a separate copy, using reader-selected row/column references:
+  `Items` Id 1 changes Id to -2147483648; `Items` Id 3 changes Value to
+  2147483647; `Later` Id 12 changes Value to -123456789. No Windows publication
+  workaround or private page-composer bypass is used.
+- Only after successful baseline/request checks and all Unix updates does the
+  second Windows phase open transferred original/updated copies read-only.
+  Compare complete captured table/field/index/relationship metadata and rows,
+  preserve uninterpreted query name/SQL/type, and bind every file to its
+  arm/replica/role and before/after/transfer identity. Independently decode the
+  original catalog, row locator and present Long span; require exact updated
+  bytes in that four-byte span and byte-for-byte preservation everywhere else.
+  Decoder's existing 64-row bound remains unchanged for these three-row tables.
+- Commit and independently review this plan before the first DAO mutation.
+  Neither phase retries or resumes after failure. Missing/failed acquisition,
+  transfer, update, schema/row comparison or preservation checks produce an
+  honest `no_outcome`; retain partial files/results and phase logs externally.
+  A new attempt after mutation requires a human decision. EXP-0152 is reserved
+  for the single validated result; no MDB/provider bytes are committed.
+- This tests only the declared present Long replacements in unindexed,
+  relationship-free tables. No null/Auto/index/relationship/overflow update,
+  insert/delete behavior, arbitrary existing-file compatibility or hosted
+  support claim follows from this plan or structural self-verification.
+
 ## EXP-0138 — Generated AutoIncrement candidates and subsequent inserts accepted locally
 
 - Status: validated `observed_accepted` for all three EXP-0137 arms and all

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11061,6 +11061,14 @@ Copy this block under the appropriate section and remove this instruction:
   insert/delete behavior, arbitrary existing-file compatibility or hosted
   support claim follows from this plan or structural self-verification.
 
+- Pre-acquisition review resolved the Unix result-envelope/source-receipt check
+  and strengthened the public updater's independent relationship-catalog guard.
+  Final reviewed implementation is `40ba58c`; the still-unconsumed EXP-0151
+  plan now has SHA-256
+  `d989a40b80cdfa2f885693cab46765738ef5f02287ca1f040d3a380e756eb326`. Source/input pins
+  were refreshed before acquisition. The result requires the declared reviewed
+  source and POSIX producer, with the harness checkout recorded separately.
+
 ## EXP-0138 — Generated AutoIncrement candidates and subsequent inserts accepted locally
 
 - Status: validated `observed_accepted` for all three EXP-0137 arms and all

--- a/oracle/windows-dao/acquisition/field-update.plan.json
+++ b/oracle/windows-dao/acquisition/field-update.plan.json
@@ -1,0 +1,131 @@
+{
+  "document_type": "dao_field_update_plan",
+  "experiment_id": "field-update",
+  "replicas": 3,
+  "development_only": true,
+  "source_revision": "7ee3b4ae56036c1552a25bb3196b2c9b75c98c6e",
+  "preregistration": {
+    "acquisition_started": false,
+    "question": "Does the public Unix field update preserve an existing DAO database outside one four-byte present Long field, and does read-only DAO observe exactly the requested replacement with unrelated schema, rows and stored query SQL unchanged?",
+    "prior_evidence": "SRC-0020, EXP-0059/0060/0061 supply existing row/schema/Long grammar. This tests existing DAO-created files; self-verification alone is not compatibility evidence.",
+    "sequence": [
+      "Commit and review pinned plan; build reviewed exporter before first DAO mutation.",
+      "Phase1 creates nine fresh databases, three replicas for each case, with two unindexed tables and one stored query; closes every writable handle and captures originals read-only.",
+      "Only after all phase1 captures pass and guest exits: copy retained originals to Linux, invoke public update_field once on each separate destination through reader-selected locator/ordinal. Preserve originals.",
+      "Only after all updates succeed: phase2 opens independent original/updated copies read-only on Windows, retaining before/after identities and complete snapshots.",
+      "Validate requested schema/rows and exact four-byte span, then record one additive EXP-0152 outcome."
+    ],
+    "retry": "Exactly one coordinated run; no resume or retry of either phase after mutation/failure. Any phase refusal, missing result, metadata mismatch, or byte-preservation failure is no_outcome; retain partial MDBs and logs. A later attempt needs a human decision.",
+    "limits": "Finite positive/negative signed Long replacements; two small unindexed relationship-free tables, stored query observed without interpreting/executing SQL. No null/Auto/index/relationship/overflow updates, general update compatibility, or hosted support claim."
+  },
+  "tables": [
+    {
+      "name": "Items",
+      "rows": [
+        [
+          1,
+          101,
+          "first"
+        ],
+        [
+          2,
+          -202,
+          "second"
+        ],
+        [
+          3,
+          303,
+          "third"
+        ]
+      ]
+    },
+    {
+      "name": "Later",
+      "rows": [
+        [
+          11,
+          -1101,
+          "later-one"
+        ],
+        [
+          12,
+          1202,
+          "later-two"
+        ],
+        [
+          13,
+          -1303,
+          "later-three"
+        ]
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 20
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "arms": [
+    {
+      "name": "first-field",
+      "table": "Items",
+      "selected_id": 1,
+      "column": "Id",
+      "replacement": -2147483648
+    },
+    {
+      "name": "later-row",
+      "table": "Items",
+      "selected_id": 3,
+      "column": "Value",
+      "replacement": 2147483647
+    },
+    {
+      "name": "later-table",
+      "table": "Later",
+      "selected_id": 12,
+      "column": "Value",
+      "replacement": -123456789
+    }
+  ],
+  "inputs": {
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "Cargo.lock": "eb8c67b84f06190369a8de28efe2a1fabdd37b2abf894989a9b076d8fe1ba3c0",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/field_update_candidate.rs": "867c42c748114e1f0ae19e84d0afdef37ac38bbbf079e332ef5e4df78cb724a0",
+    "crates/jet3/src/update.rs": "edea68663504c70c31095eca516b2854f474e00782683d48488785adde59b95e",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "oracle/windows-dao/scripts/field_update.py": "7155e5e86c7ca71a85a4e1806b140298601dd01dc836558af8f2d6b603eef8ac",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "analysis_bound": "Unmodified system_catalog decoder: 64 rows per page; each user table has exactly three rows and three columns. Refusals remain no_outcome, never an implicit limit increase."
+}

--- a/oracle/windows-dao/acquisition/field-update.plan.json
+++ b/oracle/windows-dao/acquisition/field-update.plan.json
@@ -3,7 +3,7 @@
   "experiment_id": "field-update",
   "replicas": 3,
   "development_only": true,
-  "source_revision": "7ee3b4ae56036c1552a25bb3196b2c9b75c98c6e",
+  "source_revision": "40ba58c57d37b3ccf02ef7e173a431ae0f22d0e2",
   "preregistration": {
     "acquisition_started": false,
     "question": "Does the public Unix field update preserve an existing DAO database outside one four-byte present Long field, and does read-only DAO observe exactly the requested replacement with unrelated schema, rows and stored query SQL unchanged?",
@@ -109,7 +109,7 @@
     "Cargo.lock": "eb8c67b84f06190369a8de28efe2a1fabdd37b2abf894989a9b076d8fe1ba3c0",
     "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
     "crates/jet3/examples/field_update_candidate.rs": "867c42c748114e1f0ae19e84d0afdef37ac38bbbf079e332ef5e4df78cb724a0",
-    "crates/jet3/src/update.rs": "edea68663504c70c31095eca516b2854f474e00782683d48488785adde59b95e",
+    "crates/jet3/src/update.rs": "31ec624c3bd0d8844bb4175f53bc324465ccb8151f2b8844f8a1972f1bd94553",
     "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
     "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
     "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
@@ -122,10 +122,11 @@
     "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
     "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
     "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
-    "oracle/windows-dao/scripts/field_update.py": "7155e5e86c7ca71a85a4e1806b140298601dd01dc836558af8f2d6b603eef8ac",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
     "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
     "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
     "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
   },
-  "analysis_bound": "Unmodified system_catalog decoder: 64 rows per page; each user table has exactly three rows and three columns. Refusals remain no_outcome, never an implicit limit increase."
+  "analysis_bound": "Unmodified system_catalog decoder: 64 rows per page; each user table has exactly three rows and three columns. Refusals remain no_outcome, never an implicit limit increase.",
+  "source_receipt": "The result source_revision names this reviewed public update implementation, whose relevant current source bytes are input-pinned. acquisition_revision separately records the committed harness checkout; producer_os must be posix. No binary/build attestation."
 }

--- a/oracle/windows-dao/scripts/field_update.ps1
+++ b/oracle/windows-dao/scripts/field_update.ps1
@@ -1,0 +1,102 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value) }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, ((ConvertTo-Json -InputObject $Value -Depth 30) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function Create-Original([string]$Path, $Plan) {
+    $engine = $workspace = $db = $table = $field = $rs = $query = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36; $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($spec in $Plan.tables) {
+            $table = $db.CreateTableDef([string]$spec.name)
+            foreach ($column in $Plan.fields) {
+                $field = $table.CreateField([string]$column.name, [int]$column.type, [int]$column.size)
+                $table.Fields.Append($field); Release $field; $field = $null
+            }
+            $db.TableDefs.Append($table)
+            $rs = $db.OpenRecordset([string]$spec.name, 2)
+            foreach ($row in $spec.rows) {
+                $rs.AddNew()
+                $rs.Fields.Item('Id').Value = [int]$row[0]
+                $rs.Fields.Item('Value').Value = [int]$row[1]
+                $rs.Fields.Item('Payload').Value = [string]$row[2]
+                $rs.Update()
+            }
+            $rs.Close(); Release $rs; $rs = $null; Release $table; $table = $null
+        }
+        $query = $db.CreateQueryDef([string]$Plan.query.name, [string]$Plan.query.sql)
+    } finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs; Release $query; Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $workspace; Release $engine
+    }
+}
+function Observe([string]$Path) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $status = 'pass'; $errorDetail = $null; $endpoint = 'open_database'; $snapshot = [ordered]@{}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @($db.Relations | ForEach-Object { @{name=[string]$_.Name; table=[string]$_.Table; foreign_table=[string]$_.ForeignTable; attributes=[int]$_.Attributes; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })} })
+        $snapshot.queries = @($db.QueryDefs | ForEach-Object { @{name=[string]$_.Name; sql=[string]$_.SQL; type=[int]$_.Type} } | Sort-Object { $_.name })
+        $snapshot.user_tables = @()
+        foreach ($name in @($snapshot.tables | Where-Object { -not $_.StartsWith('MSys') })) {
+            $endpoint = 'schema'; $table = $db.TableDefs.Item([string]$name)
+            $item = [ordered]@{name=[string]$table.Name; attributes=[int]$table.Attributes}
+            $item.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes; required=[bool]$_.Required; allow_zero_length=[bool]$_.AllowZeroLength; default_value=[string]$_.DefaultValue} })
+            $item.indexes = @($table.Indexes | ForEach-Object { @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })} })
+            $endpoint = 'rows'; $rs = $db.OpenRecordset([string]$name, 4)
+            $rows = New-Object Collections.ArrayList
+            while (-not $rs.EOF) {
+                [void]$rows.Add(@([int]$rs.Fields.Item('Id').Value, [int]$rs.Fields.Item('Value').Value, [string]$rs.Fields.Item('Payload').Value))
+                $rs.MoveNext()
+            }
+            $item.rows = @($rows); $rs.Close(); Release $rs; $rs = $null
+            $snapshot.user_tables += $item; Release $table; $table = $null
+        }
+    } catch { $status = 'error'; $errorDetail = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $engine
+    }
+    return @{file=[IO.Path]::GetFileName($Path); before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'field-update.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/field_update.ps1') { throw 'Script pin mismatch' }
+$phase = (Get-Content -LiteralPath (Join-Path $env:JET3_WORK 'phase.txt') -Raw).Trim()
+if ($phase -notin @('create', 'observe')) { throw 'Unknown phase' }
+$mutationStarted = $false
+$result = [ordered]@{document_type='dao_field_update_phase'; phase=$phase; plan_sha256=(Identity $planPath).sha256; environment=@{process_bits=32; provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}; mutation_started=$false; observations=@(); error=$null; endpoint='start'}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $roles = if ($phase -eq 'create') { @('original') } else { @('original', 'updated') }
+            foreach ($role in $roles) {
+                $path = Join-Path $env:JET3_WORK "$($arm.name)-r$replica-$role.mdb"
+                $result.endpoint = "$($arm.name)/$replica/$role"
+                if ($phase -eq 'create') { Create-Original $path $plan }
+                $observation = Observe $path
+                $result.observations += @{arm=[string]$arm.name; replica=$replica; role=$role; observation=$observation}
+                if ($observation.status -ne 'pass') { throw 'Read-only observation failed' }
+            }
+        }
+    }
+} catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/field_update.py
+++ b/oracle/windows-dao/scripts/field_update.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""EXP-0151: one phased DAO-create / Unix-public-update / DAO-read acquisition."""
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/field-update.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/field_update.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if subprocess.check_output(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    if os.name != 'posix' or plan['replicas'] != 3:
+        raise ValueError('Expected Unix producer and three replicas')
+    return plan
+
+
+def normalized(snapshot):
+    result = copy.deepcopy(snapshot)
+    result['user_tables'].sort(key=lambda table: table['name'])
+    for table in result['user_tables']:
+        table['rows'].sort()
+    return result
+
+
+def requested(snapshot, plan, arm=None):
+    actual = normalized(snapshot)
+    if actual['version'] != '3.0' or actual['relations'] != []:
+        return False
+    if [t['name'] for t in actual['user_tables']] != sorted(t['name'] for t in plan['tables']):
+        return False
+    if len(actual['queries']) != 1 or actual['queries'][0]['name'] != plan['query']['name'] or not actual['queries'][0]['sql'] or actual['queries'][0]['type'] != 0:
+        return False
+    for spec in plan['tables']:
+        table = next(t for t in actual['user_tables'] if t['name'] == spec['name'])
+        if table['attributes'] != 0 or table['indexes'] != []:
+            return False
+        if [{k: field[k] for k in ('name', 'type', 'size')} for field in table['fields']] != plan['fields']:
+            return False
+        if any(field['attributes'] & 16 for field in table['fields']):
+            return False
+        rows = copy.deepcopy(spec['rows'])
+        if arm and arm['table'] == spec['name']:
+            column = next(i for i, field in enumerate(plan['fields']) if field['name'] == arm['column'])
+            matches = [row for row in rows if row[0] == arm['selected_id']]
+            if len(matches) != 1:
+                return False
+            matches[0][column] = arm['replacement']
+        if table['rows'] != sorted(rows):
+            return False
+    return True
+
+
+def patch_check(original, updated, arm, locator):
+    definition, _, records = catalog._discover_catalog(original)
+    name = catalog._ordinal(definition, 'Name')
+    id_column = catalog._ordinal(definition, 'Id')
+    roots = [row['values'][id_column] for row in records if row['values'][name] == arm['table']]
+    if len(roots) != 1 or roots[0] != locator['root']:
+        raise ValueError('Target catalog binding')
+    table = catalog._definition(original, roots[0])
+    columns = table['columns']
+    ordinal = catalog._ordinal(table, arm['column'])
+    id_column = catalog._ordinal(table, 'Id')
+    column = columns[ordinal]
+    if ordinal != locator['column'] or column['type'] != 'Long' or column['storage'] != 'fixed' or column['size'] != 4:
+        raise ValueError('Target field binding')
+    pages, _ = catalog._table_pages(original, table)
+    rows = catalog._table_rows(original, table, pages)
+    selected = [row for row in rows if row['values'][id_column] == arm['selected_id']]
+    if len(selected) != 1 or selected[0]['page'] != locator['page'] or selected[0]['row'] != locator['slot'] or not selected[0]['present'][ordinal]:
+        raise ValueError('Target row binding')
+    image = catalog._page(original, locator['page'], 'target row')
+    entry = catalog._row_directory(image, locator['page'])[locator['slot']]
+    offset = locator['page'] * catalog.PAGE_BYTES + entry['start'] + 1 + column['fixed_offset']
+    expected = bytearray(original)
+    expected[offset:offset + 4] = arm['replacement'].to_bytes(4, 'little', signed=True)
+    if expected != updated:
+        raise ValueError('Bytes outside the requested field changed, or replacement differs')
+    return {'offset': offset, 'length': 4, 'before_hex': original[offset:offset + 4].hex(),
+            'after_hex': updated[offset:offset + 4].hex(),
+            'changed_offsets': [i for i, (a, b) in enumerate(zip(original, updated)) if a != b]}
+
+
+def phase_entries(phase, name, plan):
+    if (phase['document_type'] != 'dao_field_update_phase' or phase['phase'] != name
+        or phase['plan_sha256'] != digest(PLAN) or phase['error'] is not None
+        or phase['mutation_started'] != (name == 'create')
+        or phase['environment']['process_bits'] != 32 or phase['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Phase failed or has wrong identity: ' + name)
+    roles = ['original'] if name == 'create' else ['original', 'updated']
+    expected = {(arm['name'], replica, role) for arm in plan['arms'] for replica in range(1, 4) for role in roles}
+    entries = {}
+    for item in phase['observations']:
+        key = (item['arm'], item['replica'], item['role'])
+        if key in entries:
+            raise ValueError('Duplicate observation')
+        observation = item['observation']
+        if observation['status'] != 'pass' or observation['error'] is not None or observation['before'] != observation['after']:
+            raise ValueError('Read-only observation failed or mutated')
+        entries[key] = observation
+    if set(entries) != expected:
+        raise ValueError('Incomplete phase observations')
+    return entries
+
+
+def build_report(result, outbox, plan):
+    observations, reasons = [], []
+    try:
+        if result['plan_sha256'] != digest(PLAN) or result['error'] is not None or result['phase'] != 'complete':
+            raise ValueError('Coordinated acquisition failed: ' + str(result['error']))
+        phases = {}
+        for name in ('create', 'observe'):
+            path = outbox / (name + '.json')
+            if identity(path) != result['phases'][name]:
+                raise ValueError('Phase result identity mismatch')
+            phases[name] = phase_entries(json.loads(path.read_text(encoding='utf-8-sig')), name, plan)
+        updates = {(u['arm'], u['replica']): u for u in result['updates']}
+        if len(updates) != len(result['updates']) or set(updates) != {(a['name'], r) for a in plan['arms'] for r in range(1, 4)}:
+            raise ValueError('Incomplete Unix updates')
+        for arm in plan['arms']:
+            for replica in range(1, 4):
+                name = arm['name']; update = updates[name, replica]
+                before = phases['create'][name, replica, 'original']
+                after_original = phases['observe'][name, replica, 'original']
+                after = phases['observe'][name, replica, 'updated']
+                original = outbox / f'{name}-r{replica}-original.mdb'
+                updated = outbox / f'{name}-r{replica}-updated.mdb'
+                if (identity(original) != before['after'] or identity(original) != after_original['after']
+                    or identity(original) != update['original_before'] or identity(original) != update['original_after']
+                    or identity(updated) != after['before'] or identity(updated) != update['updated']):
+                    raise ValueError('Image identity chain mismatch')
+                for role, observation in [('original', before), ('original', after_original), ('updated', after)]:
+                    if observation['file'] != f'{name}-r{replica}-{role}.mdb':
+                        raise ValueError('Image filename association mismatch')
+                if normalized(before['snapshot']) != normalized(after_original['snapshot']) or not requested(before['snapshot'], plan) or not requested(after['snapshot'], plan, arm):
+                    raise ValueError('Original/requested schema or rows differ')
+                expected = normalized(before['snapshot'])
+                target = next(t for t in expected['user_tables'] if t['name'] == arm['table'])
+                field = next(i for i, f in enumerate(plan['fields']) if f['name'] == arm['column'])
+                next(row for row in target['rows'] if row[0] == arm['selected_id'])[field] = arm['replacement']
+                if normalized(expected) != normalized(after['snapshot']):
+                    raise ValueError('Unrelated schema, rows or query SQL differs')
+                span = patch_check(original.read_bytes(), updated.read_bytes(), arm, update['locator'])
+                observations.append({'arm': name, 'replica': replica, 'original': identity(original),
+                                     'updated': identity(updated), 'patch': span, 'snapshot': after['snapshot'],
+                                     'requested_change_and_preservation': True})
+    except (KeyError, ValueError, TypeError, OSError, catalog.DecodeError) as error:
+        reasons.append(str(error))
+    return {'document_type': 'dao_field_update_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'observed_accepted' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'support_matrix_movement': False,
+            'compatibility_claim': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text())
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    (outbox / 'report.json').write_text(canonical(report) + '\n')
+    print(report['outcome'])
+
+
+def dispatch(args):
+    plan = preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve(); outbox = shared / 'outbox' / args.run_id
+    paths = [outbox] + [shared / part / (args.run_id + '-' + phase) for part in ('inbox', 'outbox') for phase in ('create', 'observe')]
+    if any(path.exists() for path in paths):
+        raise ValueError('Run id used; never resume or retry')
+    subprocess.run(['cargo', 'build', '-p', 'jet3', '--example', 'field_update_candidate'], cwd=ROOT, check=True)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec); spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result = {'document_type': 'dao_field_update_result', 'plan_sha256': digest(PLAN),
+              'source_revision': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT).decode().strip(),
+              'producer_os': os.name, 'phase': 'create', 'phases': {}, 'updates': [], 'error': None}
+    try:
+        for phase in ('create', 'observe'):
+            result['phase'] = phase
+            run_id = args.run_id + '-' + phase; inbox = shared / 'inbox' / run_id; inbox.mkdir(parents=True)
+            shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1'); shutil.copyfile(PLAN, inbox / PLAN.name)
+            (inbox / 'phase.txt').write_text(phase)
+            if phase == 'observe':
+                for path in outbox.glob('*.mdb'): shutil.copyfile(path, inbox / path.name)
+            command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15', '-o', 'IdentitiesOnly=yes', '-i', args.identity,
+                       f'{args.user}@{args.host}', 'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+                       transport.encoded(transport.guest_script(args.remote_shared_root, run_id, 'script.ps1'))]
+            completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+            (outbox / (phase + '-ssh.txt')).write_bytes(completed.stdout + completed.stderr)
+            guest = shared / 'outbox' / run_id
+            shutil.copyfile(guest / 'result.json', outbox / (phase + '.json'))
+            result['phases'][phase] = identity(outbox / (phase + '.json'))
+            observations = phase_entries(json.loads((outbox / (phase + '.json')).read_text(encoding='utf-8-sig')), phase, plan)
+            if completed.returncode != 0: raise ValueError('Guest phase exited unsuccessfully')
+            if phase == 'create':
+                for path in guest.glob('*.mdb'): shutil.copyfile(path, outbox / path.name)
+                result['phase'] = 'unix_update'
+                for arm in plan['arms']:
+                    for replica in range(1, 4):
+                        prefix = f"{arm['name']}-r{replica}"
+                        original = outbox / (prefix + '-original.mdb'); updated = outbox / (prefix + '-updated.mdb')
+                        before = identity(original)
+                        if before != observations[arm['name'], replica, 'original']['after']: raise ValueError('Original transfer identity')
+                        if not requested(observations[arm['name'], replica, 'original']['snapshot'], plan): raise ValueError('Original request mismatch')
+                        command = ['cargo', 'run', '--quiet', '-p', 'jet3', '--example', 'field_update_candidate', '--', str(original), str(updated), arm['table'], str(arm['selected_id']), arm['column'], str(arm['replacement'])]
+                        done = subprocess.run(command, cwd=ROOT, capture_output=True, timeout=120)
+                        (outbox / (prefix + '-unix.txt')).write_bytes(done.stdout + done.stderr)
+                        if done.returncode: raise ValueError('Public field update failed: ' + prefix)
+                        result['updates'].append({'arm': arm['name'], 'replica': replica, 'original_before': before,
+                            'original_after': identity(original), 'updated': identity(updated), 'locator': json.loads(done.stdout)})
+                        if identity(original) != before: raise ValueError('Unix update changed original')
+                        patch_check(original.read_bytes(), updated.read_bytes(), arm, result['updates'][-1]['locator'])
+        result['phase'] = 'complete'
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        result['error'] = type(error).__name__ + ': ' + str(error)
+    finally:
+        (outbox / 'result.json').write_text(canonical(result) + '\n')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__); commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight'); report = commands.add_parser('analyze'); report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run'); run.add_argument('--run-id', required=True); run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'), ('identity', str(Path.home() / '.ssh/jet3-dao')), ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=default)
+    args = parser.parse_args()
+    if args.command == 'preflight': preflight(); print('Committed inputs match.')
+    elif args.command == 'analyze': analyze(args.outbox)
+    else: dispatch(args)
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/scripts/field_update.py
+++ b/oracle/windows-dao/scripts/field_update.py
@@ -139,6 +139,9 @@ def phase_entries(phase, name, plan):
 def build_report(result, outbox, plan):
     observations, reasons = [], []
     try:
+        if (result['document_type'] != 'dao_field_update_result' or result['producer_os'] != 'posix'
+            or result['source_revision'] != plan['source_revision']):
+            raise ValueError('Unexpected result envelope or public Unix source receipt')
         if result['plan_sha256'] != digest(PLAN) or result['error'] is not None or result['phase'] != 'complete':
             raise ValueError('Coordinated acquisition failed: ' + str(result['error']))
         phases = {}
@@ -207,7 +210,8 @@ def dispatch(args):
     transport = importlib.util.module_from_spec(spec); spec.loader.exec_module(transport)
     outbox.mkdir(parents=True)
     result = {'document_type': 'dao_field_update_result', 'plan_sha256': digest(PLAN),
-              'source_revision': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT).decode().strip(),
+              'source_revision': plan['source_revision'],
+              'acquisition_revision': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT).decode().strip(),
               'producer_os': os.name, 'phase': 'create', 'phases': {}, 'updates': [], 'error': None}
     try:
         for phase in ('create', 'observe'):

--- a/oracle/windows-dao/tests/test_field_update.py
+++ b/oracle/windows-dao/tests/test_field_update.py
@@ -24,7 +24,7 @@ class FieldUpdateTests(unittest.TestCase):
                          'user_tables': [{'name': table['name'], 'attributes': 0, 'indexes': [],
                             'fields': [{**field, 'attributes': 1, 'required': False, 'allow_zero_length': False, 'default_value': ''} for field in self.plan['fields']],
                             'rows': copy.deepcopy(table['rows'])} for table in self.plan['tables']]}
-        self.result = {'plan_sha256': m.digest(m.PLAN), 'phase': 'complete', 'error': None, 'updates': [], 'phases': {}}
+        self.result = {'document_type': 'dao_field_update_result', 'producer_os': 'posix', 'source_revision': self.plan['source_revision'], 'plan_sha256': m.digest(m.PLAN), 'phase': 'complete', 'error': None, 'updates': [], 'phases': {}}
         self.phases = {phase: {'document_type': 'dao_field_update_phase', 'phase': phase, 'plan_sha256': m.digest(m.PLAN),
             'error': None, 'mutation_started': phase == 'create', 'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'observations': []}
             for phase in ['create', 'observe']}
@@ -74,6 +74,14 @@ class FieldUpdateTests(unittest.TestCase):
             elif change == 'file': entry['file'] = 'unrelated.mdb'
             else: phase['mutation_started'] = True
             self.assertEqual(self.classify()['outcome'], 'no_outcome', change)
+
+    def test_wrong_or_missing_producer_source_receipts_fail(self):
+        original = copy.deepcopy(self.result)
+        for key, value in [('document_type', 'unrelated'), ('producer_os', 'nt'), ('source_revision', 'unrelated')]:
+            self.result = copy.deepcopy(original); self.result[key] = value
+            self.assertEqual(self.classify()['outcome'], 'no_outcome', key)
+            del self.result[key]
+            self.assertEqual(self.classify()['outcome'], 'no_outcome', 'missing ' + key)
 
     def test_byte_preservation_and_locator_binding(self):
         arm = self.plan['arms'][0]

--- a/oracle/windows-dao/tests/test_field_update.py
+++ b/oracle/windows-dao/tests/test_field_update.py
@@ -1,0 +1,103 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location('field_update_tested', SCRIPTS / 'field_update.py')
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+
+class FieldUpdateTests(unittest.TestCase):
+    def setUp(self):
+        self.plan = json.loads(m.PLAN.read_text())
+        self.directory = tempfile.TemporaryDirectory(prefix='field-update-tests-')
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.snapshot = {'version': '3.0', 'tables': ['Items', 'Later'], 'relations': [],
+                         'queries': [{'name': 'KeepQuery', 'sql': 'SELECT [Id], [Value] FROM [Items];', 'type': 0}],
+                         'user_tables': [{'name': table['name'], 'attributes': 0, 'indexes': [],
+                            'fields': [{**field, 'attributes': 1, 'required': False, 'allow_zero_length': False, 'default_value': ''} for field in self.plan['fields']],
+                            'rows': copy.deepcopy(table['rows'])} for table in self.plan['tables']]}
+        self.result = {'plan_sha256': m.digest(m.PLAN), 'phase': 'complete', 'error': None, 'updates': [], 'phases': {}}
+        self.phases = {phase: {'document_type': 'dao_field_update_phase', 'phase': phase, 'plan_sha256': m.digest(m.PLAN),
+            'error': None, 'mutation_started': phase == 'create', 'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'observations': []}
+            for phase in ['create', 'observe']}
+        for arm in self.plan['arms']:
+            for replica in range(1, 4):
+                before = after = None
+                for role in ['original', 'updated']:
+                    path = self.root / f"{arm['name']}-r{replica}-{role}.mdb"
+                    path.write_bytes(b'original' if role == 'original' else b'updated')
+                    snapshot = copy.deepcopy(self.snapshot)
+                    if role == 'updated':
+                        table = next(t for t in snapshot['user_tables'] if t['name'] == arm['table'])
+                        column = next(i for i, c in enumerate(self.plan['fields']) if c['name'] == arm['column'])
+                        next(r for r in table['rows'] if r[0] == arm['selected_id'])[column] = arm['replacement']
+                    observation = {'arm': arm['name'], 'replica': replica, 'role': role, 'observation': {
+                        'file': path.name, 'before': m.identity(path), 'after': m.identity(path), 'status': 'pass', 'error': None, 'snapshot': snapshot}}
+                    self.phases['observe']['observations'].append(observation)
+                    if role == 'original':
+                        self.phases['create']['observations'].append(copy.deepcopy(observation)); before = m.identity(path)
+                    else: after = m.identity(path)
+                self.result['updates'].append({'arm': arm['name'], 'replica': replica, 'original_before': before, 'original_after': before,
+                                               'updated': after, 'locator': {}})
+
+    def classify(self):
+        for name, phase in self.phases.items():
+            path = self.root / (name + '.json'); path.write_text(json.dumps(phase))
+            self.result['phases'][name] = m.identity(path)
+        with patch.object(m, 'patch_check', return_value={'length': 4}):
+            return m.build_report(self.result, self.root, self.plan)
+
+    def test_complete_and_order_independent_rows(self):
+        self.assertEqual(self.classify()['outcome'], 'observed_accepted')
+        for phase in self.phases.values():
+            for entry in phase['observations']:
+                for table in entry['observation']['snapshot']['user_tables']: table['rows'].reverse()
+        self.assertEqual(self.classify()['outcome'], 'observed_accepted')
+
+    def test_incomplete_identity_and_unrelated_query_fail(self):
+        original = copy.deepcopy(self.phases)
+        for change in ['missing', 'query', 'payload', 'identity', 'file', 'mutation']:
+            self.phases = copy.deepcopy(original)
+            phase = self.phases['observe']; entry = phase['observations'][1]['observation']
+            if change == 'missing': phase['observations'].pop()
+            elif change == 'query': entry['snapshot']['queries'][0]['sql'] = 'SELECT 99;'
+            elif change == 'payload': entry['snapshot']['user_tables'][0]['rows'][1][2] = 'wrong'
+            elif change == 'identity': entry['after']['sha256'] = 'f' * 64
+            elif change == 'file': entry['file'] = 'unrelated.mdb'
+            else: phase['mutation_started'] = True
+            self.assertEqual(self.classify()['outcome'], 'no_outcome', change)
+
+    def test_byte_preservation_and_locator_binding(self):
+        arm = self.plan['arms'][0]
+        locator = {'root': 20, 'page': 1, 'slot': 0, 'column': 0}
+        original = bytearray(4096); original[2149:2153] = (1).to_bytes(4, 'little', signed=True)
+        updated = bytearray(original); updated[2149:2153] = arm['replacement'].to_bytes(4, 'little', signed=True)
+        table = {'columns': [{'type': 'Long', 'storage': 'fixed', 'size': 4, 'fixed_offset': 0}]}
+        with patch.object(m.catalog, '_discover_catalog', return_value=({}, [], [{'values': ['Items', 20]}])), \
+             patch.object(m.catalog, '_ordinal', side_effect=lambda definition, name: {'Name': 0, 'Id': 1 if definition == {} else 0}[name]), \
+             patch.object(m.catalog, '_definition', return_value=table), \
+             patch.object(m.catalog, '_table_pages', return_value=([1], [])), \
+             patch.object(m.catalog, '_table_rows', return_value=[{'values': [1], 'page': 1, 'row': 0, 'present': [True]}]), \
+             patch.object(m.catalog, '_row_directory', return_value=[{'start': 100}]):
+            self.assertEqual(m.patch_check(bytes(original), bytes(updated), arm, locator)['offset'], 2149)
+            updated[42] = 1
+            with self.assertRaisesRegex(ValueError, 'Bytes outside'): m.patch_check(bytes(original), bytes(updated), arm, locator)
+            with self.assertRaisesRegex(ValueError, 'Target row'): m.patch_check(bytes(original), bytes(updated), arm, {**locator, 'slot': 1})
+
+    def test_plan_pins_and_explicit_failure_are_not_promoted(self):
+        self.result['error'] = 'phase1 failed after mutation'
+        self.assertEqual(self.classify()['outcome'], 'no_outcome')
+        changed = copy.deepcopy(self.plan); changed['inputs'] = {'missing-file': '0' * 64}
+        with patch.object(m.PLAN.__class__, 'read_text', return_value=json.dumps(changed)):
+            with self.assertRaises(FileNotFoundError): m.verify_inputs()
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Preregister a coordinated DAO-create, public Rust field-update, and read-only DAO comparison for existing-file preservation. Nine original/updated pairs cover a first field, later row, and later table, retaining a stored QueryDef and checking every byte outside the selected four-byte field.

Independent review and fix review passed. Five classifier tests, committed pin verification, PowerShell parser preflight, exporter checks, and final `just ready` passed. No acquisition has run yet; any failure is retained as one outcome without retry.
