### PR TITLE
fix: decode wide fixed prefixes in single-variable rows

### DIFF
--- a/crates/jet3/src/row.rs
+++ b/crates/jet3/src/row.rs
@@ -653,6 +653,17 @@ impl RowLayout {
                 length: row.len(),
                 minimum: minimum + 1 + trailer,
             })?;
+        // EXP-0172: one variable field following a wide fixed prefix stores
+        // same-block boundary low bytes with a zero jump byte.
+        if wide && fixed_boundary >= 256 {
+            let jump = row[offsets_start + low_count];
+            if fixed_boundary >= 512 || offsets_start >= 512 || jump != 0 {
+                return Err(RowError::UnsupportedWideVariableOffsets {
+                    variable_count,
+                    row_length: row.len(),
+                });
+            }
+        }
         let layout = Self {
             fixed_boundary,
             offsets_start,
@@ -715,7 +726,11 @@ impl RowLayout {
             return Ok(low);
         }
         let jump = row[self.offsets_start + usize::from(self.variable_count) + 1];
-        let high = usize::from((jump >> reversed) & 1);
+        let high = if self.fixed_boundary >= 256 {
+            1 // EXP-0172: validate established the second-block, zero-jump shape.
+        } else {
+            usize::from((jump >> reversed) & 1)
+        };
         Ok(low + 256 * high)
     }
 }

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -1,5 +1,5 @@
 //! Checked encoder for one logical Jet 3 data row, the inverse of the layout
-//! validated by `row.rs` (`EXP-0060`) with the scalar encodings of `EXP-0061`.
+//! validated by `row.rs` (`EXP-0060`, `EXP-0172`) with scalars of `EXP-0061`.
 //!
 //! Memo and OLE values are supplied as already-encoded long-value bytes
 //! (12-byte header plus any inline payload); writing external LVAL pages is a
@@ -18,7 +18,7 @@ const MAX_COLUMN_COUNT: usize = u8::MAX as usize;
 /// `EXP-0060`: rows longer than 255 bytes use one jump byte for boundary
 /// high bits; only single-variable-column wide rows were isolated.
 const MAX_NARROW_ROW_LEN: usize = u8::MAX as usize;
-/// `EXP-0060`: a jump bit adds 256 to a boundary, so boundaries stay below 512.
+/// `EXP-0060` / `EXP-0172`: supported single-variable boundaries stay below 512.
 const MAX_WIDE_BOUNDARY: usize = 2 * (u8::MAX as usize + 1) - 1;
 /// `EXP-0061`: every long field begins with a 12-byte header.
 const LONG_VALUE_HEADER_LEN: usize = 12;
@@ -197,7 +197,7 @@ pub enum RowWriteError {
         /// Complete row length.
         row_length: usize,
     },
