### PR TITLE
docs: record accepted nullable index successor candidates

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -12084,6 +12084,58 @@ Copy this block under the appropriate section and remove this instruction:
   updates, candidate acceptance, general compatibility or hosted support claim.
   Retain raw images/results externally and record one validated EXP-0148 outcome.
 
+## EXP-0166 — Nullable writer successor accepted in the exact six-arm matrix
+
+- Recorded 2026-09-05 from the single local run
+  `20260905T070529Z-nullable-successor`, source `f0cbd77`, EXP-0165 plan
+  SHA-256 `d765bbf7f7e219147dc15aff0b58a8cac1c6e31e745666495d55da48ffaa50b1`.
+  This is the distinct preregistered successor; EXP-0156's failed acquisition,
+  retention failure, recovered analysis and all six `no_outcome` arms remain.
+- Result: 12486669 bytes, SHA-256
+  `a4dc423a9867098869bb6c41a33b741dca43ec21f3e1588fdd276b9c4ad1d078`.
+  Report: 229085 bytes, SHA-256
+  `da58a1e467443ef9511f138d1ea4996112563bfdb44db6fac4c134d5ccc0c5d5`.
+  The pinned analyzer reproduced this report byte-identically on temporary
+  copies. All 64 retained files, including 60 MDBs, remained unchanged.
+- All six outcomes are `observed_accepted`: 18 complete baseline pairs and
+  24 independent-copy probe observations, no acquisition, cleanup or retention
+  failures. All 36 baseline and 24 probe report checks pass. Every retained
+  identity matches the corresponding recorded before/after or probe-source
+  identity; originals stay unchanged and each candidate starts with its pin.
+- Reviewed library source is `6a0e4537e7986a4b04db7616f5537cb306f17e2c`.
+  The six exact candidate identities remain those in EXP-0165's plan, identical
+  to EXP-0155. Controls are fresh matched DAO files, not reused failed controls.
+- Each arm has an empty first table and later Rows(A, B, Payload), with distinct
+  Long payloads; Auto generates B as position+1. Full schema/Auto/index flags,
+  null-preserving row multisets, complete ordered traversal and every finite
+  non-null Seek comparison match. Seek permits any actual matching duplicate;
+  traversal verifies all duplicate payloads and locators.
+- Physical rows, complete variable-length key/locator bindings, distinct
+  counts, separators, sibling chains, uniform depths and declared map checks
+  all pass. Both controls and candidates have the same following counts in
+  every replica (their page placements need not match):
+  - `unique`: 12 rows, 12 leaf entries, 9 distinct keys, depth 1, flags 1.
+  - `ignore`: 12 rows, 8 leaf entries, 8 distinct keys, depth 1, flags 3.
+  - `required`: 12 rows, 12 leaf entries, 3 distinct keys, depth 1, flags 8.
+  - `composite`: 30000 rows, 30000 leaf entries, 7503 distinct keys, depth 3, flags 1.
+  - `composite-ignore`: 1200 rows, 900 leaf entries, 302 distinct keys, depth 2, flags 2.
+  - `auto`: 1200 rows, 1200 leaf entries, 1200 distinct keys, depth 2, flags 1.
+- In these exact rows, unique indexes retain repeated null-bearing keys;
+  IgnoreAllNull omits only all-null keys and retains partial composite nulls.
+  Ascending null component `00`, descending null `ff`, and full-key distinct
+  counts satisfy the predeclared EXP-0148 correlations. The 30,000-row
+  composite arm exercises three levels and repeated null-bearing entries.
+- Unique/ignore/composite duplicate fully-present-key probes are rejected with
+  native code 3022 and HRESULT -2146825266, matching every control. Required
+  null-key probes are rejected with 3058 and HRESULT -2146825230, also matching
+  every control. Each independent probe preserves the full baseline logical
+  post-state, including traversal and Seek; no original file is made writable.
+- Acceptance is finite to these pinned images, metadata, values and probes.
+  It does not establish null Seek, nullable foreign relationships, other scalar
+  key codecs, indirect writer allocation or general existing-index maintenance.
+  Development-only local evidence: no broad compatibility claim or hosted
+  support-matrix movement. No new writer/reader format rule is introduced.
+
 ## EXP-0165 — Distinct nullable index successor preregistration
 
 - Recorded 2026-09-05; no acquisition yet. Plan

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -64,8 +64,9 @@ EXP-0146 records bounded acceptance of all three multi-level candidates from
 separately pinned analysis of the retained files; EXP-0140 preserves the
 original decoder refusal and `no_outcome`. The reader recognizes the observed
 branch header values. Nullable one/two-Long keys now have typed
-include/omit-all-null/required options and variable-size index packing; their
-composed writer policy awaits candidate validation.
+include/omit-all-null/required options and variable-size index packing.
+EXP-0166 records exact six-arm local acceptance, including matched uniqueness
+and required-null rejection probes; EXP-0156 preserves the earlier failure.
 
 EXP-0154 records matching canonical results for the twelve hosted write
 recipes in the EXP-0141 inventory, after separately reviewed read-only index
@@ -82,8 +83,8 @@ This evidence does not advance existing-row insert/update/delete, index CRUD
 maintenance or atomic failure/rollback verification.
 
 Keep broader index key codecs and allocation beyond inline maps as explicit
-creation limitations; validate the bounded nullable writer next. The bounded
-hosted write leg under #102 now has recorded evidence;
+creation limitations. Prioritize existing-file row insertion/deletion and index
+maintenance under #112. The bounded hosted write leg under #102 now has recorded evidence;
 multi-level boundary recipes and other declared write-inventory deferrals
 remain to be covered. Neither issue is complete merely from this checkpoint.
 Existing-database updates (#112) and their hosted differential (#113) remain


### PR DESCRIPTION
Record DAO acceptance of all six nullable Long-index candidates under the reviewed successor plan. Eighteen baseline pairs and twelve rejection pairs match complete rows, schema, traversal, Seek, key/locator/map state, and actual uniqueness/Required errors.

Independent review reproduced the exact report and verified all 64 retained files unchanged. Final `just ready` passed. The original failed run remains preserved; this evidence is finite and local, with no hosted support movement.
