### PR TITLE
test: preregister retained full-row update successor

### DIFF
--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -12909,6 +12909,48 @@ Copy this block under the appropriate section and remove this instruction:
   checks passed; exact integrated five-case public preparation and committed
   plan/input checks precede dispatch. Independent plan review is required.
 
+## EXP-0205 — Retained-original full-row replacement successor preregistration
+
+- Distinct successor to EXP-0197; EXP-0198 remains `no_outcome`. Reviewed
+  corrected source `b66396d` accepts the observed Boolean zero placeholder
+  while retaining scalar offset validation. No DAO acquisition yet.
+- Plan `oracle/windows-dao/acquisition/row-update-successor.plan.json`, SHA-256
+  `6b539af4b6b81874ed439558d94b5671a7ae598f7504e7c4ebef1fb37576ad22`,
+  pins scoped runtime inputs, all 30 coordinated EXP-0197 artifacts and twelve
+  predetermined Rust candidate identities. Original retained root remains
+  `/home/alex/development/vms/jet3-windows/shared/outbox/20260905T101500Z-row-update`.
+  Original create receipts verify their original plan identity; fresh observation
+  receipts bind this successor. No consumed input or receipt is edited.
+- Reuse exactly twelve unchanged originals and twelve unchanged independent DAO
+  controls from EXP-0197. Revalidate all original source/report/receipt/image
+  identities and declared baseline/control schema/rows. Copy them to a fresh
+  output directory and generate twelve Rust candidates using the corrected public
+  API and unchanged four-profile exporter. Candidate hashes and unchanged exact
+  row/page/slot/free/count/map/page-zero/slack checks must all pass before DAO.
+- Invoke the unchanged explicit typed PowerShell producer once in `observe` mode
+  only. The staging filename is conventional; its actual plan bytes/hash are this
+  committed successor. No baseline recreation or new edits of retained controls.
+  Capture original/control/Rust read-only, and use separate candidate/control
+  copies for 24 declared DAO continuation inserts. Retain 60 fresh captures and
+  60 final MDBs, with the 24 original captures preserved as prior inputs.
+- All twelve cases and continuations must match complete schema/rows/QuerySQL,
+  unchanged source/image identities and the original finite byte-preservation
+  gates. Recheck all original artifact pins before/after. Any failure produces
+  one `no_outcome`; no same-plan retry, subset promotion or original report change.
+  EXP-0206 reserves one additive outcome. Local development only; no support move.
+- Twelve actual candidates generated from retained originals passed the frozen
+  independent byte checker without changing any original artifact. Old/new row
+  lengths remained 19→82, 104→16, 14→26 and 21→14 in all three replicas.
+  Three successor tests cover phase-specific plan identity/restoration, retained
+  drift refusal and candidate identity gates. Scoped source/artifact verification
+  passed. The unchanged producer already passed EXP-0197 x86 parser and 200
+  pure typed assignments; no new PowerShell behavior is introduced. These checks
+  establish preparation only, not DAO acceptance.
+- Hypothesis and limitations remain EXP-0197's exact narrow Long/Text/Binary/
+  Boolean row replacement matrix. The encoder fix addresses a prior refusal;
+  it does not establish row movement, continuation, general offset policy,
+  arbitrary wide rows or unsupported indexed/related/Auto/LVAL behavior.
+
 ## EXP-0198 — Full-row replacement refused the DAO Boolean layout
 
 - Original outcome: **no_outcome**, reason `Coordinated phase/source failure`,

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -12915,7 +12915,7 @@ Copy this block under the appropriate section and remove this instruction:
   corrected source `b66396d` accepts the observed Boolean zero placeholder
   while retaining scalar offset validation. No DAO acquisition yet.
 - Plan `oracle/windows-dao/acquisition/row-update-successor.plan.json`, SHA-256
-  `6b539af4b6b81874ed439558d94b5671a7ae598f7504e7c4ebef1fb37576ad22`,
+  `fcfc99ffde4bc05d2eb7d7729ea318000131a8e59f08a49c84a4bf7950fc2b06`,
   pins scoped runtime inputs, all 30 coordinated EXP-0197 artifacts and twelve
   predetermined Rust candidate identities. Original retained root remains
   `/home/alex/development/vms/jet3-windows/shared/outbox/20260905T101500Z-row-update`.
@@ -12941,8 +12941,8 @@ Copy this block under the appropriate section and remove this instruction:
 - Twelve actual candidates generated from retained originals passed the frozen
   independent byte checker without changing any original artifact. Old/new row
   lengths remained 19→82, 104→16, 14→26 and 21→14 in all three replicas.
