### PR TITLE
test: add hosted creation index boundary comparisons

### DIFF
--- a/.github/workflows/windows-dao-creation-index.yml
+++ b/.github/workflows/windows-dao-creation-index.yml
@@ -1,0 +1,107 @@
+name: Windows DAO creation index differential
+on:
+  workflow_dispatch:
+    inputs:
+      run_acquisition:
+        description: Run the reviewed single write acquisition
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the committed separate creation index plan
+        type: string
+        required: false
+permissions:
+  contents: read
+concurrency:
+  group: windows-dao-creation-index-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  generate:
+    if: inputs.run_acquisition
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          python3 oracle/windows-dao/scripts/dao_creation_index_diff.py plan "$PLAN_SHA256"
+      - name: Build public fixture and snapshot producers
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-creation-index-fixture
+      - name: Create requested fixtures on supported publication platform
+        run: python3 oracle/windows-dao/scripts/dao_creation_index_diff.py prepare artifacts/dao-creation-index-v1_2 target/release/jet3-creation-index-fixture target/release/jet3-cli "$GITHUB_SHA"
+      - name: Retain exact generated files and preparation diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-creation-index-${{ github.sha }}
+          path: artifacts/dao-creation-index-v1_2
+          if-no-files-found: warn
+          retention-days: 14
+  write-differential:
+    needs: generate
+    if: always() && (needs.generate.result == 'success' || !inputs.run_acquisition)
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          if ($env:GITHUB_RUN_ATTEMPT -ne '1') { throw 'No automatic acquisition retry' }
+          python oracle/windows-dao/scripts/dao_creation_index_diff.py plan $env:PLAN_SHA256
+          if ($LASTEXITCODE -ne 0) { throw 'Reviewed write plan verification failed' }
+      - name: Probe stock x86 provider
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/probe-provider.ps1 -ProtocolVersion 1.2.0 -OutputPath artifacts/environment.json
+          if ($LASTEXITCODE -ne 0) { throw 'Stock provider unavailable; retained probe explains missing prerequisite' }
+      - name: Download the exact Unix-generated candidates
+        if: inputs.run_acquisition
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: generated-creation-index-${{ github.sha }}
+          path: artifacts/dao-creation-index-v1_2
+      - name: Build the read-only Rust snapshot producer
+        if: inputs.run_acquisition
+        shell: powershell
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-creation-index-fixture
+      - name: Verify downloads and snapshot them on Windows
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_creation_index_diff.py snapshot artifacts/dao-creation-index-v1_2 target/release/jet3-creation-index-fixture.exe target/release/jet3-cli.exe $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'Downloaded fixture snapshot failed' }
+      - name: Observe Rust files read-only with DAO
+        id: dao
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/Invoke-DaoCreationIndexV12.ps1 -InventoryPath oracle/windows-dao/protocol/v1_2/creation-index-scenarios.json -EnvironmentPath artifacts/environment.json -OutputRoot artifacts/dao-creation-index-v1_2 -SourceRevision $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'DAO write observation failed' }
+      - name: Compare protocol snapshots and recipe semantics
+        if: always() && inputs.run_acquisition && steps.dao.outcome != 'skipped'
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_creation_index_diff.py evaluate artifacts/dao-creation-index-v1_2
+          if ($LASTEXITCODE -ne 0) { throw 'Write differential failed' }
+      - name: Retain diagnostics including failed files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-creation-index-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/crates/jet3-cli/src/snapshot.rs
+++ b/crates/jet3-cli/src/snapshot.rs
@@ -6,14 +6,14 @@ use std::path::PathBuf;
 
 use jet3::TextCodePage;
 use jet3_testkit::{
-    INDEXED_UPDATE_SCENARIOS, PROTOCOL_SCENARIOS, Producer, ROW_ALLOCATION_SCENARIOS,
-    ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome, UPDATE_SCENARIOS, WRITE_SCENARIOS,
-    canonical_json, coverage, parse_scenarios, snapshot_bytes,
+    CREATION_INDEX_SCENARIOS, INDEXED_UPDATE_SCENARIOS, PROTOCOL_SCENARIOS, Producer,
+    ROW_ALLOCATION_SCENARIOS, ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome,
+    UPDATE_SCENARIOS, WRITE_SCENARIOS, canonical_json, coverage, parse_scenarios, snapshot_bytes,
 };
 
 pub(crate) const HELP: &str = "\
   jet3-cli snapshot <file> --out <dir> --scenario <DAO-READ-...|DAO-WRITE-...|DAO-UPDATE-...> \
-    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update|row-allocation|indexed-update]
+    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update|row-allocation|indexed-update|creation-index]
 
 snapshot reads the whole database with the jet3 reader and writes
 <dir>/snapshot.json (protocol 1.2 canonical semantic snapshot; omitted when
@@ -56,6 +56,7 @@ pub(crate) fn parse_args(
             source_revision = Some(text.to_owned());
         } else if option == "--inventory" {
             inventory = Some(match text {
+                "creation-index" => CREATION_INDEX_SCENARIOS,
                 "row-update" => ROW_UPDATE_SCENARIOS,
                 "row-allocation" => ROW_ALLOCATION_SCENARIOS,
                 "indexed-update" => INDEXED_UPDATE_SCENARIOS,

--- a/crates/jet3-testkit/src/bin/jet3-creation-index-fixture.rs
+++ b/crates/jet3-testkit/src/bin/jet3-creation-index-fixture.rs
@@ -1,0 +1,8 @@
+//! Finite hosted creation fixture producer and read-only layout verifier.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let [command, id, directory] = args.as_slice() else {
+        return Err("usage: jet3-creation-index-fixture generate|verify SCENARIO DIRECTORY".into());
+    };
+    jet3_testkit::creation_index_fixture(command, id, std::path::Path::new(directory))
+}

--- a/crates/jet3-testkit/src/creation_index_fixture.rs
+++ b/crates/jet3-testkit/src/creation_index_fixture.rs
@@ -224,7 +224,7 @@ pub fn creation_index_fixture(command: &str, id: &str, directory: &Path) -> Resu
     }
     Ok(())
 }
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     #[test]

