### PR TITLE
test: preregister fixed-field update preservation matrix

### DIFF
--- a/crates/jet3/examples/fixed_field_update_candidate.rs
+++ b/crates/jet3/examples/fixed_field_update_candidate.rs
@@ -1,0 +1,107 @@
+//! Update a closed DAO-created copy through the public API for EXP-0163.
+use jet3::{
+    CatalogObjectClass, DatabaseReader, FieldUpdate, ResourceBudget, ResourceLimits, RowValue,
+    update_field,
+};
+use std::{env, fs, path::Path};
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = env::args().skip(1).collect();
+    let [source, destination, table, selected_id, column, replacement] = args.as_slice() else {
+        return Err(
+            "usage: fixed_field_update_candidate SOURCE DESTINATION TABLE ORIGINAL_ID COLUMN ARM"
+                .into(),
+        );
+    };
+    if Path::new(destination).exists() {
+        return Err("destination exists".into());
+    }
+    let selected_id: i32 = selected_id.parse()?;
+    let text = vec![
+        0xe9;
+        if replacement == "fixed-text-255" {
+            255
+        } else {
+            1
+        }
+    ];
+    let replacement = match replacement.as_str() {
+        "byte" => RowValue::Byte(u8::MAX),
+        "integer" => RowValue::Integer(i16::MIN),
+        "long-control" => RowValue::Long(i32::MIN),
+        "currency" => RowValue::Currency { scaled: i64::MIN },
+        "single" => RowValue::Single(-0.0),
+        "double" => RowValue::Double(-0.0),
+        "date" => RowValue::DateTime { days: -1.25 },
+        "guid" => RowValue::Guid([
+            0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff,
+        ]),
+        "fixed-text-1" | "fixed-text-255" => RowValue::Text(&text),
+        _ => return Err("unknown fixed-field arm".into()),
+    };
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let mut database = DatabaseReader::open(source, &mut budget)?;
+    let root = {
+        let mut catalog = database.catalog(&mut budget)?;
+        let mut roots = Vec::new();
+        while let Some(record) = catalog.next_record()? {
+            if record.class() == CatalogObjectClass::User
+                && record.name().raw_bytes() == table.as_bytes()
+            {
+                roots.push(record.table_definition().ok_or("not a table")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("table not unique".into());
+        }
+        roots[0]
+    };
+    let definition = database.table_definition(root, &mut budget)?;
+    let id = definition
+        .columns()
+        .iter()
+        .find(|c| c.name().raw_bytes() == b"Id")
+        .ok_or("Id absent")?
+        .ordinal();
+    let column = definition
+        .columns()
+        .iter()
+        .find(|c| c.name().raw_bytes() == column.as_bytes())
+        .ok_or("column absent")?
+        .ordinal();
+    let locator = {
+        let mut rows = database.rows(&definition, &mut budget)?;
+        let mut found = Vec::new();
+        while let Some(row) = rows.next_row()? {
+            if row.field(id).and_then(|field| field.raw_bytes())
+                == Some(selected_id.to_le_bytes().as_slice())
+            {
+                found.push(row.locator());
+            }
+        }
+        if found.len() != 1 {
+            return Err("selected Id not unique".into());
+        }
+        found[0]
+    };
+    drop(database);
+    fs::copy(source, destination)?;
+    update_field(
+        destination,
+        FieldUpdate {
+            table: table.as_bytes(),
+            row: locator,
+            column,
+            value: replacement,
+        },
+        &mut budget,
+    )?;
+    println!(
+        "{{\"root\":{},\"page\":{},\"slot\":{},\"column\":{}}}",
+        root.get(),
+        locator.page().get(),
+        locator.slot(),
+        column.get()
+    );
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11110,6 +11110,33 @@ Copy this block under the appropriate section and remove this instruction:
   updates, deletion/insertion, arbitrary existing-file compatibility or
   hosted update support. Report compatibility/support flags remain false.
 
+## EXP-0163 — Typed existing fixed-field update preregistration
+
+- Status: preregistered only, no acquisition; outcome reserved as EXP-0164.
+- Question: can the reviewed public fixed-field extension `37bd817` change
+  exactly the requested present field in existing DAO-created databases while
+  preserving every unrelated byte, full metadata/rows and stored query SQL?
+- Pinned plan: `oracle/windows-dao/acquisition/fixed-field-update.plan.json`,
+  SHA-256 `c6958a5b238c6cee97f877ec12cf53b93ad699db190fb0aceec769045794c564`.
+- Ten arms, three replicas each: Byte 0 to 255; Integer 32767 to -32768;
+  Long 1 to -2147483648 control; Currency zero to scaled i64 minimum; Single
+  and Double 1 to exact negative-zero bits; Date OA 1 to -1.25; zero GUID to
+  `00112233-4455-6677-8899-aabbccddeeff`; fixed Text widths 1 and 255 from
+  ASCII `a` to CP1252 `é`, preserving the declared width.
+- Each original has three Items rows, an unrelated three-row Long/Text Later
+  table, and KeepQuery. Fixed Text must save with fixed attributes and actual
+  fixed storage. Negative-zero bits are compared exactly, never normalized.
+- One coordinated create / Unix public update / read-only DAO acquisition,
+  retaining 30 original/updated pairs and 90 read-only observations. All
+  source/plan/file identities, complete requested rows, unchanged schema/query
+  SQL and independently decoded exact field-span preservation must pass.
+- Actual x86 pure mock-field checks cover all typed conversions and plain CLR
+  array JSON shapes before acquisition; no DAO is invoked by this preflight.
+  Initiating endpoint and stack are retained before best-effort cleanup.
+- Any failure after mutation remains no_outcome, with partial files retained;
+  no same-plan retry. No null, Boolean, AutoIncrement, variable-width, indexed,
+  relationship, overflow or hosted compatibility/support claim is established.
+
 ## EXP-0151 — Existing-file Long field update validation preregistered
 
 - Recorded: 2026-09-05, OpenAI Codex; local development acquisition plan,

--- a/oracle/windows-dao/acquisition/fixed-field-update.plan.json
+++ b/oracle/windows-dao/acquisition/fixed-field-update.plan.json
@@ -1,0 +1,257 @@
+{
+  "document_type": "dao_fixed_field_update_plan",
+  "experiment_id": "fixed-field-update",
+  "replicas": 3,
+  "development_only": true,
+  "source_revision": "37bd8175393dccf836b96172f740a28c4be36a60",
+  "preregistration": {
+    "acquisition_started": false,
+    "question": "Do ten typed fixed-field replacements on existing DAO-created files preserve every byte outside the selected field and full unrelated schema, rows and stored query SQL?",
+    "prior_evidence": "EXP-0061 fixed scalar storage and existing EXP-0151/0152 phased Long update acceptance. FixedText must actually save as fixed storage; negative-zero bits are exact observations, never silently normalized.",
+    "sequence": [
+      "Commit and independently review all input pins; build public exporter and run x86 pure conversion/array tests before DAO.",
+      "Phase1 creates30 fresh originals (10 arms \u00d73 replicas), two unindexed tables and KeepQuery; close writable handles and retain read-only snapshots.",
+      "Only complete phase1 allows Unix publicupdate_field on separate copies, one update each. Re-derive target table/column/uniqueId/locator/fixedspan independently; compare exact replacement bytes and every other byte.",
+      "Only all30 successful updates allow one phase2 readonly capture of original/updated files. Complete90 observation identity chains and all requests must agree.",
+      "Record one additive EXP-0164, including any no_outcome; no retry."
+    ],
+    "retry": "One coordinated two-phase run only. Any failure after first mutation is retained no_outcome; no phase resume or same-plan retry. A successor requires a distinct reviewed plan under standing user authorization.",
+    "limits": "Ten finite present fixed-field arms, no Boolean/null/Auto/index/relationship/overflow or variablefield updates. No hosted support claim."
+  },
+  "tables": [
+    {
+      "name": "Items",
+      "rows": [
+        [
+          "01000000",
+          "65000000",
+          "6669727374"
+        ],
+        [
+          "02000000",
+          "36ffffff",
+          "7365636f6e64"
+        ],
+        [
+          "03000000",
+          "2f010000",
+          "7468697264"
+        ]
+      ]
+    },
+    {
+      "name": "Later",
+      "rows": [
+        [
+          "0b000000",
+          "b3fbffff",
+          "6c617465722d6f6e65"
+        ],
+        [
+          "0c000000",
+          "b2040000",
+          "6c617465722d74776f"
+        ],
+        [
+          "0d000000",
+          "e9faffff",
+          "6c617465722d7468726565"
+        ]
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4,
+      "fixed": true
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4,
+      "fixed": true
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 20,
+      "fixed": false
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "arms": [
+    {
+      "name": "byte",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 2,
+        "size": 1,
+        "fixed": true
+      },
+      "initial_hex": "00",
+      "replacement_hex": "ff"
+    },
+    {
+      "name": "integer",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 3,
+        "size": 2,
+        "fixed": true
+      },
+      "initial_hex": "ff7f",
+      "replacement_hex": "0080"
+    },
+    {
+      "name": "long-control",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 4,
+        "size": 4,
+        "fixed": true
+      },
+      "initial_hex": "01000000",
+      "replacement_hex": "00000080"
+    },
+    {
+      "name": "currency",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 5,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "0000000000000000",
+      "replacement_hex": "0000000000000080"
+    },
+    {
+      "name": "single",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 6,
+        "size": 4,
+        "fixed": true
+      },
+      "initial_hex": "0000803f",
+      "replacement_hex": "00000080"
+    },
+    {
+      "name": "double",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 7,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "000000000000f03f",
+      "replacement_hex": "0000000000000080"
+    },
+    {
+      "name": "date",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 8,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "000000000000f03f",
+      "replacement_hex": "000000000000f4bf"
+    },
+    {
+      "name": "guid",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 15,
+        "size": 16,
+        "fixed": true
+      },
+      "initial_hex": "00000000000000000000000000000000",
+      "replacement_hex": "33221100554477668899aabbccddeeff"
+    },
+    {
+      "name": "fixed-text-1",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 10,
+        "size": 1,
+        "fixed": true
+      },
+      "initial_hex": "61",
+      "replacement_hex": "e9"
+    },
+    {
+      "name": "fixed-text-255",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 10,
+        "size": 255,
+        "fixed": true
+      },
+      "initial_hex": "616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161",
+      "replacement_hex": "e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9"
+    }
+  ],
+  "inputs": {
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "Cargo.lock": "1b306e136535925889bb551ea92a606756153eb7f69eca9c9a0617aa2e551e11",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/fixed_field_update_candidate.rs": "c3baf749c0bf2df5f33fccd4284f96e8ae59f3d577f5be93c0774d618ec911e1",
+    "crates/jet3/src/update.rs": "ed169ae4cf7df0751966370fbbe15b7c6568388e3d93eac021678e4e29d67de9",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "oracle/windows-dao/scripts/fixed_field_update.py": "7cdf17f3b533f880a769eb4e42d0d7968779972faac98fea9970d988669565e6",
+    "oracle/windows-dao/scripts/fixed_field_update.ps1": "c3eb3814432de36347bb5cfbfcf007e21ae46fcc8a032cf05f0163d0fa0df8db",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/src/row_writer.rs": "c4cc40d63681391c94da5ae7b3cc451c1fe398189d75fc9c40ba53006ecaf9fc",
+    "oracle/windows-dao/tests/fixed_field_update_values.ps1": "01a4784a71d8bf5b2cd5a2d1cc9db50e7d9cf8ccaa0743a8ca1b0cb6f816925a"
+  },
+  "analysis_bound": "Unmodified system_catalog decoder:64 rows/page; every user table has3 rows and3 columns. Fixed255-byte Text uses supported existing wide-row reader. Decode refusal remainsno_outcome.",
+  "source_receipt": "The result source_revision names this reviewed public update implementation, whose relevant current source bytes are input-pinned. acquisition_revision separately records the committed harness checkout; producer_os must be posix. No binary/build attestation.",
+  "pure_preflight": "Before acquisition, actual x86 PowerShell loads only named helper ASTs and uses mock Field objects:200 exact typed assignment/readback conversions plus all plain CLR row-array JSON roundtrips and DAO GUID wrapper. No COM or DAO execution."
+}

