### PR TITLE
feat: update non-key fields while preserving existing indexes

### DIFF
--- a/crates/jet3/src/update.rs
+++ b/crates/jet3/src/update.rs
@@ -103,7 +103,10 @@ conversion!(crate::RowDirectoryError, Directory);
 conversion!(crate::RowWriteError, Encoding);
 conversion!(crate::PublishError, Publish);
 
-/// Replaces one present fixed field in an unindexed, relationship-free user table.
+/// Replaces one present fixed non-key field in a relationship-free user table.
+///
+/// Indexed tables are supported when the column is absent from every physical
+/// index. All index bytes remain unchanged; index-key maintenance is unsupported.
 ///
 /// Supports Byte, Integer, Long, Currency, Single, Double, DateTime, GUID and
 /// exact-width fixed Text. Null transitions, Boolean presence bits, AutoIncrement,
@@ -140,7 +143,7 @@ where
         return Err(UpdateError::Unsupported("null replacement"));
     }
     let mut database = DatabaseReader::open(path, budget)?;
-    let definition = writable_table(&mut database, request.table, budget)?;
+    let definition = guarded_table(&mut database, request.table, Some(request.column), budget)?;
     let column = definition
         .columns()
         .get(usize::from(request.column.get()))
@@ -227,6 +230,15 @@ pub(crate) fn writable_table(
     table: &[u8],
     budget: &mut ResourceBudget,
 ) -> Result<crate::TableDefinition, UpdateError> {
+    guarded_table(database, table, None, budget)
+}
+
+fn guarded_table(
+    database: &mut DatabaseReader<FileSource>,
+    table: &[u8],
+    field: Option<ColumnOrdinal>,
+    budget: &mut ResourceBudget,
+) -> Result<crate::TableDefinition, UpdateError> {
     let mut root = None;
     let mut relationship_root = None;
     {
@@ -250,10 +262,27 @@ pub(crate) fn writable_table(
     }
     let definition =
         database.table_definition(root.ok_or(UpdateError::NotFound("table"))?, budget)?;
-    if definition.kind() != TableDefinitionKind::User
-        || !definition.indexes().is_empty()
-        || !definition.physical_indexes().is_empty()
-    {
+    if definition.kind() != TableDefinitionKind::User {
+        return Err(UpdateError::Unsupported("non-user table"));
+    }
+    if let Some(column) = field {
+        // EXP-0059/0062: the typed decoder validates every logical selector,
+        // physical key field and complete logical-to-physical coverage.
+        for index in definition.indexes() {
+            budget.charge_items(1)?;
+            if matches!(index.kind(), crate::IndexDefinitionKind::Relationship(_)) {
+                return Err(UpdateError::Unsupported("relationship index"));
+            }
+        }
+        for index in definition.physical_indexes() {
+            for key in index.fields() {
+                budget.charge_items(1)?;
+                if key.column() == column {
+                    return Err(UpdateError::Unsupported("indexed key column"));
+                }
+            }
+        }
+    } else if !definition.indexes().is_empty() || !definition.physical_indexes().is_empty() {
         return Err(UpdateError::Unsupported(
             "table has indexes or relationships",
         ));

--- a/crates/jet3/src/update_indexed_tests.rs
+++ b/crates/jet3/src/update_indexed_tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+pub(super) fn indexed() -> Result<Fixture, Box<dyn StdError>> {
+    let fixture = simple()?;
+    fs::remove_file(fixture.path())?;
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Group", ColumnType::Long),
+        ColumnSpec::new(b"Value", ColumnType::Long),
+    ];
+    let composite = [
+        crate::IndexColumnSpec::descending(1),
+        crate::IndexColumnSpec::ascending(0),
+    ];
+    let indexes = [crate::IndexSpec {
+        name: b"ByGroup",
+        kind: crate::IndexKind::Ordinary,
+        fields: &composite,
+    }];
+    create_database_with_rows(
+        fixture.path(),
+        &TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &indexes,
+        },
+        &[
+            &[RowValue::Long(1), RowValue::Long(3), RowValue::Long(77)],
+            &[RowValue::Long(2), RowValue::Long(3), RowValue::Long(88)],
+        ],
+        &mut budget(),
+    )?;
+    Ok(fixture)
+}
+
+#[test]
+fn nonkey_update_preserves_every_index_and_unrelated_byte() -> TestResult {
+    let fixture = indexed()?;
+    let row = fixture.locator(1)?;
+    let mut original = fs::read(fixture.path())?;
+    original.extend_from_slice(&[0xab; PAGE_BYTES]);
+    fs::write(fixture.path(), &original)?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    let definition = guarded_table(&mut db, b"Items", Some(ColumnOrdinal::new(2)), &mut b)?;
+    assert_eq!(definition.physical_indexes().len(), 1);
+    let relative = {
+        let mut cursor = db.rows(&definition, &mut b)?;
+        let mut found = None;
+        while let Some(view) = cursor.next_row()? {
+            if view.locator() == row {
+                found = view.present_fixed_field_range(ColumnOrdinal::new(2));
+            }
+        }
+        found.ok_or("missing fixed field")?
+    };
+    let mut page = [0; PAGE_BYTES];
+    db.read_raw_page(row.page(), &mut page, &mut b)?;
+    let directory = RowDirectory::validate(row.page(), definition.root(), &page, &mut b)?;
+    let offset = row.page().get() as usize * PAGE_BYTES
+        + directory.entry(&page, row.slot())?.range().start
+        + relative.start;
+    drop(db);
+    update_field(
+        fixture.path(),
+        FieldUpdate {
+            column: ColumnOrdinal::new(2),
+            ..request(row, RowValue::Long(i32::MIN))
+        },
+        &mut budget(),
+    )?;
+    let mut expected = original;
+    expected[offset..offset + 4].copy_from_slice(&i32::MIN.to_le_bytes());
+    assert_eq!(fs::read(fixture.path())?, expected);
+    // Insert/delete retain their unindexed-table guard.
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    assert!(matches!(
+        writable_table(&mut db, b"Items", &mut b),
+        Err(UpdateError::Unsupported(_))
+    ));
+    for column in [0, 1] {
+        assert!(matches!(
+            update_field(
+                fixture.path(),
+                FieldUpdate {
+                    column: ColumnOrdinal::new(column),
+                    ..request(row, RowValue::Long(9))
+                },
+                &mut budget()
+            ),
+            Err(UpdateError::Unsupported("indexed key column"))
+        ));
+        assert_eq!(fs::read(fixture.path())?, expected);
+    }
+    fixture.assert_only_original()
+}
+
+#[test]
+fn inconsistent_or_out_of_range_index_mapping_refuses_publication() -> TestResult {
+    let fixture = indexed()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    let definition = guarded_table(&mut db, b"Items", Some(ColumnOrdinal::new(2)), &mut b)?;
+    let record = definition.indexes()[0].raw_record();
+    let root_offset = definition.root().get() as usize * PAGE_BYTES;
+    let matches: Vec<_> = original[root_offset..root_offset + PAGE_BYTES]
+        .windows(record.len())
+        .enumerate()
+        .filter(|(_, bytes)| *bytes == record.as_slice())
+        .map(|(offset, _)| offset)
+        .collect();
+    assert_eq!(matches.len(), 1);
+    let offset = root_offset + matches[0];
+    drop(db);
+    // EXP-0059 logical selectors: mismatched selectors and out-of-range references.
+    for (first, second) in [(1_u32, 0_u32), (1, 1)] {
+        let mut damaged = original.clone();
+        damaged[offset..offset + 4].copy_from_slice(&first.to_le_bytes());
+        damaged[offset + 4..offset + 8].copy_from_slice(&second.to_le_bytes());
+        fs::write(fixture.path(), &damaged)?;
+        assert!(matches!(
+            update_field(
+                fixture.path(),
+                FieldUpdate {
+                    column: ColumnOrdinal::new(2),
+                    ..request(row, RowValue::Long(4))
+                },
+                &mut budget()
+            ),
+            Err(UpdateError::Definition(_))
+        ));
+        assert_eq!(fs::read(fixture.path())?, damaged);
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}

--- a/crates/jet3/src/update_tests.rs
+++ b/crates/jet3/src/update_tests.rs
@@ -420,8 +420,12 @@ fn a_valid_locator_from_another_table_is_rejected() -> TestResult {
 }
 
 #[test]
-fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
-    let fixture = simple()?;
+fn relationship_catalog_rows_are_checked_with_and_without_user_indexes() -> TestResult {
+    relationship_catalog_cases(simple()?, ColumnOrdinal::new(0))?;
+    relationship_catalog_cases(indexed::indexed()?, ColumnOrdinal::new(2))
+}
+
+fn relationship_catalog_cases(fixture: Fixture, column: ColumnOrdinal) -> TestResult {
     let row = fixture.locator(0)?;
     let original = fs::read(fixture.path())?;
     let mut b = budget();
@@ -492,7 +496,10 @@ fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
         fs::write(fixture.path(), &input)?;
         let result = update_field(
             fixture.path(),
-            request(row, RowValue::Long(3)),
+            FieldUpdate {
+                column,
+                ..request(row, RowValue::Long(3))
+            },
             &mut budget(),
         );
         if refused {
@@ -508,3 +515,6 @@ fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
 
 #[path = "update_fixed_tests.rs"]
 mod fixed;
+
+#[path = "update_indexed_tests.rs"]
+mod indexed;


### PR DESCRIPTION
Allow fixed-field updates in indexed tables when the requested column belongs to no physical index and the table has no relationships. Keep all index bytes unchanged through the existing exact-field publication path; insertion, deletion and key-field restrictions remain enforced.

Validation: independent parser review, 16 focused update tests including composite keys, malformed metadata and complete byte preservation; Clippy and just ready passed. DAO candidate validation is separate.

Refs #112.
