### PR TITLE
feat: populate multiple indexes on the first table

### DIFF
--- a/crates/jet3/src/creation/api.rs
+++ b/crates/jet3/src/creation/api.rs
@@ -76,6 +76,10 @@ pub enum CandidateCheckError {
     Read(crate::Error),
     /// The candidate index tree could not be read.
     Index(crate::IndexTreeError),
+    /// A candidate index usage-map record could not be located.
+    UsageMap(crate::UsageMapError),
+    /// A candidate index allocation map could not be traversed.
+    Allocation(crate::AllocationMapError),
     /// A candidate long-value field could not be decoded.
     Value(crate::ValueError),
     /// A candidate external payload could not be streamed.
@@ -102,6 +106,10 @@ impl fmt::Display for CandidateCheckError {
         match self {
             Self::Read(source) => write!(formatter, "candidate page comparison failed: {source}"),
             Self::Index(source) => write!(formatter, "candidate index scan failed: {source}"),
+            Self::UsageMap(source) => write!(formatter, "candidate usage map failed: {source}"),
+            Self::Allocation(source) => {
+                write!(formatter, "candidate allocation map failed: {source}")
+            }
             Self::Value(source) => write!(formatter, "candidate value failed: {source}"),
             Self::LongValue(source) => write!(formatter, "candidate long value failed: {source}"),
             Self::Rows(source) => write!(formatter, "candidate row scan failed: {source}"),
@@ -125,6 +133,8 @@ impl StdError for CandidateCheckError {
         match self {
             Self::Read(source) => Some(source),
             Self::Index(source) => Some(source),
+            Self::UsageMap(source) => Some(source),
+            Self::Allocation(source) => Some(source),
             Self::Value(source) => Some(source),
             Self::LongValue(source) => Some(source),
             Self::Rows(source) => Some(source),
@@ -179,8 +189,11 @@ pub fn create_database(
 /// capacity. Each row and the table definition must fit one page. Pages with
 /// a slot and room for an all-null row are marked available; this construction
 /// policy has not been established as DAO's allocation policy.
-/// At most one index on one or two numeric columns (including a generated
-/// AutoIncrement column) is accepted, with each field ascending or descending.
+/// The first table accepts up to three indexes; later tables accept one. Each
+/// index has one or two numeric columns (including a generated AutoIncrement
+/// column), with each field ascending or descending. Multiple populated indexes
+/// combine the established separate roots/maps with independent trees; this
+/// candidate construction requires separate DAO validation.
 /// Uncompressed branch/leaf trees grow within the existing inline-map and
 /// resource limits. Unique indexes reject repeated fully present keys while
 /// allowing repeated null-bearing keys. The index null policy includes keys,
@@ -329,7 +342,7 @@ fn check_initial_table_rows(
             });
         }
     }
-    let mut expected_index = InitialLongIndex::new(table, rows.len(), budget)
+    let mut expected_indexes = InitialLongIndex::for_table(table, rows.len(), budget)
         .map_err(CandidateCheckError::RowEncoding)?;
     let mut next_payload = initial_payload_start(table, root, first_create)
         .map_err(CandidateCheckError::RowEncoding)?;
@@ -418,7 +431,7 @@ fn check_initial_table_rows(
                 });
             }
         }
-        if let Some(index) = &mut expected_index {
+        for index in &mut expected_indexes {
             index
                 .push(row, locator, cursor.owned.budget_mut())
                 .map_err(CandidateCheckError::RowEncoding)?;
@@ -434,18 +447,81 @@ fn check_initial_table_rows(
         });
     }
     drop(cursor);
