### PR TITLE
feat: create databases from typed CLI input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ version = "0.0.0"
 dependencies = [
  "jet3",
  "jet3-testkit",
+ "serde",
  "serde_json",
  "tempfile",
 ]

--- a/crates/jet3-cli/Cargo.toml
+++ b/crates/jet3-cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 jet3 = { path = "../jet3", version = "=0.0.0" }
 jet3-testkit = { path = "../jet3-testkit", version = "=0.0.0" }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.151"
 
 [dev-dependencies]

--- a/crates/jet3-cli/README.md
+++ b/crates/jet3-cli/README.md
@@ -1,0 +1,87 @@
+# jet3-cli
+
+`jet3-cli --help` lists the existing `probe`, `inspect` and protocol `snapshot`
+commands. `create` is an optional JSON frontend to the public creation APIs:
+
+```sh
+jet3-cli create example.mdb --input request.json
+cat request.json | jet3-cli create example.mdb --input -
+```
+
+The output must not exist. Creation uses the library's atomic publication,
+validation and default resource limits; publication currently requires Unix.
+Success writes one JSON object to stdout. Invalid command arguments exit 2;
+invalid JSON or a refused creation exits 1 with a JSON error on stderr. Unknown
+JSON fields are rejected. No existing database is modified by this command.
+
+A minimal request creates an empty database: `{"tables": []}`. A table request:
+
+```json
+{
+  "tables": [{
+    "name": "Items",
+    "columns": [
+      {"name": "Id", "type": "auto_increment"},
+      {"name": "Label", "type": "text", "size": 40}
+    ],
+    "indexes": [{
+      "name": "ById", "kind": "primary",
+      "fields": [{"column": "Id"}]
+    }],
+    "rows": [
+      ["auto_increment", {"text": "First"}],
+      ["auto_increment", null]
+    ]
+  }]
+}
+```
+
+Tables and columns retain their supplied order; row cells are positional.
+`indexes` and `rows` default to empty arrays. Index `kind` is `primary`, `unique`
+or `ordinary`. Each field references an exact column name and has optional
+`direction`: `ascending` (default) or `descending`. Other schema combinations
+and limits are checked by the library, including which types may be indexed.
+
+Column types are `boolean`, `byte`, `integer`, `long`, `auto_increment`,
+`currency`, `single`, `double`, `date_time`, `guid`, `text`, `fixed_text`,
+`binary`, `memo` and `long_binary`. `text`, `fixed_text` and `binary` require
+`size` from 1 through 255; other types do not accept `size`. Fixed text has an
+exact byte length; variable text and binary use the maximum byte length.
+
+Row cells use JSON `null`, the string `"auto_increment"`, or a single typed
+value object. The tag must match the column type (fixed text uses `text`):
+
+| Cell | Meaning |
+| --- | --- |
+| `{"boolean": true}` | Boolean; null is also false in Jet 3 |
+| `{"byte": 255}`, `{"integer": -32768}`, `{"long": 42}` | Unsigned 8-bit, signed 16-bit and signed 32-bit integers |
+| `{"currency": 12345}` | Exact signed 64-bit integer scaled by 10,000, here 1.2345 |
+| `{"single": 1.25}`, `{"double": -2.5}` | Floating-point values |
+| `{"date_time": 36526.0}` | OLE Automation day count |
+| `{"text": "Hello"}`, `{"memo": "Long text"}` | ASCII text encoded without conversion |
+| `{"text": [233]}`, `{"memo": [233]}` | Explicit database-code-page bytes, here Windows-1252 é |
+| `{"binary": [0, 255]}`, `{"long_binary": [0, 255]}` | Exact binary/OLE bytes |
+| `{"guid": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}` | Sixteen bytes in conventional GUID display order |
+
+Names and string text must be ASCII. For non-ASCII text use already-encoded
+byte arrays; the CLI does not silently encode UTF-8 into the database. All
+byte array elements must be integers from 0 through 255. The CLI exposes no
+raw Memo/OLE reference headers; the library allocates payload references.
+
+An optional top-level `relationship` selects a relationship creation API:
+
+```json
+{
+  "name": "ParentChild",
+  "parent": {"table": "Parent", "column": "Id"},
+  "child": {"table": "Child", "column": "ParentId"}
+}
+```
+
+Place that object alongside `tables`. Supply the parent primary index and
+matching parent/child rows in the table requests; the library creates the
+foreign index and validates its current relationship bounds. When all rows are
+empty, the CLI uses the schema-only API, including its additional supported
+index layouts; otherwise it uses the initial-row API. This interface
+adds no relationship, index, schema or payload support beyond the linked
+`jet3` library. It provides no update/delete commands or compatibility claim.

