### PR TITLE
test: preregister hosted allocation and compaction differential

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -13004,6 +13004,45 @@ Copy this block under the appropriate section and remove this instruction:
   Free-page reuse, map growth/indirection, indexed/related/Auto/LVAL insertion,
   compaction and slot reuse remain outside this one-EOF-page validation.
 
+## EXP-0195 — Hosted nine-case allocation and compaction preregistration
+
+- Preregistered: 2026-09-05, OpenAI Codex; no acquisition yet. Reviewed tooling
+  `4887818`, integrated source `e93879a572dd4dc0e068085c59ca0f970b17cc68`.
+- Plan `oracle/windows-dao/acquisition/row-allocation-v1_2.plan.json`, SHA-256
+  `e7e69071956deb9eaa31c5576b04fe599864894cccdebfc32d444e7f08808294`. Pins bind workflow,
+  nine-case inventory, fixture/CLI, shared parser allocation helper, mutation
+  codecs, read-only provider helpers and independent evaluators to reviewed source.
+  Both hosted jobs use the actual dispatched revision; root verifies its pinned
+  files before the single dispatch. MDB/provider bytes stay external.
+- Retain five historical requests exactly; add empty-table EOF insertion,
+  full-page EOF insertion with 240-byte Text payloads, unequal middle deletion,
+  and three sequential deletions around retained tombstones. Nine before/after
+  pairs receive eleven public mutations; every original starts from public
+  creation APIs. Unrelated tables and all exact values are declared in inventory.
+- One `windows-dao-row-allocation` dispatch with `run_acquisition=true` and exact
+  plan SHA: Ubuntu generates and verifies; Windows independently verifies the
+  same18images and reads them with Rust plus stock x86 DAO.DBEngine.36.
+  Canonical snapshots/coverage must match independently requested schema/rows,
+  exact environment/source/image identities and each other. No provider install
+  or license acceptance; a missing stock provider is retained as a prerequisite
+  failure. Only run attempt1, no automatic retry or partial promotion.
+- Rust and Python independently reconstruct exact patches. EOF adds one2048-byte
+  page and changes table count/three inline-map bits; compaction retains slots
+  and empty tombstones, moves surviving rows, updates offsets/free/table count
+  and preserves vacated slack. Every byte outside the specified patches, including
+  page0 and unrelated payload, stays exact; only EOF changes length. Windows receipts must equal Unix receipts.
+- All nine preparations and18readonly captures must pass; any source/provider,
+  identity/recipe/coverage/byte/semantic failure prevents `matched`. Retain both
+  artifact groups, all images, manifests, receipts, environment, raw/canonical
+  snapshots, report when reached and failure logs. EXP-0196 is reserved for one
+  additive outcome; historical consumed inputs/outcomes remain unchanged.
+- Scoped fixture/CLI/Python tests, full nine-case Linux preparation and synthetic
+  complete/incomplete evaluator checks passed without DAO. These are tooling
+  checks, not acquisition evidence. Indirect maps/reuse/sole release, indexed or
+  related mutations, null/variable replacements, QueryDef preservation and DAO
+  continuation are deferred. No general allocation policy, compatibility beyond
+  this finite hosted matrix, or automatic support movement is established.
+
 ## EXP-0174 — Hosted finite field updates, insertion and tail deletion matched
 
 - Outcome: `matched`, recorded 2026-09-05 from GitHub Actions run

