### PR TITLE
feat: create indexes with bounded numeric key components

### DIFF
--- a/crates/jet3/src/creation/api.rs
+++ b/crates/jet3/src/creation/api.rs
@@ -179,13 +179,16 @@ pub fn create_database(
 /// capacity. Each row and the table definition must fit one page. Pages with
 /// a slot and room for an all-null row are marked available; this construction
 /// policy has not been established as DAO's allocation policy.
-/// At most one index on one or two Long columns (including a generated
+/// At most one index on one or two numeric columns (including a generated
 /// AutoIncrement column) is accepted, with each field ascending or descending.
 /// Uncompressed branch/leaf trees grow within the existing inline-map and
 /// resource limits. Unique indexes reject repeated fully present keys while
 /// allowing repeated null-bearing keys. The index null policy includes keys,
 /// omits all-null keys, or requires every component; primary indexes require
-/// every component. Other key types are refused.
+/// every component. Supported components are Boolean, Byte, Integer, Long,
+/// Currency, Single and Double. Floating negative zero and nonfinite values,
+/// Boolean nulls and other key types are refused. Non-Long nullable/composite
+/// combinations are candidate generalizations awaiting DAO validation.
 /// One AutoIncrement column requires [`RowValue::AutoIncrement`] in every row;
 /// IDs start at 1 independently per table and the last generated ID is persisted.
 /// Null and explicit IDs are refused, as are counts reaching the signed Long

--- a/crates/jet3/src/creation/composer/compose_error.rs
+++ b/crates/jet3/src/creation/composer/compose_error.rs
@@ -17,8 +17,17 @@ pub enum ComposeError {
         /// Unsupported relationship constraint.
         detail: &'static str,
     },
-    /// Initial rows support at most one index on one or two Long columns.
+    /// Initial rows support at most one index on one or two supported numeric columns.
     UnsupportedInitialIndexSchema,
+    /// A scalar key value needs an unsupported encoding (including negative zero).
+    UnsupportedInitialIndexValue {
+        /// Zero-based input row.
+        row: usize,
+        /// Zero-based table column.
+        column: usize,
+    },
+    /// A unique index repeats a non-null scalar key other than an all-Long key.
+    DuplicateInitialScalarIndexKey,
     /// A required index or relationship key contains a null component.
     NullInitialIndexKey {
         /// Zero-based input row.
@@ -126,6 +135,8 @@ impl std::error::Error for ComposeError {
             | Self::InitialAutoIncrement { .. }
             | Self::OrphanInitialRelationshipKey { .. }
             | Self::UnsupportedInitialIndexSchema
+            | Self::UnsupportedInitialIndexValue { .. }
+            | Self::DuplicateInitialScalarIndexKey
             | Self::NullInitialIndexKey { .. }
             | Self::DuplicateInitialIndexKey { .. }
             | Self::DuplicateInitialCompositeIndexKey { .. }

--- a/crates/jet3/src/creation/composer/initial_index.rs
+++ b/crates/jet3/src/creation/composer/initial_index.rs
@@ -1,7 +1,9 @@
-//! Uncompressed trees of one/two Long components: EXP-0062 branch/leaf/locator
-//! grammar, EXP-0126 direction/composition, and EXP-0148 null components/policies.
+//! Uncompressed trees of one/two numeric components: EXP-0062 branch/leaf/locator
+//! grammar, EXP-0126/0150 scalar directions, and EXP-0148 null components/policies.
+//! Non-Long nullable/composite keys remain candidate constructions pending DAO.
 
 use super::*;
+use crate::numeric_index_key::{MAX_COMPONENT_BYTES, NumericKeyType};
 use crate::{IndexNullPolicy, IndexTree, RowLocator};
 
 #[path = "initial_index_pages.rs"]
@@ -11,12 +13,13 @@ use pages::IndexPages;
 const COMPONENT_BYTES: usize = 5;
 const MAX_FIELDS: usize = 2;
 const LOCATOR_BYTES: usize = 4;
-const ENTRY_CAPACITY: usize = MAX_FIELDS * COMPONENT_BYTES + LOCATOR_BYTES;
+const ENTRY_CAPACITY: usize = MAX_FIELDS * MAX_COMPONENT_BYTES + LOCATOR_BYTES;
 
 #[derive(Debug, Clone, Copy)]
 struct LongField {
     column: usize,
     direction: IndexDirection,
+    kind: NumericKeyType,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -65,6 +68,7 @@ impl InitialLongIndex {
         let mut fields = [LongField {
             column: 0,
             direction: IndexDirection::Ascending,
+            kind: NumericKeyType::Long,
         }; MAX_FIELDS];
         for (slot, field) in fields.iter_mut().zip(index.fields) {
             let column = field
@@ -72,17 +76,15 @@ impl InitialLongIndex {
                 .resolve(spec.columns)
                 .map(usize::from)
                 .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
-            if spec.columns.get(column).is_none_or(|column| {
-                !matches!(
-                    column.column_type(),
-                    ColumnType::Long | ColumnType::AutoIncrement
-                )
-            }) {
-                return Err(ComposeError::UnsupportedInitialIndexSchema);
-            }
+            let kind = spec
+                .columns
+                .get(column)
+                .and_then(|column| NumericKeyType::from_column(column.column_type()))
+                .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
             *slot = LongField {
                 column,
                 direction: field.direction,
+                kind,
             };
         }
         u32::try_from(row_count).map_err(|_| Error::IntegerConversion {
@@ -146,25 +148,23 @@ impl InitialLongIndex {
                 .get(field.column)
                 .ok_or(ComposeError::UnsupportedInitialIndexSchema)?;
             let start = entry.key_len;
-            match value {
-                RowValue::Null => {
-                    entry.has_null = true;
-                    entry.key_len += 1;
-                }
-                RowValue::Long(value) => {
-                    all_null = false;
-                    entry.bytes[start..start + COMPONENT_BYTES].copy_from_slice(
-                        &crate::long_index_key::encode(*value, IndexDirection::Ascending),
-                    );
-                    entry.key_len += COMPONENT_BYTES;
-                }
-                _ => return Err(ComposeError::UnsupportedInitialIndexSchema),
-            }
-            if field.direction == IndexDirection::Descending {
-                for byte in &mut entry.bytes[start..entry.key_len] {
-                    *byte ^= 0xff;
-                }
-            }
+            let null = matches!(value, RowValue::Null);
+            entry.has_null |= null;
+            all_null &= null;
+            let mut component = [0; MAX_COMPONENT_BYTES];
+            let length = field
+                .kind
+                .encode(*value, field.direction, &mut component)
+                .ok_or(if field.kind == NumericKeyType::Long {
+                    ComposeError::UnsupportedInitialIndexSchema
+                } else {
+                    ComposeError::UnsupportedInitialIndexValue {
+                        row,
+                        column: field.column,
+                    }
+                })?;
+            entry.bytes[start..start + length].copy_from_slice(&component[..length]);
+            entry.key_len += length;
         }
         if entry.has_null && self.null_policy == IndexNullPolicy::Required {
             return Err(ComposeError::NullInitialIndexKey { row });
@@ -191,6 +191,12 @@ impl InitialLongIndex {
         for pair in self.entries.windows(2) {
             if pair[0].key() == pair[1].key() {
                 if self.unique && !pair[1].has_null {
+                    if self.fields[..self.field_count]
+                        .iter()
+                        .any(|field| field.kind != NumericKeyType::Long)
+                    {
+                        return Err(ComposeError::DuplicateInitialScalarIndexKey);
+                    }
                     let mut values = [0_i32; MAX_FIELDS];
                     for (position, value) in values.iter_mut().enumerate().take(self.field_count) {
                         let start = position * COMPONENT_BYTES + 1;

--- a/crates/jet3/src/creation/initial_index_tests.rs
+++ b/crates/jet3/src/creation/initial_index_tests.rs
@@ -302,3 +302,6 @@ mod multi_level;
 
 #[path = "nullable_index_tests.rs"]
 mod nullable;
+
+#[path = "numeric_index_tests.rs"]
+mod numeric;

--- a/crates/jet3/src/creation/numeric_index_tests.rs
+++ b/crates/jet3/src/creation/numeric_index_tests.rs
@@ -1,0 +1,235 @@
+use super::*;
+
+#[test]
+fn observed_numeric_bytes_directions_and_locators_survive_publication() -> TestResult {
+    for (column, values, ascending) in [
+        (
+            ColumnType::Boolean,
+            [RowValue::Boolean(false), RowValue::Boolean(true)],
+            vec![vec![0x7f, 0], vec![0x7f, 0xff]],
+        ),
+        (
+            ColumnType::Byte,
+            [RowValue::Byte(255), RowValue::Byte(0)],
+            vec![vec![0x7f, 0], vec![0x7f, 0xff]],
+        ),
+        (
+            ColumnType::Integer,
+            [RowValue::Integer(i16::MAX), RowValue::Integer(i16::MIN)],
+            vec![vec![0x7f, 0, 0], vec![0x7f, 0xff, 0xff]],
+        ),
+        (
+            ColumnType::Currency,
+            [
+                RowValue::Currency { scaled: i64::MAX },
+                RowValue::Currency { scaled: i64::MIN },
+            ],
+            vec![
+                vec![0x7f, 0, 0, 0, 0, 0, 0, 0, 0],
+                vec![0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+            ],
+        ),
+        (
+            ColumnType::Single,
+            [RowValue::Single(1.0), RowValue::Single(-1.0)],
+            vec![
+                vec![0x7f, 0x40, 0x7f, 0xff, 0xff],
+                vec![0x7f, 0xbf, 0x80, 0, 0],
+            ],
+        ),
+        (
+            ColumnType::Double,
+            [RowValue::Double(1.0), RowValue::Double(-1.0)],
+            vec![
+                vec![0x7f, 0x40, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+                vec![0x7f, 0xbf, 0xf0, 0, 0, 0, 0, 0, 0],
+            ],
+        ),
+    ] {
+        for direction in [IndexDirection::Ascending, IndexDirection::Descending] {
+            let directory = TestDirectory::create()?;
+            let indexes = [IndexSpec {
+                fields: &[field(0, direction)],
+                ..one_index(IndexKind::Unique)[0]
+            }];
+            let table = TableSpec {
+                name: b"Items",
+                columns: &[ColumnSpec::new(b"Value", column)],
+                indexes: &indexes,
+            };
+            create_database_with_rows(
+                directory.target(),
+                &table,
+                &[&[values[0]], &[values[1]]],
+                &mut budget(),
+            )?;
+            let actual = tree(&directory.target())?;
+            let mut expected = ascending.clone();
+            let slots = if direction == IndexDirection::Ascending {
+                [1, 0]
+            } else {
+                [0, 1]
+            };
+            if direction == IndexDirection::Descending {
+                for key in &mut expected {
+                    for byte in key {
+                        *byte ^= 0xff;
+                    }
+                }
+                expected.reverse();
+            }
+            assert_eq!(actual.entries().len(), 2);
+            for ((entry, key), slot) in actual.entries().iter().zip(expected).zip(slots) {
+                assert_eq!(entry.key().raw_bytes(), key);
+                assert_eq!(entry.row().slot(), slot);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn nullable_numeric_composites_reuse_full_key_policy_and_scalar_duplicate_error() -> TestResult {
+    let columns = [
+        ColumnSpec::new(b"A", ColumnType::Currency),
+        ColumnSpec::new(b"B", ColumnType::Double),
+    ];
+    let fields = [
+        field(0, IndexDirection::Ascending),
+        field(1, IndexDirection::Descending),
+    ];
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Null, RowValue::Null],
+        &[RowValue::Null, RowValue::Double(1.0)],
+        &[RowValue::Null, RowValue::Double(1.0)],
+        &[RowValue::Currency { scaled: 1 }, RowValue::Null],
+        &[RowValue::Currency { scaled: 1 }, RowValue::Double(2.0)],
+    ];
+    for policy in [
+        crate::IndexNullPolicy::Include,
+        crate::IndexNullPolicy::IgnoreAllNull,
+        crate::IndexNullPolicy::Required,
+    ] {
+        let directory = TestDirectory::create()?;
+        let indexes = [IndexSpec {
+            name: b"ByKey",
+            kind: IndexKind::Unique.with_null_policy(policy),
+            fields: &fields,
+        }];
+        let table = TableSpec {
+            name: b"Items",
+            columns: &columns,
+            indexes: &indexes,
+        };
+        let result = create_database_with_rows(directory.target(), &table, rows, &mut budget());
+        if policy == crate::IndexNullPolicy::Required {
+            assert!(matches!(
+                result,
+                Err(CreateDatabaseError::Compose(
+                    ComposeError::NullInitialIndexKey { row: 0 }
+                ))
+            ));
+            assert!(directory.entries()?.is_empty());
+            continue;
+        }
+        result?;
+        let index = tree(&directory.target())?;
+        assert_eq!(
+            index.entries().len(),
+            if policy == crate::IndexNullPolicy::Include {
+                5
+            } else {
+                4
+            }
+        );
+        assert_eq!(
+            index.entries()[0].key().raw_bytes(),
+            [0, 0x80, 0x40, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+        );
+        fs::remove_file(directory.target())?;
+        assert!(matches!(
+            create_database_with_rows(
+                directory.target(),
+                &table,
+                &[rows[4], rows[4]],
+                &mut budget()
+            ),
+            Err(CreateDatabaseError::Compose(
+                ComposeError::DuplicateInitialScalarIndexKey
+            ))
+        ));
+        assert!(directory.entries()?.is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn wide_numeric_components_pack_across_leaf_boundaries() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let fields = [
+        field(0, IndexDirection::Ascending),
+        field(1, IndexDirection::Descending),
+    ];
+    let indexes = [IndexSpec {
+        name: b"ByKey",
+        kind: IndexKind::Unique,
+        fields: &fields,
+    }];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[
+            ColumnSpec::new(b"A", ColumnType::Currency),
+            ColumnSpec::new(b"B", ColumnType::Double),
+        ],
+        indexes: &indexes,
+    };
+    let values: Vec<_> = (0..170)
+        .map(|n| [RowValue::Currency { scaled: n }, RowValue::Double(n as f64)])
+        .collect();
+    let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+    create_database_with_rows(directory.target(), &table, &rows, &mut budget())?;
+    let index = tree(&directory.target())?;
+    assert_eq!(index.entries().len(), 170);
+    assert!(index.nodes().len() > 1);
+    assert!(
+        index
+            .entries()
+            .iter()
+            .all(|entry| entry.key().raw_bytes().len() == 18)
+    );
+    assert!(
+        index
+            .entries()
+            .windows(2)
+            .all(|pair| pair[0].key().raw_bytes() < pair[1].key().raw_bytes())
+    );
+    Ok(())
+}
+
+#[test]
+fn excluded_scalar_values_and_types_never_publish() -> TestResult {
+    for (column, value) in [
+        (ColumnType::Boolean, RowValue::Null),
+        (ColumnType::Single, RowValue::Single(-0.0)),
+        (ColumnType::Single, RowValue::Single(f32::INFINITY)),
+        (ColumnType::Single, RowValue::Single(f32::NAN)),
+        (ColumnType::Double, RowValue::Double(-0.0)),
+        (ColumnType::Double, RowValue::Double(f64::NEG_INFINITY)),
+        (ColumnType::Double, RowValue::Double(f64::NAN)),
+        (ColumnType::DateTime, RowValue::DateTime { days: 1.0 }),
+        (ColumnType::Guid, RowValue::Guid([0; 16])),
+    ] {
+        let directory = TestDirectory::create()?;
+        let table = TableSpec {
+            name: b"Items",
+            columns: &[ColumnSpec::new(b"Value", column)],
+            indexes: &one_index(IndexKind::Ordinary),
+        };
+        assert!(
+            create_database_with_rows(directory.target(), &table, &[&[value]], &mut budget())
+                .is_err()
+        );
+        assert!(directory.entries()?.is_empty());
+    }
+    Ok(())
+}

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -71,6 +71,7 @@ pub mod long_value;
 pub mod long_value_map;
 mod long_value_writer;
 pub mod map_location;
+mod numeric_index_key;
 pub mod offset;
 pub mod page;
 mod page_append_plan;

--- a/crates/jet3/src/numeric_index_key.rs
+++ b/crates/jet3/src/numeric_index_key.rs
@@ -1,0 +1,161 @@
+//! Numeric component transforms observed in EXP-0126/0150.
+//!
+//! Non-Long nullable/composite construction is a candidate generalization of
+//! EXP-0148. Negative zero and nonfinite floating values remain unsupported.
+use crate::{ColumnType, IndexDirection, RowValue};
+
+pub(crate) const MAX_COMPONENT_BYTES: usize = 9;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NumericKeyType {
+    Boolean,
+    Byte,
+    Integer,
+    Long,
+    Currency,
+    Single,
+    Double,
+}
+
+impl NumericKeyType {
+    pub(crate) fn from_column(column: ColumnType) -> Option<Self> {
+        Some(match column {
+            ColumnType::Boolean => Self::Boolean,
+            ColumnType::Byte => Self::Byte,
+            ColumnType::Integer => Self::Integer,
+            ColumnType::Long | ColumnType::AutoIncrement => Self::Long,
+            ColumnType::Currency => Self::Currency,
+            ColumnType::Single => Self::Single,
+            ColumnType::Double => Self::Double,
+            _ => return None,
+        })
+    }
+
+    pub(crate) fn encode(
+        self,
+        value: RowValue<'_>,
+        direction: IndexDirection,
+        output: &mut [u8; MAX_COMPONENT_BYTES],
+    ) -> Option<usize> {
+        output.fill(0);
+        output[0] = 0x7f;
+        let length = match (self, value) {
+            (Self::Boolean, RowValue::Null) => return None,
+            (_, RowValue::Null) => {
+                output[0] = 0;
+                1
+            }
+            (Self::Boolean, RowValue::Boolean(value)) => {
+                output[1] = if value { 0 } else { 0xff };
+                2
+            }
+            (Self::Byte, RowValue::Byte(value)) => {
+                output[1] = value;
+                2
+            }
+            (Self::Integer, RowValue::Integer(value)) => {
+                output[1..3].copy_from_slice(&value.to_be_bytes());
+                output[1] ^= 0x80;
+                3
+            }
+            (Self::Long, RowValue::Long(value)) => {
+                output[..5].copy_from_slice(&crate::long_index_key::encode(
+                    value,
+                    IndexDirection::Ascending,
+                ));
+                5
+            }
+            (Self::Currency, RowValue::Currency { scaled }) => {
+                output[1..9].copy_from_slice(&scaled.to_be_bytes());
+                output[1] ^= 0x80;
+                9
+            }
+            (Self::Single, RowValue::Single(value))
+                if value.is_finite() && value.to_bits() != 0x8000_0000 =>
+            {
+                let bits = value.to_bits();
+                let ordered = if value.is_sign_negative() {
+                    !bits
+                } else {
+                    bits ^ 0x8000_0000
+                };
+                output[1..5].copy_from_slice(&ordered.to_be_bytes());
+                5
+            }
+            (Self::Double, RowValue::Double(value))
+                if value.is_finite() && value.to_bits() != 0x8000_0000_0000_0000 =>
+            {
+                let bits = value.to_bits();
+                let ordered = if value.is_sign_negative() {
+                    !bits
+                } else {
+                    bits ^ 0x8000_0000_0000_0000
+                };
+                output[1..9].copy_from_slice(&ordered.to_be_bytes());
+                9
+            }
+            _ => return None,
+        };
+        if direction == IndexDirection::Descending {
+            for byte in &mut output[..length] {
+                *byte ^= 0xff;
+            }
+        }
+        Some(length)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floating_zero_subnormals_normals_and_extremes_order_exactly() {
+        let mut output = [0; MAX_COMPONENT_BYTES];
+        for (value, expected) in [
+            (0.0_f32, [0x7f, 0x80, 0, 0, 0]),
+            (f32::from_bits(1), [0x7f, 0x80, 0, 0, 1]),
+            (f32::MIN_POSITIVE, [0x7f, 0x80, 0x80, 0, 0]),
+            (-f32::MAX, [0x7f, 0, 0x80, 0, 0]),
+            (f32::MAX, [0x7f, 0xff, 0x7f, 0xff, 0xff]),
+        ] {
+            assert_eq!(
+                NumericKeyType::Single.encode(
+                    RowValue::Single(value),
+                    IndexDirection::Ascending,
+                    &mut output
+                ),
+                Some(5)
+            );
+            assert_eq!(output[..5], expected);
+        }
+        for (value, expected) in [
+            (0.0_f64, [0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0]),
+            (f64::from_bits(1), [0x7f, 0x80, 0, 0, 0, 0, 0, 0, 1]),
+            (f64::MIN_POSITIVE, [0x7f, 0x80, 0x10, 0, 0, 0, 0, 0, 0]),
+            (-f64::MAX, [0x7f, 0, 0x10, 0, 0, 0, 0, 0, 0]),
+            (
+                f64::MAX,
+                [0x7f, 0xff, 0xef, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+            ),
+        ] {
+            assert_eq!(
+                NumericKeyType::Double.encode(
+                    RowValue::Double(value),
+                    IndexDirection::Ascending,
+                    &mut output
+                ),
+                Some(9)
+            );
+            assert_eq!(output, expected);
+        }
+        assert_eq!(
+            NumericKeyType::Integer.encode(
+                RowValue::Long(1),
+                IndexDirection::Ascending,
+                &mut output
+            ),
+            None
+        );
+    }
+}


### PR DESCRIPTION
Extend initial indexes beyond Long with typed Boolean, Byte, Integer, Currency and finite Single/Double components. Retain bounded variable-width tree packing, existing Long duplicate errors and null policies, with explicit refusals for negative zero, nonfinite floats and unsupported types.

Validation: independent parser review; five numeric and 25 initial-index tests, Clippy and just ready passed. Non-Long nullable/composite DAO acceptance is tracked separately.

Refs #100.
