### PR TITLE
test: validate historical acquisition pins at their source revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"

--- a/oracle/windows-dao/tests/test_single_leaf_key_successor.py
+++ b/oracle/windows-dao/tests/test_single_leaf_key_successor.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import subprocess
 from pathlib import Path
 import sys
 import unittest
@@ -13,6 +15,10 @@ class SuccessorTests(unittest.TestCase):
         self.assertNotEqual(historical.PLAN,successor.original.PLAN)
         self.assertEqual(historical.build_report.__code__.co_code,successor.original.build_report.__code__.co_code)
         self.assertEqual(historical.patch_check.__code__.co_code,successor.original.patch_check.__code__.co_code)
-        successor.original.verify_inputs()
+        # Acquisition pins describe the committed experiment, not later main.
+        for name, expected in new['inputs'].items():
+            saved = subprocess.check_output(
+                ['git', 'show', '450bcd2:' + name], cwd=successor.ROOT)
+            self.assertEqual(hashlib.sha256(saved).hexdigest(), expected, name)
 
 if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Oracle CI incorrectly validates a historical experiment against the current parser, so later valid implementation changes fail its immutable input pins. Check the same pins at the committed acquisition revision and fetch the required history in the oracle job. Runtime acquisition validation and frozen plans remain unchanged.

Validation: focused historical binding test and `just ready` passed; independent review caught the shallow checkout dependency, which is fixed here.