-  Three successor tests cover phase-specific plan identity/restoration, retained
-  drift refusal and candidate identity gates. Scoped source/artifact verification
+  Four successor tests cover phase-specific plan identity/restoration, retained
+  drift refusal, exact copied create-receipt binding and candidate identity gates. Scoped source/artifact verification
   passed. The unchanged producer already passed EXP-0197 x86 parser and 200
   pure typed assignments; no new PowerShell behavior is introduced. These checks
   establish preparation only, not DAO acceptance.

--- a/oracle/windows-dao/acquisition/row-update-successor.plan.json
+++ b/oracle/windows-dao/acquisition/row-update-successor.plan.json
@@ -1,0 +1,830 @@
+{
+  "document_type": "dao_row_update_successor_plan",
+  "provenance": "EXP-0205",
+  "outcome_provenance": "EXP-0206",
+  "replicas": 3,
+  "source_revision": "b66396d2163b8208b3c300268219dff1209c281b",
+  "fields": [
+    {
+      "name": "Id",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Value",
+      "type": 4,
+      "size": 4
+    },
+    {
+      "name": "Payload",
+      "type": 10,
+      "size": 255
+    },
+    {
+      "name": "Bytes",
+      "type": 9,
+      "size": 255
+    },
+    {
+      "name": "Flag",
+      "type": 1,
+      "size": 1
+    }
+  ],
+  "query": {
+    "name": "KeepQuery",
+    "sql": "SELECT [Id], [Value] FROM [Items];"
+  },
+  "insert": [
+    99,
+    -9900,
+    "next",
+    "00ff",
+    true
+  ],
+  "arms": [
+    {
+      "name": "grow-first",
+      "table": "Items",
+      "selected_id": 1,
+      "replacement": [
+        1,
+        null,
+        "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+        "0123456789abcdef",
+        false
+      ],
+      "tombstone": false,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "shrink-middle",
+      "table": "Items",
+      "selected_id": 2,
+      "replacement": [
+        2,
+        -42,
+        null,
+        "0102",
+        true
+      ],
+      "tombstone": false,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "null-later",
+      "table": "Later",
+      "selected_id": 12,
+      "replacement": [
+        12,
+        -2147483648,
+        "restored",
+        "00ff0102",
+        true
+      ],
+      "tombstone": false,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tombstone",
+      "table": "Items",
+      "selected_id": 3,
+      "replacement": [
+        3,
+        null,
+        null,
+        null,
+        false
+      ],
+      "tombstone": true,
+      "tables": [
+        {
+          "name": "Items",
+          "seed_rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              false
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ],
+          "rows": [
+            [
+              1,
+              101,
+              "one",
+              "0011",
+              true
+            ],
+            [
+              3,
+              303,
+              "three",
+              "2233",
+              true
+            ],
+            [
+              4,
+              404,
+              "four",
+              "44",
+              false
+            ],
+            [
+              5,
+              505,
+              "five",
+              "55",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "seed_rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ],
+          "rows": [
+            [
+              11,
+              1100,
+              "left",
+              "ff",
+              true
+            ],
+            [
+              12,
+              null,
+              null,
+              null,
+              false
+            ],
+            [
+              13,
+              1300,
+              "right",
+              "ee",
+              false
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "inputs": {
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/row_update_candidate.rs": "3d261186c6e399e2eb986f0b0d637b2712644a1a0f9b702bbbc72a9cddae23a2",
+    "crates/jet3/src/allocation.rs": "c52b7b405280675b97b9316b6f39019a650a7d7800a0334d7ac000c766a4e82f",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/binary_writer.rs": "f12922a7bf3a522b43d48311ac6844db42e78edd5c6841deb49cbc962152e190",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/catalog_record.rs": "e4b06d60700a7abe1a9b55472930781b02659701ee1ae013f03cf18bdc66e144",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/data_page_directory.rs": "abaf82d51ed71084fe3623f8f6af3cc58f49bba26ad02249c39cd3da74e3bca1",
+    "crates/jet3/src/lib.rs": "689fb7cc1a4a19a9e29b9bb03e7736f34b99207e7170409d4fa56efd05cf2c45",
+    "crates/jet3/src/map_location.rs": "4fc00ccfaae0ed58e8f6adb82409eb3cf1e6f13fc1475caad519ff419be25c6c",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "crates/jet3/src/row.rs": "64647c6c4ed50f88841d6d28fcf170653055e44ec4e3ee61f1ec2aaa50a5d1ae",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_update.rs": "3463b89159ddd8628be758f78800a78b44808f7ec28333f899c3a74d4434d304",
+    "crates/jet3/src/row_update_page.rs": "91f8b7c07aafa71daaf77abc6c88cfdd6d7db03448b820a42648b1b35a097d86",
+    "crates/jet3/src/row_writer.rs": "35c8310d027db4321a6251b1b68616d9ae0c6c8f4e82af0b1fd5e36b729420fb",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/update.rs": "7804019e1c2b2cbfe0d287f2bdcb6bb40a527b009d28d536f2572d65e4fec534",
+    "crates/jet3/src/update_pages.rs": "431201c558c17c9a19affd0850ddf9591109a3b2b70a51546cbc155013d6d0b5",
+    "crates/jet3/src/usage_map.rs": "091f54f1b7f495215d5ff6c9ef07bdef406cf8171bf64f912f808f35b13ad0ec",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/row_delete_layout.py": "74c30a55148ec5efe4c04a154917e8780c06a63442d28c0d0b3453b968142088",
+    "oracle/windows-dao/scripts/row_update_candidate.ps1": "25113ce3952989736c08d2ba19bb3f07647ee1e0748f827b780b1ff9564bba01",
+    "oracle/windows-dao/scripts/row_update_candidate.py": "600b3e653ef001c3cd93d9ebbc25b4b9196bd0f55ae9e1e3b9af922d8e784a71",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/tests/check_row_update_candidate.ps1": "ee7a87eb3e372396413357b34baa756f7db5346ca1fe12b75bf74fc487c7980e",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "oracle/windows-dao/acquisition/row-update-candidate.plan.json": "95fa2e50c21230ed27f1c81bda93530b9fd2af460cb5760a984285c56215a0fe",
+    "oracle/windows-dao/scripts/row_update_successor.py": "ff9ecd6b243b1519fa045e7bda3ebe8889d10f5ec471a2b62bdc993e06789f7c"
+  },
+  "question": "Do corrected Boolean-layout Rust candidates on the unchanged twelve EXP0197 originals match the retained independent DAO controls and fresh read-only/continuation observations?",
+  "source_facts": [
+    "EXP-0060/0061 checked scalar/null/variable row grammar",
+    "EXP-0162 row movement; EXP-0170 known tombstone continuation"
+  ],
+  "sequence": [
+    "Commit and independently review this distinct successor; preserve EXP0198 no_outcome and every original file unchanged. Revalidate all30 retained original artifacts and24 recorded original/control read-only identities against their original plan, schema/row gates and original create receipt.",
+    "Copy unchanged twelve original/control pairs to a fresh output directory. Public update_row with reviewed corrected Boolean offset validation generates12 Rust candidates, each bound to source/request/original identity. Require unchanged full-byte/slot/count/map/page0 checker and predetermined candidate identities before DAO.",
+    "After every candidate passes, invoke frozen typed producer exactly once with phase observe only, carrying successor plan bytes under conventional staged filename. Fresh read-only captures of original/control/Rust, plus separate control/Rust continuation insert copies; no original baseline recreation or original control mutation.",
+    "All12 candidates and24 separate continuation inserts must pass complete original schema/rows/QuerySQL and exact byte/slot/identity/source gates.60fresh read-only captures combined with24 retained original captures;60finalMDBs in successor output. No subset promotion or same-plan retry."
+  ],
+  "decision_rule": "observed_accepted requires all12 profiles/replicas and continuations, complete fullschema/rows/QuerySQL, exact unrelatedbyte/slot/count/map preservation and source/input/operation/identity gates. Any failure yields one no_outcome with retained partial artifacts; no subset promotion.",
+  "bounds": "Four finite profiles; narrow two-variable rows under256bytes, fixed Long null transitions, ASCII Text, explicit byte[] Binary, Boolean bit changes. No index/relation/Auto/LVAL/overflow/map transition or arbitrary wide multivariable encoding. Local development only; no support movement. SSH300seconds perphase, Unix120seconds per edit.",
+  "hypothesis": "The observed Boolean zero-placeholder fix removes EXP0198 prepublication refusal; row movement and DAO acceptance remain experimental, not inferred from self-read.",
+  "producer": "Fresh Unix-only successor orchestrator with isolated frozen classifier/transport/typed producer. Original create receipt verifies original plan identity; fresh observe receipt verifies successor plan identity. No consumed input or receipt editing. Exact copied inputs/outputs and original pins rechecked before/after.",
+  "retained_root": "/home/alex/development/vms/jet3-windows/shared/outbox/20260905T101500Z-row-update",
+  "retained": {
+    "create-ssh.txt": {
+      "size": 616,
+      "sha256": "2ce70d6c8c9ad6726c794690c8b14a2b83673648cac88edf4ff1acc50ec46348"
+    },
+    "create.json": {
+      "size": 548830,
+      "sha256": "8f8e2d5f4d3e355e3cf5eb88ac7571f08098808aafca3e79c786a50e9cecc31d"
+    },
+    "grow-first-r1-control.mdb": {
+      "size": 57344,
+      "sha256": "c88f71047a681ac60570cd5d323d01fce71217d9e536e10de8f004d9f8a1908d"
+    },
+    "grow-first-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "29e3b33b21611493fe43746f655d0c8b8aebfdcea3e4fe4e49b5f46911cdd049"
+    },
+    "grow-first-r1-rust.mdb": {
+      "size": 57344,
+      "sha256": "29e3b33b21611493fe43746f655d0c8b8aebfdcea3e4fe4e49b5f46911cdd049"
+    },
+    "grow-first-r1-unix.txt": {
+      "size": 75,
+      "sha256": "17a1b9cfeaf39099b5ed7985d60403a87555c135d71d89ceef9b4fa104a05f27"
+    },
+    "grow-first-r2-control.mdb": {
+      "size": 57344,
+      "sha256": "f90d9bee09103d8387dbea3b8713f46b028ca6ea34cd25545bba101ceae9d85d"
+    },
+    "grow-first-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "42481e7fdc3aabaf4424926751b7bcb6491607524c66567c44040b1e52e3859a"
+    },
+    "grow-first-r3-control.mdb": {
+      "size": 57344,
+      "sha256": "186d9e50b26684111042c40e11a6ce263adc090c628467db371cb2571cf70643"
+    },
+    "grow-first-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "41a6c8535bb0886fe6e33012cbb17f50550450d01813e90a0c02765dd304dba7"
+    },
+    "null-later-r1-control.mdb": {
+      "size": 57344,
+      "sha256": "d4dfc11c463942658feafae856a05a086f0e5c80a7405f6dcfd954a2792f678b"
+    },
+    "null-later-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "e2b2c4a7f2c9d015fec4cfe0ff387e9894a41b2df34c7e2f711fef32ee1872ad"
+    },
+    "null-later-r2-control.mdb": {
+      "size": 57344,
+      "sha256": "215f18fece173031dd5419ed21002142066bceeee9377c0290edf99ec3deace4"
+    },
+    "null-later-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "ca85ed18af66df277c6942acf3905b9ed26cc12b5edbd7e463e0aa7417952b46"
+    },
+    "null-later-r3-control.mdb": {
+      "size": 57344,
+      "sha256": "1b3f474357429dc115b606d790ff5b600523cde0fd9e68e3634d7135f3aa2052"
+    },
+    "null-later-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "32f306ad0a7d87825308eece0742483e5fd3ae2cd0699649250ca434b2ad1b70"
+    },
+    "report.json": {
+      "size": 388,
+      "sha256": "1ebad1af860d484fa4f7a6b687eaa1437fa296f1e0d37146b79192903c4d9bf8"
+    },
+    "result.json": {
+      "size": 491,
+      "sha256": "e4db6bdec3c82c7388f6113217807c2205914160b1885ca6edad23541d65c1af"
+    },
+    "shrink-middle-r1-control.mdb": {
+      "size": 57344,
+      "sha256": "828f5266c6c01a79a74a0ad0bb5fdb1123e7988aed375a781ea561075562d6e0"
+    },
+    "shrink-middle-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "7cda1cf3bf7d42f60e3f482bfbf1c91aaeb57ccc9a0ee0d1d1145f6204b6e9a6"
+    },
+    "shrink-middle-r2-control.mdb": {
+      "size": 57344,
+      "sha256": "2ddc1ba6a79d7b43f8ac368040e733357ad0c6cdffa0efc6e39b7f6c0965b7b4"
+    },
+    "shrink-middle-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "a5a6ee9a5ead3c68542bba256666e254299577dce3c190cc018155ad6ba4036f"
+    },
+    "shrink-middle-r3-control.mdb": {
+      "size": 57344,
+      "sha256": "9bcedce06cdedd1342ac08f8adb2ae48be7ec2899d923db0e7778a4bc203bb8d"
+    },
+    "shrink-middle-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "60223a4027026a4a7a15fcb6788650777f5f1951640704670b9d54b5f77d079a"
+    },
+    "tombstone-r1-control.mdb": {
+      "size": 57344,
+      "sha256": "a44433a3b56e3cd3673bcfa98cfd63565f28a39cee34844f3e4eed7f6ac3b89c"
+    },
+    "tombstone-r1-original.mdb": {
+      "size": 57344,
+      "sha256": "29e44eaae8ff3ba419de15d98fdf0ad70b224d4a71cb78404bc7a15dc4cf0b48"
+    },
+    "tombstone-r2-control.mdb": {
+      "size": 57344,
+      "sha256": "e560044aeb36f15e2efe5f1ef78e9d7c581b9e6058813e5a4e4ea057b9c971f9"
+    },
+    "tombstone-r2-original.mdb": {
+      "size": 57344,
+      "sha256": "dd5c1c33cfe511ab71c508a4ccbeff58b74bc0f5cbcfae4112df6ef4b9381439"
+    },
+    "tombstone-r3-control.mdb": {
+      "size": 57344,
+      "sha256": "3b6053aed5eb8fba2666b448d70329fce09557d2fe341ac70b5aedb548063ca1"
+    },
+    "tombstone-r3-original.mdb": {
+      "size": 57344,
+      "sha256": "165daba8c9b43211cc946e4500884279e28b1c4b2969c7c84e1bad7644b9412d"
+    }
+  },
+  "original_plan_sha256": "95fa2e50c21230ed27f1c81bda93530b9fd2af460cb5760a984285c56215a0fe",
+  "candidates": {
+    "grow-first-r1-rust.mdb": {
+      "size": 57344,
+      "sha256": "fede154278d629da7333adc5c10b26a621e8fb4037a405cd8076c0396bd915d3"
+    },
+    "grow-first-r2-rust.mdb": {
+      "size": 57344,
+      "sha256": "0fe62f05743d828e5f34ddf25284eb86781a8e9dec33e3457174624b46f40b98"
+    },
+    "grow-first-r3-rust.mdb": {
+      "size": 57344,
+      "sha256": "c6fd080c144898a31227d643f34f7ef6007ce57917064840b3bf494dab2f9735"
+    },
+    "shrink-middle-r1-rust.mdb": {
+      "size": 57344,
+      "sha256": "31d04a405645e4d6da8430e7ef37b89f5293cc90e18a1b4d0bc3f79c5fbb776e"
+    },
+    "shrink-middle-r2-rust.mdb": {
+      "size": 57344,
+      "sha256": "4c410a170a755ca4555f4ff2b75e45e3b9baea62d5cfd37aaf8a3e0ae2ee5e67"
+    },
+    "shrink-middle-r3-rust.mdb": {
+      "size": 57344,
+      "sha256": "c2fa411e39948d1ef0a37c85c44441832bf0923dca91bc3496e527e20f767a90"
+    },
+    "null-later-r1-rust.mdb": {
+      "size": 57344,
+      "sha256": "f5d324e105b4f8b6b40f23a0a984e7737daf45a9de158af741e80eb645a4f001"
+    },
+    "null-later-r2-rust.mdb": {
+      "size": 57344,
+      "sha256": "d887ac0bdc6c9c36f074c9c042e801b57dbc8f55424e38bfe927a5de39d1f6de"
+    },
+    "null-later-r3-rust.mdb": {
+      "size": 57344,
+      "sha256": "2502312b76e540145dd8f9b4e19297e3856020a7374676ac219fe058d4b973be"
+    },
+    "tombstone-r1-rust.mdb": {
+      "size": 57344,
+      "sha256": "b76bb483f78351217293611eb7a32245156b163e18fcd1697113c67254198a67"
+    },
+    "tombstone-r2-rust.mdb": {
+      "size": 57344,
+      "sha256": "7d60f7287e539b23e615ce4104562744e709f9bc0da380a8a714118bdccbc824"
+    },
+    "tombstone-r3-rust.mdb": {
+      "size": 57344,
+      "sha256": "ccc7841324fb146f5df996dcac1dc091d598634363fdf0b600cfb774cef19ebc"
+    }
+  }
+}

