### PR TITLE
test: preregister corrected fixed-field DAO setter

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11110,6 +11110,28 @@ Copy this block under the appropriate section and remove this instruction:
   updates, deletion/insertion, arbitrary existing-file compatibility or
   hosted update support. Report compatibility/support flags remain false.
 
+## EXP-0171 — Distinct fixed-field Currency setter successor
+
+- Preregistered only; no acquisition. Outcome reserved as EXP-0172. The
+  EXP-0164 Decimal-to-String creation failure and consumed EXP-0163 inputs,
+  original captures and reports remain unchanged.
+- Plan `oracle/windows-dao/acquisition/fixed-field-successor.plan.json`, SHA-256
+  `01929cf68daa5d5bc8dbb4529819634c4017f8b0551a1772d3444eddc2027942`.
+- Correction: compute Currency in a local Decimal, then assign through the
+  dedicated `$field.Value = [decimal]$currencyValue` site. This matches the
+  explicit typed setter in the pinned original read producer's
+  `Set-RecordsetValue` Currency branch; it replaces the direct division RHS.
+- Same ten typed arms and three fresh replicas each, same public exporter and
+  implementation `37bd817`, exact replacement bits, schemas, query preservation,
+  independently decoded field spans and all-other-byte checks. Fresh controls
+  are required because the failed acquisition performed no Rust updates.
+- The actual x86 pure helper test passes 200 exact conversion checks and all
+  CLR row-array JSON roundtrips. It does not exercise DAO COM property binding;
+  success of the correction remains an acquisition question.
+- Root performs one coordinated create / Unix update / DAO read-only run only
+  after independent review and committed pins. Any failure remains no_outcome;
+  no same-plan retry, broad compatibility or hosted support claim.
+
 ## EXP-0164 — Fixed-field acquisition stopped at Currency assignment
 
 - Outcome: `no_outcome`, recorded 2026-09-05 from the single local coordinated

