### PR TITLE
test: preregister row deletion and slot reuse discovery

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11024,6 +11024,43 @@ Copy this block under the appropriate section and remove this instruction:
   Neither this plan nor self-validation establishes general compatibility,
   completion of #100 or support-matrix movement.
 
+## EXP-0157 — Ordinary-row deletion transitions preregistered
+
+- Recorded: 2026-09-05, OpenAI Codex; local development discovery plan,
+  not an acquisition or writer acceptance result. Plan
+  `oracle/windows-dao/acquisition/row-delete-layout.plan.json`, SHA-256
+  `18c24390fc6429d839139719ccc11ae6049a236f77e42062592ee7f315355e7a`, pins the single DAO
+  producer, analyzer, unchanged structural decoder and ordinary SSH transport.
+- Three fresh replicas each cover tail, middle and sole-row deletion from
+  unindexed `Rows(Id Long, Value Long)`. Tail/middle start with four declared
+  rows and delete Id 4/2 respectively; sole starts with Id 1 and deletes it.
+  Each database closes before the `before` checkpoint, reopens for exactly one
+  FindFirst/Delete, closes for `deleted`, then reopens for one explicit
+  `(99,-9900)` insert and closes for `inserted`. Retained checkpoint copies
+  are observed read-only with before/after hashes: 27 planned captures.
+- Correlate complete DAO schema and exact surviving values with typed raw rows,
+  row locators, active table counts, complete data pages/directories, definition
+  pages, header page and owned/available/global-map observations. Retain every
+  whole-file changed byte range and its old/new bytes, including opaque catalog
+  differences; no changed range is discarded or assigned guessed semantics.
+- `answered` requires all captures, unchanged identities and correlations plus
+  stable question-bearing directory/payload/page-header-with-owner-removed and
+  per-data-page owned/available/global-free transitions across replicas. Do not
+  demand identical absolute allocator addresses or opaque timestamp/catalog
+  bytes. Record the zero-length `0xc000` tombstone hypothesis independently;
+  stable disagreement still answers the planned question.
+- Existing facts are `SRC-0020`/EXP-0060 directory/row grammar, EXP-0063's
+  page-end tombstone diagnosis, EXP-0057 map roles, and EXP-0136 ordinary table
+  count/state changes. The unchanged decoder keeps its 64-row-per-page bound;
+  this finite experiment has at most four user rows and no Auto/index/LVAL/
+  relationship/variable-width data, compaction, or implicit counter generation.
+- Commit and independently review before the first DAO mutation. One dispatch,
+  no automatic retry/resume; failed or incomplete acquisition is `no_outcome`,
+  with partial working MDBs and logs retained externally. A new attempt after
+  mutation needs a human decision. Record one additive EXP-0158 outcome.
+  No generalized deletion/reuse/free-space/allocator policy, Rust deletion
+  acceptance, compatibility or hosted support claim follows from this plan.
+
 ## EXP-0152 — Existing DAO files accept the bounded Long field updates
 
 - Recorded: 2026-09-05, OpenAI Codex; validated local development outcome