-    if let Some(mut expected) = expected_index {
+    for (ordinal, mut expected) in expected_indexes.into_iter().enumerate() {
         expected
             .sort(budget)
             .map_err(CandidateCheckError::RowEncoding)?;
+        let physical =
+            definition
+                .physical_indexes()
+                .get(ordinal)
+                .ok_or(CandidateCheckError::Mismatch {
+                    detail: "initial index count",
+                })?;
+        if physical.distinct_key_count() != expected.distinct_count() {
+            return Err(CandidateCheckError::Mismatch {
+                detail: "initial index distinct count",
+            });
+        }
         let actual = database
-            .index_tree(&definition, 0, budget)
+            .index_tree(&definition, ordinal as u16, budget)
             .map_err(CandidateCheckError::Index)?;
-        if !expected.matches(&actual) {
+        check_initial_index_map(database, physical.usage_map(), &actual, budget)?;
+        if !expected
+            .matches(&actual, budget)
+            .map_err(CandidateCheckError::RowEncoding)?
+        {
             return Err(CandidateCheckError::Mismatch {
                 detail: "initial index entries",
             });
         }
+    }
+    Ok(())
+}
+
+fn check_initial_index_map(
+    database: &mut DatabaseReader<crate::FileSource>,
+    location: crate::IndexUsageMapReference,
+    tree: &crate::IndexTree,
+    budget: &mut ResourceBudget,
+) -> Result<(), CandidateCheckError> {
+    let mut bytes = [0; crate::PAGE_BYTES];
+    let page = database
+        .read_classified_page(location.page(), &mut bytes, budget)
+        .map_err(|error| CandidateCheckError::Definition(TableDefinitionError::Page(error)))?;
+    let record = crate::locate_usage_map(
+        page,
+        crate::MapRowLocator::new(location.page(), location.row()),
+        budget,
+    )
+    .map_err(CandidateCheckError::UsageMap)?;
+    let crate::AllocationMap::Inline(map) = crate::decode_allocation_map(record.raw(), budget)
+        .map_err(CandidateCheckError::Allocation)?
+    else {
+        return Err(CandidateCheckError::Mismatch {
+            detail: "initial index map kind",
+        });
+    };
+    let mut pages = map.allocated_pages(database.geometry());
+    let mut count = 0;
+    while let Some(page) = pages
+        .next_page(budget)
+        .map_err(CandidateCheckError::Allocation)?
+    {
+        budget
+            .charge_work_units(tree.nodes().len() as u64)
+            .map_err(CandidateCheckError::Read)?;
+        if !tree.nodes().iter().any(|node| node.page() == page) {
+            return Err(CandidateCheckError::Mismatch {
+                detail: "initial index map pages",
+            });
+        }
+        count += 1;
+    }
+    if count != tree.nodes().len() {
+        return Err(CandidateCheckError::Mismatch {
+            detail: "initial index map pages",
+        });
     }
     Ok(())
 }

--- a/crates/jet3/src/creation/composer/compose_error.rs
+++ b/crates/jet3/src/creation/composer/compose_error.rs
@@ -17,7 +17,7 @@ pub enum ComposeError {
         /// Unsupported relationship constraint.
         detail: &'static str,
     },
-    /// Initial rows support at most one index on one or two supported numeric columns.
+    /// Initial indexes require one or two supported numeric columns and bounded index counts.
     UnsupportedInitialIndexSchema,
     /// A scalar key value needs an unsupported encoding (including negative zero).
     UnsupportedInitialIndexValue {

--- a/crates/jet3/src/creation/composer/initial_index.rs
+++ b/crates/jet3/src/creation/composer/initial_index.rs
@@ -62,6 +62,39 @@ impl InitialLongIndex {
                 Err(ComposeError::UnsupportedInitialIndexSchema)
             };
         };
+        Self::for_index(spec, index, row_count, budget).map(Some)
+    }
+
+    pub(crate) fn for_table(
+        spec: &TableSpec<'_>,
+        row_count: usize,
+        budget: &mut ResourceBudget,
+    ) -> Result<Vec<Self>, ComposeError> {
+        if spec.indexes.len() > crate::creation::schema_plan::MAX_OBSERVED_INDEXES {
+            return Err(ComposeError::UnsupportedInitialIndexSchema);
+        }
+        budget.charge_allocation(ByteCount::new(
+            (spec.indexes.len() * size_of::<Self>()) as u64,
+        ))?;
+        let mut indexes = Vec::new();
+        indexes
+            .try_reserve_exact(spec.indexes.len())
+            .map_err(|_| Error::Io {
+                operation: "reserve initial indexes",
+                kind: std::io::ErrorKind::OutOfMemory,
+            })?;
+        for index in spec.indexes {
+            indexes.push(Self::for_index(spec, index, row_count, budget)?);
+        }
+        Ok(indexes)
+    }
+
+    fn for_index(
+        spec: &TableSpec<'_>,
+        index: &crate::IndexSpec<'_>,
+        row_count: usize,
+        budget: &mut ResourceBudget,
+    ) -> Result<Self, ComposeError> {
         if !(1..=MAX_FIELDS).contains(&index.fields.len()) {
             return Err(ComposeError::UnsupportedInitialIndexSchema);
         }
@@ -105,7 +138,7 @@ impl InitialLongIndex {
                 operation: "reserve initial Long index entries",
                 kind: std::io::ErrorKind::OutOfMemory,
             })?;