--- a/oracle/windows-dao/acquisition/row-update-successor.plan.json
+++ b/oracle/windows-dao/acquisition/row-update-successor.plan.json
@@ -636,7 +636,7 @@
     "oracle/windows-dao/tests/check_row_update_candidate.ps1": "ee7a87eb3e372396413357b34baa756f7db5346ca1fe12b75bf74fc487c7980e",
     "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
     "oracle/windows-dao/acquisition/row-update-candidate.plan.json": "95fa2e50c21230ed27f1c81bda93530b9fd2af460cb5760a984285c56215a0fe",
-    "oracle/windows-dao/scripts/row_update_successor.py": "ff9ecd6b243b1519fa045e7bda3ebe8889d10f5ec471a2b62bdc993e06789f7c"
+    "oracle/windows-dao/scripts/row_update_successor.py": "e6e579731c28e10965c83bf9a55a125ca12ee11bd2fa8389262efd752e39c9bf"
   },
   "question": "Do corrected Boolean-layout Rust candidates on the unchanged twelve EXP0197 originals match the retained independent DAO controls and fresh read-only/continuation observations?",
   "source_facts": [

--- a/oracle/windows-dao/scripts/row_update_successor.py
+++ b/oracle/windows-dao/scripts/row_update_successor.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""EXP-0205: corrected Rust candidates from unchanged EXP-0197 originals/controls."""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+ROOT=Path(__file__).resolve().parents[3]
+OLD_PLAN=ROOT/'oracle/windows-dao/acquisition/row-update-candidate.plan.json'
+PLAN=ROOT/'oracle/windows-dao/acquisition/row-update-successor.plan.json'
+spec=importlib.util.spec_from_file_location('_successor_candidate',ROOT/'oracle/windows-dao/scripts/row_update_candidate.py')
+base=importlib.util.module_from_spec(spec);spec.loader.exec_module(base)
+base.PLAN=PLAN
+original_entries=base.entries
+identity=base.identity
+
+
+def entries(document,phase,plan):
+    # Original create receipts retain their original plan identity. Fresh observe
+    # receipts bind the successor. No retained receipt or consumed input is edited.
+    current=base.PLAN
+    try:
+        base.PLAN=OLD_PLAN if phase=='create' else PLAN
+        return original_entries(document,phase,plan)
+    finally:base.PLAN=current
+
+
+base.entries=entries
+
+
+def verify():
+    plan=base.verify_inputs();root=Path(plan['retained_root'])
+    for name,wanted in plan['retained'].items():
+        if identity(root/name)!=wanted:raise ValueError('Retained input mismatch: '+name)
+    report=json.loads((root/'report.json').read_text());result=json.loads((root/'result.json').read_text())
+    if report['outcome']!='no_outcome' or result['updates'] or result['phase']!='unix_update':raise ValueError('Original outcome identity/state')
+    captures=entries(json.loads((root/'create.json').read_text(encoding='utf-8-sig')),'create',plan)
+    for arm in plan['arms']:
+        for replica in range(1,4):
+            for role in ('original','control'):
+                item=captures[arm['name'],replica,role]
+                if identity(root/item['file'])!=item['after']:raise ValueError('Original retained capture mismatch')
+                base.expected(item['snapshot'],arm,role,plan)
+    return plan
+
+
+def preflight():
+    plan=verify();base.preflight();return plan
+
+
+def analyze(outbox):
+    plan=verify();result=json.loads((outbox/'result.json').read_text())
+    report=base.build_report(result,outbox,plan)
+    for update in result.get('updates',[]):
+        name=f"{update['arm']}-r{update['replica']}-rust.mdb"
+        if update['rust']!=plan['candidates'].get(name):
+            report['outcome']='no_outcome';report['reasons'].append('Pinned candidate identity differs: '+name)
+    report.update(experiment='EXP-0205',outcome_provenance='EXP-0206',original_outcome='EXP-0198',original_report_sha256=plan['retained']['report.json']['sha256'],result_sha256=identity(outbox/'result.json')['sha256'])
+    (outbox/'report.json').write_text(base.canonical(report)+'\n');print(report['outcome'])
+
+
+def dispatch(args):
+    plan=preflight();retained=Path(plan['retained_root']);shared=args.shared_root.resolve()
+    if not re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id):raise ValueError('Invalid run id')
+    run_id=args.run_id+'-observe';outbox=shared/'outbox'/args.run_id;inbox=shared/'inbox'/run_id;guest=shared/'outbox'/run_id
+    if any(p.exists() for p in (outbox,inbox,guest)):raise ValueError('Used run; no retry/resume')
+    subprocess.run(['cargo','build','-p','jet3','--example','row_update_candidate'],cwd=ROOT,check=True)
+    spec=importlib.util.spec_from_file_location('_successor_transport',ROOT/'scripts/windows-dao-ps.py');transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    outbox.mkdir(parents=True)
+    result=dict(document_type='dao_row_update_candidate_result',producer_os='posix',source_revision=plan['source_revision'],acquisition_revision=subprocess.check_output(['git','rev-parse','HEAD'],cwd=ROOT).decode().strip(),plan_sha256=identity(PLAN)['sha256'],phase='copy_retained_inputs',error=None,phases={},updates=[])
+    try:
+        shutil.copyfile(retained/'create.json',outbox/'create.json');result['phases']['create']=identity(outbox/'create.json')
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                prefix=f"{arm['name']}-r{replica}"
+                for role in ('original','control'):
+                    name=prefix+'-'+role+'.mdb';shutil.copyfile(retained/name,outbox/name)
+                    if identity(outbox/name)!=plan['retained'][name]:raise ValueError('Copied retained identity')
+                original=outbox/(prefix+'-original.mdb');rust=outbox/(prefix+'-rust.mdb');before=identity(original)
+                result['phase']='unix_update/'+prefix
+                command=['cargo','run','--quiet','-p','jet3','--example','row_update_candidate','--',str(original),str(rust),arm['table'],str(arm['selected_id']),arm['name']]
+                done=subprocess.run(command,cwd=ROOT,capture_output=True,timeout=120);(outbox/(prefix+'-unix.txt')).write_bytes(done.stdout+done.stderr)
+                if done.returncode:raise ValueError('Public row update failed: '+prefix)
+                if identity(rust)!=plan['candidates'][rust.name]:raise ValueError('Pinned candidate identity mismatch: '+prefix)
+                receipt=json.loads(done.stdout);base.patch_check(original.read_bytes(),rust.read_bytes(),arm,receipt)
+                if identity(original)!=before:raise ValueError('Unix original changed')
+                result['updates'].append(dict(arm=arm['name'],replica=replica,original_before=before,original_after=identity(original),rust=identity(rust),locator=receipt))
+        verify();result['phase']='observe';inbox.mkdir(parents=True)
+        # The frozen producer reads this conventional filename; its actual plan
+        # bytes/hash are the committed successor, and phase is observe exclusively.
+        shutil.copyfile(PLAN,inbox/OLD_PLAN.name);shutil.copyfile(ROOT/base.SCRIPT,inbox/'script.ps1');shutil.copyfile(ROOT/'oracle/windows-dao/scripts/field_update.ps1',inbox/'field_update.ps1');(inbox/'phase.txt').write_text('observe')
+        for path in outbox.glob('*.mdb'):shutil.copyfile(path,inbox/path.name)
+        command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,run_id,'script.ps1'))]
+        done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=300);(outbox/'observe-ssh.txt').write_bytes(done.stdout+done.stderr)
+        shutil.copyfile(guest/'result.json',outbox/'observe.json');result['phases']['observe']=identity(outbox/'observe.json')
+        for path in guest.glob('*.mdb'):
+            destination=outbox/path.name
+            if destination.exists() and identity(destination)!=identity(path):raise ValueError('Transferred original/control/Rust image changed')
+            if not destination.exists():shutil.copyfile(path,destination)
+        entries(json.loads((outbox/'observe.json').read_text(encoding='utf-8-sig')),'observe',plan)
+        if done.returncode:raise ValueError('Guest observe phase failed')
+        verify();result['phase']='complete'
+    except (OSError,ValueError,subprocess.SubprocessError) as error:result['error']=type(error).__name__+': '+str(error)
+    finally:(outbox/'result.json').write_text(base.canonical(result)+'\n')
+    analyze(outbox)
+
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__);commands=parser.add_subparsers(dest='command',required=True)
+    commands.add_parser('preflight');report=commands.add_parser('analyze');report.add_argument('outbox',type=Path)
+    run=commands.add_parser('run');run.add_argument('--run-id',required=True);run.add_argument('--shared-root',type=Path,required=True)
+    for name,default in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:run.add_argument('--'+name,default=default)
+    args=parser.parse_args()
+    if args.command=='preflight':preflight();print('Committed successor and retained inputs match.')
+    elif args.command=='analyze':analyze(args.outbox)
+    else:dispatch(args)
+
+
+if __name__=='__main__':main()

--- a/oracle/windows-dao/scripts/row_update_successor.py
+++ b/oracle/windows-dao/scripts/row_update_successor.py
@@ -54,6 +54,11 @@ def preflight():
 def analyze(outbox):
     plan=verify();result=json.loads((outbox/'result.json').read_text())
     report=base.build_report(result,outbox,plan)
+    try:copied_create=identity(outbox/'create.json')
+    except OSError:copied_create=None
+    if (result.get('phases',{}).get('create')!=plan['retained']['create.json']
+        or copied_create!=plan['retained']['create.json']):
+        report['outcome']='no_outcome';report['reasons'].append('Pinned retained create receipt differs')
     for update in result.get('updates',[]):
         name=f"{update['arm']}-r{update['replica']}-rust.mdb"
         if update['rust']!=plan['candidates'].get(name):

--- a/oracle/windows-dao/tests/test_row_update_successor.py
+++ b/oracle/windows-dao/tests/test_row_update_successor.py
@@ -28,11 +28,22 @@ class SuccessorTests(unittest.TestCase):
     def test_candidate_pin_gate_preserves_original_failure_reference(self):
         with tempfile.TemporaryDirectory() as temp:
             out=Path(temp);candidate=dict(size=1,sha256='pinned');plan=dict(retained={'report.json':{'sha256':'original-failure'}},candidates={'grow-first-r1-rust.mdb':candidate})
-            result={'updates':[dict(arm='grow-first',replica=1,rust=candidate)]};(out/'result.json').write_text(json.dumps(result))
+            (out/'create.json').write_bytes(b'original receipt');plan['retained']['create.json']=s.identity(out/'create.json')
+            result={'phases':{'create':plan['retained']['create.json']},'updates':[dict(arm='grow-first',replica=1,rust=candidate)]};(out/'result.json').write_text(json.dumps(result))
             report=dict(outcome='observed_accepted',reasons=[])
             with patch.object(s,'verify',return_value=plan),patch.object(s.base,'build_report',side_effect=lambda *args:copy.deepcopy(report)):
                 s.analyze(out);value=json.loads((out/'report.json').read_text());self.assertEqual(value['outcome'],'observed_accepted');self.assertEqual(value['original_report_sha256'],'original-failure')
                 result['updates'][0]['rust']={'size':1,'sha256':'different'};(out/'result.json').write_text(json.dumps(result));s.analyze(out)
                 self.assertEqual(json.loads((out/'report.json').read_text())['outcome'],'no_outcome')
+
+    def test_copied_create_receipt_must_equal_retained_pin(self):
+        with tempfile.TemporaryDirectory() as temp:
+            out=Path(temp);create=out/'create.json';create.write_bytes(b'original receipt')
+            plan=dict(retained={'report.json':{'sha256':'failure'},'create.json':s.identity(create)},candidates={})
+            create.write_bytes(b'changed but internally consistent receipt')
+            result={'phases':{'create':s.identity(create)},'updates':[]};(out/'result.json').write_text(json.dumps(result))
+            with patch.object(s,'verify',return_value=plan),patch.object(s.base,'build_report',return_value=dict(outcome='observed_accepted',reasons=[])):
+                s.analyze(out)
+            report=json.loads((out/'report.json').read_text());self.assertEqual(report['outcome'],'no_outcome');self.assertIn('Pinned retained create receipt differs',report['reasons'])
 
 if __name__=='__main__':unittest.main()

--- a/oracle/windows-dao/tests/test_row_update_successor.py
+++ b/oracle/windows-dao/tests/test_row_update_successor.py
@@ -1,0 +1,38 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import row_update_successor as s
+
+class SuccessorTests(unittest.TestCase):
+    def test_phase_plan_identity_is_scoped_and_restored(self):
+        with patch.object(s,'original_entries',side_effect=lambda *args: str(s.base.PLAN)):
+            self.assertEqual(s.entries({},'create',{}),str(s.OLD_PLAN))
+            self.assertEqual(s.entries({},'observe',{}),str(s.PLAN))
+        with patch.object(s,'original_entries',side_effect=ValueError('failure')):
+            with self.assertRaises(ValueError):s.entries({},'create',{})
+        self.assertEqual(s.base.PLAN,s.PLAN)
+
+    def test_retained_identity_drift_refuses_before_receipts(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root=Path(temp);f=root/'original.mdb';f.write_bytes(b'original')
+            plan=dict(retained_root=temp,retained={f.name:s.identity(f)})
+            f.write_bytes(b'changed')
+            with patch.object(s.base,'verify_inputs',return_value=plan):
+                with self.assertRaisesRegex(ValueError,'Retained input mismatch'):s.verify()
+
+    def test_candidate_pin_gate_preserves_original_failure_reference(self):
+        with tempfile.TemporaryDirectory() as temp:
+            out=Path(temp);candidate=dict(size=1,sha256='pinned');plan=dict(retained={'report.json':{'sha256':'original-failure'}},candidates={'grow-first-r1-rust.mdb':candidate})
+            result={'updates':[dict(arm='grow-first',replica=1,rust=candidate)]};(out/'result.json').write_text(json.dumps(result))
+            report=dict(outcome='observed_accepted',reasons=[])
+            with patch.object(s,'verify',return_value=plan),patch.object(s.base,'build_report',side_effect=lambda *args:copy.deepcopy(report)):
+                s.analyze(out);value=json.loads((out/'report.json').read_text());self.assertEqual(value['outcome'],'observed_accepted');self.assertEqual(value['original_report_sha256'],'original-failure')
+                result['updates'][0]['rust']={'size':1,'sha256':'different'};(out/'result.json').write_text(json.dumps(result));s.analyze(out)
+                self.assertEqual(json.loads((out/'report.json').read_text())['outcome'],'no_outcome')
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Preregisters a distinct full-row successor using the retained DAO originals and controls plus twelve pinned candidates from the Boolean-offset fix. Exact original receipt binding, full read-only observations, and separate continuation copies preserve all prior decision and retention gates.

Validation: independent review and receipt-binding fix-only recheck, four focused tests, complete candidate preflight, and `just ready` passed. The original refusal remains unchanged.