--- a/crates/jet3-testkit/src/creation_index_fixture.rs
+++ b/crates/jet3-testkit/src/creation_index_fixture.rs
@@ -1,0 +1,249 @@
+//! Finite hosted creation boundaries from EXP-0146/0190/0202.
+use jet3::{
+    CatalogObjectClass, ColumnSpec, ColumnType, DatabaseReader, IndexColumnSpec, IndexKind,
+    IndexSpec, ResourceBudget, ResourceLimits, RowValue, TableSpec, create_database_with_rows,
+};
+use serde_json::{Value, json};
+use std::{fs, path::Path};
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub const CREATION_INDEX_SCENARIOS: &str =
+    include_str!("../../../oracle/windows-dao/protocol/v1_2/creation-index-scenarios.json");
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn recipe(id: &str) -> Result<Value> {
+    let inventory: Value = serde_json::from_str(CREATION_INDEX_SCENARIOS)?;
+    inventory["scenarios"]
+        .as_array()
+        .ok_or("scenarios")?
+        .iter()
+        .find(|s| s["id"] == id)
+        .cloned()
+        .ok_or_else(|| "unknown scenario".into())
+}
+fn generate(id: &str, path: &Path) -> Result<()> {
+    let case = recipe(id)?;
+    let name = case["recipe"].as_str().ok_or("recipe")?;
+    let (columns, rows, keys, kinds, names) = match name {
+        "long-depth-three" => (
+            vec![ColumnSpec::new(b"Id", ColumnType::Long)],
+            (-13900..=13900)
+                .map(|v| vec![RowValue::Long(v)])
+                .collect::<Vec<_>>(),
+            vec![vec![IndexColumnSpec::ascending(0)]],
+            vec![IndexKind::Primary],
+            vec![b"ById".as_slice()],
+        ),
+        "nullable-numeric" => {
+            let mut rows = (0..120)
+                .map(|n| {
+                    vec![
+                        RowValue::Currency { scaled: n - 60 },
+                        RowValue::Double(n as f64),
+                        RowValue::Long(n as i32 + 1),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            for n in 0..2 {
+                rows.extend([
+                    vec![RowValue::Null, RowValue::Null, RowValue::Long(121 + n * 3)],
+                    vec![
+                        RowValue::Null,
+                        RowValue::Double(1.0),
+                        RowValue::Long(122 + n * 3),
+                    ],
+                    vec![
+                        RowValue::Currency { scaled: 1 },
+                        RowValue::Null,
+                        RowValue::Long(123 + n * 3),
+                    ],
+                ]);
+            }
+            (
+                vec![
+                    ColumnSpec::new(b"A", ColumnType::Currency),
+                    ColumnSpec::new(b"B", ColumnType::Double),
+                    ColumnSpec::new(b"Tag", ColumnType::Long),
+                ],
+                rows,
+                vec![vec![
+                    IndexColumnSpec::ascending(0),
+                    IndexColumnSpec::descending(1),
+                ]],
+                vec![IndexKind::Unique],
+                vec![b"ByKey".as_slice()],
+            )
+        }
+        "multiple-long" => (
+            vec![
+                ColumnSpec::new(b"Id", ColumnType::Long),
+                ColumnSpec::new(b"Group", ColumnType::Long),
+                ColumnSpec::new(b"Value", ColumnType::Long),
+            ],
+            (0..201)
+                .map(|n| {
+                    vec![
+                        RowValue::Long(n + 1),
+                        RowValue::Long(n % 3 - 1),
+                        RowValue::Long(n - 100),
+                    ]
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                vec![IndexColumnSpec::ascending(0)],
+                vec![IndexColumnSpec::descending(1)],
+                vec![
+                    IndexColumnSpec::descending(1),
+                    IndexColumnSpec::ascending(2),
+                ],
+            ],
+            vec![IndexKind::Primary, IndexKind::Ordinary, IndexKind::Unique],
+            vec![
+                b"ZPrimary".as_slice(),
+                b"AGroup".as_slice(),
+                b"MMixed".as_slice(),
+            ],
+        ),
+        _ => return Err("unknown recipe".into()),
+    };
+    let indexes = keys
+        .iter()
+        .zip(&kinds)
+        .zip(&names)
+        .map(|((fields, kind), name)| IndexSpec {
+            name,
+            kind: *kind,
+            fields,
+        })
+        .collect::<Vec<_>>();
+    let slices = rows.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    create_database_with_rows(
+        path,
+        &TableSpec {
+            name: b"Rows",
+            columns: &columns,
+            indexes: &indexes,
+        },
+        &slices,
+        &mut budget(),
+    )?;
+    Ok(())
+}
+/// Rereads the tree boundary through public APIs on either platform.
+fn inspect(id: &str, path: &Path) -> Result<Value> {
+    let case = recipe(id)?;
+    let mut b = budget();
+    let mut db = DatabaseReader::open(path, &mut b)?;
+    let root = {
+        let mut catalog = db.catalog(&mut b)?;
+        let mut found = None;
+        while let Some(r) = catalog.next_record()? {
+            if r.class() == CatalogObjectClass::User && r.name().raw_bytes() == b"Rows" {
+                if found.is_some() {
+                    return Err("duplicate table".into());
+                }
+                found = r.table_definition();
+            }
+        }
+        found.ok_or("Rows absent")?
+    };
+    let definition = db.table_definition(root, &mut b)?;
+    let expected = case["trees"].as_array().ok_or("trees")?;
+    if definition.indexes().len() != expected.len() {
+        return Err("index inventory".into());
+    }
+    let mut results = Vec::new();
+    for index in definition.indexes() {
+        let name = std::str::from_utf8(index.name().raw_bytes())?;
+        let wanted = expected
+            .iter()
+            .find(|i| i["name"] == name)
+            .ok_or("index name")?;
+        let tree = db.index_tree(&definition, index.physical_index(), &mut b)?;
+        let depth = tree
+            .nodes()
+            .iter()
+            .map(|n| n.depth())
+            .max()
+            .ok_or("empty tree")?;
+        if Some(depth) != wanted["depth"].as_u64()
+            || Some(tree.entries().len() as u64) != wanted["entries"].as_u64()
+        {
+            return Err("declared tree boundary".into());
+        }
+        let physical = &definition.physical_indexes()[usize::from(index.physical_index())];
+        let location = physical.usage_map();
+        let mut bytes = [0; jet3::PAGE_BYTES];
+        let page = db.read_classified_page(location.page(), &mut bytes, &mut b)?;
+        let record = jet3::locate_usage_map(
+            page,
+            jet3::MapRowLocator::new(location.page(), location.row()),
+            &mut b,
+        )?;
+        let jet3::AllocationMap::Inline(map) = jet3::decode_allocation_map(record.raw(), &mut b)?
+        else {
+            return Err("expected inline index map".into());
+        };
+        let mut allocated = map.allocated_pages(db.geometry());
+        let mut mapped = Vec::new();
+        while let Some(page) = allocated.next_page(&mut b)? {
+            mapped.push(page.get());
+        }
+        mapped.sort_unstable();
+        let mut nodes = tree
+            .nodes()
+            .iter()
+            .map(|n| n.page().get())
+            .collect::<Vec<_>>();
+        nodes.sort_unstable();
+        if mapped != nodes {
+            return Err("exact index tree map".into());
+        }
+        results.push(json!({"name":name,"depth":depth,"entries":tree.entries().len(),"maps":mapped,"pages":tree.nodes().iter().map(|n|n.page().get()).collect::<Vec<_>>()}));
+    }
+    results.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
+    Ok(json!({"scenario_id":id,"trees":results}))
+}
+/// Generates a public creation candidate, or independently checks its tree boundary.
+pub fn creation_index_fixture(command: &str, id: &str, directory: &Path) -> Result<()> {
+    match command {
+        "generate" => {
+            generate(id, &directory.join("database.mdb"))?;
+            let receipt = inspect(id, &directory.join("database.mdb"))?;
+            fs::write(directory.join("layout.json"), serde_json::to_vec(&receipt)?)?;
+        }
+        "verify" => {
+            let actual = inspect(id, &directory.join("database.mdb"))?;
+            let expected: Value =
+                serde_json::from_slice(&fs::read(directory.join("layout.json"))?)?;
+            if actual != expected {
+                return Err("tree layout receipt differs".into());
+            }
+        }
+        _ => return Err("expected generate or verify".into()),
+    }
+    Ok(())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn finite_recipes_reach_declared_depths_and_reopen() -> Result<()> {
+        let inventory: Value = serde_json::from_str(CREATION_INDEX_SCENARIOS)?;
+        for case in inventory["scenarios"].as_array().ok_or("scenarios")? {
+            let dir = tempfile::tempdir()?;
+            let id = case["id"].as_str().ok_or("id")?;
+            creation_index_fixture("generate", id, dir.path())?;
+            creation_index_fixture("verify", id, dir.path())?;
+            let mut receipt: Value =
+                serde_json::from_slice(&fs::read(dir.path().join("layout.json"))?)?;
+            receipt["trees"][0]["depth"] = json!(99);
+            fs::write(
+                dir.path().join("layout.json"),
+                serde_json::to_vec(&receipt)?,
+            )?;
+            assert!(creation_index_fixture("verify", id, dir.path()).is_err());
+        }
+        Ok(())
+    }
+}

--- a/crates/jet3-testkit/src/lib.rs
+++ b/crates/jet3-testkit/src/lib.rs
@@ -44,3 +44,6 @@ pub use row_allocation_fixture::{ROW_ALLOCATION_SCENARIOS, row_allocation_fixtur
 
 mod indexed_update_fixture;
 pub use indexed_update_fixture::{INDEXED_UPDATE_SCENARIOS, indexed_update_fixture};
+
+mod creation_index_fixture;
+pub use creation_index_fixture::{CREATION_INDEX_SCENARIOS, creation_index_fixture};

--- a/oracle/windows-dao/protocol/v1_2/creation-index-scenarios.json
+++ b/oracle/windows-dao/protocol/v1_2/creation-index-scenarios.json
@@ -1,0 +1,99 @@
+{
+  "document_type": "dao_write_scenario_inventory",
+  "protocol_version": "1.2.0",
+  "scenarios": [
+    {
+      "id": "DAO-WRITE-INDEX-LONG-DEEP",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page",
+        "index.branch_leaf_traversal"
+      ],
+      "boundary": null,
+      "coverage": [
+        "three-level Long primary",
+        "27801 complete rows",
+        "nine boundary Seeks"
+      ],
+      "recipe": "long-depth-three",
+      "trees": [
+        {
+          "name": "ById",
+          "depth": 3,
+          "entries": 27801
+        }
+      ]
+    },
+    {
+      "id": "DAO-WRITE-INDEX-NUMERIC-NULL",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page",
+        "index.branch_leaf_traversal"
+      ],
+      "boundary": null,
+      "coverage": [
+        "nullable Currency/Double unique composite",
+        "repeated null keys",
+        "120 nonnull fullkey Seeks"
+      ],
+      "recipe": "nullable-numeric",
+      "trees": [
+        {
+          "name": "ByKey",
+          "depth": 2,
+          "entries": 126
+        }
+      ]
+    },
+    {
+      "id": "DAO-WRITE-INDEX-MULTIPLE",
+      "operation": {
+        "mode": "dao_open_rust",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page",
+        "index.branch_leaf_traversal"
+      ],
+      "boundary": null,
+      "coverage": [
+        "three independent populated indexes",
+        "ordinary duplicates",
+        "mixed directions"
+      ],
+      "recipe": "multiple-long",
+      "trees": [
+        {
+          "name": "ZPrimary",
+          "depth": 2,
+          "entries": 201
+        },
+        {
+          "name": "AGroup",
+          "depth": 2,
+          "entries": 201
+        },
+        {
+          "name": "MMixed",
+          "depth": 2,
+          "entries": 201
+        }
+      ]
+    }
+  ],
+  "deferred_requirements": [
+    "All27,801 individual Seek keys are not enumerated; full traversal plus nine declared boundaries only.",
+    "No fresh DAO writes or duplicate rejection probes; prior local failed-insert count residue is not exercised.",
+    "No Date/Binary/Text/GUID index codec or later-table multiple index claim."
+  ]
+}

--- a/oracle/windows-dao/scripts/Invoke-DaoCreationIndexV12.ps1
+++ b/oracle/windows-dao/scripts/Invoke-DaoCreationIndexV12.ps1
@@ -1,0 +1,110 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$InventoryPath,
+    [Parameter(Mandatory=$true)][string]$EnvironmentPath,
+    [Parameter(Mandatory=$true)][string]$OutputRoot,
+    [Parameter(Mandatory=$true)][string]$SourceRevision
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if ([IntPtr]::Size -ne 4) { throw 'DAO requires x86 PowerShell' }
+# Reuse only named pure snapshot helpers; never execute the read acquisition.
+$helperPath = Join-Path $PSScriptRoot 'Invoke-DaoReadV12.ps1'
+$tokens = $null; $errors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile($helperPath, [ref]$tokens, [ref]$errors)
+if ($errors.Count) { throw 'Snapshot helper parse failure' }
+foreach ($name in @('Release-ComObject','Write-JsonDocument','Convert-ToLowerHex','Get-FileSha256','Get-DateText','Get-TypedValue','Get-NormalizedSize','Get-DaoSnapshot')) {
+    $definitions = @($ast.FindAll({param($node) $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name}, $false))
+    if ($definitions.Count -ne 1) { throw "Missing snapshot helper $name" }
+    Invoke-Expression $definitions[0].Extent.Text
+}
+$DaoTypeNames = @{1='dbBoolean';2='dbByte';3='dbInteger';4='dbLong';5='dbCurrency';6='dbSingle';7='dbDouble';8='dbDate';9='dbBinary';10='dbText';11='dbLongBinary';12='dbMemo';15='dbGUID'}
+$DbAutoIncrField = 16; $DbSystemObject = -2147483646; $DbDescending = 1
+$Utf8 = New-Object Text.UTF8Encoding($false)
+$CodePage = [Text.Encoding]::GetEncoding(1252, (New-Object Text.EncoderExceptionFallback), (New-Object Text.DecoderExceptionFallback))
+function Get-RowValues($Recordset, $Columns) {
+    $values = [ordered]@{}
+    foreach ($column in $Columns) {
+        $field = $null
+        try { $field = $Recordset.Fields.Item([string]$column.name); $values[[string]$column.name] = Get-TypedValue -Field $field }
+        finally { Release-ComObject $field }
+    }
+    return $values
+}
+function Get-SeekValue($Typed) {
+    switch([string]$Typed.kind){
+        'long' {return [int]$Typed.value}
+        'double' {return [double]$Typed.value}
+        'currency' {$value=[decimal]::Parse([string]$Typed.value,[Globalization.CultureInfo]::InvariantCulture);return [Runtime.InteropServices.CurrencyWrapper]::new($value)}
+        default {throw 'Unsupported typed Seek component'}
+    }
+}
+function Get-IndexObservations($Database, $Snapshot, $Scenario) {
+    $observations = New-Object Collections.ArrayList
+    foreach ($table in $Snapshot.tables) {
+        foreach ($index in $table.indexes) {
+            $rs = $null
+            try {
+                $rs = $Database.OpenRecordset([string]$table.name, 1); $rs.Index = [string]$index.name
+                $rows = New-Object Collections.ArrayList; $seeks = New-Object Collections.ArrayList
+                if (-not $rs.EOF) { $rs.MoveFirst() }
+                while (-not $rs.EOF) { [void]$rows.Add((Get-RowValues $rs $table.columns)); $rs.MoveNext() }
+                $seen = @{}
+                foreach ($row in $rows) {
+                    $values=@($index.fields | ForEach-Object { $row[[string]$_.name] })
+                    if(@($values|Where-Object{$_.kind-eq 'null'}).Count){continue}
+                    $query=[object[]]@($values|ForEach-Object{$_.value})
+                    if($Scenario.recipe-ceq 'long-depth-three'-and $query[0]-notin @(-13900,-13899,-13701,-13700,-13699,-1,0,13899,13900)){continue}
+                    $identity=ConvertTo-Json -InputObject $query -Compress
+                    if($seen.ContainsKey($identity)){continue};$seen[$identity]=$true
+                    $first=Get-SeekValue $values[0]
+                    if($query.Count-eq 1){$rs.Seek('=',$first)}
+                    elseif($query.Count-eq 2){$second=Get-SeekValue $values[1];$rs.Seek('=',$first,$second)}
+                    else{throw 'Expected one/two numeric components'}
+                    $found = if ($rs.NoMatch) { $null } else { Get-RowValues $rs $table.columns }
+                    [void]$seeks.Add(@{query=$query; row=$found})
+                }
+                [void]$observations.Add(@{table=[string]$table.name; index=[string]$index.name; rows=@($rows); seeks=@($seeks)})
+            } finally {
+                if ($null -ne $rs) { try { $rs.Close() } catch {} }; Release-ComObject $rs
+            }
+        }
+    }
+    return ,@($observations)
+}
+$inventory = Get-Content -LiteralPath $InventoryPath -Raw | ConvertFrom-Json
+$environment = Get-Content -LiteralPath $EnvironmentPath -Raw | ConvertFrom-Json
+$prepared = Get-Content -LiteralPath (Join-Path $OutputRoot 'preparation.json') -Raw | ConvertFrom-Json
+$inventoryHash = Get-FileSha256 $InventoryPath
+if ($inventory.document_type -cne 'dao_write_scenario_inventory' -or $prepared.inventory_sha256 -cne $inventoryHash) { throw 'Write inventory identity mismatch' }
+if($environment.document_type-cne 'dao_environment'-or $environment.protocol_version-cne '1.2.0'-or $environment.status-cne 'ready'-or $environment.host.process_architecture-cne 'x86'-or $environment.accepted_provider.prog_id-cne 'DAO.DBEngine.36'-or $environment.accepted_provider.database_version-cne 'dbVersion30'){throw 'Expected ready stock x86 DAO3.0 environment'}
+Copy-Item -LiteralPath $EnvironmentPath -Destination (Join-Path $OutputRoot 'environment.json')
+if ($prepared.scenarios.Count -ne $inventory.scenarios.Count) { throw 'Incomplete Rust preparation' }
+$manifest = [ordered]@{document_type='dao_write_manifest'; protocol_version='1.2.0'; inventory_sha256=$inventoryHash; source_revision=$SourceRevision; environment_sha256=(Get-FileSha256 $EnvironmentPath); scenarios=@()}
+try {
+    for ($n=0; $n -lt $inventory.scenarios.Count; $n++) {
+        $scenario = $inventory.scenarios[$n]; $initial = $prepared.scenarios[$n]
+        if ($scenario.operation.mode -cne 'dao_open_rust' -or $scenario.id -cne $initial.scenario_id -or $initial.status -cne 'prepared') { throw 'Invalid write preparation' }
+        $root = Join-Path $OutputRoot ([string]$scenario.id); $path = Join-Path $root 'database.mdb'
+        $before = Get-FileSha256 $path
+        if ($before -cne $initial.database_sha256) { throw 'Prepared MDB identity mismatch' }
+        $entry = [ordered]@{scenario_id=[string]$scenario.id; before=$before; after=$null; status='pass'; error=$null}
+        $engine = $db = $null
+        try {
+            $engine = New-Object -ComObject ([string]$environment.accepted_provider.prog_id)
+            $db = $engine.OpenDatabase($path, $false, $true)
+            $snapshot = Get-DaoSnapshot -Database $db -Scenario $scenario.id -Revision $SourceRevision -DatabaseHash $before
+            Write-JsonDocument -Path (Join-Path $root 'dao-snapshot.raw.json') -Document $snapshot
+            $indexes = Get-IndexObservations $db $snapshot $scenario
+            [IO.File]::WriteAllText((Join-Path $root 'dao-indexes.raw.json'), ((ConvertTo-Json -InputObject $indexes -Depth 32 -Compress) + "`n"), $Utf8)
+        } catch { $entry.status='fail'; $entry.error=$_.Exception.GetType().FullName + ': ' + $_.Exception.Message }
+        finally {
+            if ($null -ne $db) { try { $db.Close() } catch { $entry.status='fail'; $entry.error=$_.Exception.Message } }
+            Release-ComObject $db; Release-ComObject $engine
+            [GC]::Collect(); [GC]::WaitForPendingFinalizers()
+            $entry.after = Get-FileSha256 $path
+            $manifest.scenarios += $entry
+        }
+    }
+} finally { Write-JsonDocument -Path (Join-Path $OutputRoot 'dao-manifest.raw.json') -Document $manifest }
+if (@($manifest.scenarios | Where-Object { $_.status -ne 'pass' -or $_.before -cne $_.after }).Count) { exit 1 }

--- a/oracle/windows-dao/scripts/dao_creation_index_diff.py
+++ b/oracle/windows-dao/scripts/dao_creation_index_diff.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Separate finite hosted creation-index expansion; original write runtime is frozen."""
+import argparse
+import copy
+from decimal import Decimal
+import json
+import importlib.util
+from pathlib import Path
+import platform
+import subprocess
+from hosted_write_reanalysis import validate_environment
+ROOT=Path(__file__).resolve().parents[3]
+spec=importlib.util.spec_from_file_location('_creation_index_write',ROOT/'oracle/windows-dao/scripts/dao_write_diff.py')
+original=importlib.util.module_from_spec(spec);spec.loader.exec_module(original)
+INVENTORY=ROOT/'oracle/windows-dao/protocol/v1_2/creation-index-scenarios.json'
+PLAN=ROOT/'oracle/windows-dao/acquisition/creation-index-v1_2.plan.json'
+load=original.load_json;digest=original.digest;fail=original.ValidationError
+read_inventory=original.inventory
+
+
+def expanded(case):
+    case=copy.deepcopy(case);recipe=case['recipe']
+    column=lambda name,kind:dict(name=name,kind=kind)
+    index=lambda name,kind,fields:dict(name=name,kind=kind,fields=[dict(column=c,descending=d) for c,d in fields])
+    if recipe=='long-depth-three':
+        columns=[column('Id','Long')];rows=[[n] for n in range(-13900,13901)];indexes=[index('ById','primary',[(0,False)])]
+    elif recipe=='nullable-numeric':
+        columns=[column('A','Currency'),column('B','Double'),column('Tag','Long')];rows=[[n-60,float(n),n+1] for n in range(120)]
+        for n in range(2):rows.extend([[None,None,121+n*3],[None,1.0,122+n*3],[1,None,123+n*3]])
+        indexes=[index('ByKey','unique',[(0,False),(1,True)])]
+    elif recipe=='multiple-long':
+        columns=[column(n,'Long') for n in ['Id','Group','Value']];rows=[[n+1,n%3-1,n-100] for n in range(201)]
+        indexes=[index('ZPrimary','primary',[(0,False)]),index('AGroup','ordinary',[(1,True)]),index('MMixed','unique',[(1,True),(2,False)])]
+    else:raise fail('Unknown creation recipe')
+    case['tables']=[dict(name='Rows',columns=columns,rows=rows,indexes=indexes,repeat=None)];case['relationship']=None;return case
+
+
+def inventory():
+    value=read_inventory(INVENTORY);value['scenarios']=[expanded(s) for s in value['scenarios']];return value
+
+
+def query_values(row,index):return tuple(row[f['name']]['value'] for f in index['fields'])
+def directed(row,index):
+    result=[]
+    for field in index['fields']:
+        value=row[field['name']];sign=-1 if field['descending'] else 1
+        result.append((0,0) if value['kind']=='null' else (sign,sign*(Decimal(value['value']) if value['kind']=='currency' else value['value'])))
+    return tuple(result)
+
+def queries(rows,index,case):
+    if case['recipe']=='long-depth-three':return {(n,) for n in [-13900,-13899,-13701,-13700,-13699,-1,0,13899,13900]}
+    return {query_values(row,index) for row in rows if all(row[f['name']]['kind']!='null' for f in index['fields'])}
+
+def assert_indexes(observations,snapshot):
+    case=next(s for s in inventory()['scenarios'] if s['id']==snapshot['scenario_id'])
+    expected={(t['name'],i['name']):(t,i) for t in snapshot['tables'] for i in t['indexes']}
+    keys=[(o['table'],o['index']) for o in observations]
+    if len(keys)!=len(set(keys)) or set(keys)!=set(expected):raise fail('Index observation inventory')
+    for obs in observations:
+        table,index=expected[obs['table'],obs['index']];rows=[r['values'] for r in table['rows']];actual=obs['rows'];canonical=original.common.canonical_bytes
+        if sorted(map(canonical,rows))!=sorted(map(canonical,actual)) or [directed(r,index) for r in actual]!=sorted(directed(r,index) for r in rows):raise fail('Complete directed traversal')
+        observed=[tuple(s['query']) for s in obs['seeks']]
+        if len(observed)!=len(set(observed)) or set(observed)!=queries(rows,index,case):raise fail('Declared finite Seek inventory')
+        valid={}
+        for row in rows:valid.setdefault(query_values(row,index),set()).add(canonical(row))
+        for seek in obs['seeks']:
+            if canonical(seek['row']) not in valid[tuple(seek['query'])]:raise fail('Full-key Seek row')
+
+original.INVENTORY=INVENTORY;original.PLAN=PLAN;original.inventory=inventory;original.assert_indexes=assert_indexes
+
+def run(root,label,command):
+    done=subprocess.run(command,capture_output=True,text=True,timeout=300);(root/(label+'.stdout.log')).write_text(done.stdout);(root/(label+'.stderr.log')).write_text(done.stderr)
+    if done.returncode:raise fail(label+' failed')
+
+def snapshot(root,reader,scenario,revision,label):
+    run(root,label,[str(reader),'snapshot',str(root/'database.mdb'),'--scenario',scenario['id'],'--inventory','creation-index','--out',str(root/'rust'),'--source-revision',revision])
+    value=load(root/'rust/snapshot.json');original.bind_snapshot(value,scenario['id'],revision,'rust',digest(root/'database.mdb'));original.assert_recipe(value,scenario);original.validate_write_coverage(load(root/'rust/coverage.json'),inventory()['scenarios'],value)
+
+def prepare(out,generator,reader,revision):
+    out.mkdir(parents=True,exist_ok=False);manifest=dict(document_type='dao_write_preparation',protocol_version='1.2.0',source_revision=revision,producer_os=platform.system(),inventory_sha256=digest(INVENTORY),scenarios=[])
+    try:
+        for scenario in inventory()['scenarios']:
+            root=out/scenario['id'];root.mkdir();entry=dict(scenario_id=scenario['id'],status='failed',error=None);manifest['scenarios'].append(entry)
+            try:
+                run(root,'generate',[str(generator),'generate',scenario['id'],str(root)])
+                entry.update(database_sha256=digest(root/'database.mdb'),layout_sha256=digest(root/'layout.json'))
+                snapshot(root,reader,scenario,revision,'snapshot')
+                if digest(root/'database.mdb')!=entry['database_sha256']:raise fail('Unix read changed candidate')
+                entry['status']='prepared'
+            except Exception as error:entry['error']=str(error);raise
+    finally:original.common.write_canonical(out/'preparation.json',manifest)
+
+def resnapshot(out,generator,reader,revision):
+    prepared=load(out/'preparation.json');cases=inventory()['scenarios']
+    if prepared['source_revision']!=revision or prepared['inventory_sha256']!=digest(INVENTORY) or [s['scenario_id'] for s in prepared['scenarios']]!=[s['id'] for s in cases]:raise fail('Downloaded preparation binding')
+    for scenario,entry in zip(cases,prepared['scenarios']):
+        root=out/scenario['id']
+        if entry['status']!='prepared' or digest(root/'database.mdb')!=entry['database_sha256'] or digest(root/'layout.json')!=entry['layout_sha256']:raise fail('Downloaded artifact identity')
+        run(root,'windows-layout',[str(generator),'verify',scenario['id'],str(root)]);snapshot(root,reader,scenario,revision,'windows-snapshot')
+        if digest(root/'database.mdb')!=entry['database_sha256']:raise fail('Windows read changed candidate')
+    original.common.write_canonical(out/'reader.json',dict(source_revision=revision,reader_os=platform.system()))
+
+def evaluate(out):
+    try:
+        environment=load(out/'environment.json');validate_environment(environment);manifest=load(out/'dao-manifest.raw.json')
+        if manifest['environment_sha256']!=digest(out/'environment.json'):raise fail('Provider receipt identity')
+        prepared=load(out/'preparation.json')
+        for scenario,entry in zip(inventory()['scenarios'],prepared['scenarios']):
+            root=out/scenario['id'];layout=load(root/'layout.json')
+            if digest(root/'layout.json')!=entry['layout_sha256'] or layout['scenario_id']!=scenario['id']:raise fail('Layout receipt identity')
+            expected={i['name']:(i['depth'],i['entries']) for i in scenario['trees']}
+            if len(layout['trees'])!=len(expected) or {i['name']:(i['depth'],i['entries']) for i in layout['trees']}!=expected:raise fail('Tree boundary receipt')
+        original.evaluate_checked(out);report=load(out/'report.json');report['document_type']='dao_creation_index_report';report['seek_scope']='nine declared boundaries for deep Long; every non-null full key for other recipes';original.common.write_canonical(out/'report.json',report)
+    except Exception as error:
+        original.common.write_canonical(out/'report.json',dict(document_type='dao_creation_index_report',outcome='no_outcome',error=str(error),support_matrix_movement=False));raise
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__);sub=parser.add_subparsers(dest='command',required=True);p=sub.add_parser('plan');p.add_argument('sha256');sub.add_parser('inventory')
+    for command in ['prepare','snapshot']:
+        p=sub.add_parser(command);p.add_argument('out',type=Path);p.add_argument('generator',type=Path);p.add_argument('reader',type=Path);p.add_argument('revision')
+    p=sub.add_parser('evaluate');p.add_argument('out',type=Path);args=parser.parse_args()
+    if args.command=='plan':original.validate_plan(args.sha256)
+    elif args.command=='inventory':inventory()
+    elif args.command=='prepare':prepare(args.out,args.generator,args.reader,args.revision)
+    elif args.command=='snapshot':resnapshot(args.out,args.generator,args.reader,args.revision)
+    else:evaluate(args.out)
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/test_dao_creation_index_diff.py
+++ b/oracle/windows-dao/tests/test_dao_creation_index_diff.py
@@ -1,0 +1,100 @@
+import copy
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import dao_creation_index_diff as expansion
+import dao_write_diff as historical
+
+
+def snapshot(case):
+    value = expansion.original.common.minimal_snapshot('rust')
+    value['scenario_id'] = case['id']
+    value['tables'], value['relationships'] = expansion.original.expected_schema(case)
+    return expansion.original.common.canonicalize_snapshot(value)
+
+
+def observations(value, case):
+    result = []
+    for table in value['tables']:
+        for index in table['indexes']:
+            rows = sorted([r['values'] for r in table['rows']], key=lambda r: expansion.directed(r, index))
+            by_key = {expansion.query_values(r, index): r for r in rows}
+            result.append(dict(table=table['name'], index=index['name'], rows=rows,
+                seeks=[dict(query=list(q), row=by_key[q]) for q in sorted(expansion.queries(rows, index, case))]))
+    return result
+
+
+class CreationIndexTests(unittest.TestCase):
+    def test_deterministic_recipes_and_separate_historical_runtime(self):
+        cases = expansion.inventory()['scenarios']
+        self.assertEqual([len(c['tables'][0]['rows']) for c in cases], [27801, 126, 201])
+        self.assertEqual(len(historical.inventory()['scenarios']), 12)
+        self.assertEqual([t['depth'] for c in cases for t in c['trees']], [3, 2, 2, 2, 2])
+        for case in cases:
+            value = snapshot(case)
+            expansion.original.assert_recipe(value, case)
+            actual = observations(value, case)
+            expansion.assert_indexes(actual, value)
+            if case['recipe'] == 'long-depth-three': self.assertEqual(len(actual[0]['seeks']), 9)
+            if case['recipe'] == 'nullable-numeric': self.assertEqual(len(actual[0]['seeks']), 120)
+
+    def test_complete_traversal_seek_and_unique_index_inventory(self):
+        for case in expansion.inventory()['scenarios'][1:]:
+            value = snapshot(case); actual = observations(value, case)
+            for change in ('missing_row', 'reversed', 'missing_seek', 'wrong_seek', 'duplicate_index'):
+                broken = copy.deepcopy(actual)
+                if change == 'missing_row': broken[0]['rows'].pop()
+                elif change == 'reversed': broken[0]['rows'].reverse()
+                elif change == 'missing_seek': broken[0]['seeks'].pop()
+                elif change == 'wrong_seek': broken[0]['seeks'][0]['row'] = {}
+                else: broken.append(broken[0])
+                with self.subTest(case=case['id'], change=change), self.assertRaises(expansion.fail):
+                    expansion.assert_indexes(broken, value)
+            # Record ordering is irrelevant; duplicate-key Seek may select any complete matching row.
+            expansion.assert_indexes(list(reversed(actual)), value)
+            for table in value['tables']:
+                for index, obs in zip(table['indexes'], actual):
+                    for seek in obs['seeks']:
+                        seek['row'] = next(r for r in obs['rows'] if expansion.query_values(r, index) == tuple(seek['query']))
+            expansion.assert_indexes(actual, value)
+
+    def test_complete_evaluator_and_retained_environment_layout_identity_gates(self):
+        write = expansion.original
+        with tempfile.TemporaryDirectory() as temporary:
+            out = Path(temporary); cases = expansion.inventory()['scenarios']
+            emit = write.common.write_canonical
+            emit(out / 'environment.json', dict(document_type='dao_environment', protocol_version='1.2.0', status='ready',
+                host=dict(process_architecture='x86'), accepted_provider=dict(prog_id='DAO.DBEngine.36', database_version='dbVersion30')))
+            prepared = dict(producer_os='Linux', source_revision='test', inventory_sha256=expansion.digest(expansion.INVENTORY), scenarios=[])
+            manifest = dict(source_revision='test', inventory_sha256=prepared['inventory_sha256'], environment_sha256=expansion.digest(out / 'environment.json'), scenarios=[])
+            for case in cases:
+                root = out / case['id']; (root / 'rust').mkdir(parents=True)
+                (root / 'database.mdb').write_bytes(b'synthetic identity')
+                sha = expansion.digest(root / 'database.mdb'); value = snapshot(case)
+                value['database_sha256'] = sha; value['producer']['source_revision'] = 'test'
+                emit(root / 'rust/snapshot.json', value)
+                dao = copy.deepcopy(value); dao['producer']['kind'] = 'dao'; emit(root / 'dao-snapshot.raw.json', dao)
+                emit(root / 'dao-indexes.raw.json', observations(value, case))
+                emit(root / 'layout.json', dict(scenario_id=case['id'], trees=case['trees']))
+                emit(root / 'rust/coverage.json', dict(document_type='coverage_receipt', protocol_version='1.2.0', scenario_id=case['id'],
+                    database_sha256=sha, producer=value['producer'], outcome='success', error_class=None,
+                    branches=sorted(case['required_branches']), scenarios=[dict(id=c['id'], missing_branches=[], forbidden_observed=[], outcome_matches=True, satisfied=True) for c in cases]))
+                prepared['scenarios'].append(dict(scenario_id=case['id'], status='prepared', database_sha256=sha, layout_sha256=expansion.digest(root / 'layout.json')))
+                manifest['scenarios'].append(dict(scenario_id=case['id'], status='pass', error=None, before=sha, after=sha))
+            emit(out / 'preparation.json', prepared); emit(out / 'dao-manifest.raw.json', manifest)
+            emit(out / 'reader.json', dict(source_revision='test', reader_os='Windows'))
+            expansion.evaluate(out); self.assertEqual(expansion.load(out / 'report.json')['outcome'], 'matched')
+            for path in [out / 'environment.json', out / cases[0]['id'] / 'layout.json', out / cases[1]['id'] / 'dao-indexes.raw.json']:
+                saved = path.read_bytes(); path.unlink()
+                with self.assertRaises(Exception): expansion.evaluate(out)
+                self.assertEqual(expansion.load(out / 'report.json')['outcome'], 'no_outcome'); path.write_bytes(saved)
+            environment = expansion.load(out / 'environment.json'); environment['host']['process_architecture'] = 'x64'
+            emit(out / 'environment.json', environment)
+            manifest['environment_sha256'] = expansion.digest(out / 'environment.json'); emit(out / 'dao-manifest.raw.json', manifest)
+            with self.assertRaisesRegex(ValueError, 'provider'): expansion.evaluate(out)
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
Adds three hosted creation recipes for a three-level Long tree, a nullable numeric composite tree, and multiple populated indexes. Public fixtures verify exact depths and ownership maps, while full DAO snapshots, traversal, and declared boundary/full-key Seek checks compare the pinned candidates.

Validation: independent review, focused Rust/Python tests, all three public preparations, x86 helper checks, Clippy, and `just ready` passed. A separate pinned plan is required before acquisition; original write runtime remains unchanged.

Progress toward #102.
