### PR TITLE
feat: expose public row mutations through JSON CLI requests

### DIFF
--- a/crates/jet3-cli/README.md
+++ b/crates/jet3-cli/README.md
@@ -84,4 +84,47 @@ foreign index and validates its current relationship bounds. When all rows are
 empty, the CLI uses the schema-only API, including its additional supported
 index layouts; otherwise it uses the initial-row API. This interface
 adds no relationship, index, schema or payload support beyond the linked
-`jet3` library. It provides no update/delete commands or compatibility claim.
+`jet3` library. It makes no compatibility claim beyond the underlying library and its recorded evidence.
+
+`mutate` applies one public row operation to an existing database:
+
+```sh
+jet3-cli mutate example.mdb --input request.json
+```
+
+Use `--input -` for stdin. Requests have one of these shapes:
+
+```json
+{"operation":"insert","table":"Items","values":[{"long":4},{"text":"New"}]}
+```
+
+```json
+{"operation":"update","table":"Items","row":{"page":23,"slot":1},"column":0,"value":{"long":42}}
+```
+
+```json
+{"operation":"delete","table":"Items","row":{"page":23,"slot":1}}
+```
+
+Page/slot locators come from the public row reader; column ordinals come from
+its table definition. They describe the unchanged source, not a primary key or
+row position. The CLI resolves the exact supplied table and locator with that
+reader before an update/delete. Names are ASCII, and values use the same typed
+JSON cells as creation. There is no batch, implicit retry, index maintenance or
+schema conversion. Each accepted request invokes its public mutation API once
+with the default library resource budget.
+
+Success returns JSON with `ok`, `operation`, `file` and `row` (the new locator
+for insertion; the addressed locator for update/deletion). Failures return
+`mutation_failed` JSON on stderr and exit 1; invalid command arguments exit 2.
+`publication_stage`, when present, identifies a library publication failure.
+A sync error after publication can mean the change is already visible: do not
+blindly retry a failed mutation. Exclude concurrent writers for the entire
+operation; publication currently requires Unix.
+
+Current library restrictions apply unchanged: field updates support present
+fixed values, insertion needs room on a populated available page, and deletion
+supports a live tail slot without releasing its page. Indexes, relationships,
+AutoIncrement/LVAL insertion or deletion, null field transitions, page allocation,
+and inconsistent free/count metadata may be refused. Unit tests of command
+dispatch do not establish DAO compatibility for any additional operation.

--- a/crates/jet3-cli/src/create.rs
+++ b/crates/jet3-cli/src/create.rs
@@ -1,11 +1,12 @@
 //! JSON input translation for the public database creation APIs.
-use std::{ffi::OsString, fs::File, num::NonZeroU8, path::PathBuf};
+use std::{ffi::OsString, num::NonZeroU8, path::PathBuf};
 
+use crate::values::{self, Cell, ascii};
 use jet3::{
     ColumnRef, ColumnSpec, ColumnType, IndexColumnSpec, IndexDirection, IndexKind, IndexSpec,
-    RelationshipColumn, RelationshipSpec, ResourceBudget, ResourceLimits, RowValue, TableRef,
-    TableRows, TableSpec, create_database, create_database_with_relationship,
-    create_database_with_relationship_rows, create_database_with_table_rows,
+    RelationshipColumn, RelationshipSpec, RowValue, TableRef, TableRows, TableSpec,
+    create_database, create_database_with_relationship, create_database_with_relationship_rows,
+    create_database_with_table_rows,
 };
 use serde::Deserialize;
 