--- a/oracle/windows-dao/acquisition/fixed-field-successor.plan.json
+++ b/oracle/windows-dao/acquisition/fixed-field-successor.plan.json
@@ -1,0 +1,277 @@
+{
+  "document_type": "dao_fixed_field_update_plan",
+  "experiment_id": "fixed-field-successor",
+  "replicas": 3,
+  "development_only": true,
+  "source_revision": "37bd8175393dccf836b96172f740a28c4be36a60",
+  "preregistration": {
+    "acquisition_started": false,
+    "question": "Do ten typed fixed-field replacements on existing DAO-created files preserve every byte outside the selected field and full unrelated schema, rows and stored query SQL?",
+    "prior_evidence": "EXP-0061 fixed scalar storage and existing EXP-0151/0152 phased Long update acceptance. FixedText must actually save as fixed storage; negative-zero bits are exact observations, never silently normalized.",
+    "sequence": [
+      "Commit and independently review all input pins; build public exporter and run x86 pure conversion/array tests before DAO.",
+      "Phase1 creates30 fresh originals (10 arms \u00d73 replicas), two unindexed tables and KeepQuery; close writable handles and retain read-only snapshots.",
+      "Only complete phase1 allows Unix publicupdate_field on separate copies, one update each. Re-derive target table/column/uniqueId/locator/fixedspan independently; compare exact replacement bytes and every other byte.",
+      "Only all30 successful updates allow one phase2 readonly capture of original/updated files. Complete90 observation identity chains and all requests must agree.",
+      "Record one additive EXP-0172; preserve original EXP-0164 and all consumed artifacts even if this successor also fails. No same-plan retry."
+    ],
+    "retry": "One coordinated two-phase run only. Any failure after first mutation is retained no_outcome; no phase resume or same-plan retry. A successor requires a distinct reviewed plan under standing user authorization.",
+    "limits": "Ten finite present fixed-field arms, no Boolean/null/Auto/index/relationship/overflow or variablefield updates. No hosted support claim.",
+    "authorization": "Standing user authorization covers this distinct reviewed successor. Root dispatches only after committed pins and independent review; no acquisition by implementation agent."
+  },
+  "tables": [
+    {
+      "name": "Items",
+      "rows": [
+        [
+          "01000000",
+          "65000000",
+          "6669727374"
+        ],
+        [
+          "02000000",
+          "36ffffff",
+          "7365636f6e64"
+        ],
+        [
+          "03000000",
+          "2f010000",
+          "7468697264"
+        ]
+      ]
+    },
+    {
+      "name": "Later",
+      "rows": [
+        [
+          "0b000000",
+          "b3fbffff",
+          "6c617465722d6f6e65"
+        ],
+        [
+          "0c000000",
+          "b2040000",
+          "6c617465722d74776f"
+        ],
+        [
+          "0d000000",
+          "e9faffff",
+          "6c617465722d7468726565"
+        ]
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4,
+      "fixed": true
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4,
+      "fixed": true
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 20,
+      "fixed": false
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "arms": [
+    {
+      "name": "byte",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 2,
+        "size": 1,
+        "fixed": true
+      },
+      "initial_hex": "00",
+      "replacement_hex": "ff"
+    },
+    {
+      "name": "integer",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 3,
+        "size": 2,
+        "fixed": true
+      },
+      "initial_hex": "ff7f",
+      "replacement_hex": "0080"
+    },
+    {
+      "name": "long-control",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 4,
+        "size": 4,
+        "fixed": true
+      },
+      "initial_hex": "01000000",
+      "replacement_hex": "00000080"
+    },
+    {
+      "name": "currency",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 5,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "0000000000000000",
+      "replacement_hex": "0000000000000080"
+    },
+    {
+      "name": "single",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 6,
+        "size": 4,
+        "fixed": true
+      },
+      "initial_hex": "0000803f",
+      "replacement_hex": "00000080"
+    },
+    {
+      "name": "double",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 7,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "000000000000f03f",
+      "replacement_hex": "0000000000000080"
+    },
+    {
+      "name": "date",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 8,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "000000000000f03f",
+      "replacement_hex": "000000000000f4bf"
+    },
+    {
+      "name": "guid",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 15,
+        "size": 16,
+        "fixed": true
+      },
+      "initial_hex": "00000000000000000000000000000000",
+      "replacement_hex": "33221100554477668899aabbccddeeff"
+    },
+    {
+      "name": "fixed-text-1",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 10,
+        "size": 1,
+        "fixed": true
+      },
+      "initial_hex": "61",
+      "replacement_hex": "e9"
+    },
+    {
+      "name": "fixed-text-255",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 10,
+        "size": 255,
+        "fixed": true
+      },
+      "initial_hex": "616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161",
+      "replacement_hex": "e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9"
+    }
+  ],
+  "inputs": {
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "Cargo.lock": "1b306e136535925889bb551ea92a606756153eb7f69eca9c9a0617aa2e551e11",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/fixed_field_update_candidate.rs": "c3baf749c0bf2df5f33fccd4284f96e8ae59f3d577f5be93c0774d618ec911e1",
+    "crates/jet3/src/update.rs": "ed169ae4cf7df0751966370fbbe15b7c6568388e3d93eac021678e4e29d67de9",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "oracle/windows-dao/scripts/fixed_field_successor.py": "47e4b0e7776bda396ce0fc8c770fa9ad90cd6de008b3aa938658d1d519ea0601",
+    "oracle/windows-dao/scripts/fixed_field_successor.ps1": "effe902ca9799bf898c1c20ccd4bc9b823a50cc1f69d2869c763e267922f954d",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "crates/jet3/src/row_writer.rs": "c4cc40d63681391c94da5ae7b3cc451c1fe398189d75fc9c40ba53006ecaf9fc",
+    "oracle/windows-dao/tests/fixed_field_update_values.ps1": "01a4784a71d8bf5b2cd5a2d1cc9db50e7d9cf8ccaa0743a8ca1b0cb6f816925a",
+    "oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1": "78fb338668271a23158f0cfc65f0393931e4a04945af0ed84808964b2a073c89",
+    "oracle/windows-dao/acquisition/fixed-field-update.plan.json": "c6958a5b238c6cee97f877ec12cf53b93ad699db190fb0aceec769045794c564"
+  },
+  "analysis_bound": "Unmodified system_catalog decoder:64 rows/page; every user table has3 rows and3 columns. Fixed255-byte Text uses supported existing wide-row reader. Decode refusal remainsno_outcome.",
+  "source_receipt": "The result source_revision names this reviewed public update implementation, whose relevant current source bytes are input-pinned. acquisition_revision separately records the committed harness checkout; producer_os must be posix. No binary/build attestation.",
+  "pure_preflight": "Before acquisition, actual x86 PowerShell loads only named helper ASTs and uses mock Field objects:200 exact typed assignment/readback conversions plus all plain CLR row-array JSON roundtrips and DAO GUID wrapper. No COM or DAO execution.",
+  "provenance": "EXP-0171",
+  "outcome_provenance": "EXP-0172",
+  "prior_failure": {
+    "provenance": "EXP-0164",
+    "run": "20260905T071241Z-fixed-field-update",
+    "acquisition_revision": "836492916f43a900e0eac7e85bdccc6b4cd93b43",
+    "plan_sha256": "c6958a5b238c6cee97f877ec12cf53b93ad699db190fb0aceec769045794c564",
+    "result_sha256": "bb62c9b86d823dc8a45e490bc49598e4e369a51257518f12c2bbcc9a56a05700",
+    "report_sha256": "f68a41a90c9531a8bd2abe8dd5b34539be61597d0aebda59261a9aaa53b05b7a",
+    "outcome": "no_outcome",
+    "limitation": "Nine original captures completed; Currency replica1 Decimal-to-String COM assignment failure prevented all Rust updates. No acceptance is recovered from those baseline captures."
+  },
+  "correction": {
+    "scope": "Only Currency property assignment and new plan/script identities differ. Compute scaled Decimal in a local variable and explicitly cast it at the dedicated DAO property setter, matching the consumed Invoke-DaoReadV12.ps1 Set-RecordsetValue dbCurrency pattern. All arms, expected bytes, exporter, snapshots, classifier, identity/preservation and no-retry checks stay unchanged.",
+    "fresh_controls": "All ten arms get three fresh originals because no previous Rust update ran. No reuse of partial or failed controls.",
+    "mock_limit": "Actual x86 mock-field tests check200 conversions and JSON array shapes; they do not exercise DAO COM binding and cannot establish the correction succeeded."
+  }
+}

