### PR TITLE
test: preregister same-page row replacement comparisons

### DIFF
--- a/crates/jet3/examples/row_update_candidate.rs
+++ b/crates/jet3/examples/row_update_candidate.rs
@@ -1,0 +1,107 @@
+//! Replace one complete row through the public API for EXP-0197.
+use jet3::{
+    CatalogObjectClass, DatabaseReader, ResourceBudget, ResourceLimits, RowUpdate, RowValue,
+    update_row,
+};
+use std::{env, fs, path::Path};
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = env::args().skip(1).collect();
+    let [source, destination, table, selected_id, profile] = args.as_slice() else {
+        return Err(
+            "usage: row_update_candidate SOURCE DESTINATION TABLE ORIGINAL_ID PROFILE".into(),
+        );
+    };
+    if Path::new(destination).exists() {
+        return Err("destination exists".into());
+    }
+    let selected_id: i32 = selected_id.parse()?;
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let mut database = DatabaseReader::open(source, &mut budget)?;
+    let root = {
+        let mut catalog = database.catalog(&mut budget)?;
+        let mut roots = Vec::new();
+        while let Some(record) = catalog.next_record()? {
+            if record.class() == CatalogObjectClass::User
+                && record.name().raw_bytes() == table.as_bytes()
+            {
+                roots.push(record.table_definition().ok_or("not a table")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("table not unique".into());
+        }
+        roots[0]
+    };
+    let definition = database.table_definition(root, &mut budget)?;
+    let id = definition
+        .columns()
+        .iter()
+        .find(|c| c.name().raw_bytes() == b"Id")
+        .ok_or("Id absent")?
+        .ordinal();
+    let locator = {
+        let mut rows = database.rows(&definition, &mut budget)?;
+        let mut found = Vec::new();
+        while let Some(row) = rows.next_row()? {
+            if row.field(id).and_then(|field| field.raw_bytes())
+                == Some(selected_id.to_le_bytes().as_slice())
+            {
+                found.push(row.locator());
+            }
+        }
+        if found.len() != 1 {
+            return Err("selected Id not unique".into());
+        }
+        found[0]
+    };
+    drop(database);
+    fs::copy(source, destination)?;
+    let grow = [b'g'; 60];
+    let values = match profile.as_str() {
+        "grow-first" => [
+            RowValue::Long(1),
+            RowValue::Null,
+            RowValue::Text(&grow),
+            RowValue::Binary(&[1, 35, 69, 103, 137, 171, 205, 239]),
+            RowValue::Boolean(false),
+        ],
+        "shrink-middle" => [
+            RowValue::Long(2),
+            RowValue::Long(-42),
+            RowValue::Null,
+            RowValue::Binary(&[1, 2]),
+            RowValue::Boolean(true),
+        ],
+        "null-later" => [
+            RowValue::Long(12),
+            RowValue::Long(i32::MIN),
+            RowValue::Text(b"restored"),
+            RowValue::Binary(&[0, 255, 1, 2]),
+            RowValue::Boolean(true),
+        ],
+        "tombstone" => [
+            RowValue::Long(3),
+            RowValue::Null,
+            RowValue::Null,
+            RowValue::Null,
+            RowValue::Boolean(false),
+        ],
+        _ => return Err("unknown profile".into()),
+    };
+    update_row(
+        destination,
+        RowUpdate {
+            table: table.as_bytes(),
+            row: locator,
+            values: &values,
+        },
+        &mut budget,
+    )?;
+    println!(
+        "{{\"root\":{},\"page\":{},\"slot\":{}}}",
+        root.get(),
+        locator.page().get(),
+        locator.slot()
+    );
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -12909,6 +12909,49 @@ Copy this block under the appropriate section and remove this instruction:
   checks passed; exact integrated five-case public preparation and committed
   plan/input checks precede dispatch. Independent plan review is required.
 
+## EXP-0197 — Same-page full-row replacement candidate preregistration
+
+- Preregistered 2026-09-05; no acquisition yet. Reviewed implementation
+  `c255849` supplies public `RowUpdate`/`update_row`. Plan
+  `oracle/windows-dao/acquisition/row-update-candidate.plan.json`, SHA-256
+  `95fa2e50c21230ed27f1c81bda93530b9fd2af460cb5760a984285c56215a0fe`,
+  pins 33 scoped source/exporter/producer/analyzer/transport/helper inputs.
+  Dispatch and retained-data analysis both verify these exact pins.
+- Four natural DAO profiles, three fresh originals each, with Items/Later
+  Long Id, nullable Long Value, Text255, Binary255 and Boolean fields plus
+  KeepQuery. Grow the first row with scalar null transition and Text/Binary
+  growth; shrink an unequal-width middle row; populate a later-table row's
+  null fields; replace a row adjacent to a known empty tombstone created by
+  a separate baseline DAO deletion. Exact seed/final values reside in the plan.
+- Independent DAO copies receive complete-row edits; Unix copies receive the
+  public API replacement. Original slots and all other row values remain stable.
+  The independent checker repacks existing physical slots, replacing only the
+  selected encoded row, with exact offsets/free count and unchanged vacated
+  slack, table/physical counts, maps, page zero and every unrelated byte.
+  Actual ordinary/inline-map/capacity/tombstone gates are checked, not assumed.
+- After all twelve public candidates pass, read original/control/Rust images
+  read-only and insert `[99,-9900,"next","00ff",true]` into separate control
+  and Rust continuation copies. Require complete schema/row/QuerySQL equality,
+  unchanged read-only identities and exact source/operation/image bindings.
+  Retain 60 MDBs and 84 DAO captures: twelve public edits, twelve DAO control
+  edits and 24 continuation inserts, plus baseline creation/three seed deletes.
+- One phased acquisition, no retry/resume or subset promotion. Any acquisition,
+  eligibility, mutation, capture, byte or semantic failure yields `no_outcome`
+  with partial artifacts and initiating endpoint/stack retained. Explicit
+  Int32/String/byte[]/Boolean/DBNull setter sites use plain CLR arrays;
+  cleanup preserves the initiating failure. EXP-0198 reserves one additive result.
+- Three Python classifier/preservation/pin tests, exporter Clippy and actual
+  four-profile public creation/exporter/checker preparations passed. Prepared
+  old/new row lengths were 19→82, 104→16, 14→26 and 21→14 bytes; these are
+  tooling checks, not DAO observations. Actual x86 parser and 200 typed mock
+  assignments plus first-error preservation passed without DAO. Temporary
+  preparation/share files were removed; mocks do not establish COM behavior.
+- Hypothesis: anchored in-page row movement with unchanged maps/counts/page0 is
+  accepted for these exact narrow two-variable rows. Existing EXP-0060/0061,
+  EXP-0162 and EXP-0170 motivate encoding/movement/tombstone construction.
+  No arbitrary wide multivariable shape, index/relationship/Auto/LVAL/overflow,
+  allocation/map transition, general update policy or support movement claimed.
+
 ## EXP-0170 — Public row insertion and DAO continuation accepted in three cases
 
 - Outcome: `observed_accepted`, recorded 2026-09-05 from the single local run

--- a/oracle/windows-dao/acquisition/row-update-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/row-update-candidate.plan.json
@@ -1,0 +1,654 @@
+{
+  "document_type": "dao_row_update_candidate_plan",
+  "provenance": "EXP-0197",
+  "outcome_provenance": "EXP-0198",
+  "replicas": 3,
+  "source_revision": "c255849a71b26fe5152f35aad58854583513ccd5",
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 255
+    },
+    {
+      "name": "Bytes",
+      "type": 9,
+      "size": 255
+    },
+    {
+      "name": "Flag",
+      "type": 1,
+      "size": 1
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "insert": [
+    99,
+    -9900,
+    "next",
+    "00ff",
+    true
+  ],
+  "arms": [
+    {
+      "name": "grow-first",
+      "table": "Items",
+      "selected_id": 1,
+      "replacement": [
+        1,
+        null,
+        "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+        "0123456789abcdef",
+        false
+      ],
+      "tombstone": false,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "shrink-middle",
+      "table": "Items",
+      "selected_id": 2,
+      "replacement": [
+        2,
+        -42,
+        null,
+        "0102",
+        true
+      ],
+      "tombstone": false,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "null-later",
+      "table": "Later",
+      "selected_id": 12,
+      "replacement": [
+        12,
+        -2147483648,
+        "restored",
+        "00ff0102",
+        true
+      ],
+      "tombstone": false,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tombstone",
+      "table": "Items",
+      "selected_id": 3,
+      "replacement": [
+        3,
+        null,
+        null,
+        null,
+        false
+      ],
+      "tombstone": true,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "inputs": {
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/row_update_candidate.rs": "3d261186c6e399e2eb986f0b0d637b2712644a1a0f9b702bbbc72a9cddae23a2",
+    "crates/jet3/src/allocation.rs": "c52b7b405280675b97b9316b6f39019a650a7d7800a0334d7ac000c766a4e82f",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/lib.rs": "689fb7cc1a4a19a9e29b9bb03e7736f34b99207e7170409d4fa56efd05cf2c45",
+    "crates/jet3/src/map_location.rs": "4fc00ccfaae0ed58e8f6adb82409eb3cf1e6f13fc1475caad519ff419be25c6c",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "crates/jet3/src/row.rs": "64647c6c4ed50f88841d6d28fcf170653055e44ec4e3ee61f1ec2aaa50a5d1ae",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_update.rs": "3463b89159ddd8628be758f78800a78b44808f7ec28333f899c3a74d4434d304",
+    "crates/jet3/src/row_update_page.rs": "91f8b7c07aafa71daaf77abc6c88cfdd6d7db03448b820a42648b1b35a097d86",
+    "crates/jet3/src/row_writer.rs": "585c0769b03f060bdf4897752821ff32ef4f769010e109c885f151fcacd815e1",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/update.rs": "7804019e1c2b2cbfe0d287f2bdcb6bb40a527b009d28d536f2572d65e4fec534",
+    "crates/jet3/src/update_pages.rs": "431201c558c17c9a19affd0850ddf9591109a3b2b70a51546cbc155013d6d0b5",
+    "crates/jet3/src/usage_map.rs": "091f54f1b7f495215d5ff6c9ef07bdef406cf8171bf64f912f808f35b13ad0ec",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/row_delete_layout.py": "74c30a55148ec5efe4c04a154917e8780c06a63442d28c0d0b3453b968142088",
+    "oracle/windows-dao/scripts/row_update_candidate.ps1": "25113ce3952989736c08d2ba19bb3f07647ee1e0748f827b780b1ff9564bba01",
+    "oracle/windows-dao/scripts/row_update_candidate.py": "600b3e653ef001c3cd93d9ebbc25b4b9196bd0f55ae9e1e3b9af922d8e784a71",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/tests/check_row_update_candidate.ps1": "ee7a87eb3e372396413357b34baa756f7db5346ca1fe12b75bf74fc487c7980e",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "question": "Does bounded public same-page full-row replacement match independent DAO edits and continuation while preserving every unrelated byte and physical slot?",
+  "source_facts": [
+    "EXP-0060/0061 checked scalar/null/variable row grammar",
+    "EXP-0162 row movement; EXP-0170 known tombstone continuation"
+  ],
+  "sequence": [
+    "Commit exact source/input-pinned plan, independently review, dispatch once. No retry/resume after first mutation.",
+    "Create four natural Long/Long/Text255/Binary255/Boolean Items/Later profiles, each three fresh replicas, plus KeepQuery. For tombstone profile delete Id2 with DAO before baseline capture; retain actual physical shape and refuse if known empty c000 tombstone absent. Make independent DAO edit control copies.",
+    "Unix public exporter copies original once, replaces selected complete row with exact profile values. Require ordinary live target, inline owned+available page, narrow offsets and retained capacity. Independently rebuild page in original slot order; only replacement/moved bytes, affected offsets and free count may differ. Counts/maps/page0/slack and every other byte exact.",
+    "Observe original/control/Rust copies read-only; make separate continuation copies and DAO insert [99,-9900,next,00ff,true]. Full schema/rows/QuerySQL and exact read-only identities must match controls. Retain60 MDBs/84 captures,12 public edits/12 DAO control edits/24 continuation inserts, plus natural baseline creation and3 seed deletions."
+  ],
+  "decision_rule": "observed_accepted requires all12 profiles/replicas and continuations, complete fullschema/rows/QuerySQL, exact unrelatedbyte/slot/count/map preservation and source/input/operation/identity gates. Any failure yields one no_outcome with retained partial artifacts; no subset promotion.",
+  "bounds": "Four finite profiles; narrow two-variable rows under256bytes, fixed Long null transitions, ASCII Text, explicit byte[] Binary, Boolean bit changes. No index/relation/Auto/LVAL/overflow/map transition or arbitrary wide multivariable encoding. Local development only; no support movement. SSH300seconds perphase, Unix120seconds per edit.",
+  "hypothesis": "Anchored row replacement with later-row shift and unchanged page0/maps/count/slack is accepted for these exact finite cases, not asserted as DAO general update policy.",
+  "producer": "Stageful explicit Int32/String/byte[]/Boolean/DBNull setters, plain CLR arrays; first error endpoint/stack preserved through best-effort closure and artifact retention."
+}

--- a/oracle/windows-dao/scripts/row_update_candidate.ps1
+++ b/oracle/windows-dao/scripts/row_update_candidate.ps1
@@ -1,0 +1,163 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'Expected x86 DAO' }
+$tokens=$null; $errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile((Join-Path $env:JET3_WORK 'field_update.ps1'),[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Pinned helper parse failure'}
+foreach($name in @('Identity','Release','Write-Json')) {
+    $definitions=@($ast.FindAll({param($node) $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name},$false))
+    if($definitions.Count-ne 1){throw 'Helper missing'}
+    Invoke-Expression $definitions[0].Extent.Text
+}
+function Remember($Record) {
+    if($null-eq $script:failure){$script:failure=@{endpoint=$script:endpoint; message=$Record.Exception.Message; stack=[string]$Record.ScriptStackTrace; hresult=[int]$Record.Exception.HResult}}
+}
+function Close-Object($Value,[bool]$Close) {
+    if($null-eq $Value){return}
+    try{if($Close){$Value.Close()}}catch{Remember $_}
+    try{Release $Value}catch{Remember $_}
+}
+function Set-Row($Recordset,$Row) {
+    foreach($ordinal in 0..4){
+        $script:endpoint='field/'+[string]$ordinal;$field=$Recordset.Fields.Item($ordinal)
+        try {
+            if($null-eq $Row[$ordinal]){$field.Value=[DBNull]::Value}
+            elseif($ordinal-le 1){$field.Value=[int]$Row[$ordinal]}
+            elseif($ordinal-eq 2){$field.Value=[string]$Row[$ordinal]}
+            elseif($ordinal-eq 3){
+                $hex=[string]$Row[3];$bytes=[byte[]]::new($hex.Length/2)
+                for($i=0;$i-lt $bytes.Length;$i++){$bytes[$i]=[Convert]::ToByte($hex.Substring(2*$i,2),16)}
+                $field.Value=[byte[]]$bytes
+            }else{$field.Value=[bool]$Row[$ordinal]}
+        }catch{Remember $_;throw}finally{Close-Object $field $false}
+    }
+}
+function Append-Row($Recordset,$Row) {
+    $script:endpoint='add_new';$Recordset.AddNew();Set-Row $Recordset $Row
+    $script:endpoint='insert_update';$Recordset.Update()
+}
+function Select-Row($Recordset,[int]$Id) {
+    $Recordset.MoveFirst();$found=0
+    while(-not $Recordset.EOF){if([int]$Recordset.Fields.Item('Id').Value-eq $Id){$found++};$Recordset.MoveNext()}
+    if($found-ne 1){throw 'Id not unique'}
+    $Recordset.MoveFirst();while([int]$Recordset.Fields.Item('Id').Value-ne $Id){$Recordset.MoveNext()}
+}
+function Create-Original([string]$Path,$Arm) {
+    $engine=$workspace=$db=$table=$field=$rs=$query=$null
+    try {
+        $engine=New-Object -ComObject DAO.DBEngine.36; $workspace=$engine.Workspaces.Item(0)
+        $script:mutationStarted=$true; $script:endpoint='create_database'
+        $db=$workspace.CreateDatabase($Path,';LANGID=0x0409;CP=1252;COUNTRY=0',32)
+        foreach($spec in $Arm.tables){
+            $script:endpoint='schema/'+$spec.name; $table=$db.CreateTableDef([string]$spec.name)
+            foreach($column in $plan.fields){
+                $field=$table.CreateField([string]$column.name,[int]$column.type,[int]$column.size)
+                $table.Fields.Append($field);Close-Object $field $false;$field=$null
+            }
+            $db.TableDefs.Append($table);$rs=$db.OpenRecordset([string]$spec.name,2)
+            foreach($row in $spec.seed_rows){$script:endpoint='insert/'+$spec.name;Append-Row $rs $row}
+            if($Arm.tombstone-and $spec.name-eq $Arm.table){Select-Row $rs 2;$script:endpoint='seed_delete';$rs.Delete()}
+            Close-Object $rs $true;$rs=$null;Close-Object $table $false;$table=$null
+        }
+        $query=$db.CreateQueryDef([string]$plan.query.name,[string]$plan.query.sql)
+    }catch{Remember $_;throw}finally{
+        Close-Object $rs $true;Close-Object $field $false;Close-Object $table $false;Close-Object $query $false
+        Close-Object $db $true;Close-Object $workspace $false;Close-Object $engine $false
+    }
+}
+function Mutate-Copy([string]$Source,[string]$Path,$Arm,[string]$Operation) {
+    Copy-Item -LiteralPath $Source -Destination $Path
+    $engine=$db=$rs=$null;$outcome=@{operation=$Operation;status='complete';selected_id=$Arm.selected_id}
+    try {
+        $script:mutationStarted=$true;$script:endpoint=$Operation+'/open'
+        $engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$false)
+        $rs=$db.OpenRecordset([string]$Arm.table,2)
+        if($Operation-eq 'update'){
+            Select-Row $rs ([int]$Arm.selected_id)
+            $script:endpoint='edit';$rs.Edit();Set-Row $rs $Arm.replacement
+            $script:endpoint='row_update';$rs.Update()
+        }else{$script:endpoint='follow-on insert';Append-Row $rs $plan.insert}
+    }catch{Remember $_;throw}finally{Close-Object $rs $true;Close-Object $db $true;Close-Object $engine $false}
+    return $outcome
+}
+function Observe([string]$Path) {
+    $before = Identity $Path
+    $engine = $db = $table = $rs = $null
+    $status = 'pass'; $errorDetail = $null; $script:endpoint = 'open_database'; $snapshot = [ordered]@{}
+    try {
+        $engine = New-Object -ComObject DAO.DBEngine.36
+        $db = $engine.OpenDatabase($Path, $false, $true)
+        $snapshot.version = [string]$db.Version
+        $snapshot.tables = @($db.TableDefs | ForEach-Object { [string]$_.Name } | Sort-Object)
+        $snapshot.relations = @($db.Relations | ForEach-Object { @{name=[string]$_.Name; table=[string]$_.Table; foreign_table=[string]$_.ForeignTable; attributes=[int]$_.Attributes; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; foreign_name=[string]$_.ForeignName} })} })
+        $snapshot.queries = @($db.QueryDefs | ForEach-Object { @{name=[string]$_.Name; sql=[string]$_.SQL; type=[int]$_.Type} } | Sort-Object { $_.name })
+        $snapshot.user_tables = @()
+        foreach ($name in @($snapshot.tables | Where-Object { -not $_.StartsWith('MSys') })) {
+            $script:endpoint = 'schema'; $table = $db.TableDefs.Item([string]$name)
+            $item = [ordered]@{name=[string]$table.Name; attributes=[int]$table.Attributes}
+            $item.fields = @($table.Fields | ForEach-Object { @{name=[string]$_.Name; type=[int]$_.Type; size=[int]$_.Size; attributes=[int]$_.Attributes; required=[bool]$_.Required; allow_zero_length=[bool]$_.AllowZeroLength; default_value=[string]$_.DefaultValue} })
+            $item.indexes = @($table.Indexes | ForEach-Object { @{name=[string]$_.Name; primary=[bool]$_.Primary; unique=[bool]$_.Unique; required=[bool]$_.Required; foreign=[bool]$_.Foreign; ignore_nulls=[bool]$_.IgnoreNulls; fields=@($_.Fields | ForEach-Object { @{name=[string]$_.Name; attributes=[int]$_.Attributes} })} })
+            $script:endpoint = 'rows'; $rs = $db.OpenRecordset([string]$name, 4)
+            $rows = New-Object Collections.ArrayList
+            while (-not $rs.EOF) {
+                $values=[object[]]::new(5)
+                foreach($ordinal in 0..4){
+                    $field=$rs.Fields.Item($ordinal)
+                    try{$v=$field.Value
+                        if($v-is [DBNull]){$values[$ordinal]=$null}
+                        elseif($ordinal-le 1){$values[$ordinal]=[int]$v}
+                        elseif($ordinal-eq 2){$values[$ordinal]=[string]$v}
+                        elseif($ordinal-eq 3){$values[$ordinal]=([BitConverter]::ToString([byte[]]$v)).Replace('-','').ToLowerInvariant()}
+                        else{$values[$ordinal]=[bool]$v}
+                    }finally{Close-Object $field $false}
+                }
+                [void]$rows.Add($values)
+                $rs.MoveNext()
+            }
+            $item.rows = @($rows); $rs.Close(); Release $rs; $rs = $null
+            $snapshot.user_tables += $item; Release $table; $table = $null
+        }
+    } catch { Remember $_; $status = 'error'; $errorDetail = $_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+    finally {
+        Close-Object $rs $true; Close-Object $table $false
+        Close-Object $db $true; Close-Object $engine $false
+    }
+    return @{file=[IO.Path]::GetFileName($Path); before=$before; after=(Identity $Path); status=$status; endpoint=$endpoint; error=$errorDetail; snapshot=$snapshot}
+}
+$planPath=Join-Path $env:JET3_WORK 'row-update-candidate.plan.json'
+$plan=Get-Content -LiteralPath $planPath -Raw|ConvertFrom-Json
+foreach($entry in @(@('row_update_candidate.ps1',$PSCommandPath),@('field_update.ps1',(Join-Path $env:JET3_WORK 'field_update.ps1')))){
+    if((Identity $entry[1]).sha256-cne $plan.inputs.('oracle/windows-dao/scripts/'+$entry[0])){throw 'Script pin mismatch'}
+}
+$phase=(Get-Content (Join-Path $env:JET3_WORK 'phase.txt') -Raw).Trim()
+if($phase-notin @('create','observe')){throw 'Unknown phase'}
+$failure=$null;$mutationStarted=$false;$endpoint='start'
+$result=@{document_type='dao_row_update_candidate_phase';phase=$phase;plan_sha256=(Identity $planPath).sha256;environment=@{process_bits=32;provider='DAO.DBEngine.36'};observations=@();operations=@();error=$null;retention_failures=@()}
+try{
+    foreach($arm in $plan.arms){foreach($replica in 1..3){
+        $prefix="$($arm.name)-r$replica";$original=Join-Path $env:JET3_WORK "$prefix-original.mdb";$control=Join-Path $env:JET3_WORK "$prefix-control.mdb"
+        if($phase-eq 'create'){
+            Create-Original $original $arm
+            $result.operations+=@{arm=$arm.name;replica=$replica;role='control';result=(Mutate-Copy $original $control $arm 'update')}
+            $roles=@('original','control')
+        }else{$roles=@('original','control','rust','control-next','rust-next')}
+        foreach($role in $roles){
+            $path=Join-Path $env:JET3_WORK "$prefix-$role.mdb"
+            if($role.EndsWith('-next')){
+                $source=Join-Path $env:JET3_WORK "$prefix-$($role.Replace('-next','')).mdb"
+                $result.operations+=@{arm=$arm.name;replica=$replica;role=$role;result=(Mutate-Copy $source $path $arm 'insert')}
+            }
+            $observation=Observe $path
+            $result.observations+=@{arm=$arm.name;replica=$replica;role=$role;observation=$observation}
+            if($observation.status-ne 'pass'-or $null-ne $failure){throw 'Capture or cleanup failed'}
+        }
+    }}
+}catch{Remember $_}finally{
+    $result.error=$failure;$result.mutation_started=$mutationStarted
+    [GC]::Collect();[GC]::WaitForPendingFinalizers()
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb'){
+        try{Copy-Item -LiteralPath $file.FullName -Destination $env:JET3_OUTBOX}catch{$result.retention_failures+=@{file=$file.Name;message=$_.Exception.Message}}
+    }
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if($null-ne $failure-or $result.retention_failures.Count){exit 1}

--- a/oracle/windows-dao/scripts/row_update_candidate.py
+++ b/oracle/windows-dao/scripts/row_update_candidate.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""EXP-0197: same-page full-row replacement and DAO continuation, no retries."""
+import argparse
+import copy
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import field_update as common
+import row_delete_layout as layout
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/row-update-candidate.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/row_update_candidate.ps1'
+identity, canonical = common.identity, common.canonical
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, sha in plan['inputs'].items():
+        if identity(ROOT / name)['sha256'] != sha: raise ValueError('Input pin mismatch: ' + name)
+    return plan
+
+
+def preflight():
+    plan = verify_inputs()
+    if os.name != 'posix' or subprocess.check_output(['git','show',f'HEAD:{PLAN.relative_to(ROOT)}'],cwd=ROOT) != PLAN.read_bytes():
+        raise ValueError('Expected committed Unix plan')
+    return plan
+
+
+def expected(snapshot, arm, role, plan):
+    value = common.normalized(snapshot)
+    tables = copy.deepcopy(arm['tables'])
+    target = next(t for t in tables if t['name'] == arm['table'])
+    if role != 'original': target['rows'] = [arm['replacement'] if r[0] == arm['selected_id'] else r for r in target['rows']]
+    if role.endswith('-next'): target['rows'].append(plan['insert'])
+    if (value['version'] != '3.0' or value['relations'] != []
+        or value['tables'] != sorted(['MSysACEs','MSysObjects','MSysQueries','MSysRelationships']+[t['name'] for t in tables])
+        or [t['name'] for t in value['user_tables']] != sorted(t['name'] for t in tables)
+        or len(value['queries']) != 1 or value['queries'][0]['name'] != plan['query']['name']
+        or value['queries'][0]['type'] != 0 or not value['queries'][0]['sql']):
+        raise ValueError('Requested database inventory')
+    for spec in tables:
+        table = next(t for t in value['user_tables'] if t['name'] == spec['name'])
+        if (table['attributes'] != 0 or table['indexes'] != [] or table['rows'] != sorted(spec['rows'])
+            or [{k:f[k] for k in ('name','type','size')} for f in table['fields']] != plan['fields']
+            or [f['attributes'] for f in table['fields']] != [1,1,2,2,1]):
+            raise ValueError('Requested table schema/rows')
+    return value
+
+
+def shape(data, arm):
+    catalog = layout.catalog
+    definition, _, records = catalog._discover_catalog(data)
+    name, ident = [catalog._ordinal(definition, n) for n in ('Name','Id')]
+    roots = [r['values'][ident] for r in records if r['values'][name] == arm['table']]
+    if len(roots) != 1: raise ValueError('Target table binding')
+    table = catalog._definition(data, roots[0]); pages, lval = catalog._table_pages(data, table)
+    if lval or table['physical_indexes']: raise ValueError('Unsupported source shape')
+    rows = catalog._table_rows(data, table, pages)
+    if table['row_count'] != len(rows): raise ValueError('Raw row count')
+    return table, rows, {k:sorted(catalog._locator_pages(data,v,k)) for k,v in table['maps'].items()}
+
+
+def encode(values):
+    ident,value,text,binary,flag=values
+    fixed=bytes([5])+ident.to_bytes(4,'little',signed=True)+(0 if value is None else value).to_bytes(4,'little',signed=True)
+    text=b'' if text is None else text.encode('ascii');binary=b'' if binary is None else bytes.fromhex(binary)
+    end=9+len(text)+len(binary)
+    if end>=256: raise ValueError('Finite narrow variable offsets')
+    bitmap=1|(2 if values[1] is not None else 0)|(4 if values[2] is not None else 0)|(8 if values[3] is not None else 0)|(16 if flag else 0)
+    return fixed+text+binary+bytes([end,9+len(text),9,2,bitmap])
+
+
+def patch_check(before, after, arm, receipt):
+    table,rows,maps=shape(before,arm)
+    selected=[r for r in rows if r['values'][0]==arm['selected_id']]
+    if len(selected)!=1: raise ValueError('Selected row identity')
+    row=selected[0];page=row['page'];base=page*2048;slot=row['row']
+    if receipt!=dict(root=table['root'],page=page,slot=slot): raise ValueError('Slot receipt')
+    raw=layout.catalog._page(before,page,'replacement source');slots=layout.catalog._row_directory(raw,page)
+    if page not in maps['owned'] or page not in maps['available'] or len(slots)>=256: raise ValueError('Available ordinary page')
+    if any((s['hidden'] or s['overflow'] or s['start']==s['end']) and not(s['hidden'] and s['overflow'] and s['start']==s['end']) for s in slots): raise ValueError('Unsupported row flags')
+    if arm['tombstone'] and not any(s['hidden'] and s['overflow'] and s['start']==s['end'] for s in slots): raise ValueError('Expected known empty tombstone')
+    old=slots[slot];old_width=old['end']-old['start'];new=encode(arm['replacement'])
+    free=int.from_bytes(raw[2:4],'little')
+    if free!=slots[-1]['start']-10-2*len(slots) or free+old_width-len(new)<16: raise ValueError('Free/capacity gate')
+    expected=bytearray(before);end=2048
+    for ordinal,s in enumerate(slots):
+        body=new if ordinal==slot else raw[s['start']:s['end']]
+        end-=len(body);expected[base+end:base+end+len(body)]=body
+        flags=0xc000 if s['hidden'] else 0
+        expected[base+10+2*ordinal:base+12+2*ordinal]=(flags|end).to_bytes(2,'little')
+    expected[base+2:base+4]=(end-10-2*len(slots)).to_bytes(2,'little')
+    if expected!=after: raise ValueError('Exact replacement/offset/free/slack/maps/count/page0 preservation')
+    after_table,after_rows,after_maps=shape(after,arm)
+    binding=lambda values:sorted((r['page'],r['row']) for r in values)
+    if after_maps!=maps or after_table['row_count']!=table['row_count'] or binding(after_rows)!=binding(rows): raise ValueError('Row slots/count/maps changed')
+    return dict(locator=receipt,old_length=old_width,new_length=len(new),row_count=table['row_count'],maps=maps,free_before=free,free_after=end-10-2*len(slots),changes=layout.changed_ranges(before,after),page0_unchanged=before[:2048]==after[:2048])
+
+
+def entries(document, phase, plan):
+    if (document['document_type']!='dao_row_update_candidate_phase' or document['phase']!=phase
+        or document['plan_sha256']!=identity(PLAN)['sha256'] or document['error'] is not None
+        or document['retention_failures'] or document['mutation_started'] is not True
+        or document['environment']!={'process_bits':32,'provider':'DAO.DBEngine.36'}):
+        raise ValueError('Failed/incomplete phase')
+    roles=['original','control'] if phase=='create' else ['original','control','rust','control-next','rust-next']
+    wanted={(a['name'],r,role) for a in plan['arms'] for r in range(1,4) for role in roles}
+    result={}
+    for item in document['observations']:
+        key=(item['arm'],item['replica'],item['role']); obs=item['observation']
+        if key in result or key not in wanted or obs['file']!=f'{key[0]}-r{key[1]}-{key[2]}.mdb' or obs['status']!='pass' or obs['error'] is not None or obs['before']!=obs['after']:
+            raise ValueError('Observation binding/failure')
+        result[key]=obs
+    if set(result)!=wanted: raise ValueError('Missing capture')
+    op_roles=['control'] if phase=='create' else ['control-next','rust-next']
+    operations={(o['arm'],o['replica'],o['role']):o['result'] for o in document['operations']}
+    if len(operations)!=len(document['operations']) or set(operations)!={(a['name'],r,role) for a in plan['arms'] for r in range(1,4) for role in op_roles}: raise ValueError('Missing operation')
+    for a in plan['arms']:
+        for r in range(1,4):
+            for role in op_roles:
+                if operations[a['name'],r,role]!=dict(operation='update' if phase=='create' else 'insert',status='complete',selected_id=a['selected_id']): raise ValueError('Operation failed')
+    return result
+
+
+def build_report(result, outbox, plan):
+    observations=[]; reasons=[]
+    try:
+        if (result['document_type']!='dao_row_update_candidate_result' or result['producer_os']!='posix' or result['source_revision']!=plan['source_revision'] or result['plan_sha256']!=identity(PLAN)['sha256'] or result['phase']!='complete' or result['error'] is not None): raise ValueError('Coordinated phase/source failure')
+        phases={}
+        for phase in ('create','observe'):
+            path=outbox/(phase+'.json')
+            if identity(path)!=result['phases'][phase]: raise ValueError('Phase identity')
+            phases[phase]=entries(json.loads(path.read_text(encoding='utf-8-sig')),phase,plan)
+        updates={(u['arm'],u['replica']):u for u in result['updates']}
+        if len(updates)!=len(result['updates']) or set(updates)!={(a['name'],r) for a in plan['arms'] for r in range(1,4)}: raise ValueError('Update inventory')
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                prefix=f"{arm['name']}-r{replica}"; snapshots={}; images={}
+                for role in ('original','control','rust','control-next','rust-next'):
+                    item=phases['observe'][arm['name'],replica,role]; path=outbox/f'{prefix}-{role}.mdb'
+                    if identity(path)!=item['after']: raise ValueError('Retained identity')
+                    images[role]=identity(path); snapshots[role]=expected(item['snapshot'],arm,role,plan)
+                    if role in ('original','control') and item!=phases['create'][arm['name'],replica,role]: raise ValueError('Original/control changed between phases')
+                update=updates[arm['name'],replica]
+                if update['original_before']!=images['original'] or update['original_after']!=images['original'] or update['rust']!=images['rust']: raise ValueError('Unix identity chain')
+                before=(outbox/f'{prefix}-original.mdb').read_bytes(); rust=(outbox/f'{prefix}-rust.mdb').read_bytes()
+                patch=patch_check(before,rust,arm,update['locator'])
+                if snapshots['rust']!=snapshots['control'] or snapshots['rust-next']!=snapshots['control-next']: raise ValueError('DAO control differs')
+                baseline=copy.deepcopy(snapshots['original']); target=next(t for t in baseline['user_tables'] if t['name']==arm['table']); target['rows']=[arm['replacement'] if r[0]==arm['selected_id'] else r for r in target['rows']]
+                if baseline!=snapshots['rust']: raise ValueError('Unrelated metadata/SQL changed')
+                target['rows'].append(plan['insert']); baseline=common.normalized(baseline)
+                if baseline!=snapshots['rust-next']: raise ValueError('Follow-on metadata/SQL changed')
+                control_maps=shape((outbox/f'{prefix}-control.mdb').read_bytes(),arm)[2]
+                if control_maps!=patch['maps']: raise ValueError('Control map membership differs')
+                observations.append(dict(arm=arm['name'],replica=replica,identities=images,patch=patch,snapshot=snapshots['rust-next']))
+    except (ValueError,KeyError,TypeError,OSError,layout.catalog.DecodeError) as error: reasons.append(str(error))
+    return dict(document_type='dao_row_update_candidate_report',plan_sha256=identity(PLAN)['sha256'],outcome='observed_accepted' if not reasons else 'no_outcome',reasons=reasons,observations=observations,development_only=True,compatibility_claim=False,support_matrix_movement=False)
+
+
+def analyze(outbox):
+    plan=verify_inputs(); report=build_report(json.loads((outbox/'result.json').read_text()),outbox,plan)
+    report['result_sha256']=identity(outbox/'result.json')['sha256']; (outbox/'report.json').write_text(canonical(report)+'\n'); print(report['outcome'])
+
+
+def dispatch(args):
+    plan=preflight()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id): raise ValueError('Invalid run id')
+    shared=args.shared_root.resolve(); outbox=shared/'outbox'/args.run_id
+    paths=[outbox]+[shared/part/(args.run_id+'-'+phase) for part in ('inbox','outbox') for phase in ('create','observe')]
+    if any(p.exists() for p in paths): raise ValueError('Run used; no retry/resume')
+    subprocess.run(['cargo','build','-p','jet3','--example','row_update_candidate'],cwd=ROOT,check=True)
+    spec=importlib.util.spec_from_file_location('transport',ROOT/'scripts/windows-dao-ps.py'); transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result=dict(document_type='dao_row_update_candidate_result',producer_os=os.name,source_revision=plan['source_revision'],acquisition_revision=subprocess.check_output(['git','rev-parse','HEAD'],cwd=ROOT).decode().strip(),plan_sha256=identity(PLAN)['sha256'],phase='create',error=None,phases={},updates=[])
+    try:
+        for phase in ('create','observe'):
+            result['phase']=phase; run_id=args.run_id+'-'+phase; inbox=shared/'inbox'/run_id;inbox.mkdir(parents=True)
+            shutil.copyfile(ROOT/SCRIPT,inbox/'script.ps1');shutil.copyfile(ROOT/'oracle/windows-dao/scripts/field_update.ps1',inbox/'field_update.ps1');shutil.copyfile(PLAN,inbox/PLAN.name);(inbox/'phase.txt').write_text(phase)
+            if phase=='observe':
+                for path in outbox.glob('*.mdb'): shutil.copyfile(path,inbox/path.name)
+            command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,run_id,'script.ps1'))]
+            done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=300)
+            (outbox/(phase+'-ssh.txt')).write_bytes(done.stdout+done.stderr);guest=shared/'outbox'/run_id
+            shutil.copyfile(guest/'result.json',outbox/(phase+'.json'));result['phases'][phase]=identity(outbox/(phase+'.json'))
+            for path in guest.glob('*.mdb'):
+                destination=outbox/path.name
+                if destination.exists() and identity(destination)!=identity(path): raise ValueError('Transferred original/control/Rust image changed')
+                if not destination.exists(): shutil.copyfile(path,destination)
+            observed=entries(json.loads((outbox/(phase+'.json')).read_text(encoding='utf-8-sig')),phase,plan)
+            if done.returncode: raise ValueError('Guest failed')
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    for role in ('original','control'):
+                        item=observed[arm['name'],replica,role];expected(item['snapshot'],arm,role,plan)
+                        if identity(outbox/item['file'])!=item['after']: raise ValueError('Transferred image identity')
+            if phase=='create':
+                result['phase']='unix_update'
+                for arm in plan['arms']:
+                    for replica in range(1,4):
+                        prefix=f"{arm['name']}-r{replica}"; original=outbox/(prefix+'-original.mdb');rust=outbox/(prefix+'-rust.mdb');before=identity(original)
+                        command=['cargo','run','--quiet','-p','jet3','--example','row_update_candidate','--',str(original),str(rust),arm['table'],str(arm['selected_id']),arm['name']]
+                        done=subprocess.run(command,cwd=ROOT,capture_output=True,timeout=120);(outbox/(prefix+'-unix.txt')).write_bytes(done.stdout+done.stderr)
+                        if done.returncode: raise ValueError('Public row update failed: '+prefix)
+                        receipt=json.loads(done.stdout);patch_check(original.read_bytes(),rust.read_bytes(),arm,receipt)
+                        result['updates'].append(dict(arm=arm['name'],replica=replica,original_before=before,original_after=identity(original),rust=identity(rust),locator=receipt))
+                        if identity(original)!=before: raise ValueError('Unix original changed')
+        result['phase']='complete'
+    except (OSError,ValueError,subprocess.SubprocessError) as error: result['error']=type(error).__name__+': '+str(error)
+    finally: (outbox/'result.json').write_text(canonical(result)+'\n')
+    analyze(outbox)
+
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__);commands=parser.add_subparsers(dest='command',required=True)
+    commands.add_parser('preflight');report=commands.add_parser('analyze');report.add_argument('outbox',type=Path)
+    run=commands.add_parser('run');run.add_argument('--run-id',required=True);run.add_argument('--shared-root',type=Path,required=True)
+    for name,default in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:run.add_argument('--'+name,default=default)
+    args=parser.parse_args()
+    if args.command=='preflight':preflight();print('Committed inputs match.')
+    elif args.command=='analyze':analyze(args.outbox)
+    else:dispatch(args)
+
+
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/check_row_update_candidate.ps1
+++ b/oracle/windows-dao/tests/check_row_update_candidate.ps1
@@ -1,0 +1,38 @@
+param([string]$Root)
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected x86 runtime'}
+$tokens=$null;$errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile((Join-Path $Root 'producer.ps1'),[ref]$tokens,[ref]$errors)
+if($errors.Count){throw ($errors|Out-String)}
+function Release($Value) {}
+foreach($name in @('Remember','Close-Object','Set-Row')){
+ $defs=@($ast.FindAll({param($n) $n -is [Management.Automation.Language.FunctionDefinitionAst] -and $n.Name-eq $name},$false))
+ if($defs.Count-ne 1){throw 'Missing pure helper'}
+ Invoke-Expression $defs[0].Extent.Text
+}
+$plan=Get-Content (Join-Path $Root 'plan.json') -Raw|ConvertFrom-Json
+$failure=$null;$endpoint='pure test';$count=0
+foreach($arm in $plan.arms){
+ $rows=[Collections.ArrayList]::new();[void]$rows.Add($arm.replacement);[void]$rows.Add($plan.insert)
+ foreach($table in $arm.tables){foreach($row in $table.seed_rows){[void]$rows.Add($row)}}
+ foreach($row in $rows){
+  $fields=[pscustomobject]@{Storage=@{}}
+  $fields|Add-Member ScriptMethod Item {param($n) return $this.Storage[[int]$n]}
+  foreach($n in 0..4){$fields.Storage[$n]=[pscustomobject]@{Value='untouched'}}
+  $rs=[pscustomobject]@{Fields=$fields};Set-Row $rs $row
+  foreach($n in 0..4){
+   $actual=$fields.Storage[$n].Value
+   if($null-eq $row[$n]){if($actual-isnot [DBNull]){throw 'Null assignment'}}
+   elseif($n-eq 3){if($actual.GetType().FullName-cne 'System.Byte[]'-or ([BitConverter]::ToString($actual)).Replace('-','').ToLowerInvariant()-cne $row[$n]){throw 'Binary assignment'}}
+   elseif($n-le 1){if($actual-isnot [int]-or $actual-ne $row[$n]){throw 'Long assignment'}}
+   elseif($n-eq 2){if($actual-isnot [string]-or $actual-cne $row[$n]){throw 'Text assignment'}}
+   elseif($actual-isnot [bool]-or $actual-ne $row[$n]){throw 'Boolean assignment'}
+   $count++
+  }
+ }
+}
+$endpoint='initiating';try{throw 'first'}catch{Remember $_}
+$mock=[pscustomobject]@{};$mock|Add-Member ScriptMethod Close {throw 'cleanup'};Close-Object $mock $true
+if($failure.endpoint-cne 'initiating'-or $failure.message-cne 'first'){throw 'Masked first failure'}
+Write-Output "Parser and $count explicit typed mock assignments passed; no DAO."

--- a/oracle/windows-dao/tests/test_row_update_candidate.py
+++ b/oracle/windows-dao/tests/test_row_update_candidate.py
@@ -1,0 +1,70 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import row_update_candidate as experiment
+
+
+class CandidateTests(unittest.TestCase):
+    def setUp(self): self.plan=json.loads(experiment.PLAN.read_text())
+
+    def snapshot(self,arm,role):
+        tables=[]
+        for spec in arm['tables']:
+            rows=copy.deepcopy(spec['rows'])
+            if spec['name']==arm['table']:
+                if role!='original':rows=[arm['replacement'] if r[0]==arm['selected_id'] else r for r in rows]
+                if role.endswith('-next'):rows.append(self.plan['insert'])
+            tables.append(dict(name=spec['name'],attributes=0,indexes=[],fields=[dict(f,attributes=2 if f['type'] in (9,10) else 1) for f in self.plan['fields']],rows=rows))
+        return dict(version='3.0',relations=[],tables=sorted(['MSysACEs','MSysObjects','MSysQueries','MSysRelationships','Items','Later']),queries=[dict(name='KeepQuery',sql='retained SQL',type=0)],user_tables=tables)
+
+    def test_complete_classifier_and_failure_bindings(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);identity=experiment.identity
+            result=dict(document_type='dao_row_update_candidate_result',producer_os='posix',source_revision=self.plan['source_revision'],plan_sha256=identity(experiment.PLAN)['sha256'],phase='complete',error=None,phases={},updates=[])
+            for phase in ('create','observe'):
+                document=dict(document_type='dao_row_update_candidate_phase',phase=phase,plan_sha256=result['plan_sha256'],error=None,retention_failures=[],mutation_started=True,environment=dict(process_bits=32,provider='DAO.DBEngine.36'),observations=[],operations=[])
+                for arm in self.plan['arms']:
+                    for replica in range(1,4):
+                        roles=['original','control'] if phase=='create' else ['original','control','rust','control-next','rust-next']
+                        for role in roles:
+                            name=f"{arm['name']}-r{replica}-{role}.mdb";file=root/name;file.write_bytes(b'x')
+                            document['observations'].append(dict(arm=arm['name'],replica=replica,role=role,observation=dict(file=name,before=identity(file),after=identity(file),status='pass',error=None,snapshot=self.snapshot(arm,role))))
+                        for role in (['control'] if phase=='create' else ['control-next','rust-next']):document['operations'].append(dict(arm=arm['name'],replica=replica,role=role,result=dict(operation='update' if phase=='create' else 'insert',status='complete',selected_id=arm['selected_id'])))
+                        if phase=='create':result['updates'].append(dict(arm=arm['name'],replica=replica,original_before=identity(file),original_after=identity(file),rust=identity(file),locator={}))
+                file=root/(phase+'.json');file.write_text(json.dumps(document));result['phases'][phase]=identity(file)
+            with patch.object(experiment,'patch_check',return_value={'maps':{}}),patch.object(experiment,'shape',return_value=(None,None,{})):
+                self.assertEqual(experiment.build_report(result,root,self.plan)['outcome'],'observed_accepted')
+                for key,value in [('producer_os','nt'),('source_revision','wrong'),('error','failed'),('phase','create')]:
+                    bad=dict(result,**{key:value});self.assertEqual(experiment.build_report(bad,root,self.plan)['outcome'],'no_outcome')
+                bad=copy.deepcopy(result);bad['updates'].pop();self.assertEqual(experiment.build_report(bad,root,self.plan)['outcome'],'no_outcome')
+                (root/'grow-first-r1-rust.mdb').write_bytes(b'changed');self.assertEqual(experiment.build_report(result,root,self.plan)['outcome'],'no_outcome')
+
+    def test_exact_replacement_and_unrelated_byte_rejection(self):
+        arm=self.plan['arms'][0];raw=experiment.encode([1,101,'one','0011',True]);new=experiment.encode(arm['replacement'])
+        before=bytearray(24*2048);base=23*2048;start=2048-len(raw)
+        before[base:base+2]=b'\1\1';before[base+2:base+4]=(start-12).to_bytes(2,'little');before[base+8:base+10]=b'\1\0';before[base+10:base+12]=start.to_bytes(2,'little');before[base+start:base+2048]=raw
+        after=bytearray(before);end=2048-len(new);after[base+end:base+2048]=new;after[base+10:base+12]=end.to_bytes(2,'little');after[base+2:base+4]=(end-12).to_bytes(2,'little')
+        maps=dict(owned=[23],available=[23]);rows=[dict(page=23,row=0,values=[1])]
+        with patch.object(experiment,'shape',return_value=(dict(root=20,row_count=1),rows,maps)):
+            receipt=dict(root=20,page=23,slot=0);experiment.patch_check(before,after,arm,receipt)
+            for offset in [1538,base+100,base+8,base+2047,base+2]:
+                bad=bytearray(after);bad[offset]^=1
+                with self.assertRaises(ValueError):experiment.patch_check(before,bad,arm,receipt)
+            with self.assertRaises(ValueError):experiment.patch_check(before,after,dict(arm,tombstone=True),receipt)
+
+    def test_schema_rows_query_and_pins(self):
+        arm=self.plan['arms'][0];value=self.snapshot(arm,'rust-next');experiment.expected(value,arm,'rust-next',self.plan)
+        value['user_tables'][0]['rows'].pop()
+        with self.assertRaises(ValueError):experiment.expected(value,arm,'rust-next',self.plan)
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);(root/'x').write_text('changed');plan=root/'plan.json';plan.write_text(json.dumps(dict(inputs={'x':'0'*64})))
+            with patch.object(experiment,'ROOT',root),patch.object(experiment,'PLAN',plan):
+                with self.assertRaisesRegex(ValueError,'Input pin'):experiment.verify_inputs()
+
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Preregisters finite full-row replacement comparisons for growth, shrinkage, scalar null transitions, Boolean/Binary changes, and tombstone adjacency. Exact page repacking and unrelated-byte preservation are checked against full DAO snapshots and separate continuation controls.

Validation: independent review, three focused tests, four public preparation checks, typed x86 helper checks, committed preflight, and `just ready` passed.

Progress toward #112 and #113.
