### PR TITLE
test: extend hosted updates with row replacement and release

### DIFF
--- a/.github/workflows/windows-dao-row-replacement.yml
+++ b/.github/workflows/windows-dao-row-replacement.yml
@@ -1,0 +1,107 @@
+name: Windows DAO row replacement differential
+on:
+  workflow_dispatch:
+    inputs:
+      run_acquisition:
+        description: Run the reviewed single update acquisition
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the committed row replacement plan
+        type: string
+        required: false
+permissions:
+  contents: read
+concurrency:
+  group: windows-dao-row-replacement-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  generate:
+    if: inputs.run_acquisition
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          python3 oracle/windows-dao/scripts/dao_row_replacement_diff.py plan "$PLAN_SHA256"
+      - name: Build public fixture and snapshot producers
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-row-replacement-fixture
+      - name: Create requested fixtures on supported publication platform
+        run: python3 oracle/windows-dao/scripts/dao_row_replacement_diff.py prepare artifacts/dao-row-replacement-v1_2 target/release/jet3-row-replacement-fixture target/release/jet3-cli "$GITHUB_SHA"
+      - name: Retain exact generated files and preparation diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-row-replacement-${{ github.sha }}
+          path: artifacts/dao-row-replacement-v1_2
+          if-no-files-found: warn
+          retention-days: 14
+  update-differential:
+    needs: generate
+    if: always() && (needs.generate.result == 'success' || !inputs.run_acquisition)
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          if ($env:GITHUB_RUN_ATTEMPT -ne '1') { throw 'No automatic acquisition retry' }
+          python oracle/windows-dao/scripts/dao_row_replacement_diff.py plan $env:PLAN_SHA256
+          if ($LASTEXITCODE -ne 0) { throw 'Reviewed update plan verification failed' }
+      - name: Probe stock x86 provider
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/probe-provider.ps1 -ProtocolVersion 1.2.0 -OutputPath artifacts/environment.json
+          if ($LASTEXITCODE -ne 0) { throw 'Stock provider unavailable; retained probe explains missing prerequisite' }
+      - name: Download the exact Unix-generated candidates
+        if: inputs.run_acquisition
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: generated-row-replacement-${{ github.sha }}
+          path: artifacts/dao-row-replacement-v1_2
+      - name: Build the read-only Rust snapshot producer
+        if: inputs.run_acquisition
+        shell: powershell
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-row-replacement-fixture
+      - name: Verify downloads and snapshot them on Windows
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_row_replacement_diff.py snapshot artifacts/dao-row-replacement-v1_2 target/release/jet3-row-replacement-fixture.exe target/release/jet3-cli.exe $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'Downloaded fixture snapshot failed' }
+      - name: Observe Rust files read-only with DAO
+        id: dao
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/Invoke-DaoIndexedUpdateV12.ps1 -InventoryPath oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json -EnvironmentPath artifacts/environment.json -OutputRoot artifacts/dao-row-replacement-v1_2 -SourceRevision $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'DAO update observation failed' }
+      - name: Compare protocol snapshots and recipe semantics
+        if: always() && inputs.run_acquisition && steps.dao.outcome != 'skipped'
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_row_replacement_diff.py evaluate artifacts/dao-row-replacement-v1_2
+          if ($LASTEXITCODE -ne 0) { throw 'Update differential failed' }
+      - name: Retain diagnostics including failed files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-row-replacement-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/crates/jet3-cli/src/snapshot.rs
+++ b/crates/jet3-cli/src/snapshot.rs
@@ -7,13 +7,13 @@ use std::path::PathBuf;
 use jet3::TextCodePage;
 use jet3_testkit::{
     INDEXED_UPDATE_SCENARIOS, PROTOCOL_SCENARIOS, Producer, ROW_ALLOCATION_SCENARIOS,
-    ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome, UPDATE_SCENARIOS, WRITE_SCENARIOS,
-    canonical_json, coverage, parse_scenarios, snapshot_bytes,
+    ROW_REPLACEMENT_SCENARIOS, ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome,
+    UPDATE_SCENARIOS, WRITE_SCENARIOS, canonical_json, coverage, parse_scenarios, snapshot_bytes,
 };
 
 pub(crate) const HELP: &str = "\
   jet3-cli snapshot <file> --out <dir> --scenario <DAO-READ-...|DAO-WRITE-...|DAO-UPDATE-...> \
-    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update|row-allocation|indexed-update]
+    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update|row-allocation|indexed-update|row-replacement]
 
 snapshot reads the whole database with the jet3 reader and writes
 <dir>/snapshot.json (protocol 1.2 canonical semantic snapshot; omitted when
@@ -59,6 +59,7 @@ pub(crate) fn parse_args(
                 "row-update" => ROW_UPDATE_SCENARIOS,
                 "row-allocation" => ROW_ALLOCATION_SCENARIOS,
                 "indexed-update" => INDEXED_UPDATE_SCENARIOS,
+                "row-replacement" => ROW_REPLACEMENT_SCENARIOS,
                 _ => return Err("invalid_inventory"),
             });
         } else if option == "--code-page" {

--- a/crates/jet3-testkit/src/bin/jet3-row-replacement-fixture.rs
+++ b/crates/jet3-testkit/src/bin/jet3-row-replacement-fixture.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    let [command, scenario, directory] = args.as_slice() else {
+        return Err(
+            "usage: jet3-row-replacement-fixture generate|verify SCENARIO DIRECTORY".into(),
+        );
+    };
+    jet3_testkit::row_replacement_fixture(command, scenario, std::path::Path::new(directory))
+}

