### PR TITLE
test: preregister existing-row insertion DAO comparison

### DIFF
--- a/crates/jet3/examples/row_insert_candidate.rs
+++ b/crates/jet3/examples/row_insert_candidate.rs
@@ -1,0 +1,52 @@
+//! One public insertion into a closed DAO-created copy for EXP-0169.
+use jet3::{
+    CatalogObjectClass, DatabaseReader, ResourceBudget, ResourceLimits, RowValue, insert_row,
+};
+use std::{env, fs, path::Path};
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = env::args().skip(1).collect();
+    let [source, destination, table, id, value, payload] = args.as_slice() else {
+        return Err(
+            "usage: row_insert_candidate SOURCE DESTINATION TABLE ID VALUE ASCII_PAYLOAD".into(),
+        );
+    };
+    if Path::new(destination).exists() || !payload.is_ascii() {
+        return Err("existing destination or non-ASCII payload".into());
+    }
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let mut database = DatabaseReader::open(source, &mut budget)?;
+    let root = {
+        let mut catalog = database.catalog(&mut budget)?;
+        let mut roots = Vec::new();
+        while let Some(record) = catalog.next_record()? {
+            if record.class() == CatalogObjectClass::User
+                && record.name().raw_bytes() == table.as_bytes()
+            {
+                roots.push(record.table_definition().ok_or("not a table")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("table not unique".into());
+        }
+        roots[0]
+    };
+    drop(database);
+    fs::copy(source, destination)?;
+    let locator = insert_row(
+        destination,
+        table.as_bytes(),
+        &[
+            RowValue::Long(id.parse()?),
+            RowValue::Long(value.parse()?),
+            RowValue::Text(payload.as_bytes()),
+        ],
+        &mut budget,
+    )?;
+    println!(
+        "{{\"root\":{},\"page\":{},\"slot\":{}}}",
+        root.get(),
+        locator.page().get(),
+        locator.slot()
+    );
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -12304,6 +12304,44 @@ Copy this block under the appropriate section and remove this instruction:
   updates, candidate acceptance, general compatibility or hosted support claim.
   Retain raw images/results externally and record one validated EXP-0148 outcome.
 
+## EXP-0169 — Existing-row insertion candidate preregistration
+
+- Status: preregistered only; no acquisition. Outcome reserved as EXP-0170.
+- Question: does the bounded public insertion match DAO insertion and subsequent
+  DAO use while retaining all unrelated bytes, maps and uninterpreted page zero?
+- Committed plan: `oracle/windows-dao/acquisition/row-insert-candidate.plan.json`,
+  SHA-256 `c1a902a208baa27c7801aa2131180af008b1a53e4f9ee5ae8ae6f1d73309f413`.
+  Reviewed implementation source: `2fdd791cae4ce1649fb634b01c40cac98f2b4340`.
+  The plan pins the exporter, relevant row/reader/publication inputs, PowerShell
+  producer, analyzer, imported diagnostic/read helpers and transport. Dispatch
+  and analysis share input-pin verification. Acquisition revision is recorded
+  separately from the reviewed library source.
+- Three cases, each with three independent originals: first-page insertion,
+  insertion in a later table with multiple data pages and 180-byte Text payloads,
+  and insertion after a preparatory DAO tail deletion. Each database contains
+  the complete declared Long/Long/Text tables and an unrelated stored KeepQuery.
+- A complete DAO creation/control phase precedes any Unix insertion. The public
+  exporter copies each original and calls `insert_row` once; an independent raw
+  decoder binds its table/page/new slot, exact encoded row, free-byte and row
+  counts, retained tombstones and map membership. The entire remaining file,
+  including original payload/slack and page zero, must remain byte-identical.
+- Separate DAO continuation copies receive one further declared row. Require
+  full schema/rows/index/relation metadata and original stored QueryDef SQL
+  preservation, Rust/control equality after both operations and unchanged
+  original/control/Rust identities. Nine originals plus controls, Rust candidates
+  and continuation copies produce 45 retained MDBs and 63 read-only captures;
+  control/continuation inserts and three preparatory deletes are finite endpoints.
+- Any mismatch, native/public failure or incomplete phase is `no_outcome` without
+  subset promotion or retry/resume. The raw decoder's finite bounds and phase
+  timeouts are declared. No DAO free-space threshold, page-zero interpretation,
+  empty-table/new-page allocator or general compatibility claim is inferred.
+  This local validation cannot move the hosted support matrix.
+- Pre-acquisition checks: three focused classifier/preservation/pin tests and
+  exporter Clippy pass. An actual x86 parser-only producer check passes without
+  execution/DAO. Public insertion plus independent exact-byte analysis passes on
+  a temporary copy of a retained original, which remains unchanged. Independent
+  review is required before dispatch.
+
 ## EXP-0166 — Nullable writer successor accepted in the exact six-arm matrix
 
 - Recorded 2026-09-05 from the single local run

--- a/oracle/windows-dao/acquisition/row-insert-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/row-insert-candidate.plan.json
@@ -1,0 +1,288 @@
+{
+  "document_type": "dao_row_insert_candidate_plan",
+  "provenance": "EXP-0169",
+  "outcome_provenance": "EXP-0170",
+  "replicas": 3,
+  "source_revision": "2fdd791cae4ce1649fb634b01c40cac98f2b4340",
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 255
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "insert": [
+    99,
+    -9900,
+    "next"
+  ],
+  "arms": [
+    {
+      "name": "first-page",
+      "table": "Items",
+      "delete_id": null,
+      "insert": [
+        88,
+        -8800,
+        "inserted"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "later-page",
+      "table": "Later",
+      "delete_id": null,
+      "insert": [
+        88,
+        -8800,
+        "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "rows": [
+            [
+              11,
+              -11,
+              "LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL"
+            ],
+            [
+              12,
+              -12,
+              "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM"
+            ],
+            [
+              13,
+              -13,
+              "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN"
+            ],
+            [
+              14,
+              -14,
+              "OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO"
+            ],
+            [
+              15,
+              -15,
+              "PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP"
+            ],
+            [
+              16,
+              -16,
+              "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ"
+            ],
+            [
+              17,
+              -17,
+              "RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR"
+            ],
+            [
+              18,
+              -18,
+              "SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS"
+            ],
+            [
+              19,
+              -19,
+              "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
+            ],
+            [
+              20,
+              -20,
+              "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            ],
+            [
+              21,
+              -21,
+              "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+            ],
+            [
+              22,
+              -22,
+              "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "after-tail",
+      "table": "Items",
+      "delete_id": 4,
+      "insert": [
+        88,
+        -8800,
+        "inserted"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ],
+            [
+              4,
+              -404,
+              "deleted"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "inputs": {
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/row_insert_candidate.rs": "8588779c4fdd4ce03e2b0ea301f6987e7f55311a33d5012811f4390a2e3240b1",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/insert.rs": "5e8a80e864d88a6b3da312705a76ff612ef4712077633562f689400553ab7a18",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_insert_page.rs": "c338292a412b187b097defc4a4f88fc17dd2a30549c6ee93ad5ce754b7d44a6a",
+    "crates/jet3/src/row_writer.rs": "c4cc40d63681391c94da5ae7b3cc451c1fe398189d75fc9c40ba53006ecaf9fc",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/update.rs": "707d18f566149e87a02913da1c2d68317ad071fbe79d01c8b06f858a693978c3",
+    "crates/jet3/src/update_pages.rs": "df312df67ae1e6d3ef5ec93df53a191918b3f8a79c7b70ae8f2013d063fc68ae",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/row_delete_layout.py": "74c30a55148ec5efe4c04a154917e8780c06a63442d28c0d0b3453b968142088",
+    "oracle/windows-dao/scripts/row_insert_candidate.ps1": "04747fa0cfca8a5a70567dd030de49ff6a2d7ba370d98aff9290b12746c77232",
+    "oracle/windows-dao/scripts/row_insert_candidate.py": "f46a80b7531e3aaa40d28081b30d8148af72201fb66014f6355ad0bdefe8bc53",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "question": "Does bounded public insertion into populated available data pages match DAO insertion and subsequent DAO use while preserving every unrelated byte and retaining page0/maps?",
+  "source_facts": [
+    "EXP-0060 finite Long/Long/Text row and directory grammar",
+    "EXP-0162 append-after-delete physical slot/free/count observations; page0 remains uninterpreted",
+    "EXP-0152 existing-file publication and unrelated QueryDef preservation"
+  ],
+  "sequence": [
+    "Commit and independently review exact input/source pins before one coordinated acquisition; no retry or phase resume.",
+    "Create nine fresh DAO originals with two declared tables and KeepQuery. after-tail additionally deletes Id4 before closing the original; this prepares a known tombstone. Copy each closed original and insert the declared arm row through DAO once. Retain original/control observations and images.",
+    "Only a complete phase with exact expected schema/rows and retained identities permits Unix operations. Public exporter copies each original and calls insert_row once with the exact declared row. Independently check returned root/page/slot and entire raw patch. Original remains unchanged.",
+    "Only nine valid Unix insertions permit read-only observations of original/control/rust and separate control-next/rust-next copies with the declared continuation row inserted once through DAO. Retain all original identities and compare full snapshots before/after both phases.",
+    "Nine originals, nine controls, nine Rust candidates and eighteen independent continuation copies give45MDBs and63read captures. Additional DAO mutations are9control inserts+18continuations+3preparatory deletes, in addition to baseline schema/row/query creation."
+  ],
+  "decision_rule": "observed_accepted only when all nine finite comparisons pass complete phase/operation/source/image identities, requested full schema/rows and exact original stored QueryDef SQL, unchanged maps, exact new row/slot/free/count patch, and all unrelated byte preservation. Any incomplete observation/failure/mismatch is no_outcome without subset promotion. Common input verification precedes dispatch and analysis.",
+  "bounds": "Three finite Long/Long/Text, unindexed relationship-free non-Auto/LVAL cases. One later-table multi-page case and one pre-existing tail tombstone. Existing64page/64row-per-page diagnostic limits suffice. SSH300seconds per phase; Unix120seconds. No new-page allocation, empty-table insertion, wide variable-offset inference, hosted compatibility or support movement.",
+  "hypothesis": "Rust appends a new slot and retains contiguous capacity for another equal-sized row/slot; this candidate restriction is not a DAO available-map threshold. Page0, maps and all unrelated bytes remain exact; DAO control physical placement need not equal Rust placement. Subsequent insertion acceptance is an experimental question.",
+  "producer": "Public Unix insert_row on closed copies from reviewed source. Source revision plus relevant file pins; acquisition revision separately records committed harness. No build attestation."
+}

--- a/oracle/windows-dao/scripts/row_insert_candidate.ps1
+++ b/oracle/windows-dao/scripts/row_insert_candidate.ps1
@@ -1,0 +1,106 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'Expected x86 DAO' }
+$tokens=$null; $errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile((Join-Path $env:JET3_WORK 'field_update.ps1'),[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Pinned helper parse failure'}
+foreach($name in @('Identity','Release','Write-Json','Observe')) {
+    $definitions=@($ast.FindAll({param($node) $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name},$false))
+    if($definitions.Count-ne 1){throw 'Helper missing'}
+    Invoke-Expression $definitions[0].Extent.Text
+}
+function Remember($Record) {
+    if($null-eq $script:failure){$script:failure=@{endpoint=$script:endpoint; message=$Record.Exception.Message; stack=[string]$Record.ScriptStackTrace; hresult=[int]$Record.Exception.HResult}}
+}
+function Close-Object($Value,[bool]$Close) {
+    if($null-eq $Value){return}
+    try{if($Close){$Value.Close()}}catch{Remember $_}
+    try{Release $Value}catch{Remember $_}
+}
+function Append-Row($Recordset,$Row) {
+    $Recordset.AddNew()
+    foreach($ordinal in 0..2){
+        $field=$Recordset.Fields.Item($ordinal)
+        try { if($ordinal-eq 2){$field.Value=[string]$Row[$ordinal]}else{$field.Value=[int]$Row[$ordinal]} }
+        catch{Remember $_;throw} finally{Close-Object $field $false}
+    }
+    $Recordset.Update()
+}
+function Create-Original([string]$Path,$Arm) {
+    $engine=$workspace=$db=$table=$field=$rs=$query=$null
+    try {
+        $engine=New-Object -ComObject DAO.DBEngine.36; $workspace=$engine.Workspaces.Item(0)
+        $script:mutationStarted=$true; $script:endpoint='create_database'
+        $db=$workspace.CreateDatabase($Path,';LANGID=0x0409;CP=1252;COUNTRY=0',32)
+        foreach($spec in $Arm.tables){
+            $script:endpoint='schema/'+$spec.name; $table=$db.CreateTableDef([string]$spec.name)
+            foreach($column in $plan.fields){
+                $field=$table.CreateField([string]$column.name,[int]$column.type,[int]$column.size)
+                $table.Fields.Append($field);Close-Object $field $false;$field=$null
+            }
+            $db.TableDefs.Append($table);$rs=$db.OpenRecordset([string]$spec.name,2)
+            foreach($row in $spec.rows){$script:endpoint='insert/'+$spec.name;Append-Row $rs $row}
+            Close-Object $rs $true;$rs=$null;Close-Object $table $false;$table=$null
+        }
+        if($null-ne $Arm.delete_id){
+            $rs=$db.OpenRecordset([string]$Arm.table,2);$found=0
+            while(-not $rs.EOF){if([int]$rs.Fields.Item('Id').Value-eq [int]$Arm.delete_id){$found++};$rs.MoveNext()}
+            if($found-ne 1){throw 'Preparatory delete Id not unique'}
+            $rs.MoveFirst();while([int]$rs.Fields.Item('Id').Value-ne [int]$Arm.delete_id){$rs.MoveNext()}
+            $script:endpoint='prepare/delete';$rs.Delete();Close-Object $rs $true;$rs=$null
+        }
+        $query=$db.CreateQueryDef([string]$plan.query.name,[string]$plan.query.sql)
+    }catch{Remember $_;throw}finally{
+        Close-Object $rs $true;Close-Object $field $false;Close-Object $table $false;Close-Object $query $false
+        Close-Object $db $true;Close-Object $workspace $false;Close-Object $engine $false
+    }
+}
+function Mutate-Copy([string]$Source,[string]$Path,$Arm,[string]$Operation) {
+    Copy-Item -LiteralPath $Source -Destination $Path
+    $engine=$db=$rs=$null;$outcome=@{operation=$Operation;status='complete'}
+    try {
+        $script:mutationStarted=$true;$script:endpoint=$Operation+'/open'
+        $engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$false)
+        $rs=$db.OpenRecordset([string]$Arm.table,2)
+        $script:endpoint=$Operation+'/append'
+        if($Operation-eq 'insert'){Append-Row $rs $Arm.insert}else{Append-Row $rs $plan.insert}
+    }catch{Remember $_;throw}finally{Close-Object $rs $true;Close-Object $db $true;Close-Object $engine $false}
+    return $outcome
+}
+$planPath=Join-Path $env:JET3_WORK 'row-insert-candidate.plan.json'
+$plan=Get-Content -LiteralPath $planPath -Raw|ConvertFrom-Json
+foreach($entry in @(@('row_insert_candidate.ps1',$PSCommandPath),@('field_update.ps1',(Join-Path $env:JET3_WORK 'field_update.ps1')))){
+    if((Identity $entry[1]).sha256-cne $plan.inputs.('oracle/windows-dao/scripts/'+$entry[0])){throw 'Script pin mismatch'}
+}
+$phase=(Get-Content (Join-Path $env:JET3_WORK 'phase.txt') -Raw).Trim()
+if($phase-notin @('create','observe')){throw 'Unknown phase'}
+$failure=$null;$mutationStarted=$false;$endpoint='start'
+$result=@{document_type='dao_row_insert_candidate_phase';phase=$phase;plan_sha256=(Identity $planPath).sha256;environment=@{process_bits=32;provider='DAO.DBEngine.36'};observations=@();operations=@();error=$null;retention_failures=@()}
+try{
+    foreach($arm in $plan.arms){foreach($replica in 1..3){
+        $prefix="$($arm.name)-r$replica";$original=Join-Path $env:JET3_WORK "$prefix-original.mdb";$control=Join-Path $env:JET3_WORK "$prefix-control.mdb"
+        if($phase-eq 'create'){
+            Create-Original $original $arm
+            $result.operations+=@{arm=$arm.name;replica=$replica;role='control';result=(Mutate-Copy $original $control $arm 'insert')}
+            $roles=@('original','control')
+        }else{$roles=@('original','control','rust','control-next','rust-next')}
+        foreach($role in $roles){
+            $path=Join-Path $env:JET3_WORK "$prefix-$role.mdb"
+            if($role.EndsWith('-next')){
+                $source=Join-Path $env:JET3_WORK "$prefix-$($role.Replace('-next','')).mdb"
+                $result.operations+=@{arm=$arm.name;replica=$replica;role=$role;result=(Mutate-Copy $source $path $arm 'continue')}
+            }
+            $observation=Observe $path
+            $result.observations+=@{arm=$arm.name;replica=$replica;role=$role;observation=$observation}
+            if($observation.status-ne 'pass'-or $null-ne $failure){throw 'Capture or cleanup failed'}
+        }
+    }}
+}catch{Remember $_}finally{
+    $result.error=$failure;$result.mutation_started=$mutationStarted
+    [GC]::Collect();[GC]::WaitForPendingFinalizers()
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb'){
+        try{Copy-Item -LiteralPath $file.FullName -Destination $env:JET3_OUTBOX}catch{$result.retention_failures+=@{file=$file.Name;message=$_.Exception.Message}}
+    }
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if($null-ne $failure-or $result.retention_failures.Count){exit 1}

--- a/oracle/windows-dao/scripts/row_insert_candidate.py
+++ b/oracle/windows-dao/scripts/row_insert_candidate.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""EXP-0169: phased public row insertion and DAO continuation, no retries."""
+import argparse
+import copy
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import field_update as common
+import row_delete_layout as layout
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/row-insert-candidate.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/row_insert_candidate.ps1'
+identity, canonical = common.identity, common.canonical
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, sha in plan['inputs'].items():
+        if identity(ROOT / name)['sha256'] != sha: raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if os.name != 'posix' or subprocess.check_output(['git','show',f'HEAD:{PLAN.relative_to(ROOT)}'],cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Expected committed Unix plan')
+    return plan
+
+
+def expected(snapshot, arm, role, plan):
+    value = common.normalized(snapshot)
+    tables = copy.deepcopy(arm['tables'])
+    target = next(t for t in tables if t['name'] == arm['table'])
+    if arm['delete_id'] is not None: target['rows'] = [r for r in target['rows'] if r[0] != arm['delete_id']]
+    if role != 'original': target['rows'].append(arm['insert'])
+    if role.endswith('-next'): target['rows'].append(plan['insert'])
+    if (value['version'] != '3.0' or value['relations'] != []
+        or value['tables'] != sorted(['MSysACEs','MSysObjects','MSysQueries','MSysRelationships']+[t['name'] for t in tables])
+        or [t['name'] for t in value['user_tables']] != sorted(t['name'] for t in tables)
+        or len(value['queries']) != 1 or value['queries'][0]['name'] != plan['query']['name']
+        or value['queries'][0]['type'] != 0 or not value['queries'][0]['sql']):
+        raise ValueError('Requested database inventory')
+    for spec in tables:
+        table = next(t for t in value['user_tables'] if t['name'] == spec['name'])
+        if (table['attributes'] != 0 or table['indexes'] != [] or table['rows'] != sorted(spec['rows'])
+            or [{k:f[k] for k in ('name','type','size')} for f in table['fields']] != plan['fields']
+            or [f['attributes'] for f in table['fields']] != [1,1,2]):
+            raise ValueError('Requested table schema/rows')
+    return value
+
+
+def shape(data, arm):
+    catalog = layout.catalog
+    definition, _, records = catalog._discover_catalog(data)
+    name, ident = [catalog._ordinal(definition, n) for n in ('Name','Id')]
+    roots = [r['values'][ident] for r in records if r['values'][name] == arm['table']]
+    if len(roots) != 1: raise ValueError('Target table binding')
+    table = catalog._definition(data, roots[0]); pages, lval = catalog._table_pages(data, table)
+    if lval or table['physical_indexes']: raise ValueError('Unsupported source shape')
+    rows = catalog._table_rows(data, table, pages)
+    if table['row_count'] != len(rows): raise ValueError('Raw row count')
+    return table, rows, {k:sorted(catalog._locator_pages(data,v,k)) for k,v in table['maps'].items()}
+
+
+def patch_check(before, after, arm, receipt):
+    table, rows, maps = shape(before, arm)
+    page, slot = receipt['page'], receipt['slot']
+    if receipt['root'] != table['root'] or page not in maps['owned'] or page not in maps['available']:
+        raise ValueError('Locator receipt/map ownership')
+    raw = layout.catalog._page(before,page,'target'); entries = layout.catalog._row_directory(raw,page)
+    if not entries or slot != len(entries) or slot >= 255:
+        raise ValueError('Not an appended representable slot')
+    tombstones = [e for e in entries if e['hidden'] and e['overflow'] and e['start']==e['end']]
+    live = [e for e in entries if not e['hidden'] and not e['overflow'] and e['start']<e['end']]
+    if not live or len(live)+len(tombstones)!=len(entries): raise ValueError('Nonordinary source page')
+    if arm['delete_id'] is not None and not tombstones: raise ValueError('Expected retained tombstone')
+    if arm['name']=='later-page' and (len(maps['owned'])<2 or page==min(maps['owned'])):
+        raise ValueError('Expected later data page')
+    # EXP-0060: this finite non-null Long/Long/Text row uses narrow variable offsets.
+    ident, value, text = arm['insert']; payload=text.encode('cp1252')
+    if len(payload)>246: raise ValueError('Finite narrow Text scope')
+    encoded = bytes([3])+ident.to_bytes(4,'little',signed=True)+value.to_bytes(4,'little',signed=True)+payload+bytes([9+len(payload),9,1,7])
+    directory_end=10+2*len(entries); packed_start=entries[-1]['start']; free=packed_start-directory_end
+    if int.from_bytes(raw[2:4],'little')!=free or free<2*(len(encoded)+2): raise ValueError('Source free/capacity')
+    start=packed_start-len(encoded); expected_bytes=bytearray(before); base=page*2048; root=table['root']*2048
+    expected_bytes[base+start:base+packed_start]=encoded
+    expected_bytes[base+directory_end:base+directory_end+2]=start.to_bytes(2,'little')
+    expected_bytes[base+2:base+4]=(free-len(encoded)-2).to_bytes(2,'little')
+    expected_bytes[base+8:base+10]=(slot+1).to_bytes(2,'little')
+    expected_bytes[root+12:root+16]=(len(rows)+1).to_bytes(4,'little')
+    if expected_bytes != after: raise ValueError('Exact insertion/payload/slack/page0 preservation')
+    after_table, after_rows, after_maps = shape(after,arm)
+    if maps != after_maps or sorted(r['values'] for r in after_rows) != sorted([r['values'] for r in rows]+[arm['insert']]):
+        raise ValueError('Inserted raw rows/maps')
+    return dict(locator=receipt,row_count=after_table['row_count'],maps=maps,
+        inserted_payload_hex=encoded.hex(),tombstones=tombstones,changes=layout.changed_ranges(before,after),
+        page0_unchanged=before[:2048]==after[:2048])
+
+
+def entries(document, phase, plan):
+    if (document['document_type']!='dao_row_insert_candidate_phase' or document['phase']!=phase
+        or document['plan_sha256']!=identity(PLAN)['sha256'] or document['error'] is not None
+        or document['retention_failures'] or document['mutation_started'] is not True
+        or document['environment']!={'process_bits':32,'provider':'DAO.DBEngine.36'}):
+        raise ValueError('Failed/incomplete phase')
+    roles=['original','control'] if phase=='create' else ['original','control','rust','control-next','rust-next']
+    wanted={(a['name'],r,role) for a in plan['arms'] for r in range(1,4) for role in roles}
+    result={}
+    for item in document['observations']:
+        key=(item['arm'],item['replica'],item['role']); obs=item['observation']
+        if key in result or key not in wanted or obs['file']!=f'{key[0]}-r{key[1]}-{key[2]}.mdb' or obs['status']!='pass' or obs['error'] is not None or obs['before']!=obs['after']:
+            raise ValueError('Observation binding/failure')
+        result[key]=obs
+    if set(result)!=wanted: raise ValueError('Missing capture')
+    op_roles=['control'] if phase=='create' else ['control-next','rust-next']
+    operations={(o['arm'],o['replica'],o['role']):o['result'] for o in document['operations']}
+    if len(operations)!=len(document['operations']) or set(operations)!={(a['name'],r,role) for a in plan['arms'] for r in range(1,4) for role in op_roles}: raise ValueError('Missing operation')
+    for a in plan['arms']:
+        for r in range(1,4):
+            for role in op_roles:
+                if operations[a['name'],r,role]!=dict(operation='insert' if phase=='create' else 'continue',status='complete'): raise ValueError('Operation failed')
+    return result
+
+
+def build_report(result, outbox, plan):
+    observations=[]; reasons=[]
+    try:
+        if (result['document_type']!='dao_row_insert_candidate_result' or result['producer_os']!='posix' or result['source_revision']!=plan['source_revision'] or result['plan_sha256']!=identity(PLAN)['sha256'] or result['phase']!='complete' or result['error'] is not None): raise ValueError('Coordinated phase/source failure')
+        phases={}
+        for phase in ('create','observe'):
+            path=outbox/(phase+'.json')
+            if identity(path)!=result['phases'][phase]: raise ValueError('Phase identity')
+            phases[phase]=entries(json.loads(path.read_text(encoding='utf-8-sig')),phase,plan)
+        updates={(u['arm'],u['replica']):u for u in result['updates']}
+        if len(updates)!=len(result['updates']) or set(updates)!={(a['name'],r) for a in plan['arms'] for r in range(1,4)}: raise ValueError('Update inventory')
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                prefix=f"{arm['name']}-r{replica}"; snapshots={}; images={}
+                for role in ('original','control','rust','control-next','rust-next'):
+                    item=phases['observe'][arm['name'],replica,role]; path=outbox/f'{prefix}-{role}.mdb'
+                    if identity(path)!=item['after']: raise ValueError('Retained identity')
+                    images[role]=identity(path); snapshots[role]=expected(item['snapshot'],arm,role,plan)
+                    if role in ('original','control') and item!=phases['create'][arm['name'],replica,role]: raise ValueError('Original/control changed between phases')
+                update=updates[arm['name'],replica]
+                if update['original_before']!=images['original'] or update['original_after']!=images['original'] or update['rust']!=images['rust']: raise ValueError('Unix identity chain')
+                before=(outbox/f'{prefix}-original.mdb').read_bytes(); rust=(outbox/f'{prefix}-rust.mdb').read_bytes()
+                patch=patch_check(before,rust,arm,update['locator'])
+                if snapshots['rust']!=snapshots['control'] or snapshots['rust-next']!=snapshots['control-next']: raise ValueError('DAO control differs')
+                baseline=copy.deepcopy(snapshots['original']); target=next(t for t in baseline['user_tables'] if t['name']==arm['table']); target['rows'].append(arm['insert'])
+                if common.normalized(baseline)!=snapshots['rust']: raise ValueError('Unrelated metadata/SQL changed')
+                target['rows'].append(plan['insert']); baseline=common.normalized(baseline)
+                if baseline!=snapshots['rust-next']: raise ValueError('Follow-on metadata/SQL changed')
+                control_maps=shape((outbox/f'{prefix}-control.mdb').read_bytes(),arm)[2]
+                if control_maps!=patch['maps']: raise ValueError('Control map membership differs')
+                observations.append(dict(arm=arm['name'],replica=replica,identities=images,patch=patch,snapshot=snapshots['rust-next']))
+    except (ValueError,KeyError,TypeError,OSError,layout.catalog.DecodeError) as error: reasons.append(str(error))
+    return dict(document_type='dao_row_insert_candidate_report',plan_sha256=identity(PLAN)['sha256'],outcome='observed_accepted' if not reasons else 'no_outcome',reasons=reasons,observations=observations,development_only=True,compatibility_claim=False,support_matrix_movement=False)
+
+
+def analyze(outbox):
+    plan=verify_inputs(); report=build_report(json.loads((outbox/'result.json').read_text()),outbox,plan)
+    report['result_sha256']=identity(outbox/'result.json')['sha256']; (outbox/'report.json').write_text(canonical(report)+'\n'); print(report['outcome'])
+
+
+def dispatch(args):
+    plan=preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id): raise ValueError('Invalid run id')
+    shared=args.shared_root.resolve(); outbox=shared/'outbox'/args.run_id
+    paths=[outbox]+[shared/part/(args.run_id+'-'+phase) for part in ('inbox','outbox') for phase in ('create','observe')]
+    if any(p.exists() for p in paths): raise ValueError('Run used; no retry/resume')
+    subprocess.run(['cargo','build','-p','jet3','--example','row_insert_candidate'],cwd=ROOT,check=True)
+    spec=importlib.util.spec_from_file_location('transport',ROOT/'scripts/windows-dao-ps.py'); transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result=dict(document_type='dao_row_insert_candidate_result',producer_os=os.name,source_revision=plan['source_revision'],acquisition_revision=subprocess.check_output(['git','rev-parse','HEAD'],cwd=ROOT).decode().strip(),plan_sha256=identity(PLAN)['sha256'],phase='create',error=None,phases={},updates=[])
+    try:
+        for phase in ('create','observe'):
+            result['phase']=phase; run_id=args.run_id+'-'+phase; inbox=shared/'inbox'/run_id;inbox.mkdir(parents=True)
+            shutil.copyfile(ROOT/SCRIPT,inbox/'script.ps1');shutil.copyfile(ROOT/'oracle/windows-dao/scripts/field_update.ps1',inbox/'field_update.ps1');shutil.copyfile(PLAN,inbox/PLAN.name);(inbox/'phase.txt').write_text(phase)
+            if phase=='observe':
+                for path in outbox.glob('*.mdb'): shutil.copyfile(path,inbox/path.name)
+            command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,run_id,'script.ps1'))]
+            done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=300)
+            (outbox/(phase+'-ssh.txt')).write_bytes(done.stdout+done.stderr);guest=shared/'outbox'/run_id
+            shutil.copyfile(guest/'result.json',outbox/(phase+'.json'));result['phases'][phase]=identity(outbox/(phase+'.json'))
+            for path in guest.glob('*.mdb'):
+                destination=outbox/path.name
+                if destination.exists() and identity(destination)!=identity(path): raise ValueError('Transferred original/control/Rust image changed')
+                if not destination.exists(): shutil.copyfile(path,destination)
+            observed=entries(json.loads((outbox/(phase+'.json')).read_text(encoding='utf-8-sig')),phase,plan)
+            if done.returncode: raise ValueError('Guest failed')
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    for role in ('original','control'):
+                        item=observed[arm['name'],replica,role];expected(item['snapshot'],arm,role,plan)
+                        if identity(outbox/item['file'])!=item['after']: raise ValueError('Transferred image identity')
+            if phase=='create':
+                result['phase']='unix_insert'
+                for arm in plan['arms']:
+                    for replica in range(1,4):
+                        prefix=f"{arm['name']}-r{replica}"; original=outbox/(prefix+'-original.mdb');rust=outbox/(prefix+'-rust.mdb');before=identity(original)
+                        command=['cargo','run','--quiet','-p','jet3','--example','row_insert_candidate','--',str(original),str(rust),arm['table'],*[str(v) for v in arm['insert']]]
+                        done=subprocess.run(command,cwd=ROOT,capture_output=True,timeout=120);(outbox/(prefix+'-unix.txt')).write_bytes(done.stdout+done.stderr)
+                        if done.returncode: raise ValueError('Public insert failed: '+prefix)
+                        receipt=json.loads(done.stdout);patch_check(original.read_bytes(),rust.read_bytes(),arm,receipt)
+                        result['updates'].append(dict(arm=arm['name'],replica=replica,original_before=before,original_after=identity(original),rust=identity(rust),locator=receipt))
+                        if identity(original)!=before: raise ValueError('Unix original changed')
+        result['phase']='complete'
+    except (OSError,ValueError,subprocess.SubprocessError) as error: result['error']=type(error).__name__+': '+str(error)
+    finally: (outbox/'result.json').write_text(canonical(result)+'\n')
+    analyze(outbox)
+
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__);commands=parser.add_subparsers(dest='command',required=True)
+    commands.add_parser('preflight');report=commands.add_parser('analyze');report.add_argument('outbox',type=Path)
+    run=commands.add_parser('run');run.add_argument('--run-id',required=True);run.add_argument('--shared-root',type=Path,required=True)
+    for name,default in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:run.add_argument('--'+name,default=default)
+    args=parser.parse_args()
+    if args.command=='preflight':preflight();print('Committed inputs match.')
+    elif args.command=='analyze':analyze(args.outbox)
+    else:dispatch(args)
+
+
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/test_row_insert_candidate.py
+++ b/oracle/windows-dao/tests/test_row_insert_candidate.py
@@ -1,0 +1,80 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import row_insert_candidate as experiment
+
+
+class CandidateTests(unittest.TestCase):
+    def setUp(self): self.plan=json.loads(experiment.PLAN.read_text())
+
+    def snapshot(self,arm,role):
+        tables=[]
+        for spec in arm['tables']:
+            rows=copy.deepcopy(spec['rows'])
+            if spec['name']==arm['table']:
+                if arm['delete_id'] is not None:rows=[r for r in rows if r[0]!=arm['delete_id']]
+                if role!='original':rows.append(arm['insert'])
+                if role.endswith('-next'):rows.append(self.plan['insert'])
+            tables.append(dict(name=spec['name'],attributes=0,indexes=[],fields=[dict(f,attributes=2 if f['type']==10 else 1) for f in self.plan['fields']],rows=rows))
+        return dict(version='3.0',relations=[],tables=sorted(['MSysACEs','MSysObjects','MSysQueries','MSysRelationships','Items','Later']),queries=[dict(name='KeepQuery',sql='retained SQL',type=0)],user_tables=tables)
+
+    def test_complete_classifier_and_failure_bindings(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);identity=experiment.identity
+            result=dict(document_type='dao_row_insert_candidate_result',producer_os='posix',source_revision=self.plan['source_revision'],plan_sha256=identity(experiment.PLAN)['sha256'],phase='complete',error=None,phases={},updates=[])
+            for phase in ('create','observe'):
+                document=dict(document_type='dao_row_insert_candidate_phase',phase=phase,plan_sha256=result['plan_sha256'],error=None,retention_failures=[],mutation_started=True,environment=dict(process_bits=32,provider='DAO.DBEngine.36'),observations=[],operations=[])
+                for arm in self.plan['arms']:
+                    for replica in range(1,4):
+                        roles=['original','control'] if phase=='create' else ['original','control','rust','control-next','rust-next']
+                        for role in roles:
+                            name=f"{arm['name']}-r{replica}-{role}.mdb";file=root/name;file.write_bytes(b'x')
+                            document['observations'].append(dict(arm=arm['name'],replica=replica,role=role,observation=dict(file=name,before=identity(file),after=identity(file),status='pass',error=None,snapshot=self.snapshot(arm,role))))
+                        for role in (['control'] if phase=='create' else ['control-next','rust-next']):document['operations'].append(dict(arm=arm['name'],replica=replica,role=role,result=dict(operation='insert' if phase=='create' else 'continue',status='complete')))
+                        if phase=='create':result['updates'].append(dict(arm=arm['name'],replica=replica,original_before=identity(file),original_after=identity(file),rust=identity(file),locator={}))
+                file=root/(phase+'.json');file.write_text(json.dumps(document));result['phases'][phase]=identity(file)
+            with patch.object(experiment,'patch_check',return_value={'maps':{}}),patch.object(experiment,'shape',return_value=(None,None,{})):
+                self.assertEqual(experiment.build_report(result,root,self.plan)['outcome'],'observed_accepted')
+                for key,value in [('producer_os','nt'),('source_revision','wrong'),('error','failed'),('phase','create')]:
+                    bad=dict(result,**{key:value});self.assertEqual(experiment.build_report(bad,root,self.plan)['outcome'],'no_outcome')
+                bad=copy.deepcopy(result);bad['updates'].pop();self.assertEqual(experiment.build_report(bad,root,self.plan)['outcome'],'no_outcome')
+                (root/'first-page-r1-rust.mdb').write_bytes(b'changed');self.assertEqual(experiment.build_report(result,root,self.plan)['outcome'],'no_outcome')
+
+    def test_exact_patch_and_tombstone_preservation(self):
+        for deleted in [False,True]:
+            data=bytearray(24*2048);base=23*2048;root=20*2048
+            data[base]=1;data[base+8:base+10]=(2).to_bytes(2,'little')
+            data[base+10:base+14]=bytes.fromhex('f607f6c7' if deleted else 'f607ec07')
+            start=2038 if deleted else 2028;data[base+2:base+4]=(start-14).to_bytes(2,'little')
+            rows=[dict(page=23,row=0,values=[1,2,'old'])]
+            if not deleted:rows.append(dict(page=23,row=1,values=[2,3,'old']))
+            data[root+12:root+16]=len(rows).to_bytes(4,'little');maps=dict(owned=[23],available=[23]);arm=dict(name='after-tail' if deleted else 'first-page',delete_id=2 if deleted else None,insert=[88,-8800,'new'])
+            encoded=bytes.fromhex('0358000000a0ddffff6e65770c090107')
+            after=bytearray(data);after[base+start-len(encoded):base+start]=encoded
+            after[base+14:base+16]=(start-len(encoded)).to_bytes(2,'little');after[base+8:base+10]=(3).to_bytes(2,'little')
+            after[base+2:base+4]=(start-14-len(encoded)-2).to_bytes(2,'little');after[root+12:root+16]=(len(rows)+1).to_bytes(4,'little')
+            def shape(raw,_):return (dict(root=20,row_count=len(rows) if raw==data else len(rows)+1),rows if raw==data else rows+[dict(values=arm['insert'])],maps)
+            with patch.object(experiment,'shape',side_effect=shape):
+                receipt=dict(root=20,page=23,slot=2)
+                self.assertTrue(experiment.patch_check(data,after,arm,receipt)['page0_unchanged'])
+                for offset in (1538,base+2038,base+100,base+12):
+                    bad=bytearray(after);bad[offset]^=1
+                    with self.assertRaisesRegex(ValueError,'preservation'):experiment.patch_check(data,bad,arm,receipt)
+                with self.assertRaises(ValueError):experiment.patch_check(data,after,arm,dict(receipt,slot=1))
+
+    def test_schema_rows_query_and_pins(self):
+        arm=self.plan['arms'][0];value=self.snapshot(arm,'rust-next');experiment.expected(value,arm,'rust-next',self.plan)
+        value['user_tables'][0]['rows'].pop()
+        with self.assertRaises(ValueError):experiment.expected(value,arm,'rust-next',self.plan)
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);(root/'x').write_text('changed');plan=root/'plan.json';plan.write_text(json.dumps(dict(inputs={'x':'0'*64})))
+            with patch.object(experiment,'ROOT',root),patch.object(experiment,'PLAN',plan):
+                with self.assertRaisesRegex(ValueError,'Input pin'):experiment.verify_inputs()
+
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Preregister public existing-row insertion against independent DAO insert controls on first-page, later-table/page and retained-tombstone cases. Verify complete rows, schema and stored queries, exact unrelated-byte preservation and follow-on inserts.

Validation: independent review, three focused Python tests, exporter Clippy, committed preflight, actual x86 parser and just ready passed. The acquisition outcome is recorded separately.
