### PR TITLE
test: preregister indexed non-key update comparisons

### DIFF
--- a/crates/jet3/src/update.rs
+++ b/crates/jet3/src/update.rs
@@ -103,7 +103,10 @@ conversion!(crate::RowDirectoryError, Directory);
 conversion!(crate::RowWriteError, Encoding);
 conversion!(crate::PublishError, Publish);
 
-/// Replaces one present fixed field in an unindexed, relationship-free user table.
+/// Replaces one present fixed non-key field in a relationship-free user table.
+///
+/// Indexed tables are supported when the column is absent from every physical
+/// index. All index bytes remain unchanged; index-key maintenance is unsupported.
 ///
 /// Supports Byte, Integer, Long, Currency, Single, Double, DateTime, GUID and
 /// exact-width fixed Text. Null transitions, Boolean presence bits, AutoIncrement,
@@ -140,7 +143,7 @@ where
         return Err(UpdateError::Unsupported("null replacement"));
     }
     let mut database = DatabaseReader::open(path, budget)?;
-    let definition = writable_table(&mut database, request.table, budget)?;
+    let definition = guarded_table(&mut database, request.table, Some(request.column), budget)?;
     let column = definition
         .columns()
         .get(usize::from(request.column.get()))
@@ -227,6 +230,15 @@ pub(crate) fn writable_table(
     table: &[u8],
     budget: &mut ResourceBudget,
 ) -> Result<crate::TableDefinition, UpdateError> {
+    guarded_table(database, table, None, budget)
+}
+
+fn guarded_table(
+    database: &mut DatabaseReader<FileSource>,
+    table: &[u8],
+    field: Option<ColumnOrdinal>,
+    budget: &mut ResourceBudget,
+) -> Result<crate::TableDefinition, UpdateError> {
     let mut root = None;
     let mut relationship_root = None;
     {
@@ -250,10 +262,27 @@ pub(crate) fn writable_table(
     }
     let definition =
         database.table_definition(root.ok_or(UpdateError::NotFound("table"))?, budget)?;
-    if definition.kind() != TableDefinitionKind::User
-        || !definition.indexes().is_empty()
-        || !definition.physical_indexes().is_empty()
-    {
+    if definition.kind() != TableDefinitionKind::User {
+        return Err(UpdateError::Unsupported("non-user table"));
+    }
+    if let Some(column) = field {
+        // EXP-0059/0062: the typed decoder validates every logical selector,
+        // physical key field and complete logical-to-physical coverage.
+        for index in definition.indexes() {
+            budget.charge_items(1)?;
+            if matches!(index.kind(), crate::IndexDefinitionKind::Relationship(_)) {
+                return Err(UpdateError::Unsupported("relationship index"));
+            }
+        }
+        for index in definition.physical_indexes() {
+            for key in index.fields() {
+                budget.charge_items(1)?;
+                if key.column() == column {
+                    return Err(UpdateError::Unsupported("indexed key column"));
+                }
+            }
+        }
+    } else if !definition.indexes().is_empty() || !definition.physical_indexes().is_empty() {
         return Err(UpdateError::Unsupported(
             "table has indexes or relationships",
         ));

--- a/crates/jet3/src/update_indexed_tests.rs
+++ b/crates/jet3/src/update_indexed_tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+pub(super) fn indexed() -> Result<Fixture, Box<dyn StdError>> {
+    let fixture = simple()?;
+    fs::remove_file(fixture.path())?;
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Group", ColumnType::Long),
+        ColumnSpec::new(b"Value", ColumnType::Long),
+    ];
+    let composite = [
+        crate::IndexColumnSpec::descending(1),
+        crate::IndexColumnSpec::ascending(0),
+    ];
+    let indexes = [crate::IndexSpec {
+        name: b"ByGroup",
+        kind: crate::IndexKind::Ordinary,
+        fields: &composite,
+    }];
+    create_database_with_rows(
+        fixture.path(),
+        &TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &indexes,
+        },
+        &[
+            &[RowValue::Long(1), RowValue::Long(3), RowValue::Long(77)],
+            &[RowValue::Long(2), RowValue::Long(3), RowValue::Long(88)],
+        ],
+        &mut budget(),
+    )?;
+    Ok(fixture)
+}
+
+#[test]
+fn nonkey_update_preserves_every_index_and_unrelated_byte() -> TestResult {
+    let fixture = indexed()?;
+    let row = fixture.locator(1)?;
+    let mut original = fs::read(fixture.path())?;
+    original.extend_from_slice(&[0xab; PAGE_BYTES]);
+    fs::write(fixture.path(), &original)?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    let definition = guarded_table(&mut db, b"Items", Some(ColumnOrdinal::new(2)), &mut b)?;
+    assert_eq!(definition.physical_indexes().len(), 1);
+    let relative = {
+        let mut cursor = db.rows(&definition, &mut b)?;
+        let mut found = None;
+        while let Some(view) = cursor.next_row()? {
+            if view.locator() == row {
+                found = view.present_fixed_field_range(ColumnOrdinal::new(2));
+            }
+        }
+        found.ok_or("missing fixed field")?
+    };
+    let mut page = [0; PAGE_BYTES];
+    db.read_raw_page(row.page(), &mut page, &mut b)?;
+    let directory = RowDirectory::validate(row.page(), definition.root(), &page, &mut b)?;
+    let offset = row.page().get() as usize * PAGE_BYTES
+        + directory.entry(&page, row.slot())?.range().start
+        + relative.start;
+    drop(db);
+    update_field(
+        fixture.path(),
+        FieldUpdate {
+            column: ColumnOrdinal::new(2),
+            ..request(row, RowValue::Long(i32::MIN))
+        },
+        &mut budget(),
+    )?;
+    let mut expected = original;
+    expected[offset..offset + 4].copy_from_slice(&i32::MIN.to_le_bytes());
+    assert_eq!(fs::read(fixture.path())?, expected);
+    // Insert/delete retain their unindexed-table guard.
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    assert!(matches!(
+        writable_table(&mut db, b"Items", &mut b),
+        Err(UpdateError::Unsupported(_))
+    ));
+    for column in [0, 1] {
+        assert!(matches!(
+            update_field(
+                fixture.path(),
+                FieldUpdate {
+                    column: ColumnOrdinal::new(column),
+                    ..request(row, RowValue::Long(9))
+                },
+                &mut budget()
+            ),
+            Err(UpdateError::Unsupported("indexed key column"))
+        ));
+        assert_eq!(fs::read(fixture.path())?, expected);
+    }
+    fixture.assert_only_original()
+}
+
+#[test]
+fn inconsistent_or_out_of_range_index_mapping_refuses_publication() -> TestResult {
+    let fixture = indexed()?;
+    let row = fixture.locator(0)?;
+    let original = fs::read(fixture.path())?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
+    let definition = guarded_table(&mut db, b"Items", Some(ColumnOrdinal::new(2)), &mut b)?;
+    let record = definition.indexes()[0].raw_record();
+    let root_offset = definition.root().get() as usize * PAGE_BYTES;
+    let matches: Vec<_> = original[root_offset..root_offset + PAGE_BYTES]
+        .windows(record.len())
+        .enumerate()
+        .filter(|(_, bytes)| *bytes == record.as_slice())
+        .map(|(offset, _)| offset)
+        .collect();
+    assert_eq!(matches.len(), 1);
+    let offset = root_offset + matches[0];
+    drop(db);
+    // EXP-0059 logical selectors: mismatched selectors and out-of-range references.
+    for (first, second) in [(1_u32, 0_u32), (1, 1)] {
+        let mut damaged = original.clone();
+        damaged[offset..offset + 4].copy_from_slice(&first.to_le_bytes());
+        damaged[offset + 4..offset + 8].copy_from_slice(&second.to_le_bytes());
+        fs::write(fixture.path(), &damaged)?;
+        assert!(matches!(
+            update_field(
+                fixture.path(),
+                FieldUpdate {
+                    column: ColumnOrdinal::new(2),
+                    ..request(row, RowValue::Long(4))
+                },
+                &mut budget()
+            ),
+            Err(UpdateError::Definition(_))
+        ));
+        assert_eq!(fs::read(fixture.path())?, damaged);
+        fixture.assert_only_original()?;
+    }
+    Ok(())
+}

--- a/crates/jet3/src/update_tests.rs
+++ b/crates/jet3/src/update_tests.rs
@@ -420,8 +420,12 @@ fn a_valid_locator_from_another_table_is_rejected() -> TestResult {
 }
 
 #[test]
-fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
-    let fixture = simple()?;
+fn relationship_catalog_rows_are_checked_with_and_without_user_indexes() -> TestResult {
+    relationship_catalog_cases(simple()?, ColumnOrdinal::new(0))?;
+    relationship_catalog_cases(indexed::indexed()?, ColumnOrdinal::new(2))
+}
+
+fn relationship_catalog_cases(fixture: Fixture, column: ColumnOrdinal) -> TestResult {
     let row = fixture.locator(0)?;
     let original = fs::read(fixture.path())?;
     let mut b = budget();
@@ -492,7 +496,10 @@ fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
         fs::write(fixture.path(), &input)?;
         let result = update_field(
             fixture.path(),
-            request(row, RowValue::Long(3)),
+            FieldUpdate {
+                column,
+                ..request(row, RowValue::Long(3))
+            },
             &mut budget(),
         );
         if refused {
@@ -508,3 +515,6 @@ fn relationship_catalog_rows_are_checked_without_user_indexes() -> TestResult {
 
 #[path = "update_fixed_tests.rs"]
 mod fixed;
+
+#[path = "update_indexed_tests.rs"]
+mod indexed;

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11431,6 +11431,37 @@ Copy this block under the appropriate section and remove this instruction:
   unchanged. No retry, compatibility promotion, or hosted support movement is
   implied; any corrected implementation or retained-data successor is separate.
 
+## EXP-0177 — Indexed non-key Long update validation plan
+
+- Preregistered only; no acquisition. Outcome reserved as EXP-0178. Plan
+  `oracle/windows-dao/acquisition/indexed-payload-update.plan.json`, SHA-256
+  `3f9aa6a27174680dfbd8a1fb04306e709280014f3e60b78be4974ab05a1962ae`.
+- Reviewed implementation `0f06a3a` is integrated without conflicts in source
+  `aaa02d7079772ecd846e58614195c12b3159b206`. The existing public
+  `field_update_candidate` exporter remains unchanged and receives the declared
+  table, unique Id, column and replacement; no index-key update is attempted.
+- Three arms times three fresh DAO originals: primary ascending Id, ordinary
+  Group with duplicates, and ordinary Group descending / Id ascending composite.
+  Every original has six indexed Items rows, two unrelated Later rows and stored
+  KeepQuery. Update only Items Id3 / Value Long from 303 to -2147483648.
+- All nine original captures must satisfy full requested schema, exact index
+  flags/directions, rows, complete directed traversal and every distinct key plus
+  a missing-key Seek before Unix updates begin. Each update independently binds
+  its catalog/column/row span and preserves every other file byte, including all
+  original index bytes. Only nine complete updates permit the read-only phase.
+- Capture all eighteen original/updated images in the final DAO phase (27 reads
+  total). Require complete identities, x86 DAO.DBEngine.36 / Jet3.0, full requested
+  rows and original schema/QueryDef SQL, traversal completeness and exact payloads.
+  Duplicate Seek may return any complete matching row; missing rows, wrong payloads
+  or traversal order do not pass. All nine pairs are required for acceptance.
+- Initiating errors, stack/endpoint and partial images are retained; failure is
+  `no_outcome` without retry/resume or subset promotion. Tests include classifier
+  failures, retained input pins and actual x86 pure Read-Row / one- and two-key
+  JSON roundtrips. The pure helper test does not exercise DAO COM calls.
+- Local development only. No index maintenance, actual key updates, multiple-index
+  acceptance, relationship mutation, hosted compatibility or support movement is
+  claimed. Consumed earlier plans and outcomes remain unchanged.
+
 ## EXP-0171 — Distinct fixed-field Currency setter successor
 
 - Preregistered only; no acquisition. Outcome reserved as EXP-0172. The

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11435,7 +11435,7 @@ Copy this block under the appropriate section and remove this instruction:
 
 - Preregistered only; no acquisition. Outcome reserved as EXP-0178. Plan
   `oracle/windows-dao/acquisition/indexed-payload-update.plan.json`, SHA-256
-  `3f9aa6a27174680dfbd8a1fb04306e709280014f3e60b78be4974ab05a1962ae`.
+  `0f471e7449cf50466ee0aa62d7e7fca9debe474e26903cf631a2831e8431ffc7`.
 - Reviewed implementation `0f06a3a` is integrated without conflicts in source
   `aaa02d7079772ecd846e58614195c12b3159b206`. The existing public
   `field_update_candidate` exporter remains unchanged and receives the declared

--- a/oracle/windows-dao/acquisition/indexed-payload-update.plan.json
+++ b/oracle/windows-dao/acquisition/indexed-payload-update.plan.json
@@ -1,0 +1,243 @@
+{
+  "document_type": "dao_indexed_payload_update_plan",
+  "provenance": "EXP-0177",
+  "outcome_provenance": "EXP-0178",
+  "source_revision": "aaa02d7079772ecd846e58614195c12b3159b206",
+  "implementation_revision": "0f06a3a",
+  "replicas": 3,
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Group",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4
+    }
+  ],
+  "tables": [
+    {
+      "name": "Items",
+      "rows": [
+        [
+          1,
+          -2,
+          101
+        ],
+        [
+          2,
+          -2,
+          -202
+        ],
+        [
+          3,
+          0,
+          303
+        ],
+        [
+          4,
+          0,
+          -404
+        ],
+        [
+          5,
+          2,
+          505
+        ],
+        [
+          6,
+          2,
+          -606
+        ]
+      ]
+    },
+    {
+      "name": "Later",
+      "rows": [
+        [
+          11,
+          11,
+          -1100
+        ],
+        [
+          12,
+          12,
+          1200
+        ]
+      ]
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "arms": [
+    {
+      "name": "primary",
+      "table": "Items",
+      "column": "Value",
+      "selected_id": 3,
+      "replacement": -2147483648,
+      "index": {
+        "primary": true,
+        "unique": true,
+        "fields": [
+          {
+            "name": "Id",
+            "descending": false
+          }
+        ]
+      },
+      "queries": [
+        [
+          1
+        ],
+        [
+          2
+        ],
+        [
+          3
+        ],
+        [
+          4
+        ],
+        [
+          5
+        ],
+        [
+          6
+        ],
+        [
+          99
+        ]
+      ]
+    },
+    {
+      "name": "ordinary-duplicates",
+      "table": "Items",
+      "column": "Value",
+      "selected_id": 3,
+      "replacement": -2147483648,
+      "index": {
+        "primary": false,
+        "unique": false,
+        "fields": [
+          {
+            "name": "Group",
+            "descending": false
+          }
+        ]
+      },
+      "queries": [
+        [
+          -2
+        ],
+        [
+          0
+        ],
+        [
+          2
+        ],
+        [
+          99
+        ]
+      ]
+    },
+    {
+      "name": "composite-directions",
+      "table": "Items",
+      "column": "Value",
+      "selected_id": 3,
+      "replacement": -2147483648,
+      "index": {
+        "primary": false,
+        "unique": false,
+        "fields": [
+          {
+            "name": "Group",
+            "descending": true
+          },
+          {
+            "name": "Id",
+            "descending": false
+          }
+        ]
+      },
+      "queries": [
+        [
+          -2,
+          1
+        ],
+        [
+          -2,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          2,
+          5
+        ],
+        [
+          2,
+          6
+        ],
+        [
+          99,
+          99
+        ]
+      ]
+    }
+  ],
+  "inputs": {
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/field_update_candidate.rs": "867c42c748114e1f0ae19e84d0afdef37ac38bbbf079e332ef5e4df78cb724a0",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/index_definition.rs": "8e9c99fd2a0a1441de0fc3e2d897ba64709439a3ea548b4bc845bad48df513d6",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/physical_index_definition.rs": "d62e2c1b4dcbc903fc7cab6370dc4e485279702df72d7ed66516f68b2305c7c5",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/update.rs": "48be13eb2180f212a924517ee4b95db2294eff602a17bd54d2d3747818d10425",
+    "crates/jet3/src/update_pages.rs": "df312df67ae1e6d3ef5ec93df53a191918b3f8a79c7b70ae8f2013d063fc68ae",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/indexed_payload_update.ps1": "b03fbcdfb42228183dfac440935972e3504956496acc7afdc09f43f1fff7f6c5",
+    "oracle/windows-dao/scripts/indexed_payload_update.py": "52caa185aa5bdc7553427bdad57c375e087923b0afccc16f38fe861e44ebe961",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "question": "Does updating only a non-key Long payload through the public field API preserve primary, ordinary duplicate, and mixed-direction composite index behavior and every unrelated byte?",
+  "sequence": [
+    "Commit and independently review all pins before one coordinated acquisition. Create nine fresh DAO originals with indexed Items, unrelated Later and KeepQuery, and close/reopen each for complete original observation.",
+    "Only all nine complete schema/row/index/traversal/Seek observations and retained identities permit public Unix updates. The unchanged field_update_candidate exporter resolves Id3/Value with the public reader, copies each original and calls update_field once. No index key is targeted.",
+    "Check independently resolved table/column/row and exact replacement/whole-file preservation, including all original index bytes. Only all nine Unix updates permit one read-only DAO phase with eighteen original/updated captures.",
+    "Validate exact tables/fields/index flags and field directions, every row, complete key-ordered traversal, every distinct full key plus one missing-key Seek. Duplicate Seek may select any complete matching row; no incomplete traversal or payload mismatch is normalized away. Compare complete unrelated metadata and original stored QueryDef SQL.",
+    "Retain initiating endpoint/stack and all partial images on any failure; stop as no_outcome without retry/resume or partial acceptance."
+  ],
+  "decision_rule": "observed_accepted only if all9 pairs and27 total read captures pass x86DAO.DBEngine.36/Jet3.0, complete identities, requested state/index operations and exact full-file-outside-four-byte preservation. Original and updated physical index bytes stay unchanged. No DAO mutation after initial control creation.",
+  "bounds": "Three arms times3replicas; six Items rows and two Later rows, one index each; 18retainedMDBs and27captures. One non-null Long Value change Id3 from303 to i32MIN. No key update, relationship, index maintenance or allocation, multiple-index claim, Text collation, hosted compatibility or support movement. Existing diagnostic64-page/64-row limits suffice; SSH300seconds per phase, Unix120seconds per update."
+}

--- a/oracle/windows-dao/acquisition/indexed-payload-update.plan.json
+++ b/oracle/windows-dao/acquisition/indexed-payload-update.plan.json
@@ -219,6 +219,7 @@
     "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
     "crates/jet3/src/row.rs": "c0d85ee83c64d063fa80ac2bdb38ac6ea32efc16d8d6961010bf8463bd98ac95",
     "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_writer.rs": "c4cc40d63681391c94da5ae7b3cc451c1fe398189d75fc9c40ba53006ecaf9fc",
     "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
     "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
     "crates/jet3/src/update.rs": "48be13eb2180f212a924517ee4b95db2294eff602a17bd54d2d3747818d10425",

--- a/oracle/windows-dao/scripts/indexed_payload_update.ps1
+++ b/oracle/windows-dao/scripts/indexed_payload_update.ps1
@@ -1,0 +1,125 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+function Identity([string]$Path) {
+    return @{size=(Get-Item -LiteralPath $Path).Length; sha256=(Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()}
+}
+function Release($Value) {
+    if ($null -ne $Value -and [Runtime.InteropServices.Marshal]::IsComObject($Value)) { [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($Value) }
+}
+function Write-Json($Value, [string]$Path) {
+    [IO.File]::WriteAllText($Path, ((ConvertTo-Json -InputObject $Value -Depth 30) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+function Failure($Record) { return @{type=$Record.Exception.GetType().FullName;message=$Record.Exception.Message;stack=[string]$Record.ScriptStackTrace;endpoint=$script:endpoint} }
+function Close-Value($Value,[bool]$Close) {
+    if($null-eq $Value){return}
+    try{if($Close){$Value.Close()};Release $Value}catch{if($null-eq $script:failure){$script:failure=Failure $_}}
+}
+function Read-Row($Recordset) {
+    $values=[object[]]::new(3)
+    for($i=0;$i-lt 3;$i++){$field=$Recordset.Fields.Item($i);try{$values[$i]=[int]$field.Value}finally{Close-Value $field $false}}
+    return ,$values
+}
+function Create-Original([string]$Path,$Plan,$Arm) {
+    $engine=$workspace=$db=$table=$field=$rs=$query=$index=$key=$null
+    try {
+        $engine=New-Object -ComObject DAO.DBEngine.36;$workspace=$engine.Workspaces.Item(0)
+        $script:mutationStarted=$true;$script:endpoint='create_database'
+        $db=$workspace.CreateDatabase($Path,';LANGID=0x0409;CP=1252;COUNTRY=0',32)
+        foreach($spec in $Plan.tables){
+            $script:endpoint='schema/'+$spec.name;$table=$db.CreateTableDef([string]$spec.name)
+            foreach($column in $Plan.fields){$field=$table.CreateField([string]$column.name,[int]$column.type,[int]$column.size);$table.Fields.Append($field);Close-Value $field $false;$field=$null}
+            if($spec.name-eq $Arm.table){
+                $index=$table.CreateIndex('ByKey');$index.Primary=[bool]$Arm.index.primary;$index.Unique=[bool]$Arm.index.unique
+                foreach($definition in $Arm.index.fields){
+                    $key=$index.CreateField([string]$definition.name)
+                    if($definition.descending){$key.Attributes=1}
+                    $index.Fields.Append($key);Close-Value $key $false;$key=$null
+                }
+                $table.Indexes.Append($index);Close-Value $index $false;$index=$null
+            }
+            $db.TableDefs.Append($table);$rs=$db.OpenRecordset([string]$spec.name,2)
+            foreach($row in $spec.rows){
+                $rs.AddNew()
+                for($i=0;$i-lt 3;$i++){
+                    $script:endpoint='assign/'+$spec.name+'/'+$Plan.fields[$i].name
+                    $field=$rs.Fields.Item($i);try{$field.Value=[int]$row[$i]}catch{$script:failure=Failure $_;throw}finally{Close-Value $field $false;$field=$null}
+                }
+                $script:endpoint='update/'+$spec.name;$rs.Update()
+            }
+            Close-Value $rs $true;$rs=$null;Close-Value $table $false;$table=$null
+        }
+        $script:endpoint='query';$query=$db.CreateQueryDef([string]$Plan.query.name,[string]$Plan.query.sql)
+    }catch{if($null-eq $script:failure){$script:failure=Failure $_};throw}finally{
+        Close-Value $rs $true;Close-Value $query $false;Close-Value $key $false;Close-Value $index $false;Close-Value $field $false;Close-Value $table $false
+        Close-Value $db $true;Close-Value $workspace $false;Close-Value $engine $false
+    }
+}
+function Observe([string]$Path,$Arm) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $status = 'pass'; $errorDetail = $null; $endpoint = 'open_database'; $snapshot = [ordered]@{}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @($db.Relations | ForEach-Object { @{name=[string]$_.Name; table=[string]$_.Table; foreign_table=[string]$_.ForeignTable; attributes=[int]$_.Attributes; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })} })
+        $snapshot.queries = @($db.QueryDefs | ForEach-Object { @{name=[string]$_.Name; sql=[string]$_.SQL; type=[int]$_.Type} } | Sort-Object { $_.name })
+        $snapshot.user_tables = @()
+        foreach ($name in @($snapshot.tables | Where-Object { -not $_.StartsWith('MSys') })) {
+            $endpoint = 'schema';$script:endpoint=$endpoint; $table = $db.TableDefs.Item([string]$name)
+            $item = [ordered]@{name=[string]$table.Name; attributes=[int]$table.Attributes}
+            $item.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes; required=[bool]$_.Required; allow_zero_length=[bool]$_.AllowZeroLength; default_value=[string]$_.DefaultValue} })
+            $item.indexes = @($table.Indexes | ForEach-Object { @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })} })
+            $endpoint = 'rows';$script:endpoint=$endpoint; $rs = $db.OpenRecordset([string]$name, 4)
+            $rows = New-Object Collections.ArrayList
+            while (-not $rs.EOF) {
+                [void]$rows.Add((Read-Row $rs))
+                $rs.MoveNext()
+            }
+            $item.rows = @($rows); Close-Value $rs $true; $rs = $null
+            $snapshot.user_tables += $item; Release $table; $table = $null
+        }
+        $script:endpoint='traversal';$rs=$db.OpenRecordset([string]$Arm.table,1);$rs.Index='ByKey';$rs.MoveFirst()
+        $traversal=New-Object Collections.ArrayList
+        while(-not $rs.EOF){[void]$traversal.Add((Read-Row $rs));$rs.MoveNext()}
+        $script:endpoint='seek';$seeks=New-Object Collections.ArrayList
+        foreach($query in $Arm.queries){
+            if($Arm.index.fields.Count-eq 1){$rs.Seek('=',[int]$query[0])}else{$rs.Seek('=',[int]$query[0],[int]$query[1])}
+            $value=if($rs.NoMatch){$null}else{Read-Row $rs}
+            [void]$seeks.Add(@{query=[object[]]$query;row=$value})
+        }
+        $snapshot.index_observations=@{traversal=@($traversal);seek=@($seeks)}
+    } catch { $status='error';$errorDetail=Failure $_;$script:failure=$errorDetail }
+    finally { Close-Value $rs $true;Close-Value $table $false;Close-Value $db $true;Close-Value $engine $false }
+    return @{file=[IO.Path]::GetFileName($Path); before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath = Join-Path $env:JET3_WORK 'indexed-payload-update.plan.json'
+$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json
+if ((Identity $PSCommandPath).sha256 -cne $plan.inputs.'oracle/windows-dao/scripts/indexed_payload_update.ps1') { throw 'Script pin mismatch' }
+$phase = (Get-Content -LiteralPath (Join-Path $env:JET3_WORK 'phase.txt') -Raw).Trim()
+if ($phase -notin @('create', 'observe')) { throw 'Unknown phase' }
+$mutationStarted = $false;$failure=$null;$endpoint='start'
+$result = [ordered]@{document_type='dao_indexed_payload_update_phase'; phase=$phase; plan_sha256=(Identity $planPath).sha256; environment=@{process_bits=32; provider='DAO.DBEngine.36'; os=[Environment]::OSVersion.VersionString}; mutation_started=$false; observations=@(); error=$null; retention_failures=@(); endpoint='start'}
+try {
+    foreach ($arm in $plan.arms) {
+        foreach ($replica in 1..3) {
+            $roles = if ($phase -eq 'create') { @('original') } else { @('original', 'updated') }
+            foreach ($role in $roles) {
+                $path = Join-Path $env:JET3_WORK "$($arm.name)-r$replica-$role.mdb"
+                $result.endpoint = "$($arm.name)/$replica/$role"
+                if ($phase -eq 'create') { Create-Original $path $plan $arm }
+                $observation = Observe $path $arm
+                $result.observations += @{arm=[string]$arm.name; replica=$replica; role=$role; observation=$observation}
+                if ($observation.status -ne 'pass' -or $null-ne $failure) { throw 'Read-only observation failed' }
+            }
+        }
+    }
+} catch { $result.error=if($null-ne $failure){$failure}else{Failure $_} }
+finally {
+    $result.mutation_started = $mutationStarted
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb'){try{Copy-Item -LiteralPath $file.FullName -Destination $env:JET3_OUTBOX}catch{$result.retention_failures+=@{file=$file.Name;error=$_.Exception.Message}}}
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if ($null -ne $result.error -or $result.retention_failures.Count) { exit 1 }

--- a/oracle/windows-dao/scripts/indexed_payload_update.py
+++ b/oracle/windows-dao/scripts/indexed_payload_update.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""EXP-0177: one phased DAO-create / Unix-public-update / DAO-read acquisition."""
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+import system_catalog as catalog
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/indexed-payload-update.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/indexed_payload_update.ps1'
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identity(path):
+    return {'size': path.stat().st_size, 'sha256': digest(path)}
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, expected in plan['inputs'].items():
+        if digest(ROOT / name) != expected:
+            raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if subprocess.check_output(['git', 'show', f'HEAD:{PLAN.relative_to(ROOT)}'], cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Plan must be committed before acquisition')
+    if os.name != 'posix' or plan['replicas'] != 3:
+        raise ValueError('Expected Unix producer and three replicas')
+    return plan
+
+
+def normalized(snapshot):
+    result = copy.deepcopy(snapshot)
+    result.pop('index_observations', None)
+    result['user_tables'].sort(key=lambda table: table['name'])
+    for table in result['user_tables']:
+        table['rows'].sort()
+    return result
+
+
+def wanted_rows(plan, arm, updated):
+    rows = copy.deepcopy(next(t['rows'] for t in plan['tables'] if t['name'] == arm['table']))
+    if updated:
+        next(r for r in rows if r[0] == arm['selected_id'])[2] = arm['replacement']
+    return rows
+
+
+def validate_index(snapshot, plan, arm, updated):
+    rows = wanted_rows(plan, arm, updated)
+    columns = [next(i for i,f in enumerate(plan['fields']) if f['name']==k['name']) for k in arm['index']['fields']]
+    def key(row): return tuple(row[i] * (-1 if k['descending'] else 1) for i,k in zip(columns,arm['index']['fields']))
+    observation = snapshot['index_observations']
+    traversal = observation['traversal']
+    if sorted(traversal) != sorted(rows) or [key(r) for r in traversal] != sorted(key(r) for r in rows):
+        raise ValueError('Incomplete or misordered traversal')
+    if len(observation['seek']) != len(arm['queries']): raise ValueError('Seek inventory')
+    for observed, query in zip(observation['seek'], arm['queries']):
+        matches = [r for r in rows if [r[i] for i in columns] == query]
+        if observed['query'] != query or (observed['row'] not in matches if matches else observed['row'] is not None):
+            raise ValueError('Seek missing/extra/wrong complete row')
+
+
+def requested(snapshot, plan, arm, updated=False):
+    try: validate_index(snapshot, plan, arm, updated)
+    except (KeyError, TypeError, ValueError): return False
+    actual = normalized(snapshot)
+    if actual['version'] != '3.0' or actual['relations'] != []:
+        return False
+    if [t['name'] for t in actual['user_tables']] != sorted(t['name'] for t in plan['tables']):
+        return False
+    if len(actual['queries']) != 1 or actual['queries'][0]['name'] != plan['query']['name'] or not actual['queries'][0]['sql'] or actual['queries'][0]['type'] != 0:
+        return False
+    for spec in plan['tables']:
+        table = next(t for t in actual['user_tables'] if t['name'] == spec['name'])
+        expected_indexes = []
+        if spec['name'] == arm['table']:
+            index = arm['index']
+            expected_indexes = [dict(name='ByKey',primary=index['primary'],unique=index['unique'],required=index['primary'],foreign=False,ignore_nulls=False,
+                fields=[dict(name=k['name'],attributes=int(k['descending'])) for k in index['fields']])]
+        if table['attributes'] != 0 or table['indexes'] != expected_indexes:
+            return False
+        if [{k: field[k] for k in ('name', 'type', 'size')} for field in table['fields']] != plan['fields']:
+            return False
+        if any(field['attributes'] != 1 for field in table['fields']): return False
+        rows = wanted_rows(plan,arm,updated) if spec['name']==arm['table'] else spec['rows']
+        if table['rows'] != sorted(rows): return False
+    return True
+
+
+def patch_check(original, updated, arm, locator):
+    definition, _, records = catalog._discover_catalog(original)
+    name = catalog._ordinal(definition, 'Name')
+    id_column = catalog._ordinal(definition, 'Id')
+    roots = [row['values'][id_column] for row in records if row['values'][name] == arm['table']]
+    if len(roots) != 1 or roots[0] != locator['root']:
+        raise ValueError('Target catalog binding')
+    table = catalog._definition(original, roots[0])
+    columns = table['columns']
+    ordinal = catalog._ordinal(table, arm['column'])
+    id_column = catalog._ordinal(table, 'Id')
+    column = columns[ordinal]
+    if ordinal != locator['column'] or column['type'] != 'Long' or column['storage'] != 'fixed' or column['size'] != 4:
+        raise ValueError('Target field binding')
+    pages, _ = catalog._table_pages(original, table)
+    rows = catalog._table_rows(original, table, pages)
+    selected = [row for row in rows if row['values'][id_column] == arm['selected_id']]
+    if len(selected) != 1 or selected[0]['page'] != locator['page'] or selected[0]['row'] != locator['slot'] or not selected[0]['present'][ordinal]:
+        raise ValueError('Target row binding')
+    image = catalog._page(original, locator['page'], 'target row')
+    entry = catalog._row_directory(image, locator['page'])[locator['slot']]
+    offset = locator['page'] * catalog.PAGE_BYTES + entry['start'] + 1 + column['fixed_offset']
+    expected = bytearray(original)
+    expected[offset:offset + 4] = arm['replacement'].to_bytes(4, 'little', signed=True)
+    if expected != updated:
+        raise ValueError('Bytes outside the requested field changed, or replacement differs')
+    return {'offset': offset, 'length': 4, 'before_hex': original[offset:offset + 4].hex(),
+            'after_hex': updated[offset:offset + 4].hex(),
+            'changed_offsets': [i for i, (a, b) in enumerate(zip(original, updated)) if a != b]}
+
+
+def phase_entries(phase, name, plan):
+    if (phase['document_type'] != 'dao_indexed_payload_update_phase' or phase['phase'] != name
+        or phase['plan_sha256'] != digest(PLAN) or phase['error'] is not None
+        or phase['retention_failures']
+        or phase['mutation_started'] != (name == 'create')
+        or phase['environment']['process_bits'] != 32 or phase['environment']['provider'] != 'DAO.DBEngine.36'):
+        raise ValueError('Phase failed or has wrong identity: ' + name)
+    roles = ['original'] if name == 'create' else ['original', 'updated']
+    expected = {(arm['name'], replica, role) for arm in plan['arms'] for replica in range(1, 4) for role in roles}
+    entries = {}
+    for item in phase['observations']:
+        key = (item['arm'], item['replica'], item['role'])
+        if key in entries:
+            raise ValueError('Duplicate observation')
+        observation = item['observation']
+        if observation['status'] != 'pass' or observation['error'] is not None or observation['before'] != observation['after']:
+            raise ValueError('Read-only observation failed or mutated')
+        entries[key] = observation
+    if set(entries) != expected:
+        raise ValueError('Incomplete phase observations')
+    return entries
+
+
+def build_report(result, outbox, plan):
+    observations, reasons = [], []
+    try:
+        if (result['document_type'] != 'dao_indexed_payload_update_result' or result['producer_os'] != 'posix'
+            or result['source_revision'] != plan['source_revision']):
+            raise ValueError('Unexpected result envelope or public Unix source receipt')
+        if result['plan_sha256'] != digest(PLAN) or result['error'] is not None or result['phase'] != 'complete':
+            raise ValueError('Coordinated acquisition failed: ' + str(result['error']))
+        phases = {}
+        for name in ('create', 'observe'):
+            path = outbox / (name + '.json')
+            if identity(path) != result['phases'][name]:
+                raise ValueError('Phase result identity mismatch')
+            phases[name] = phase_entries(json.loads(path.read_text(encoding='utf-8-sig')), name, plan)
+        updates = {(u['arm'], u['replica']): u for u in result['updates']}
+        if len(updates) != len(result['updates']) or set(updates) != {(a['name'], r) for a in plan['arms'] for r in range(1, 4)}:
+            raise ValueError('Incomplete Unix updates')
+        for arm in plan['arms']:
+            for replica in range(1, 4):
+                name = arm['name']; update = updates[name, replica]
+                before = phases['create'][name, replica, 'original']
+                after_original = phases['observe'][name, replica, 'original']
+                after = phases['observe'][name, replica, 'updated']
+                original = outbox / f'{name}-r{replica}-original.mdb'
+                updated = outbox / f'{name}-r{replica}-updated.mdb'
+                if (identity(original) != before['after'] or identity(original) != after_original['after']
+                    or identity(original) != update['original_before'] or identity(original) != update['original_after']
+                    or identity(updated) != after['before'] or identity(updated) != update['updated']):
+                    raise ValueError('Image identity chain mismatch')
+                for role, observation in [('original', before), ('original', after_original), ('updated', after)]:
+                    if observation['file'] != f'{name}-r{replica}-{role}.mdb':
+                        raise ValueError('Image filename association mismatch')
+                if normalized(before['snapshot']) != normalized(after_original['snapshot']) or not requested(before['snapshot'], plan, arm) or not requested(after_original['snapshot'], plan, arm) or not requested(after['snapshot'], plan, arm, True):
+                    raise ValueError('Original/requested schema or rows differ')
+                expected = normalized(before['snapshot'])
+                target = next(t for t in expected['user_tables'] if t['name'] == arm['table'])
+                field = next(i for i, f in enumerate(plan['fields']) if f['name'] == arm['column'])
+                next(row for row in target['rows'] if row[0] == arm['selected_id'])[field] = arm['replacement']
+                if normalized(expected) != normalized(after['snapshot']):
+                    raise ValueError('Unrelated schema, rows or query SQL differs')
+                span = patch_check(original.read_bytes(), updated.read_bytes(), arm, update['locator'])
+                observations.append({'arm': name, 'replica': replica, 'original': identity(original),
+                                     'updated': identity(updated), 'patch': span, 'snapshot': after['snapshot'],
+                                     'requested_change_and_preservation': True})
+    except (KeyError, ValueError, TypeError, OSError, catalog.DecodeError) as error:
+        reasons.append(str(error))
+    return {'document_type': 'dao_indexed_payload_update_report', 'development_only': True,
+            'plan_sha256': digest(PLAN), 'outcome': 'observed_accepted' if not reasons else 'no_outcome',
+            'reasons': reasons, 'observations': observations, 'support_matrix_movement': False,
+            'compatibility_claim': False}
+
+
+def analyze(outbox):
+    plan = verify_inputs()
+    result = json.loads((outbox / 'result.json').read_text())
+    report = build_report(result, outbox, plan)
+    report['result_sha256'] = digest(outbox / 'result.json')
+    (outbox / 'report.json').write_text(canonical(report) + '\n')
+    print(report['outcome'])
+
+
+def dispatch(args):
+    plan = preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}', args.run_id):
+        raise ValueError('Invalid run id')
+    shared = args.shared_root.resolve(); outbox = shared / 'outbox' / args.run_id
+    paths = [outbox] + [shared / part / (args.run_id + '-' + phase) for part in ('inbox', 'outbox') for phase in ('create', 'observe')]
+    if any(path.exists() for path in paths):
+        raise ValueError('Run id used; never resume or retry')
+    subprocess.run(['cargo', 'build', '-p', 'jet3', '--example', 'field_update_candidate'], cwd=ROOT, check=True)
+    spec = importlib.util.spec_from_file_location('transport', ROOT / 'scripts/windows-dao-ps.py')
+    transport = importlib.util.module_from_spec(spec); spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result = {'document_type': 'dao_indexed_payload_update_result', 'plan_sha256': digest(PLAN),
+              'source_revision': plan['source_revision'],
+              'acquisition_revision': subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=ROOT).decode().strip(),
+              'producer_os': os.name, 'phase': 'create', 'phases': {}, 'updates': [], 'error': None}
+    try:
+        for phase in ('create', 'observe'):
+            result['phase'] = phase
+            run_id = args.run_id + '-' + phase; inbox = shared / 'inbox' / run_id; inbox.mkdir(parents=True)
+            shutil.copyfile(ROOT / SCRIPT, inbox / 'script.ps1'); shutil.copyfile(PLAN, inbox / PLAN.name)
+            (inbox / 'phase.txt').write_text(phase)
+            if phase == 'observe':
+                for path in outbox.glob('*.mdb'): shutil.copyfile(path, inbox / path.name)
+            command = ['ssh', '-p', args.port, '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15', '-o', 'IdentitiesOnly=yes', '-i', args.identity,
+                       f'{args.user}@{args.host}', 'powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand',
+                       transport.encoded(transport.guest_script(args.remote_shared_root, run_id, 'script.ps1'))]
+            completed = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True, timeout=300)
+            (outbox / (phase + '-ssh.txt')).write_bytes(completed.stdout + completed.stderr)
+            guest = shared / 'outbox' / run_id
+            shutil.copyfile(guest / 'result.json', outbox / (phase + '.json'))
+            result['phases'][phase] = identity(outbox / (phase + '.json'))
+            if phase == 'create':
+                for path in guest.glob('*.mdb'): shutil.copyfile(path, outbox / path.name)
+            observations = phase_entries(json.loads((outbox / (phase + '.json')).read_text(encoding='utf-8-sig')), phase, plan)
+            if completed.returncode != 0: raise ValueError('Guest phase exited unsuccessfully')
+            for observation in observations.values():
+                if identity(guest / observation['file']) != observation['after']: raise ValueError('Guest retained identity')
+                if phase == 'observe' and identity(outbox / observation['file']) != observation['after']: raise ValueError('Read-only phase changed image')
+            if phase == 'create':
+                for arm in plan['arms']:
+                    for replica in range(1, 4):
+                        if not requested(observations[arm['name'], replica, 'original']['snapshot'], plan, arm): raise ValueError('Original request mismatch before Unix updates')
+                result['phase'] = 'unix_update'
+                for arm in plan['arms']:
+                    for replica in range(1, 4):
+                        prefix = f"{arm['name']}-r{replica}"
+                        original = outbox / (prefix + '-original.mdb'); updated = outbox / (prefix + '-updated.mdb')
+                        before = identity(original)
+                        if before != observations[arm['name'], replica, 'original']['after']: raise ValueError('Original transfer identity')
+                        if not requested(observations[arm['name'], replica, 'original']['snapshot'], plan, arm): raise ValueError('Original request mismatch')
+                        command = ['cargo', 'run', '--quiet', '-p', 'jet3', '--example', 'field_update_candidate', '--', str(original), str(updated), arm['table'], str(arm['selected_id']), arm['column'], str(arm['replacement'])]
+                        done = subprocess.run(command, cwd=ROOT, capture_output=True, timeout=120)
+                        (outbox / (prefix + '-unix.txt')).write_bytes(done.stdout + done.stderr)
+                        if done.returncode: raise ValueError('Public field update failed: ' + prefix)
+                        result['updates'].append({'arm': arm['name'], 'replica': replica, 'original_before': before,
+                            'original_after': identity(original), 'updated': identity(updated), 'locator': json.loads(done.stdout)})
+                        if identity(original) != before: raise ValueError('Unix update changed original')
+                        patch_check(original.read_bytes(), updated.read_bytes(), arm, result['updates'][-1]['locator'])
+        result['phase'] = 'complete'
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        result['error'] = type(error).__name__ + ': ' + str(error)
+    finally:
+        (outbox / 'result.json').write_text(canonical(result) + '\n')
+    analyze(outbox)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__); commands = parser.add_subparsers(dest='command', required=True)
+    commands.add_parser('preflight'); report = commands.add_parser('analyze'); report.add_argument('outbox', type=Path)
+    run = commands.add_parser('run'); run.add_argument('--run-id', required=True); run.add_argument('--shared-root', type=Path, required=True)
+    for name, default in [('host', '127.0.0.1'), ('port', '2222'), ('user', 'jet3runner'), ('identity', str(Path.home() / '.ssh/jet3-dao')), ('remote-shared-root', r'\\host.lan\Data')]:
+        run.add_argument('--' + name, default=default)
+    args = parser.parse_args()
+    if args.command == 'preflight': preflight(); print('Committed inputs match.')
+    elif args.command == 'analyze': analyze(args.outbox)
+    else: dispatch(args)
+
+
+if __name__ == '__main__': main()

--- a/oracle/windows-dao/tests/indexed_payload_values.ps1
+++ b/oracle/windows-dao/tests/indexed_payload_values.ps1
@@ -1,0 +1,23 @@
+param([Parameter(Mandatory=$true)][string]$ScriptPath)
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected actual x86 helper check'}
+$t=$null;$e=$null;$ast=[Management.Automation.Language.Parser]::ParseFile($ScriptPath,[ref]$t,[ref]$e)
+if($e.Count){throw ($e|Out-String)}
+foreach($name in @('Release','Close-Value','Read-Row')){
+    $defs=@($ast.FindAll({param($n) $n -is [Management.Automation.Language.FunctionDefinitionAst] -and $n.Name-eq $name},$false))
+    if($defs.Count-ne 1){throw 'Helper missing'}
+    Invoke-Expression $defs[0].Extent.Text
+}
+$failure=$null
+$fields=[pscustomobject]@{Values=[object[]]@([int]1,[int]-2,[int]::MinValue)}
+$fields|Add-Member ScriptMethod Item {param($i) return [pscustomobject]@{Value=$this.Values[$i]}}
+$rs=[pscustomobject]@{Fields=$fields}
+$row=Read-Row $rs
+$rows=New-Object Collections.ArrayList;[void]$rows.Add($row)
+foreach($query in @(@(1),@(-2,1))){
+    $record=@{rows=@($rows);seek=@(@{query=[object[]]$query;row=$row})}
+    $json=ConvertTo-Json -InputObject $record -Depth 10;$back=$json|ConvertFrom-Json
+    if($back.rows.Count-ne 1-or $back.rows[0].Count-ne 3-or $back.rows[0][2]-ne [int]::MinValue-or $back.seek[0].query.Count-ne $query.Count-or $back.seek[0].row[1]-ne -2){throw 'Scalar row/query JSON mismatch'}
+}
+Write-Output 'x86 Read-Row and one/two-key JSON checks passed; no DAO'

--- a/oracle/windows-dao/tests/test_indexed_payload_update.py
+++ b/oracle/windows-dao/tests/test_indexed_payload_update.py
@@ -1,0 +1,70 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import indexed_payload_update as m
+
+
+def snapshot(plan,arm,updated=False):
+    tables=[]
+    for spec in plan['tables']:
+        index=arm['index'];indexes=[]
+        if spec['name']==arm['table']:
+            indexes=[dict(name='ByKey',primary=index['primary'],unique=index['unique'],required=index['primary'],foreign=False,ignore_nulls=False,fields=[dict(name=k['name'],attributes=int(k['descending'])) for k in index['fields']])]
+        tables.append(dict(name=spec['name'],attributes=0,fields=[dict(f,attributes=1) for f in plan['fields']],indexes=indexes,rows=m.wanted_rows(plan,arm,updated) if indexes else spec['rows']))
+    columns=[next(i for i,f in enumerate(plan['fields']) if f['name']==k['name']) for k in arm['index']['fields']]
+    rows=m.wanted_rows(plan,arm,updated)
+    traversal=sorted(rows,key=lambda r:tuple(r[i]*(-1 if k['descending'] else 1) for i,k in zip(columns,arm['index']['fields'])))
+    seeks=[]
+    for q in arm['queries']:
+        matches=[r for r in rows if [r[i] for i in columns]==q];seeks.append(dict(query=q,row=matches[-1] if matches else None))
+    return dict(version='3.0',relations=[],queries=[dict(name=plan['query']['name'],sql=plan['query']['sql'],type=0)],user_tables=tables,index_observations=dict(traversal=traversal,seek=seeks))
+
+
+class IndexedPayloadTests(unittest.TestCase):
+    def test_complete_index_semantics_and_missing_duplicate_rows(self):
+        plan=json.loads(m.PLAN.read_text())
+        for arm in plan['arms']:
+            for updated in (False,True):
+                value=snapshot(plan,arm,updated);self.assertTrue(m.requested(value,plan,arm,updated))
+                for part in ('traversal','seek'):
+                    bad=copy.deepcopy(value);bad['index_observations'][part].pop();self.assertFalse(m.requested(bad,plan,arm,updated))
+                bad=copy.deepcopy(value);bad['index_observations']['traversal'].reverse();self.assertFalse(m.requested(bad,plan,arm,updated))
+                bad=copy.deepcopy(value);bad['index_observations']['seek'][0]['row'][2]=999;self.assertFalse(m.requested(bad,plan,arm,updated))
+                bad=copy.deepcopy(value);bad['user_tables'][0]['indexes'][0]['fields'][0]['attributes']^=1;self.assertFalse(m.requested(bad,plan,arm,updated))
+
+    def test_full_matrix_and_no_outcome(self):
+        plan=json.loads(m.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as d:
+            root=Path(d);phases={n:dict(document_type='dao_indexed_payload_update_phase',phase=n,plan_sha256=m.digest(m.PLAN),error=None,retention_failures=[],mutation_started=n=='create',environment=dict(process_bits=32,provider='DAO.DBEngine.36'),observations=[]) for n in ('create','observe')}
+            result=dict(document_type='dao_indexed_payload_update_result',producer_os='posix',source_revision=plan['source_revision'],plan_sha256=m.digest(m.PLAN),phase='complete',error=None,updates=[],phases={})
+            for arm in plan['arms']:
+                for r in range(1,4):
+                    ids={}
+                    for role in ('original','updated'):
+                        p=root/f"{arm['name']}-r{r}-{role}.mdb";p.write_bytes(role.encode());ids[role]=m.identity(p)
+                        obs=dict(arm=arm['name'],replica=r,role=role,observation=dict(file=p.name,before=ids[role],after=ids[role],status='pass',error=None,snapshot=snapshot(plan,arm,role=='updated')))
+                        phases['observe']['observations'].append(obs)
+                        if role=='original':phases['create']['observations'].append(copy.deepcopy(obs))
+                    result['updates'].append(dict(arm=arm['name'],replica=r,original_before=ids['original'],original_after=ids['original'],updated=ids['updated'],locator={}))
+            def classify():
+                for n,p in phases.items():
+                    path=root/(n+'.json');path.write_text(json.dumps(p));result['phases'][n]=m.identity(path)
+                with patch.object(m,'patch_check',return_value={}):return m.build_report(result,root,plan)['outcome']
+            self.assertEqual(classify(),'observed_accepted')
+            phases['observe']['observations'][0]['observation']['snapshot']['index_observations']['seek'].pop();self.assertEqual(classify(),'no_outcome')
+            result['error']='failed';self.assertEqual(classify(),'no_outcome')
+
+    def test_dispatch_and_analysis_input_pins(self):
+        with tempfile.TemporaryDirectory() as d:
+            root=Path(d);script=root/'producer';script.write_text('original');p=root/'plan';p.write_text(json.dumps(dict(inputs={'producer':m.digest(script)})))
+            with patch.object(m,'ROOT',root),patch.object(m,'PLAN',p):
+                m.verify_inputs();script.write_text('changed')
+                with self.assertRaisesRegex(ValueError,'Input pin'):m.verify_inputs()
+                with self.assertRaisesRegex(ValueError,'Input pin'):m.analyze(root)
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Preregister non-key fixed-field updates in three indexed table layouts. Compare complete rows, schema, index traversal and finite seeks through DAO while verifying every byte outside the four-byte field remains exact.

Validation: independent review and encoder-pin fix verification; three focused tests, actual x86 parser/row-and-key helpers, committed preflight and just ready passed. Acquisition results are recorded separately.