--- a/oracle/windows-dao/acquisition/row-delete-layout.plan.json
+++ b/oracle/windows-dao/acquisition/row-delete-layout.plan.json
@@ -1,0 +1,87 @@
+{
+  "document_type": "dao_row_delete_layout_plan",
+  "experiment_id": "row-delete-layout",
+  "replicas": 3,
+  "development_only": true,
+  "preregistration": {
+    "acquisition_started": false,
+    "question": "What exact row-directory/packed-byte/table-count/map transitions accompany tail, middle and sole-row deletion in a closed unindexed ordinary-Long table, followed by one explicit insertion?",
+    "prior_evidence": "SRC-0020/EXP-0060 source data-page owner/count/directory masks, hidden and zero-length c000 tombstones. EXP-0063 records page-end c800 tombstones. EXP-0136 sources table row count and unchanged ordinary state during deletion. EXP-0057 sources owned/available/global map roles. None defines a general existing-file delete algorithm.",
+    "procedure": "For each arm and replica create one fresh Rows(Id Long, Value Long), insert exact declared rows, close and retain before. Reopen/delete exactly one selected Id using FindFirst/Delete, close and retain deleted. Reopen/insert explicit (99,-9900), close and retain inserted. Each retained checkpoint is observed read-only, before/after hashed. No compaction, indexed/Auto/null/LVAL/relationship table or other writable action. Every operation is attempted once.",
+    "classification": "answered requires27 complete unchanged captures, exact DAO schema/rows and typed raw-row correlations, valid known structural decode, and stable question-bearing data-directory/header-with-owner-removed/row-value/per-data-page map-membership transitions across3replicas. Do not require physical page numbers, file timestamps, or opaque catalog changes to agree. Stable zero-length-c000 hypothesis disagreement is still answered; retain actual observations.",
+    "retention": "Retain all MDBs, including partial working files, results and logs externally. Record one additive EXP-0158 result derived from validated JSON. No MDB/provider bytes in git.",
+    "failure": "Commit SHA256-pinned plan and independently review before first DAO mutation. One dispatch, no automatic retry or resume; failure after mutation is no_outcome and a new attempt requires a human decision.",
+    "limits": "At most4 initial rows/two ordinaryLong fields/one unindexed table; original decoder64-row page bound unchanged. No generalized free-space threshold, slot-reuse/allocator policy, delete writer acceptance or hosted support claim."
+  },
+  "arms": [
+    {
+      "name": "tail",
+      "rows": [
+        [
+          1,
+          101
+        ],
+        [
+          2,
+          -202
+        ],
+        [
+          3,
+          303
+        ],
+        [
+          4,
+          -404
+        ]
+      ],
+      "delete_id": 4
+    },
+    {
+      "name": "middle",
+      "rows": [
+        [
+          1,
+          101
+        ],
+        [
+          2,
+          -202
+        ],
+        [
+          3,
+          303
+        ],
+        [
+          4,
+          -404
+        ]
+      ],
+      "delete_id": 2
+    },
+    {
+      "name": "sole",
+      "rows": [
+        [
+          1,
+          101
+        ]
+      ],
+      "delete_id": 1
+    }
+  ],
+  "insert": [
+    99,
+    -9900
+  ],
+  "checkpoints": [
+    "before",
+    "deleted",
+    "inserted"
+  ],
+  "inputs": {
+    "oracle/windows-dao/scripts/row_delete_layout.py": "74c30a55148ec5efe4c04a154917e8780c06a63442d28c0d0b3453b968142088",
+    "oracle/windows-dao/scripts/row_delete_layout.ps1": "0d7507eefe0e4ecc76e87c57e79f6b8667a9b35533bffebb38ab6845a6a16a5f",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  }
+}