@@ -177,81 +178,9 @@ impl Endpoint {
     }
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "snake_case", deny_unknown_fields)]
-enum Cell {
-    AutoIncrement,
-    Boolean(bool),
-    Byte(u8),
-    Integer(i16),
-    Long(i32),
-    Currency(i64),
-    Single(f32),
-    Double(f64),
-    DateTime(f64),
-    Text(Text),
-    Memo(Text),
-    Binary(Vec<u8>),
-    LongBinary(Vec<u8>),
-    Guid([u8; 16]),
-}
-
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum Text {
-    Ascii(String),
-    Bytes(Vec<u8>),
-}
-
-impl Text {
-    fn bytes(&self) -> Result<&[u8], String> {
-        match self {
-            Self::Ascii(text) => ascii(text),
-            Self::Bytes(bytes) => Ok(bytes),
-        }
-    }
-}
-
-impl Cell {
-    fn value(&self) -> Result<RowValue<'_>, String> {
-        Ok(match self {
-            Self::AutoIncrement => RowValue::AutoIncrement,
-            Self::Boolean(v) => RowValue::Boolean(*v),
-            Self::Byte(v) => RowValue::Byte(*v),
-            Self::Integer(v) => RowValue::Integer(*v),
-            Self::Long(v) => RowValue::Long(*v),
-            Self::Currency(v) => RowValue::Currency { scaled: *v },
-            Self::Single(v) if !v.is_finite() => {
-                return Err("single value exceeds finite range".into());
-            }
-            Self::Single(v) => RowValue::Single(*v),
-            Self::Double(v) => RowValue::Double(*v),
-            Self::DateTime(v) => RowValue::DateTime { days: *v },
-            Self::Text(v) => RowValue::Text(v.bytes()?),
-            Self::Memo(v) => RowValue::Memo(v.bytes()?),
-            Self::Binary(v) => RowValue::Binary(v),
-            Self::LongBinary(v) => RowValue::LongBinary(v),
-            Self::Guid(v) => RowValue::Guid(*v),
-        })
-    }
-}
-
-fn ascii(text: &str) -> Result<&[u8], String> {
-    if text.is_ascii() {
-        Ok(text.as_bytes())
-    } else {
-        Err("names and text strings must be ASCII; use byte arrays for encoded text".into())
-    }
-}
-
 pub(crate) fn run(command: &CreateCommand) -> Result<String, String> {
-    let request: Request = if command.input == "-" {
-        serde_json::from_reader(std::io::stdin().lock())
-    } else {
-        let file = File::open(&command.input).map_err(|e| format!("read request: {e}"))?;
-        serde_json::from_reader(file)
-    }
-    .map_err(|e| format!("invalid creation request: {e}"))?;
+    let request: Request = values::read_request(&command.input)
+        .map_err(|e| format!("invalid creation request: {e}"))?;
     let columns = request
         .tables
         .iter()
@@ -338,7 +267,7 @@ pub(crate) fn run(command: &CreateCommand) -> Result<String, String> {
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
-    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let mut budget = values::budget();
     let empty = tables.iter().all(|table| table.rows.is_empty());
     let schema = tables.iter().map(|table| table.table).collect::<Vec<_>>();
     if let Some(relation) = &request.relationship {

--- a/crates/jet3-cli/src/main.rs
+++ b/crates/jet3-cli/src/main.rs
@@ -15,7 +15,9 @@ use std::process::ExitCode;
 
 mod create;
 mod inspect;
+mod mutate;
 mod snapshot;
+mod values;
 
 use jet3::{
     ByteCount, CandidateError, DatabaseFormatError, DatabaseOpenError, DatabaseReader, FileSource,
@@ -81,6 +83,7 @@ enum Command {
     Snapshot(snapshot::SnapshotCommand),
     Inspect(inspect::InspectCommand),
     Create(create::CreateCommand),
+    Mutate(mutate::MutationCommand),
 }
 
 fn main() -> ExitCode {
@@ -94,10 +97,11 @@ fn main() -> ExitCode {
     match command {
         Command::Help => exit_after_write(
             write_stdout(&format!(
-                "{HELP}{}\n{}\n{}",
+                "{HELP}{}\n{}\n{}\n{}",
                 snapshot::HELP,
                 inspect::HELP,
-                create::HELP
+                create::HELP,
+                mutate::HELP
             )),
             0,
         ),
@@ -112,6 +116,10 @@ fn main() -> ExitCode {
         Command::Snapshot(command) => match snapshot::run(&command) {
             Ok(json) => exit_after_write(write_stdout(&json), 0),
             Err(message) => exit_after_write(write_stderr(&format!("jet3-cli: {message}\n")), 1),
+        },
+        Command::Mutate(command) => match mutate::run(&command) {
+            Ok(json) => exit_after_write(write_stdout(&json), 0),
+            Err(error) => exit_after_write(write_stderr(&(serde_json::json!({"ok":false,"error":"mutation_failed","message":error.message,"publication_stage":error.publication_stage}).to_string()+"\n")),1),
         },
         Command::Create(command) => match create::run(&command) {
             Ok(json) => exit_after_write(write_stdout(&json), 0),
@@ -146,6 +154,9 @@ fn parse_args(arguments: impl Iterator<Item = OsString>) -> Result<Command, &'st
     }
     if first == "snapshot" {
         return snapshot::parse_args(arguments).map(Command::Snapshot);
+    }
+    if first == "mutate" {
+        return mutate::parse_args(arguments).map(Command::Mutate);
     }
     if first == "create" {
         return create::parse_args(arguments).map(Command::Create);

--- a/crates/jet3-cli/src/mutate.rs
+++ b/crates/jet3-cli/src/mutate.rs
@@ -1,0 +1,197 @@
+//! JSON requests over public row mutation APIs; no storage or publication logic.
+use crate::values::{self, Cell};
+use jet3::{
+    CatalogObjectClass, ColumnOrdinal, DatabaseReader, ResourceBudget, RowLocator, RowValue,
+    UpdateError,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::{
+    ffi::{OsStr, OsString},
+    path::PathBuf,
+};
+
+pub(crate) const HELP: &str = "\
+  jet3-cli mutate <file.mdb> --input <request.json|->
+
+mutate applies one insert, update or delete JSON request through the public API.
+Targets use exact ASCII table names; update/delete require a current page/slot.
+Callers must exclude concurrent writers. See README.md for current library bounds.
+";
+#[derive(Debug)]
+pub(crate) struct MutationCommand {
+    path: PathBuf,
+    input: OsString,
+}
+pub(crate) fn parse_args(
+    mut args: impl Iterator<Item = OsString>,
+) -> Result<MutationCommand, &'static str> {
+    let path = args
+        .next()
+        .filter(|p| !p.to_string_lossy().starts_with('-'))
+        .ok_or("missing_file")?;
+    if args.next().as_deref() != Some(OsStr::new("--input")) {
+        return Err("mutation_input_required");
+    }
+    let input = args.next().ok_or("missing_option_value")?;
+    if args.next().is_some() {
+        return Err("unexpected_argument");
+    }
+    Ok(MutationCommand {
+        path: path.into(),
+        input,
+    })
+}
+#[derive(Deserialize)]
+#[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
+enum Request {
+    Insert {
+        table: String,
+        values: Vec<Option<Cell>>,
+    },
+    Update {
+        table: String,
+        row: Locator,
+        column: u16,
+        #[serde(deserialize_with = "required_value")]
+        value: Option<Cell>,
+    },
+    Delete {
+        table: String,
+        row: Locator,
+    },
+}
+fn required_value<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<Cell>, D::Error> {
+    Option::deserialize(deserializer)
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Locator {
+    page: u64,
+    slot: u8,
+}
+
+pub(crate) struct Failure {
+    pub message: String,
+    pub publication_stage: Option<String>,
+}
+impl From<String> for Failure {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            publication_stage: None,
+        }
+    }
+}
+impl From<UpdateError> for Failure {
+    fn from(error: UpdateError) -> Self {
+        let publication_stage = match &error {
+            UpdateError::Publish(error) => Some(format!("{:?}", error.stage())),
+            _ => None,
+        };
+        Self {
+            message: error.to_string(),
+            publication_stage,
+        }
+    }
+}
+
+fn resolve(
+    path: &std::path::Path,
+    table: &[u8],
+    target: &Locator,
+    budget: &mut ResourceBudget,
+    column: Option<u16>,
+) -> Result<(RowLocator, Option<ColumnOrdinal>), String> {
+    let mut database = DatabaseReader::open(path, budget).map_err(|e| e.to_string())?;
+    let root = {
+        let mut catalog = database.catalog(budget).map_err(|e| e.to_string())?;
+        let mut root = None;
+        while let Some(record) = catalog.next_record().map_err(|e| e.to_string())? {
+            if record.class() == CatalogObjectClass::User && record.name().raw_bytes() == table {
+                if root.is_some() {
+                    return Err("ambiguous table name".into());
+                }
+                root = record.table_definition();
+            }
+        }
+        root.ok_or("table not found")?
+    };
+    let definition = database
+        .table_definition(root, budget)
+        .map_err(|e| e.to_string())?;
+    let column = column
+        .map(|ordinal| {
+            definition
+                .columns()
+                .iter()
+                .find(|c| c.ordinal().get() == ordinal)
+                .map(|c| c.ordinal())
+                .ok_or_else(|| "column ordinal not found".to_owned())
+        })
+        .transpose()?;
+    let mut rows = database
+        .rows(&definition, budget)
+        .map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next_row().map_err(|e| e.to_string())? {
+        let locator = row.locator();
+        if locator.page().get() == target.page && locator.slot() == target.slot {
+            return Ok((locator, column));
+        }
+    }
+    Err("row locator not found in requested table".into())
+}
+
+pub(crate) fn run(command: &MutationCommand) -> Result<String, Failure> {
+    let request: Request = values::read_request(&command.input)?;
+    let mut budget = values::budget();
+    let (operation, locator) = match &request {
+        Request::Insert { table, values } => {
+            let values = values
+                .iter()
+                .map(|cell| cell.as_ref().map_or(Ok(RowValue::Null), Cell::value))
+                .collect::<Result<Vec<_>, _>>()?;
+            (
+                "insert",
+                jet3::insert_row(&command.path, values::ascii(table)?, &values, &mut budget)?,
+            )
+        }
+        Request::Update {
+            table,
+            row,
+            column,
+            value,
+        } => {
+            let table = values::ascii(table)?;
+            let (locator, column) = resolve(&command.path, table, row, &mut budget, Some(*column))?;
+            let value = value.as_ref().map_or(Ok(RowValue::Null), Cell::value)?;
+            jet3::update_field(
+                &command.path,
+                jet3::FieldUpdate {
+                    table,
+                    row: locator,
+                    column: column.ok_or_else(|| "column ordinal not found".to_owned())?,
+                    value,
+                },
+                &mut budget,
+            )?;
+            ("update", locator)
+        }
+        Request::Delete { table, row } => {
+            let table = values::ascii(table)?;
+            let (locator, _) = resolve(&command.path, table, row, &mut budget, None)?;
+            jet3::delete_row(
+                &command.path,
+                jet3::RowDelete {
+                    table,
+                    row: locator,
+                },
+                &mut budget,
+            )?;
+            ("delete", locator)
+        }
+    };
+    Ok(json!({"ok":true,"operation":operation,"file":command.path.to_string_lossy(),"row":{"page":locator.page().get(),"slot":locator.slot()}}).to_string()+"\n")
+}

--- a/crates/jet3-cli/src/values.rs
+++ b/crates/jet3-cli/src/values.rs
@@ -1,0 +1,83 @@
+//! Shared typed JSON cells for creation and mutation requests.
+use jet3::{ResourceBudget, ResourceLimits, RowValue};
+use serde::{Deserialize, de::DeserializeOwned};
+use std::{ffi::OsStr, fs::File};
+
+pub(crate) fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+pub(crate) fn read_request<T: DeserializeOwned>(input: &OsStr) -> Result<T, String> {
+    if input == "-" {
+        serde_json::from_reader(std::io::stdin().lock()).map_err(|e| e.to_string())
+    } else {
+        serde_json::from_reader(File::open(input).map_err(|e| format!("read request: {e}"))?)
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum Cell {
+    AutoIncrement,
+    Boolean(bool),
+    Byte(u8),
+    Integer(i16),
+    Long(i32),
+    Currency(i64),
+    Single(f32),
+    Double(f64),
+    DateTime(f64),
+    Text(Text),
+    Memo(Text),
+    Binary(Vec<u8>),
+    LongBinary(Vec<u8>),
+    Guid([u8; 16]),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(crate) enum Text {
+    Ascii(String),
+    Bytes(Vec<u8>),
+}
+
+impl Text {
+    fn bytes(&self) -> Result<&[u8], String> {
+        match self {
+            Self::Ascii(text) => ascii(text),
+            Self::Bytes(bytes) => Ok(bytes),
+        }
+    }
+}
+
+impl Cell {
+    pub(crate) fn value(&self) -> Result<RowValue<'_>, String> {
+        Ok(match self {
+            Self::AutoIncrement => RowValue::AutoIncrement,
+            Self::Boolean(v) => RowValue::Boolean(*v),
+            Self::Byte(v) => RowValue::Byte(*v),
+            Self::Integer(v) => RowValue::Integer(*v),
+            Self::Long(v) => RowValue::Long(*v),
+            Self::Currency(v) => RowValue::Currency { scaled: *v },
+            Self::Single(v) if !v.is_finite() => {
+                return Err("single value exceeds finite range".into());
+            }
+            Self::Single(v) => RowValue::Single(*v),
+            Self::Double(v) => RowValue::Double(*v),
+            Self::DateTime(v) => RowValue::DateTime { days: *v },
+            Self::Text(v) => RowValue::Text(v.bytes()?),
+            Self::Memo(v) => RowValue::Memo(v.bytes()?),
+            Self::Binary(v) => RowValue::Binary(v),
+            Self::LongBinary(v) => RowValue::LongBinary(v),
+            Self::Guid(v) => RowValue::Guid(*v),
+        })
+    }
+}
+
+pub(crate) fn ascii(text: &str) -> Result<&[u8], String> {
+    if text.is_ascii() {
+        Ok(text.as_bytes())
+    } else {
+        Err("names and text strings must be ASCII; use byte arrays for encoded text".into())
+    }
+}

--- a/crates/jet3-cli/tests/mutate.rs
+++ b/crates/jet3-cli/tests/mutate.rs
@@ -1,0 +1,178 @@
+#![cfg(unix)]
+use serde_json::{Value, json};
+use std::{
+    io::Write,
+    path::Path,
+    process::{Command, Output, Stdio},
+};
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+fn request(command: &str, path: &Path, input: &Value) -> Result<Output> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_jet3-cli"))
+        .arg(command)
+        .arg(path)
+        .args(["--input", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or("stdin")?
+        .write_all(input.to_string().as_bytes())?;
+    Ok(child.wait_with_output()?)
+}
+fn create(path: &Path) -> Result {
+    let output = request(
+        "create",
+        path,
+        &json!({"tables":[{"name":"Rows","columns":[{"name":"Id","type":"long"}],"rows":[[{"long":1}],[{"long":2}],[{"long":3}]]}]}),
+    )?;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+fn rows(path: &Path) -> Result<Vec<(jet3::RowLocator, i32, usize)>> {
+    let mut budget = jet3::ResourceBudget::new(jet3::ResourceLimits::default());
+    let mut db = jet3::DatabaseReader::open(path, &mut budget)?;
+    let root = {
+        let mut catalog = db.catalog(&mut budget)?;
+        let mut root = None;
+        while let Some(record) = catalog.next_record()? {
+            if record.name().raw_bytes() == b"Rows" {
+                root = record.table_definition();
+            }
+        }
+        root.ok_or("table")?
+    };
+    let definition = db.table_definition(root, &mut budget)?;
+    let ordinal = definition.columns().first().ok_or("column")?.ordinal();
+    let mut cursor = db.rows(&definition, &mut budget)?;
+    let mut rows = Vec::new();
+    while let Some(row) = cursor.next_row()? {
+        let bytes: [u8; 4] = row
+            .field(ordinal)
+            .and_then(|f| f.raw_bytes())
+            .ok_or("field")?
+            .try_into()?;
+        rows.push((
+            row.locator(),
+            i32::from_le_bytes(bytes),
+            row.raw_bytes().len(),
+        ));
+    }
+    Ok(rows)
+}
+fn locator(row: jet3::RowLocator) -> Value {
+    json!({"page":row.page().get(),"slot":row.slot()})
+}
+
+#[test]
+fn public_create_update_and_typed_errors_preserve_source() -> Result {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("file.mdb");
+    create(&path)?;
+    let row = rows(&path)?[1].0;
+    let output = request(
+        "mutate",
+        &path,
+        &json!({"operation":"update","table":"Rows","row":locator(row),"column":0,"value":{"long":-42}}),
+    )?;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout)?["row"],
+        locator(row)
+    );
+    assert_eq!(rows(&path)?[1].1, -42);
+    let before = std::fs::read(&path)?;
+    for input in [
+        json!({"operation":"update","table":"Rows","row":locator(row),"column":0,"value":null}),
+        json!({"operation":"update","table":"Rows","row":locator(row),"column":0}),
+        json!({"operation":"update","table":"Rows","row":{"page":999,"slot":1},"column":0,"value":{"long":7}}),
+        json!({"operation":"update","table":"Rows","row":locator(row),"column":0,"value":{"long":2147483648_i64}}),
+        json!({"operation":"insert","table":"Rows","values":[{"text":"é"}]}),
+        json!({"operation":"delete","table":"Other","row":locator(row)}),
+        json!({"operation":"delete","table":"Rows","row":{"page":23,"slot":256}}),
+        json!({"operation":"delete","table":"Rows","row":locator(row),"overwrite":true}),
+    ] {
+        let output = request("mutate", &path, &input)?;
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            serde_json::from_slice::<Value>(&output.stderr)?["error"],
+            "mutation_failed"
+        );
+        assert_eq!(std::fs::read(&path)?, before);
+    }
+    Ok(())
+}
+
+#[test]
+fn synthetic_consistent_page_fixture_exercises_public_insert_delete_dispatch() -> Result {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("file.mdb");
+    create(&path)?;
+    let initial = rows(&path)?;
+    let page = initial[0].0.page();
+    assert!(initial.iter().all(|r| r.0.page() == page));
+    // Synthetic unit-test fixture: source the free-byte field from EXP-0162.
+    // This checks CLI dispatch and makes no DAO compatibility assertion.
+    let free =
+        jet3::PAGE_BYTES - 10 - 2 * initial.len() - initial.iter().map(|r| r.2).sum::<usize>();
+    let mut bytes = std::fs::read(&path)?;
+    let offset = page.get() as usize * jet3::PAGE_BYTES + 2;
+    bytes[offset..offset + 2].copy_from_slice(&u16::try_from(free)?.to_le_bytes());
+    std::fs::write(&path, &bytes)?;
+    let output = request(
+        "mutate",
+        &path,
+        &json!({"operation":"insert","table":"Rows","values":[{"long":4}]}),
+    )?;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let after = rows(&path)?;
+    assert_eq!(
+        after.iter().map(|r| r.1).collect::<Vec<_>>(),
+        vec![1, 2, 3, 4]
+    );
+    let new = after[3].0;
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout)?["row"],
+        locator(new)
+    );
+    let output = request(
+        "mutate",
+        &path,
+        &json!({"operation":"delete","table":"Rows","row":locator(new)}),
+    )?;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        rows(&path)?.iter().map(|r| r.1).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        request(
+            "mutate",
+            &path,
+            &json!({"operation":"delete","table":"Rows","row":locator(new)})
+        )?
+        .status
+        .code(),
+        Some(1)
+    );
+    Ok(())
+}


### PR DESCRIPTION
Expose insert, update and delete JSON requests through the public library APIs. Share creation value conversion, resolve row locators through the reader, and return script-friendly results and publication-stage errors. Current library limits remain explicit in CLI documentation.

Validation: separate implementation and independent review; eight create/inspect/mutation integration tests, CLI Clippy and just ready passed.

Closes #104.
