### PR TITLE
test: preregister retained fixed-field update validation

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11110,6 +11110,35 @@ Copy this block under the appropriate section and remove this instruction:
   updates, deletion/insertion, arbitrary existing-file compatibility or
   hosted update support. Report compatibility/support flags remain false.
 
+## EXP-0175 — Distinct validation of retained fixed-field updates
+
+- Preregistered only; no acquisition. Outcome reserved as EXP-0176. The
+  original EXP-0172 failed acquisition and consumed EXP-0171 inputs remain
+  unchanged; this is a separate post-acquisition reuse experiment.
+- Plan `oracle/windows-dao/acquisition/fixed-field-reuse.plan.json`, SHA-256
+  `410084e32005ea98748017d3fbd9850c33e28f9f1f3e5e83f6dcc2935301df11`.
+  It pins all 30 retained originals, 27 completed updates, original result,
+  report, create snapshots and initiating Unix error log (61 artifacts), plus
+  meaningful implementation, exporter, observer and diagnostic inputs.
+- Copy the retained images into a fresh exclusive tree. Preserve the original
+  27 update receipts and label them with implementation `37bd817`. Only the
+  missing three `fixed-text-255` updates use the unchanged public exporter and
+  reviewed wide-prefix fix `2c99b3d`; each report observation binds its actual
+  source revision and retained/new origin explicitly.
+- The private diagnostic decoder adds only the EXP-0172 same-second-block,
+  one-variable, zero-jump interpretation, retaining the original decoder and
+  all MDB bytes. Independent row/field selection, exact replacement bytes and
+  every byte outside the target span are checked before guest dispatch.
+- One read-only x86 `DAO.DBEngine.36` job captures all 60 images using the frozen
+  EXP-0171 observer and scalar readback helpers. No DAO creation or mutation
+  occurs. Compare each original to its frozen creation snapshot and each update
+  to the precise requested schema/rows/values, including negative-zero bits,
+  fixed Text width, unrelated tables and original stored QueryDef SQL.
+- All 30 pairs, complete identities, provider and preservation gates are
+  required; failure is `no_outcome`, without partial promotion or retry/resume.
+  This local experiment cannot change hosted support or imply broad
+  compatibility, and cannot turn the original EXP-0172 result into acceptance.
+
 ## EXP-0172 — Fixed-field successor stopped at wide fixed-prefix decoding
 
 - Outcome: `no_outcome`, recorded 2026-09-05 from the single local run