--- a/oracle/windows-dao/scripts/fixed_field_update.ps1
+++ b/oracle/windows-dao/scripts/fixed_field_update.ps1
@@ -1,0 +1,177 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value) }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, ((ConvertTo-Json -InputObject $Value -Depth 30) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function From-Hex([string]$Text) {
+    $bytes = New-Object byte[] ($Text.Length / 2)
+    for ($i = 0; $i -lt $bytes.Length; $i++) { $bytes[$i] = [Convert]::ToByte($Text.Substring($i * 2, 2), 16) }
+    return ,$bytes
+}
+function To-Hex([byte[]]$Bytes) { return [BitConverter]::ToString($Bytes).Replace('-', '').ToLowerInvariant() }
+function Set-Value($Recordset, $Definition, $Value) {
+    $field = $Recordset.Fields.Item([string]$Definition.name)
+    try {
+        if ($null -eq $Value) { $field.Value = [DBNull]::Value; return }
+        if ($Definition.type -eq 1) { $field.Value = [bool]$Value; return }
+        $raw = From-Hex ([string]$Value)
+        switch ([int]$Definition.type) {
+            2 { $field.Value = [byte]$raw[0] }
+            3 { $field.Value = [int16][BitConverter]::ToInt16($raw, 0) }
+            4 { $field.Value = [int][BitConverter]::ToInt32($raw, 0) }
+            5 { $field.Value = ([decimal][BitConverter]::ToInt64($raw, 0) / [decimal]10000) }
+            6 { $field.Value = [single][BitConverter]::ToSingle($raw, 0) }
+            7 { $field.Value = [double][BitConverter]::ToDouble($raw, 0) }
+            8 {
+                $dateValue = [datetime]::FromOADate([BitConverter]::ToDouble($raw, 0))
+                $field.Value = [datetime]$dateValue
+            }
+            9 { $field.Value = [byte[]]$raw }
+            10 { $field.Value = $CodePage.GetString($raw) }
+            15 { $field.Value = '{' + ([guid]::new([byte[]]$raw)).ToString() + '}' }
+            default { throw 'Undeclared field type' }
+        }
+    }
+    finally { Release $field }
+}
+function Read-Value($Recordset, $Definition) {
+    $field = $Recordset.Fields.Item([string]$Definition.name)
+    try {
+        $value = $field.Value
+        if ($null -eq $value -or $value -is [DBNull]) { return $null }
+        switch ([int]$Definition.type) {
+            1 { return [bool]$value }
+            2 { return To-Hex ([byte[]]@([byte]$value)) }
+            3 { return To-Hex ([BitConverter]::GetBytes([int16]$value)) }
+            4 { return To-Hex ([BitConverter]::GetBytes([int]$value)) }
+            5 { return To-Hex ([BitConverter]::GetBytes([long]([decimal]$value * [decimal]10000))) }
+            6 { return To-Hex ([BitConverter]::GetBytes([single]$value)) }
+            7 { return To-Hex ([BitConverter]::GetBytes([double]$value)) }
+            8 { return To-Hex ([BitConverter]::GetBytes(([datetime]$value).ToOADate())) }
+            9 { return To-Hex ([byte[]]$value) }
+            10 { return To-Hex ($CodePage.GetBytes([string]$value)) }
+            15 {
+                $text = [string]$value
+                if ($text -notmatch '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}') { throw 'Unrecognized GUID value' }
+                return To-Hex (([guid]$Matches[0]).ToByteArray())
+            }
+            default { throw 'Undeclared field type' }
+        }
+    }
+    finally { Release $field }
+}
+function Get-Fields($Plan, $Arm, [string]$TableName) {
+    $fields = [object[]]::new($Plan.fields.Count)
+    for ($i=0; $i -lt $fields.Length; $i++) {
+        $fields[$i] = if ($TableName -eq 'Items' -and $Plan.fields[$i].name -eq 'Value') { $Arm.field } else { $Plan.fields[$i] }
+    }
+    return ,$fields
+}
+function Failure($Record) {
+    return @{type=$Record.Exception.GetType().FullName; message=$Record.Exception.Message; stack=[string]$Record.ScriptStackTrace; endpoint=$script:endpoint}
+}
+$CodePage = [Text.Encoding]::GetEncoding(1252, (New-Object Text.EncoderExceptionFallback), (New-Object Text.DecoderExceptionFallback))
+function Create-Original([string]$Path, $Plan, $Arm) {
+    $engine = $workspace = $db = $table = $field = $rs = $query = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36; $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $script:endpoint = 'create_database'; $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($spec in $Plan.tables) {
+            $script:endpoint = 'create_table'; $table = $db.CreateTableDef([string]$spec.name)
+            foreach ($column in (Get-Fields $Plan $Arm ([string]$spec.name))) {
+                $script:endpoint = "create_field/$($column.name)"; $field = $table.CreateField([string]$column.name, [int]$column.type, [int]$column.size)
+                if ($column.fixed) { $field.Attributes = 1 }
+                $table.Fields.Append($field); Release $field; $field = $null
+            }
+            $db.TableDefs.Append($table)
+            $rs = $db.OpenRecordset([string]$spec.name, 2)
+            foreach ($row in $spec.rows) {
+                $rs.AddNew()
+                $definitions = Get-Fields $Plan $Arm ([string]$spec.name)
+                for ($i=0; $i -lt $definitions.Length; $i++) {
+                    $value = if ($spec.name -eq 'Items' -and $definitions[$i].name -eq 'Value') { $Arm.initial_hex } else { $row[$i] }
+                    $script:endpoint = "assign/$($spec.name)/$($definitions[$i].name)"
+                    Set-Value $rs $definitions[$i] $value
+                }
+                $script:endpoint = "update/$($spec.name)"
+                $rs.Update()
+            }
+            $rs.Close(); Release $rs; $rs = $null; Release $table; $table = $null
+        }
+        $script:endpoint = 'create_query'; $query = $db.CreateQueryDef([string]$Plan.query.name, [string]$Plan.query.sql)
+    } catch { $script:failure = Failure $_; throw } finally {
+        if ($null -ne $rs) { try { $rs.Close() } catch {} }; Release $rs; Release $query; Release $field; Release $table
+        if ($null -ne $db) { try { $db.Close() } catch {} }; Release $db; Release $workspace; Release $engine
+    }
+}
+function Observe([string]$Path, $Plan, $Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $status = 'pass'; $errorDetail = $null; $endpoint = 'open_database'; $script:endpoint = $endpoint; $snapshot = [ordered]@{}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @($db.Relations | ForEach-Object { @{name=[string]$_.Name; table=[string]$_.Table; foreign_table=[string]$_.ForeignTable; attributes=[int]$_.Attributes; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })} })
+        $snapshot.queries = @($db.QueryDefs | ForEach-Object { @{name=[string]$_.Name; sql=[string]$_.SQL; type=[int]$_.Type} } | Sort-Object { $_.name })
+        $snapshot.user_tables = @()
+        foreach ($name in @($snapshot.tables | Where-Object { -not $_.StartsWith('MSys') })) {
+            $endpoint = 'schema'; $script:endpoint = $endpoint; $table = $db.TableDefs.Item([string]$name)
+            $item = [ordered]@{name=[string]$table.Name; attributes=[int]$table.Attributes}
+            $item.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes; required=[bool]$_.Required; allow_zero_length=[bool]$_.AllowZeroLength; default_value=[string]$_.DefaultValue} })
+            $item.indexes = @($table.Indexes | ForEach-Object { @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })} })
+            $endpoint = 'rows'; $script:endpoint = $endpoint; $rs = $db.OpenRecordset([string]$name, 4)
+            $rows = New-Object Collections.ArrayList
+            while (-not $rs.EOF) {
+                $values = [object[]]::new($item.fields.Count)
+                for ($i=0; $i -lt $values.Length; $i++) { $values[$i] = Read-Value $rs $item.fields[$i] }
+                [void]$rows.Add($values)
+                $rs.MoveNext()
+            }
+            $item.rows = @($rows); $rs.Close(); Release $rs; $rs = $null
+            $snapshot.user_tables += $item; Release $table; $table = $null
+        }
+    } catch { $status = 'error'; $errorDetail = Failure $_; $script:failure = $errorDetail }
+    finally {
+        if ($null -ne $rs) { try { $rs.Close() } catch {} }; Release $rs; Release $table
+        if ($null -ne $db) { try { $db.Close() } catch {} }; Release $db; Release $engine
+    }
+    return @{file=[IO.Path]::GetFileName($Path); before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'fixed-field-update.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/fixed_field_update.ps1') { throw 'Script pin mismatch' }
+$phase = (Get-Content -LiteralPath (Join-Path $env:JET3_WORK 'phase.txt') -Raw).Trim()
+if ($phase -notin @('create', 'observe')) { throw 'Unknown phase' }
+$mutationStarted = $false; $failure = $null; $endpoint = 'start'
+$result = [ordered]@{document_type='dao_fixed_field_update_phase'; phase=$phase; plan_sha256=(Identity $planPath).sha256; environment=@{process_bits=32; provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}; mutation_started=$false; observations=@(); error=$null; endpoint='start'}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $roles = if ($phase -eq 'create') { @('original') } else { @('original', 'updated') }
+            foreach ($role in $roles) {
+                $path = Join-Path $env:JET3_WORK "$($arm.name)-r$replica-$role.mdb"
+                $result.endpoint = "$($arm.name)/$replica/$role"; $script:endpoint = $result.endpoint
+                if ($phase -eq 'create') { Create-Original $path $plan $arm }
+                $observation = Observe $path $plan $arm
+                $result.observations += @{arm=[string]$arm.name; replica=$replica; role=$role; observation=$observation}
+                if ($observation.status -ne 'pass') { throw 'Read-only observation failed' }
+            }
+        }
+    }
+} catch { $result.error = if ($null -ne $failure) { $failure } else { Failure $_ } }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/fixed_field_update.py
+++ b/oracle/windows-dao/scripts/fixed_field_update.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""EXP-0163: one phased DAO-create / Unix-public-update / DAO-read acquisition."""
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/fixed-field-update.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/fixed_field_update.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if subprocess.check_output(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    if os.name != 'posix' or plan['replicas'] != 3:
+        raise ValueError('Expected Unix producer and three replicas')
+    return plan
+
+
+def normalized(snapshot):
+    result = copy.deepcopy(snapshot)
+    result['user_tables'].sort(key=lambda table: table['name'])
+    for table in result['user_tables']:
+        table['rows'].sort()
+    return result
+
+
+def arm_tables(plan, arm, updated=False):
+    tables = copy.deepcopy(plan['tables'])
+    for table in tables:
+        table['fields'] = copy.deepcopy(plan['fields'])
+        if table['name'] == arm['table']:
+            ordinal = next(i for i, field in enumerate(table['fields']) if field['name'] == arm['column'])
+            table['fields'][ordinal] = arm['field']
+            for row in table['rows']:
+                row[ordinal] = arm['replacement_hex'] if updated and int.from_bytes(bytes.fromhex(row[0]), 'little', signed=True) == arm['selected_id'] else arm['initial_hex']
+    return tables
+
+
+def requested(snapshot, plan, arm, updated=False):
+    actual = normalized(snapshot)
+    if actual['version'] != '3.0' or actual['relations'] != []:
+        return False
+    if [t['name'] for t in actual['user_tables']] != sorted(t['name'] for t in plan['tables']):
+        return False
+    if len(actual['queries']) != 1 or actual['queries'][0]['name'] != plan['query']['name'] or not actual['queries'][0]['sql'] or actual['queries'][0]['type'] != 0:
+        return False
+    for spec in arm_tables(plan, arm, updated):
+        table = next(t for t in actual['user_tables'] if t['name'] == spec['name'])
+        if table['attributes'] != 0 or table['indexes'] != []:
+            return False
+        if [{k: field[k] for k in ('name', 'type', 'size')} for field in table['fields']] != [{k: field[k] for k in ('name', 'type', 'size')} for field in spec['fields']]:
+            return False
+        if any(field['attributes'] != (1 if declared['fixed'] else 2) for field, declared in zip(table['fields'], spec['fields'])):
+            return False
+        if table['rows'] != sorted(spec['rows']): return False
+    return True
+
+
+def patch_check(original, updated, arm, locator):
+    definition, _, records = catalog._discover_catalog(original)
+    name = catalog._ordinal(definition, 'Name')
+    id_column = catalog._ordinal(definition, 'Id')
+    roots = [row['values'][id_column] for row in records if row['values'][name] == arm['table']]
+    if len(roots) != 1 or roots[0] != locator['root']:
+        raise ValueError('Target catalog binding')
+    table = catalog._definition(original, roots[0])
+    columns = table['columns']
+    ordinal = catalog._ordinal(table, arm['column'])
+    id_column = catalog._ordinal(table, 'Id')
+    column = columns[ordinal]
+    if ordinal != locator['column'] or column['type'] != catalog.PHYSICAL_TYPES[arm['field']['type']] or column['storage'] != 'fixed' or column['size'] != arm['field']['size']:
+        raise ValueError('Target field binding')
+    pages, _ = catalog._table_pages(original, table)
+    rows = catalog._table_rows(original, table, pages)
+    selected = [row for row in rows if row['values'][id_column] == arm['selected_id']]
+    if len(selected) != 1 or selected[0]['page'] != locator['page'] or selected[0]['row'] != locator['slot'] or not selected[0]['present'][ordinal]:
+        raise ValueError('Target row binding')
+    image = catalog._page(original, locator['page'], 'target row')
+    entry = catalog._row_directory(image, locator['page'])[locator['slot']]
+    offset = locator['page'] * catalog.PAGE_BYTES + entry['start'] + 1 + column['fixed_offset']
+    replacement = bytes.fromhex(arm['replacement_hex']); width = arm['field']['size']
+    if len(replacement) != width or original[offset:offset + width].hex() != arm['initial_hex']:
+        raise ValueError('Declared present fixed field bytes mismatch')
+    expected = bytearray(original)
+    expected[offset:offset + width] = replacement
+    if expected != updated:
+        raise ValueError('Bytes outside the requested field changed, or replacement differs')
+    return {'offset': offset, 'length': width, 'before_hex': original[offset:offset + width].hex(),
+            'after_hex': updated[offset:offset + width].hex(),
+            'changed_offsets': [i for i, (a, b) in enumerate(zip(original, updated)) if a != b]}
+
+
+def phase_entries(phase, name, plan):
+    if (phase['document_type'] != 'dao_fixed_field_update_phase' or phase['phase'] != name
+        or phase['plan_sha256'] != digest(PLAN) or phase['error'] is not None
+        or phase['mutation_started'] != (name == 'create')
+        or phase['environment']['process_bits'] != 32 or phase['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Phase failed or has wrong identity: ' + name)
+    roles = ['original'] if name == 'create' else ['original', 'updated']
+    expected = {(arm['name'], replica, role) for arm in plan['arms'] for replica in range(1, 4) for role in roles}
+    entries = {}
+    for item in phase['observations']:
+        key = (item['arm'], item['replica'], item['role'])
+        if key in entries:
+            raise ValueError('Duplicate observation')
+        observation = item['observation']
+        if observation['status'] != 'pass' or observation['error'] is not None or observation['before'] != observation['after']:
+            raise ValueError('Read-only observation failed or mutated')
+        entries[key] = observation
+    if set(entries) != expected:
+        raise ValueError('Incomplete phase observations')
+    return entries
+
+
+def build_report(result, outbox, plan):
+    observations, reasons = [], []
+    try:
+        if (result['document_type'] != 'dao_fixed_field_update_result' or result['producer_os'] != 'posix'
+            or result['source_revision'] != plan['source_revision']):
+            raise ValueError('Unexpected result envelope or public Unix source receipt')
+        if result['plan_sha256'] != digest(PLAN) or result['error'] is not None or result['phase'] != 'complete':
+            raise ValueError('Coordinated acquisition failed: ' + str(result['error']))
+        phases = {}
+        for name in ('create', 'observe'):
+            path = outbox / (name + '.json')
+            if identity(path) != result['phases'][name]:
+                raise ValueError('Phase result identity mismatch')
+            phases[name] = phase_entries(json.loads(path.read_text(encoding='utf-8-sig')), name, plan)
+        updates = {(u['arm'], u['replica']): u for u in result['updates']}
+        if len(updates) != len(result['updates']) or set(updates) != {(a['name'], r) for a in plan['arms'] for r in range(1, 4)}:
+            raise ValueError('Incomplete Unix updates')
+        for arm in plan['arms']:
+            for replica in range(1, 4):
+                name = arm['name']; update = updates[name, replica]
+                before = phases['create'][name, replica, 'original']
+                after_original = phases['observe'][name, replica, 'original']
+                after = phases['observe'][name, replica, 'updated']
+                original = outbox / f'{name}-r{replica}-original.mdb'
+                updated = outbox / f'{name}-r{replica}-updated.mdb'
+                if (identity(original) != before['after'] or identity(original) != after_original['after']
+                    or identity(original) != update['original_before'] or identity(original) != update['original_after']
+                    or identity(updated) != after['before'] or identity(updated) != update['updated']):
+                    raise ValueError('Image identity chain mismatch')
+                for role, observation in [('original', before), ('original', after_original), ('updated', after)]:
+                    if observation['file'] != f'{name}-r{replica}-{role}.mdb':
+                        raise ValueError('Image filename association mismatch')
+                if normalized(before['snapshot']) != normalized(after_original['snapshot']) or not requested(before['snapshot'], plan, arm) or not requested(after['snapshot'], plan, arm, True):
+                    raise ValueError('Original/requested schema or rows differ')
+                expected = normalized(before['snapshot'])
+                target = next(t for t in expected['user_tables'] if t['name'] == arm['table'])
+                field = next(i for i, f in enumerate(plan['fields']) if f['name'] == arm['column'])
+                next(row for row in target['rows'] if int.from_bytes(bytes.fromhex(row[0]), 'little', signed=True) == arm['selected_id'])[field] = arm['replacement_hex']
+                if normalized(expected) != normalized(after['snapshot']):
+                    raise ValueError('Unrelated schema, rows or query SQL differs')
+                span = patch_check(original.read_bytes(), updated.read_bytes(), arm, update['locator'])
+                observations.append({'arm': name, 'replica': replica, 'original': identity(original),
+                                     'updated': identity(updated), 'patch': span, 'snapshot': after['snapshot'],
+                                     'requested_change_and_preservation': True})
+    except (KeyError, ValueError, TypeError, OSError, catalog.DecodeError) as error:
+        reasons.append(str(error))
+    return {'document_type': 'dao_fixed_field_update_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'observed_accepted' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'support_matrix_movement': False,
+            'compatibility_claim': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text())
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    (outbox / 'report.json').write_text(canonical(report) + '\n')
+    print(report['outcome'])
+
+
+def dispatch(args):
+    plan = preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve(); outbox = shared / 'outbox' / args.run_id
+    paths = [outbox] + [shared / part / (args.run_id + '-' + phase) for part in ('inbox', 'outbox') for phase in ('create', 'observe')]
+    if any(path.exists() for path in paths):
+        raise ValueError('Run id used; never resume or retry')
+    subprocess.run(['cargo', 'build', '-p', 'jet3', '--example', 'fixed_field_update_candidate'], cwd=ROOT, check=True)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec); spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result = {'document_type': 'dao_fixed_field_update_result', 'plan_sha256': digest(PLAN),
+              'source_revision': plan['source_revision'],
+              'acquisition_revision': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT).decode().strip(),
+              'producer_os': os.name, 'phase': 'create', 'phases': {}, 'updates': [], 'error': None}
+    try:
+        for phase in ('create', 'observe'):
+            result['phase'] = phase
+            run_id = args.run_id + '-' + phase; inbox = shared / 'inbox' / run_id; inbox.mkdir(parents=True)
+            shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1'); shutil.copyfile(PLAN, inbox / PLAN.name)
+            (inbox / 'phase.txt').write_text(phase)
+            if phase == 'observe':
+                for path in outbox.glob('*.mdb'): shutil.copyfile(path, inbox / path.name)
+            command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15', '-o', 'IdentitiesOnly=yes', '-i', args.identity,
+                       f'{args.user}@{args.host}', 'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+                       transport.encoded(transport.guest_script(args.remote_shared_root, run_id, 'script.ps1'))]
+            completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+            (outbox / (phase + '-ssh.txt')).write_bytes(completed.stdout + completed.stderr)
+            guest = shared / 'outbox' / run_id
+            shutil.copyfile(guest / 'result.json', outbox / (phase + '.json'))
+            result['phases'][phase] = identity(outbox / (phase + '.json'))
+            if phase == 'create':
+                for path in guest.glob('*.mdb'): shutil.copyfile(path, outbox / path.name)
+            observations = phase_entries(json.loads((outbox / (phase + '.json')).read_text(encoding='utf-8-sig')), phase, plan)
+            if completed.returncode != 0: raise ValueError('Guest phase exited unsuccessfully')
+            if phase == 'create':
+                result['phase'] = 'unix_update'
+                for arm in plan['arms']:
+                    for replica in range(1, 4):
+                        prefix = f"{arm['name']}-r{replica}"
+                        original = outbox / (prefix + '-original.mdb'); updated = outbox / (prefix + '-updated.mdb')
+                        before = identity(original)
+                        if before != observations[arm['name'], replica, 'original']['after']: raise ValueError('Original transfer identity')
+                        if not requested(observations[arm['name'], replica, 'original']['snapshot'], plan, arm): raise ValueError('Original request mismatch')
+                        command = ['cargo', 'run', '--quiet', '-p', 'jet3', '--example', 'fixed_field_update_candidate', '--', str(original), str(updated), arm['table'], str(arm['selected_id']), arm['column'], arm['name']]
+                        done = subprocess.run(command, cwd=ROOT, capture_output=True, timeout=120)
+                        (outbox / (prefix + '-unix.txt')).write_bytes(done.stdout + done.stderr)
+                        if done.returncode: raise ValueError('Public field update failed: ' + prefix)
+                        result['updates'].append({'arm': arm['name'], 'replica': replica, 'original_before': before,
+                            'original_after': identity(original), 'updated': identity(updated), 'locator': json.loads(done.stdout)})
+                        if identity(original) != before: raise ValueError('Unix update changed original')
+                        patch_check(original.read_bytes(), updated.read_bytes(), arm, result['updates'][-1]['locator'])
+        result['phase'] = 'complete'
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        result['error'] = type(error).__name__ + ': ' + str(error)
+    finally:
+        (outbox / 'result.json').write_text(canonical(result) + '\n')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__); commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight'); report = commands.add_parser('analyze'); report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run'); run.add_argument('--run-id', required=True); run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'), ('identity', str(Path.home() / '.ssh/jet3-dao')), ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=default)
+    args = parser.parse_args()
+    if args.command == 'preflight': preflight(); print('Committed inputs match.')
+    elif args.command == 'analyze': analyze(args.outbox)
+    else: dispatch(args)
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/tests/fixed_field_update_values.ps1
+++ b/oracle/windows-dao/tests/fixed_field_update_values.ps1
@@ -1,0 +1,50 @@
+param([string]$ScriptPath, [string]$PlanPath)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'Expected actual x86 helper test' }
+$tokens=$null; $errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile($ScriptPath,[ref]$tokens,[ref]$errors)
+if ($errors.Count) { throw ($errors | Out-String) }
+foreach ($name in @('Release','From-Hex','To-Hex','Set-Value','Read-Value','Get-Fields')) {
+    $functions=@($ast.FindAll({param($node) $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name},$false))
+    if ($functions.Count -ne 1) { throw "Missing helper $name" }
+    Invoke-Expression $functions[0].Extent.Text
+}
+$CodePage=[Text.Encoding]::GetEncoding(1252,(New-Object Text.EncoderExceptionFallback),(New-Object Text.DecoderExceptionFallback))
+$plan=Get-Content -LiteralPath $PlanPath -Raw | ConvertFrom-Json
+$mockField=[pscustomobject]@{Value=$null}
+$fields=New-Object PSObject
+$fields | Add-Member ScriptMethod Item {param($name) return $script:mockField}
+$rs=[pscustomobject]@{Fields=$fields}
+$count=0
+foreach ($arm in $plan.arms) {
+    foreach ($hex in @($arm.initial_hex,$arm.replacement_hex)) {
+        Set-Value $rs $arm.field $hex
+        $actual=Read-Value $rs $arm.field
+        if ($actual -cne $hex) { throw "Typed conversion drift $($arm.name): $actual != $hex" }
+        $count++
+    }
+    foreach ($table in $plan.tables) {
+        $definitions=Get-Fields $plan $arm ([string]$table.name)
+        $rows=New-Object Collections.ArrayList
+        foreach ($row in $table.rows) {
+            $values=[object[]]::new($definitions.Length)
+            for ($i=0;$i -lt $values.Length;$i++) {
+                $expected=if($table.name -eq 'Items' -and $definitions[$i].name -eq 'Value'){$arm.initial_hex}else{$row[$i]}
+                Set-Value $rs $definitions[$i] $expected
+                $values[$i]=Read-Value $rs $definitions[$i]
+                if($values[$i] -cne $expected){throw 'Common field conversion drift'}
+                $count++
+            }
+            [void]$rows.Add($values)
+        }
+        $json=ConvertTo-Json -InputObject @{rows=@($rows)} -Depth 12
+        $roundtrip=$json|ConvertFrom-Json
+        if($roundtrip.rows.Count -ne 3){throw 'Row array drift'}
+        foreach($row in $roundtrip.rows){if($row -isnot [array] -or $row.Count -ne 3 -or $row[0] -isnot [string]){throw 'Saved value array wrapper'}}
+    }
+}
+$mockField.Value='{guid {00112233-4455-6677-8899-AABBCCDDEEFF}}'
+$guid=@{name='Value';type=15}
+if((Read-Value $rs $guid) -cne '33221100554477668899aabbccddeeff'){throw 'DAO GUID wrapper drift'}
+Write-Output "Passed $count exact typed conversion checks and all row JSON roundtrips; no DAO."

--- a/oracle/windows-dao/tests/test_fixed_field_update.py
+++ b/oracle/windows-dao/tests/test_fixed_field_update.py
@@ -1,0 +1,81 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import fixed_field_update as experiment
+
+
+def snapshot(plan, arm, updated=False):
+    tables=[]
+    for table in experiment.arm_tables(plan,arm,updated):
+        fields=[dict({k:f[k] for k in ('name','type','size')},attributes=1 if f['fixed'] else 2) for f in table['fields']]
+        tables.append(dict(name=table['name'],attributes=0,indexes=[],fields=fields,rows=table['rows']))
+    return dict(version='3.0',relations=[],queries=[dict(name=plan['query']['name'],sql=plan['query']['sql'],type=0)],user_tables=tables)
+
+
+class FixedUpdateTests(unittest.TestCase):
+    def test_exact_typed_requests_and_negative_zero(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        self.assertEqual(len(plan['arms']),10)
+        for arm in plan['arms']:
+            before=snapshot(plan,arm);after=snapshot(plan,arm,True)
+            self.assertTrue(experiment.requested(before,plan,arm))
+            self.assertTrue(experiment.requested(after,plan,arm,True))
+            self.assertFalse(experiment.requested(before,plan,arm,True))
+            wrong=copy.deepcopy(after);wrong['user_tables'][1]['rows'][0][2]='ff'
+            self.assertFalse(experiment.requested(wrong,plan,arm,True))
+        for name in ('single','double'):
+            arm=next(a for a in plan['arms'] if a['name']==name)
+            after=snapshot(plan,arm,True);after['user_tables'][0]['rows'][1][1]='00'*arm['field']['size']
+            self.assertFalse(experiment.requested(after,plan,arm,True))
+
+    def test_fixed_text_requires_saved_fixed_attributes(self):
+        plan=json.loads(experiment.PLAN.read_text());arm=plan['arms'][-1]
+        actual=snapshot(plan,arm);actual['user_tables'][0]['fields'][1]['attributes']=2
+        self.assertFalse(experiment.requested(actual,plan,arm))
+
+    def test_failure_result_and_input_pins(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory)
+            result={'document_type':'dao_fixed_field_update_result','producer_os':'posix','source_revision':plan['source_revision'],
+                    'plan_sha256':experiment.digest(experiment.PLAN),'phase':'create','error':{'endpoint':'assign','message':'failed'}}
+            report=experiment.build_report(result,root,plan)
+            self.assertEqual(report['outcome'],'no_outcome');self.assertEqual(report['observations'],[])
+            script=root/'producer.py';script.write_text('original');p=root/'plan.json';p.write_text(json.dumps({'inputs':{'producer.py':experiment.digest(script)}}))
+            with patch.object(experiment,'ROOT',root),patch.object(experiment,'PLAN',p):
+                experiment.verify_inputs();script.write_text('changed')
+                with self.assertRaisesRegex(ValueError,'Input pin'):experiment.verify_inputs()
+
+    def test_complete_matrix_and_query_preservation_gate(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory); phases={name:{'document_type':'dao_fixed_field_update_phase','phase':name,'plan_sha256':experiment.digest(experiment.PLAN),
+                'error':None,'mutation_started':name=='create','environment':{'process_bits':32,'provider':'DAO.DBEngine.36'},'observations':[]} for name in ('create','observe')}
+            result={'document_type':'dao_fixed_field_update_result','producer_os':'posix','source_revision':plan['source_revision'],
+                'plan_sha256':experiment.digest(experiment.PLAN),'phase':'complete','error':None,'updates':[],'phases':{}}
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    ids={}
+                    for role in ('original','updated'):
+                        path=root/f"{arm['name']}-r{replica}-{role}.mdb";path.write_bytes(role.encode());ids[role]=experiment.identity(path)
+                        obs={'arm':arm['name'],'replica':replica,'role':role,'observation':{'file':path.name,'before':ids[role],'after':ids[role],
+                            'status':'pass','error':None,'snapshot':snapshot(plan,arm,role=='updated')}}
+                        phases['observe']['observations'].append(obs)
+                        if role=='original':phases['create']['observations'].append(copy.deepcopy(obs))
+                    result['updates'].append({'arm':arm['name'],'replica':replica,'original_before':ids['original'],'original_after':ids['original'],'updated':ids['updated'],'locator':{}})
+            def classify():
+                for name,phase in phases.items():
+                    path=root/(name+'.json');path.write_text(json.dumps(phase));result['phases'][name]=experiment.identity(path)
+                with patch.object(experiment,'patch_check',return_value={}):return experiment.build_report(result,root,plan)
+            self.assertEqual(classify()['outcome'],'observed_accepted')
+            phases['observe']['observations'][1]['observation']['snapshot']['queries'][0]['sql']='SELECT 99;'
+            self.assertEqual(classify()['outcome'],'no_outcome')
+
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Preregister thirty existing-file fixed-field updates covering ten finite Byte/Integer/Long/Currency/Single/Double/Date/GUID/fixed-Text cases. DAO creates originals, Unix invokes the public typed update API, and read-only DAO snapshots plus independent raw-span checks verify exact replacements and unrelated bytes, rows, schema, and stored-query SQL.

Independent review passed. Four classifier tests, 200 actual x86 no-DAO conversion/JSON checks, committed input pins, exporter Clippy, and final `just ready` passed. Exact negative-zero and saved fixed-Text storage are explicit gates; failures remain outcomes without retry.