--- a/crates/jet3-testkit/src/lib.rs
+++ b/crates/jet3-testkit/src/lib.rs
@@ -44,3 +44,6 @@ pub use row_allocation_fixture::{ROW_ALLOCATION_SCENARIOS, row_allocation_fixtur
 
 mod indexed_update_fixture;
 pub use indexed_update_fixture::{INDEXED_UPDATE_SCENARIOS, indexed_update_fixture};
+
+mod row_replacement_fixture;
+pub use row_replacement_fixture::{ROW_REPLACEMENT_SCENARIOS, row_replacement_fixture};

--- a/crates/jet3-testkit/src/row_replacement_fixture.rs
+++ b/crates/jet3-testkit/src/row_replacement_fixture.rs
@@ -1,0 +1,392 @@
+//! Finite hosted sole-release and full-row replacements through public APIs.
+use jet3::{
+    CatalogObjectClass, ColumnSpec, ColumnType, DatabaseReader, ResourceBudget, ResourceLimits,
+    RowDelete, RowLocator, RowUpdate, RowValue, TableRows, TableSpec,
+    create_database_with_table_rows, delete_row, update_row,
+};
+use serde_json::{Value, json};
+use std::{fs, num::NonZeroU8, path::Path};
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub const ROW_REPLACEMENT_SCENARIOS: &str =
+    include_str!("../../../oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json");
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn integer(v: &Value) -> Result<i32> {
+    Ok(v.as_i64().ok_or("Long")?.try_into()?)
+}
+fn scenario(id: &str) -> Result<Value> {
+    let v: Value = serde_json::from_str(ROW_REPLACEMENT_SCENARIOS)?;
+    v["scenarios"]
+        .as_array()
+        .ok_or("scenarios")?
+        .iter()
+        .find(|s| s["id"] == id)
+        .cloned()
+        .ok_or_else(|| "unknown scenario".into())
+}
+fn values(row: &Value) -> Result<Vec<RowValue<'_>>> {
+    row.as_array()
+        .ok_or("row")?
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            Ok(if v.is_null() {
+                RowValue::Null
+            } else {
+                match i {
+                    0 | 1 => RowValue::Long(integer(v)?),
+                    2 => RowValue::Text(v.as_str().ok_or("Text")?.as_bytes()),
+                    3 => RowValue::Binary(v.as_str().ok_or("Binary ASCII")?.as_bytes()),
+                    4 => RowValue::Boolean(v.as_bool().ok_or("Boolean")?),
+                    _ => return Err("column".into()),
+                }
+            })
+        })
+        .collect()
+}
+fn generate(path: &Path, case: &Value) -> Result<()> {
+    let tables = case["tables"].as_array().ok_or("tables")?;
+    let columns = tables
+        .iter()
+        .map(|t| {
+            t["columns"]
+                .as_array()
+                .ok_or("columns")?
+                .iter()
+                .map(|c| {
+                    Ok(ColumnSpec::new(
+                        c["name"].as_str().ok_or("name")?.as_bytes(),
+                        match c["kind"].as_str() {
+                            Some("Long") => ColumnType::Long,
+                            Some("Text") => ColumnType::Text {
+                                max_len: NonZeroU8::MAX,
+                            },
+                            Some("Binary") => ColumnType::Binary {
+                                max_len: NonZeroU8::MAX,
+                            },
+                            Some("Boolean") => ColumnType::Boolean,
+                            _ => return Err("column type".into()),
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let rows = tables
+        .iter()
+        .map(|t| {
+            t.get("seed_rows")
+                .unwrap_or(&t["rows"])
+                .as_array()
+                .ok_or("rows")?
+                .iter()
+                .map(values)
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let slices = rows
+        .iter()
+        .map(|r| r.iter().map(Vec::as_slice).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let requests = tables
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            Ok(TableRows {
+                table: TableSpec {
+                    name: t["name"].as_str().ok_or("name")?.as_bytes(),
+                    columns: &columns[i],
+                    indexes: &[],
+                },
+                rows: &slices[i],
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    create_database_with_table_rows(path, &requests, &mut budget())?;
+    if let Some(id) = case["request"].get("seed_delete") {
+        let table = case["request"]["table"].as_str().ok_or("table")?;
+        let (_, row) = locate(path, table, integer(id)?)?;
+        delete_row(
+            path,
+            RowDelete {
+                table: table.as_bytes(),
+                row,
+            },
+            &mut budget(),
+        )?;
+    }
+    Ok(())
+}
+fn locate(path: &Path, table: &str, id: i32) -> Result<(u64, RowLocator)> {
+    let mut b = budget();
+    let mut db = DatabaseReader::open(path, &mut b)?;
+    let root = {
+        let mut c = db.catalog(&mut b)?;
+        let mut roots = Vec::new();
+        while let Some(r) = c.next_record()? {
+            if r.class() == CatalogObjectClass::User && r.name().raw_bytes() == table.as_bytes() {
+                roots.push(r.table_definition().ok_or("root")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("table identity".into());
+        }
+        roots[0]
+    };
+    let def = db.table_definition(root, &mut b)?;
+    let column = def.columns().first().ok_or("Id")?.ordinal();
+    let mut found = Vec::new();
+    {
+        let mut rows = db.rows(&def, &mut b)?;
+        while let Some(r) = rows.next_row()? {
+            if r.field(column).and_then(|v| v.raw_bytes()) == Some(id.to_le_bytes().as_slice()) {
+                if r.locator() != r.storage_locator() {
+                    return Err("overflow".into());
+                }
+                found.push(r.locator());
+            }
+        }
+    }
+    if found.len() != 1 {
+        return Err("selected Id".into());
+    }
+    Ok((root.get(), found[0]))
+}
+fn word(bytes: &[u8], offset: usize) -> Result<usize> {
+    Ok(u16::from_le_bytes(
+        bytes
+            .get(offset..offset + 2)
+            .ok_or("word range")?
+            .try_into()?,
+    ) as usize)
+}
+fn dword(bytes: &[u8], offset: usize) -> Result<usize> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .ok_or("dword range")?
+            .try_into()?,
+    ) as usize)
+}
+fn put(bytes: &mut [u8], offset: usize, value: &[u8]) -> Result<()> {
+    bytes
+        .get_mut(offset..offset + value.len())
+        .ok_or("patch range")?
+        .copy_from_slice(value);
+    Ok(())
+}
+fn encoded(row: &Value) -> Result<Vec<u8>> {
+    let r = row.as_array().ok_or("row")?;
+    if r.len() != 5 {
+        return Err("five columns".into());
+    }
+    let mut bytes = vec![5];
+    bytes.extend(integer(&r[0])?.to_le_bytes());
+    bytes.extend(if r[1].is_null() { 0 } else { integer(&r[1])? }.to_le_bytes());
+    let mut ends = vec![9_u8];
+    let mut bitmap = 1_u8;
+    if !r[1].is_null() {
+        bitmap |= 2;
+    }
+    for (n, v) in r.iter().enumerate().take(4).skip(2) {
+        if !v.is_null() {
+            let text = v.as_str().ok_or("ASCII variable field")?;
+            if !text.is_ascii() {
+                return Err("ASCII recipe".into());
+            }
+            bytes.extend(text.as_bytes());
+            bitmap |= 1 << n;
+        }
+        ends.push(bytes.len().try_into()?);
+    }
+    if r[4].as_bool().ok_or("Boolean")? {
+        bitmap |= 16;
+    }
+    bytes.extend(ends.into_iter().rev());
+    bytes.extend([2, bitmap]);
+    Ok(bytes)
+}
+fn release_maps(bytes: &mut [u8], root: usize, page: usize) -> Result<()> {
+    let locators = [
+        (1, 0),
+        (dword(bytes, root + 35)? >> 8, bytes[root + 35] as usize),
+        (dword(bytes, root + 39)? >> 8, bytes[root + 39] as usize),
+    ];
+    for (role, (map, slot)) in locators.into_iter().enumerate() {
+        let base = map * 2048;
+        let start = word(bytes, base + 10 + 2 * slot)?;
+        let end = if slot == 0 {
+            2048
+        } else {
+            word(bytes, base + 8 + 2 * slot)?
+        };
+        if start >= end || end > 2048 || bytes.get(base + start) != Some(&0) {
+            return Err("inline map".into());
+        }
+        let relative = page
+            .checked_sub(dword(bytes, base + start + 1)?)
+            .ok_or("map base")?;
+        let offset = base + start + 5 + relative / 8;
+        if offset >= base + end {
+            return Err("map coverage".into());
+        }
+        let mask = 1 << (relative % 8);
+        if (bytes[offset] & mask != 0) == (role == 0) {
+            return Err("release membership".into());
+        }
+        bytes[offset] = if role == 0 {
+            bytes[offset] | mask
+        } else {
+            bytes[offset] & !mask
+        };
+    }
+    Ok(())
+}
+fn verify(id: &str, case: &Value, directory: &Path) -> Result<Value> {
+    let request = &case["request"];
+    let table = request["table"].as_str().ok_or("table")?;
+    let original = directory.join("before/database.mdb");
+    let updated = directory.join("after/database.mdb");
+    let before = fs::read(&original)?;
+    let after = fs::read(&updated)?;
+    let (root, locator) = locate(&original, table, integer(&request["selected_id"])?)?;
+    let base = locator.page().get() as usize * 2048;
+    let count = word(&before, base + 8)?;
+    let mut expected = before.clone();
+    if request["kind"] == "sole_release" {
+        if count != 1 || locator.slot() != 0 || word(&before, base + 10)? >= 2048 {
+            return Err("sole physical row".into());
+        }
+        expected[base] = 9;
+        put(&mut expected, base + 2, &2036_u16.to_le_bytes())?;
+        put(&mut expected, base + 10, &0xc800_u16.to_le_bytes())?;
+        let definition = root as usize * 2048;
+        let rows = dword(&before, definition + 12)?
+            .checked_sub(1)
+            .ok_or("row count")?;
+        put(
+            &mut expected,
+            definition + 12,
+            &u32::try_from(rows)?.to_le_bytes(),
+        )?;
+        release_maps(&mut expected, definition, locator.page().get() as usize)?;
+    } else {
+        let replacement = encoded(&request["replacement"])?;
+        let mut end = 2048_usize;
+        let mut has_tombstone = false;
+        for slot in 0..count {
+            let raw = word(&before, base + 10 + 2 * slot)?;
+            let start = raw & 0x1fff;
+            let oldend = if slot == 0 {
+                2048
+            } else {
+                word(&before, base + 8 + 2 * slot)? & 0x1fff
+            };
+            if start > oldend || oldend > 2048 {
+                return Err("row boundaries".into());
+            }
+            if raw & 0xe000 != 0 {
+                if raw & 0xe000 != 0xc000 || start != oldend {
+                    return Err("row flags".into());
+                }
+                has_tombstone = true;
+            }
+            let row = if slot == locator.slot() as usize {
+                replacement.as_slice()
+            } else {
+                &before[base + start..base + oldend]
+            };
+            end = end.checked_sub(row.len()).ok_or("row width")?;
+            put(&mut expected, base + end, row)?;
+            put(
+                &mut expected,
+                base + 10 + 2 * slot,
+                &u16::try_from((raw & 0xe000) | end)?.to_le_bytes(),
+            )?;
+        }
+        if request["tombstone"] == true && !has_tombstone {
+            return Err("missing tombstone".into());
+        }
+        let free = end.checked_sub(10 + 2 * count).ok_or("directory overlap")?;
+        put(&mut expected, base + 2, &u16::try_from(free)?.to_le_bytes())?;
+        if locate(&updated, table, integer(&request["selected_id"])?)?.1 != locator {
+            return Err("changed target slot".into());
+        }
+    }
+    if before.len() != after.len() || expected != after {
+        return Err("unplanned replacement/release bytes".into());
+    }
+    Ok(
+        json!({"scenario_id":id,"request":request,"locator":{"root":root,"page":locator.page().get(),"slot":locator.slot()},"preserved":true,"before_sha256":crate::sha256_hex(&before),"after_sha256":crate::sha256_hex(&after)}),
+    )
+}
+/// Generates finite public mutation pairs, or verifies retained bytes read-only.
+pub fn row_replacement_fixture(command: &str, id: &str, directory: &Path) -> Result<()> {
+    let case = scenario(id)?;
+    let kind = case["request"]["kind"].as_str().unwrap_or("");
+    if !matches!(kind, "sole_release" | "row_replace") {
+        return crate::indexed_update_fixture(command, id, directory);
+    }
+    if command == "generate" {
+        fs::create_dir(directory.join("before"))?;
+        fs::create_dir(directory.join("after"))?;
+        let before = directory.join("before/database.mdb");
+        let after = directory.join("after/database.mdb");
+        generate(&before, &case)?;
+        fs::copy(&before, &after)?;
+        let request = &case["request"];
+        let table = request["table"].as_str().ok_or("table")?;
+        let (_, row) = locate(&before, table, integer(&request["selected_id"])?)?;
+        if kind == "sole_release" {
+            delete_row(
+                &after,
+                RowDelete {
+                    table: table.as_bytes(),
+                    row,
+                },
+                &mut budget(),
+            )?;
+        } else {
+            update_row(
+                &after,
+                RowUpdate {
+                    table: table.as_bytes(),
+                    row,
+                    values: &values(&request["replacement"])?,
+                },
+                &mut budget(),
+            )?;
+        }
+    } else if command != "verify" {
+        return Err("expected generate or verify".into());
+    }
+    println!("{}", verify(id, &case, directory)?);
+    Ok(())
+}
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    #[test]
+    fn public_replacement_release_and_exact_preservation() -> Result<()> {
+        for suffix in [
+            "SOLE-RELEASE",
+            "ROW-GROW",
+            "ROW-SHRINK",
+            "ROW-LATER-TOMBSTONE",
+        ] {
+            let id = format!("DAO-UPDATE-{suffix}");
+            let d = tempfile::tempdir()?;
+            row_replacement_fixture("generate", &id, d.path())?;
+            let p = d.path().join("after/database.mdb");
+            let original = fs::read(&p)?;
+            for offset in [1538, original.len() - 1] {
+                let mut bad = original.clone();
+                bad[offset] ^= 1;
+                fs::write(&p, bad)?;
+                assert!(verify(&id, &scenario(&id)?, d.path()).is_err());
+            }
+        }
+        Ok(())
+    }
+}

--- a/oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json
+++ b/oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json
@@ -1,0 +1,3530 @@
+{
+  "document_type": "dao_update_scenario_inventory",
+  "protocol_version": "1.2.0",
+  "scenarios": [
+    {
+      "id": "DAO-UPDATE-FIRST-FIELD",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              1000,
+              "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "00!!"
+            ],
+            [
+              1,
+              1001,
+              "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "01!!"
+            ],
+            [
+              2,
+              1002,
+              "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "02!!"
+            ],
+            [
+              3,
+              1003,
+              "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "03!!"
+            ],
+            [
+              4,
+              1004,
+              "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "04!!"
+            ],
+            [
+              5,
+              1005,
+              "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "05!!"
+            ],
+            [
+              6,
+              1006,
+              "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "06!!"
+            ],
+            [
+              7,
+              1007,
+              "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "07!!"
+            ],
+            [
+              8,
+              1008,
+              "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "08!!"
+            ],
+            [
+              9,
+              1009,
+              "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "09!!"
+            ],
+            [
+              10,
+              1010,
+              "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "10!!"
+            ],
+            [
+              11,
+              1011,
+              "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "11!!"
+            ],
+            [
+              12,
+              1012,
+              "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "12!!"
+            ],
+            [
+              13,
+              1013,
+              "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "13!!"
+            ],
+            [
+              14,
+              1014,
+              "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "14!!"
+            ],
+            [
+              15,
+              1015,
+              "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "15!!"
+            ],
+            [
+              16,
+              1016,
+              "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "16!!"
+            ],
+            [
+              17,
+              1017,
+              "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "17!!"
+            ],
+            [
+              18,
+              1018,
+              "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "18!!"
+            ],
+            [
+              19,
+              1019,
+              "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "19!!"
+            ],
+            [
+              20,
+              1020,
+              "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "20!!"
+            ],
+            [
+              21,
+              1021,
+              "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "21!!"
+            ],
+            [
+              22,
+              1022,
+              "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "22!!"
+            ],
+            [
+              23,
+              1023,
+              "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "23!!"
+            ],
+            [
+              24,
+              1024,
+              "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "24!!"
+            ],
+            [
+              25,
+              1025,
+              "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "25!!"
+            ],
+            [
+              26,
+              1026,
+              "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "26!!"
+            ],
+            [
+              27,
+              1027,
+              "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "27!!"
+            ],
+            [
+              28,
+              1028,
+              "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "28!!"
+            ],
+            [
+              29,
+              1029,
+              "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "29!!"
+            ],
+            [
+              30,
+              1030,
+              "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "30!!"
+            ],
+            [
+              31,
+              1031,
+              "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "31!!"
+            ],
+            [
+              32,
+              1032,
+              "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "32!!"
+            ]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Id",
+        "row_index": 0,
+        "before": 0,
+        "after": -42
+      }
+    },
+    {
+      "id": "DAO-UPDATE-LATER-ROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              1000,
+              "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "00!!"
+            ],
+            [
+              1,
+              1001,
+              "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "01!!"
+            ],
+            [
+              2,
+              1002,
+              "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "02!!"
+            ],
+            [
+              3,
+              1003,
+              "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "03!!"
+            ],
+            [
+              4,
+              1004,
+              "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "04!!"
+            ],
+            [
+              5,
+              1005,
+              "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "05!!"
+            ],
+            [
+              6,
+              1006,
+              "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "06!!"
+            ],
+            [
+              7,
+              1007,
+              "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "07!!"
+            ],
+            [
+              8,
+              1008,
+              "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "08!!"
+            ],
+            [
+              9,
+              1009,
+              "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "09!!"
+            ],
+            [
+              10,
+              1010,
+              "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "10!!"
+            ],
+            [
+              11,
+              1011,
+              "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "11!!"
+            ],
+            [
+              12,
+              1012,
+              "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "12!!"
+            ],
+            [
+              13,
+              1013,
+              "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "13!!"
+            ],
+            [
+              14,
+              1014,
+              "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "14!!"
+            ],
+            [
+              15,
+              1015,
+              "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "15!!"
+            ],
+            [
+              16,
+              1016,
+              "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "16!!"
+            ],
+            [
+              17,
+              1017,
+              "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "17!!"
+            ],
+            [
+              18,
+              1018,
+              "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "18!!"
+            ],
+            [
+              19,
+              1019,
+              "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "19!!"
+            ],
+            [
+              20,
+              1020,
+              "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "20!!"
+            ],
+            [
+              21,
+              1021,
+              "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "21!!"
+            ],
+            [
+              22,
+              1022,
+              "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "22!!"
+            ],
+            [
+              23,
+              1023,
+              "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "23!!"
+            ],
+            [
+              24,
+              1024,
+              "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "24!!"
+            ],
+            [
+              25,
+              1025,
+              "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "25!!"
+            ],
+            [
+              26,
+              1026,
+              "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "26!!"
+            ],
+            [
+              27,
+              1027,
+              "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "27!!"
+            ],
+            [
+              28,
+              1028,
+              "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "28!!"
+            ],
+            [
+              29,
+              1029,
+              "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "29!!"
+            ],
+            [
+              30,
+              1030,
+              "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "30!!"
+            ],
+            [
+              31,
+              1031,
+              "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "31!!"
+            ],
+            [
+              32,
+              1032,
+              "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "32!!"
+            ]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Value",
+        "row_index": 31,
+        "before": 1031,
+        "after": -2147483648
+      }
+    },
+    {
+      "id": "DAO-UPDATE-LATER-TABLE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Prefix",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              100
+            ],
+            [
+              101
+            ]
+          ]
+        },
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              1000,
+              "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "00!!"
+            ],
+            [
+              1,
+              1001,
+              "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "01!!"
+            ],
+            [
+              2,
+              1002,
+              "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "02!!"
+            ],
+            [
+              3,
+              1003,
+              "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "03!!"
+            ],
+            [
+              4,
+              1004,
+              "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "04!!"
+            ],
+            [
+              5,
+              1005,
+              "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "05!!"
+            ],
+            [
+              6,
+              1006,
+              "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "06!!"
+            ],
+            [
+              7,
+              1007,
+              "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "07!!"
+            ],
+            [
+              8,
+              1008,
+              "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "08!!"
+            ],
+            [
+              9,
+              1009,
+              "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "09!!"
+            ],
+            [
+              10,
+              1010,
+              "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "10!!"
+            ],
+            [
+              11,
+              1011,
+              "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "11!!"
+            ],
+            [
+              12,
+              1012,
+              "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "12!!"
+            ],
+            [
+              13,
+              1013,
+              "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "13!!"
+            ],
+            [
+              14,
+              1014,
+              "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "14!!"
+            ],
+            [
+              15,
+              1015,
+              "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "15!!"
+            ],
+            [
+              16,
+              1016,
+              "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "16!!"
+            ],
+            [
+              17,
+              1017,
+              "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "17!!"
+            ],
+            [
+              18,
+              1018,
+              "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "18!!"
+            ],
+            [
+              19,
+              1019,
+              "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "19!!"
+            ],
+            [
+              20,
+              1020,
+              "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "20!!"
+            ],
+            [
+              21,
+              1021,
+              "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "21!!"
+            ],
+            [
+              22,
+              1022,
+              "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "22!!"
+            ],
+            [
+              23,
+              1023,
+              "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "23!!"
+            ],
+            [
+              24,
+              1024,
+              "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "24!!"
+            ],
+            [
+              25,
+              1025,
+              "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "25!!"
+            ],
+            [
+              26,
+              1026,
+              "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "26!!"
+            ],
+            [
+              27,
+              1027,
+              "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "27!!"
+            ],
+            [
+              28,
+              1028,
+              "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "28!!"
+            ],
+            [
+              29,
+              1029,
+              "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "29!!"
+            ],
+            [
+              30,
+              1030,
+              "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "30!!"
+            ],
+            [
+              31,
+              1031,
+              "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "31!!"
+            ],
+            [
+              32,
+              1032,
+              "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "32!!"
+            ]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Value",
+        "row_index": 17,
+        "before": 1017,
+        "after": 2147483647
+      }
+    },
+    {
+      "id": "DAO-UPDATE-INSERT-ROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public row insert",
+        "exact unrelated-byte and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "insert",
+        "table": "Items",
+        "row": [
+          88,
+          -8800,
+          "inserted"
+        ]
+      }
+    },
+    {
+      "id": "DAO-UPDATE-DELETE-TAIL",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public row delete",
+        "exact unrelated-byte and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "delete",
+        "table": "Items",
+        "selected_id": 3
+      }
+    },
+    {
+      "id": "DAO-UPDATE-EMPTY-EOF",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded eof_insert",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": []
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "eof_insert",
+        "row": [
+          88,
+          -8800,
+          "inserted"
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-FULL-EOF",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded eof_insert",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              -1,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              2,
+              -2,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              3,
+              -3,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              4,
+              -4,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              5,
+              -5,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              6,
+              -6,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              7,
+              -7,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "eof_insert",
+        "row": [
+          88,
+          -8800,
+          "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-MIDDLE-COMPACT",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded compact_delete",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "a"
+            ],
+            [
+              2,
+              -202,
+              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ],
+            [
+              3,
+              303,
+              "short"
+            ],
+            [
+              4,
+              404,
+              "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "compact_delete",
+        "selected_ids": [
+          2
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-REPEATED-COMPACT",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded compact_delete",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "a"
+            ],
+            [
+              2,
+              -202,
+              "bb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ],
+            [
+              4,
+              404,
+              "dddd"
+            ],
+            [
+              5,
+              505,
+              "eeeee"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "compact_delete",
+        "selected_ids": [
+          2,
+          4,
+          1
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-PRIMARY-KEY",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              -10,
+              100,
+              "payload"
+            ],
+            [
+              0,
+              101,
+              "payload"
+            ],
+            [
+              10,
+              102,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 0,
+        "selector_column": 0,
+        "selected": 0,
+        "replacement": -2147483648
+      },
+      "index_queries": [
+        -2147483648,
+        -10,
+        0,
+        10,
+        999
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-DESCENDING-KEY",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "unique",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": true
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              -2147483648,
+              100,
+              "payload"
+            ],
+            [
+              0,
+              101,
+              "payload"
+            ],
+            [
+              2147483647,
+              102,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 0,
+        "selector_column": 0,
+        "selected": 0,
+        "replacement": 2147483646
+      },
+      "index_queries": [
+        -2147483648,
+        0,
+        999,
+        2147483646,
+        2147483647
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-FULL-LEAF-KEY",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              100,
+              "payload"
+            ],
+            [
+              1,
+              101,
+              "payload"
+            ],
+            [
+              2,
+              102,
+              "payload"
+            ],
+            [
+              3,
+              103,
+              "payload"
+            ],
+            [
+              4,
+              104,
+              "payload"
+            ],
+            [
+              5,
+              105,
+              "payload"
+            ],
+            [
+              6,
+              106,
+              "payload"
+            ],
+            [
+              7,
+              107,
+              "payload"
+            ],
+            [
+              8,
+              108,
+              "payload"
+            ],
+            [
+              9,
+              109,
+              "payload"
+            ],
+            [
+              10,
+              110,
+              "payload"
+            ],
+            [
+              11,
+              111,
+              "payload"
+            ],
+            [
+              12,
+              112,
+              "payload"
+            ],
+            [
+              13,
+              113,
+              "payload"
+            ],
+            [
+              14,
+              114,
+              "payload"
+            ],
+            [
+              15,
+              115,
+              "payload"
+            ],
+            [
+              16,
+              116,
+              "payload"
+            ],
+            [
+              17,
+              117,
+              "payload"
+            ],
+            [
+              18,
+              118,
+              "payload"
+            ],
+            [
+              19,
+              119,
+              "payload"
+            ],
+            [
+              20,
+              120,
+              "payload"
+            ],
+            [
+              21,
+              121,
+              "payload"
+            ],
+            [
+              22,
+              122,
+              "payload"
+            ],
+            [
+              23,
+              123,
+              "payload"
+            ],
+            [
+              24,
+              124,
+              "payload"
+            ],
+            [
+              25,
+              125,
+              "payload"
+            ],
+            [
+              26,
+              126,
+              "payload"
+            ],
+            [
+              27,
+              127,
+              "payload"
+            ],
+            [
+              28,
+              128,
+              "payload"
+            ],
+            [
+              29,
+              129,
+              "payload"
+            ],
+            [
+              30,
+              130,
+              "payload"
+            ],
+            [
+              31,
+              131,
+              "payload"
+            ],
+            [
+              32,
+              132,
+              "payload"
+            ],
+            [
+              33,
+              133,
+              "payload"
+            ],
+            [
+              34,
+              134,
+              "payload"
+            ],
+            [
+              35,
+              135,
+              "payload"
+            ],
+            [
+              36,
+              136,
+              "payload"
+            ],
+            [
+              37,
+              137,
+              "payload"
+            ],
+            [
+              38,
+              138,
+              "payload"
+            ],
+            [
+              39,
+              139,
+              "payload"
+            ],
+            [
+              40,
+              140,
+              "payload"
+            ],
+            [
+              41,
+              141,
+              "payload"
+            ],
+            [
+              42,
+              142,
+              "payload"
+            ],
+            [
+              43,
+              143,
+              "payload"
+            ],
+            [
+              44,
+              144,
+              "payload"
+            ],
+            [
+              45,
+              145,
+              "payload"
+            ],
+            [
+              46,
+              146,
+              "payload"
+            ],
+            [
+              47,
+              147,
+              "payload"
+            ],
+            [
+              48,
+              148,
+              "payload"
+            ],
+            [
+              49,
+              149,
+              "payload"
+            ],
+            [
+              50,
+              150,
+              "payload"
+            ],
+            [
+              51,
+              151,
+              "payload"
+            ],
+            [
+              52,
+              152,
+              "payload"
+            ],
+            [
+              53,
+              153,
+              "payload"
+            ],
+            [
+              54,
+              154,
+              "payload"
+            ],
+            [
+              55,
+              155,
+              "payload"
+            ],
+            [
+              56,
+              156,
+              "payload"
+            ],
+            [
+              57,
+              157,
+              "payload"
+            ],
+            [
+              58,
+              158,
+              "payload"
+            ],
+            [
+              59,
+              159,
+              "payload"
+            ],
+            [
+              60,
+              160,
+              "payload"
+            ],
+            [
+              61,
+              161,
+              "payload"
+            ],
+            [
+              62,
+              162,
+              "payload"
+            ],
+            [
+              63,
+              163,
+              "payload"
+            ],
+            [
+              64,
+              164,
+              "payload"
+            ],
+            [
+              65,
+              165,
+              "payload"
+            ],
+            [
+              66,
+              166,
+              "payload"
+            ],
+            [
+              67,
+              167,
+              "payload"
+            ],
+            [
+              68,
+              168,
+              "payload"
+            ],
+            [
+              69,
+              169,
+              "payload"
+            ],
+            [
+              70,
+              170,
+              "payload"
+            ],
+            [
+              71,
+              171,
+              "payload"
+            ],
+            [
+              72,
+              172,
+              "payload"
+            ],
+            [
+              73,
+              173,
+              "payload"
+            ],
+            [
+              74,
+              174,
+              "payload"
+            ],
+            [
+              75,
+              175,
+              "payload"
+            ],
+            [
+              76,
+              176,
+              "payload"
+            ],
+            [
+              77,
+              177,
+              "payload"
+            ],
+            [
+              78,
+              178,
+              "payload"
+            ],
+            [
+              79,
+              179,
+              "payload"
+            ],
+            [
+              80,
+              180,
+              "payload"
+            ],
+            [
+              81,
+              181,
+              "payload"
+            ],
+            [
+              82,
+              182,
+              "payload"
+            ],
+            [
+              83,
+              183,
+              "payload"
+            ],
+            [
+              84,
+              184,
+              "payload"
+            ],
+            [
+              85,
+              185,
+              "payload"
+            ],
+            [
+              86,
+              186,
+              "payload"
+            ],
+            [
+              87,
+              187,
+              "payload"
+            ],
+            [
+              88,
+              188,
+              "payload"
+            ],
+            [
+              89,
+              189,
+              "payload"
+            ],
+            [
+              90,
+              190,
+              "payload"
+            ],
+            [
+              91,
+              191,
+              "payload"
+            ],
+            [
+              92,
+              192,
+              "payload"
+            ],
+            [
+              93,
+              193,
+              "payload"
+            ],
+            [
+              94,
+              194,
+              "payload"
+            ],
+            [
+              95,
+              195,
+              "payload"
+            ],
+            [
+              96,
+              196,
+              "payload"
+            ],
+            [
+              97,
+              197,
+              "payload"
+            ],
+            [
+              98,
+              198,
+              "payload"
+            ],
+            [
+              99,
+              199,
+              "payload"
+            ],
+            [
+              100,
+              200,
+              "payload"
+            ],
+            [
+              101,
+              201,
+              "payload"
+            ],
+            [
+              102,
+              202,
+              "payload"
+            ],
+            [
+              103,
+              203,
+              "payload"
+            ],
+            [
+              104,
+              204,
+              "payload"
+            ],
+            [
+              105,
+              205,
+              "payload"
+            ],
+            [
+              106,
+              206,
+              "payload"
+            ],
+            [
+              107,
+              207,
+              "payload"
+            ],
+            [
+              108,
+              208,
+              "payload"
+            ],
+            [
+              109,
+              209,
+              "payload"
+            ],
+            [
+              110,
+              210,
+              "payload"
+            ],
+            [
+              111,
+              211,
+              "payload"
+            ],
+            [
+              112,
+              212,
+              "payload"
+            ],
+            [
+              113,
+              213,
+              "payload"
+            ],
+            [
+              114,
+              214,
+              "payload"
+            ],
+            [
+              115,
+              215,
+              "payload"
+            ],
+            [
+              116,
+              216,
+              "payload"
+            ],
+            [
+              117,
+              217,
+              "payload"
+            ],
+            [
+              118,
+              218,
+              "payload"
+            ],
+            [
+              119,
+              219,
+              "payload"
+            ],
+            [
+              120,
+              220,
+              "payload"
+            ],
+            [
+              121,
+              221,
+              "payload"
+            ],
+            [
+              122,
+              222,
+              "payload"
+            ],
+            [
+              123,
+              223,
+              "payload"
+            ],
+            [
+              124,
+              224,
+              "payload"
+            ],
+            [
+              125,
+              225,
+              "payload"
+            ],
+            [
+              126,
+              226,
+              "payload"
+            ],
+            [
+              127,
+              227,
+              "payload"
+            ],
+            [
+              128,
+              228,
+              "payload"
+            ],
+            [
+              129,
+              229,
+              "payload"
+            ],
+            [
+              130,
+              230,
+              "payload"
+            ],
+            [
+              131,
+              231,
+              "payload"
+            ],
+            [
+              132,
+              232,
+              "payload"
+            ],
+            [
+              133,
+              233,
+              "payload"
+            ],
+            [
+              134,
+              234,
+              "payload"
+            ],
+            [
+              135,
+              235,
+              "payload"
+            ],
+            [
+              136,
+              236,
+              "payload"
+            ],
+            [
+              137,
+              237,
+              "payload"
+            ],
+            [
+              138,
+              238,
+              "payload"
+            ],
+            [
+              139,
+              239,
+              "payload"
+            ],
+            [
+              140,
+              240,
+              "payload"
+            ],
+            [
+              141,
+              241,
+              "payload"
+            ],
+            [
+              142,
+              242,
+              "payload"
+            ],
+            [
+              143,
+              243,
+              "payload"
+            ],
+            [
+              144,
+              244,
+              "payload"
+            ],
+            [
+              145,
+              245,
+              "payload"
+            ],
+            [
+              146,
+              246,
+              "payload"
+            ],
+            [
+              147,
+              247,
+              "payload"
+            ],
+            [
+              148,
+              248,
+              "payload"
+            ],
+            [
+              149,
+              249,
+              "payload"
+            ],
+            [
+              150,
+              250,
+              "payload"
+            ],
+            [
+              151,
+              251,
+              "payload"
+            ],
+            [
+              152,
+              252,
+              "payload"
+            ],
+            [
+              153,
+              253,
+              "payload"
+            ],
+            [
+              154,
+              254,
+              "payload"
+            ],
+            [
+              155,
+              255,
+              "payload"
+            ],
+            [
+              156,
+              256,
+              "payload"
+            ],
+            [
+              157,
+              257,
+              "payload"
+            ],
+            [
+              158,
+              258,
+              "payload"
+            ],
+            [
+              159,
+              259,
+              "payload"
+            ],
+            [
+              160,
+              260,
+              "payload"
+            ],
+            [
+              161,
+              261,
+              "payload"
+            ],
+            [
+              162,
+              262,
+              "payload"
+            ],
+            [
+              163,
+              263,
+              "payload"
+            ],
+            [
+              164,
+              264,
+              "payload"
+            ],
+            [
+              165,
+              265,
+              "payload"
+            ],
+            [
+              166,
+              266,
+              "payload"
+            ],
+            [
+              167,
+              267,
+              "payload"
+            ],
+            [
+              168,
+              268,
+              "payload"
+            ],
+            [
+              169,
+              269,
+              "payload"
+            ],
+            [
+              170,
+              270,
+              "payload"
+            ],
+            [
+              171,
+              271,
+              "payload"
+            ],
+            [
+              172,
+              272,
+              "payload"
+            ],
+            [
+              173,
+              273,
+              "payload"
+            ],
+            [
+              174,
+              274,
+              "payload"
+            ],
+            [
+              175,
+              275,
+              "payload"
+            ],
+            [
+              176,
+              276,
+              "payload"
+            ],
+            [
+              177,
+              277,
+              "payload"
+            ],
+            [
+              178,
+              278,
+              "payload"
+            ],
+            [
+              179,
+              279,
+              "payload"
+            ],
+            [
+              180,
+              280,
+              "payload"
+            ],
+            [
+              181,
+              281,
+              "payload"
+            ],
+            [
+              182,
+              282,
+              "payload"
+            ],
+            [
+              183,
+              283,
+              "payload"
+            ],
+            [
+              184,
+              284,
+              "payload"
+            ],
+            [
+              185,
+              285,
+              "payload"
+            ],
+            [
+              186,
+              286,
+              "payload"
+            ],
+            [
+              187,
+              287,
+              "payload"
+            ],
+            [
+              188,
+              288,
+              "payload"
+            ],
+            [
+              189,
+              289,
+              "payload"
+            ],
+            [
+              190,
+              290,
+              "payload"
+            ],
+            [
+              191,
+              291,
+              "payload"
+            ],
+            [
+              192,
+              292,
+              "payload"
+            ],
+            [
+              193,
+              293,
+              "payload"
+            ],
+            [
+              194,
+              294,
+              "payload"
+            ],
+            [
+              195,
+              295,
+              "payload"
+            ],
+            [
+              196,
+              296,
+              "payload"
+            ],
+            [
+              197,
+              297,
+              "payload"
+            ],
+            [
+              198,
+              298,
+              "payload"
+            ],
+            [
+              199,
+              299,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 0,
+        "selector_column": 0,
+        "selected": 100,
+        "replacement": -1
+      },
+      "index_queries": [
+        -1,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        128,
+        129,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        144,
+        145,
+        146,
+        147,
+        148,
+        149,
+        150,
+        151,
+        152,
+        153,
+        154,
+        155,
+        156,
+        157,
+        158,
+        159,
+        160,
+        161,
+        162,
+        163,
+        164,
+        165,
+        166,
+        167,
+        168,
+        169,
+        170,
+        171,
+        172,
+        173,
+        174,
+        175,
+        176,
+        177,
+        178,
+        179,
+        180,
+        181,
+        182,
+        183,
+        184,
+        185,
+        186,
+        187,
+        188,
+        189,
+        190,
+        191,
+        192,
+        193,
+        194,
+        195,
+        196,
+        197,
+        198,
+        199,
+        999
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-INDEXED-PAYLOAD",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "ordinary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "payload"
+            ],
+            [
+              1,
+              202,
+              "payload"
+            ],
+            [
+              2,
+              303,
+              "payload"
+            ],
+            [
+              2,
+              404,
+              "payload"
+            ],
+            [
+              3,
+              505,
+              "payload"
+            ],
+            [
+              3,
+              606,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 1,
+        "selector_column": 1,
+        "selected": 303,
+        "replacement": -2147483648
+      },
+      "index_queries": [
+        1,
+        2,
+        3,
+        999
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-SOLE-RELEASE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public sole release",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "sole"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "sole_release",
+        "table": "Items",
+        "selected_id": 1
+      }
+    },
+    {
+      "id": "DAO-UPDATE-ROW-GROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public full-row replacement",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa",
+              "bytes",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "bbbbbbbbbbbbbbbbbbbb",
+              false
+            ],
+            [
+              3,
+              303,
+              "ccc",
+              "bytes",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              12,
+              1202,
+              "eee",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "row_replace",
+        "table": "Items",
+        "selected_id": 1,
+        "replacement": [
+          1,
+          null,
+          "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+          "abcdefgh",
+          false
+        ],
+        "tombstone": false
+      }
+    },
+    {
+      "id": "DAO-UPDATE-ROW-SHRINK",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public full-row replacement",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa",
+              "bytes",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "bbbbbbbbbbbbbbbbbbbb",
+              false
+            ],
+            [
+              3,
+              303,
+              "ccc",
+              "bytes",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              12,
+              1202,
+              "eee",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "row_replace",
+        "table": "Items",
+        "selected_id": 2,
+        "replacement": [
+          2,
+          -42,
+          null,
+          "ab",
+          true
+        ],
+        "tombstone": false
+      }
+    },
+    {
+      "id": "DAO-UPDATE-ROW-LATER-TOMBSTONE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public full-row replacement",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa",
+              "bytes",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "bbbbbbbbbbbbbbbbbbbb",
+              false
+            ],
+            [
+              3,
+              303,
+              "ccc",
+              "bytes",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ],
+          "seed_rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              12,
+              1202,
+              "eee",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "row_replace",
+        "table": "Later",
+        "selected_id": 13,
+        "replacement": [
+          13,
+          null,
+          null,
+          null,
+          false
+        ],
+        "tombstone": true,
+        "seed_delete": 12
+      }
+    }
+  ],
+  "deferred_requirements": [
+    "free-page or slot reuse, indirect allocation maps",
+    "indexed row insertion/deletion and relationship mutations",
+    "arbitrary wide full-row replacement and Auto/LVAL targets",
+    "hosted stored-query preservation and continuation DAO mutations"
+  ]
+}

