### PR TITLE
feat: compact existing rows while preserving physical slots

### DIFF
--- a/crates/jet3/src/delete.rs
+++ b/crates/jet3/src/delete.rs
@@ -1,4 +1,4 @@
-//! Bounded existing-row deletion using the tail transition observed in EXP-0162.
+//! Bounded existing-row deletion using the compaction observed in EXP-0162.
 use crate::{DatabaseReader, PAGE_BYTES, PublishStage, ResourceBudget, RowLocator, UpdateError};
 use std::convert::Infallible;
 use std::error::Error as StdError;
@@ -13,14 +13,17 @@ pub struct RowDelete<'a> {
     pub row: RowLocator,
 }
 
-/// Deletes the final physical row slot from a page containing at least two rows.
+/// Deletes one ordinary row from a page containing at least two live rows.
 ///
 /// Supports unindexed, relationship-free tables without AutoIncrement or long
-/// values. All slots on the affected page must be ordinary live rows, and the
-/// page must already appear in its inline available map. Non-tail compaction,
-/// tombstone reuse, page release and inconsistent free/count metadata are refused.
-/// The removed payload remains in unused space; every byte except the directory
-/// word, free-byte count and table row count is preserved, including page zero.
+/// values. Slots must be ordinary live rows or known empty `c000` tombstones;
+/// the page must already appear in its inline available map. Later rows move
+/// upward without changing their physical slot numbers or stored values. The
+/// deleted slot becomes an empty tombstone; existing tombstone flags are retained.
+/// Page release and inconsistent free/count metadata are refused.
+/// Only the shifted row bytes, affected directory offsets, free-byte count and
+/// table row count change. Vacated slack, maps, page zero and unrelated objects
+/// remain exact.
 /// Keeping page zero unchanged is a candidate construction awaiting DAO validation.
 /// This operation makes no DAO compatibility claim.
 ///
@@ -57,7 +60,7 @@ where
     }
     let mut source_page = [0; PAGE_BYTES];
     database.read_raw_page(request.row.page(), &mut source_page, budget)?;
