### PR TITLE
feat: append a bounded data page for existing-table insertion

### DIFF
--- a/crates/jet3/src/insert.rs
+++ b/crates/jet3/src/insert.rs
@@ -8,17 +8,20 @@ use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::path::Path;
 
-/// Appends an encoded row to an existing populated, owned and available data page.
+/// Inserts an encoded row on a populated available page or one new EOF page.
 ///
 /// Values use the existing checked scalar/Text/Binary row encoder, including null
 /// and Boolean fields. AutoIncrement, long values, indexes and relationships are
-/// refused. Owned/available maps must be inline. No slot reuse, compaction, page
-/// allocation or empty-table insertion is implemented. The selected page must
+/// refused. If no populated page fits, including an empty table, one EOF page is
+/// appended only within existing inline global/owned/available maps. No reuse,
+/// map growth or compaction is implemented. An existing selected page must
 /// retain capacity for one more equal-sized row and representable directory slot;
 /// this is a candidate restriction, not a DAO free-space threshold.
 ///
 /// Only the new row, appended slot, page free/count fields and table row count
-/// change. All other bytes, including page zero and maps, remain exact. This
+/// change on existing-page insertion. EOF insertion also clears its global free
+/// bit and sets owned/available bits, marking available when a minimum encoded
+/// row still fits. All other bytes, including page zero, remain exact. This
 /// construction requires separate DAO validation and makes no compatibility claim.
 /// Callers must exclude external writers throughout this Unix-only operation.
 /// A pre-publication failure preserves the original; publication errors identify
@@ -107,9 +110,6 @@ where
                 .ok_or(UpdateError::Mismatch("row count overflow"))?;
         }
     }
-    if observed_rows == 0 {
-        return Err(UpdateError::Unsupported("empty-table insertion"));
-    }
     let mut source_definition = [0; PAGE_BYTES];
     database.read_raw_page(definition.root(), &mut source_definition, budget)?;
     let patched_definition =
@@ -136,9 +136,7 @@ where
             .next_page(budget)
             .map_err(UpdateError::Allocation)?
         else {
-            return Err(UpdateError::Unsupported(
-                "no populated page with retained row capacity",
-            ));
+            break None;
         };
         let mut owned_pages = owned.allocated_pages(geometry);
         let mut member = false;
@@ -159,8 +157,40 @@ where
             &encoded[..length],
             budget,
         )? {
-            break (page, patched, slot);
+            break Some((page, patched, slot));
         }