--- a/crates/jet3-cli/src/create.rs
+++ b/crates/jet3-cli/src/create.rs
@@ -1,0 +1,371 @@
+//! JSON input translation for the public database creation APIs.
+use std::{ffi::OsString, fs::File, num::NonZeroU8, path::PathBuf};
+
+use jet3::{
+    ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
+    RelationshipColumn, RelationshipSpec, ResourceBudget, ResourceLimits, RowValue, TableRef,
+    TableRows, TableSpec, create_database, create_database_with_relationship,
+    create_database_with_relationship_rows, create_database_with_table_rows,
+};
+use serde::Deserialize;
+
+pub(crate) const HELP: &str = "\
+  jet3-cli create <output.mdb> --input <request.json|->
+
+create reads a JSON request from a file or stdin (-), then calls the public
+creation API once. Existing output files are refused. See crates/jet3-cli/README.md
+for typed rows, indexes, relationships and the library's current limits.
+";
+
+#[derive(Debug)]
+pub(crate) struct CreateCommand {
+    output: PathBuf,
+    input: OsString,
+}
+
+pub(crate) fn parse_args(
+    mut arguments: impl Iterator<Item = OsString>,
+) -> Result<CreateCommand, &'static str> {
+    let output = arguments.next().ok_or("missing_file")?;
+    if output.to_string_lossy().starts_with('-') {
+        return Err("missing_file");
+    }
+    if arguments.next().as_deref() != Some(std::ffi::OsStr::new("--input")) {
+        return Err("create_input_required");
+    }
+    let input = arguments.next().ok_or("missing_option_value")?;
+    if arguments.next().is_some() {
+        return Err("unexpected_argument");
+    }
+    Ok(CreateCommand {
+        output: output.into(),
+        input,
+    })
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Request {
+    tables: Vec<Table>,
+    relationship: Option<Relation>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Table {
+    name: String,
+    columns: Vec<Column>,
+    #[serde(default)]
+    indexes: Vec<Index>,
+    #[serde(default)]
+    rows: Vec<Vec<Option<Cell>>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Column {
+    name: String,
+    #[serde(rename = "type")]
+    kind: Kind,
+    size: Option<NonZeroU8>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Kind {
+    Boolean,
+    Byte,
+    Integer,
+    Long,
+    AutoIncrement,
+    Currency,
+    Single,
+    Double,
+    DateTime,
+    Guid,
+    Text,
+    FixedText,
+    Binary,
+    Memo,
+    LongBinary,
+}
+
+impl Column {
+    fn spec(&self) -> Result<ColumnSpec<'_>, String> {
+        let size = || {
+            self.size
+                .ok_or_else(|| format!("column {} requires size (1..255)", self.name))
+        };
+        if self.size.is_some() && !matches!(self.kind, Kind::Text | Kind::FixedText | Kind::Binary)
+        {
+            return Err(format!("column {} does not accept size", self.name));
+        }
+        let kind = match self.kind {
+            Kind::Boolean => ColumnType::Boolean,
+            Kind::Byte => ColumnType::Byte,
+            Kind::Integer => ColumnType::Integer,
+            Kind::Long => ColumnType::Long,
+            Kind::AutoIncrement => ColumnType::AutoIncrement,
+            Kind::Currency => ColumnType::Currency,
+            Kind::Single => ColumnType::Single,
+            Kind::Double => ColumnType::Double,
+            Kind::DateTime => ColumnType::DateTime,
+            Kind::Guid => ColumnType::Guid,
+            Kind::Text => ColumnType::Text { max_len: size()? },
+            Kind::FixedText => ColumnType::FixedText { len: size()? },
+            Kind::Binary => ColumnType::Binary { max_len: size()? },
+            Kind::Memo => ColumnType::Memo,
+            Kind::LongBinary => ColumnType::LongBinary,
+        };
+        Ok(ColumnSpec::new(ascii(&self.name)?, kind))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Index {
+    name: String,
+    kind: KeyKind,
+    fields: Vec<IndexField>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum KeyKind {
+    Primary,
+    Unique,
+    Ordinary,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IndexField {
+    column: String,
+    #[serde(default)]
+    direction: Direction,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Direction {
+    #[default]
+    Ascending,
+    Descending,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Relation {
+    name: String,
+    parent: Endpoint,
+    child: Endpoint,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Endpoint {
+    table: String,
+    column: String,
+}
+
+impl Endpoint {
+    fn spec(&self) -> Result<RelationshipColumn<'_>, String> {
+        Ok(RelationshipColumn {
+            table: TableRef::Name(ascii(&self.table)?),
+            column: ColumnRef::Name(ascii(&self.column)?),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+enum Cell {
+    AutoIncrement,
+    Boolean(bool),
+    Byte(u8),
+    Integer(i16),
+    Long(i32),
+    Currency(i64),
+    Single(f32),
+    Double(f64),
+    DateTime(f64),
+    Text(Text),
+    Memo(Text),
+    Binary(Vec<u8>),
+    LongBinary(Vec<u8>),
+    Guid([u8; 16]),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum Text {
+    Ascii(String),
+    Bytes(Vec<u8>),
+}
+
+impl Text {
+    fn bytes(&self) -> Result<&[u8], String> {
+        match self {
+            Self::Ascii(text) => ascii(text),
+            Self::Bytes(bytes) => Ok(bytes),
+        }
+    }
+}
+
+impl Cell {
+    fn value(&self) -> Result<RowValue<'_>, String> {
+        Ok(match self {
+            Self::AutoIncrement => RowValue::AutoIncrement,
+            Self::Boolean(v) => RowValue::Boolean(*v),
+            Self::Byte(v) => RowValue::Byte(*v),
+            Self::Integer(v) => RowValue::Integer(*v),
+            Self::Long(v) => RowValue::Long(*v),
+            Self::Currency(v) => RowValue::Currency { scaled: *v },
+            Self::Single(v) if !v.is_finite() => {
+                return Err("single value exceeds finite range".into());
+            }
+            Self::Single(v) => RowValue::Single(*v),
+            Self::Double(v) => RowValue::Double(*v),
+            Self::DateTime(v) => RowValue::DateTime { days: *v },
+            Self::Text(v) => RowValue::Text(v.bytes()?),
+            Self::Memo(v) => RowValue::Memo(v.bytes()?),
+            Self::Binary(v) => RowValue::Binary(v),
+            Self::LongBinary(v) => RowValue::LongBinary(v),
+            Self::Guid(v) => RowValue::Guid(*v),
+        })
+    }
+}
+
+fn ascii(text: &str) -> Result<&[u8], String> {
+    if text.is_ascii() {
+        Ok(text.as_bytes())
+    } else {
+        Err("names and text strings must be ASCII; use byte arrays for encoded text".into())
+    }
+}
+
+pub(crate) fn run(command: &CreateCommand) -> Result<String, String> {
+    let request: Request = if command.input == "-" {
+        serde_json::from_reader(std::io::stdin().lock())
+    } else {
+        let file = File::open(&command.input).map_err(|e| format!("read request: {e}"))?;
+        serde_json::from_reader(file)
+    }
+    .map_err(|e| format!("invalid creation request: {e}"))?;
+    let columns = request
+        .tables
+        .iter()
+        .map(|t| t.columns.iter().map(Column::spec).collect())
+        .collect::<Result<Vec<Vec<_>>, String>>()?;
+    let fields = request
+        .tables
+        .iter()
+        .map(|t| {
+            t.indexes
+                .iter()
+                .map(|index| {
+                    index
+                        .fields
+                        .iter()
+                        .map(|field| {
+                            Ok(IndexColumnSpec {
+                                column: ColumnRef::Name(ascii(&field.column)?),
+                                direction: match field.direction {
+                                    Direction::Ascending => IndexDirection::Ascending,
+                                    Direction::Descending => IndexDirection::Descending,
+                                },
+                            })
+                        })
+                        .collect::<Result<Vec<_>, String>>()
+                })
+                .collect()
+        })
+        .collect::<Result<Vec<Vec<_>>, String>>()?;
+    let indexes = request
+        .tables
+        .iter()
+        .zip(&fields)
+        .map(|(table, fields)| {
+            table
+                .indexes
+                .iter()
+                .zip(fields)
+                .map(|(index, fields)| {
+                    Ok(IndexSpec {
+                        name: ascii(&index.name)?,
+                        fields,
+                        kind: match index.kind {
+                            KeyKind::Primary => IndexKind::Primary,
+                            KeyKind::Unique => IndexKind::Unique,
+                            KeyKind::Ordinary => IndexKind::Ordinary,
+                        },
+                    })
+                })
+                .collect()
+        })
+        .collect::<Result<Vec<Vec<_>>, String>>()?;
+    let rows = request
+        .tables
+        .iter()
+        .map(|table| {
+            table
+                .rows
+                .iter()
+                .map(|row| {
+                    row.iter()
+                        .map(|cell| cell.as_ref().map_or(Ok(RowValue::Null), Cell::value))
+                        .collect()
+                })
+                .collect()
+        })
+        .collect::<Result<Vec<Vec<Vec<_>>>, String>>()?;
+    let slices = rows
+        .iter()
+        .map(|rows| rows.iter().map(Vec::as_slice).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let tables = request
+        .tables
+        .iter()
+        .enumerate()
+        .map(|(n, table)| {
+            Ok(TableRows {
+                table: TableSpec {
+                    name: ascii(&table.name)?,
+                    columns: &columns[n],
+                    indexes: &indexes[n],
+                },
+                rows: &slices[n],
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let empty = tables.iter().all(|table| table.rows.is_empty());
+    let schema = tables.iter().map(|table| table.table).collect::<Vec<_>>();
+    if let Some(relation) = &request.relationship {
+        let relationship = RelationshipSpec {
+            name: ascii(&relation.name)?,
+            parent: relation.parent.spec()?,
+            child: relation.child.spec()?,
+        };
+        if empty {
+            create_database_with_relationship(&command.output, &schema, &relationship, &mut budget)
+        } else {
+            create_database_with_relationship_rows(
+                &command.output,
+                &tables,
+                &relationship,
+                &mut budget,
+            )
+        }
+    } else if empty {
+        create_database(&command.output, &schema, &mut budget)
+    } else {
+        create_database_with_table_rows(&command.output, &tables, &mut budget)
+    }
+    .map_err(|e| format!("create database: {e}"))?;
+    Ok(
+        serde_json::json!({"ok": true, "operation": "create", "output": command.output.to_string_lossy()})
+            .to_string()
+            + "\n",
+    )
+}

--- a/crates/jet3-cli/src/main.rs
+++ b/crates/jet3-cli/src/main.rs
@@ -13,6 +13,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+mod create;
 mod inspect;
 mod snapshot;
 
@@ -79,6 +80,7 @@ enum Command {
     Probe(ProbeOptions),
     Snapshot(snapshot::SnapshotCommand),
     Inspect(inspect::InspectCommand),
+    Create(create::CreateCommand),
 }
 
 fn main() -> ExitCode {
@@ -91,7 +93,12 @@ fn main() -> ExitCode {
 
     match command {
         Command::Help => exit_after_write(
-            write_stdout(&format!("{HELP}{}\n{}", snapshot::HELP, inspect::HELP)),
+            write_stdout(&format!(
+                "{HELP}{}\n{}\n{}",
+                snapshot::HELP,
+                inspect::HELP,
+                create::HELP
+            )),
             0,
         ),
         Command::Version => exit_after_write(
@@ -105,6 +112,19 @@ fn main() -> ExitCode {
         Command::Snapshot(command) => match snapshot::run(&command) {
             Ok(json) => exit_after_write(write_stdout(&json), 0),
             Err(message) => exit_after_write(write_stderr(&format!("jet3-cli: {message}\n")), 1),
+        },
+        Command::Create(command) => match create::run(&command) {
+            Ok(json) => exit_after_write(write_stdout(&json), 0),
+            Err(message) => exit_after_write(
+                write_stderr(
+                    &(serde_json::json!({
+                        "ok": false, "error": "create_failed", "message": message,
+                    })
+                    .to_string()
+                        + "\n"),
+                ),
+                1,
+            ),
         },
         Command::Inspect(command) => match inspect::run(&command) {
             Ok(json) => exit_after_write(write_stdout(&json), 0),
@@ -126,6 +146,9 @@ fn parse_args(arguments: impl Iterator<Item = OsString>) -> Result<Command, &'st
     }
     if first == "snapshot" {
         return snapshot::parse_args(arguments).map(Command::Snapshot);
+    }
+    if first == "create" {
+        return create::parse_args(arguments).map(Command::Create);
     }
     if first == "inspect" {
         return inspect::parse_args(arguments).map(Command::Inspect);

--- a/crates/jet3-cli/tests/create.rs
+++ b/crates/jet3-cli/tests/create.rs
@@ -1,0 +1,172 @@
+#![forbid(unsafe_code)]
+use serde_json::Value;
+#[cfg(unix)]
+use serde_json::json;
+#[cfg(unix)]
+use std::fs;
+use std::{
+    io::Write,
+    process::{Command, Output, Stdio},
+};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn run(output: &std::path::Path, request: &str) -> Result<Output> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg("create")
+        .arg(output)
+        .args(["--input", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or("missing stdin")?
+        .write_all(request.as_bytes())?;
+    Ok(child.wait_with_output()?)
+}
+
+#[test]
+fn create_rejects_unknown_fields_types_and_arguments() -> Result {
+    let directory = tempfile::tempdir()?;
+    let output = directory.path().join("invalid.mdb");
+    for request in [
+        r#"{"tables":[],"overwrite":true}"#,
+        r#"{"tables":[{"name":"T","columns":[],"unknown":0}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"Id","type":"long","unknown":0}]}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"Id","type":"long"}],"rows":[[{"long":2147483648}]]}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"Id","type":"long","size":4}]}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"Text","type":"text","size":0}]}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"Text","type":"text","size":10}],"rows":[[{"text":"é"}]]}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"B","type":"binary","size":2}],"rows":[[{"binary":[256]}]]}]}"#,
+        r#"{"tables":[{"name":"T","columns":[{"name":"F","type":"single"}],"rows":[[{"single":1e300}]]}]}"#,
+        r#"{"tables":[],"relationship":{"name":"R","parent":{"table":"A","column":"Id","cascade":true},"child":{"table":"B","column":"Id"}}}"#,
+    ] {
+        let result = run(&output, request)?;
+        assert_eq!(result.status.code(), Some(1), "{request}");
+        assert!(result.stdout.is_empty());
+        let error: Value = serde_json::from_slice(&result.stderr)?;
+        assert_eq!(error["error"], "create_failed");
+        assert!(!output.exists());
+    }
+    let missing = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg("create")
+        .arg(&output)
+        .output()?;
+    assert_eq!(missing.status.code(), Some(2));
+    let duplicate = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg("create")
+        .arg(&output)
+        .args(["--input", "-", "--input", "-"])
+        .output()?;
+    assert_eq!(duplicate.status.code(), Some(2));
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn create_file_input_preserves_typed_rows_and_refuses_overwrite() -> Result {
+    let directory = tempfile::tempdir()?;
+    let output = directory.path().join("created.mdb");
+    let input = directory.path().join("request.json");
+    let request = json!({"tables":[{
+        "name":"Items", "columns":[{"name":"Id","type":"auto_increment"},{"name":"Label","type":"text","size":20}],
+        "indexes":[{"name":"ById","kind":"primary","fields":[{"column":"Id"}]}],
+        "rows":[["auto_increment",{"text":"Hello"}],["auto_increment",{"text":[233]}]]
+    }]});
+    fs::write(&input, request.to_string())?;
+    let result = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg("create")
+        .arg(&output)
+        .arg("--input")
+        .arg(&input)
+        .output()?;
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(serde_json::from_slice::<Value>(&result.stdout)?["ok"], true);
+    let bytes = fs::read(&output)?;
+    let inspection = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg("inspect")
+        .arg(&output)
+        .arg("--rows")
+        .output()?;
+    assert!(inspection.status.success());
+    let document: Value = serde_json::from_slice(&inspection.stdout)?;
+    let table = document["tables"]
+        .as_array()
+        .ok_or("missing tables")?
+        .iter()
+        .find(|t| t["kind"] == "User" && t["columns"][0]["name"] == "Id")
+        .ok_or("Items not found")?;
+    assert_eq!(
+        table["rows"],
+        json!([{"Id":1,"Label":"Hello"},{"Id":2,"Label":"é"}])
+    );
+    assert_eq!(table["indexes"][0]["name"], "ById");
+    assert!(!run(&output, r#"{"tables":[]}"#)?.status.success());
+    assert_eq!(fs::read(&output)?, bytes);
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn create_stdin_relationship_and_empty_database_use_public_api() -> Result {
+    let directory = tempfile::tempdir()?;
+    let empty = directory.path().join("empty.mdb");
+    let result = run(&empty, r#"{"tables":[]}"#)?;
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let output = directory.path().join("related.mdb");
+    let request = json!({"tables":[
+        {"name":"Parent","columns":[{"name":"Id","type":"long"}],"indexes":[{"name":"ById","kind":"primary","fields":[{"column":"Id"}]}],"rows":[[{"long":1}]]},
+        {"name":"Child","columns":[{"name":"ParentId","type":"long"}],"rows":[[{"long":1}],[{"long":1}]]}
+    ],"relationship":{"name":"ParentChild","parent":{"table":"Parent","column":"Id"},"child":{"table":"Child","column":"ParentId"}}});
+    let result = run(&output, &request.to_string())?;
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let snapshot = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg("inspect")
+        .arg(&output)
+        .arg("--rows")
+        .output()?;
+    assert!(snapshot.status.success());
+    let document: Value = serde_json::from_slice(&snapshot.stdout)?;
+    let child = document["tables"]
+        .as_array()
+        .ok_or("missing tables")?
+        .iter()
+        .find(|t| t["columns"][0]["name"] == "ParentId")
+        .ok_or("Child not found")?;
+    assert_eq!(child["rows"], json!([{"ParentId":1},{"ParentId":1}]));
+    assert_eq!(child["indexes"][0]["name"], "ParentChild");
+    let mut empty_request = request;
+    empty_request["tables"][0]["rows"] = json!([]);
+    empty_request["tables"][1]["rows"] = json!([]);
+    empty_request["tables"][0]["columns"]
+        .as_array_mut()
+        .ok_or("missing columns")?
+        .push(json!({"name":"Alternate","type":"long"}));
+    empty_request["tables"][0]["indexes"]
+        .as_array_mut()
+        .ok_or("missing indexes")?
+        .push(json!({"name":"ByAlternate","kind":"unique","fields":[{"column":"Alternate"}]}));
+    let empty_related = directory.path().join("empty-related.mdb");
+    let result = run(&empty_related, &empty_request.to_string())?;
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    Ok(())
+}


### PR DESCRIPTION
Add an optional `create OUTPUT --input FILE|-` command that translates typed JSON tables, columns, indexes, rows, and a relationship into one existing public creation API call. Success and creation errors are JSON, unknown input fields are refused, and the library retains responsibility for limits and atomic publication.

Independent review passed. Three creation integration tests, ten existing CLI tests, scoped Clippy, and final `just ready` passed. Current library limits and explicit text-byte input are documented.
