### PR TITLE
feat: make database inspection selectable and script-friendly

### DIFF
--- a/crates/jet3-cli/README.md
+++ b/crates/jet3-cli/README.md
@@ -8,7 +8,31 @@ jet3-cli create example.mdb --input request.json
 cat request.json | jet3-cli create example.mdb --input -
 ```
 
-The output must not exist. Creation uses the library's atomic publication,
+Inspect metadata and optional rows as JSON:
+
+```sh
+jet3-cli inspect example.mdb
+jet3-cli inspect example.mdb --table Items --rows --code-page 1252
+jet3-cli inspect example.mdb --page 0 --hex
+```
+
+`inspect` reads pages through the library's file reader, with a 256 MiB input
+limit. Its existing `pages`, `catalog`, `tables` and raw diagnostic fields remain
+available. Table entries include their catalog names. `--table` selects an exact
+ASCII table name for definition and row inspection; the page/catalog inventory
+still describes the file. Text values use the selected code page (1252 by default,
+or 1251). Non-ASCII metadata names retain their raw hexadecimal representation.
+`--page` cannot be combined with `--table` or `--rows`.
+
+A complete requested inspection returns `ok: true` and exit 0. If a table,
+allocation map, row or field cannot be decoded, available diagnostic output is
+retained on stdout with `ok: false`, an `issues` array and exit 1. Opening, catalog
+or selection failures instead produce a JSON `inspect_failed` error on stderr
+with exit 1. Invalid arguments produce JSON errors on stderr with exit 2. A
+successful inspection describes the requested decoded content; it is not a
+whole-file compatibility verdict. Inspection never modifies the database.
+
+The `create` output path must not exist. Creation uses the library's atomic publication,
 validation and default resource limits; publication currently requires Unix.
 Success writes one JSON object to stdout. Invalid command arguments exit 2;
 invalid JSON or a refused creation exits 1 with a JSON error on stderr. Unknown

--- a/crates/jet3-cli/src/inspect.rs
+++ b/crates/jet3-cli/src/inspect.rs
@@ -5,23 +5,24 @@
 
 use std::ffi::OsString;
 use std::fmt::Write as _;
-use std::fs;
 use std::path::PathBuf;
 
 use jet3::{
-    ByteCount, DatabaseReader, PageKind, PageNumber, ReadLimits, ResourceBudget, ResourceLimits,
-    SliceSource, TableDefinition, TextCodePage, ValueKind,
+    ByteCount, DatabaseReader, FileSource, PageKind, PageNumber, ReadLimits, ResourceBudget,
+    ResourceLimits, TableDefinition, TextCodePage, ValueKind,
 };
 use serde_json::{Value, json};
 
 pub(crate) const HELP: &str = "\
-  jet3-cli inspect <file> [--rows] [--code-page 1252|1251]
+  jet3-cli inspect <file> [--table <ASCII-name>] [--rows] [--code-page 1252|1251]
   jet3-cli inspect <file> --page <number> [--hex]
 
 inspect classifies every page, lists catalog records, decodes every
 catalogued table definition (system tables included), lists the pages each
 table owns, and names tag-02 pages no catalog record points at. --rows also
-streams every row of every decoded table.
+includes every row of every decoded table. --table restricts table definitions
+and rows to one exact catalog name; page and catalog diagnostics remain present.
+JSON includes ok=false and issues on partial decode failure (exit 1).
 --page dumps one page's classification, and --hex adds its bytes.
 ";
 
@@ -34,6 +35,7 @@ pub(crate) struct InspectCommand {
     hex: bool,
     rows: bool,
     code_page: TextCodePage,
+    table: Option<String>,
 }
 
 pub(crate) fn parse_args(
@@ -49,6 +51,7 @@ pub(crate) fn parse_args(
         hex: false,
         rows: false,
         code_page: TextCodePage::Windows1252,
+        table: None,
     };
     while let Some(option) = arguments.next() {
         if option == "--hex" {
@@ -59,6 +62,16 @@ pub(crate) fn parse_args(
             let value = arguments.next().ok_or("missing_option_value")?;
             let text = value.to_str().ok_or("invalid_option_value")?;
             command.page = Some(text.parse().map_err(|_| "invalid_page")?);
+        } else if option == "--table" {
+            if command.table.is_some() {
+                return Err("duplicate_option");
+            }
+            let value = arguments.next().ok_or("missing_option_value")?;
+            let text = value
+                .to_str()
+                .filter(|text| !text.is_empty() && text.is_ascii())
+                .ok_or("invalid_table_name")?;
+            command.table = Some(text.to_owned());
         } else if option == "--code-page" {
             let value = arguments.next().ok_or("missing_option_value")?;
             command.code_page = match value.to_str() {
@@ -73,6 +86,9 @@ pub(crate) fn parse_args(
     if command.hex && command.page.is_none() {
         return Err("hex_requires_page");
     }
+    if command.page.is_some() && (command.rows || command.table.is_some()) {
+        return Err("page_conflicts_with_table_or_rows");
+    }
     Ok(command)
 }
 
@@ -85,13 +101,16 @@ fn budget() -> ResourceBudget {
     ResourceBudget::new(ResourceLimits::new(read))
 }
 
-/// Returns one pretty-printed JSON document.
-pub(crate) fn run(command: &InspectCommand) -> Result<String, String> {
-    let bytes = fs::read(&command.path).map_err(|error| format!("read input: {error}"))?;
+pub(crate) struct InspectOutput {
+    pub json: String,
+    pub complete: bool,
+}
+
+/// Returns a diagnostic document, retaining partial results with explicit issues.
+pub(crate) fn run(command: &InspectCommand) -> Result<InspectOutput, String> {
     let mut budget = budget();
-    let source = SliceSource::new(&bytes, budget.read_budget()).map_err(|e| e.to_string())?;
     let mut database =
-        DatabaseReader::from_source(source, &mut budget).map_err(|e| e.to_string())?;
+        DatabaseReader::open(&command.path, &mut budget).map_err(|e| e.to_string())?;
 
     let document = match command.page {
         Some(page) => inspect_page(&mut database, &mut budget, page, command.hex)?,
@@ -99,11 +118,14 @@ pub(crate) fn run(command: &InspectCommand) -> Result<String, String> {
     };
     let mut text = serde_json::to_string_pretty(&document).map_err(|e| e.to_string())?;
     text.push('\n');
-    Ok(text)
+    Ok(InspectOutput {
+        complete: document["ok"] == true,
+        json: text,
+    })
 }
 
 fn inspect_page(
-    database: &mut DatabaseReader<SliceSource<'_>>,
+    database: &mut DatabaseReader<FileSource>,
     budget: &mut ResourceBudget,
     page: u64,
     hex: bool,
@@ -113,6 +135,7 @@ fn inspect_page(
         .read_classified_page(PageNumber::new(page), &mut raw, budget)
         .map_err(|e| e.to_string())?;
     let mut document = json!({
+        "ok": true,
         "page": page,
         "kind": format!("{:?}", classified.kind()),
         "tag": raw[0],
@@ -135,7 +158,7 @@ fn inspect_page(
 }
 
 fn inspect_database(
-    database: &mut DatabaseReader<SliceSource<'_>>,
+    database: &mut DatabaseReader<FileSource>,
     budget: &mut ResourceBudget,
     command: &InspectCommand,
 ) -> Result<Value, String> {
@@ -155,10 +178,12 @@ fn inspect_database(
 
     let mut catalog = Vec::new();
     let mut roots = Vec::new();
+    let mut table_names = std::collections::BTreeMap::new();
     let mut cursor = database.catalog(budget).map_err(|e| e.to_string())?;
     while let Some(record) = cursor.next_record().map_err(|e| e.to_string())? {
         if let Some(root) = record.table_definition() {
             roots.push(root.get());
+            table_names.insert(root.get(), record.name().raw_bytes().to_vec());
         }
         catalog.push(json!({
             "id": format!("{:?}", record.id()),
@@ -172,20 +197,51 @@ fn inspect_database(
     drop(cursor);
 
     let mut tables = Vec::new();
+    let mut issues = Vec::new();
+    let mut selected = false;
     for &root in &roots {
+        let raw_name = &table_names[&root];
+        if command
+            .table
+            .as_ref()
+            .is_some_and(|name| name.as_bytes() != raw_name)
+        {
+            continue;
+        }
+        selected = true;
+        let name = name_json(
+            std::str::from_utf8(raw_name)
+                .ok()
+                .filter(|name| name.is_ascii()),
+            raw_name,
+        );
+
         let definition = match database.table_definition(PageNumber::new(root), budget) {
             Ok(definition) => definition,
             Err(error) => {
-                tables.push(json!({"root": root, "error": error.to_string()}));
+                issues.push(
+                    json!({"root": root, "operation": "definition", "error": error.to_string()}),
+                );
+                tables.push(json!({"root": root, "name": name, "error": error.to_string()}));
                 continue;
             }
         };
         let mut entry = definition_json(&definition);
-        entry["owned_pages"] = owned_pages_json(database, budget, root);
+        entry["name"] = name;
+        entry["owned_pages"] = owned_pages_json(database, budget, root, &mut issues);
         if command.rows {
-            entry["rows"] = rows_json(database, budget, &definition, command.code_page);
+            entry["rows"] = rows_json(
+                database,
+                budget,
+                &definition,
+                command.code_page,
+                &mut issues,
+            );
         }
         tables.push(entry);
+    }
+    if command.table.is_some() && !selected {
+        return Err("table not found".to_owned());
     }
     // Continuation pages share the definition tag, so these are listed, not decoded.
     let uncatalogued: Vec<u64> = definition_pages
@@ -194,6 +250,8 @@ fn inspect_database(
         .collect();
 
     Ok(json!({
+        "ok": issues.is_empty(),
+        "issues": issues,
         "file": command.path.display().to_string(),
         "page_count": page_count,
         "pages": pages,
@@ -302,13 +360,19 @@ fn definition_json(definition: &TableDefinition) -> Value {
 }
 
 fn owned_pages_json(
-    database: &mut DatabaseReader<SliceSource<'_>>,
+    database: &mut DatabaseReader<FileSource>,
     budget: &mut ResourceBudget,
     root: u64,
+    issues: &mut Vec<Value>,
 ) -> Value {
     let mut owned = match database.owned_pages(PageNumber::new(root), budget) {
         Ok(owned) => owned,
-        Err(error) => return json!({"error": error.to_string()}),
+        Err(error) => {
+            issues.push(
+                json!({"root": root, "operation": "owned_pages", "error": error.to_string()}),
+            );
+            return json!({"error": error.to_string()});
+        }
     };
     let mut pages = Vec::new();
     loop {
@@ -316,6 +380,9 @@ fn owned_pages_json(
             Ok(Some(page)) => pages.push(json!(page.get())),
             Ok(None) => break,
             Err(error) => {
+                issues.push(
+                    json!({"root": root, "operation": "owned_pages", "error": error.to_string()}),
+                );
                 pages.push(json!({"error": error.to_string()}));
                 break;
             }
@@ -325,14 +392,18 @@ fn owned_pages_json(
 }
 
 fn rows_json(
-    database: &mut DatabaseReader<SliceSource<'_>>,
+    database: &mut DatabaseReader<FileSource>,
     budget: &mut ResourceBudget,
     definition: &TableDefinition,
     code_page: TextCodePage,
+    issues: &mut Vec<Value>,
 ) -> Value {
     let mut cursor = match database.rows(definition, budget) {
         Ok(cursor) => cursor,
-        Err(error) => return json!({"error": error.to_string()}),
+        Err(error) => {
+            issues.push(json!({"root": definition.root().get(), "operation": "rows", "error": error.to_string()}));
+            return json!({"error": error.to_string()});
+        }
     };
     let mut rows = Vec::new();
     loop {
@@ -340,6 +411,7 @@ fn rows_json(
             Ok(Some(row)) => row,
             Ok(None) => break,
             Err(error) => {
+                issues.push(json!({"root": definition.root().get(), "operation": "rows", "error": error.to_string()}));
                 rows.push(json!({"error": error.to_string()}));
                 break;
             }
@@ -353,7 +425,10 @@ fn rows_json(
             let value = match row.value(column.ordinal(), code_page) {
                 Ok(Some(decoded)) => value_json(decoded.kind(), decoded.raw_bytes()),
                 Ok(None) => Value::Null,
-                Err(error) => json!({"error": error.to_string()}),
+                Err(error) => {
+                    issues.push(json!({"root": definition.root().get(), "operation": "value", "column": column.ordinal().get(), "error": error.to_string()}));
+                    json!({"error": error.to_string()})
+                }
             };
             fields.insert(key, value);
         }

--- a/crates/jet3-cli/src/main.rs
+++ b/crates/jet3-cli/src/main.rs
@@ -127,8 +127,8 @@ fn main() -> ExitCode {
             ),
         },
         Command::Inspect(command) => match inspect::run(&command) {
-            Ok(json) => exit_after_write(write_stdout(&json), 0),
-            Err(message) => exit_after_write(write_stderr(&format!("jet3-cli: {message}\n")), 1),
+            Ok(output) => exit_after_write(write_stdout(&output.json), u8::from(!output.complete)),
+            Err(message) => exit_after_write(write_stderr(&(serde_json::json!({"ok": false, "error": "inspect_failed", "message": message}).to_string() + "\n")), 1),
         },
     }
 }

--- a/crates/jet3-cli/tests/inspect.rs
+++ b/crates/jet3-cli/tests/inspect.rs
@@ -1,0 +1,158 @@
+#![cfg(unix)]
+use serde_json::{Value, json};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+}
+fn create(path: &Path) -> Result {
+    let request = json!({"tables": [
+        {"name":"Items", "columns":[{"name":"Id","type":"long"},{"name":"Label","type":"text","size":20}],"rows":[[{"long":1},{"text":[233]}],[{"long":2},null]]},
+        {"name":"Other", "columns":[{"name":"error","type":"long"}],"rows":[[{"long":7}]]}
+    ]});
+    let mut process = cli()
+        .arg("create")
+        .arg(path)
+        .args(["--input", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    process
+        .stdin
+        .take()
+        .ok_or("missing stdin")?
+        .write_all(request.to_string().as_bytes())?;
+    let output = process.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+fn inspect(path: &Path, args: &[&str]) -> Result<Output> {
+    Ok(cli().arg("inspect").arg(path).args(args).output()?)
+}
+fn document(output: &Output) -> Result<Value> {
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+#[test]
+fn create_then_inspect_named_tables_rows_and_page_without_modifying_input() -> Result {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("input.mdb");
+    create(&path)?;
+    let before = std::fs::read(&path)?;
+    let output = inspect(&path, &["--table", "Items", "--rows"])?;
+    assert!(output.status.success());
+    let value = document(&output)?;
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["issues"], json!([]));
+    assert_eq!(value["tables"].as_array().ok_or("expected array")?.len(), 1);
+    assert_eq!(value["tables"][0]["name"], "Items");
+    assert_eq!(
+        value["tables"][0]["rows"],
+        json!([{"Id":1,"Label":"é"},{"Id":2,"Label":null}])
+    );
+    assert!(value["catalog"].as_array().ok_or("expected array")?.len() > 2);
+    let other = document(&inspect(&path, &["--table", "Other", "--rows"])?)?;
+    assert_eq!(other["ok"], true);
+    assert_eq!(other["tables"][0]["rows"], json!([{"error":7}]));
+    let page = inspect(&path, &["--page", "0", "--hex"])?;
+    assert!(page.status.success());
+    assert_eq!(document(&page)?["page"], 0);
+    assert_eq!(
+        document(&page)?["hex"]
+            .as_array()
+            .ok_or("expected array")?
+            .len(),
+        128
+    );
+    assert_eq!(std::fs::read(path)?, before);
+    Ok(())
+}
+
+#[test]
+fn partial_decode_failure_is_json_with_nonzero_status() -> Result {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("input.mdb");
+    create(&path)?;
+    let original = document(&inspect(&path, &["--table", "Items"])?)?;
+    let root = original["tables"][0]["root"]
+        .as_u64()
+        .ok_or("expected number")? as usize;
+    let mut bytes = std::fs::read(&path)?;
+    bytes[root * 2048 + 20] = 0;
+    std::fs::write(&path, &bytes)?;
+    let output = inspect(&path, &["--rows"])?;
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty());
+    let value = document(&output)?;
+    assert_eq!(value["ok"], false);
+    assert!(
+        !value["issues"]
+            .as_array()
+            .ok_or("expected array")?
+            .is_empty()
+    );
+    assert!(
+        value["tables"]
+            .as_array()
+            .ok_or("expected array")?
+            .iter()
+            .any(|t| t["name"] == "Other")
+    );
+    assert!(
+        inspect(&path, &["--table", "Other", "--rows"])?
+            .status
+            .success()
+    );
+    assert_eq!(std::fs::read(path)?, bytes);
+    Ok(())
+}
+
+#[test]
+fn argument_open_selection_and_input_limit_errors_are_script_friendly() -> Result {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("input.mdb");
+    create(&path)?;
+    for args in [
+        ["--page", "0", "--rows"].as_slice(),
+        ["--table", "Items", "--table", "Other"].as_slice(),
+        ["--table", "é"].as_slice(),
+    ] {
+        let output = inspect(&path, args)?;
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output.stderr)?["ok"],
+            false
+        );
+    }
+    for (file, args) in [
+        (directory.path().join("missing.mdb"), vec![]),
+        (path.clone(), vec!["--table", "Missing"]),
+    ] {
+        let output = inspect(&file, &args)?;
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output.stderr)?["error"],
+            "inspect_failed"
+        );
+    }
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)?
+        .set_len(256 * 1024 * 1024 + 2048)?;
+    let output = inspect(&path, &["--page", "0"])?;
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stderr)?["error"],
+        "inspect_failed"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Database inspection now supports selecting an exact table and reports incomplete decoding explicitly through JSON and exit status. Read through the library FileSource, retaining existing page/catalog diagnostics and adding table names.

Validation: independent review; three inspect and three existing create integration tests, CLI Clippy and just ready passed. Input databases remain unchanged.

Refs #104.