--- a/oracle/windows-dao/scripts/row_delete_layout.ps1
+++ b/oracle/windows-dao/scripts/row_delete_layout.ps1
@@ -1,0 +1,98 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value) }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, ((ConvertTo-Json -InputObject $Value -Depth 30) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function Append-Row($Recordset, $Row) {
+    $Recordset.AddNew(); $Recordset.Fields.Item('Id').Value = [int]$Row[0]
+    $Recordset.Fields.Item('Value').Value = [int]$Row[1]; $Recordset.Update()
+}
+function Mutate([string]$Path, $Arm, [string]$Step, $Plan) {
+    $engine = $workspace = $db = $table = $field = $rs = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        if ($Step -eq 'before') {
+            $workspace = $engine.Workspaces.Item(0); $script:mutationStarted = $true
+            $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+            $table = $db.CreateTableDef('Rows')
+            foreach ($name in @('Id', 'Value')) {
+                $field = $table.CreateField($name, 4); $table.Fields.Append($field)
+                Release $field; $field = $null
+            }
+            $db.TableDefs.Append($table)
+        } else { $db = $engine.OpenDatabase($Path, $false, $false) }
+        $rs = $db.OpenRecordset('Rows', 2)
+        if ($Step -eq 'deleted') {
+            $rs.FindFirst('[Id] = ' + [string]$Arm.delete_id)
+            if ($rs.NoMatch) { throw 'Selected deletion Id absent' }
+            $rs.Delete()
+        } elseif ($Step -eq 'before') {
+            foreach ($row in $Arm.rows) { Append-Row $rs $row }
+        } else { Append-Row $rs $Plan.insert }
+    } finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs; Release $field; Release $table
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $workspace; Release $engine
+    }
+}
+function Observe([string]$Path) {
+    $before = Identity $Path; $engine = $db = $table = $rs = $null
+    $snapshot = [ordered]@{}; $status = 'pass'; $errorDetail = $null; $endpoint = 'open_database'
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @($db.Relations | ForEach-Object { [string]$_.Name })
+        $snapshot.queries = @($db.QueryDefs | ForEach-Object { [string]$_.Name })
+        $endpoint = 'schema'; $table = $db.TableDefs.Item('Rows')
+        $snapshot.attributes = [int]$table.Attributes
+        $snapshot.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes} })
+        $snapshot.indexes = @($table.Indexes | ForEach-Object { [string]$_.Name })
+        $endpoint = 'rows'; $rs = $db.OpenRecordset('Rows', 4); $rows = New-Object Collections.ArrayList
+        while (-not $rs.EOF) {
+            [void]$rows.Add(@([int]$rs.Fields.Item('Id').Value, [int]$rs.Fields.Item('Value').Value)); $rs.MoveNext()
+        }
+        $snapshot.rows = @($rows)
+    } catch { $status = 'error'; $errorDetail = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+    finally {
+        if ($null -ne $rs) { $rs.Close() }; Release $rs; Release $table
+        if ($null -ne $db) { $db.Close() }; Release $db; Release $engine
+    }
+    return @{before=$before; after=(Identity $Path); status=$status; error=$errorDetail; endpoint=$endpoint; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'row-delete-layout.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/row_delete_layout.ps1') { throw 'Script pin mismatch' }
+$mutationStarted = $false
+$result = [ordered]@{document_type='dao_row_delete_layout_result'; plan_sha256=(Identity $planPath).sha256; mutation_started=$false;
+    environment=@{process_bits=32; provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}; captures=@(); endpoint='start'; error=$null}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $working = Join-Path $env:JET3_WORK "$($arm.name)-r$replica-working.mdb"
+            foreach ($checkpoint in @('before', 'deleted', 'inserted')) {
+                $result.endpoint = "$($arm.name)/$replica/$checkpoint/mutate"
+                Mutate $working $arm $checkpoint $plan
+                $file = "$($arm.name)-r$replica-$checkpoint.mdb"
+                $retained = Join-Path $env:JET3_WORK $file; Copy-Item -LiteralPath $working -Destination $retained
+                $result.endpoint = "$($arm.name)/$replica/$checkpoint/observe"
+                $observation = Observe $retained
+                $result.captures += @{arm=[string]$arm.name; replica=$replica; checkpoint=$checkpoint; file=$file; observation=$observation}
+                if ($observation.status -ne 'pass') { throw 'Read-only observation failed' }
+            }
+        }
+    }
+} catch { $result.error = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/row_delete_layout.py
+++ b/oracle/windows-dao/scripts/row_delete_layout.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""EXP-0157: bounded deletion layout observations, not a deletion writer."""
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/row-delete-layout.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/row_delete_layout.ps1'
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': hashlib.sha256(path.read_bytes()).hexdigest()}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, expected in plan['inputs'].items():
+        if identity(ROOT / name)['sha256'] != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if subprocess.check_output(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    return plan
+
+
+def expected_rows(arm, checkpoint, plan):
+    rows = copy.deepcopy(arm['rows'])
+    if checkpoint != 'before': rows = [row for row in rows if row[0] != arm['delete_id']]
+    if checkpoint == 'inserted': rows.append(plan['insert'])
+    return sorted(rows)
+
+
+def check_snapshot(snapshot, rows):
+    expected = {'version': '3.0', 'tables': ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows'],
+        'relations': [], 'queries': [], 'attributes': 0, 'indexes': [],
+        'fields': [{'name': name, 'type': 4, 'size': 4, 'attributes': 1} for name in ('Id', 'Value')], 'rows': rows}
+    snapshot = copy.deepcopy(snapshot); snapshot['rows'].sort()
+    if snapshot != expected: raise ValueError('DAO schema or requested rows differ')
+
+
+def data_page(data, page):
+    image = catalog._page(data, page, 'retained row page')
+    entries = None
+    if image[0] == 1:
+        entries = catalog._row_directory(image, page)
+        for entry in entries:
+            offset = 10 + 2 * entry['row']
+            entry['raw_word'] = int.from_bytes(image[offset:offset + 2], 'little')
+            entry['raw_hex'] = image[entry['start']:entry['end']].hex()
+    return {'page': page, 'hex': image.hex(), 'directory': entries}
+
+
+def observe(data, wanted):
+    analysis = catalog.analyze_checkpoint(data)
+    tables = [table for table in analysis['tables'].values() if table['name'] == 'Rows']
+    if len(tables) != 1: raise ValueError('Rows table not unique')
+    table = tables[0]; definition = table['definition']
+    rows = catalog._table_rows(data, definition, table['data_pages'])
+    if definition['row_count'] != len(wanted) or sorted(row['values'] for row in rows) != wanted or any(not all(row['present']) for row in rows):
+        raise ValueError('Raw rows/count disagree with requested DAO rows')
+    if [(c['name'], c['type'], c['size']) for c in definition['columns']] != [('Id', 'Long', 4), ('Value', 'Long', 4)]:
+        raise ValueError('Raw column schema mismatch')
+    return {'definition_root': definition['root'], 'row_count': definition['row_count'], 'rows': rows,
+            'definition_pages': [{'page': p, 'hex': catalog._page(data, p, 'TDEF').hex()} for p in definition['pages']],
+            'header_hex': data[:catalog.PAGE_BYTES].hex(), 'page_count': len(data) // catalog.PAGE_BYTES,
+            'maps': {role: {'locator': locator, 'hex': catalog._locator_row(data, locator, role).hex(),
+                           'pages': sorted(catalog._locator_pages(data, locator, role))} for role, locator in definition['maps'].items()},
+            'data_pages': [data_page(data, p) for p in table['data_pages']],
+            'global_free_pages': analysis['free_pages']}
+
+
+def changed_ranges(before, after):
+    ranges, start = [], None
+    for offset in range(max(len(before), len(after)) + 1):
+        different = offset < max(len(before), len(after)) and before[offset:offset + 1] != after[offset:offset + 1]
+        if different and start is None: start = offset
+        if not different and start is not None:
+            ranges.append({'offset': start, 'end': offset, 'before_hex': before[start:offset].hex(), 'after_hex': after[start:offset].hex()})
+            start = None
+    return ranges
+
+
+def transition(before_data, after_data, before, after):
+    pages = sorted({p['page'] for p in before['data_pages'] + after['data_pages']})
+    tracked = []
+    for page in pages:
+        states = []
+        for data, observation in [(before_data, before), (after_data, after)]:
+            states.append({'image': data_page(data, page) if page < observation['page_count'] else None,
+                           'owned': page in observation['maps']['owned']['pages'],
+                           'available': page in observation['maps']['available']['pages'],
+                           'globally_free': page in observation['global_free_pages']})
+        tracked.append({'page': page, 'before': states[0], 'after': states[1]})
+    changes = changed_ranges(before_data, after_data)
+    return {'row_count_before': before['row_count'], 'row_count_after': after['row_count'],
+            'page_count_before': before['page_count'], 'page_count_after': after['page_count'],
+            'changed_ranges': changes,
+            'changed_pages': sorted({p for change in changes for p in range(change['offset'] // catalog.PAGE_BYTES, (change['end'] - 1) // catalog.PAGE_BYTES + 1)}),
+            'tracked_data_pages': tracked,
+            'global_free_added': sorted(set(after['global_free_pages']) - set(before['global_free_pages'])),
+            'global_free_removed': sorted(set(before['global_free_pages']) - set(after['global_free_pages']))}
+
+
+def question_signature(checkpoints, transitions):
+    # Absolute allocator addresses and opaque catalog/timestamp differences are retained diagnostics.
+    signature = {'checkpoints': [], 'transitions': []}
+    for name in ('before', 'deleted', 'inserted'):
+        obs = checkpoints[name]
+        signature['checkpoints'].append({'name': name, 'row_count': obs['row_count'],
+            'rows': [{k: row[k] for k in ('row', 'present', 'values')} for row in obs['rows']]})
+    for movement in transitions:
+        states = []
+        for tracked in movement['tracked_data_pages']:
+            pair = []
+            for role in ('before', 'after'):
+                state = tracked[role]; image = state['image']
+                raw = bytes.fromhex(image['hex']) if image else None
+                pair.append({'owned': state['owned'], 'available': state['available'], 'globally_free': state['globally_free'],
+                             'page_bytes_without_owner': (raw[:4] + raw[8:]).hex() if raw else None,
+                             'directory': image['directory'] if image else None})
+            states.append(pair)
+        signature['transitions'].append({'tracked': states,
+            'row_delta': movement['row_count_after'] - movement['row_count_before'],
+            'page_delta': movement['page_count_after'] - movement['page_count_before'],
+            'global_added_count': len(movement['global_free_added']), 'global_removed_count': len(movement['global_free_removed'])})
+    return signature
+
+
+def build_report(result, outbox, plan):
+    observations, reasons, signatures = [], [], {}
+    expected = {(a['name'], replica, checkpoint) for a in plan['arms'] for replica in range(1, 4) for checkpoint in plan['checkpoints']}
+    entries, decoded, images = {}, {}, {}
+    try:
+        if (result['document_type'] != 'dao_row_delete_layout_result' or result['plan_sha256'] != identity(PLAN)['sha256']
+            or result['mutation_started'] is not True or result['error'] is not None
+            or result['environment']['process_bits'] != 32 or result['environment']['provider'] != 'DAO.DBEngine.36'):
+            raise ValueError('Acquisition incomplete or failed: ' + str(result['error']))
+        for capture in result['captures']:
+            key = (capture['arm'], capture['replica'], capture['checkpoint'])
+            if key in entries or key not in expected: raise ValueError('Unexpected/duplicate checkpoint')
+            arm = next(a for a in plan['arms'] if a['name'] == capture['arm']); observation = capture['observation']
+            filename = f'{key[0]}-r{key[1]}-{key[2]}.mdb'
+            if capture['file'] != filename or observation['status'] != 'pass' or observation['error'] is not None:
+                raise ValueError('Failed/misassociated checkpoint')
+            path = outbox / filename
+            if observation['before'] != observation['after'] or identity(path) != observation['after']:
+                raise ValueError('Retained checkpoint identity changed')
+            wanted = expected_rows(arm, capture['checkpoint'], plan); check_snapshot(observation['snapshot'], wanted)
+            image = path.read_bytes(); raw = observe(image, wanted)
+            entries[key] = capture; decoded[key] = raw; images[key] = image
+        if set(entries) != expected: raise ValueError('Missing checkpoint')
+        for arm in plan['arms']:
+            groups = []
+            for replica in range(1, 4):
+                checks = {name: decoded[arm['name'], replica, name] for name in plan['checkpoints']}
+                movements = [transition(images[arm['name'], replica, first], images[arm['name'], replica, last], checks[first], checks[last])
+                             for first, last in [('before', 'deleted'), ('deleted', 'inserted')]]
+                signature = question_signature(checks, movements); groups.append(signature)
+                observations.append({'arm': arm['name'], 'replica': replica, 'checkpoints': checks, 'transitions': movements,
+                    'identities': {name: entries[arm['name'], replica, name]['observation']['after'] for name in plan['checkpoints']},
+                    'deleted_has_zero_length_c000': any(entry['raw_word'] & 0xe000 == 0xc000 and entry['start'] == entry['end']
+                        for tracked in movements[0]['tracked_data_pages'] if tracked['after']['image'] and tracked['after']['image']['directory']
+                        for entry in tracked['after']['image']['directory'])})
+            signatures[arm['name']] = all(group == groups[0] for group in groups)
+            if not signatures[arm['name']]: reasons.append(arm['name'] + ': question-bearing replica disagreement')
+    except (ValueError, KeyError, TypeError, OSError) as error:
+        reasons.append(str(error))
+    return {'document_type': 'dao_row_delete_layout_report', 'plan_sha256': identity(PLAN)['sha256'],
+            'development_only': True, 'outcome': 'answered' if not reasons else 'no_outcome', 'reasons': reasons,
+            'observations': observations, 'replica_agreement': signatures, 'compatibility_claim': False, 'support_matrix_movement': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs(); result = json.loads((outbox / 'result.json').read_text(encoding='utf-8-sig'))
+    report = build_report(result, outbox, plan); report['result_sha256'] = identity(outbox / 'result.json')['sha256']
+    (outbox / 'report.json').write_text(canonical(report) + '\n'); print(report['outcome'])
+
+
+def dispatch(args):
+    preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,32}', args.run_id): raise ValueError('Invalid run id')
+    inbox, outbox = (args.shared_root.resolve() / part / args.run_id for part in ('inbox', 'outbox'))
+    if inbox.exists() or outbox.exists(): raise ValueError('Run id used; never retry or resume')
+    inbox.mkdir(parents=True); shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1'); shutil.copyfile(PLAN, inbox / PLAN.name)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec); spec.loader.exec_module(transport)
+    command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15', '-o', 'IdentitiesOnly=yes', '-i', args.identity,
+               f'{args.user}@{args.host}', 'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+               transport.encoded(transport.guest_script(args.remote_shared_root, args.run_id, 'script.ps1'))]
+    completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+    if not (outbox / 'result.json').exists(): raise RuntimeError(f'No result (SSH {completed.returncode}); inspect retained run, never retry')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__); commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight'); report = commands.add_parser('analyze'); report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run'); run.add_argument('--run-id', required=True); run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'), ('identity', str(Path.home() / '.ssh/jet3-dao')), ('remote-shared-root', r'\\host.lan\Data')]: run.add_argument('--' + name, default=default)
+    args = parser.parse_args()
+    if args.command == 'preflight': preflight(); print('Committed inputs match.')
+    elif args.command == 'analyze': analyze(args.outbox)
+    else: dispatch(args)
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/tests/test_row_delete_layout.py
+++ b/oracle/windows-dao/tests/test_row_delete_layout.py
@@ -1,0 +1,88 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location('delete_layout_tested', SCRIPTS / 'row_delete_layout.py')
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+
+class DeleteLayoutTests(unittest.TestCase):
+    def setUp(self):
+        self.plan = json.loads(m.PLAN.read_text())
+        self.temporary = tempfile.TemporaryDirectory(prefix='delete-layout-test-'); self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.result = {'document_type': 'dao_row_delete_layout_result', 'plan_sha256': m.identity(m.PLAN)['sha256'],
+            'mutation_started': True, 'error': None, 'environment': {'process_bits': 32, 'provider': 'DAO.DBEngine.36'}, 'captures': []}
+        for arm in self.plan['arms']:
+            for replica in range(1, 4):
+                for number, checkpoint in enumerate(self.plan['checkpoints']):
+                    name = f"{arm['name']}-r{replica}-{checkpoint}.mdb"; path = self.root / name
+                    data = bytearray(4096); data[2048] = 1; data[2100] = number; path.write_bytes(data)
+                    snapshot = {'version': '3.0', 'tables': ['MSysACEs', 'MSysObjects', 'MSysQueries', 'MSysRelationships', 'Rows'],
+                        'relations': [], 'queries': [], 'attributes': 0, 'indexes': [],
+                        'fields': [{'name': name, 'type': 4, 'size': 4, 'attributes': 1} for name in ['Id', 'Value']],
+                        'rows': m.expected_rows(arm, checkpoint, self.plan)}
+                    self.result['captures'].append({'arm': arm['name'], 'replica': replica, 'checkpoint': checkpoint, 'file': name,
+                        'observation': {'status': 'pass', 'error': None, 'before': m.identity(path), 'after': m.identity(path), 'snapshot': snapshot}})
+
+    def decoded(self, data, wanted):
+        return {'row_count': len(wanted), 'page_count': 2, 'rows': [{'page': 1, 'row': i, 'values': row, 'present': [True, True]} for i, row in enumerate(wanted)],
+            'data_pages': [m.data_page(data, 1)], 'global_free_pages': [],
+            'maps': {role: {'pages': [1]} for role in ['owned', 'available']}}
+
+    def classify(self):
+        with patch.object(m, 'observe', side_effect=self.decoded): return m.build_report(self.result, self.root, self.plan)
+
+    def test_complete_hypothesis_false_is_answered(self):
+        report = self.classify()
+        self.assertEqual(report['outcome'], 'answered'); self.assertEqual(len(report['observations']), 9)
+        self.assertTrue(all(not item['deleted_has_zero_length_c000'] for item in report['observations']))
+        self.assertEqual(report['observations'][0]['transitions'][0]['changed_ranges'],
+                         [{'offset': 2100, 'end': 2101, 'before_hex': '00', 'after_hex': '01'}])
+
+    def test_failure_missing_identity_and_payload_are_not_promoted(self):
+        original = copy.deepcopy(self.result)
+        for failure in ['mutation', 'error', 'missing', 'duplicate', 'identity', 'payload', 'file']:
+            self.result = copy.deepcopy(original); capture = self.result['captures'][0]
+            if failure == 'mutation': self.result['mutation_started'] = False
+            elif failure == 'error': self.result['error'] = 'after first mutation'
+            elif failure == 'missing': self.result['captures'].pop()
+            elif failure == 'duplicate': self.result['captures'].append(copy.deepcopy(capture))
+            elif failure == 'identity': capture['observation']['after']['sha256'] = 'f' * 64
+            elif failure == 'file': capture['file'] = 'different.mdb'
+            else: capture['observation']['snapshot']['rows'][0][1] = 999
+            self.assertEqual(self.classify()['outcome'], 'no_outcome', failure)
+
+    def test_input_pin_mismatch_is_rejected(self):
+        with patch.object(m, 'identity', return_value={'sha256': 'wrong'}):
+            with self.assertRaisesRegex(ValueError, 'Input pin mismatch'): m.verify_inputs()
+
+    def test_whole_byte_growth_and_page_address_independent_signature(self):
+        self.assertEqual(m.changed_ranges(b'abc', b'aXcYZ'), [
+            {'offset': 1, 'end': 2, 'before_hex': '62', 'after_hex': '58'},
+            {'offset': 3, 'end': 5, 'before_hex': '', 'after_hex': '595a'}])
+        report = self.classify()['observations'][0]
+        before = m.question_signature(report['checkpoints'], report['transitions'])
+        moved = copy.deepcopy(report)
+        for obs in moved['checkpoints'].values():
+            for row in obs['rows']: row['page'] = 77
+        for movement in moved['transitions']:
+            for tracked in movement['tracked_data_pages']:
+                tracked['page'] = 77
+                for role in ['before', 'after']:
+                    tracked[role]['image']['page'] = 77
+                    raw = bytearray.fromhex(tracked[role]['image']['hex']); raw[4:8] = (88).to_bytes(4, 'little')
+                    tracked[role]['image']['hex'] = raw.hex()
+        self.assertEqual(before, m.question_signature(moved['checkpoints'], moved['transitions']))
+        moved['transitions'][0]['tracked_data_pages'][0]['after']['available'] = False
+        self.assertNotEqual(before, m.question_signature(moved['checkpoints'], moved['transitions']))
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Preregister finite DAO deletion transitions needed for preservation-aware row deletion. Tail, middle, and sole-row cases each retain closed before/delete/follow-on-insert captures across three replicas, with full byte differences, slot directories, row counts, and allocation maps.

Stable observations remain answered even if the tombstone hypothesis is false. Independent review, four focused tests, committed pins, PowerShell parser preflight, and final `just ready` passed. No acquisition has run yet; failures are retained without retry.