-        Ok(Some(Self {
+        Ok(Self {
             fields,
             field_count: index.fields.len(),
             unique: index.kind.is_unique(),
@@ -114,7 +147,7 @@ impl InitialLongIndex {
             entries,
             distinct: 0,
             pages,
-        }))
+        })
     }
 
     pub(crate) fn push(
@@ -263,8 +296,13 @@ impl InitialLongIndex {
             .is_ok())
     }
 
-    pub(crate) fn matches(&self, tree: &IndexTree) -> bool {
-        self.entries.len() == tree.entries().len()
+    pub(crate) fn matches(
+        &self,
+        tree: &IndexTree,
+        budget: &mut ResourceBudget,
+    ) -> Result<bool, ComposeError> {
+        budget.charge_work_units(self.entries.len() as u64 * ENTRY_CAPACITY as u64)?;
+        Ok(self.entries.len() == tree.entries().len()
             && self
                 .entries
                 .iter()
@@ -280,7 +318,7 @@ impl InitialLongIndex {
                                 expected.bytes[key_bytes + 2],
                             ]))
                         && actual.row().slot() == expected.bytes[key_bytes + 3]
-                })
+                }))
     }
 }
 

--- a/crates/jet3/src/creation/composer/table_create.rs
+++ b/crates/jet3/src/creation/composer/table_create.rs
@@ -54,7 +54,7 @@ pub(super) struct PlannedCreate<'a> {
     initial_data: Vec<InitialDataPage>,
     initial_long_values: Option<InitialLongValues>,
     initial_row_count: u32,
-    initial_index: Option<InitialLongIndex>,
+    initial_indexes: Vec<InitialLongIndex>,
     initial_autoincrement: Option<InitialAutoIncrement>,
 }
 
@@ -91,7 +91,7 @@ impl<'a> PlannedCreate<'a> {
             initial_data: Vec::new(),
             initial_long_values: None,
             initial_row_count: 0,
-            initial_index: None,
+            initial_indexes: Vec::new(),
             initial_autoincrement: None,
         })
     }
@@ -110,7 +110,7 @@ impl<'a> PlannedCreate<'a> {
         }
         let generated = InitialAutoIncrement::new(self.spec, rows.len())?;
         self.initial_autoincrement = generated;
-        self.initial_index = InitialLongIndex::new(self.spec, rows.len(), budget)?;
+        self.initial_indexes = InitialLongIndex::for_table(self.spec, rows.len(), budget)?;
         if rows.is_empty() {
             return Ok(self);
         }
@@ -162,11 +162,11 @@ impl<'a> PlannedCreate<'a> {
                 Err(error) => return Err(error.into()),
             };
             let locator = crate::RowLocator::new(PageNumber::new(self.data_end()), slot);
-            if let Some(index) = &mut self.initial_index {
+            for index in &mut self.initial_indexes {
                 index.push(row, locator, budget)?;
             }
         }
