### PR TITLE
docs: record bounded hosted index maintenance support

### DIFF
--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -92,9 +92,16 @@ inline-map coverage; compaction preserves physical slots and vacated slack.
 The combined `rows.insert_update_delete` capability remains partial with DAO
 differential evidence limited to these recipes. Sole-row release, free-page or
 slot reuse, indirect map growth, other fixed update types, null transitions,
-indexed or related targets, variable-width replacement and stored-query
-preservation remain unverified by this hosted inventory. Index CRUD stays
-unverified; atomic failure/rollback verification remains internal-only.
+related targets, variable-width replacement and stored-query preservation
+remain unverified by this hosted inventory. EXP-0204 adds four hosted indexed
+cases: ascending primary and descending unique Long-key reorder, a 200-entry
+isolated leaf reorder, and ordinary indexed non-key Long replacement. Complete
+before/after rows, directed traversal, present/removed/missing Seek results and
+independent exact-byte preservation checks passed. Index CRUD maintenance is
+partial with DAO differential evidence restricted to those unique single-leaf
+key replacements; compressed/branch/composite/nonunique key changes and indexed
+insertion/deletion remain unverified. Atomic failure/rollback verification
+remains internal-only.
 
 Keep broader index key codecs and allocation beyond inline maps as explicit
 creation limitations. Prioritize existing-file row insertion/deletion and index

--- a/docs/validation/support-matrix.json
+++ b/docs/validation/support-matrix.json
@@ -190,7 +190,14 @@
         "oracle/windows-dao/scripts/dao_row_allocation_diff.py",
         "crates/jet3-testkit/src/row_allocation_fixture.rs",
         "crates/jet3/src/row_insert_eof.rs",
-        "crates/jet3/src/row_delete_page.rs"
+        "crates/jet3/src/row_delete_page.rs",
+        "oracle/windows-dao/protocol/v1_2/indexed-update-scenarios.json",
+        "oracle/windows-dao/acquisition/indexed-update-v1_2.plan.json",
+        "oracle/windows-dao/scripts/dao_indexed_update_diff.py",
+        "oracle/windows-dao/scripts/Invoke-DaoIndexedUpdateV12.ps1",
+        "crates/jet3-testkit/src/indexed_update_fixture.rs",
+        "crates/jet3/src/update_index_key.rs",
+        "crates/jet3/src/index_key_page.rs"
       ]
     },
     {
@@ -225,9 +232,18 @@
     },
     {
       "id": "indexes.crud_maintenance",
-      "implementation": "not_started",
-      "verification": "unverified",
-      "evidence": []
+      "implementation": "partial",
+      "verification": "dao_differential",
+      "evidence": [
+        "docs/PROVENANCE.md",
+        "oracle/windows-dao/protocol/v1_2/indexed-update-scenarios.json",
+        "oracle/windows-dao/acquisition/indexed-update-v1_2.plan.json",
+        "oracle/windows-dao/scripts/dao_indexed_update_diff.py",
+        "oracle/windows-dao/scripts/Invoke-DaoIndexedUpdateV12.ps1",
+        "crates/jet3-testkit/src/indexed_update_fixture.rs",
+        "crates/jet3/src/update_index_key.rs",
+        "crates/jet3/src/index_key_page.rs"
+      ]
     },
     {
       "id": "relationships.create_drop_preserve_metadata",


### PR DESCRIPTION
Adds the hosted indexed-update evidence to the support matrix and V1 checkpoint. Index CRUD becomes partial with DAO differential evidence only for unique ordinary Long replacements within one isolated leaf; row CRUD remains partial with its explicit limits.

Validation: independent review, support-matrix and catalog checks, and `just ready` passed. Indexed insertion/deletion, splits, relationships, and broader key types are not promoted.