--- a/oracle/windows-dao/scripts/dao_row_replacement_diff.py
+++ b/oracle/windows-dao/scripts/dao_row_replacement_diff.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Seventeen-case hosted update adapter; frozen indexed sidecar gates retained."""
+import copy
+import importlib.util
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[3]
+def private(name,file):
+    spec=importlib.util.spec_from_file_location(name,ROOT/'oracle/windows-dao/scripts'/file);module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module);return module
+indexed=private('_replacement_indexed','dao_indexed_update_diff.py');base=indexed.base
+release=private('_replacement_release','row_delete_release.py')
+replacement=private('_replacement_rows','row_update_candidate.py')
+base.INVENTORY=ROOT/'oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json'
+base.PLAN=ROOT/'oracle/windows-dao/acquisition/row-replacement-v1_2.plan.json'
+IDS=indexed.IDS+['DAO-UPDATE-'+n for n in ('SOLE-RELEASE','ROW-GROW','ROW-SHRINK','ROW-LATER-TOMBSTONE')]
+require=indexed.require
+
+def recipe(scenario,role):
+    request=scenario['request'];kind=request.get('kind')
+    if kind not in ('sole_release','row_replace'):return indexed.recipe(scenario,role)
+    result=copy.deepcopy(scenario);table,=[t for t in result['tables'] if t['name']==request['table']]
+    require(sum(r[0]==request['selected_id'] for r in table['rows'])==1,'Unique requested row')
+    if role=='after':
+        table['rows']=[r for r in table['rows'] if r[0]!=request['selected_id']] if kind=='sole_release' else [request['replacement'] if r[0]==request['selected_id'] else r for r in table['rows']]
+    else:require(role=='before','Unknown role')
+    return result
+
+def inventory():
+    value=base.load_json(base.INVENTORY)
+    require(value['document_type']=='dao_update_scenario_inventory' and value['protocol_version']=='1.2.0' and [s['id'] for s in value['scenarios']]==IDS,'Seventeen-case inventory')
+    historical=base.load_json(ROOT/'oracle/windows-dao/protocol/v1_2/indexed-update-scenarios.json')['scenarios'];require(value['scenarios'][:13]==historical,'Historical indexed cases changed')
+    for scenario in value['scenarios']:
+        require(scenario['operation']==dict(mode='dao_open_rust_update',expected_outcome='success',error_class=None) and not set(scenario['required_branches'])-base.write.protocol.load_branch_ids() and scenario['coverage'],'Operation/coverage');recipe(scenario,'after')
+    require(value['deferred_requirements'],'Missing limitations');return value
+
+def check_preservation(root,scenario,receipt):
+    request=scenario['request'];kind=request.get('kind')
+    if kind not in ('sole_release','row_replace'):return indexed.check_preservation(root,scenario,receipt)
+    require(receipt.get('scenario_id')==scenario['id'] and receipt.get('request')==request and receipt.get('preserved') is True,'Replacement request binding')
+    before,after=[(root/role/'database.mdb').read_bytes() for role in base.ROLES]
+    for role in base.ROLES:require(receipt[role+'_sha256']==base.write.digest(root/role/'database.mdb'),'Replacement image identity')
+    if kind=='sole_release':release.patch_check(before,after,request,receipt['locator'])
+    else:
+        arm=copy.deepcopy(request);binary=arm['replacement'][3]
+        if binary is not None:arm['replacement'][3]=binary.encode('ascii').hex()
+        replacement.patch_check(before,after,arm,receipt['locator'])
+
+def command(root,label,args):
+    if len(args)>1 and str(args[1])=='snapshot':args=[*args,'--inventory','row-replacement']
+    return indexed.allocation.rows.old_command(root,label,args)
+
+# The indexed evaluator directly reads its module's inventory for every sidecar;
+# make that same complete inventory visible without changing any frozen source.
+indexed.inventory=inventory
+base.inventory,base.recipe,base.check_preservation,base.command=inventory,recipe,check_preservation,command
+if __name__=='__main__':base.main()

--- a/oracle/windows-dao/tests/test_dao_row_replacement_diff.py
+++ b/oracle/windows-dao/tests/test_dao_row_replacement_diff.py
@@ -1,0 +1,41 @@
+import copy
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import dao_row_replacement_diff as a
+import dao_indexed_update_diff as historical
+
+class ReplacementTests(unittest.TestCase):
+    def test_inventory_recipe_and_sidecar_inventory(self):
+        cases=a.inventory()['scenarios'];self.assertEqual(len(cases),17)
+        self.assertEqual(cases[:13],historical.inventory()['scenarios'])
+        self.assertEqual(a.indexed.inventory()['scenarios'],cases)
+        for case,count in zip(cases[13:],[0,3,3,2]):
+            expected=a.recipe(case,'after');table=next(t for t in expected['tables'] if t['name']==case['request']['table']);self.assertEqual(len(table['rows']),count)
+        tombstone=cases[-1];self.assertEqual(len(tombstone['tables'][1]['seed_rows']),3);self.assertEqual(len(tombstone['tables'][1]['rows']),2)
+        self.assertEqual(a.recipe(tombstone,'after')['tables'][1]['rows'][1],[13,None,None,None,False])
+
+    def test_request_identity_and_binary_conversion(self):
+        case=a.inventory()['scenarios'][14]
+        with tempfile.TemporaryDirectory() as temp:
+            root=Path(temp)
+            for role in a.base.ROLES:(root/role).mkdir();(root/role/'database.mdb').write_bytes(role.encode())
+            receipt=dict(scenario_id=case['id'],request=case['request'],preserved=True,locator={'root':20,'page':23,'slot':0},before_sha256=a.base.write.digest(root/'before/database.mdb'),after_sha256=a.base.write.digest(root/'after/database.mdb'))
+            with patch.object(a.replacement,'patch_check') as check:
+                a.check_preservation(root,case,receipt);self.assertEqual(check.call_args.args[2]['replacement'][3],b'abcdefgh'.hex());self.assertEqual(check.call_args.args[3],receipt['locator'])
+                self.assertEqual(case['request']['replacement'][3],'abcdefgh')
+                bad=copy.deepcopy(receipt);bad['request']['selected_id']=9
+                with self.assertRaises(a.base.ValidationError):a.check_preservation(root,case,bad)
+                (root/'after/database.mdb').write_bytes(b'changed')
+                with self.assertRaises(a.base.ValidationError):a.check_preservation(root,case,receipt)
+
+    def test_cli_selector_retains_frozen_indexed_runner(self):
+        with patch.object(a.indexed.allocation.rows,'old_command') as run:
+            a.command(Path('.'),'snapshot',['cli','snapshot','file'])
+            self.assertEqual(run.call_args.args[2][-2:],['--inventory','row-replacement'])
+        self.assertEqual(len(historical.inventory()['scenarios']),13)
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Extends the hosted update inventory to seventeen cases, adding sole-row page release and full-row growth, shrinkage, and tombstone-adjacent replacement. Public fixtures and independent exact-byte checks retain the original thirteen cases and their index sidecars.

Validation: independent review, focused Rust/Python tests, all 17 public preparations and 34 snapshots, Clippy, and `just ready` passed. A separate pinned plan is required before acquisition.

Progress toward #113.