--- a/oracle/windows-dao/acquisition/fixed-field-reuse.plan.json
+++ b/oracle/windows-dao/acquisition/fixed-field-reuse.plan.json
@@ -1,0 +1,507 @@
+{
+  "replicas": 3,
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4,
+      "fixed": true
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4,
+      "fixed": true
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 20,
+      "fixed": false
+    }
+  ],
+  "tables": [
+    {
+      "name": "Items",
+      "rows": [
+        [
+          "01000000",
+          "65000000",
+          "6669727374"
+        ],
+        [
+          "02000000",
+          "36ffffff",
+          "7365636f6e64"
+        ],
+        [
+          "03000000",
+          "2f010000",
+          "7468697264"
+        ]
+      ]
+    },
+    {
+      "name": "Later",
+      "rows": [
+        [
+          "0b000000",
+          "b3fbffff",
+          "6c617465722d6f6e65"
+        ],
+        [
+          "0c000000",
+          "b2040000",
+          "6c617465722d74776f"
+        ],
+        [
+          "0d000000",
+          "e9faffff",
+          "6c617465722d7468726565"
+        ]
+      ]
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "arms": [
+    {
+      "name": "byte",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 2,
+        "size": 1,
+        "fixed": true
+      },
+      "initial_hex": "00",
+      "replacement_hex": "ff"
+    },
+    {
+      "name": "integer",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 3,
+        "size": 2,
+        "fixed": true
+      },
+      "initial_hex": "ff7f",
+      "replacement_hex": "0080"
+    },
+    {
+      "name": "long-control",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 4,
+        "size": 4,
+        "fixed": true
+      },
+      "initial_hex": "01000000",
+      "replacement_hex": "00000080"
+    },
+    {
+      "name": "currency",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 5,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "0000000000000000",
+      "replacement_hex": "0000000000000080"
+    },
+    {
+      "name": "single",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 6,
+        "size": 4,
+        "fixed": true
+      },
+      "initial_hex": "0000803f",
+      "replacement_hex": "00000080"
+    },
+    {
+      "name": "double",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 7,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "000000000000f03f",
+      "replacement_hex": "0000000000000080"
+    },
+    {
+      "name": "date",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 8,
+        "size": 8,
+        "fixed": true
+      },
+      "initial_hex": "000000000000f03f",
+      "replacement_hex": "000000000000f4bf"
+    },
+    {
+      "name": "guid",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 15,
+        "size": 16,
+        "fixed": true
+      },
+      "initial_hex": "00000000000000000000000000000000",
+      "replacement_hex": "33221100554477668899aabbccddeeff"
+    },
+    {
+      "name": "fixed-text-1",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 10,
+        "size": 1,
+        "fixed": true
+      },
+      "initial_hex": "61",
+      "replacement_hex": "e9"
+    },
+    {
+      "name": "fixed-text-255",
+      "table": "Items",
+      "selected_id": 2,
+      "column": "Value",
+      "field": {
+        "name": "Value",
+        "type": 10,
+        "size": 255,
+        "fixed": true
+      },
+      "initial_hex": "616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161",
+      "replacement_hex": "e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9"
+    }
+  ],
+  "document_type": "dao_fixed_field_reuse_plan",
+  "provenance": "EXP-0175",
+  "outcome_provenance": "EXP-0176",
+  "source_revision": "2c99b3dc78a3046837592fdf29e6a8bacaf99b20",
+  "original_source_revision": "37bd8175393dccf836b96172f740a28c4be36a60",
+  "original_acquisition_revision": "b39ee054bc3360d778d3113fc68ba9df27fd47ad",
+  "original_plan_sha256": "01929cf68daa5d5bc8dbb4529819634c4017f8b0551a1772d3444eddc2027942",
+  "retained_root": "/home/alex/development/vms/jet3-windows/shared/outbox/20260905T072835Z-fixed-field-successor",
+  "retained": {
+    "byte-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "a3bc24176d595745fd545f52ad10674c255ccbab86a109f493720e35bfb24a4e"
+    },
+    "byte-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "22d77e99cffc7d611adfac9058a6f7234f62ebf102490158afa666371eee53ac"
+    },
+    "byte-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "26429e03d7e69a9d04265cca3d2ca1f333ad73c6f803c731fa7c45bc69c3dc5f"
+    },
+    "byte-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "8a7fbb5d2f5f3f2b0b578061467070c06418a7147dcc2a32639d2ee76a718378"
+    },
+    "byte-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "1c179b61b474a644f280949b38097c10ce9d7fb91d290fa6602da00b85137644"
+    },
+    "byte-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "d3ca56ca5eb0818fd019b3691a571812d663f074d569d3ba96e53c15e091a89f"
+    },
+    "create.json": {
+      "size": 469595,
+      "sha256": "9a47f321d582c99f0288bed8cc8d113df828327000d65e577bdee22bb70f735c"
+    },
+    "currency-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "1f6a2414120a754b997a1263e19ad49d7c3f2d48f05b2838d1fae4223745a130"
+    },
+    "currency-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "e13671990e4f001af0350aa2a2cb89aa955d63866e93b31e4431d089f2a34008"
+    },
+    "currency-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "7840813767d7d9fdc871bf08078ce376241699a7adc448cf670bc942e780ce3d"
+    },
+    "currency-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "2c4161a9a7251bfed57a5af41a36f2f96e248bdce86c16e36e09557f66fed116"
+    },
+    "currency-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "d2d8af0f6db99b78c5097d5beda6e8405483053626696a38e2c56dc13366f5b3"
+    },
+    "currency-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "725f5395c78ca69f17902ddfebda3f0fabe2756b82c303febce26f2662cc0d78"
+    },
+    "date-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "313dd730d8c7f81d77ffcf36031a9095d787e54048ec3bebde571de0c71a6ecb"
+    },
+    "date-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "32218a5465997ace074e9a634691350905ed3bfc14874a11815305695eee5b5c"
+    },
+    "date-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "973541fc5d1abc18b8860e97e6a9b0aa201b89e77e2729fd5cd02b0a402585b3"
+    },
+    "date-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "dc6766a0de4f51eef78ac0483d60925568274ef7dd4f7f337ae740b2929f2e51"
+    },
+    "date-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "02805b23b3ca02cb7448bc1cdb7a58a9c7c5827a0e4fbcffb1adae8634f95770"
+    },
+    "date-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "64a342594d8d24bad7ebd1699a7de95d894a3cd2513a8f523dd00e96621748ff"
+    },
+    "double-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "aaf98ff7e868d158a671bbe5c57eb7bb6e929dc044484e871123e3c4455e9adc"
+    },
+    "double-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "180b76f530a5ce93142685f7d09845e3a4a20a04965958e142d2ae7c5f4bbc84"
+    },
+    "double-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "30e6324777b380965cb281a6e0910ce42d8945d922a1e679da6e0b7e961368fb"
+    },
+    "double-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "e38eeaf9d49b48a913f04b3b605d21e3232684c9d95e47c8b5d754a1ea9ab851"
+    },
+    "double-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "8dd67367bb1cfd3f325a2c0f9ce2fe7b5bf83361f4893edab6b5d532f43ee82f"
+    },
+    "double-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "30d4d5ce4d0c544cf37119888989d64e942da1469c2ec3756afd61f735b0d00c"
+    },
+    "fixed-text-1-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "a02895a2ac7a99032b6a42998204a0bb43f8d0ac9740932bb15ec883632d6b4e"
+    },
+    "fixed-text-1-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "8ebea3e1adbc4d6a907c62766376a6611b9d967beaafbf5d1817eaecd0121485"
+    },
+    "fixed-text-1-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "2d584bbb2cbf25d68412c8f25356035044514b4d72e119454d24d825e208254d"
+    },
+    "fixed-text-1-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "77f70a469ce39cb330d6a0c78971c3df2c0a0204ee666d8040d01701d53dde38"
+    },
+    "fixed-text-1-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "26370ceed51ebb88bf3f0d15f6fd9f4d2a22e67d538670c75a2a691a6d35ae0d"
+    },
+    "fixed-text-1-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "667584c1a1bf21babe1f163b29bb7f3df40a90270f12085407fb4b95d1237a34"
+    },
+    "fixed-text-255-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "7c23281c622eb75c6948d70fd39f0151caee4da651d8e21b9c174e56eb8ca1f4"
+    },
+    "fixed-text-255-r1-unix.txt": {
+      "size": 57,
+      "sha256": "aedbb2783500a1407f8b10b0b5fecb869e28843bf2229b2a8bfd626c02a983ef"
+    },
+    "fixed-text-255-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "43b6dd99f3ed76ea66e1efe5328094a077e9cc0583943e81d060a375cef5ec15"
+    },
+    "fixed-text-255-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "71fc744abcea9eedbe2733f1ffd4984252f21133a8fde342e9c1332e83307321"
+    },
+    "guid-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "7e634a17a711675e87e669e8ecf83e75fcbff2f7c89bbb243b94034437c1acdc"
+    },
+    "guid-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "5d130f06def0aa8b8cdec7088bc0f5da5a0323ababd7763da23b89a06b6c852f"
+    },
+    "guid-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "b3d53d1ff1a2588ec5402f11e5354371c6729a0719ea72318544b93a41ee6eba"
+    },
+    "guid-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "d5c913aa4c4c54407935bb58d73e774b5713e0cbbaf88b097fa52383d6b3da43"
+    },
+    "guid-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "4d0f27923ea96a6da999ba1afe3acc48c0b51bb5190fc7379c240577ee9e03dd"
+    },
+    "guid-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "ca5fbaa4343ec2a680a597cf773236ec32433b7720076810bc7333cfbdb79122"
+    },
+    "integer-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "2fb4500eb6f7a29a22c511eb180da88696c452bd95edac6cc6b1c1e727ca5d1c"
+    },
+    "integer-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "5d475f7c5f8d0f667a0bf5bf51c4b11c59d390ac13f9047b7fcde44f5ff181ae"
+    },
+    "integer-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "09f0b938d7141341f7af88a4db5c1a2c69a1add4e56d666ac3178faa260943ce"
+    },
+    "integer-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "28d5aba38920e2526cacf58b73d9045c6896e5fea50c11bec870c62f066ad037"
+    },
+    "integer-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "e4c6be3d72d6df28ef210f04e6419c826ddee94080a869c4f6b4a063eb3e01d7"
+    },
+    "integer-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "e41b12f325f6ee19be91deeb78fa17a48b3e65804542010aa203eac109151ecf"
+    },
+    "long-control-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "076c0393c3a1a2e3a6559a908aac55761ce006bbe7f1340d7c4971b127e220e1"
+    },
+    "long-control-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "155814085e39de0d408014ff490357b50b83ba714e3bc520640f8fca36c24545"
+    },
+    "long-control-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "96b314a19c5c05956a8c7807a8a4353dfa539bca58bd9369abb44085d8f2b9ae"
+    },
+    "long-control-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "3e0274ca1b53133932bd47c4965b2e41f8041bd8ce5eb230bc79b0b29a6d484f"
+    },
+    "long-control-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "2079b20c8a532894df4d53b2c7cf08250da007909e2fd037462603ae793c0473"
+    },
+    "long-control-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "08918d337770d0ab6801ffda47398c8a98fea7c3b3b57b79713e003f6c4f87f2"
+    },
+    "report.json": {
+      "size": 443,
+      "sha256": "e5038422be9fa5dcd4eac0301e773254bfbd211112178d09f1c4d9d4ff5526a0"
+    },
+    "result.json": {
+      "size": 11294,
+      "sha256": "c65483f1fa0996e447dc10dac925e7998b4caaf70d09b526da7346d59a03b640"
+    },
+    "single-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "73ffb8cbd03c680ccef036b971f9248eed72c4540f0ea571d620e0e7a4df22b5"
+    },
+    "single-r1-updated.mdb": {
+      "size": 57344,
+      "sha256": "bf1d345e1d6d50cd262ed558f569a01be9c465d71ead17ea9302ed15f916f54c"
+    },
+    "single-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "e6176ca11f6b5cfa14584aa4ea4a0f4daa292db00d6f41c4e91422a139d1264f"
+    },
+    "single-r2-updated.mdb": {
+      "size": 57344,
+      "sha256": "100669f3700677865ebd7045f010bf997dbb12f844aa01f82b93c56330e5b4a7"
+    },
+    "single-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "1bc107946006047751d4718bb969e173fa8a526cf52367f525cdfb35b4cff648"
+    },
+    "single-r3-updated.mdb": {
+      "size": 57344,
+      "sha256": "f8785ecdad5a9a82b7ab91e9821077f2834e5e1a27cdcf4b1b4885dcbe40d24e"
+    }
+  },
+  "inputs": {
+    "Cargo.lock": "1b306e136535925889bb551ea92a606756153eb7f69eca9c9a0617aa2e551e11",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/fixed_field_update_candidate.rs": "c3baf749c0bf2df5f33fccd4284f96e8ae59f3d577f5be93c0774d618ec911e1",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "crates/jet3/src/row.rs": "64647c6c4ed50f88841d6d28fcf170653055e44ec4e3ee61f1ec2aaa50a5d1ae",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_writer.rs": "585c0769b03f060bdf4897752821ff32ef4f769010e109c885f151fcacd815e1",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/update.rs": "ed169ae4cf7df0751966370fbbe15b7c6568388e3d93eac021678e4e29d67de9",
+    "oracle/windows-dao/acquisition/fixed-field-successor.plan.json": "01929cf68daa5d5bc8dbb4529819634c4017f8b0551a1772d3444eddc2027942",
+    "oracle/windows-dao/acquisition/fixed-field-update.plan.json": "c6958a5b238c6cee97f877ec12cf53b93ad699db190fb0aceec769045794c564",
+    "oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1": "78fb338668271a23158f0cfc65f0393931e4a04945af0ed84808964b2a073c89",
+    "oracle/windows-dao/scripts/fixed_field_reuse.ps1": "5443089e97924bd79691edbcd81ea31a2f9a6d4a51c48c2c3241d45b910e5ad9",
+    "oracle/windows-dao/scripts/fixed_field_reuse.py": "6fe2d6634c38f4cff285792e1c0e0127f29bba330349426b17decd778c16522d",
+    "oracle/windows-dao/scripts/fixed_field_successor.ps1": "effe902ca9799bf898c1c20ccd4bc9b823a50cc1f69d2869c763e267922f954d",
+    "oracle/windows-dao/scripts/fixed_field_successor.py": "47e4b0e7776bda396ce0fc8c770fa9ad90cd6de008b3aa938658d1d519ea0601",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/tests/fixed_field_update_values.ps1": "01a4784a71d8bf5b2cd5a2d1cc9db50e7d9cf8ccaa0743a8ca1b0cb6f816925a",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "question": "Do the 27 frozen EXP0171 Unix updates and three missing updates produced with the bounded EXP0172 reader fix pass complete read-only DAO comparison against the 30 retained originals?",
+  "sequence": [
+    "Commit and independently review this distinct plan before any new public update or DAO capture. Preserve original EXP0172 no_outcome, all consumed inputs and original retained artifacts. No original acquisition retry/resume.",
+    "Hash-bind all 30 originals, 27 existing updated MDBs, failed coordinated result/report, creation snapshots and initiating Unix failure log. Copy images into a new exclusive output tree; never modify the original tree.",
+    "Reuse each of the 27 original update receipts and images exactly, identifying source37bd817 per case. Only fixed-text-255 replicas1/2/3 invoke the unchanged public exporter with reviewed corrected source2c99b3d. All three operate on private copies. Recheck complete original identity and exact field span/all-other-byte equality before DAO.",
+    "Capture 60 read-only DAO observations in one guest job using frozen EXP0171 Observe/Read-Value helpers. Retain every image, initiating errors and retention failures. No DAO creation, insertion, update or deletion occurs.",
+    "Compare every original snapshot to its frozen creation snapshot and every updated snapshot to the exact requested change, including complete schema, query SQL, other rows/tables and exact saved scalar bits. Report all30 pairs only if every gate passes; otherwise no_outcome without subset promotion."
+  ],
+  "diagnostic_change": "A private decoder wrapper supports only one variable field with fixed prefix and end in256..511 and recorded zero jump, from EXP0172. It adjusts only an in-memory diagnostic trailer to the old decoder representation, preserving raw MDBs. All original decoder structure checks and exact whole-file patch comparison remain. No general wide-offset inference.",
+  "source_binding": "Each observation and update receipt labels retained_update/source37bd817 or new_public_update/source2c99b3d. The original27 are never attributed to the corrected source; original full acquisition remains no_outcome regardless of this distinct result.",
+  "decision_rule": "observed_accepted requires all30 exact pairs, 60 unchanged x86DAO.DBEngine.36/Jet3.0 captures, complete per-case source/request/image binding, exact raw replacements and all-other-byte preservation, all original snapshots and stored QueryDef SQL preserved. Negative zero stays exact bits; no normalization. Any failure stops once and is no_outcome; no implicit retry.",
+  "bounds": "Ten original typed arms times3 replicas, 60MDBs in new output, no new controls or provider installation. Existing diagnostic bounds suffice. Three Unix calls<=120seconds each and one SSH job<=300seconds. Local development only; no compatibility/support promotion. Original retained data are post-acquisition selected explicitly; no reinterpretation of the failed original run."
+}