--- a/oracle/windows-dao/acquisition/row-allocation-v1_2.plan.json
+++ b/oracle/windows-dao/acquisition/row-allocation-v1_2.plan.json
@@ -1,0 +1,209 @@
+{
+  "document_type": "dao_update_acquisition_plan",
+  "experiment_id": "hosted-row-allocation-v1_2",
+  "provenance": "EXP-0195",
+  "outcome_provenance": "EXP-0196",
+  "protocol_version": "1.2.0",
+  "mode": "dao_open_rust_update",
+  "acquisition_started": false,
+  "source": {
+    "reviewed_implementation_commit": "4887818",
+    "integrated_implementation_commit": "e93879a572dd4dc0e068085c59ca0f970b17cc68",
+    "execution_source": "Both jobs check out the same dispatched committed Git revision containing this plan. Preparation, Windows verification, all DAO/Rust snapshots and coverage bind that source revision; artifact names identify that same run/source. The scoped workflow/producer/parser/evaluator input pins below bind the integrated source before acquisition."
+  },
+  "authorization": "The user authorized DAO experiments and mutations. Independently review and commit this plan before one windows-dao-row-allocation workflow_dispatch with run_acquisition=true and its exact SHA-256. Root dispatches after reviewed tooling merges. No provider installation or license acceptance.",
+  "question": "Do nine exact public field/row mutation recipes, including empty/full-page EOF allocation and slot-preserving compaction, preserve every independently specified unrelated byte and complete semantics under hosted stock x86 DAO and Rust reads?",
+  "inventory": {
+    "path": "oracle/windows-dao/protocol/v1_2/row-allocation-scenarios.json",
+    "sha256": "37538e96a6caa91207063f91cb1051dea584d7730c1d494587be8e037a76e66e",
+    "scenario_ids": [
+      "DAO-UPDATE-FIRST-FIELD",
+      "DAO-UPDATE-LATER-ROW",
+      "DAO-UPDATE-LATER-TABLE",
+      "DAO-UPDATE-INSERT-ROW",
+      "DAO-UPDATE-DELETE-TAIL",
+      "DAO-UPDATE-EMPTY-EOF",
+      "DAO-UPDATE-FULL-EOF",
+      "DAO-UPDATE-MIDDLE-COMPACT",
+      "DAO-UPDATE-REPEATED-COMPACT"
+    ],
+    "scenario_count": 9,
+    "image_count": 18,
+    "contract": "First five cases equal frozen row-update inventory exactly. Four additions retain unrelated Later rows: empty Items EOF insertion; seven 240-byte Text payload rows followed by another 240-byte payload requiring EOF; unequal middle deletion; sequential deletion of IDs2,4,1 from five differently sized rows with stable tombstone slots. Exact schema/rows/requests reside in pinned inventory."
+  },
+  "requests": [
+    {
+      "scenario_id": "DAO-UPDATE-FIRST-FIELD",
+      "table": "Items",
+      "column": "Id",
+      "row_index": 0,
+      "before": 0,
+      "after": -42
+    },
+    {
+      "scenario_id": "DAO-UPDATE-LATER-ROW",
+      "table": "Items",
+      "column": "Value",
+      "row_index": 31,
+      "before": 1031,
+      "after": -2147483648
+    },
+    {
+      "scenario_id": "DAO-UPDATE-LATER-TABLE",
+      "table": "Items",
+      "column": "Value",
+      "row_index": 17,
+      "before": 1017,
+      "after": 2147483647
+    },
+    {
+      "scenario_id": "DAO-UPDATE-INSERT-ROW",
+      "kind": "insert",
+      "table": "Items",
+      "row": [
+        88,
+        -8800,
+        "inserted"
+      ]
+    },
+    {
+      "scenario_id": "DAO-UPDATE-DELETE-TAIL",
+      "kind": "delete",
+      "table": "Items",
+      "selected_id": 3
+    },
+    {
+      "scenario_id": "DAO-UPDATE-EMPTY-EOF",
+      "kind": "eof_insert",
+      "row": [
+        88,
+        -8800,
+        "inserted"
+      ],
+      "table": "Items"
+    },
+    {
+      "scenario_id": "DAO-UPDATE-FULL-EOF",
+      "kind": "eof_insert",
+      "row": [
+        88,
+        -8800,
+        "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+      ],
+      "table": "Items"
+    },
+    {
+      "scenario_id": "DAO-UPDATE-MIDDLE-COMPACT",
+      "kind": "compact_delete",
+      "selected_ids": [
+        2
+      ],
+      "table": "Items"
+    },
+    {
+      "scenario_id": "DAO-UPDATE-REPEATED-COMPACT",
+      "kind": "compact_delete",
+      "selected_ids": [
+        2,
+        4,
+        1
+      ],
+      "table": "Items"
+    }
+  ],
+  "execution": {
+    "workflow": ".github/workflows/windows-dao-row-allocation.yml",
+    "event": "workflow_dispatch",
+    "inputs": {
+      "run_acquisition": true,
+      "plan_sha256": "SHA-256 of these exact committed plan bytes"
+    },
+    "attempts": 1,
+    "producer": "Ubuntu builds locked jet3-row-allocation-fixture and jet3-cli. Nine public creation calls produce before images; copies receive declared public update_field/insert_row/delete_row calls. Repeated compaction performs exactly three sequential deletes; all other cases one mutation. Independent Rust verification derives original fields/rows/maps and exact final bytes without mutation encoders. Require complete preparation, both Rust snapshots/request semantics/coverage and unchanged identities.",
+    "consumer": "Windows2022 downloads exact same-source artifacts, rebuilds reader/checker, independently derives all nine receipts and requires exact equality with Unix receipts. Snapshot both roles with unchanged hashes. Stock probe must report ready protocol1.2 x86 DAO.DBEngine.36/dbVersion30. Frozen read-only DAO producer retains exact environment bytes/hash and all18images/full semantic snapshots. No installation or license acceptance.",
+    "comparison": "Require nine preparations and18complete DAO/Rust snapshots, exact requested schemas/rows and all source/platform/environment/image/coverage bindings. Python independently reads catalog/rows to reconstruct patches: EOF adds one specified2048-byte page, table count and three inline-map bits; prior rows stay fixed. Compaction moves later rows upward without renumbering slots, preserving empty tombstones/vacated slack while changing offsets/free/table count. Every other byte, page0 and unrelated objects remains exact. Non-EOF lengths stay fixed; EOF grows exactly2048. No DAO mutation control is claimed; before/after semantics are independently asserted.",
+    "helpers": "Separate adapter privately configures frozen five-case/update evaluator gates; original scripts/inventories/plans stay unchanged. Additive row-allocation CLI inventory selects nine cases. New verifier shares no mutation planner. Frozen Invoke-DaoUpdateV12 imports named read-only snapshot helpers. All cases unindexed/relationship-free; no traversal/Seek claim.",
+    "limits": "Nine before/after pairs in one run: eleven public mutations across nine recipes,18DAOreadonly captures. Subprocesses120seconds;Ubuntu20minutes;Windows30minutes. Retain partial failures, no automatic retry/changed requests/phase resume."
+  },
+  "decision_rule": {
+    "matched": "All nine finite recipes,18complete DAO/Rust comparisons and independent Windows byte checks pass, with exact schemas/rows, patch/length behavior, unrelated bytes and all identities. Support_matrix_movement remains false.",
+    "no_outcome": "Any provider, source, retained identity, verifier, recipe, capture, coverage or semantic failure prevents matched. Reached evaluation failures retain report.json no_outcome; earlier failures retain available preparation/provider/workflow logs without inventing a report. Input-pin mismatches reject dispatch or retained-data analysis.",
+    "retry": "Only GitHub run attempt 1; no rerun or redispatch of this consumed plan. A failure after provider probe or other first DAO mutation is a scientific result. Preserve it; any successor requires a distinct reviewed plan under standing user authorization."
+  },
+  "retention": {
+    "artifact_names": [
+      "generated-row-allocation-SOURCE_REVISION",
+      "windows-dao-row-allocation-SOURCE_REVISION-RUN_ATTEMPT"
+    ],
+    "contents": "All eighteen before/after MDBs; preparation/independent verifier receipts and logs; exact environment.json; DAO manifest; raw and canonical full snapshots; coverage; report when reached; job stdout/stderr/failure logs. Never commit MDB/provider bytes.",
+    "outcome": "One additive EXP-0196 from validated retained JSON; preserve all historical outcomes. No automatic support movement."
+  },
+  "coverage_limits": [
+    "sole-row release, free-page reuse or indirect map growth",
+    "indexed/related/AutoIncrement/long-value row mutations",
+    "null transitions and variable-width field replacement",
+    "hosted stored-query preservation or follow-on DAO mutations",
+    "arbitrary concurrent writers, non-Unix publication or general rollback guarantees",
+    "all remaining CRUD/index support completion"
+  ],
+  "claims": "Only these nine finite hosted cases can be accepted; no general allocation/compaction policy or automatic support promotion. Existing EXP0162/0182 motivate construction; hosted acceptance requires this separate result.",
+  "inputs": {
+    ".github/workflows/windows-dao-row-allocation.yml": "e6952fc952007de006d1dda3fd4f90d6faf2f24d8634af9b955ae81adc468c55",
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3-cli/Cargo.toml": "027785d6f6755603bf6ee052d3f9df3e56a76f10930fc72d58352c7b29467d32",
+    "crates/jet3-cli/src/main.rs": "73c996d525b7d39d8ad33c4c1a671a4c48b8a7a372ee71af38fe02d3fc1c4c21",
+    "crates/jet3-cli/src/snapshot.rs": "a96e7b22cab2efdc991f0ed5063855034fc20a13d3565caabc7ad3df819c5f8b",
+    "crates/jet3-testkit/Cargo.toml": "79d8432043f68c1d419d070e5fb5274a015c6010e73e7c72064ca7a29a99509c",
+    "crates/jet3-testkit/src/bin/jet3-row-allocation-fixture.rs": "2a20fa3b5225741dbddc32a0a6431eb073c47f994befe51904ce7a09334ad928",
+    "crates/jet3-testkit/src/bin/jet3-row-update-fixture.rs": "af92a40519a844e86ce7e8793df66173a1cefd1a9a4a6f427e51b182c5e13a34",
+    "crates/jet3-testkit/src/coverage.rs": "7a99e54d15dd2e49e76137468511be518f961adb84adc12d29353c22859f564b",
+    "crates/jet3-testkit/src/lib.rs": "cadf967b2b1920e75626e422bd75ef98e5c5bd20e5f89e33f86ad0b25425bf67",
+    "crates/jet3-testkit/src/row_allocation_fixture.rs": "5b06066709b145f9647db3ca1bd2567e67852fea3ad504bf0fe6536c6e40f9fc",
+    "crates/jet3-testkit/src/row_update_fixture.rs": "c6e05b6fe41a0534a91e3f5521890e8a8fbfaead6a0abb1fb5df3af323340693",
+    "crates/jet3-testkit/src/semantic_reader.rs": "8c75aacfbc8aeb47fc4b79fe99263c645f2690eb9749c64ee902526351907438",
+    "crates/jet3-testkit/src/semantic_snapshot.rs": "55cbc49c7113054a846d9dc5626c45292fa6474a8b9d5e9dfb9eddd696152cae",
+    "crates/jet3-testkit/src/semantic_values.rs": "95e3674e7aec6e6c7953092cd38256715c7607903acd33f161c78caa111d6a1a",
+    "crates/jet3-testkit/src/update_fixture.rs": "ecb91ad458b3cb92b247a7fff10916ecd3392e0f6e8eeb7a2f262fe76265bea3",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/src/allocation.rs": "c52b7b405280675b97b9316b6f39019a650a7d7800a0334d7ac000c766a4e82f",
+    "crates/jet3/src/allocation_patch.rs": "13f962e9704a3cd7a5bcdd9f132c404e5d6c86c727920ca04da0d162fecd41c1",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/creation/api.rs": "15653f26cf00dc6e7d9735c25bb3e820930c68f9ac83412dfd9d265912fc7a9c",
+    "crates/jet3/src/creation/composer/mod.rs": "e47212b7ddec4d0dfe8114b95343223ea41697b5d3731cef5309169a09814632",
+    "crates/jet3/src/creation/composer/table_create.rs": "503ae10ca17bb9e88a933dda107fc110a7e48f536895ecfca1292a37bfd45d66",
+    "crates/jet3/src/delete.rs": "adf9b8a85dc058771820479c195ce1a7f80ee360ee2ea6d2549edc0a96e4d187",
+    "crates/jet3/src/insert.rs": "30cc1741973683a121657e634c4af466d1b1a6f6b01df191ff7db311897d5f2c",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/row.rs": "64647c6c4ed50f88841d6d28fcf170653055e44ec4e3ee61f1ec2aaa50a5d1ae",
+    "crates/jet3/src/row_delete_page.rs": "ab61456a71c46aa6ab8db25afb55dae00a05a915c89ae003b6b129b7d7706de8",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_insert_eof.rs": "2b33c18de09f377bddf91b19431d7af8b7708e872e59bf2775f420b69629b5de",
+    "crates/jet3/src/row_insert_page.rs": "c338292a412b187b097defc4a4f88fc17dd2a30549c6ee93ad5ce754b7d44a6a",
+    "crates/jet3/src/row_writer.rs": "585c0769b03f060bdf4897752821ff32ef4f769010e109c885f151fcacd815e1",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/update.rs": "7804019e1c2b2cbfe0d287f2bdcb6bb40a527b009d28d536f2572d65e4fec534",
+    "crates/jet3/src/update_pages.rs": "431201c558c17c9a19affd0850ddf9591109a3b2b70a51546cbc155013d6d0b5",
+    "crates/jet3/src/usage_map.rs": "091f54f1b7f495215d5ff6c9ef07bdef406cf8171bf64f912f808f35b13ad0ec",
+    "oracle/windows-dao/protocol/v1_2/branch-registry.json": "a6010fd5649a9476686c5dc70ba038b667a1daeb279bf5a625123cf1fbd6df8c",
+    "oracle/windows-dao/protocol/v1_2/branch-registry.schema.json": "dc1a126f4f89ae60c78ec2e099938cc0a743dc9b464d85154e9660db056b525c",
+    "oracle/windows-dao/protocol/v1_2/canonical-semantic-snapshot.schema.json": "1c4ed41a01b45fa2357aa2355c2101958e9196d42532386d2e84b393f40066b9",
+    "oracle/windows-dao/protocol/v1_2/coverage-receipt.schema.json": "a362c1d63866ed77465e512902c14e8578f1fadda306c8b35dc9e16b5ff809f1",
+    "oracle/windows-dao/protocol/v1_2/row-allocation-scenarios.json": "37538e96a6caa91207063f91cb1051dea584d7730c1d494587be8e037a76e66e",
+    "oracle/windows-dao/protocol/v1_2/row-update-scenarios.json": "5cc0a15d987da928814f013e58a992f210d3ded1f79e7933d7460a97b07433c9",
+    "oracle/windows-dao/protocol/v1_2/update-scenarios.json": "08248cebba898b1209bc980c1c286bfa9922fcc16b25f4b308e4df2710f62657",
+    "oracle/windows-dao/scripts/Invoke-DaoReadV12.ps1": "78fb338668271a23158f0cfc65f0393931e4a04945af0ed84808964b2a073c89",
+    "oracle/windows-dao/scripts/Invoke-DaoUpdateV12.ps1": "f7716e726132c8f20720fbfdd4fd0980b4694e39d75d141b89bbc7200da2576f",
+    "oracle/windows-dao/scripts/build_v1_2_inventory.py": "f2c928b11b45ae4f2896526c18a6edf8d4b8fdc19f743d9b0cdff180d9a81561",
+    "oracle/windows-dao/scripts/dao_read_diff.py": "696e3b8192fc8b110b020e00dfdcbf479bd3ca3f83648b7c5a1bb17c4a017d26",
+    "oracle/windows-dao/scripts/dao_row_allocation_diff.py": "bd62c7fd28e9ae9714fda7879d537f37374f28aaa765687a9f2f58cf3d0436d8",
+    "oracle/windows-dao/scripts/dao_row_update_diff.py": "0dd4fc8dc18cffca8707aca20ce82c20de4485f609d8682020382c2629d16d47",
+    "oracle/windows-dao/scripts/dao_update_diff.py": "e398d10ed8ea4de481f79e8231303bd343f041a3e4f848b6448c914eee573a88",
+    "oracle/windows-dao/scripts/dao_write_diff.py": "0d598b570f8f5a3008a51c8bc6743d7166b7e3b4a49432000ff01055f4e133a7",
+    "oracle/windows-dao/scripts/probe-provider.ps1": "695e357959f7882f2608dfcc32cf9d6bc5d1fd128126552d656daabbfe0b0ebd",
+    "oracle/windows-dao/scripts/protocol_validation.py": "ce857b3f818e2e5298da093e97ef4ceba1e410a77e4f74048af129db504dac50",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/scripts/validate_protocol_v1_2.py": "de8910e207a6774a426ddca90502e1c6a189b799452d7704d46d0c8a7015232e"
+  }
+}


### PR DESCRIPTION
Preregisters the hosted nine-case update differential, retaining existing updates and adding EOF allocation plus middle/repeated deletion. Runtime inputs are SHA-pinned; the actual dispatched source, all 18 images/snapshots, independent byte preservation, and provider identities must validate before an outcome can be recorded.

Validation: independent review, exact committed preflight, and `just ready` passed. No hosted acquisition yet.

Progress toward #113.