-    /// A variable boundary exceeds what the jump byte can represent.
+    /// A variable boundary exceeds the supported two-block representation.
     BoundaryTooLarge {
         /// Zero-based variable index whose end boundary overflowed.
         index: u16,
@@ -654,7 +654,8 @@ fn write_row(
             let boundary = boundaries[ordinal];
             writer.write_u8((boundary & 0xff) as u8)?;
             let reversed = shape.variable_count - ordinal;
-            if shape.wide && boundary & 0x100 != 0 {
+            // EXP-0172: same-block wide fixed prefixes use a zero jump byte.
+            if shape.wide && boundaries[0] < 256 && boundary & 0x100 != 0 {
                 jump |= 1 << reversed;
             }
         }

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -512,3 +512,142 @@ fn rejects_mismatches_unsupported_shapes_small_output_and_exhausted_budget() {
         .contains("row encoding failed")
     );
 }
+
+fn wide_prefix_columns() -> [ColumnSpec<'static>; 3] {
+    [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Value", ColumnType::FixedText { len: nz(255) }),
+        ColumnSpec::new(b"Payload", ColumnType::Text { max_len: nz(255) }),
+    ]
+}
+
+#[test]
+fn reproduces_exp_0172_wide_fixed_prefix_rows() -> Result<(), Box<dyn std::error::Error>> {
+    let columns = wide_prefix_columns();
+    let layout = layouts(&columns)?;
+    for (id, payload) in [(1_i32, b"first".as_slice()), (2, b"second"), (3, b"third")] {
+        // Independently transcribed EXP-0172 row bytes, including zero jump.
+        let mut raw = vec![3];
+        raw.extend_from_slice(&id.to_le_bytes());
+        raw.extend_from_slice(&[b'a'; 255]);
+        raw.extend_from_slice(payload);
+        raw.extend_from_slice(&[(4 + payload.len()) as u8, 4, 0, 1, 7]);
+        assert_eq!(
+            encode(
+                &layout,
+                &[
+                    RowValue::Long(id),
+                    RowValue::Text(&[b'a'; 255]),
+                    RowValue::Text(payload)
+                ]
+            )?,
+            raw
+        );
+        let bytes = database_bytes(&columns, &[&raw])?;
+        let mut budget = budget_for(&bytes);
+        let source = SliceSource::new(&bytes, budget.read_budget())?;
+        let mut database = DatabaseReader::from_source(source, &mut budget)?;
+        let definition = database.table_definition(PageNumber::new(ROOT as u64), &mut budget)?;
+        let mut rows = database.rows(&definition, &mut budget)?;
+        let row = rows.next_row()?.ok_or("missing row")?;
+        assert_eq!(
+            row.field(ColumnOrdinal::new(1)),
+            Some(crate::RawField::Bytes(&[b'a'; 255]))
+        );
+        assert_eq!(
+            row.field(ColumnOrdinal::new(2)),
+            Some(crate::RawField::Bytes(payload))
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn rejects_wide_fixed_prefix_corruption() -> Result<(), Box<dyn std::error::Error>> {
+    let columns = wide_prefix_columns();
+    let raw = encode(
+        &layouts(&columns)?,
+        &[
+            RowValue::Long(2),
+            RowValue::Text(&[b'a'; 255]),
+            RowValue::Text(b"second"),
+        ],
+    )?;
+    for (from_end, value) in [(3, 1), (3, 3), (4, 3), (5, 3), (5, 11)] {
+        let mut damaged = raw.clone();
+        let offset = damaged.len() - from_end;
+        damaged[offset] = value;
+        let bytes = database_bytes(&columns, &[&damaged])?;
+        let mut budget = budget_for(&bytes);
+        let source = SliceSource::new(&bytes, budget.read_budget())?;
+        let mut database = DatabaseReader::from_source(source, &mut budget)?;
+        let definition = database.table_definition(PageNumber::new(ROOT as u64), &mut budget)?;
+        let mut rows = database.rows(&definition, &mut budget)?;
+        assert!(matches!(
+            rows.next_row(),
+            Err(crate::RowError::UnsupportedWideVariableOffsets { .. }
+                | crate::RowError::InvalidFixedBoundary { .. }
+                | crate::RowError::InvalidVariableBounds { .. })
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn wide_fixed_prefix_stays_within_second_boundary_block() -> Result<(), Box<dyn std::error::Error>>
+{
+    let columns = wide_prefix_columns();
+    let layout = layouts(&columns)?;
+    for size in [0, 251] {
+        let payload = vec![b'x'; size];
+        let raw = encode(
+            &layout,
+            &[
+                RowValue::Long(2),
+                RowValue::Text(&[b'a'; 255]),
+                RowValue::Text(&payload),
+            ],
+        )?;
+        assert_eq!(&raw[raw.len() - 5..], &[(260 + size) as u8, 4, 0, 1, 7]);
+        let bytes = database_bytes(&columns, &[&raw])?;
+        let mut budget = budget_for(&bytes);
+        let source = SliceSource::new(&bytes, budget.read_budget())?;
+        let mut database = DatabaseReader::from_source(source, &mut budget)?;
+        let definition = database.table_definition(PageNumber::new(ROOT as u64), &mut budget)?;
+        let mut rows = database.rows(&definition, &mut budget)?;
+        assert_eq!(
+            rows.next_row()?
+                .ok_or("missing row")?
+                .field(ColumnOrdinal::new(2)),
+            Some(crate::RawField::Bytes(payload.as_slice()))
+        );
+    }
+    assert!(matches!(
+        encode(
+            &layout,
+            &[
+                RowValue::Long(2),
+                RowValue::Text(&[b'a'; 255]),
+                RowValue::Text(&[b'x'; 252])
+            ]
+        ),
+        Err(RowWriteError::BoundaryTooLarge { boundary: 512, .. })
+    ));
+    // Refuse the unsupported third block even when low offsets look valid.
+    let mut raw = vec![3];
+    raw.extend_from_slice(&2_i32.to_le_bytes());
+    raw.extend_from_slice(&[b'a'; 255]);
+    raw.extend_from_slice(&[b'x'; 252]);
+    raw.extend_from_slice(&[0, 4, 0, 1, 7]);
+    let bytes = database_bytes(&columns, &[&raw])?;
+    let mut budget = budget_for(&bytes);
+    let source = SliceSource::new(&bytes, budget.read_budget())?;
+    let mut database = DatabaseReader::from_source(source, &mut budget)?;
+    let definition = database.table_definition(PageNumber::new(ROOT as u64), &mut budget)?;
+    let mut rows = database.rows(&definition, &mut budget)?;
+    assert!(matches!(
+        rows.next_row(),
+        Err(crate::RowError::UnsupportedWideVariableOffsets { .. })
+    ));
+    Ok(())
+}

--- a/crates/jet3/src/update_fixed_tests.rs
+++ b/crates/jet3/src/update_fixed_tests.rs
@@ -212,3 +212,56 @@ fn checked_single_field_encoder_rejects_noop_and_invalid_layouts() -> TestResult
     assert_eq!(output, [0xa5; 3]);
     Ok(())
 }
+
+#[test]
+fn wide_fixed_text_with_variable_payload_preserves_all_other_bytes() -> TestResult {
+    let fixture = Fixture::new(
+        &[
+            ColumnSpec::new(b"Id", ColumnType::Long),
+            ColumnSpec::new(
+                b"Target",
+                ColumnType::FixedText {
+                    len: NonZeroU8::MAX,
+                },
+            ),
+            ColumnSpec::new(
+                b"Payload",
+                ColumnType::Text {
+                    max_len: NonZeroU8::MAX,
+                },
+            ),
+        ],
+        &[
+            &[
+                RowValue::Long(1),
+                RowValue::Text(&[b'a'; 255]),
+                RowValue::Text(b"first"),
+            ],
+            &[
+                RowValue::Long(2),
+                RowValue::Text(&[b'a'; 255]),
+                RowValue::Text(b"second"),
+            ],
+        ],
+    )?;
+    let row = fixture.locator(1)?;
+    let original = fs::read(fixture.path())?;
+    let page_start = row.page().get() as usize * PAGE_BYTES;
+    let slot_offset = page_start + 10 + usize::from(row.slot()) * 2;
+    let row_start = usize::from(u16::from_le_bytes([
+        original[slot_offset],
+        original[slot_offset + 1],
+    ]));
+    let mut expected = original;
+    expected[page_start + row_start + 5..page_start + row_start + 260].fill(0xe9);
+    update_field(
+        fixture.path(),
+        FieldUpdate {
+            column: ColumnOrdinal::new(1),
+            ..request(row, RowValue::Text(&[0xe9; 255]))
+        },
+        &mut budget(),
+    )?;
+    assert_eq!(fs::read(fixture.path())?, expected);
+    fixture.assert_only_original()
+}


### PR DESCRIPTION
DAO-created rows with a 260-byte fixed prefix exposed InvalidFixedBoundary during field-update validation. Decode and encode the observed single-variable, same-block wide-prefix layout with a zero jump byte, retaining explicit refusals for unsupported wider shapes.

Validation: independent review against retained DAO evidence; four new boundary, corruption and exact-public-update tests, 26 focused tests, Clippy and just ready passed. The failed acquisition remains recorded; DAO verification of corrected candidates is separate.
