### PR TITLE
feat: update present fixed-width scalar fields safely

### DIFF
--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -267,6 +267,42 @@ pub fn encode_row(
     Ok(ByteCount::new(writer.position().get()))
 }
 
+/// Encodes one present fixed field after the same layout/value checks as a row.
+pub(crate) fn encode_present_fixed_field(
+    ordinal: u16,
+    column: RowColumnLayout,
+    value: RowValue<'_>,
+    output: &mut [u8],
+    budget: &mut ResourceBudget,
+) -> Result<usize, RowWriteError> {
+    budget.charge_items(1).map_err(RowWriteError::Resource)?;
+    let ColumnStorageClass::Fixed { offset } = column.storage else {
+        return Err(RowWriteError::InvalidStorage {
+            ordinal,
+            physical_type: column.physical_type,
+        });
+    };
+    if column.physical_type == ColumnPhysicalType::Boolean || matches!(value, RowValue::Null) {
+        return Err(RowWriteError::TypeMismatch {
+            ordinal,
+            physical_type: column.physical_type,
+        });
+    }
+    let mut next_offset = offset;
+    validate_column_layout(ordinal, column, &mut next_offset)?;
+    let width = value_width(ordinal, column, value)?;
+    let available = output.len();
+    let target = output
+        .get_mut(..width)
+        .ok_or(RowWriteError::OutputTooSmall {
+            needed: width,
+            available,
+        })?;
+    let mut writer = BinaryWriter::new(target, budget).map_err(RowWriteError::Resource)?;
+    write_scalar(&mut writer, value).map_err(RowWriteError::Resource)?;
+    Ok(width)
+}
+
 fn validate(
     columns: &[RowColumnLayout],
     values: &[RowValue<'_>],

--- a/crates/jet3/src/update.rs
+++ b/crates/jet3/src/update.rs
@@ -1,5 +1,5 @@
 //! Preservation-aware field updates using `EXP-0059` schema, `SRC-0020`/
-//! `EXP-0060` row spans, the signed Long encoding from `EXP-0061`, and
+//! `EXP-0060` row spans, the fixed scalar encodings from `EXP-0061`, and
 //! `EXP-0073`/`EXP-0114` relationship catalog endpoints.
 
 use std::convert::Infallible;
@@ -25,7 +25,7 @@ pub struct FieldUpdate<'a> {
     pub row: RowLocator,
     /// Column ordinal from that table's definition.
     pub column: ColumnOrdinal,
-    /// Replacement value; currently only an ordinary, present Long is supported.
+    /// Replacement value matching the present fixed-width column.
     pub value: RowValue<'a>,
 }
 
@@ -53,6 +53,8 @@ pub enum UpdateError {
     Rows(crate::RowError),
     /// Row directory failure.
     Directory(crate::RowDirectoryError),
+    /// Replacement value or fixed layout failed checked row encoding.
+    Encoding(crate::RowWriteError),
     /// Atomic publication failed; its stage indicates whether publication occurred.
     Publish(crate::PublishError),
 }
@@ -72,6 +74,7 @@ impl StdError for UpdateError {
             Self::Definition(source) => Some(source),
             Self::Rows(source) => Some(source),
             Self::Directory(source) => Some(source),
+            Self::Encoding(source) => Some(source),
             Self::Publish(source) => Some(source),
             Self::NotFound(_) | Self::Unsupported(_) | Self::Mismatch(_) => None,
         }
@@ -94,13 +97,16 @@ conversion!(crate::CatalogError, Catalog);
 conversion!(crate::TableDefinitionError, Definition);
 conversion!(crate::RowError, Rows);
 conversion!(crate::RowDirectoryError, Directory);
+conversion!(crate::RowWriteError, Encoding);
 conversion!(crate::PublishError, Publish);
 
-/// Replaces one present Long field in an unindexed, relationship-free user table.
+/// Replaces one present fixed field in an unindexed, relationship-free user table.
 ///
-/// Null transitions, AutoIncrement columns, hidden/overflow rows and other value
-/// types are unsupported. A missing or unreadable relationship catalog and
-/// unresolved non-ASCII relationship endpoint names are also refused.
+/// Supports Byte, Integer, Long, Currency, Single, Double, DateTime, GUID and
+/// exact-width fixed Text. Null transitions, Boolean presence bits, AutoIncrement,
+/// variable fields and hidden/overflow rows remain unsupported. A missing or
+/// unreadable relationship catalog and unresolved non-ASCII relationship endpoint
+/// names are also refused.
 /// The exact requested field bytes are the only bytes
 /// changed, including when the database contains opaque pages or unused space.
 /// Locators remain valid only while the source is unchanged: callers must exclude
@@ -127,9 +133,9 @@ where
     H: FnMut(PublishStage) -> Result<(), HE>,
     HE: StdError + Send + Sync + 'static,
 {
-    let RowValue::Long(value) = request.value else {
-        return Err(UpdateError::Unsupported("replacement must be Long"));
-    };
+    if matches!(request.value, RowValue::Null) {
+        return Err(UpdateError::Unsupported("null replacement"));
+    }
     let mut database = DatabaseReader::open(path, budget)?;
     let mut root = None;
     let mut relationship_root = None;
@@ -174,9 +180,17 @@ where
         .columns()
         .get(usize::from(request.column.get()))
         .ok_or(UpdateError::NotFound("column"))?;
-    if column.physical_type() != ColumnPhysicalType::Long || column.auto_increment() {
-        return Err(UpdateError::Unsupported("column must be ordinary Long"));
+    if column.auto_increment() || column.physical_type() == ColumnPhysicalType::Boolean {
+        return Err(UpdateError::Unsupported("AutoIncrement or Boolean column"));
     }
+    let mut replacement = [0; u8::MAX as usize];
+    let width = crate::row_writer::encode_present_fixed_field(
+        request.column.get(),
+        column.into(),
+        request.value,
+        &mut replacement,
+        budget,
+    )?;
     let mut original_page = [0; PAGE_BYTES];
     database.read_raw_page(request.row.page(), &mut original_page, budget)?;
     let directory = RowDirectory::validate(
@@ -189,7 +203,8 @@ where
     if entry.hidden() || entry.overflow() {
         return Err(UpdateError::Unsupported("hidden or overflow row"));
     }
-    let (relative, before) = {
+    let mut before = [0; u8::MAX as usize];
+    let relative = {
         let mut rows = database.rows(&definition, budget)?;
         let mut found = None;
         while let Some(row) = rows.next_row()? {
@@ -202,12 +217,13 @@ where
             let range = row
                 .present_fixed_field_range(request.column)
                 .ok_or(UpdateError::Unsupported("null or variable field"))?;
-            let bytes: [u8; 4] = row
+            let bytes = row
                 .field(request.column)
                 .and_then(|field| field.raw_bytes())
-                .and_then(|bytes| bytes.try_into().ok())
-                .ok_or(UpdateError::Mismatch("Long width"))?;
-            found = Some((range, bytes));
+                .filter(|bytes| bytes.len() == width && range.len() == width)
+                .ok_or(UpdateError::Mismatch("fixed field width"))?;
+            before[..width].copy_from_slice(bytes);
+            found = Some(range);
             break;
         }
         found.ok_or(UpdateError::NotFound("row"))?
@@ -221,13 +237,13 @@ where
         .checked_add(relative.start)
         .ok_or(UpdateError::Mismatch("field offset"))?;
     let end = start
-        .checked_add(before.len())
+        .checked_add(width)
         .ok_or(UpdateError::Mismatch("field end"))?;
-    if original_page.get(start..end) != Some(before.as_slice()) {
+    if original_page.get(start..end) != Some(&before[..width]) {
         return Err(UpdateError::Mismatch("source changed during planning"));
     }
     let mut patched = PageImage::from_bytes(original_page);
-    patched.write_at(PageOffset::new(start as u64), &value.to_le_bytes(), budget)?;
+    patched.write_at(PageOffset::new(start as u64), &replacement[..width], budget)?;
     let page_offset = request
         .row
         .page()
@@ -243,7 +259,7 @@ where
         path,
         budget,
         |file, budget| -> Result<(), UpdateError> {
-            budget.charge_work_units(before.len() as u64)?;
+            budget.charge_work_units(width as u64)?;
             file.seek(SeekFrom::Start(offset))?;
             file.write_all(&patched.as_bytes()[start..end])?;
             Ok(())

--- a/crates/jet3/src/update_fixed_tests.rs
+++ b/crates/jet3/src/update_fixed_tests.rs
@@ -1,0 +1,214 @@
+use super::*;
+use std::num::NonZeroU8;
+
+fn replace_and_compare(
+    kind: ColumnType,
+    initial: RowValue<'_>,
+    replacement: RowValue<'_>,
+    raw: &[u8],
+) -> TestResult {
+    let fixture = Fixture::new(
+        &[
+            ColumnSpec::new(b"Left", ColumnType::Long),
+            ColumnSpec::new(b"Target", kind),
+            ColumnSpec::new(b"Right", ColumnType::Long),
+        ],
+        &[&[RowValue::Long(123), initial, RowValue::Long(-456)]],
+    )?;
+    let row = fixture.locator(0)?;
+    let mut original = fs::read(fixture.path())?;
+    original[row.page().get() as usize * PAGE_BYTES + 100] = 0xa9;
+    original.extend_from_slice(&[0xe7; PAGE_BYTES]);
+    fs::write(fixture.path(), &original)?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    let definition = db.table_definition(crate::PageNumber::new(20), &mut b)?;
+    let relative = {
+        let mut rows = db.rows(&definition, &mut b)?;
+        rows.next_row()?
+            .ok_or("missing row")?
+            .present_fixed_field_range(ColumnOrdinal::new(1))
+            .ok_or("missing field")?
+    };
+    assert_eq!(relative.len(), raw.len());
+    let mut page = [0; PAGE_BYTES];
+    db.read_raw_page(row.page(), &mut page, &mut b)?;
+    let directory = RowDirectory::validate(row.page(), definition.root(), &page, &mut b)?;
+    let start = row.page().get() as usize * PAGE_BYTES
+        + directory.entry(&page, row.slot())?.range().start
+        + relative.start;
+    let mut expected = original;
+    expected[start..start + raw.len()].copy_from_slice(raw);
+    update_field(
+        fixture.path(),
+        FieldUpdate {
+            column: ColumnOrdinal::new(1),
+            ..request(row, replacement)
+        },
+        &mut budget(),
+    )?;
+    assert_eq!(fs::read(fixture.path())?, expected);
+    fixture.assert_only_original()
+}
+
+#[test]
+fn fixed_scalar_types_preserve_every_surrounding_byte() -> TestResult {
+    let guid = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    for (kind, initial, value, bytes) in [
+        (
+            ColumnType::Byte,
+            RowValue::Byte(0),
+            RowValue::Byte(u8::MAX),
+            vec![255],
+        ),
+        (
+            ColumnType::Integer,
+            RowValue::Integer(0),
+            RowValue::Integer(i16::MIN),
+            i16::MIN.to_le_bytes().to_vec(),
+        ),
+        (
+            ColumnType::Long,
+            RowValue::Long(0),
+            RowValue::Long(i32::MAX),
+            i32::MAX.to_le_bytes().to_vec(),
+        ),
+        (
+            ColumnType::Currency,
+            RowValue::Currency { scaled: 0 },
+            RowValue::Currency { scaled: i64::MIN },
+            i64::MIN.to_le_bytes().to_vec(),
+        ),
+        (
+            ColumnType::Single,
+            RowValue::Single(1.0),
+            RowValue::Single(-0.0),
+            (-0.0_f32).to_le_bytes().to_vec(),
+        ),
+        (
+            ColumnType::Double,
+            RowValue::Double(1.0),
+            RowValue::Double(-0.0),
+            (-0.0_f64).to_le_bytes().to_vec(),
+        ),
+        (
+            ColumnType::DateTime,
+            RowValue::DateTime { days: 1.0 },
+            RowValue::DateTime { days: -1.25 },
+            (-1.25_f64).to_le_bytes().to_vec(),
+        ),
+        (
+            ColumnType::Guid,
+            RowValue::Guid([0; 16]),
+            RowValue::Guid(guid),
+            vec![3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15],
+        ),
+    ] {
+        replace_and_compare(kind, initial, value, &bytes)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn fixed_text_exact_width_boundaries_and_mismatches() -> TestResult {
+    for width in [1_u8, 255] {
+        let len = NonZeroU8::new(width).ok_or("zero width")?;
+        let original = vec![b'a'; usize::from(width)];
+        let replacement = vec![0xe9; usize::from(width)];
+        replace_and_compare(
+            ColumnType::FixedText { len },
+            RowValue::Text(&original),
+            RowValue::Text(&replacement),
+            &replacement,
+        )?;
+        let fixture = Fixture::new(
+            &[ColumnSpec::new(b"Target", ColumnType::FixedText { len })],
+            &[&[RowValue::Text(&original)]],
+        )?;
+        let bytes = fs::read(fixture.path())?;
+        for bad in [
+            vec![b'b'; usize::from(width) - 1],
+            vec![b'b'; usize::from(width) + 1],
+        ] {
+            assert!(matches!(
+                update_field(
+                    fixture.path(),
+                    request(fixture.locator(0)?, RowValue::Text(&bad)),
+                    &mut budget()
+                ),
+                Err(UpdateError::Encoding(
+                    crate::RowWriteError::InvalidWidth { .. }
+                ))
+            ));
+            assert_eq!(fs::read(fixture.path())?, bytes);
+            fixture.assert_only_original()?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn checked_single_field_encoder_rejects_noop_and_invalid_layouts() -> TestResult {
+    use crate::{ColumnPhysicalType as T, ColumnStorageClass as S, RowColumnLayout as L};
+    for (layout, value) in [
+        (L::new(T::Long, S::Fixed { offset: 0 }, 4), RowValue::Null),
+        (
+            L::new(T::Long, S::Fixed { offset: 0 }, 4),
+            RowValue::AutoIncrement,
+        ),
+        (
+            L::new(T::Long, S::Fixed { offset: 0 }, 4),
+            RowValue::Byte(1),
+        ),
+        (
+            L::new(T::Long, S::Fixed { offset: 0 }, 5),
+            RowValue::Long(1),
+        ),
+        (
+            L::new(T::Long, S::Fixed { offset: u16::MAX }, 4),
+            RowValue::Long(1),
+        ),
+        (
+            L::new(T::Boolean, S::Fixed { offset: 0 }, 1),
+            RowValue::Boolean(true),
+        ),
+        (
+            L::new(T::Text, S::Variable { index: 0 }, 4),
+            RowValue::Text(b"text"),
+        ),
+        (
+            L::new(T::Binary, S::Fixed { offset: 0 }, 4),
+            RowValue::Binary(b"data"),
+        ),
+        (
+            L::new(T::Memo, S::Variable { index: 0 }, 0),
+            RowValue::LongValue(&[0; 12]),
+        ),
+    ] {
+        let mut output = [0xa5; 16];
+        assert!(
+            crate::row_writer::encode_present_fixed_field(
+                3,
+                layout,
+                value,
+                &mut output,
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(output, [0xa5; 16]);
+    }
+    let mut output = [0xa5; 3];
+    assert!(matches!(
+        crate::row_writer::encode_present_fixed_field(
+            3,
+            L::new(T::Long, S::Fixed { offset: 7 }, 4),
+            RowValue::Long(1),
+            &mut output,
+            &mut budget()
+        ),
+        Err(crate::RowWriteError::OutputTooSmall { .. })
+    ));
+    assert_eq!(output, [0xa5; 3]);
+    Ok(())
+}

--- a/crates/jet3/src/update_tests.rs
+++ b/crates/jet3/src/update_tests.rs
@@ -183,7 +183,7 @@ fn bad_requests_and_resource_failures_preserve_original() -> TestResult {
 }
 
 #[test]
-fn auto_and_non_long_columns_are_refused() -> TestResult {
+fn auto_columns_and_mismatched_values_are_refused() -> TestResult {
     for (kind, initial) in [
         (ColumnType::AutoIncrement, RowValue::AutoIncrement),
         (ColumnType::Byte, RowValue::Byte(1)),
@@ -196,7 +196,7 @@ fn auto_and_non_long_columns_are_refused() -> TestResult {
                 request(fixture.locator(0)?, RowValue::Long(2)),
                 &mut budget()
             ),
-            Err(UpdateError::Unsupported(_))
+            Err(UpdateError::Unsupported(_) | UpdateError::Encoding(_))
         ));
         assert_eq!(fs::read(fixture.path())?, original);
     }
@@ -505,3 +505,6 @@ fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
     }
     Ok(())
 }
+
+#[path = "update_fixed_tests.rs"]
+mod fixed;


### PR DESCRIPTION
Extend existing-file field updates from Long to supported present fixed-width scalar fields, including exact-width fixed Text. Reuse the checked row encoder, enforce the stored field width, and retain full-file verification that every byte outside the requested span is unchanged.

Null transitions, Boolean-bit storage, AutoIncrement, variable-length values, indexes, and relationships remain refused. Independent review, thirteen focused update tests, Clippy, and final `just ready` passed. This adds no DAO compatibility claim for the new types.