--- a/oracle/windows-dao/scripts/fixed_field_successor.ps1
+++ b/oracle/windows-dao/scripts/fixed_field_successor.ps1
@@ -1,0 +1,180 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value) }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, ((ConvertTo-Json -InputObject $Value -Depth 30) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function From-Hex([string]$Text) {
+    $bytes = New-Object byte[] ($Text.Length / 2)
+    for ($i = 0; $i -lt $bytes.Length; $i++) { $bytes[$i] = [Convert]::ToByte($Text.Substring($i * 2, 2), 16) }
+    return ,$bytes
+}
+function To-Hex([byte[]]$Bytes) { return [BitConverter]::ToString($Bytes).Replace('-', '').ToLowerInvariant() }
+function Set-Value($Recordset, $Definition, $Value) {
+    $field = $Recordset.Fields.Item([string]$Definition.name)
+    try {
+        if ($null -eq $Value) { $field.Value = [DBNull]::Value; return }
+        if ($Definition.type -eq 1) { $field.Value = [bool]$Value; return }
+        $raw = From-Hex ([string]$Value)
+        switch ([int]$Definition.type) {
+            2 { $field.Value = [byte]$raw[0] }
+            3 { $field.Value = [int16][BitConverter]::ToInt16($raw, 0) }
+            4 { $field.Value = [int][BitConverter]::ToInt32($raw, 0) }
+            5 {
+                $currencyValue = [decimal][BitConverter]::ToInt64($raw, 0) / [decimal]10000
+                $field.Value = [decimal]$currencyValue
+            }
+            6 { $field.Value = [single][BitConverter]::ToSingle($raw, 0) }
+            7 { $field.Value = [double][BitConverter]::ToDouble($raw, 0) }
+            8 {
+                $dateValue = [datetime]::FromOADate([BitConverter]::ToDouble($raw, 0))
+                $field.Value = [datetime]$dateValue
+            }
+            9 { $field.Value = [byte[]]$raw }
+            10 { $field.Value = $CodePage.GetString($raw) }
+            15 { $field.Value = '{' + ([guid]::new([byte[]]$raw)).ToString() + '}' }
+            default { throw 'Undeclared field type' }
+        }
+    }
+    finally { Release $field }
+}
+function Read-Value($Recordset, $Definition) {
+    $field = $Recordset.Fields.Item([string]$Definition.name)
+    try {
+        $value = $field.Value
+        if ($null -eq $value -or $value -is [DBNull]) { return $null }
+        switch ([int]$Definition.type) {
+            1 { return [bool]$value }
+            2 { return To-Hex ([byte[]]@([byte]$value)) }
+            3 { return To-Hex ([BitConverter]::GetBytes([int16]$value)) }
+            4 { return To-Hex ([BitConverter]::GetBytes([int]$value)) }
+            5 { return To-Hex ([BitConverter]::GetBytes([long]([decimal]$value * [decimal]10000))) }
+            6 { return To-Hex ([BitConverter]::GetBytes([single]$value)) }
+            7 { return To-Hex ([BitConverter]::GetBytes([double]$value)) }
+            8 { return To-Hex ([BitConverter]::GetBytes(([datetime]$value).ToOADate())) }
+            9 { return To-Hex ([byte[]]$value) }
+            10 { return To-Hex ($CodePage.GetBytes([string]$value)) }
+            15 {
+                $text = [string]$value
+                if ($text -notmatch '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}') { throw 'Unrecognized GUID value' }
+                return To-Hex (([guid]$Matches[0]).ToByteArray())
+            }
+            default { throw 'Undeclared field type' }
+        }
+    }
+    finally { Release $field }
+}
+function Get-Fields($Plan, $Arm, [string]$TableName) {
+    $fields = [object[]]::new($Plan.fields.Count)
+    for ($i=0; $i -lt $fields.Length; $i++) {
+        $fields[$i] = if ($TableName -eq 'Items' -and $Plan.fields[$i].name -eq 'Value') { $Arm.field } else { $Plan.fields[$i] }
+    }
+    return ,$fields
+}
+function Failure($Record) {
+    return @{type=$Record.Exception.GetType().FullName; message=$Record.Exception.Message; stack=[string]$Record.ScriptStackTrace; endpoint=$script:endpoint}
+}
+$CodePage = [Text.Encoding]::GetEncoding(1252, (New-Object Text.EncoderExceptionFallback), (New-Object Text.DecoderExceptionFallback))
+function Create-Original([string]$Path, $Plan, $Arm) {
+    $engine = $workspace = $db = $table = $field = $rs = $query = $null
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36; $workspace = $engine.Workspaces.Item(0)
+        $script:mutationStarted = $true
+        $script:endpoint = 'create_database'; $db = $workspace.CreateDatabase($Path, ';LANGID=0x0409;CP=1252;COUNTRY=0', 32)
+        foreach ($spec in $Plan.tables) {
+            $script:endpoint = 'create_table'; $table = $db.CreateTableDef([string]$spec.name)
+            foreach ($column in (Get-Fields $Plan $Arm ([string]$spec.name))) {
+                $script:endpoint = "create_field/$($column.name)"; $field = $table.CreateField([string]$column.name, [int]$column.type, [int]$column.size)
+                if ($column.fixed) { $field.Attributes = 1 }
+                $table.Fields.Append($field); Release $field; $field = $null
+            }
+            $db.TableDefs.Append($table)
+            $rs = $db.OpenRecordset([string]$spec.name, 2)
+            foreach ($row in $spec.rows) {
+                $rs.AddNew()
+                $definitions = Get-Fields $Plan $Arm ([string]$spec.name)
+                for ($i=0; $i -lt $definitions.Length; $i++) {
+                    $value = if ($spec.name -eq 'Items' -and $definitions[$i].name -eq 'Value') { $Arm.initial_hex } else { $row[$i] }
+                    $script:endpoint = "assign/$($spec.name)/$($definitions[$i].name)"
+                    Set-Value $rs $definitions[$i] $value
+                }
+                $script:endpoint = "update/$($spec.name)"
+                $rs.Update()
+            }
+            $rs.Close(); Release $rs; $rs = $null; Release $table; $table = $null
+        }
+        $script:endpoint = 'create_query'; $query = $db.CreateQueryDef([string]$Plan.query.name, [string]$Plan.query.sql)
+    } catch { $script:failure = Failure $_; throw } finally {
+        if ($null -ne $rs) { try { $rs.Close() } catch {} }; Release $rs; Release $query; Release $field; Release $table
+        if ($null -ne $db) { try { $db.Close() } catch {} }; Release $db; Release $workspace; Release $engine
+    }
+}
+function Observe([string]$Path, $Plan, $Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $status = 'pass'; $errorDetail = $null; $endpoint = 'open_database'; $script:endpoint = $endpoint; $snapshot = [ordered]@{}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @($db.Relations | ForEach-Object { @{name=[string]$_.Name; table=[string]$_.Table; foreign_table=[string]$_.ForeignTable; attributes=[int]$_.Attributes; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })} })
+        $snapshot.queries = @($db.QueryDefs | ForEach-Object { @{name=[string]$_.Name; sql=[string]$_.SQL; type=[int]$_.Type} } | Sort-Object { $_.name })
+        $snapshot.user_tables = @()
+        foreach ($name in @($snapshot.tables | Where-Object { -not $_.StartsWith('MSys') })) {
+            $endpoint = 'schema'; $script:endpoint = $endpoint; $table = $db.TableDefs.Item([string]$name)
+            $item = [ordered]@{name=[string]$table.Name; attributes=[int]$table.Attributes}
+            $item.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes; required=[bool]$_.Required; allow_zero_length=[bool]$_.AllowZeroLength; default_value=[string]$_.DefaultValue} })
+            $item.indexes = @($table.Indexes | ForEach-Object { @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })} })
+            $endpoint = 'rows'; $script:endpoint = $endpoint; $rs = $db.OpenRecordset([string]$name, 4)
+            $rows = New-Object Collections.ArrayList
+            while (-not $rs.EOF) {
+                $values = [object[]]::new($item.fields.Count)
+                for ($i=0; $i -lt $values.Length; $i++) { $values[$i] = Read-Value $rs $item.fields[$i] }
+                [void]$rows.Add($values)
+                $rs.MoveNext()
+            }
+            $item.rows = @($rows); $rs.Close(); Release $rs; $rs = $null
+            $snapshot.user_tables += $item; Release $table; $table = $null
+        }
+    } catch { $status = 'error'; $errorDetail = Failure $_; $script:failure = $errorDetail }
+    finally {
+        if ($null -ne $rs) { try { $rs.Close() } catch {} }; Release $rs; Release $table
+        if ($null -ne $db) { try { $db.Close() } catch {} }; Release $db; Release $engine
+    }
+    return @{file=[IO.Path]::GetFileName($Path); before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'fixed-field-successor.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/fixed_field_successor.ps1') { throw 'Script pin mismatch' }
+$phase = (Get-Content -LiteralPath (Join-Path $env:JET3_WORK 'phase.txt') -Raw).Trim()
+if ($phase -notin @('create', 'observe')) { throw 'Unknown phase' }
+$mutationStarted = $false; $failure = $null; $endpoint = 'start'
+$result = [ordered]@{document_type='dao_fixed_field_update_phase'; phase=$phase; plan_sha256=(Identity $planPath).sha256; environment=@{process_bits=32; provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}; mutation_started=$false; observations=@(); error=$null; endpoint='start'}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $roles = if ($phase -eq 'create') { @('original') } else { @('original', 'updated') }
+            foreach ($role in $roles) {
+                $path = Join-Path $env:JET3_WORK "$($arm.name)-r$replica-$role.mdb"
+                $result.endpoint = "$($arm.name)/$replica/$role"; $script:endpoint = $result.endpoint
+                if ($phase -eq 'create') { Create-Original $path $plan $arm }
+                $observation = Observe $path $plan $arm
+                $result.observations += @{arm=[string]$arm.name; replica=$replica; role=$role; observation=$observation}
+                if ($observation.status -ne 'pass') { throw 'Read-only observation failed' }
+            }
+        }
+    }
+} catch { $result.error = if ($null -ne $failure) { $failure } else { Failure $_ } }
+finally {
+    $result.mutation_started = $mutationStarted
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+    Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb' | Copy-Item -Destination $env:JET3_OUTBOX
+}
+if ($null -ne $result.error) { exit 1 }

