### PR TITLE
test: preregister retained deletion transition reanalysis

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11024,6 +11024,38 @@ Copy this block under the appropriate section and remove this instruction:
   Neither this plan nor self-validation establishes general compatibility,
   completion of #100 or support-matrix movement.
 
+## EXP-0161 — Pinned post-acquisition deletion comparison plan
+
+- Date: 2026-09-05.
+- Status: committed secondary-analysis plan; independent review and execution pending.
+- Plan: `oracle/windows-dao/acquisition/row-delete-reanalysis.plan.json`,
+  SHA-256 `cc9b9ac21f6910dbaf696540a3e5f0b2007fcb80b56506f70c9e4e3aec1c48a5`.
+- Source: EXP-0157 run `20260905T064000Z-row-delete-layout`, whose original
+  EXP-0158 outcome remains `no_outcome`. This is explicitly post-acquisition
+  secondary analysis, not preregistration of another acquisition.
+- Inputs: the plan pins the unchanged original plan, analyzer, decoder and
+  acquisition inputs, the new secondary analyzer, and all 40 retained files,
+  including the original result/report and all 27 checkpoint MDB identities.
+- Question: do the three replica transitions agree when unused bytes that
+  remain unchanged within each transition are retained as diagnostics rather
+  than required to have the same initial contents across fresh databases?
+- Finite comparison change: for decoded data-page pairs, compare exact header,
+  directory and stored-row spans from both states plus every changed byte.
+  Validate directory/row boundaries before deriving these spans. Preserve the
+  original exclusion of owner-address bytes `[4, 8)`; leave non-data images
+  and every other signature component unchanged. Changed unused bytes remain
+  comparison-bearing. Retain full original page images and whole-file change
+  ranges and enumerate every omitted unchanged unused span with its raw bytes.
+- Execution: reproduce the original report byte-identically first on temporary
+  copies, then use an isolated analyzer instance with only the comparison
+  function replaced. Require identical raw observations and preserve all
+  original acquisition/schema/row/identity/map/classification gates. Verify
+  input and artifact pins before and after; output must be new and outside
+  the source outbox. No DAO, new captures, redispatch or original-file edits.
+- Review must precede secondary execution. Record its outcome separately as
+  EXP-0162. No deletion implementation, compatibility or support claim follows
+  from this plan.
+
 ## EXP-0158 — Deletion acquisition retained with replica-disagreement no outcome
 
 - Recorded: 2026-09-05, OpenAI Codex; validated `no_outcome` from the single

