### PR TITLE
fix: accept DAO Boolean fixed-offset placeholders

### DIFF
--- a/crates/jet3/src/row_update_tests.rs
+++ b/crates/jet3/src/row_update_tests.rs
@@ -513,3 +513,75 @@ fn physical_slot_capacity_and_hidden_payload_are_refused() -> TestResult {
     ));
     Ok(())
 }
+
+#[test]
+fn dao_boolean_zero_offset_schema_reaches_public_row_replacement() -> TestResult {
+    let f = Fixture::new(3)?;
+    fs::remove_file(f.path())?;
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Value", ColumnType::Long),
+        ColumnSpec::new(
+            b"Payload",
+            ColumnType::Text {
+                max_len: NonZeroU8::MAX,
+            },
+        ),
+        ColumnSpec::new(
+            b"Bytes",
+            ColumnType::Binary {
+                max_len: NonZeroU8::MAX,
+            },
+        ),
+        ColumnSpec::new(b"Flag", ColumnType::Boolean),
+    ];
+    let original_values = [
+        RowValue::Long(1),
+        RowValue::Long(101),
+        RowValue::Text(b"one"),
+        RowValue::Binary(&[0, 17]),
+        RowValue::Boolean(true),
+    ];
+    crate::create_database_with_rows(
+        f.path(),
+        &TableSpec {
+            name: b"Rows",
+            columns: &columns,
+            indexes: &[],
+        },
+        &[&original_values, &original_values],
+        &mut budget(),
+    )?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(f.path(), &mut b)?;
+    let definition = db.table_definition(f.root, &mut b)?;
+    let raw = *definition.columns()[4].raw_record();
+    assert_eq!(
+        definition.columns()[4].storage(),
+        ColumnStorageClass::Fixed { offset: 8 }
+    );
+    drop(db);
+    let mut before = fs::read(f.path())?;
+    let base = f.root.get() as usize * PAGE_BYTES;
+    let positions: Vec<_> = before[base..base + PAGE_BYTES]
+        .windows(raw.len())
+        .enumerate()
+        .filter_map(|(i, v)| (v == raw).then_some(base + i))
+        .collect();
+    assert_eq!(positions.len(), 1);
+    // EXP-0198 retained DAO definition: Boolean ordinal4, size1, fixed offset0.
+    before[positions[0] + 14..positions[0] + 16].copy_from_slice(&0_u16.to_le_bytes());
+    fs::write(f.path(), &before)?;
+    let values = [
+        RowValue::Long(1),
+        RowValue::Null,
+        RowValue::Text(&[b'g'; 60]),
+        RowValue::Binary(&[1, 35, 69, 103, 137, 171, 205, 239]),
+        RowValue::Boolean(false),
+    ];
+    let wanted = expected(&before, f.locators[0], &encoded(&f, &values)?);
+    update_row(f.path(), f.request(0, &values), &mut budget())?;
+    assert_eq!(fs::read(f.path())?, wanted);
+    assert_eq!(f.rows()?.len(), 2);
+    Ok(())
+}

--- a/crates/jet3/src/row_writer.rs
+++ b/crates/jet3/src/row_writer.rs
@@ -464,7 +464,11 @@ fn validate_column_layout(
             ) {
                 return Err(storage_error());
             }
-            if offset != *next_fixed_offset {
+            // EXP-0198: DAO Boolean records can use zero instead of the current
+            // fixed offset; the value occupies only its presence bit.
+            let boolean_placeholder =
+                column.physical_type == ColumnPhysicalType::Boolean && offset == 0;
+            if offset != *next_fixed_offset && !boolean_placeholder {
                 return Err(RowWriteError::InvalidFixedOffset {
                     ordinal,
                     offset,

--- a/crates/jet3/src/row_writer_tests.rs
+++ b/crates/jet3/src/row_writer_tests.rs
@@ -651,3 +651,74 @@ fn wide_fixed_prefix_stays_within_second_boundary_block() -> Result<(), Box<dyn 
     ));
     Ok(())
 }
+
+#[test]
+fn boolean_zero_placeholder_does_not_relax_scalar_offsets() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut columns = [
+        RowColumnLayout::new(
+            ColumnPhysicalType::Long,
+            ColumnStorageClass::Fixed { offset: 0 },
+            4,
+        ),
+        RowColumnLayout::new(
+            ColumnPhysicalType::Boolean,
+            ColumnStorageClass::Fixed { offset: 0 },
+            1,
+        ),
+        RowColumnLayout::new(
+            ColumnPhysicalType::Long,
+            ColumnStorageClass::Fixed { offset: 4 },
+            4,
+        ),
+    ];
+    let values = [
+        RowValue::Long(11),
+        RowValue::Boolean(true),
+        RowValue::Long(-22),
+    ];
+    let mut bytes = [0; 64];
+    let mut budget = ResourceBudget::new(ResourceLimits::default());
+    let length = encode_row(&columns, &values, &mut bytes, &mut budget)?.get() as usize;
+    assert_eq!(&bytes[..length], &[3, 11, 0, 0, 0, 234, 255, 255, 255, 7]);
+    columns[1] = RowColumnLayout::new(
+        ColumnPhysicalType::Boolean,
+        ColumnStorageClass::Fixed { offset: 4 },
+        1,
+    );
+    let mut current = [0; 64];
+    encode_row(&columns, &values, &mut current, &mut budget)?;
+    assert_eq!(bytes, current);
+    columns[2] = RowColumnLayout::new(
+        ColumnPhysicalType::Long,
+        ColumnStorageClass::Fixed { offset: 0 },
+        4,
+    );
+    assert!(matches!(
+        encode_row(&columns, &values, &mut current, &mut budget),
+        Err(RowWriteError::InvalidFixedOffset {
+            ordinal: 2,
+            offset: 0,
+            expected: 4
+        })
+    ));
+    columns[2] = RowColumnLayout::new(
+        ColumnPhysicalType::Long,
+        ColumnStorageClass::Fixed { offset: 4 },
+        4,
+    );
+    columns[1] = RowColumnLayout::new(
+        ColumnPhysicalType::Boolean,
+        ColumnStorageClass::Fixed { offset: 2 },
+        1,
+    );
+    assert!(matches!(
+        encode_row(&columns, &values, &mut current, &mut budget),
+        Err(RowWriteError::InvalidFixedOffset {
+            ordinal: 1,
+            offset: 2,
+            expected: 4
+        })
+    ));
+    Ok(())
+}


### PR DESCRIPTION
DAO can report fixed Boolean columns with offset zero after preceding scalar fields. The encoder now accepts that observed placeholder while retaining exact offsets for all stored scalar fields; Boolean still occupies no fixed payload bytes.

Validation: independent review, two focused regressions including the exact DAO-shaped public replacement and unrelated-byte preservation, Clippy, and `just ready` passed.

Fixes the refusal recorded in EXP-0198; a separate successor validates the new candidates.