--- a/oracle/windows-dao/scripts/fixed_field_successor.py
+++ b/oracle/windows-dao/scripts/fixed_field_successor.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""EXP-0171: one phased DAO-create / Unix-public-update / DAO-read acquisition."""
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/fixed-field-successor.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/fixed_field_successor.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if subprocess.check_output(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    if os.name != 'posix' or plan['replicas'] != 3:
+        raise ValueError('Expected Unix producer and three replicas')
+    return plan
+
+
+def normalized(snapshot):
+    result = copy.deepcopy(snapshot)
+    result['user_tables'].sort(key=lambda table: table['name'])
+    for table in result['user_tables']:
+        table['rows'].sort()
+    return result
+
+
+def arm_tables(plan, arm, updated=False):
+    tables = copy.deepcopy(plan['tables'])
+    for table in tables:
+        table['fields'] = copy.deepcopy(plan['fields'])
+        if table['name'] == arm['table']:
+            ordinal = next(i for i, field in enumerate(table['fields']) if field['name'] == arm['column'])
+            table['fields'][ordinal] = arm['field']
+            for row in table['rows']:
+                row[ordinal] = arm['replacement_hex'] if updated and int.from_bytes(bytes.fromhex(row[0]), 'little', signed=True) == arm['selected_id'] else arm['initial_hex']
+    return tables
+
+
+def requested(snapshot, plan, arm, updated=False):
+    actual = normalized(snapshot)
+    if actual['version'] != '3.0' or actual['relations'] != []:
+        return False
+    if [t['name'] for t in actual['user_tables']] != sorted(t['name'] for t in plan['tables']):
+        return False
+    if len(actual['queries']) != 1 or actual['queries'][0]['name'] != plan['query']['name'] or not actual['queries'][0]['sql'] or actual['queries'][0]['type'] != 0:
+        return False
+    for spec in arm_tables(plan, arm, updated):
+        table = next(t for t in actual['user_tables'] if t['name'] == spec['name'])
+        if table['attributes'] != 0 or table['indexes'] != []:
+            return False
+        if [{k: field[k] for k in ('name', 'type', 'size')} for field in table['fields']] != [{k: field[k] for k in ('name', 'type', 'size')} for field in spec['fields']]:
+            return False
+        if any(field['attributes'] != (1 if declared['fixed'] else 2) for field, declared in zip(table['fields'], spec['fields'])):
+            return False
+        if table['rows'] != sorted(spec['rows']): return False
+    return True
+
+
+def patch_check(original, updated, arm, locator):
+    definition, _, records = catalog._discover_catalog(original)
+    name = catalog._ordinal(definition, 'Name')
+    id_column = catalog._ordinal(definition, 'Id')
+    roots = [row['values'][id_column] for row in records if row['values'][name] == arm['table']]
+    if len(roots) != 1 or roots[0] != locator['root']:
+        raise ValueError('Target catalog binding')
+    table = catalog._definition(original, roots[0])
+    columns = table['columns']
+    ordinal = catalog._ordinal(table, arm['column'])
+    id_column = catalog._ordinal(table, 'Id')
+    column = columns[ordinal]
+    if ordinal != locator['column'] or column['type'] != catalog.PHYSICAL_TYPES[arm['field']['type']] or column['storage'] != 'fixed' or column['size'] != arm['field']['size']:
+        raise ValueError('Target field binding')
+    pages, _ = catalog._table_pages(original, table)
+    rows = catalog._table_rows(original, table, pages)
+    selected = [row for row in rows if row['values'][id_column] == arm['selected_id']]
+    if len(selected) != 1 or selected[0]['page'] != locator['page'] or selected[0]['row'] != locator['slot'] or not selected[0]['present'][ordinal]:
+        raise ValueError('Target row binding')
+    image = catalog._page(original, locator['page'], 'target row')
+    entry = catalog._row_directory(image, locator['page'])[locator['slot']]
+    offset = locator['page'] * catalog.PAGE_BYTES + entry['start'] + 1 + column['fixed_offset']
+    replacement = bytes.fromhex(arm['replacement_hex']); width = arm['field']['size']
+    if len(replacement) != width or original[offset:offset + width].hex() != arm['initial_hex']:
+        raise ValueError('Declared present fixed field bytes mismatch')
+    expected = bytearray(original)
+    expected[offset:offset + width] = replacement
+    if expected != updated:
+        raise ValueError('Bytes outside the requested field changed, or replacement differs')
+    return {'offset': offset, 'length': width, 'before_hex': original[offset:offset + width].hex(),
+            'after_hex': updated[offset:offset + width].hex(),
+            'changed_offsets': [i for i, (a, b) in enumerate(zip(original, updated)) if a != b]}
+
+
+def phase_entries(phase, name, plan):
+    if (phase['document_type'] != 'dao_fixed_field_update_phase' or phase['phase'] != name
+        or phase['plan_sha256'] != digest(PLAN) or phase['error'] is not None
+        or phase['mutation_started'] != (name == 'create')
+        or phase['environment']['process_bits'] != 32 or phase['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Phase failed or has wrong identity: ' + name)
+    roles = ['original'] if name == 'create' else ['original', 'updated']
+    expected = {(arm['name'], replica, role) for arm in plan['arms'] for replica in range(1, 4) for role in roles}
+    entries = {}
+    for item in phase['observations']:
+        key = (item['arm'], item['replica'], item['role'])
+        if key in entries:
+            raise ValueError('Duplicate observation')
+        observation = item['observation']
+        if observation['status'] != 'pass' or observation['error'] is not None or observation['before'] != observation['after']:
+            raise ValueError('Read-only observation failed or mutated')
+        entries[key] = observation
+    if set(entries) != expected:
+        raise ValueError('Incomplete phase observations')
+    return entries
+
+
+def build_report(result, outbox, plan):
+    observations, reasons = [], []
+    try:
+        if (result['document_type'] != 'dao_fixed_field_update_result' or result['producer_os'] != 'posix'
+            or result['source_revision'] != plan['source_revision']):
+            raise ValueError('Unexpected result envelope or public Unix source receipt')
+        if result['plan_sha256'] != digest(PLAN) or result['error'] is not None or result['phase'] != 'complete':
+            raise ValueError('Coordinated acquisition failed: ' + str(result['error']))
+        phases = {}
+        for name in ('create', 'observe'):
+            path = outbox / (name + '.json')
+            if identity(path) != result['phases'][name]:
+                raise ValueError('Phase result identity mismatch')
+            phases[name] = phase_entries(json.loads(path.read_text(encoding='utf-8-sig')), name, plan)
+        updates = {(u['arm'], u['replica']): u for u in result['updates']}
+        if len(updates) != len(result['updates']) or set(updates) != {(a['name'], r) for a in plan['arms'] for r in range(1, 4)}:
+            raise ValueError('Incomplete Unix updates')
+        for arm in plan['arms']:
+            for replica in range(1, 4):
+                name = arm['name']; update = updates[name, replica]
+                before = phases['create'][name, replica, 'original']
+                after_original = phases['observe'][name, replica, 'original']
+                after = phases['observe'][name, replica, 'updated']
+                original = outbox / f'{name}-r{replica}-original.mdb'
+                updated = outbox / f'{name}-r{replica}-updated.mdb'
+                if (identity(original) != before['after'] or identity(original) != after_original['after']
+                    or identity(original) != update['original_before'] or identity(original) != update['original_after']
+                    or identity(updated) != after['before'] or identity(updated) != update['updated']):
+                    raise ValueError('Image identity chain mismatch')
+                for role, observation in [('original', before), ('original', after_original), ('updated', after)]:
+                    if observation['file'] != f'{name}-r{replica}-{role}.mdb':
+                        raise ValueError('Image filename association mismatch')
+                if normalized(before['snapshot']) != normalized(after_original['snapshot']) or not requested(before['snapshot'], plan, arm) or not requested(after['snapshot'], plan, arm, True):
+                    raise ValueError('Original/requested schema or rows differ')
+                expected = normalized(before['snapshot'])
+                target = next(t for t in expected['user_tables'] if t['name'] == arm['table'])
+                field = next(i for i, f in enumerate(plan['fields']) if f['name'] == arm['column'])
+                next(row for row in target['rows'] if int.from_bytes(bytes.fromhex(row[0]), 'little', signed=True) == arm['selected_id'])[field] = arm['replacement_hex']
+                if normalized(expected) != normalized(after['snapshot']):
+                    raise ValueError('Unrelated schema, rows or query SQL differs')
+                span = patch_check(original.read_bytes(), updated.read_bytes(), arm, update['locator'])
+                observations.append({'arm': name, 'replica': replica, 'original': identity(original),
+                                     'updated': identity(updated), 'patch': span, 'snapshot': after['snapshot'],
+                                     'requested_change_and_preservation': True})
+    except (KeyError, ValueError, TypeError, OSError, catalog.DecodeError) as error:
+        reasons.append(str(error))
+    return {'document_type': 'dao_fixed_field_update_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'observed_accepted' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'support_matrix_movement': False,
+            'compatibility_claim': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text())
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    (outbox / 'report.json').write_text(canonical(report) + '\n')
+    print(report['outcome'])
+
+
+def dispatch(args):
+    plan = preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve(); outbox = shared / 'outbox' / args.run_id
+    paths = [outbox] + [shared / part / (args.run_id + '-' + phase) for part in ('inbox', 'outbox') for phase in ('create', 'observe')]
+    if any(path.exists() for path in paths):
+        raise ValueError('Run id used; never resume or retry')
+    subprocess.run(['cargo', 'build', '-p', 'jet3', '--example', 'fixed_field_update_candidate'], cwd=ROOT, check=True)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec); spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result = {'document_type': 'dao_fixed_field_update_result', 'plan_sha256': digest(PLAN),
+              'source_revision': plan['source_revision'],
+              'acquisition_revision': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT).decode().strip(),
+              'producer_os': os.name, 'phase': 'create', 'phases': {}, 'updates': [], 'error': None}
+    try:
+        for phase in ('create', 'observe'):
+            result['phase'] = phase
+            run_id = args.run_id + '-' + phase; inbox = shared / 'inbox' / run_id; inbox.mkdir(parents=True)
+            shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1'); shutil.copyfile(PLAN, inbox / PLAN.name)
+            (inbox / 'phase.txt').write_text(phase)
+            if phase == 'observe':
+                for path in outbox.glob('*.mdb'): shutil.copyfile(path, inbox / path.name)
+            command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15', '-o', 'IdentitiesOnly=yes', '-i', args.identity,
+                       f'{args.user}@{args.host}', 'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+                       transport.encoded(transport.guest_script(args.remote_shared_root, run_id, 'script.ps1'))]
+            completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+            (outbox / (phase + '-ssh.txt')).write_bytes(completed.stdout + completed.stderr)
+            guest = shared / 'outbox' / run_id
+            shutil.copyfile(guest / 'result.json', outbox / (phase + '.json'))
+            result['phases'][phase] = identity(outbox / (phase + '.json'))
+            if phase == 'create':
+                for path in guest.glob('*.mdb'): shutil.copyfile(path, outbox / path.name)
+            observations = phase_entries(json.loads((outbox / (phase + '.json')).read_text(encoding='utf-8-sig')), phase, plan)
+            if completed.returncode != 0: raise ValueError('Guest phase exited unsuccessfully')
+            if phase == 'create':
+                result['phase'] = 'unix_update'
+                for arm in plan['arms']:
+                    for replica in range(1, 4):
+                        prefix = f"{arm['name']}-r{replica}"
+                        original = outbox / (prefix + '-original.mdb'); updated = outbox / (prefix + '-updated.mdb')
+                        before = identity(original)
+                        if before != observations[arm['name'], replica, 'original']['after']: raise ValueError('Original transfer identity')
+                        if not requested(observations[arm['name'], replica, 'original']['snapshot'], plan, arm): raise ValueError('Original request mismatch')
+                        command = ['cargo', 'run', '--quiet', '-p', 'jet3', '--example', 'fixed_field_update_candidate', '--', str(original), str(updated), arm['table'], str(arm['selected_id']), arm['column'], arm['name']]
+                        done = subprocess.run(command, cwd=ROOT, capture_output=True, timeout=120)
+                        (outbox / (prefix + '-unix.txt')).write_bytes(done.stdout + done.stderr)
+                        if done.returncode: raise ValueError('Public field update failed: ' + prefix)
+                        result['updates'].append({'arm': arm['name'], 'replica': replica, 'original_before': before,
+                            'original_after': identity(original), 'updated': identity(updated), 'locator': json.loads(done.stdout)})
+                        if identity(original) != before: raise ValueError('Unix update changed original')
+                        patch_check(original.read_bytes(), updated.read_bytes(), arm, result['updates'][-1]['locator'])
+        result['phase'] = 'complete'
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        result['error'] = type(error).__name__ + ': ' + str(error)
+    finally:
+        (outbox / 'result.json').write_text(canonical(result) + '\n')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__); commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight'); report = commands.add_parser('analyze'); report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run'); run.add_argument('--run-id', required=True); run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'), ('identity', str(Path.home() / '.ssh/jet3-dao')), ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=default)
+    args = parser.parse_args()
+    if args.command == 'preflight': preflight(); print('Committed inputs match.')
+    elif args.command == 'analyze': analyze(args.outbox)
+    else: dispatch(args)
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/tests/test_fixed_field_successor.py
+++ b/oracle/windows-dao/tests/test_fixed_field_successor.py
@@ -1,0 +1,81 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import fixed_field_successor as experiment
+
+
+def snapshot(plan, arm, updated=False):
+    tables=[]
+    for table in experiment.arm_tables(plan,arm,updated):
+        fields=[dict({k:f[k] for k in ('name','type','size')},attributes=1 if f['fixed'] else 2) for f in table['fields']]
+        tables.append(dict(name=table['name'],attributes=0,indexes=[],fields=fields,rows=table['rows']))
+    return dict(version='3.0',relations=[],queries=[dict(name=plan['query']['name'],sql=plan['query']['sql'],type=0)],user_tables=tables)
+
+
+class FixedSuccessorTests(unittest.TestCase):
+    def test_exact_typed_requests_and_negative_zero(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        self.assertEqual(len(plan['arms']),10)
+        for arm in plan['arms']:
+            before=snapshot(plan,arm);after=snapshot(plan,arm,True)
+            self.assertTrue(experiment.requested(before,plan,arm))
+            self.assertTrue(experiment.requested(after,plan,arm,True))
+            self.assertFalse(experiment.requested(before,plan,arm,True))
+            wrong=copy.deepcopy(after);wrong['user_tables'][1]['rows'][0][2]='ff'
+            self.assertFalse(experiment.requested(wrong,plan,arm,True))
+        for name in ('single','double'):
+            arm=next(a for a in plan['arms'] if a['name']==name)
+            after=snapshot(plan,arm,True);after['user_tables'][0]['rows'][1][1]='00'*arm['field']['size']
+            self.assertFalse(experiment.requested(after,plan,arm,True))
+
+    def test_fixed_text_requires_saved_fixed_attributes(self):
+        plan=json.loads(experiment.PLAN.read_text());arm=plan['arms'][-1]
+        actual=snapshot(plan,arm);actual['user_tables'][0]['fields'][1]['attributes']=2
+        self.assertFalse(experiment.requested(actual,plan,arm))
+
+    def test_failure_result_and_input_pins(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory)
+            result={'document_type':'dao_fixed_field_update_result','producer_os':'posix','source_revision':plan['source_revision'],
+                    'plan_sha256':experiment.digest(experiment.PLAN),'phase':'create','error':{'endpoint':'assign','message':'failed'}}
+            report=experiment.build_report(result,root,plan)
+            self.assertEqual(report['outcome'],'no_outcome');self.assertEqual(report['observations'],[])
+            script=root/'producer.py';script.write_text('original');p=root/'plan.json';p.write_text(json.dumps({'inputs':{'producer.py':experiment.digest(script)}}))
+            with patch.object(experiment,'ROOT',root),patch.object(experiment,'PLAN',p):
+                experiment.verify_inputs();script.write_text('changed')
+                with self.assertRaisesRegex(ValueError,'Input pin'):experiment.verify_inputs()
+
+    def test_complete_matrix_and_query_preservation_gate(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory); phases={name:{'document_type':'dao_fixed_field_update_phase','phase':name,'plan_sha256':experiment.digest(experiment.PLAN),
+                'error':None,'mutation_started':name=='create','environment':{'process_bits':32,'provider':'DAO.DBEngine.36'},'observations':[]} for name in ('create','observe')}
+            result={'document_type':'dao_fixed_field_update_result','producer_os':'posix','source_revision':plan['source_revision'],
+                'plan_sha256':experiment.digest(experiment.PLAN),'phase':'complete','error':None,'updates':[],'phases':{}}
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    ids={}
+                    for role in ('original','updated'):
+                        path=root/f"{arm['name']}-r{replica}-{role}.mdb";path.write_bytes(role.encode());ids[role]=experiment.identity(path)
+                        obs={'arm':arm['name'],'replica':replica,'role':role,'observation':{'file':path.name,'before':ids[role],'after':ids[role],
+                            'status':'pass','error':None,'snapshot':snapshot(plan,arm,role=='updated')}}
+                        phases['observe']['observations'].append(obs)
+                        if role=='original':phases['create']['observations'].append(copy.deepcopy(obs))
+                    result['updates'].append({'arm':arm['name'],'replica':replica,'original_before':ids['original'],'original_after':ids['original'],'updated':ids['updated'],'locator':{}})
+            def classify():
+                for name,phase in phases.items():
+                    path=root/(name+'.json');path.write_text(json.dumps(phase));result['phases'][name]=experiment.identity(path)
+                with patch.object(experiment,'patch_check',return_value={}):return experiment.build_report(result,root,plan)
+            self.assertEqual(classify()['outcome'],'observed_accepted')
+            phases['observe']['observations'][1]['observation']['snapshot']['queries'][0]['sql']='SELECT 99;'
+            self.assertEqual(classify()['outcome'],'no_outcome')
+
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
The original fixed-field acquisition failed during the DAO Currency setter. Preregister a distinct successor using the proven dedicated typed setter and fresh controls for all ten field cases, retaining the original failure.

Validation: independent review, four focused Python tests, actual x86 pure conversion checks, committed preflight and just ready passed. Acquisition results will be recorded separately.