-    let patched_page = crate::row_delete_page::tail(
+    let patched_page = crate::row_delete_page::remove(
         request.row.page(),
         definition.root(),
         &source_page,

--- a/crates/jet3/src/delete_compaction_tests.rs
+++ b/crates/jet3/src/delete_compaction_tests.rs
@@ -1,0 +1,264 @@
+use super::*;
+
+fn expected_delete(before: &[u8], f: &Fixture, slot: u8) -> Result<Vec<u8>, Box<dyn StdError>> {
+    let base = f.row.page().get() as usize * PAGE_BYTES;
+    let source: &[u8; PAGE_BYTES] = before[base..base + PAGE_BYTES].try_into()?;
+    let directory =
+        crate::row_directory::RowDirectory::validate(f.row.page(), f.root, source, &mut budget())?;
+    let mut expected = before.to_vec();
+    let mut end = PAGE_BYTES;
+    let mut live = 0_u32;
+    for ordinal in 0..directory.row_count() {
+        let entry = directory.entry(source, ordinal as u8)?;
+        let word = if ordinal == u16::from(slot) || entry.range().is_empty() {
+            end as u16 | 0xc000
+        } else {
+            let bytes = &source[entry.range()];
+            let start = end - bytes.len();
+            expected[base + start..base + end].copy_from_slice(bytes);
+            end = start;
+            live += 1;
+            start as u16
+        };
+        let offset = base + 10 + 2 * ordinal as usize;
+        expected[offset..offset + 2].copy_from_slice(&word.to_le_bytes());
+    }
+    expected[base + 2..base + 4]
+        .copy_from_slice(&((end - 10 - 2 * directory.row_count() as usize) as u16).to_le_bytes());
+    let root = f.root.get() as usize * PAGE_BYTES;
+    expected[root + 12..root + 16].copy_from_slice(&live.to_le_bytes());
+    Ok(expected)
+}
+
+type ObservedRows = Vec<(u8, Vec<u8>)>;
+fn observed(f: &Fixture) -> Result<ObservedRows, Box<dyn StdError>> {
+    let mut b = budget();
+    let mut db = DatabaseReader::open(f.path(), &mut b)?;
+    let definition = db.table_definition(f.root, &mut b)?;
+    let mut rows = db.rows(&definition, &mut b)?;
+    let mut values = Vec::new();
+    while let Some(row) = rows.next_row()? {
+        assert_eq!(row.locator(), row.storage_locator());
+        assert_eq!(row.locator().page(), f.row.page());
+        values.push((
+            row.locator().slot(),
+            row.field(crate::ColumnOrdinal::new(0))
+                .and_then(|v| v.raw_bytes())
+                .ok_or("missing Id")?
+                .to_vec(),
+        ));
+    }
+    Ok(values)
+}
+
+#[test]
+fn first_middle_and_tail_unequal_rows_preserve_slots_and_vacated_slack() -> ResultTest {
+    let f = Fixture::new(4)?;
+    fs::remove_file(f.path())?;
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(
+            b"Payload",
+            ColumnType::Text {
+                max_len: crate::column_definition_writer::nz(255),
+            },
+        ),
+    ];
+    let text = [b'x'; 255];
+    let values = [
+        [RowValue::Long(1), RowValue::Text(b"a")],
+        [RowValue::Long(2), RowValue::Text(&text[..170])],
+        [RowValue::Long(3), RowValue::Text(b"short")],
+        [RowValue::Long(4), RowValue::Text(&text)],
+    ];
+    let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+    crate::create_database_with_rows(
+        f.path(),
+        &TableSpec {
+            name: b"Rows",
+            columns: &columns,
+            indexes: &[],
+        },
+        &rows,
+        &mut budget(),
+    )?;
+    let before = fs::read(f.path())?;
+    for slot in [0, 1, 2, 3] {
+        fs::write(f.path(), &before)?;
+        delete_row(
+            f.path(),
+            RowDelete {
+                row: RowLocator::new(f.row.page(), slot),
+                ..f.request()
+            },
+            &mut budget(),
+        )?;
+        assert_eq!(fs::read(f.path())?, expected_delete(&before, &f, slot)?);
+        assert_eq!(
+            observed(&f)?,
+            (0..4_u8)
+                .filter(|i| *i != slot)
+                .map(|i| (i, (i as i32 + 1).to_le_bytes().to_vec()))
+                .collect::<Vec<_>>()
+        );
+        f.clean()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn repeated_deletions_shift_empty_tombstones_until_one_live_row_remains() -> ResultTest {
+    let f = Fixture::new(5)?;
+    let mut remaining = vec![0, 1, 2, 3, 4];
+    for slot in [1, 3, 0, 4] {
+        let before = fs::read(f.path())?;
+        delete_row(
+            f.path(),
+            RowDelete {
+                row: RowLocator::new(f.row.page(), slot),
+                ..f.request()
+            },
+            &mut budget(),
+        )?;
+        assert_eq!(fs::read(f.path())?, expected_delete(&before, &f, slot)?);
+        remaining.retain(|v| *v != slot);
+        assert_eq!(
+            observed(&f)?,
+            remaining
+                .iter()
+                .map(|v| (*v, (*v as i32).to_le_bytes().to_vec()))
+                .collect::<Vec<_>>()
+        );
+        let after = fs::read(f.path())?;
+        assert!(
+            delete_row(
+                f.path(),
+                RowDelete {
+                    row: RowLocator::new(f.row.page(), slot),
+                    ..f.request()
+                },
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(f.path())?, after);
+    }
+    let before = fs::read(f.path())?;
+    assert!(matches!(
+        delete_row(
+            f.path(),
+            RowDelete {
+                row: RowLocator::new(f.row.page(), 2),
+                ..f.request()
+            },
+            &mut budget()
+        ),
+        Err(UpdateError::Unsupported("sole-row page release"))
+    ));
+    assert_eq!(fs::read(f.path())?, before);
+    let inserted = crate::insert_row(
+        f.path(),
+        b"Rows",
+        &[RowValue::Long(99), RowValue::Long(-9900)],
+        &mut budget(),
+    )?;
+    assert_eq!(inserted, RowLocator::new(f.row.page(), 5));
+    let before = fs::read(f.path())?;
+    delete_row(
+        f.path(),
+        RowDelete {
+            row: RowLocator::new(f.row.page(), 2),
+            ..f.request()
+        },
+        &mut budget(),
+    )?;
+    assert_eq!(fs::read(f.path())?, expected_delete(&before, &f, 2)?);
+    assert_eq!(observed(&f)?, vec![(5, 99_i32.to_le_bytes().to_vec())]);
+    f.clean()
+}
+
+#[test]
+fn malformed_compaction_sources_and_nonempty_flags_preserve_original() -> ResultTest {
+    let f = Fixture::new(4)?;
+    let before = fs::read(f.path())?;
+    let base = f.row.page().get() as usize * PAGE_BYTES;
+    for (offset, word) in [
+        (12, 0xc7ec_u16),
+        (12, 0x87ec),
+        (12, 0x07f6),
+        (14, 0x07ff),
+        (12, 0x0001),
+        (12, 0xc800),
+        (2, 0),
+    ] {
+        let mut bad = before.clone();
+        bad[base + offset..base + offset + 2].copy_from_slice(&word.to_le_bytes());
+        fs::write(f.path(), &bad)?;
+        assert!(
+            delete_row(
+                f.path(),
+                RowDelete {
+                    row: RowLocator::new(f.row.page(), 0),
+                    ..f.request()
+                },
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(f.path())?, bad);
+        f.clean()?;
+    }
+    Ok(())
+}
+
+#[test]
+fn compaction_budget_and_full_private_verification_preserve_original() -> ResultTest {
+    let f = Fixture::new(4)?;
+    let request = RowDelete {
+        row: RowLocator::new(f.row.page(), 0),
+        ..f.request()
+    };
+    let before = fs::read(f.path())?;
+    let mut exact = budget();
+    delete_row(f.path(), request, &mut exact)?;
+    for limits in [
+        ResourceLimits::default()
+            .with_max_encoded_bytes(ByteCount::new(exact.encoded_bytes().get() - 1)),
+        ResourceLimits::default().with_max_total_work_units(exact.total_work_units() - 1),
+    ] {
+        fs::write(f.path(), &before)?;
+        assert!(delete_row(f.path(), request, &mut ResourceBudget::new(limits)).is_err());
+        assert_eq!(fs::read(f.path())?, before);
+        f.clean()?;
+    }
+    for offset in [
+        64,
+        f.row.page().get() as usize * PAGE_BYTES + 100,
+        f.row.page().get() as usize * PAGE_BYTES + 2020,
+    ] {
+        let error = delete_with_hook(
+            &f.path(),
+            request,
+            &mut budget(),
+            |stage| -> Result<(), std::io::Error> {
+                if stage == PublishStage::Validation {
+                    for entry in fs::read_dir(&f.directory)? {
+                        let path = entry?.path();
+                        if path != f.path() {
+                            let mut bytes = fs::read(&path)?;
+                            bytes[offset] ^= 1;
+                            fs::write(path, bytes)?;
+                        }
+                    }
+                }
+                Ok(())
+            },
+        );
+        assert!(
+            matches!(error,Err(UpdateError::Publish(e)) if e.stage()==PublishStage::Validation)
+        );
+        assert_eq!(fs::read(f.path())?, before);
+        f.clean()?;
+    }
+    Ok(())
+}

--- a/crates/jet3/src/delete_tests.rs
+++ b/crates/jet3/src/delete_tests.rs
@@ -144,10 +144,6 @@ fn unsupported_locators_pages_and_metadata_preserve_original() -> ResultTest {
             ..f.request()
         },
         RowDelete {
-            row: RowLocator::new(f.row.page(), 1),
-            ..f.request()
-        },
-        RowDelete {
             row: RowLocator::new(f.row.page(), 200),
             ..f.request()
         },
@@ -324,3 +320,6 @@ fn generated_long_value_index_and_available_map_states_are_refused() -> ResultTe
     assert_eq!(fs::read(f.path())?, original);
     f.clean()
 }
+
+#[path = "delete_compaction_tests.rs"]
+mod compaction;

--- a/crates/jet3/src/row_delete_page.rs
+++ b/crates/jet3/src/row_delete_page.rs
@@ -1,4 +1,4 @@
-//! Preservation-aware tail tombstones and counts from EXP-0162 (EXP-0059/0060 layout).
+//! Slot-preserving compaction and tombstones from EXP-0162 (EXP-0059/0060 layout).
 use crate::row_directory::RowDirectory;
 use crate::{PAGE_BYTES, PageImage, PageNumber, PageOffset, ResourceBudget, UpdateError};
 const FREE_BYTES: usize = 2;
@@ -7,7 +7,7 @@ const ENTRY_BYTES: usize = 2;
 const TOMBSTONE: u16 = 0xc000;
 const TABLE_COUNT: usize = 12;
 
-pub(crate) fn tail(
+pub(crate) fn remove(
     page: PageNumber,
     owner: PageNumber,
     source: &[u8; PAGE_BYTES],
@@ -15,42 +15,78 @@ pub(crate) fn tail(
     budget: &mut ResourceBudget,
 ) -> Result<PageImage, UpdateError> {
     let directory = RowDirectory::validate(page, owner, source, budget)?;
-    if directory.row_count() < 2 {
-        return Err(UpdateError::Unsupported("sole-row page release"));
-    }
-    if u16::from(slot) + 1 != directory.row_count() {
-        return Err(UpdateError::Unsupported("non-tail row compaction"));
-    }
+    let range = directory.entry(source, slot)?.range();
+    let mut live = 0;
+    budget.charge_work_units(2 * u64::from(directory.row_count()))?;
     for ordinal in 0..directory.row_count() {
         let entry = directory.entry(source, ordinal as u8)?;
+        if entry.hidden() && entry.overflow() && entry.range().is_empty() {
+            continue;
+        }
         if entry.hidden() || entry.overflow() || entry.range().is_empty() {
             return Err(UpdateError::Unsupported(
-                "page contains hidden, overflow or deleted slots",
+                "page contains an unsupported row slot",
             ));
         }
+        live += 1;
     }
-    let range = directory.entry(source, slot)?.range();
+    if range.is_empty() {
+        return Err(UpdateError::NotFound("live row slot"));
+    }
+    if live < 2 {
+        return Err(UpdateError::Unsupported("sole-row page release"));
+    }
+    let lowest = directory
+        .entry(source, (directory.row_count() - 1) as u8)?
+        .range()
+        .start;
     let directory_end = DIRECTORY + ENTRY_BYTES * usize::from(directory.row_count());
     let free = usize::from(u16::from_le_bytes([
         source[FREE_BYTES],
         source[FREE_BYTES + 1],
     ]));
-    if free != range.start - directory_end {
+    if free != lowest - directory_end {
         return Err(UpdateError::Mismatch("data page free-byte count"));
     }
-    let new_free = u16::try_from(range.end - directory_end)
-        .map_err(|_| UpdateError::Mismatch("free-byte range"))?;
-    let word = u16::try_from(range.end).map_err(|_| UpdateError::Mismatch("tombstone offset"))?
-        | TOMBSTONE;
+    let removed = range.len();
+    let new_free =
+        u16::try_from(free + removed).map_err(|_| UpdateError::Mismatch("free-byte range"))?;
     let mut patched = PageImage::from_bytes(*source);
+    // EXP-0162 moves later row bytes upward and leaves the vacated slack intact.
+    budget.charge_work_units((range.start - lowest) as u64)?;
+    patched.write_at(
+        PageOffset::new((lowest + removed) as u64),
+        &source[lowest..range.start],
+        budget,
+    )?;
+    for ordinal in u16::from(slot)..directory.row_count() {
+        let entry = directory.entry(source, ordinal as u8)?;
+        let start = if ordinal == u16::from(slot) {
+            range.end
+        } else {
+            entry
+                .range()
+                .start
+                .checked_add(removed)
+                .filter(|v| *v <= PAGE_BYTES)
+                .ok_or(UpdateError::Mismatch("compacted row offset"))?
+        };
+        let flags = if ordinal == u16::from(slot) || entry.hidden() {
+            TOMBSTONE
+        } else {
+            0
+        };
+        let word =
+            u16::try_from(start).map_err(|_| UpdateError::Mismatch("tombstone offset"))? | flags;
+        patched.write_at(
+            PageOffset::new((DIRECTORY + ENTRY_BYTES * usize::from(ordinal)) as u64),
+            &word.to_le_bytes(),
+            budget,
+        )?;
+    }
     patched.write_at(
         PageOffset::new(FREE_BYTES as u64),
         &new_free.to_le_bytes(),
-        budget,
-    )?;
-    patched.write_at(
-        PageOffset::new((DIRECTORY + ENTRY_BYTES * usize::from(slot)) as u64),
-        &word.to_le_bytes(),
         budget,
     )?;
     Ok(patched)


### PR DESCRIPTION
Existing-row deletion now supports first and middle rows, including repeated deletion around empty tombstones, while keeping physical row slots stable. The bounded page compaction preserves vacated slack, maps, page zero, and unrelated bytes; sole-row release remains unsupported.

Validation: independent implementation review, nine focused deletion tests, exact comparisons with the retained EXP-0162 middle-row pages, and `just ready` passed. A separate preregistered DAO experiment will validate the additional candidate cases.

Progress toward #112.