--- a/oracle/windows-dao/acquisition/row-delete-reanalysis.plan.json
+++ b/oracle/windows-dao/acquisition/row-delete-reanalysis.plan.json
@@ -1,0 +1,200 @@
+{
+  "experiment": "EXP-0161",
+  "outcome": "EXP-0162",
+  "kind": "post-acquisition retained-artifact secondary analysis",
+  "source_commit": "df987adb3b445e3c59e0f7b4f251bb92fdd83100",
+  "source_run": "20260905T064000Z-row-delete-layout",
+  "source_outcome": "no_outcome",
+  "comparison_change": "For pairs of decoded data pages only, replace whole-page bytes excluding owner with exact header/directory/stored-row bytes from both states plus every byte changed within the transition. Omit only unchanged bytes outside both active spans. Owner bytes 4..8 remain excluded exactly as in the original signature. Non-data pages and all other signature fields unchanged.",
+  "gates": "Reproduce original report exactly first; original acquisition, schema, identity, row, map, structural and classification checks unchanged. Require raw observations identical. Retain complete raw pages and whole-file changed ranges, and explicitly enumerate omitted unchanged unused spans including their raw bytes. Replica disagreement remains no_outcome. Original result and report never overwritten.",
+  "execution": "Commit and independently review this secondary plan before analysis. Preflight only hashes inputs/artifacts. Analyze on temporary copies with output outside source outbox and no overwrite; no DAO, redispatch, new capture, or retry. This plan is post-acquisition, not a preregistration of new acquisition.",
+  "scope": "Only the three tail/middle/sole arms and three replicas captured in EXP-0157. No deletion API, compatibility or support claim.",
+  "inputs": {
+    "oracle/windows-dao/scripts/row_delete_reanalysis.py": {
+      "size": 6799,
+      "sha256": "81a1d83905a92c371380a5b5dbe0af11dfe1ab8cbec40a141bd9a6150c176d1c"
+    },
+    "oracle/windows-dao/scripts/row_delete_layout.py": {
+      "size": 13471,
+      "sha256": "74c30a55148ec5efe4c04a154917e8780c06a63442d28c0d0b3453b968142088"
+    },
+    "oracle/windows-dao/scripts/system_catalog.py": {
+      "size": 74849,
+      "sha256": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9"
+    },
+    "oracle/windows-dao/acquisition/row-delete-layout.plan.json": {
+      "size": 3670,
+      "sha256": "18c24390fc6429d839139719ccc11ae6049a236f77e42062592ee7f315355e7a"
+    },
+    "oracle/windows-dao/scripts/row_delete_layout.ps1": {
+      "size": 5797,
+      "sha256": "0d7507eefe0e4ecc76e87c57e79f6b8667a9b35533bffebb38ab6845a6a16a5f"
+    },
+    "scripts/windows-dao-ps.py": {
+      "size": 5676,
+      "sha256": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+    }
+  },
+  "artifacts": {
+    "exit.txt": {
+      "size": 3,
+      "sha256": "13bf7b3039c63bf5a50491fa3cfd8eb4e699d1ba1436315aef9cbe5711530354"
+    },
+    "log.txt": {
+      "size": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "middle-r1-before.mdb": {
+      "size": 49152,
+      "sha256": "b992dc77b3ac2516514d7d3dbf9e665997eb917249ae96ef31730d5a34748597"
+    },
+    "middle-r1-deleted.mdb": {
+      "size": 49152,
+      "sha256": "2e54fff7084cb44b019771b7c8529de7fb683c2cb192e633faa79ddb4f00bb59"
+    },
+    "middle-r1-inserted.mdb": {
+      "size": 49152,
+      "sha256": "9487a40c2e0a89762970ce5e18d7d70a6d5322decf49069c6171fdb850214974"
+    },
+    "middle-r1-working.mdb": {
+      "size": 49152,
+      "sha256": "9487a40c2e0a89762970ce5e18d7d70a6d5322decf49069c6171fdb850214974"
+    },
+    "middle-r2-before.mdb": {
+      "size": 49152,
+      "sha256": "f34dcc03fdb8c0f8f5abf53f34c5a077804735675ae55bd3a634fe68614fb009"
+    },
+    "middle-r2-deleted.mdb": {
+      "size": 49152,
+      "sha256": "27a3dcd694d3739a3eb8d3355e408d6969331a827c897c0a502b016e698643b6"
+    },
+    "middle-r2-inserted.mdb": {
+      "size": 49152,
+      "sha256": "9776f310104991a996b16b4742b3bebe0eaaff069912c2beb27856c595d6c91c"
+    },
+    "middle-r2-working.mdb": {
+      "size": 49152,
+      "sha256": "9776f310104991a996b16b4742b3bebe0eaaff069912c2beb27856c595d6c91c"
+    },
+    "middle-r3-before.mdb": {
+      "size": 49152,
+      "sha256": "38eb1d22e5617fd4e67b4ea3d963edcb688f34c3f659a5bb1179ce00feb5d546"
+    },
+    "middle-r3-deleted.mdb": {
+      "size": 49152,
+      "sha256": "76ed5fa0f24b73803d2307a989f5e57b1a84e183bd6dc044ed6cce2ae40fe62e"
+    },
+    "middle-r3-inserted.mdb": {
+      "size": 49152,
+      "sha256": "b983087d66ca42717507f8a84389073cf73726ab62fb40e2d032af1549a11865"
+    },
+    "middle-r3-working.mdb": {
+      "size": 49152,
+      "sha256": "b983087d66ca42717507f8a84389073cf73726ab62fb40e2d032af1549a11865"
+    },
+    "report.json": {
+      "size": 537270,
+      "sha256": "4ae900dea9a46d5400855698a09a6097ec0e3dec2a57f46251ab78ec6755b9a6"
+    },
+    "result.json": {
+      "size": 130713,
+      "sha256": "669248d038f9a910d0ec5870cf45f33587a1c3cc400823bdea388e56e0342bc4"
+    },
+    "sole-r1-before.mdb": {
+      "size": 49152,
+      "sha256": "9498b3fad5b202b238dd537b523337bf024387b5954524cd5db096649f23ddcc"
+    },
+    "sole-r1-deleted.mdb": {
+      "size": 49152,
+      "sha256": "8ba62799344e3794dbca59bcdcb55e068629b7daf8bd1f5f9c1abd540f26d080"
+    },
+    "sole-r1-inserted.mdb": {
+      "size": 49152,
+      "sha256": "9cd22d0eba942cad7cc463e30e9031d43a3353cb02856cb752a58683fa51fa4f"
+    },
+    "sole-r1-working.mdb": {
+      "size": 49152,
+      "sha256": "9cd22d0eba942cad7cc463e30e9031d43a3353cb02856cb752a58683fa51fa4f"
+    },
+    "sole-r2-before.mdb": {
+      "size": 49152,
+      "sha256": "7c3413b1c19781c62f2b3153ae415b37bed39ee7dbad01274f56da079d2aac2c"
+    },
+    "sole-r2-deleted.mdb": {
+      "size": 49152,
+      "sha256": "a641ef85ab99c091d1acc377df3593a9792a093c68dbfdcd813ff2463db6eb24"
+    },
+    "sole-r2-inserted.mdb": {
+      "size": 49152,
+      "sha256": "1d449c652891723eb0d992714ddb2e99312905e1ff7b482b39c07ba3d0ea5777"
+    },
+    "sole-r2-working.mdb": {
+      "size": 49152,
+      "sha256": "1d449c652891723eb0d992714ddb2e99312905e1ff7b482b39c07ba3d0ea5777"
+    },
+    "sole-r3-before.mdb": {
+      "size": 49152,
+      "sha256": "da83ed50150ecf8f079dd1cf6e9e80a267cd469481a1dd8218c58e5f85d1d35f"
+    },
+    "sole-r3-deleted.mdb": {
+      "size": 49152,
+      "sha256": "4b6a47c40670243bf65a4c049868069afd4caf39c5851ce8fb11a46aae6dad16"
+    },
+    "sole-r3-inserted.mdb": {
+      "size": 49152,
+      "sha256": "67f676fc50fa31d39df749d9e37dc127716d68a2e5aa5df4300bc164a7c83e99"
+    },
+    "sole-r3-working.mdb": {
+      "size": 49152,
+      "sha256": "67f676fc50fa31d39df749d9e37dc127716d68a2e5aa5df4300bc164a7c83e99"
+    },
+    "tail-r1-before.mdb": {
+      "size": 49152,
+      "sha256": "f274a501b440e5bf323bbee9801350b4e6519e1ed1f9d208f1431bc688c12563"
+    },
+    "tail-r1-deleted.mdb": {
+      "size": 49152,
+      "sha256": "877f9769323caedbfa7f15f22b23e512328ef7089511ab3b7d03c2ab30b39f2f"
+    },
+    "tail-r1-inserted.mdb": {
+      "size": 49152,
+      "sha256": "c3e2b325b7ca8b014b7a59076bf423dd84b3d6f49208dd45079372b48eacf3f1"
+    },
+    "tail-r1-working.mdb": {
+      "size": 49152,
+      "sha256": "c3e2b325b7ca8b014b7a59076bf423dd84b3d6f49208dd45079372b48eacf3f1"
+    },
+    "tail-r2-before.mdb": {
+      "size": 49152,
+      "sha256": "2b2bfe4f1c17971046cd2ea4ff974e9efb6a364e2af3833843c446da84b1dc0d"
+    },
+    "tail-r2-deleted.mdb": {
+      "size": 49152,
+      "sha256": "1935d21bf8fcf8223fb051f48af11d3e232198cb088b156d0069102be39a51ef"
+    },
+    "tail-r2-inserted.mdb": {
+      "size": 49152,
+      "sha256": "754ed876e8f30567c0f6a74b411d029297bf566fcce1839ace635e13af18d4e9"
+    },
+    "tail-r2-working.mdb": {
+      "size": 49152,
+      "sha256": "754ed876e8f30567c0f6a74b411d029297bf566fcce1839ace635e13af18d4e9"
+    },
+    "tail-r3-before.mdb": {
+      "size": 49152,
+      "sha256": "19640771b4ec7ec13a17181d27ea457520cac730502bd34c56e4942463d36a13"
+    },
+    "tail-r3-deleted.mdb": {
+      "size": 49152,
+      "sha256": "176524ca2a2f04a116c9aea2b6726ad8ecadf43c5e499966eb3777ceed31fb6d"
+    },
+    "tail-r3-inserted.mdb": {
+      "size": 49152,
+      "sha256": "6064ba76f3d974246ea8e377c99d1310332f7399586ad2d728412709b554b3bf"
+    },
+    "tail-r3-working.mdb": {
+      "size": 49152,
+      "sha256": "6064ba76f3d974246ea8e377c99d1310332f7399586ad2d728412709b554b3bf"
+    }
+  }
+}

--- a/oracle/windows-dao/scripts/row_delete_reanalysis.py
+++ b/oracle/windows-dao/scripts/row_delete_reanalysis.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""EXP-0161: post-acquisition deletion analysis; no DAO or capture path."""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import shutil
+
+import row_delete_layout as original
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/row-delete-reanalysis.plan.json'
+
+
+def verify(outbox):
+    plan = json.loads(PLAN.read_text())
+    for name, expected in plan['inputs'].items():
+        if original.identity(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    for name, expected in plan['artifacts'].items():
+        if original.identity(outbox / name) != expected:
+            raise ValueError('Artifact pin mismatch: ' + name)
+    return plan
+
+
+def active_bytes(image):
+    raw = bytes.fromhex(image['hex'])
+    entries = image['directory']
+    if len(raw) != 2048 or raw[0] != 1 or entries is None:
+        raise ValueError('Expected decoded data page')
+    end = 10 + 2 * len(entries)
+    if int.from_bytes(raw[8:10], 'little') != len(entries) or end > len(raw):
+        raise ValueError('Directory boundary mismatch')
+    active = set(range(end))
+    previous = len(raw)
+    for ordinal, entry in enumerate(entries):
+        start, stop = entry['start'], entry['end']
+        if entry['row'] != ordinal or not end <= start <= stop <= previous:
+            raise ValueError('Stored row boundary mismatch')
+        if raw[start:stop].hex() != entry['raw_hex']:
+            raise ValueError('Stored row bytes mismatch')
+        active.update(range(start, stop)); previous = start
+    return raw, active
+
+
+def spans(positions):
+    result = []
+    for position in sorted(positions):
+        if result and result[-1][1] == position: result[-1][1] += 1
+        else: result.append([position, position + 1])
+    return result
+
+
+def signature(checkpoints, transitions):
+    result = original.question_signature(checkpoints, transitions)
+    for movement, projected in zip(transitions, result['transitions']):
+        for tracked, pair in zip(movement['tracked_data_pages'], projected['tracked']):
+            images = [tracked[role]['image'] for role in ('before', 'after')]
+            if not all(image and image['directory'] is not None for image in images):
+                continue
+            before, active_before = active_bytes(images[0])
+            after, active_after = active_bytes(images[1])
+            # Retain all changed bytes, even when outside either state's stored rows.
+            selected = active_before | active_after | {i for i in range(2048) if before[i] != after[i]}
+            selected.difference_update(range(4, 8))  # Existing owner-address exclusion.
+            ranges = spans(selected)
+            for state, raw in zip(pair, (before, after)):
+                del state['page_bytes_without_owner']
+                state['compared_ranges'] = [[start, end, raw[start:end].hex()] for start, end in ranges]
+    return result
+
+
+def slack_diagnostics(observations):
+    diagnostics = []
+    for observation in observations:
+        for number, movement in enumerate(observation['transitions']):
+            for tracked in movement['tracked_data_pages']:
+                images = [tracked[role]['image'] for role in ('before', 'after')]
+                if not all(image and image['directory'] is not None for image in images): continue
+                before, first = active_bytes(images[0]); after, second = active_bytes(images[1])
+                ignored = set(range(2048)) - first - second
+                ignored = {i for i in ignored if before[i] == after[i]}
+                diagnostics.append(dict(arm=observation['arm'], replica=observation['replica'],
+                    transition=number, page=tracked['page'], unchanged_unused_ranges=
+                    [[start, end, before[start:end].hex()] for start, end in spans(ignored)]))
+    return diagnostics
+
+
+def build_report(outbox):
+    plan = verify(outbox)
+    with tempfile.TemporaryDirectory(prefix='jet3-delete-secondary-') as directory:
+        temporary = Path(directory)
+        for name in plan['artifacts']: shutil.copyfile(outbox / name, temporary / name)
+        original_plan = original.verify_inputs()
+        result = json.loads((temporary / 'result.json').read_text(encoding='utf-8-sig'))
+        prior = original.build_report(result, temporary, original_plan)
+        prior['result_sha256'] = original.identity(temporary / 'result.json')['sha256']
+        if (original.canonical(prior) + '\n').encode() != (temporary / 'report.json').read_bytes():
+            raise ValueError('Original report does not reproduce')
+        if prior['outcome'] != 'no_outcome': raise ValueError('Expected original no_outcome')
+        spec = importlib.util.spec_from_file_location('private_delete_secondary', ROOT / 'oracle/windows-dao/scripts/row_delete_layout.py')
+        private = importlib.util.module_from_spec(spec); spec.loader.exec_module(private)
+        private.question_signature = signature
+        revised = private.build_report(result, temporary, original_plan)
+    if revised['observations'] != prior['observations']:
+        raise ValueError('Secondary analysis changed raw observations')
+    revised.update(document_type='dao_row_delete_secondary_report', secondary_analysis=True,
+        plan_sha256=original.identity(PLAN)['sha256'], source_outcome=prior['outcome'],
+        source_reasons=prior['reasons'], source_report=plan['artifacts']['report.json'],
+        source_result=plan['artifacts']['result.json'], comparison_change=plan['comparison_change'],
+        unused_bytes=slack_diagnostics(revised['observations']))
+    verify(outbox)
+    return revised
+
+
+def analyze(outbox, output):
+    if output.resolve().is_relative_to(outbox.resolve()):
+        raise ValueError('Output must be outside source outbox')
+    if output.exists(): raise ValueError('Output already exists')
+    report = build_report(outbox)
+    with output.open('x') as stream: stream.write(original.canonical(report) + '\n')
+    print(report['outcome'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=['preflight', 'analyze'])
+    parser.add_argument('outbox', type=Path); parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    verify(args.outbox)
+    if subprocess.check_output(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Secondary plan must be committed')
+    if args.command == 'analyze':
+        if args.output is None: parser.error('--output required')
+        analyze(args.outbox, args.output)
+    else: print('Committed secondary inputs and retained artifacts match.')
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/tests/test_row_delete_reanalysis.py
+++ b/oracle/windows-dao/tests/test_row_delete_reanalysis.py
@@ -1,0 +1,61 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import row_delete_reanalysis as secondary
+
+
+class SecondaryTests(unittest.TestCase):
+    def image(self):
+        raw = bytearray(2048); raw[0] = 1; raw[8:10] = (1).to_bytes(2, 'little')
+        raw[10:12] = (2040).to_bytes(2, 'little'); raw[2040:] = b'abcdefgh'
+        return dict(hex=raw.hex(), directory=[dict(row=0, start=2040, end=2048, raw_hex=raw[2040:].hex(), raw_word=2040)])
+
+    def signature(self, image, changed=None):
+        checks = {name: dict(row_count=1, rows=[]) for name in ('before', 'deleted', 'inserted')}
+        state = dict(image=image, owned=True, available=True, globally_free=False)
+        movement = dict(tracked_data_pages=[dict(before=state, after=dict(state, image=changed or image))],
+            row_count_before=1, row_count_after=1, page_count_before=24, page_count_after=24,
+            global_free_added=[], global_free_removed=[])
+        return secondary.signature(checks, [movement])
+
+    def test_only_unchanged_unused_bytes_are_excluded(self):
+        image = self.image(); other = copy.deepcopy(image)
+        raw = bytearray.fromhex(other['hex']); raw[100] = 99; other['hex'] = raw.hex()
+        self.assertEqual(self.signature(image), self.signature(other))
+        self.assertNotEqual(self.signature(image), self.signature(image, other))
+        raw[2] = 3; other['hex'] = raw.hex()
+        self.assertNotEqual(self.signature(image), self.signature(other))
+        bad = self.image(); bad['directory'][0]['start'] = 11
+        with self.assertRaisesRegex(ValueError, 'boundary'): self.signature(bad)
+        bad = self.image(); bad['directory'][0]['raw_hex'] = '00'
+        with self.assertRaisesRegex(ValueError, 'row bytes'): self.signature(bad)
+
+    def test_pins_and_output_preservation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory); source = root / 'source'; source.mkdir()
+            artifact = source / 'report.json'; artifact.write_text('original')
+            code = root / 'code.py'; code.write_text('code')
+            plan = root / 'plan.json'
+            plan.write_text(json.dumps(dict(inputs={'code.py': secondary.original.identity(code)},
+                artifacts={'report.json': secondary.original.identity(artifact)})))
+            with patch.object(secondary, 'ROOT', root), patch.object(secondary, 'PLAN', plan):
+                secondary.verify(source)
+                code.write_text('changed')
+                with self.assertRaisesRegex(ValueError, 'Input pin'): secondary.verify(source)
+                code.write_text('code'); artifact.write_text('changed')
+                with self.assertRaisesRegex(ValueError, 'Artifact pin'): secondary.verify(source)
+            nested = source / 'nested'; nested.mkdir()
+            for output in (artifact, nested / 'new.json'):
+                with self.assertRaisesRegex(ValueError, 'outside source'): secondary.analyze(source, output)
+            existing = root / 'existing.json'; existing.write_text('preserve')
+            with self.assertRaisesRegex(ValueError, 'already exists'): secondary.analyze(source, existing)
+            self.assertEqual(existing.read_text(), 'preserve')
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Preregister a read-only secondary analysis of retained deletion transitions. The original full-page replica comparison rejected unchanged unused-byte differences; compare the union of before/after header, directory, and stored-row spans while retaining every changed byte and all original raw observations.

Original no-outcome and all forty source artifacts remain pinned and immutable. Independent review, two focused tests, committed artifact verification, and final `just ready` passed. No corrected analysis has run yet.