-        if let Some(index) = &mut self.initial_index {
+        for index in &mut self.initial_indexes {
             index.sort(budget)?;
         }
         self.push_initial_page(builder, minimum, budget)?;
@@ -232,9 +232,22 @@ impl<'a> PlannedCreate<'a> {
     pub(super) fn page_count(&self) -> u64 {
         self.data_end()
             + self
-                .initial_index
-                .as_ref()
-                .map_or(0, InitialLongIndex::extra_page_count)
+                .initial_indexes
+                .iter()
+                .map(InitialLongIndex::extra_page_count)
+                .sum::<u64>()
+    }
+
+    // EXP-0093 gives each index its own root/map. Extra tree pages are grouped
+    // by physical index after the shared data pages (EXP-0062 tree grammar).
+    fn index_extra_start(&self, ordinal: usize) -> u64 {
+        self.data_end()
+            + self
+                .initial_indexes
+                .iter()
+                .take(ordinal)
+                .map(InitialLongIndex::extra_page_count)
+                .sum::<u64>()
     }
 
     fn data_end(&self) -> u64 {
@@ -252,8 +265,8 @@ impl<'a> PlannedCreate<'a> {
     }
 
     pub(super) fn index_distinct_count(&self) -> u32 {
-        self.initial_index
-            .as_ref()
+        self.initial_indexes
+            .first()
             .map_or(0, InitialLongIndex::distinct_count)
     }
 
@@ -275,8 +288,8 @@ impl<'a> PlannedCreate<'a> {
         value: i32,
         budget: &mut ResourceBudget,
     ) -> Result<bool, ComposeError> {
-        self.initial_index
-            .as_ref()
+        self.initial_indexes
+            .first()
             .ok_or(ComposeError::UnsupportedInitialIndexSchema)?
             .contains_single_long(value, budget)
     }
@@ -322,12 +335,12 @@ impl<'a> PlannedCreate<'a> {
             plan.append(continuation, append_map, budget)?;
         }
         let owner = self.plan.definition_root().get();
-        for (root, _) in self.plan.index_placements() {
-            let image = if let Some(index) = &self.initial_index {
+        for (ordinal, (root, _)) in self.plan.index_placements().enumerate() {
+            let image = if let Some(index) = self.initial_indexes.get(ordinal) {
                 index.image(
                     self.plan.definition_root(),
                     root,
-                    self.data_end(),
+                    self.index_extra_start(ordinal),
                     None,
                     budget,
                 )?
@@ -342,19 +355,18 @@ impl<'a> PlannedCreate<'a> {
         for data in &self.initial_data {
             plan.append(data.image.clone(), append_map, budget)?;
         }
-        if let Some(index) = &self.initial_index {
-            let root = self
-                .plan
-                .index_placements()
-                .next()
-                .ok_or(ComposeError::UnsupportedInitialIndexSchema)?
-                .0;
+        for (position, (index, (root, _))) in self
+            .initial_indexes
+            .iter()
+            .zip(self.plan.index_placements())
+            .enumerate()
+        {
             for ordinal in 0..index.extra_page_count() {
                 plan.append(
                     index.image(
                         self.plan.definition_root(),
                         root,
-                        self.data_end(),
+                        self.index_extra_start(position),
                         Some(ordinal as usize),
                         budget,
                     )?,
@@ -417,18 +429,21 @@ impl<'a> PlannedCreate<'a> {
             .index_placements()
             .zip(spec.indexes)
             .zip(self.plan.index_fields())
-            .map(|(((root, row), index), fields)| PhysicalIndexSpec {
-                fields,
-                usage_map_page: map,
-                usage_map_row: row,
-                root,
-                flags: index.kind.flags(),
-                // EXP-0073: the prefix counts distinct keys, not leaf entries.
-                entry_count: self
-                    .initial_index
-                    .as_ref()
-                    .map_or(0, InitialLongIndex::distinct_count),
-            })
+            .enumerate()
+            .map(
+                |(ordinal, (((root, row), index), fields))| PhysicalIndexSpec {
+                    fields,
+                    usage_map_page: map,
+                    usage_map_row: row,
+                    root,
+                    flags: index.kind.flags(),
+                    // EXP-0073: the prefix counts distinct keys, not leaf entries.
+                    entry_count: self
+                        .initial_indexes
+                        .get(ordinal)
+                        .map_or(0, InitialLongIndex::distinct_count),
+                },
+            )
             .collect::<Vec<_>>();
         let logical = logical_index_order(spec.indexes)
             .into_iter()
@@ -511,12 +526,12 @@ impl<'a> PlannedCreate<'a> {
         owned.encode_into(&mut owned_row, budget)?;
         available.encode_into(&mut available_row, budget)?;
         let mut rows: Vec<[u8; 133]> = vec![owned_row, available_row];
-        for (root, _) in self.plan.index_placements() {
+        for (ordinal, (root, _)) in self.plan.index_placements().enumerate() {
             rows.push(initial_index_map(
                 root,
-                self.data_end(),
-                self.initial_index
-                    .as_ref()
+                self.index_extra_start(ordinal),
+                self.initial_indexes
+                    .get(ordinal)
                     .map_or(0, InitialLongIndex::extra_page_count),
                 budget,
             )?);

--- a/crates/jet3/src/creation/initial_index_tests.rs
+++ b/crates/jet3/src/creation/initial_index_tests.rs
@@ -195,13 +195,6 @@ fn required_null_keys_and_unsupported_key_schemas_fail_before_publication() -> T
             ))
         ));
     }
-    let multiple = [
-        one_index(IndexKind::Ordinary)[0],
-        IndexSpec {
-            name: b"Other",
-            ..one_index(IndexKind::Ordinary)[0]
-        },
-    ];
     let composite = [IndexSpec {
         fields: &[
             field(0, IndexDirection::Ascending),
@@ -213,7 +206,7 @@ fn required_null_keys_and_unsupported_key_schemas_fail_before_publication() -> T
         fields: &[IndexColumnSpec::ascending(b"Code")],
         ..one_index(IndexKind::Ordinary)[0]
     }];
-    for indexes in [&multiple[..], &composite, &text] {
+    for indexes in [&composite, &text] {
         let table = TableSpec {
             name: b"Items",
             columns: &[ID, CODE],
@@ -305,3 +298,6 @@ mod nullable;
 
 #[path = "numeric_index_tests.rs"]
 mod numeric;
+
+#[path = "multiple_index_tests.rs"]
+mod multiple;

--- a/crates/jet3/src/creation/multiple_index_tests.rs
+++ b/crates/jet3/src/creation/multiple_index_tests.rs
@@ -1,0 +1,315 @@
+use super::*;
+use std::collections::BTreeSet;
+
+const GROUP: ColumnSpec<'static> = ColumnSpec::new(b"Group", ColumnType::Currency);
+const PRIMARY: [IndexColumnSpec<'static>; 1] = [field(0, IndexDirection::Ascending)];
+const GROUP_KEY: [IndexColumnSpec<'static>; 1] = [field(1, IndexDirection::Descending)];
+const MIXED: [IndexColumnSpec<'static>; 2] = [
+    field(1, IndexDirection::Ascending),
+    field(0, IndexDirection::Descending),
+];
+fn indexes() -> [IndexSpec<'static>; 3] {
+    [
+        IndexSpec {
+            name: b"ZPrimary",
+            kind: IndexKind::Primary,
+            fields: &PRIMARY,
+        },
+        IndexSpec {
+            name: b"AGroup",
+            kind: IndexKind::Ordinary,
+            fields: &GROUP_KEY,
+        },
+        IndexSpec {
+            name: b"MMixed",
+            kind: IndexKind::Unique,
+            fields: &MIXED,
+        },
+    ]
+}
+
+#[test]
+fn three_separate_trees_counts_and_maps_precede_a_later_table() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = indexes();
+    let columns = [
+        ID,
+        GROUP,
+        ColumnSpec::new(b"Payload", ColumnType::Text { max_len: nz(255) }),
+    ];
+    let payload = [b'x'; 180];
+    let values: Vec<_> = (0..201)
+        .rev()
+        .map(|id| {
+            [
+                RowValue::Long(id),
+                RowValue::Currency {
+                    scaled: i64::from(id % 3),
+                },
+                RowValue::Text(&payload),
+            ]
+        })
+        .collect();
+    let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+    let later_indexes = one_index(IndexKind::Primary);
+    let requests = [
+        crate::TableRows {
+            table: TableSpec {
+                name: b"Items",
+                columns: &columns,
+                indexes: &indexes,
+            },
+            rows: &rows,
+        },
+        crate::TableRows {
+            table: TableSpec {
+                name: b"Later",
+                columns: &[ID],
+                indexes: &later_indexes,
+            },
+            rows: &[&[RowValue::Long(99)]],
+        },
+    ];
+    crate::create_database_with_table_rows(directory.target(), &requests, &mut budget())?;
+    let bytes = fs::read(directory.target())?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(directory.target(), &mut b)?;
+    let def = db.table_definition(PageNumber::new(20), &mut b)?;
+    assert_eq!(
+        def.indexes()
+            .iter()
+            .map(|i| i.physical_index())
+            .collect::<Vec<_>>(),
+        [1, 2, 0]
+    );
+    let mut locations = Vec::new();
+    {
+        let mut cursor = db.rows(&def, &mut b)?;
+        while let Some(row) = cursor.next_row()? {
+            locations.push(row.locator());
+        }
+    }
+    assert_eq!(locations.len(), 201);
+    assert_eq!(locations[0].page(), PageNumber::new(26));
+    let mut all_pages = BTreeSet::new();
+    for ordinal in 0..3 {
+        let physical = &def.physical_indexes()[ordinal];
+        assert_eq!(
+            physical.distinct_key_count(),
+            if ordinal == 1 { 3 } else { 201 }
+        );
+        let tree = db.index_tree(&def, ordinal as u16, &mut b)?;
+        assert_eq!(tree.root(), PageNumber::new(23 + ordinal as u64));
+        assert!(tree.nodes().len() >= 3);
+        let mut expected: Vec<_> = (0..201_usize).collect();
+        expected.sort_by_key(|&input| {
+            let id = 200 - input as i32;
+            match ordinal {
+                0 => (id, 0),
+                1 => (-(id % 3), input as i32),
+                _ => (id % 3, -id),
+            }
+        });
+        assert_eq!(
+            tree.entries().iter().map(|e| e.row()).collect::<Vec<_>>(),
+            expected.iter().map(|&i| locations[i]).collect::<Vec<_>>()
+        );
+        for node in tree.nodes() {
+            assert!(all_pages.insert(node.page().get()));
+            assert!(map_bit(&bytes, 21, (2 + ordinal) as u8, node.page().get())?);
+            for other in 0..3 {
+                if other != ordinal {
+                    assert!(!map_bit(&bytes, 21, (2 + other) as u8, node.page().get())?);
+                }
+            }
+            assert!(!map_bit(&bytes, 21, 0, node.page().get())?);
+        }
+    }
+    let later_root = all_pages.iter().max().ok_or("no index pages")? + 1;
+    let later = db.table_definition(PageNumber::new(later_root), &mut b)?;
+    let tree = db.index_tree(&later, 0, &mut b)?;
+    assert_eq!(tree.entries().len(), 1);
+    assert_eq!(tree.entries()[0].row().page().get(), later_root + 3);
+    Ok(())
+}
+
+#[test]
+fn independent_null_policies_generated_ids_and_empty_trees() -> TestResult {
+    let indexes = [
+        IndexSpec {
+            name: b"ZId",
+            kind: IndexKind::Primary,
+            fields: &PRIMARY,
+        },
+        IndexSpec {
+            name: b"AGroup",
+            kind: IndexKind::Ordinary.with_null_policy(crate::IndexNullPolicy::IgnoreAllNull),
+            fields: &GROUP_KEY,
+        },
+    ];
+    let columns = [ColumnSpec::new(b"Id", ColumnType::AutoIncrement), GROUP];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &indexes,
+    };
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::AutoIncrement, RowValue::Null],
+        &[RowValue::AutoIncrement, RowValue::Currency { scaled: 5 }],
+        &[RowValue::AutoIncrement, RowValue::Currency { scaled: 5 }],
+    ];
+    for requested in [&rows[..0], rows] {
+        let directory = TestDirectory::create()?;
+        create_database_with_rows(directory.target(), &table, requested, &mut budget())?;
+        let mut b = budget();
+        let mut db = DatabaseReader::open(directory.target(), &mut b)?;
+        let def = db.table_definition(PageNumber::new(20), &mut b)?;
+        for ordinal in 0..2 {
+            let tree = db.index_tree(&def, ordinal, &mut b)?;
+            assert_eq!(
+                tree.entries().len(),
+                if requested.is_empty() {
+                    0
+                } else if ordinal == 0 {
+                    3
+                } else {
+                    2
+                }
+            );
+            assert_eq!(
+                def.physical_indexes()[ordinal as usize].distinct_key_count(),
+                if requested.is_empty() {
+                    0
+                } else if ordinal == 0 {
+                    3
+                } else {
+                    1
+                }
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn later_index_corruption_and_publication_failures_are_detected() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let indexes = indexes();
+    let columns = [ID, GROUP];
+    let table = TableSpec {
+        name: b"Items",
+        columns: &columns,
+        indexes: &indexes,
+    };
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(1), RowValue::Currency { scaled: 7 }],
+        &[RowValue::Long(2), RowValue::Currency { scaled: 8 }],
+    ];
+    create_database_with_rows(directory.target(), &table, rows, &mut budget())?;
+    let original = fs::read(directory.target())?;
+    let map_start = u16::from_le_bytes(
+        original[21 * crate::PAGE_BYTES + 16..21 * crate::PAGE_BYTES + 18].try_into()?,
+    ) as usize;
+    // Later physical key, locator, distinct count and map membership.
+    for offset in [
+        24 * crate::PAGE_BYTES + 249,
+        25 * crate::PAGE_BYTES + 265,
+        20 * crate::PAGE_BYTES + 55,
+        21 * crate::PAGE_BYTES + map_start + 5 + 24 / 8,
+    ] {
+        let mut bad = original.clone();
+        bad[offset] ^= 1;
+        fs::write(directory.target(), bad)?;
+        assert!(
+            crate::creation::api::check_initial_rows(
+                &directory.target(),
+                &table,
+                rows,
+                &mut budget()
+            )
+            .is_err()
+        );
+    }
+    fs::write(directory.target(), &original)?;
+    assert!(create_database_with_rows(directory.target(), &table, rows, &mut budget()).is_err());
+    assert_eq!(fs::read(directory.target())?, original);
+    let one = TableSpec {
+        indexes: &indexes[..1],
+        ..table
+    };
+    let mut charged = budget();
+    crate::creation::composer::InitialLongIndex::for_table(&one, 20, &mut charged)?;
+    let mut limited = ResourceBudget::new(
+        ResourceLimits::default().with_max_allocation_bytes(charged.allocation_bytes()),
+    );
+    assert!(
+        crate::creation::composer::InitialLongIndex::for_table(&table, 20, &mut limited).is_err()
+    );
+    Ok(())
+}
+
+#[test]
+fn second_unique_index_refuses_duplicates_and_later_tables_keep_their_bound() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let mut indexes = indexes();
+    indexes[1].kind = IndexKind::Unique;
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID, GROUP],
+        indexes: &indexes[..2],
+    };
+    let rows: &[&[RowValue<'_>]] = &[
+        &[RowValue::Long(1), RowValue::Currency { scaled: 7 }],
+        &[RowValue::Long(2), RowValue::Currency { scaled: 7 }],
+    ];
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(
+            ComposeError::DuplicateInitialScalarIndexKey
+        ))
+    ));
+    let requests = [
+        crate::TableRows {
+            table: TableSpec {
+                name: b"First",
+                columns: &[ID],
+                indexes: &[],
+            },
+            rows: &[],
+        },
+        crate::TableRows {
+            table,
+            rows: &rows[..1],
+        },
+    ];
+    assert!(
+        crate::create_database_with_table_rows(directory.target(), &requests, &mut budget())
+            .is_err()
+    );
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn aggregate_index_pages_cannot_exceed_the_inline_map() -> TestResult {
+    let directory = TestDirectory::create()?;
+    let fields = [field(0, IndexDirection::Ascending)];
+    let indexes = [b"First".as_slice(), b"Second", b"Third"].map(|name| IndexSpec {
+        name,
+        kind: IndexKind::Ordinary,
+        fields: &fields,
+    });
+    let table = TableSpec {
+        name: b"Items",
+        columns: &[ID],
+        indexes: &indexes,
+    };
+    let row = [RowValue::Long(1)];
+    let rows = vec![row.as_slice(); 60000];
+    assert!(matches!(
+        create_database_with_rows(directory.target(), &table, &rows, &mut budget()),
+        Err(CreateDatabaseError::Compose(ComposeError::UsageMap(_)))
+    ));
+    assert!(directory.entries()?.is_empty());
+    Ok(())
+}

--- a/crates/jet3/src/physical_index_definition.rs
+++ b/crates/jet3/src/physical_index_definition.rs
@@ -102,6 +102,16 @@ impl PhysicalIndexDefinition {
         &self.sourced_prefix
     }
 
+    /// EXP-0073: the prefix count records distinct full keys, not leaf entries.
+    pub(crate) const fn distinct_key_count(&self) -> u32 {
+        u32::from_le_bytes([
+            self.sourced_prefix[4],
+            self.sourced_prefix[5],
+            self.sourced_prefix[6],
+            self.sourced_prefix[7],
+        ])
+    }
+
     /// Returns the ordered physical key fields.
     #[must_use]
     pub fn fields(&self) -> &[IndexField] {


### PR DESCRIPTION
Populated first tables can now have up to three supported numeric indexes, each with its own tree, map, and counts. All indexes share the actual row locators, and publication verifies every index and its allocation membership. Existing later-table limits remain.

Validation: independent review, five new tests covering multiple trees and per-index policies, focused initial-row/relationship tests, Clippy, and `just ready` passed. A separate preregistered DAO experiment will validate finite multi-index candidates.

Progress toward #100.