--- a/oracle/windows-dao/scripts/fixed_field_reuse.ps1
+++ b/oracle/windows-dao/scripts/fixed_field_reuse.ps1
@@ -1,0 +1,33 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected x86 DAO'}
+$helper=Join-Path $env:JET3_WORK 'fixed_field_successor.ps1'
+$tokens=$null;$errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile($helper,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Pinned helper parse failure'}
+foreach($name in @('Identity','Release','Write-Json','To-Hex','Read-Value','Failure','Observe')){
+    $found=@($ast.FindAll({param($n) $n -is [Management.Automation.Language.FunctionDefinitionAst] -and $n.Name-eq $name},$false))
+    if($found.Count-ne 1){throw 'Missing helper'}
+    Invoke-Expression $found[0].Extent.Text
+}
+$CodePage=[Text.Encoding]::GetEncoding(1252,(New-Object Text.EncoderExceptionFallback),(New-Object Text.DecoderExceptionFallback))
+$planPath=Join-Path $env:JET3_WORK 'fixed-field-reuse.plan.json'
+$plan=Get-Content -LiteralPath $planPath -Raw|ConvertFrom-Json
+if((Identity $helper).sha256-cne $plan.inputs.'oracle/windows-dao/scripts/fixed_field_successor.ps1'-or (Identity $PSCommandPath).sha256-cne $plan.inputs.'oracle/windows-dao/scripts/fixed_field_reuse.ps1'){throw 'Producer input pin mismatch'}
+$failure=$null;$endpoint='start'
+$result=@{document_type='dao_fixed_field_reuse_phase';plan_sha256=(Identity $planPath).sha256;environment=@{process_bits=32;provider='DAO.DBEngine.36';os=[Environment]::OSVersion.VersionString};mutation_started=$false;observations=@();error=$null;retention_failures=@()}
+try{
+    foreach($arm in $plan.arms){foreach($replica in 1..3){foreach($role in @('original','updated')){
+        $endpoint="$($arm.name)/$replica/$role";$script:endpoint=$endpoint
+        $path=Join-Path $env:JET3_WORK "$($arm.name)-r$replica-$role.mdb"
+        $obs=Observe $path $plan $arm
+        $result.observations+=@{arm=[string]$arm.name;replica=$replica;role=$role;observation=$obs}
+        if($obs.status-ne 'pass'){throw 'Read-only capture failed'}
+    }}}
+}catch{$result.error=if($null-ne $failure){$failure}else{Failure $_}}finally{
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb'){
+        try{Copy-Item -LiteralPath $file.FullName -Destination $env:JET3_OUTBOX}catch{$result.retention_failures+=@{file=$file.Name;error=$_.Exception.Message}}
+    }
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if($null-ne $result.error-or $result.retention_failures.Count){exit 1}

--- a/oracle/windows-dao/scripts/fixed_field_reuse.py
+++ b/oracle/windows-dao/scripts/fixed_field_reuse.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""EXP-0175: distinct retained fixed-field candidate validation, no retry."""
+import argparse
+import copy
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import types
+import fixed_field_successor as original
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/fixed-field-reuse.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/fixed_field_reuse.ps1'
+identity, digest, canonical = original.identity, original.digest, original.canonical
+
+# Private diagnostic interpretation only; original decoder and MDB bytes stay frozen.
+spec = importlib.util.spec_from_file_location('reuse_catalog', ROOT / 'oracle/windows-dao/scripts/system_catalog.py')
+catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(catalog)
+base_decode = catalog._decode_row
+
+def decode_row(raw, columns, what):
+    fixed, variables = catalog._row_layout(columns)
+    if variables == 1 and fixed >= 256:
+        trailer = len(raw) - (len(columns) + 7) // 8 - 4
+        if not 256 <= fixed <= trailer < 512 or raw[trailer + 2] != 0:
+            raise catalog.DecodeError('Unsupported wide fixed-prefix shape')
+        # EXP-0172: both boundaries are in block one with a recorded zero jump.
+        decoded = bytearray(raw)
+        decoded[trailer + 2] = 3
+        return base_decode(bytes(decoded), columns, what)
+    return base_decode(raw, columns, what)
+
+catalog._decode_row = decode_row
+patch_globals = dict(original.patch_check.__globals__, catalog=catalog)
+patch_check = types.FunctionType(original.patch_check.__code__, patch_globals)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, sha in plan['inputs'].items():
+        if digest(ROOT / name) != sha: raise ValueError('Input pin mismatch: ' + name)
+    source = Path(plan['retained_root'])
+    for name, ident in plan['retained'].items():
+        if identity(source / name) != ident: raise ValueError('Retained identity mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if os.name != 'posix' or subprocess.check_output(['git','show',f'HEAD:{PLAN.relative_to(ROOT)}'],cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Expected committed Unix plan')
+    return plan
+
+
+def source_updates(plan):
+    source = Path(plan['retained_root'])
+    result = json.loads((source/'result.json').read_text())
+    if result['phase'] != 'unix_update' or result['plan_sha256'] != plan['original_plan_sha256'] or result['source_revision'] != plan['original_source_revision']:
+        raise ValueError('Original failed-run identity')
+    updates = {(u['arm'],u['replica']):u for u in result['updates']}
+    wanted = {(a['name'],r) for a in plan['arms'] if a['name'] != 'fixed-text-255' for r in range(1,4)}
+    if len(updates) != 27 or set(updates) != wanted: raise ValueError('Original 27-update inventory')
+    return updates
+
+
+def capture_entries(document, plan):
+    if (document['document_type'] != 'dao_fixed_field_reuse_phase' or document['plan_sha256'] != digest(PLAN)
+        or document['error'] is not None or document['retention_failures'] or document['mutation_started'] is not False
+        or document['environment']['process_bits'] != 32 or document['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Read-only phase failure/environment')
+    entries = {}
+    wanted = {(a['name'],r,role) for a in plan['arms'] for r in range(1,4) for role in ('original','updated')}
+    for item in document['observations']:
+        key = item['arm'],item['replica'],item['role']; obs = item['observation']
+        if key in entries or key not in wanted or obs['file'] != f'{key[0]}-r{key[1]}-{key[2]}.mdb' or obs['status'] != 'pass' or obs['error'] is not None or obs['before'] != obs['after']:
+            raise ValueError('Observation identity or failure')
+        entries[key] = obs
+    if set(entries) != wanted: raise ValueError('Incomplete 60-capture inventory')
+    return entries
+
+
+def build_report(result, outbox, plan):
+    observations, reasons = [], []
+    try:
+        if (result['document_type'] != 'dao_fixed_field_reuse_result' or result['plan_sha256'] != digest(PLAN)
+            or result['source_revision'] != plan['source_revision'] or result['producer_os'] != 'posix'
+            or result['error'] is not None or result['phase'] != 'complete'):
+            raise ValueError('Coordinated acquisition failed: ' + str(result.get('error')))
+        if identity(outbox/'observe.json') != result['observe']: raise ValueError('Capture receipt identity')
+        entries = capture_entries(json.loads((outbox/'observe.json').read_text(encoding='utf-8-sig')),plan)
+        source = Path(plan['retained_root']); old = source_updates(plan)
+        create = json.loads((source/'create.json').read_text(encoding='utf-8-sig'))
+        if create['plan_sha256'] != plan['original_plan_sha256'] or create['error'] is not None: raise ValueError('Original creation receipt')
+        originals = {(o['arm'],o['replica']):o['observation'] for o in create['observations']}
+        updates = {(u['arm'],u['replica']):u for u in result['updates']}
+        wanted = {(a['name'],r) for a in plan['arms'] for r in range(1,4)}
+        if len(updates) != 30 or set(updates) != wanted or set(originals) != wanted: raise ValueError('Update/original inventory')
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                key = arm['name'],replica; prefix=f'{key[0]}-r{replica}'; update=updates[key]
+                new = arm['name']=='fixed-text-255'
+                revision = plan['source_revision'] if new else plan['original_source_revision']
+                if update['source_revision'] != revision or update['origin'] != ('new_public_update' if new else 'retained_update'):
+                    raise ValueError('Per-case source binding')
+                if not new and {k:v for k,v in update.items() if k not in ('source_revision','origin')} != old[key]:
+                    raise ValueError('Frozen update receipt changed')
+                before = entries[key+('original',)]; after=entries[key+('updated',)]
+                original_path=outbox/f'{prefix}-original.mdb'; updated_path=outbox/f'{prefix}-updated.mdb'
+                if (identity(original_path) != plan['retained'][original_path.name]
+                    or identity(original_path) != before['after'] or identity(original_path) != originals[key]['after']
+                    or identity(original_path) != update['original_before'] or identity(original_path) != update['original_after']
+                    or identity(updated_path) != after['after'] or identity(updated_path) != update['updated']):
+                    raise ValueError('Complete image identity chain')
+                if not new and identity(updated_path) != plan['retained'][updated_path.name]: raise ValueError('Retained updated image changed')
+                if original.normalized(before['snapshot']) != original.normalized(originals[key]['snapshot']): raise ValueError('Original snapshot changed')
+                if not original.requested(before['snapshot'],plan,arm) or not original.requested(after['snapshot'],plan,arm,True): raise ValueError('Requested schema/payload bits')
+                expected=original.normalized(before['snapshot']); table=next(t for t in expected['user_tables'] if t['name']==arm['table'])
+                ordinal=next(i for i,f in enumerate(table['fields']) if f['name']==arm['column'])
+                selected=[r for r in table['rows'] if int.from_bytes(bytes.fromhex(r[0]),'little',signed=True)==arm['selected_id']]
+                if len(selected)!=1: raise ValueError('Selected row is not unique')
+                selected[0][ordinal]=arm['replacement_hex']
+                if original.normalized(expected)!=original.normalized(after['snapshot']): raise ValueError('Unrelated schema/rows/query differs')
+                span=patch_check(original_path.read_bytes(),updated_path.read_bytes(),arm,update['locator'])
+                observations.append(dict(arm=arm['name'],replica=replica,source_revision=revision,origin=update['origin'],original=identity(original_path),updated=identity(updated_path),patch=span,snapshot=after['snapshot']))
+    except (ValueError,KeyError,TypeError,OSError,catalog.DecodeError) as error: reasons.append(str(error))
+    return dict(document_type='dao_fixed_field_reuse_report',plan_sha256=digest(PLAN),outcome='observed_accepted' if not reasons else 'no_outcome',observations=observations,reasons=reasons,development_only=True,compatibility_claim=False,support_matrix_movement=False,original_outcome='no_outcome')
+
+
+def analyze(outbox):
+    plan=verify_inputs()
+    if outbox.resolve().is_relative_to(Path(plan['retained_root']).resolve()): raise ValueError('Output inside original retained tree')
+    report=build_report(json.loads((outbox/'result.json').read_text()),outbox,plan)
+    report['result_sha256']=digest(outbox/'result.json');(outbox/'report.json').write_text(canonical(report)+'\n');print(report['outcome'])
+
+
+def dispatch(args):
+    plan=preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id): raise ValueError('Invalid run id')
+    shared=args.shared_root.resolve();outbox=shared/'outbox'/args.run_id;run_id=args.run_id+'-observe';inbox=shared/'inbox'/run_id;guest=shared/'outbox'/run_id
+    for path in (outbox,inbox,guest):
+        if path.exists() or path.resolve().is_relative_to(Path(plan['retained_root']).resolve()): raise ValueError('Used or original output; no retry/resume')
+    subprocess.run(['cargo','build','-p','jet3','--example','fixed_field_update_candidate'],cwd=ROOT,check=True)
+    spec=importlib.util.spec_from_file_location('transport',ROOT/'scripts/windows-dao-ps.py');transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result=dict(document_type='dao_fixed_field_reuse_result',plan_sha256=digest(PLAN),source_revision=plan['source_revision'],acquisition_revision=subprocess.check_output(['git','rev-parse','HEAD'],cwd=ROOT).decode().strip(),producer_os=os.name,phase='unix_update',error=None,updates=[])
+    try:
+        for name in plan['retained']:
+            if name.endswith('.mdb'): shutil.copyfile(Path(plan['retained_root'])/name,outbox/name)
+        old=source_updates(plan)
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                key=arm['name'],replica;prefix=f'{key[0]}-r{replica}';before_path=outbox/f'{prefix}-original.mdb';after_path=outbox/f'{prefix}-updated.mdb'
+                if key in old:
+                    update=dict(old[key],source_revision=plan['original_source_revision'],origin='retained_update')
+                else:
+                    before=identity(before_path)
+                    command=['cargo','run','--quiet','-p','jet3','--example','fixed_field_update_candidate','--',str(before_path),str(after_path),arm['table'],str(arm['selected_id']),arm['column'],arm['name']]
+                    done=subprocess.run(command,cwd=ROOT,capture_output=True,timeout=120);(outbox/f'{prefix}-unix.txt').write_bytes(done.stdout+done.stderr)
+                    if done.returncode: raise ValueError('Public update failed: '+prefix)
+                    update=dict(arm=arm['name'],replica=replica,original_before=before,original_after=identity(before_path),updated=identity(after_path),locator=json.loads(done.stdout),source_revision=plan['source_revision'],origin='new_public_update')
+                result['updates'].append(update)
+                if identity(before_path)!=update['original_before'] or identity(before_path)!=update['original_after'] or identity(after_path)!=update['updated']: raise ValueError('Unix transfer/source identity')
+                patch_check(before_path.read_bytes(),after_path.read_bytes(),arm,update['locator'])
+        verify_inputs();result['phase']='observe';inbox.mkdir(parents=True)
+        for name in (SCRIPT,'oracle/windows-dao/scripts/fixed_field_successor.ps1'):
+            shutil.copyfile(ROOT/name,inbox/Path(name).name)
+        shutil.copyfile(inbox/Path(SCRIPT).name,inbox/'script.ps1');shutil.copyfile(PLAN,inbox/PLAN.name)
+        for path in outbox.glob('*.mdb'): shutil.copyfile(path,inbox/path.name)
+        command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,run_id,'script.ps1'))]
+        done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=300);(outbox/'observe-ssh.txt').write_bytes(done.stdout+done.stderr)
+        shutil.copyfile(guest/'result.json',outbox/'observe.json');result['observe']=identity(outbox/'observe.json')
+        entries=capture_entries(json.loads((outbox/'observe.json').read_text(encoding='utf-8-sig')),plan)
+        if done.returncode: raise ValueError('Guest capture failed')
+        for obs in entries.values():
+            if identity(guest/obs['file'])!=obs['after'] or identity(outbox/obs['file'])!=obs['after']: raise ValueError('Retained guest image identity')
+        verify_inputs();result['phase']='complete'
+    except (OSError,ValueError,subprocess.SubprocessError) as error: result['error']=type(error).__name__+': '+str(error)
+    finally: (outbox/'result.json').write_text(canonical(result)+'\n')
+    analyze(outbox)
+
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__);commands=parser.add_subparsers(dest='command',required=True)
+    commands.add_parser('preflight');report=commands.add_parser('analyze');report.add_argument('outbox',type=Path)
+    run=commands.add_parser('run');run.add_argument('--run-id',required=True);run.add_argument('--shared-root',type=Path,required=True)
+    for name,default in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:run.add_argument('--'+name,default=default)
+    args=parser.parse_args()
+    if args.command=='preflight':preflight();print('Committed input and retained pins match.')
+    elif args.command=='analyze':analyze(args.outbox)
+    else:dispatch(args)
+
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/test_fixed_field_reuse.py
+++ b/oracle/windows-dao/tests/test_fixed_field_reuse.py
@@ -1,0 +1,74 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import fixed_field_reuse as experiment
+
+
+def snapshot(plan,arm,updated):
+    tables=[]
+    for table in experiment.original.arm_tables(plan,arm,updated):
+        fields=[dict({k:f[k] for k in ('name','type','size')},attributes=1 if f['fixed'] else 2) for f in table['fields']]
+        tables.append(dict(name=table['name'],attributes=0,indexes=[],fields=fields,rows=table['rows']))
+    return dict(version='3.0',relations=[],queries=[dict(name=plan['query']['name'],sql=plan['query']['sql'],type=0)],user_tables=tables)
+
+
+class ReuseTests(unittest.TestCase):
+    def test_complete_matrix_and_source_query_inventory_gates(self):
+        plan=json.loads(experiment.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);source=root/'source';source.mkdir();out=root/'out';out.mkdir();plan['retained_root']=str(source);plan['retained']={}
+            create=dict(plan_sha256=plan['original_plan_sha256'],error=None,observations=[])
+            old=dict(phase='unix_update',plan_sha256=plan['original_plan_sha256'],source_revision=plan['original_source_revision'],updates=[])
+            capture=dict(document_type='dao_fixed_field_reuse_phase',plan_sha256=experiment.digest(experiment.PLAN),error=None,retention_failures=[],mutation_started=False,environment=dict(process_bits=32,provider='DAO.DBEngine.36'),observations=[])
+            result=dict(document_type='dao_fixed_field_reuse_result',plan_sha256=experiment.digest(experiment.PLAN),source_revision=plan['source_revision'],producer_os='posix',phase='complete',error=None,updates=[])
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    ids={};new=arm['name']=='fixed-text-255'
+                    for role in ('original','updated'):
+                        path=out/f"{arm['name']}-r{replica}-{role}.mdb";path.write_bytes(role.encode());ids[role]=experiment.identity(path)
+                        if role=='original' or not new:plan['retained'][path.name]=ids[role]
+                        obs=dict(arm=arm['name'],replica=replica,role=role,observation=dict(file=path.name,before=ids[role],after=ids[role],status='pass',error=None,snapshot=snapshot(plan,arm,role=='updated')))
+                        capture['observations'].append(obs)
+                        if role=='original':create['observations'].append(copy.deepcopy(obs))
+                    update=dict(arm=arm['name'],replica=replica,original_before=ids['original'],original_after=ids['original'],updated=ids['updated'],locator={})
+                    if not new:old['updates'].append(copy.deepcopy(update))
+                    result['updates'].append(dict(update,source_revision=plan['source_revision'] if new else plan['original_source_revision'],origin='new_public_update' if new else 'retained_update'))
+            (source/'result.json').write_text(json.dumps(old));(source/'create.json').write_text(json.dumps(create))
+            def classify():
+                (out/'observe.json').write_text(json.dumps(capture));result['observe']=experiment.identity(out/'observe.json')
+                with patch.object(experiment,'patch_check',return_value={}):return experiment.build_report(result,out,plan)['outcome']
+            self.assertEqual(classify(),'observed_accepted')
+            result['updates'][0]['source_revision']=plan['source_revision'];self.assertEqual(classify(),'no_outcome');result['updates'][0]['source_revision']=plan['original_source_revision']
+            capture['observations'][1]['observation']['snapshot']['queries'][0]['sql']='changed';self.assertEqual(classify(),'no_outcome');capture['observations'][1]['observation']['snapshot']['queries'][0]['sql']=plan['query']['sql']
+            capture['environment']['provider']='other';self.assertEqual(classify(),'no_outcome');capture['environment']['provider']='DAO.DBEngine.36'
+            capture['observations'].pop();self.assertEqual(classify(),'no_outcome')
+
+    def test_private_decoder_wide_shape_and_original_unchanged(self):
+        columns=[dict(ordinal=0,type='Long',storage='fixed',fixed_offset=0,size=4),dict(ordinal=1,type='Text',storage='fixed',fixed_offset=4,size=255),dict(ordinal=2,type='Text',storage='variable',variable_index=0,size=20)]
+        raw=bytes([3])+bytes.fromhex('02000000')+b'a'*255+b'second'+bytes([10,4,0,1,7])
+        self.assertEqual(experiment.decode_row(raw,columns,'test')['values'],[2,'a'*255,'second'])
+        with self.assertRaises(experiment.original.catalog.DecodeError):experiment.original.catalog._decode_row(raw,columns,'original')
+        bad=bytearray(raw);bad[-3]=3
+        with self.assertRaises(experiment.catalog.DecodeError):experiment.decode_row(bytes(bad),columns,'test')
+        bad=bytearray(raw);bad[-5]=11
+        with self.assertRaises(experiment.catalog.DecodeError):experiment.decode_row(bytes(bad),columns,'test')
+
+    def test_input_retained_and_output_preservation_gates(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);script=root/'script';script.write_text('pinned');source=root/'source';source.mkdir();image=source/'one.mdb';image.write_bytes(b'original')
+            p=root/'plan.json';p.write_text(json.dumps(dict(inputs={'script':experiment.digest(script)},retained_root=str(source),retained={'one.mdb':experiment.identity(image)})))
+            with patch.object(experiment,'ROOT',root),patch.object(experiment,'PLAN',p):
+                experiment.verify_inputs()
+                with self.assertRaisesRegex(ValueError,'original retained'):experiment.analyze(source/'nested')
+                self.assertEqual(image.read_bytes(),b'original')
+                script.write_text('changed')
+                with self.assertRaisesRegex(ValueError,'Input pin'):experiment.verify_inputs()
+                script.write_text('pinned');image.write_bytes(b'changed')
+                with self.assertRaisesRegex(ValueError,'Retained identity'):experiment.verify_inputs()
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Preregister a distinct validation run over the retained fixed-field originals and 27 completed updates. Generate only the three missing wide-prefix updates using the reviewed parser fix, then capture all 60 before/after files through read-only DAO. Preserve the earlier failure and attribute each candidate to its exact source.

Validation: independent review, three focused Python tests, committed 61-input preflight, PowerShell parser and just ready passed. Results are recorded separately.