+    };
+    let Some(selected) = selected else {
+        let mut minimum = [0; PAGE_BYTES];
+        let nulls = [RowValue::Null; u8::MAX as usize];
+        let minimum_length = crate::encode_row(
+            &layout[..columns.len()],
+            &nulls[..columns.len()],
+            &mut minimum,
+            budget,
+        )?
+        .get() as usize;
+        let plan = crate::row_insert_eof::plan(
+            &mut database,
+            &definition,
+            &encoded[..length],
+            &minimum[..minimum_length],
+            budget,
+        )?;
+        let (changes, count) = plan.changes(crate::update_pages::PageChange {
+            page: definition.root(),
+            before: &source_definition,
+            after: patched_definition.as_bytes(),
+        });
+        crate::update_pages::publish_changes_with_append(
+            path,
+            database.into_source(),
+            &changes[..count],
+            Some(plan.image.as_bytes()),
+            budget,
+            hook,
+        )?;
+        return Ok(RowLocator::new(plan.page, 0));
     };
     crate::update_pages::publish_changes(
         path,

--- a/crates/jet3/src/insert_eof_tests.rs
+++ b/crates/jet3/src/insert_eof_tests.rs
@@ -1,0 +1,342 @@
+use super::*;
+
+type MapRecords = [(MapRowLocator, std::ops::Range<usize>); 3];
+fn maps(f: &Fixture) -> Result<MapRecords, Box<dyn StdError>> {
+    let mut b = budget();
+    let mut db = DatabaseReader::open(f.path(), &mut b)?;
+    let def = db.table_definition(f.root, &mut b)?;
+    let locators = [
+        MapRowLocator::new(PageNumber::new(1), 0),
+        def.maps().owned(),
+        def.maps().available(),
+    ];
+    let mut result = std::array::from_fn(|i| (locators[i], 0..0));
+    for (locator, range) in &mut result {
+        let mut bytes = [0; PAGE_BYTES];
+        let page = db.read_classified_page(locator.page(), &mut bytes, &mut b)?;
+        *range = crate::locate_usage_map(page, *locator, &mut b)?.range();
+    }
+    Ok(result)
+}
+
+#[test]
+fn empty_and_full_pages_append_exactly_one_page_then_reuse_it() -> TestResult {
+    for full in [false, true] {
+        let text = [b'z'; 180];
+        let columns = [
+            ColumnSpec::new(b"Id", ColumnType::Long),
+            ColumnSpec::new(b"Value", ColumnType::Long),
+            ColumnSpec::new(
+                b"Text",
+                ColumnType::Text {
+                    max_len: crate::column_definition_writer::nz(255),
+                },
+            ),
+        ];
+        let values: Vec<_> = (0..if full { 10 } else { 0 })
+            .map(|i| [RowValue::Long(i), RowValue::Long(-i), RowValue::Text(&text)])
+            .collect();
+        let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+        let f = Fixture::new(&columns, &rows)?;
+        let map_records = maps(&f)?;
+        let before = fs::read(f.path())?;
+        let page = before.len() / PAGE_BYTES;
+        let locator = insert_row(
+            f.path(),
+            b"Rows",
+            &[
+                RowValue::Long(88),
+                RowValue::Long(-8800),
+                RowValue::Text(&text),
+            ],
+            &mut budget(),
+        )?;
+        assert_eq!(locator, RowLocator::new(PageNumber::new(page as u64), 0));
+        let mut expected = before.clone();
+        let root = f.root.get() as usize * PAGE_BYTES;
+        expected[root + 12..root + 16]
+            .copy_from_slice(&(if full { 11_u32 } else { 1 }).to_le_bytes());
+        for (role, (locator, range)) in map_records.iter().enumerate() {
+            let offset = locator.page().get() as usize * PAGE_BYTES + range.start + 5 + page / 8;
+            if role == 0 {
+                expected[offset] &= !(1 << (page % 8));
+            } else {
+                expected[offset] |= 1 << (page % 8);
+            }
+        }
+        let mut new_page = [0_u8; PAGE_BYTES];
+        new_page[0..4].copy_from_slice(&[1, 1, 0x33, 0x07]); // 1843 contiguous free bytes.
+        new_page[4..8].copy_from_slice(&(f.root.get() as u32).to_le_bytes());
+        new_page[8..12].copy_from_slice(&[1, 0, 0x3f, 0x07]); // Slot 0 starts at 1855.
+        new_page[1855..1864].copy_from_slice(&[3, 88, 0, 0, 0, 0xa0, 0xdd, 0xff, 0xff]);
+        new_page[1864..2044].copy_from_slice(&text);
+        new_page[2044..].copy_from_slice(&[189, 9, 1, 7]);
+        expected.extend_from_slice(&new_page);
+        assert_eq!(fs::read(f.path())?, expected);
+        let second = insert_row(
+            f.path(),
+            b"Rows",
+            &[
+                RowValue::Long(99),
+                RowValue::Long(-9900),
+                RowValue::Text(&text),
+            ],
+            &mut budget(),
+        )?;
+        assert_eq!(second, RowLocator::new(locator.page(), 1));
+        assert_eq!(fs::metadata(f.path())?.len(), expected.len() as u64);
+        let mut b = budget();
+        let mut db = DatabaseReader::open(f.path(), &mut b)?;
+        let def = db.table_definition(f.root, &mut b)?;
+        let mut reader = db.rows(&def, &mut b)?;
+        let mut count = 0;
+        while reader.next_row()?.is_some() {
+            count += 1;
+        }
+        assert_eq!(count, if full { 12 } else { 2 });
+        f.clean()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn eof_map_coverage_free_bit_and_aliases_refuse_without_publication() -> TestResult {
+    let f = Fixture::longs(0)?;
+    let records = maps(&f)?;
+    let original = fs::read(f.path())?;
+    let page = original.len() / PAGE_BYTES;
+    let root = f.root.get() as usize * PAGE_BYTES;
+    let global = records[0].0.page().get() as usize * PAGE_BYTES + records[0].1.start;
+    let mut corruptions = Vec::new();
+    let mut in_use = original.clone();
+    in_use[global + 5 + page / 8] &= !(1 << (page % 8));
+    corruptions.push(in_use);
+    let mut out_of_range = original.clone();
+    out_of_range[global + 1..global + 5].copy_from_slice(&((page + 1) as u32).to_le_bytes());
+    corruptions.push(out_of_range);
+    let mut indirect = original.clone();
+    indirect[global] = 1;
+    corruptions.push(indirect);
+    let mut alias = original.clone();
+    let owned: [u8; 4] = alias[root + 35..root + 39].try_into()?;
+    alias[root + 39..root + 43].copy_from_slice(&owned);
+    corruptions.push(alias);
+    let mut missing = original.clone();
+    missing[root + 35] = 254;
+    corruptions.push(missing);
+    for bad in corruptions {
+        fs::write(f.path(), &bad)?;
+        assert!(
+            insert_row(
+                f.path(),
+                b"Rows",
+                &[RowValue::Long(1), RowValue::Long(2)],
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(f.path())?, bad);
+        f.clean()?;
+    }
+    // Both owned and available can reside on one page, but not in the same record.
+    assert_eq!(records[1].0.page(), records[2].0.page());
+    fs::write(f.path(), &original)?;
+    insert_row(
+        f.path(),
+        b"Rows",
+        &[RowValue::Long(1), RowValue::Long(2)],
+        &mut budget(),
+    )?;
+    f.clean()
+}
+
+#[test]
+fn last_inline_bit_is_allowed_but_map_growth_is_refused() -> TestResult {
+    let f = Fixture::longs(0)?;
+    let original = fs::read(f.path())?;
+    for pages in [1023_usize, 1024] {
+        let mut before = original.clone();
+        before.resize(pages * PAGE_BYTES, 0xb6);
+        fs::write(f.path(), &before)?;
+        let result = insert_row(
+            f.path(),
+            b"Rows",
+            &[RowValue::Long(1), RowValue::Long(2)],
+            &mut budget(),
+        );
+        if pages == 1023 {
+            assert_eq!(result?, RowLocator::new(PageNumber::new(1023), 0));
+            assert_eq!(fs::metadata(f.path())?.len(), 1024 * PAGE_BYTES as u64);
+        } else {
+            assert!(matches!(
+                result,
+                Err(UpdateError::Unsupported("EOF outside existing inline map"))
+            ));
+            assert_eq!(fs::read(f.path())?, before);
+        }
+        f.clean()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn eof_budget_and_private_append_corruption_preserve_original() -> TestResult {
+    let f = Fixture::longs(0)?;
+    let before = fs::read(f.path())?;
+    for limits in [
+        ResourceLimits::new(crate::ReadLimits::new(
+            ByteCount::new(before.len() as u64),
+            crate::limits::DEFAULT_MAX_SINGLE_READ_BYTES,
+            crate::limits::DEFAULT_MAX_TOTAL_READ_BYTES,
+        )),
+        ResourceLimits::default().with_max_encoded_bytes(ByteCount::new(PAGE_BYTES as u64)),
+        ResourceLimits::default().with_max_total_work_units(1),
+    ] {
+        assert!(
+            insert_row(
+                f.path(),
+                b"Rows",
+                &[RowValue::Long(1), RowValue::Long(2)],
+                &mut ResourceBudget::new(limits)
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(f.path())?, before);
+        f.clean()?;
+    }
+    for failure_stage in [PublishStage::Mutation, PublishStage::PrePublish] {
+        let error = insert_with_hook(
+            &f.path(),
+            b"Rows",
+            &[RowValue::Long(1), RowValue::Long(2)],
+            &mut budget(),
+            |stage| {
+                if stage == failure_stage {
+                    Err(std::io::Error::other("injected publication failure"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+        assert!(
+            matches!(error, Err(UpdateError::Publish(error)) if error.stage() == failure_stage)
+        );
+        assert_eq!(fs::read(f.path())?, before);
+        f.clean()?;
+    }
+    for mode in 0..4 {
+        let error = insert_with_hook(
+            &f.path(),
+            b"Rows",
+            &[RowValue::Long(1), RowValue::Long(2)],
+            &mut budget(),
+            |stage| -> Result<(), std::io::Error> {
+                if stage == PublishStage::Validation {
+                    for entry in fs::read_dir(&f.directory)? {
+                        let path = entry?.path();
+                        if path != f.path() {
+                            let mut bytes = fs::read(&path)?;
+                            match mode {
+                                0 => bytes[before.len() + 100] ^= 1,
+                                1 => {
+                                    bytes.pop();
+                                }
+                                2 => bytes.push(0),
+                                _ => bytes[64] ^= 1,
+                            }
+                            fs::write(path, bytes)?;
+                        }
+                    }
+                }
+                Ok(())
+            },
+        );
+        assert!(
+            matches!(error,Err(UpdateError::Publish(e)) if e.stage()==PublishStage::Validation)
+        );
+        assert_eq!(fs::read(f.path())?, before);
+        f.clean()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn later_table_ownership_and_minimum_row_availability() -> TestResult {
+    let mut f = Fixture::longs(0)?;
+    fs::remove_file(f.path())?;
+    let first_columns = [ColumnSpec::new(b"Id", ColumnType::Long)];
+    let names: [&[u8]; 7] = [b"A", b"B", b"C", b"D", b"E", b"F", b"G"];
+    let columns = names.map(|name| {
+        ColumnSpec::new(
+            name,
+            ColumnType::FixedText {
+                len: crate::column_definition_writer::nz(255),
+            },
+        )
+    });
+    crate::create_database_with_table_rows(
+        f.path(),
+        &[
+            crate::TableRows {
+                table: TableSpec {
+                    name: b"First",
+                    columns: &first_columns,
+                    indexes: &[],
+                },
+                rows: &[&[RowValue::Long(42)]],
+            },
+            crate::TableRows {
+                table: TableSpec {
+                    name: b"Rows",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                rows: &[],
+            },
+        ],
+        &mut budget(),
+    )?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(f.path(), &mut b)?;
+    f.root = crate::update::writable_table(&mut db, b"Rows", &mut b)?.root();
+    drop(db);
+    let records = maps(&f)?;
+    let before = fs::read(f.path())?;
+    let text = [b'x'; 255];
+    let locator = insert_row(
+        f.path(),
+        b"Rows",
+        &[RowValue::Text(&text); 7],
+        &mut budget(),
+    )?;
+    assert_eq!(
+        locator.page().get(),
+        before.len() as u64 / PAGE_BYTES as u64
+    );
+    let after = fs::read(f.path())?;
+    let page = locator.page().get() as usize;
+    assert_eq!(
+        &after[page * PAGE_BYTES + 4..page * PAGE_BYTES + 8],
+        &(f.root.get() as u32).to_le_bytes()
+    );
+    let mut expected = before.clone();
+    let root = f.root.get() as usize * PAGE_BYTES;
+    expected[root + 12..root + 16].copy_from_slice(&1_u32.to_le_bytes());
+    for (role, (location, range)) in records.iter().enumerate() {
+        let offset = location.page().get() as usize * PAGE_BYTES + range.start + 5 + page / 8;
+        if role == 0 {
+            expected[offset] &= !(1 << (page % 8));
+        }
+        if role == 1 {
+            expected[offset] |= 1 << (page % 8);
+        }
+        if role == 2 {
+            assert_eq!(after[offset] & (1 << (page % 8)), 0);
+        }
+    }
+    assert_eq!(&after[..before.len()], expected);
+    // A second fixed-width row needs another EOF page; the first is not advertised available.
+    let second = insert_row(f.path(), b"Rows", &[RowValue::Null; 7], &mut budget())?;
+    assert_eq!(second.page().get(), locator.page().get() + 1);
+    f.clean()
+}

--- a/crates/jet3/src/insert_tests.rs
+++ b/crates/jet3/src/insert_tests.rs
@@ -334,18 +334,6 @@ fn unsupported_tables_and_available_map_membership_are_refused() -> TestResult {
         ));
         assert_eq!(fs::read(f.path())?, original);
     }
-    let empty = Fixture::longs(0)?;
-    let original = fs::read(empty.path())?;
-    assert!(matches!(
-        insert_row(
-            empty.path(),
-            b"Rows",
-            &[RowValue::Long(1), RowValue::Long(2)],
-            &mut budget()
-        ),
-        Err(UpdateError::Unsupported("empty-table insertion"))
-    ));
-    assert_eq!(fs::read(empty.path())?, original);
     let f = Fixture::longs(4)?;
     let mut b = budget();
     let mut db = DatabaseReader::open(f.path(), &mut b)?;
@@ -356,14 +344,12 @@ fn unsupported_tables_and_available_map_membership_are_refused() -> TestResult {
     let range = crate::locate_usage_map(page, locator, &mut b)?.range();
     drop(db);
     let original = fs::read(f.path())?;
-    for foreign in [false, true] {
+    {
         let mut bad = original.clone();
         let base = locator.page().get() as usize * PAGE_BYTES;
-        // EXP-0057 inline bitmap: either empty or an unowned in-file page.
+        // EXP-0057 inline bitmap: an unowned in-file page.
         bad[base + range.start + 5..base + range.end].fill(0);
-        if foreign {
-            bad[base + range.start + 5] = 1;
-        }
+        bad[base + range.start + 5] = 1;
         fs::write(f.path(), &bad)?;
         assert!(
             insert_row(
@@ -410,3 +396,6 @@ fn physical_slot_limit_and_table_count_overflow_are_structured() -> TestResult {
     ));
     Ok(())
 }
+
+#[path = "insert_eof_tests.rs"]
+mod eof;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -81,6 +81,7 @@ pub mod resource;
 pub mod row;
 mod row_delete_page;
 pub mod row_directory;
+mod row_insert_eof;
 mod row_insert_page;
 pub mod row_writer;
 pub mod source;

--- a/crates/jet3/src/row_insert_eof.rs
+++ b/crates/jet3/src/row_insert_eof.rs
@@ -1,0 +1,144 @@
+//! Single EOF allocation: SRC-0020/EXP-0057 map framing and EXP-0051 free bits;
+//! EXP-0065 Q2 clears the new EOF bit. Row packing uses EXP-0060/EXP-0116.
+use crate::allocation::{AllocationMapLayout, decode_allocation_map_layout};
+use crate::update_pages::PageChange;
+use crate::{
+    DatabaseReader, FileSource, MapRowLocator, PAGE_BYTES, PageImage, PageImageError, PageNumber,
+    PageOffset, ResourceBudget, TableDefinition, UpdateError,
+};
+
+struct MapPage {
+    page: PageNumber,
+    before: [u8; PAGE_BYTES],
+    after: PageImage,
+}
+
+pub(crate) struct EofInsert {
+    pub page: PageNumber,
+    pub image: PageImage,
+    maps: [MapPage; 3],
+    count: usize,
+}
+
+impl EofInsert {
+    pub fn changes<'a>(&'a self, definition: PageChange<'a>) -> ([PageChange<'a>; 4], usize) {
+        let mut changes = [definition; 4];
+        for (change, map) in changes.iter_mut().skip(1).zip(&self.maps[..self.count]) {
+            *change = PageChange {
+                page: map.page,
+                before: &map.before,
+                after: map.after.as_bytes(),
+            };
+        }
+        (changes, self.count + 1)
+    }
+}
+
+fn page_error(error: PageImageError) -> UpdateError {
+    match error {
+        PageImageError::Encoding(error) => UpdateError::Resource(error),
+        _ => UpdateError::Unsupported("row or owner does not fit new data page"),
+    }
+}
+
+pub(crate) fn plan(
+    database: &mut DatabaseReader<FileSource>,
+    definition: &TableDefinition,
+    encoded: &[u8],
+    minimum: &[u8],
+    budget: &mut ResourceBudget,
+) -> Result<EofInsert, UpdateError> {
+    let page = PageNumber::new(database.geometry().page_count());
+    // Map references to data pages must remain representable by Jet's u24 locators.
+    if page.get() > 0x00ff_ffff {
+        return Err(UpdateError::Unsupported("EOF page reference width"));
+    }
+    let mut builder = crate::DataPageBuilder::new(definition.root(), budget).map_err(page_error)?;
+    builder.append_row(encoded, budget).map_err(page_error)?;
+    let free = u16::try_from(builder.free_bytes().get())
+        .map_err(|_| UpdateError::Mismatch("new data page free bytes"))?;
+    // The same candidate policy as initial creation: physically fit a minimum row.
+    let available = match builder.clone().append_row(minimum, budget) {
+        Ok(_) => true,
+        Err(PageImageError::PageFull { .. } | PageImageError::RowSlotsExhausted { .. }) => false,
+        Err(error) => return Err(page_error(error)),
+    };
+    let mut image = builder.finish();
+    let [lo, hi] = free.to_le_bytes();
+    image.write_at(PageOffset::new(1), &[1, lo, hi], budget)?;
+    let mut result = EofInsert {
+        page,
+        image,
+        maps: std::array::from_fn(|_| MapPage {
+            page: PageNumber::new(0),
+            before: [0; PAGE_BYTES],
+            after: PageImage::from_bytes([0; PAGE_BYTES]),
+        }),
+        count: 0,
+    };
+    // EXP-0051 identifies the global free-page map at page 1, row 0.
+    let locators = [
+        MapRowLocator::new(PageNumber::new(1), 0),
+        definition.maps().owned(),
+        definition.maps().available(),
+    ];
+    let mut ranges = std::array::from_fn::<_, 3, _>(|_| 0..0);
+    for (role, locator) in locators.iter().copied().enumerate() {
+        if locator.page() == definition.root() || locators[..role].contains(&locator) {
+            return Err(UpdateError::Mismatch(
+                "overlapping allocation map references",
+            ));
+        }
+        let index = match result.maps[..result.count]
+            .iter()
+            .position(|m| m.page == locator.page())
+        {
+            Some(index) => index,
+            None => {
+                let index = result.count;
+                let map = &mut result.maps[index];
+                map.page = locator.page();
+                database.read_raw_page(map.page, &mut map.before, budget)?;
+                map.after = PageImage::from_bytes(map.before);
+                result.count += 1;
+                index
+            }
+        };
+        let map = &mut result.maps[index];
+        let classified = database
+            .read_classified_page(locator.page(), &mut map.before, budget)
+            .map_err(crate::TableDefinitionError::Page)?;
+        let record =
+            crate::locate_usage_map(classified, locator, budget).map_err(UpdateError::UsageMap)?;
+        let range = record.range();
+        if (0..role).any(|prior| {
+            locators[prior].page() == locator.page()
+                && range.start < ranges[prior].end
+                && ranges[prior].start < range.end
+        }) {
+            return Err(UpdateError::Mismatch("overlapping allocation map records"));
+        }
+        ranges[role] = range.clone();
+        let AllocationMapLayout::Inline { start_page, bitmap } =
+            decode_allocation_map_layout(record.raw(), budget).map_err(UpdateError::Allocation)?
+        else {
+            return Err(UpdateError::Unsupported("indirect EOF allocation map"));
+        };
+        let bit = page
+            .get()
+            .checked_sub(start_page.get())
+            .filter(|bit| *bit / 8 < bitmap.len() as u64)
+            .ok_or(UpdateError::Unsupported("EOF outside existing inline map"))?;
+        let offset = range.start + bitmap.start + (bit / 8) as usize;
+        let mask = 1_u8 << (bit % 8);
+        let old = map.before[offset];
+        if (old & mask != 0) != (role == 0) {
+            return Err(UpdateError::Mismatch("EOF page already in use or owned"));
+        }
+        let set = role == 1 || (role == 2 && available);
+        let value = if set { old | mask } else { old & !mask };
+        map.after
+            .write_at(PageOffset::new(offset as u64), &[value], budget)?;
+    }
+    Ok(result)
+}

--- a/crates/jet3/src/update_pages.rs
+++ b/crates/jet3/src/update_pages.rs
@@ -1,4 +1,4 @@
-//! Existing-page publication with exact byte preservation; no page reconstruction.
+//! Exact prefix publication with an optional single planned EOF page.
 use crate::{
     ByteOffset, FileSource, PAGE_BYTES, PageNumber, PublishStage, ReadAt, ResourceBudget,
     UpdateError,
@@ -7,6 +7,7 @@ use std::error::Error as StdError;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 
+#[derive(Clone, Copy)]
 pub(crate) struct PageChange<'a> {
     pub page: PageNumber,
     pub before: &'a [u8; PAGE_BYTES],
@@ -15,7 +16,7 @@ pub(crate) struct PageChange<'a> {
 
 pub(crate) fn publish_changes<H, HE>(
     path: &Path,
-    mut original: FileSource,
+    original: FileSource,
     changes: &[PageChange<'_>],
     budget: &mut ResourceBudget,
     hook: H,
@@ -24,7 +25,39 @@ where
     H: FnMut(PublishStage) -> Result<(), HE>,
     HE: StdError + Send + Sync + 'static,
 {
+    publish_changes_with_append(path, original, changes, None, budget, hook)
+}
+
+pub(crate) fn publish_changes_with_append<H, HE>(
+    path: &Path,
+    mut original: FileSource,
+    changes: &[PageChange<'_>],
+    append: Option<&[u8; PAGE_BYTES]>,
+    budget: &mut ResourceBudget,
+    hook: H,
+) -> Result<(), UpdateError>
+where
+    H: FnMut(PublishStage) -> Result<(), HE>,
+    HE: StdError + Send + Sync + 'static,
+{
     let length = original.len();
+    let expected_length = if append.is_some() {
+        if !length.get().is_multiple_of(PAGE_BYTES as u64) {
+            return Err(UpdateError::Mismatch("unaligned append"));
+        }
+        budget.charge_encoded_bytes(crate::ByteCount::new(PAGE_BYTES as u64))?;
+        length
+            .get()
+            .checked_add(PAGE_BYTES as u64)
+            .ok_or(UpdateError::Mismatch("append length overflow"))?
+    } else {
+        length.get()
+    };
+    if append.is_some() {
+        budget
+            .read_budget()
+            .check_input(crate::ByteCount::new(expected_length))?;
+    }
     for (index, change) in changes.iter().enumerate() {
         let end = change
             .page
@@ -62,11 +95,16 @@ where
                     file.write_all(&change.after[start..offset])?;
                 }
             }
+            if let Some(image) = append {
+                budget.charge_work_units(PAGE_BYTES as u64)?;
+                file.seek(SeekFrom::Start(length.get()))?;
+                file.write_all(image)?;
+            }
             Ok(())
         },
         |private, budget| -> Result<(), UpdateError> {
             let mut candidate = FileSource::open(private, budget.read_budget())?;
-            if candidate.len() != length {
+            if candidate.len().get() != expected_length {
                 return Err(UpdateError::Mismatch("file length"));
             }
             let mut expected = [0; PAGE_BYTES];
@@ -97,6 +135,17 @@ where
                     return Err(UpdateError::Mismatch("unrelated or requested bytes"));
                 }
                 position += count as u64;
+            }
+            if let Some(image) = append {
+                candidate.read_exact_at(
+                    ByteOffset::new(length.get()),
+                    &mut actual,
+                    budget.read_budget(),
+                )?;
+                budget.charge_work_units(PAGE_BYTES as u64)?;
+                if &actual != image {
+                    return Err(UpdateError::Mismatch("appended page bytes"));
+                }
             }
             Ok(())
         },


### PR DESCRIPTION
Allow insert_row to populate an empty table or grow a full table by appending one data page where existing inline allocation maps cover EOF. Patch only the relevant map bits and count, preserve unrelated bytes, and verify the original prefix and appended page through the atomic publisher.

Map growth, page reuse, indirect maps, indexed/related tables and long values remain refused. DAO candidate validation is separate.

Validation: independent parser review; 45 focused insertion/update/delete/atomic tests, Clippy and just ready passed.

Refs #112.
