### PR TITLE
test: extend hosted differential to row insertion and deletion

### DIFF
--- a/.github/workflows/windows-dao-row-update.yml
+++ b/.github/workflows/windows-dao-row-update.yml
@@ -1,0 +1,107 @@
+name: Windows DAO row mutation differential
+on:
+  workflow_dispatch:
+    inputs:
+      run_acquisition:
+        description: Run the reviewed single update acquisition
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the committed EXP-0173 row update plan
+        type: string
+        required: false
+permissions:
+  contents: read
+concurrency:
+  group: windows-dao-row-update-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  generate:
+    if: inputs.run_acquisition
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          python3 oracle/windows-dao/scripts/dao_row_update_diff.py plan "$PLAN_SHA256"
+      - name: Build public fixture and snapshot producers
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-row-update-fixture
+      - name: Create requested fixtures on supported publication platform
+        run: python3 oracle/windows-dao/scripts/dao_row_update_diff.py prepare artifacts/dao-row-update-v1_2 target/release/jet3-row-update-fixture target/release/jet3-cli "$GITHUB_SHA"
+      - name: Retain exact generated files and preparation diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-row-update-${{ github.sha }}
+          path: artifacts/dao-row-update-v1_2
+          if-no-files-found: warn
+          retention-days: 14
+  update-differential:
+    needs: generate
+    if: always() && (needs.generate.result == 'success' || !inputs.run_acquisition)
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          if ($env:GITHUB_RUN_ATTEMPT -ne '1') { throw 'No automatic acquisition retry' }
+          python oracle/windows-dao/scripts/dao_row_update_diff.py plan $env:PLAN_SHA256
+          if ($LASTEXITCODE -ne 0) { throw 'Reviewed update plan verification failed' }
+      - name: Probe stock x86 provider
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/probe-provider.ps1 -ProtocolVersion 1.2.0 -OutputPath artifacts/environment.json
+          if ($LASTEXITCODE -ne 0) { throw 'Stock provider unavailable; retained probe explains missing prerequisite' }
+      - name: Download the exact Unix-generated candidates
+        if: inputs.run_acquisition
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: generated-row-update-${{ github.sha }}
+          path: artifacts/dao-row-update-v1_2
+      - name: Build the read-only Rust snapshot producer
+        if: inputs.run_acquisition
+        shell: powershell
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-row-update-fixture
+      - name: Verify downloads and snapshot them on Windows
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_row_update_diff.py snapshot artifacts/dao-row-update-v1_2 target/release/jet3-row-update-fixture.exe target/release/jet3-cli.exe $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'Downloaded fixture snapshot failed' }
+      - name: Observe Rust files read-only with DAO
+        id: dao
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/Invoke-DaoUpdateV12.ps1 -InventoryPath oracle/windows-dao/protocol/v1_2/row-update-scenarios.json -EnvironmentPath artifacts/environment.json -OutputRoot artifacts/dao-row-update-v1_2 -SourceRevision $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'DAO update observation failed' }
+      - name: Compare protocol snapshots and recipe semantics
+        if: always() && inputs.run_acquisition && steps.dao.outcome != 'skipped'
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_row_update_diff.py evaluate artifacts/dao-row-update-v1_2
+          if ($LASTEXITCODE -ne 0) { throw 'Update differential failed' }
+      - name: Retain diagnostics including failed files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-row-update-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/crates/jet3-cli/src/snapshot.rs
+++ b/crates/jet3-cli/src/snapshot.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 
 use jet3::TextCodePage;
 use jet3_testkit::{
-    PROTOCOL_SCENARIOS, Producer, SnapshotOptions, SnapshotOutcome, UPDATE_SCENARIOS,
-    WRITE_SCENARIOS, canonical_json, coverage, parse_scenarios, snapshot_bytes,
+    PROTOCOL_SCENARIOS, Producer, ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome,
+    UPDATE_SCENARIOS, WRITE_SCENARIOS, canonical_json, coverage, parse_scenarios, snapshot_bytes,
 };
 
 pub(crate) const HELP: &str = "\
   jet3-cli snapshot <file> --out <dir> --scenario <DAO-READ-...|DAO-WRITE-...|DAO-UPDATE-...> \
-    [--source-revision <text>] [--code-page 1252|1251]
+    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update]
 
 snapshot reads the whole database with the jet3 reader and writes
 <dir>/snapshot.json (protocol 1.2 canonical semantic snapshot; omitted when
@@ -27,6 +27,7 @@ pub(crate) struct SnapshotCommand {
     scenario_id: String,
     source_revision: String,
     code_page: TextCodePage,
+    row_update_inventory: bool,
 }
 
 pub(crate) fn parse_args(
@@ -40,6 +41,7 @@ pub(crate) fn parse_args(
     let mut scenario_id = None;
     let mut source_revision = None;
     let mut code_page = TextCodePage::Windows1252;
+    let mut row_update_inventory = false;
     while let Some(option) = arguments.next() {
         let value = arguments.next().ok_or("missing_option_value")?;
         if option == "--out" {
@@ -51,6 +53,11 @@ pub(crate) fn parse_args(
             scenario_id = Some(text.to_owned());
         } else if option == "--source-revision" {
             source_revision = Some(text.to_owned());
+        } else if option == "--inventory" {
+            if text != "row-update" {
+                return Err("invalid_inventory");
+            }
+            row_update_inventory = true;
         } else if option == "--code-page" {
             code_page = match text {
                 "1252" => TextCodePage::Windows1252,
@@ -68,12 +75,15 @@ pub(crate) fn parse_args(
         source_revision: source_revision
             .unwrap_or_else(|| format!("jet3-cli {}", env!("CARGO_PKG_VERSION"))),
         code_page,
+        row_update_inventory,
     })
 }
 
 /// Writes the artifact pair and returns a one-line JSON summary.
 pub(crate) fn run(command: &SnapshotCommand) -> Result<String, String> {
-    let scenarios = parse_scenarios(if command.scenario_id.starts_with("DAO-WRITE-") {
+    let scenarios = parse_scenarios(if command.row_update_inventory {
+        ROW_UPDATE_SCENARIOS
+    } else if command.scenario_id.starts_with("DAO-WRITE-") {
         WRITE_SCENARIOS
     } else if command.scenario_id.starts_with("DAO-UPDATE-") {
         UPDATE_SCENARIOS

--- a/crates/jet3-testkit/src/bin/jet3-row-update-fixture.rs
+++ b/crates/jet3-testkit/src/bin/jet3-row-update-fixture.rs
@@ -1,0 +1,8 @@
+//! Public row mutation fixture producer; no DAO dependency.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let [command, id, directory] = args.as_slice() else {
+        return Err("usage: jet3-row-update-fixture generate|verify SCENARIO DIRECTORY".into());
+    };
+    jet3_testkit::row_update_fixture(command, id, std::path::Path::new(directory))
+}

--- a/crates/jet3-testkit/src/lib.rs
+++ b/crates/jet3-testkit/src/lib.rs
@@ -35,3 +35,6 @@ pub use write_fixture::{WRITE_SCENARIOS, write_fixture};
 
 mod update_fixture;
 pub use update_fixture::{UPDATE_SCENARIOS, update_fixture};
+
+mod row_update_fixture;
+pub use row_update_fixture::{ROW_UPDATE_SCENARIOS, row_update_fixture};

--- a/crates/jet3-testkit/src/row_update_fixture.rs
+++ b/crates/jet3-testkit/src/row_update_fixture.rs
@@ -1,0 +1,375 @@
+//! Finite hosted public row mutations; byte checks follow EXP-0162/0168/0170.
+use jet3::{
+    CatalogObjectClass, ColumnSpec, ColumnType, DatabaseReader, ResourceBudget, ResourceLimits,
+    RowDelete, RowLocator, RowValue, TableRows, TableSpec, create_database_with_table_rows,
+    delete_row, insert_row,
+};
+use serde_json::{Value, json};
+use std::{fs, num::NonZeroU8, ops::Range, path::Path};
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub const ROW_UPDATE_SCENARIOS: &str =
+    include_str!("../../../oracle/windows-dao/protocol/v1_2/row-update-scenarios.json");
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn scenario(id: &str) -> Result<Value> {
+    let inventory: Value = serde_json::from_str(ROW_UPDATE_SCENARIOS)?;
+    inventory["scenarios"]
+        .as_array()
+        .ok_or("scenarios")?
+        .iter()
+        .find(|s| s["id"] == id)
+        .cloned()
+        .ok_or_else(|| "unknown scenario".into())
+}
+fn generate(path: &Path) -> Result<()> {
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Value", ColumnType::Long),
+        ColumnSpec::new(
+            b"Payload",
+            ColumnType::Text {
+                max_len: NonZeroU8::MAX,
+            },
+        ),
+    ];
+    let items = [
+        &[
+            RowValue::Long(1),
+            RowValue::Long(101),
+            RowValue::Text(b"aaa"),
+        ][..],
+        &[
+            RowValue::Long(2),
+            RowValue::Long(-202),
+            RowValue::Text(b"bbb"),
+        ][..],
+        &[
+            RowValue::Long(3),
+            RowValue::Long(303),
+            RowValue::Text(b"ccc"),
+        ][..],
+    ];
+    let later = [
+        &[
+            RowValue::Long(11),
+            RowValue::Long(-1101),
+            RowValue::Text(b"ddd"),
+        ][..],
+        &[
+            RowValue::Long(12),
+            RowValue::Long(1202),
+            RowValue::Text(b"eee"),
+        ][..],
+        &[
+            RowValue::Long(13),
+            RowValue::Long(-1303),
+            RowValue::Text(b"fff"),
+        ][..],
+    ];
+    create_database_with_table_rows(
+        path,
+        &[
+            TableRows {
+                table: TableSpec {
+                    name: b"Items",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                rows: &items,
+            },
+            TableRows {
+                table: TableSpec {
+                    name: b"Later",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                rows: &later,
+            },
+        ],
+        &mut budget(),
+    )?;
+    Ok(())
+}
+struct Located {
+    root: u64,
+    row: RowLocator,
+    range: Range<usize>,
+    count: usize,
+}
+fn locate(path: &Path, table: &str, id: i32) -> Result<Located> {
+    let bytes = fs::read(path)?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(path, &mut b)?;
+    let root = {
+        let mut catalog = db.catalog(&mut b)?;
+        let mut roots = Vec::new();
+        while let Some(r) = catalog.next_record()? {
+            if r.class() == CatalogObjectClass::User && r.name().raw_bytes() == table.as_bytes() {
+                roots.push(r.table_definition().ok_or("table root")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("ambiguous table".into());
+        }
+        roots[0]
+    };
+    let def = db.table_definition(root, &mut b)?;
+    let ordinal = def
+        .columns()
+        .iter()
+        .find(|c| {
+            c.name().raw_bytes() == b"Id" && c.physical_type() == jet3::ColumnPhysicalType::Long
+        })
+        .ok_or("ordinary Id absent")?
+        .ordinal();
+    let mut rows = db.rows(&def, &mut b)?;
+    let mut found = None;
+    let mut count = 0;
+    while let Some(row) = rows.next_row()? {
+        count += 1;
+        if row.field(ordinal).and_then(|f| f.raw_bytes()) != Some(id.to_le_bytes().as_slice()) {
+            continue;
+        }
+        if found.is_some() || row.locator() != row.storage_locator() {
+            return Err("ambiguous or overflow row".into());
+        }
+        let base = usize::try_from(row.locator().page().get())? * jet3::PAGE_BYTES;
+        let page = bytes
+            .get(base..base + jet3::PAGE_BYTES)
+            .ok_or("page absent")?;
+        let raw = row.raw_bytes();
+        let positions = page
+            .windows(raw.len())
+            .enumerate()
+            .filter_map(|(n, v)| (v == raw).then_some(n))
+            .collect::<Vec<_>>();
+        let [start] = positions.as_slice() else {
+            return Err("raw row match not unique".into());
+        };
+        found = Some((row.locator(), base + start..base + start + raw.len()));
+    }
+    let (row, range) = found.ok_or("target row absent")?;
+    Ok(Located {
+        root: root.get(),
+        row,
+        range,
+        count,
+    })
+}
+fn patch(expected: &mut [u8], changes: &mut Vec<Value>, offset: usize, value: &[u8]) -> Result<()> {
+    let target = expected
+        .get_mut(offset..offset + value.len())
+        .ok_or("patch range")?;
+    changes.push(json!({"offset":offset,"before":target,"after":value}));
+    target.copy_from_slice(value);
+    Ok(())
+}
+fn verify(id: &str, request: &Value, directory: &Path) -> Result<Value> {
+    let before_path = directory.join("before/database.mdb");
+    let after_path = directory.join("after/database.mdb");
+    let before = fs::read(&before_path)?;
+    let after = fs::read(&after_path)?;
+    let insert = request["kind"] == "insert";
+    let selected = if insert { 88 } else { 3 };
+    let located = locate(
+        if insert { &after_path } else { &before_path },
+        "Items",
+        selected,
+    )?;
+    let page = usize::try_from(located.row.page().get())?;
+    let base = page * jet3::PAGE_BYTES;
+    let root = usize::try_from(located.root)? * jet3::PAGE_BYTES;
+    let slot = usize::from(located.row.slot());
+    let count = u16::from_le_bytes(
+        before
+            .get(base + 8..base + 10)
+            .ok_or("slot count")?
+            .try_into()?,
+    );
+    let free = u16::from_le_bytes(
+        before
+            .get(base + 2..base + 4)
+            .ok_or("free bytes")?
+            .try_into()?,
+    );
+    let stored = u32::from_le_bytes(
+        before
+            .get(root + 12..root + 16)
+            .ok_or("table count")?
+            .try_into()?,
+    );
+    let mut expected = before.clone();
+    let mut changes = Vec::new();
+    if insert {
+        // Independently specified finite EXP-0060 Long/Long/Text row.
+        let mut row = vec![3];
+        row.extend_from_slice(&88_i32.to_le_bytes());
+        row.extend_from_slice(&(-8800_i32).to_le_bytes());
+        row.extend_from_slice(b"inserted");
+        row.extend_from_slice(&[17, 9, 1, 7]);
+        if slot != usize::from(count)
+            || located.range.len() != row.len()
+            || located.count != stored as usize + 1
+            || count < 1
+        {
+            return Err("insert locator/count".into());
+        }
+        let packed = usize::from(
+            u16::from_le_bytes(
+                before
+                    .get(base + 8 + 2 * usize::from(count)..base + 10 + 2 * usize::from(count))
+                    .ok_or("last slot")?
+                    .try_into()?,
+            ) & 0x1fff,
+        );
+        if located.range.end != base + packed
+            || usize::from(free) != packed - 10 - 2 * usize::from(count)
+        {
+            return Err("insert contiguous space".into());
+        }
+        patch(&mut expected, &mut changes, located.range.start, &row)?;
+        patch(
+            &mut expected,
+            &mut changes,
+            base + 10 + 2 * slot,
+            &u16::try_from(located.range.start - base)?.to_le_bytes(),
+        )?;
+        patch(
+            &mut expected,
+            &mut changes,
+            base + 8,
+            &(count + 1).to_le_bytes(),
+        )?;
+        patch(
+            &mut expected,
+            &mut changes,
+            base + 2,
+            &free
+                .checked_sub(u16::try_from(row.len() + 2)?)
+                .ok_or("free bytes")?
+                .to_le_bytes(),
+        )?;
+        patch(
+            &mut expected,
+            &mut changes,
+            root + 12,
+            &(stored + 1).to_le_bytes(),
+        )?;
+    } else {
+        if slot + 1 != usize::from(count) || count < 2 || located.count != stored as usize {
+            return Err("delete tail/count".into());
+        }
+        if usize::from(free) != located.range.start - base - 10 - 2 * usize::from(count) {
+            return Err("delete contiguous space".into());
+        }
+        patch(
+            &mut expected,
+            &mut changes,
+            base + 10 + 2 * slot,
+            &(0xc000 | u16::try_from(located.range.end - base)?).to_le_bytes(),
+        )?;
+        patch(
+            &mut expected,
+            &mut changes,
+            base + 2,
+            &free
+                .checked_add(u16::try_from(located.range.len())?)
+                .ok_or("free bytes")?
+                .to_le_bytes(),
+        )?;
+        patch(
+            &mut expected,
+            &mut changes,
+            root + 12,
+            &(stored - 1).to_le_bytes(),
+        )?;
+    }
+    if expected != after {
+        return Err("row mutation changed unplanned bytes".into());
+    }
+    Ok(
+        json!({"scenario_id":id,"request":request,"root":located.root,"page":page,"slot":slot,"row_offset":located.range.start,"row_length":located.range.len(),"patches":changes,"before_sha256":crate::sha256_hex(&before),"after_sha256":crate::sha256_hex(&after),"preserved":true}),
+    )
+}
+/// Generates through public APIs or independently verifies retained images.
+pub fn row_update_fixture(command: &str, id: &str, directory: &Path) -> Result<()> {
+    let case = scenario(id)?;
+    let request = &case["request"];
+    if request.get("kind").is_none() {
+        return crate::update_fixture(command, id, directory);
+    }
+    if command == "generate" {
+        fs::create_dir(directory.join("before"))?;
+        fs::create_dir(directory.join("after"))?;
+        let before = directory.join("before/database.mdb");
+        let after = directory.join("after/database.mdb");
+        generate(&before)?;
+        fs::copy(&before, &after)?;
+        if request["kind"] == "insert" {
+            insert_row(
+                &after,
+                b"Items",
+                &[
+                    RowValue::Long(88),
+                    RowValue::Long(-8800),
+                    RowValue::Text(b"inserted"),
+                ],
+                &mut budget(),
+            )?;
+        } else {
+            let row = locate(&before, "Items", 3)?.row;
+            delete_row(
+                &after,
+                RowDelete {
+                    table: b"Items",
+                    row,
+                },
+                &mut budget(),
+            )?;
+        }
+    } else if command != "verify" {
+        return Err("expected generate or verify".into());
+    }
+    println!("{}", verify(id, request, directory)?);
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    #[test]
+    fn public_row_mutations_and_independent_byte_checks() -> Result<()> {
+        for id in ["DAO-UPDATE-INSERT-ROW", "DAO-UPDATE-DELETE-TAIL"] {
+            let directory = tempfile::tempdir()?;
+            row_update_fixture("generate", id, directory.path())?;
+            let case = scenario(id)?;
+            let receipt = verify(id, &case["request"], directory.path())?;
+            assert_eq!(receipt["slot"], if id.ends_with("TAIL") { 2 } else { 3 });
+            let path = directory.path().join("after/database.mdb");
+            let original = fs::read(&path)?;
+            for offset in [1538, original.len() - 1] {
+                let mut bad = original.clone();
+                bad[offset] ^= 1;
+                fs::write(&path, bad)?;
+                assert!(verify(id, &case["request"], directory.path()).is_err());
+            }
+            fs::write(&path, original)?;
+        }
+        Ok(())
+    }
+    #[test]
+    fn unique_reader_row_binding_is_required() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("before.mdb");
+        generate(&path)?;
+        let located = locate(&path, "Items", 3)?;
+        let mut bytes = fs::read(&path)?;
+        let raw = bytes[located.range.clone()].to_vec();
+        let start = located.row.page().get() as usize * jet3::PAGE_BYTES + 128;
+        bytes[start..start + raw.len()].copy_from_slice(&raw);
+        fs::write(&path, bytes)?;
+        assert!(locate(&path, "Items", 3).is_err());
+        Ok(())
+    }
+}

--- a/oracle/windows-dao/protocol/v1_2/row-update-scenarios.json
+++ b/oracle/windows-dao/protocol/v1_2/row-update-scenarios.json
@@ -1,0 +1,573 @@
+{
+  "document_type": "dao_update_scenario_inventory",
+  "protocol_version": "1.2.0",
+  "scenarios": [
+    {
+      "id": "DAO-UPDATE-FIRST-FIELD",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [0, 1000, "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "00!!"],
+            [1, 1001, "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "01!!"],
+            [2, 1002, "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "02!!"],
+            [3, 1003, "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "03!!"],
+            [4, 1004, "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "04!!"],
+            [5, 1005, "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "05!!"],
+            [6, 1006, "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "06!!"],
+            [7, 1007, "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "07!!"],
+            [8, 1008, "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "08!!"],
+            [9, 1009, "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "09!!"],
+            [10, 1010, "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "10!!"],
+            [11, 1011, "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "11!!"],
+            [12, 1012, "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "12!!"],
+            [13, 1013, "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "13!!"],
+            [14, 1014, "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "14!!"],
+            [15, 1015, "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "15!!"],
+            [16, 1016, "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "16!!"],
+            [17, 1017, "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "17!!"],
+            [18, 1018, "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "18!!"],
+            [19, 1019, "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "19!!"],
+            [20, 1020, "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "20!!"],
+            [21, 1021, "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "21!!"],
+            [22, 1022, "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "22!!"],
+            [23, 1023, "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "23!!"],
+            [24, 1024, "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "24!!"],
+            [25, 1025, "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "25!!"],
+            [26, 1026, "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "26!!"],
+            [27, 1027, "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "27!!"],
+            [28, 1028, "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "28!!"],
+            [29, 1029, "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "29!!"],
+            [30, 1030, "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "30!!"],
+            [31, 1031, "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "31!!"],
+            [32, 1032, "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "32!!"]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Id",
+        "row_index": 0,
+        "before": 0,
+        "after": -42
+      }
+    },
+    {
+      "id": "DAO-UPDATE-LATER-ROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [0, 1000, "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "00!!"],
+            [1, 1001, "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "01!!"],
+            [2, 1002, "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "02!!"],
+            [3, 1003, "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "03!!"],
+            [4, 1004, "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "04!!"],
+            [5, 1005, "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "05!!"],
+            [6, 1006, "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "06!!"],
+            [7, 1007, "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "07!!"],
+            [8, 1008, "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "08!!"],
+            [9, 1009, "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "09!!"],
+            [10, 1010, "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "10!!"],
+            [11, 1011, "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "11!!"],
+            [12, 1012, "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "12!!"],
+            [13, 1013, "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "13!!"],
+            [14, 1014, "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "14!!"],
+            [15, 1015, "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "15!!"],
+            [16, 1016, "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "16!!"],
+            [17, 1017, "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "17!!"],
+            [18, 1018, "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "18!!"],
+            [19, 1019, "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "19!!"],
+            [20, 1020, "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "20!!"],
+            [21, 1021, "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "21!!"],
+            [22, 1022, "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "22!!"],
+            [23, 1023, "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "23!!"],
+            [24, 1024, "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "24!!"],
+            [25, 1025, "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "25!!"],
+            [26, 1026, "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "26!!"],
+            [27, 1027, "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "27!!"],
+            [28, 1028, "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "28!!"],
+            [29, 1029, "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "29!!"],
+            [30, 1030, "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "30!!"],
+            [31, 1031, "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "31!!"],
+            [32, 1032, "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "32!!"]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Value",
+        "row_index": 31,
+        "before": 1031,
+        "after": -2147483648
+      }
+    },
+    {
+      "id": "DAO-UPDATE-LATER-TABLE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Prefix",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              100
+            ],
+            [
+              101
+            ]
+          ]
+        },
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [0, 1000, "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "00!!"],
+            [1, 1001, "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "01!!"],
+            [2, 1002, "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "02!!"],
+            [3, 1003, "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "03!!"],
+            [4, 1004, "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "04!!"],
+            [5, 1005, "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "05!!"],
+            [6, 1006, "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "06!!"],
+            [7, 1007, "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "07!!"],
+            [8, 1008, "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "08!!"],
+            [9, 1009, "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "09!!"],
+            [10, 1010, "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "10!!"],
+            [11, 1011, "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "11!!"],
+            [12, 1012, "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "12!!"],
+            [13, 1013, "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "13!!"],
+            [14, 1014, "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "14!!"],
+            [15, 1015, "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "15!!"],
+            [16, 1016, "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "16!!"],
+            [17, 1017, "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "17!!"],
+            [18, 1018, "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "18!!"],
+            [19, 1019, "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "19!!"],
+            [20, 1020, "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "20!!"],
+            [21, 1021, "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "21!!"],
+            [22, 1022, "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "22!!"],
+            [23, 1023, "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "23!!"],
+            [24, 1024, "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "24!!"],
+            [25, 1025, "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "25!!"],
+            [26, 1026, "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "26!!"],
+            [27, 1027, "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "27!!"],
+            [28, 1028, "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "28!!"],
+            [29, 1029, "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "29!!"],
+            [30, 1030, "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "30!!"],
+            [31, 1031, "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "31!!"],
+            [32, 1032, "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "32!!"]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Value",
+        "row_index": 17,
+        "before": 1017,
+        "after": 2147483647
+      }
+    },
+    {
+      "id": "DAO-UPDATE-INSERT-ROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public row insert",
+        "exact unrelated-byte and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "insert",
+        "table": "Items",
+        "row": [
+          88,
+          -8800,
+          "inserted"
+        ]
+      }
+    },
+    {
+      "id": "DAO-UPDATE-DELETE-TAIL",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public row delete",
+        "exact unrelated-byte and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "delete",
+        "table": "Items",
+        "selected_id": 3
+      }
+    }
+  ],
+  "deferred_requirements": [
+  "allocation/empty-table insertion, non-tail/sole-row deletion and indexed/related row mutations",
+  "indexed or relationship target fields",
+  "null transitions and variable-length updates",
+  "hosted stored-query preservation"
+]
+}

--- a/oracle/windows-dao/scripts/dao_row_update_diff.py
+++ b/oracle/windows-dao/scripts/dao_row_update_diff.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Five-case hosted row-mutation successor, reusing the frozen update evaluator."""
+import copy
+import importlib.util
+from pathlib import Path
+
+# An isolated module instance supplies the unchanged identity/provider/coverage/
+# acquisition gates; configuring it never changes the historical three-case runner.
+ROOT = Path(__file__).resolve().parents[3]
+spec = importlib.util.spec_from_file_location('_row_update_base', ROOT / 'oracle/windows-dao/scripts/dao_update_diff.py')
+base = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(base)
+base.INVENTORY = ROOT / 'oracle/windows-dao/protocol/v1_2/row-update-scenarios.json'
+base.PLAN = ROOT / 'oracle/windows-dao/acquisition/row-update-v1_2.plan.json'
+old_recipe, old_check, old_command, old_evaluate = base.recipe, base.check_preservation, base.command, base.evaluate
+IDS = ['DAO-UPDATE-FIRST-FIELD','DAO-UPDATE-LATER-ROW','DAO-UPDATE-LATER-TABLE','DAO-UPDATE-INSERT-ROW','DAO-UPDATE-DELETE-TAIL']
+
+
+def recipe(scenario, role):
+    request = scenario['request']
+    if 'kind' not in request: return old_recipe(scenario, role)
+    expected = copy.deepcopy(scenario)
+    table, = [t for t in expected['tables'] if t['name'] == request['table']]
+    if role == 'after':
+        if request['kind'] == 'insert': table['rows'].append(request['row'])
+        else: table['rows'] = [r for r in table['rows'] if r[0] != request['selected_id']]
+    elif role != 'before': raise base.ValidationError('Unknown role')
+    return expected
+
+
+def inventory():
+    value = base.load_json(base.INVENTORY)
+    if value['document_type'] != 'dao_update_scenario_inventory' or value['protocol_version'] != '1.2.0' or [s['id'] for s in value['scenarios']] != IDS:
+        raise base.ValidationError('Wrong five-case inventory')
+    historical = base.load_json(ROOT / 'oracle/windows-dao/protocol/v1_2/update-scenarios.json')['scenarios']
+    if value['scenarios'][:3] != historical: raise base.ValidationError('Historical cases changed')
+    for scenario in value['scenarios']:
+        if (scenario['operation'] != dict(mode='dao_open_rust_update',expected_outcome='success',error_class=None)
+                or set(scenario['required_branches']) - base.write.protocol.load_branch_ids() or not scenario['coverage']):
+            raise base.ValidationError('Invalid operation/coverage')
+        recipe(scenario, 'after')
+    if value['scenarios'][3]['request'] != dict(kind='insert',table='Items',row=[88,-8800,'inserted']) or value['scenarios'][4]['request'] != dict(kind='delete',table='Items',selected_id=3):
+        raise base.ValidationError('Wrong finite row requests')
+    if not value['deferred_requirements']: raise base.ValidationError('Missing limitations')
+    return value
+
+
+def encoded(row):
+    ident, value, text = row; payload = text.encode('ascii')
+    if len(payload)>246: raise base.ValidationError('Narrow finite Text row required')
+    return bytes([3])+ident.to_bytes(4,'little',signed=True)+value.to_bytes(4,'little',signed=True)+payload+bytes([9+len(payload),9,1,7])
+
+
+def check_preservation(root, scenario, receipt):
+    request=scenario['request']
+    if 'kind' not in request: return old_check(root,scenario,receipt)
+    if receipt.get('scenario_id')!=scenario['id'] or receipt.get('request')!=request or receipt.get('preserved') is not True:
+        raise base.ValidationError('Independent row verification request mismatch')
+    before,after=[(root/role/'database.mdb').read_bytes() for role in base.ROLES]
+    for role in base.ROLES:
+        if receipt[role+'_sha256']!=base.write.digest(root/role/'database.mdb'): raise base.ValidationError('Image identity')
+    names=['root','page','slot','row_offset','row_length']
+    if any(type(receipt[n]) is not int or receipt[n]<0 for n in names): raise base.ValidationError('Row coordinates')
+    page=receipt['page']*2048;definition=receipt['root']*2048;slot=receipt['slot'];start=receipt['row_offset'];length=receipt['row_length']
+    if len(before)!=len(after) or page+2048>len(before) or definition+2048>len(before) or start<page+10 or start+length>page+2048:
+        raise base.ValidationError('Row image bounds')
+    count=int.from_bytes(before[page+8:page+10],'little');free=int.from_bytes(before[page+2:page+4],'little')
+    rows=next(t['rows'] for t in scenario['tables'] if t['name']==request['table'])
+    if int.from_bytes(before[definition+12:definition+16],'little')!=len(rows): raise base.ValidationError('Table count')
+    expected=bytearray(before); patches=[]
+    def put(offset,value):
+        patches.append(dict(offset=offset,before=list(expected[offset:offset+len(value)]),after=list(value)))
+        expected[offset:offset+len(value)]=value
+    if request['kind']=='insert':
+        row=encoded(request['row'])
+        if slot!=count or length!=len(row) or not 0<count<255: raise base.ValidationError('Insert slot/width')
+        packed=int.from_bytes(before[page+8+2*count:page+10+2*count],'little')&0x1fff
+        if start+length!=page+packed or free!=packed-10-2*count: raise base.ValidationError('Insert contiguous space')
+        put(start,row);put(page+10+2*slot,(start-page).to_bytes(2,'little'));put(page+8,(count+1).to_bytes(2,'little'))
+        put(page+2,(free-length-2).to_bytes(2,'little'));put(definition+12,(len(rows)+1).to_bytes(4,'little'))
+    else:
+        selected,=[r for r in rows if r[0]==request['selected_id']]
+        if slot+1!=count or count<2 or before[start:start+length]!=encoded(selected) or free!=start-page-10-2*count:
+            raise base.ValidationError('Delete row/tail/free span')
+        put(page+10+2*slot,(0xc000|start+length-page).to_bytes(2,'little'));put(page+2,(free+length).to_bytes(2,'little'));put(definition+12,(len(rows)-1).to_bytes(4,'little'))
+    if patches!=receipt['patches'] or expected!=after: raise base.ValidationError('Exact row patch/unrelated byte mismatch')
+
+
+def command(root,label,args):
+    if len(args)>1 and str(args[1])=='snapshot': args=[*args,'--inventory','row-update']
+    return old_command(root,label,args)
+
+
+def evaluate(out):
+    # Both dispatch and retained-data analysis require the successor's own pins.
+    plan_hash=base.write.digest(base.PLAN)
+    base.validate_plan(plan_hash)
+    old_evaluate(out)
+    report=base.load_json(out/'report.json');report['plan_sha256']=plan_hash
+    base.common.write_canonical(out/'report.json',report)
+
+
+base.inventory,base.recipe,base.check_preservation,base.command,base.evaluate=inventory,recipe,check_preservation,command,evaluate
+if __name__=='__main__':base.main()

--- a/oracle/windows-dao/tests/test_dao_row_update_diff.py
+++ b/oracle/windows-dao/tests/test_dao_row_update_diff.py
@@ -1,0 +1,64 @@
+import copy
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import dao_row_update_diff as rows
+import dao_update_diff as historical
+
+
+def images(root,scenario):
+    request=scenario['request'];values=next(t['rows'] for t in scenario['tables'] if t['name']=='Items')
+    before=bytearray(24*2048);page=23*2048;definition=20*2048;end=2048
+    for slot,value in enumerate(values):
+        data=rows.encoded(value);start=end-len(data);before[page+start:page+end]=data;before[page+10+2*slot:page+12+2*slot]=start.to_bytes(2,'little');end=start
+    before[definition+12:definition+16]=(3).to_bytes(4,'little');before[page+8:page+10]=(3).to_bytes(2,'little');free=end-16;before[page+2:page+4]=free.to_bytes(2,'little')
+    expected=bytearray(before);changes=[]
+    def put(offset,value):
+        changes.append(dict(offset=offset,before=list(expected[offset:offset+len(value)]),after=list(value)));expected[offset:offset+len(value)]=value
+    if request['kind']=='insert':
+        data=rows.encoded(request['row']);start=page+end-len(data);length=len(data);slot=3
+        put(start,data);put(page+16,(start-page).to_bytes(2,'little'));put(page+8,(4).to_bytes(2,'little'));put(page+2,(free-length-2).to_bytes(2,'little'));put(definition+12,(4).to_bytes(4,'little'))
+    else:
+        start=page+end;length=len(rows.encoded(values[-1]));slot=2
+        put(page+14,(0xc000|end+length).to_bytes(2,'little'));put(page+2,(free+length).to_bytes(2,'little'));put(definition+12,(2).to_bytes(4,'little'))
+    receipt=dict(scenario_id=scenario['id'],request=request,root=20,page=23,slot=slot,row_offset=start,row_length=length,patches=changes,preserved=True)
+    for role,data in [('before',before),('after',expected)]:
+        folder=root/role;folder.mkdir();(folder/'database.mdb').write_bytes(data);receipt[role+'_sha256']=rows.base.write.digest(folder/'database.mdb')
+    return receipt
+
+
+class RowUpdateTests(unittest.TestCase):
+    def test_inventory_adapter_preserves_historical_membership(self):
+        self.assertEqual(len(rows.inventory()['scenarios']),5)
+        self.assertEqual(len(historical.inventory()['scenarios']),3)
+        self.assertIsNot(rows.base,historical)
+        for scenario in rows.inventory()['scenarios'][3:]:
+            expected=rows.recipe(scenario,'after');table=next(t for t in expected['tables'] if t['name']=='Items')
+            self.assertEqual(len(table['rows']),4 if scenario['request']['kind']=='insert' else 2)
+
+    def test_exact_row_patch_and_unrelated_bytes(self):
+        for scenario in rows.inventory()['scenarios'][3:]:
+            with tempfile.TemporaryDirectory() as d:
+                root=Path(d);receipt=images(root,scenario);rows.check_preservation(root,scenario,receipt)
+                for key,value in [('slot',99),('root',21),('row_length',1),('request',{})]:
+                    bad=copy.deepcopy(receipt);bad[key]=value
+                    with self.assertRaises(rows.base.ValidationError):rows.check_preservation(root,scenario,bad)
+                path=root/'after/database.mdb';data=bytearray(path.read_bytes());data[1538]^=1;path.write_bytes(data);receipt['after_sha256']=rows.base.write.digest(path)
+                with self.assertRaisesRegex(rows.base.ValidationError,'unrelated byte'):rows.check_preservation(root,scenario,receipt)
+
+    def test_snapshot_command_selects_five_case_inventory(self):
+        with patch.object(rows,'old_command',return_value='done') as run:
+            self.assertEqual(rows.command(Path('.'),'snapshot',['cli','snapshot','file']),'done')
+            self.assertEqual(run.call_args.args[2],['cli','snapshot','file','--inventory','row-update'])
+            rows.command(Path('.'),'generate',['checker','generate','case'])
+            self.assertEqual(run.call_args.args[2],['checker','generate','case'])
+
+    def test_unreviewed_plan_gate_fails(self):
+        with self.assertRaises((OSError,rows.base.ValidationError)):
+            rows.base.validate_plan('0'*64)
+
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Extend hosted update validation to public insert and delete operations alongside the three existing field-update cases. Generate through the library, verify exact permitted byte changes independently, and compare all ten Rust/DAO snapshots through the existing provider, identity and coverage checks.

Keep the earlier three-case workflow and consumed inputs available. Acquisition stays gated until a separate reviewed plan pins the final sources.

Validation: independent review, two Rust and nine Python tests, actual five-case Linux preparation, synthetic comparison/failure checks, Clippy and just ready passed.

Refs #113.
