### PR TITLE
feat: maintain unique Long indexes during bounded row insertion and deletion

### DIFF
--- a/crates/jet3/src/delete.rs
+++ b/crates/jet3/src/delete.rs
@@ -15,16 +15,20 @@ pub struct RowDelete<'a> {
 
 /// Deletes one ordinary row, compacting its page or releasing a single-slot page.
 ///
-/// Supports unindexed, relationship-free tables without AutoIncrement or long
-/// values. Slots must be ordinary live rows or known empty `c000` tombstones;
+/// Supports relationship-free tables without AutoIncrement or long values.
+/// One unique/primary present Long index additionally supports retained-page
+/// deletion when its complete tree is an uncompressed root leaf. The matching
+/// leaf entry is removed, its boundary/free and physical distinct-key count are
+/// updated, and unused leaf bytes remain exact. Other indexed deletions are refused.
+/// Slots must be ordinary live rows or known empty `c000` tombstones;
 /// the page must already appear in its inline available map. Later rows move
 /// upward without changing their physical slot numbers or stored values. The
 /// deleted slot becomes an empty tombstone; existing tombstone flags are retained.
 /// A page containing exactly one physical row is released through its existing
 /// inline global/owned/available maps. A sole live row alongside tombstones and
 /// inconsistent free/count metadata are refused.
-/// Only the shifted row bytes, affected directory offsets, free-byte count and
-/// table row count change. Vacated slack, maps, page zero and unrelated objects
+/// On retained unindexed pages, only shifted row bytes, affected directory offsets,
+/// free-byte count and table row count change. Vacated slack, maps, page zero and unrelated objects
 /// remain exact for retained pages. Released pages change their tag, directory
 /// word and free count, and their three map bits; payload/slack and file length
 /// remain exact.
@@ -54,7 +58,7 @@ where
     HE: StdError + Send + Sync + 'static,
 {
     let mut database = DatabaseReader::open(path, budget)?;
-    let definition = crate::update::writable_table(&mut database, request.table, budget)?;
+    let definition = crate::update::indexed_writable_table(&mut database, request.table, budget)?;
     if !definition.long_value_maps().is_empty()
         || definition.columns().iter().any(|c| c.auto_increment())
     {
@@ -62,6 +66,21 @@ where
             "AutoIncrement or long-value table",
         ));
     }
+    let mut index = if definition.indexes().is_empty() && definition.physical_indexes().is_empty() {
+        None
+    } else {
+        if definition.columns().iter().any(|c| {
+            matches!(
+                c.physical_type(),
+                crate::ColumnPhysicalType::Memo | crate::ColumnPhysicalType::LongBinary
+            )
+        }) {
+            return Err(UpdateError::Unsupported("indexed long-value table"));
+        }
+        let leaf = crate::unique_leaf::validate(&mut database, &definition, budget)?;
+        leaf.check_map(&mut database, &definition, budget)?;
+        Some(leaf)
+    };
     let mut source_page = [0; PAGE_BYTES];
     database.read_raw_page(request.row.page(), &mut source_page, budget)?;
     let patched_page = crate::row_delete_page::remove(
@@ -115,8 +134,40 @@ where
     }
     let mut source_definition = [0; PAGE_BYTES];
     database.read_raw_page(definition.root(), &mut source_definition, budget)?;
-    let patched_definition =
+    let mut patched_definition =
         crate::row_delete_page::decrement_count(&source_definition, observed_rows, budget)?;
+    if let Some(leaf) = &mut index {
+        if matches!(patched_page, crate::row_delete_page::Deletion::Released(_)) {
+            return Err(UpdateError::Unsupported(
+                "indexed deletion requires retained data page",
+            ));
+        }
+        let after = leaf.remove(request.row, budget)?;
+        crate::index_key_page::set_distinct_count(&mut patched_definition, leaf.count, budget)?;
+        return crate::update_pages::publish_changes(
+            path,
+            database.into_source(),
+            &[
+                crate::update_pages::PageChange {
+                    page: request.row.page(),
+                    before: &source_page,
+                    after: patched_page.image().as_bytes(),
+                },
+                crate::update_pages::PageChange {
+                    page: definition.root(),
+                    before: &source_definition,
+                    after: patched_definition.as_bytes(),
+                },
+                crate::update_pages::PageChange {
+                    page: leaf.page,
+                    before: &leaf.before,
+                    after: after.as_bytes(),
+                },
+            ],
+            budget,
+            hook,
+        );
+    }
     if matches!(patched_page, crate::row_delete_page::Deletion::Released(_)) {
         if definition.columns().iter().any(|column| {
             matches!(

--- a/crates/jet3/src/index_key_page.rs
+++ b/crates/jet3/src/index_key_page.rs
@@ -102,3 +102,50 @@ pub(crate) fn locator(record: &[u8]) -> Option<crate::RowLocator> {
         record[8],
     ))
 }
+
+// EXP-0062 cumulative boundaries and free bytes; retain all vacated entry slack.
+pub(crate) fn resize(
+    original: &[u8; PAGE_BYTES],
+    records: &[[u8; RECORD_BYTES]],
+    budget: &mut ResourceBudget,
+) -> Result<PageImage, UpdateError> {
+    let mut image = replace(original, records, budget)?;
+    let mut bitmap = [0_u8; crate::index_tree_page::ENTRY_AREA_OFFSET - 22];
+    for ordinal in 1..=records.len() {
+        let end = ordinal * RECORD_BYTES;
+        bitmap[end / 8] |= 1 << (end % 8);
+    }
+    image.write_at(PageOffset::new(22), &bitmap, budget)?;
+    let free = (PAGE_BYTES
+        - crate::index_tree_page::ENTRY_AREA_OFFSET
+        - records.len() * RECORD_BYTES) as u16;
+    image.write_at(PageOffset::new(2), &free.to_le_bytes(), budget)?;
+    Ok(image)
+}
+
+pub(crate) fn encode_record(
+    key: [u8; 5],
+    row: crate::RowLocator,
+) -> Result<[u8; RECORD_BYTES], UpdateError> {
+    let page = u32::try_from(row.page().get())
+        .ok()
+        .filter(|p| *p <= 0xff_ffff)
+        .ok_or(UpdateError::Unsupported("index row page reference"))?;
+    let mut record = [0; RECORD_BYTES];
+    record[..5].copy_from_slice(&key);
+    record[5..8].copy_from_slice(&page.to_be_bytes()[1..]);
+    record[8] = row.slot();
+    Ok(record)
+}
+
+// EXP-0059 first physical prefix follows the 43-byte header; EXP-0073 count.
+// Callers require exactly one physical index and have already validated old counts.
+pub(crate) fn set_distinct_count(
+    image: &mut PageImage,
+    count: usize,
+    budget: &mut ResourceBudget,
+) -> Result<(), UpdateError> {
+    let count = u32::try_from(count).map_err(|_| UpdateError::Mismatch("distinct key count"))?;
+    image.write_at(PageOffset::new(47), &count.to_le_bytes(), budget)?;
+    Ok(())
+}

--- a/crates/jet3/src/indexed_row_tests.rs
+++ b/crates/jet3/src/indexed_row_tests.rs
@@ -1,0 +1,489 @@
+use super::*;
+use crate::{
+    ColumnSpec, ColumnType, IndexColumnSpec, IndexKind, IndexSpec, ResourceLimits, RowDelete,
+    TableRows, TableSpec,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+type TestResult = Result<(), Box<dyn StdError>>;
+static NEXT: AtomicU64 = AtomicU64::new(0);
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+struct Fixture {
+    directory: PathBuf,
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.directory);
+    }
+}
+impl Fixture {
+    fn new(count: usize, descending: bool, kind: IndexKind) -> Result<Self, Box<dyn StdError>> {
+        let directory = std::env::temp_dir().join(format!(
+            "jet3-indexed-mutations-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&directory)?;
+        let f = Self { directory };
+        let columns = [
+            ColumnSpec::new(b"Id", ColumnType::Long),
+            ColumnSpec::new(b"Value", ColumnType::Long),
+        ];
+        let fields = [if descending {
+            IndexColumnSpec::descending(0)
+        } else {
+            IndexColumnSpec::ascending(0)
+        }];
+        let indexes = [IndexSpec {
+            name: b"ById",
+            kind,
+            fields: &fields,
+        }];
+        let values: Vec<_> = (0..count)
+            .map(|n| [RowValue::Long(n as i32), RowValue::Long(-(n as i32))])
+            .collect();
+        let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+        let extra = [RowValue::Long(99), RowValue::Long(88)];
+        let tables = [
+            TableRows {
+                table: TableSpec {
+                    name: b"Unrelated",
+                    columns: &columns,
+                    indexes: &[],
+                },
+                rows: &[&extra],
+            },
+            TableRows {
+                table: TableSpec {
+                    name: b"Rows",
+                    columns: &columns,
+                    indexes: &indexes,
+                },
+                rows: &rows,
+            },
+        ];
+        crate::create_database_with_table_rows(f.path(), &tables, &mut budget())?;
+        let mut bytes = fs::read(f.path())?;
+        bytes.extend_from_slice(&[0xb7; PAGE_BYTES]);
+        fs::write(f.path(), bytes)?;
+        Ok(f)
+    }
+    fn path(&self) -> PathBuf {
+        self.directory.join("source.mdb")
+    }
+    fn definition(&self) -> Result<crate::TableDefinition, Box<dyn StdError>> {
+        let mut b = budget();
+        let mut db = DatabaseReader::open(self.path(), &mut b)?;
+        Ok(crate::update::indexed_writable_table(
+            &mut db, b"Rows", &mut b,
+        )?)
+    }
+    fn rows(&self) -> Result<Vec<(i32, RowLocator)>, Box<dyn StdError>> {
+        let mut b = budget();
+        let mut db = DatabaseReader::open(self.path(), &mut b)?;
+        let def = crate::update::indexed_writable_table(&mut db, b"Rows", &mut b)?;
+        let mut cursor = db.rows(&def, &mut b)?;
+        let mut result = Vec::new();
+        while let Some(row) = cursor.next_row()? {
+            let raw = row
+                .field(crate::ColumnOrdinal::new(0))
+                .and_then(|f| f.raw_bytes())
+                .ok_or("Id")?;
+            result.push((i32::from_le_bytes(raw.try_into()?), row.locator()));
+        }
+        Ok(result)
+    }
+    fn validate(&self) -> TestResult {
+        let mut b = budget();
+        let mut db = DatabaseReader::open(self.path(), &mut b)?;
+        let def = crate::update::indexed_writable_table(&mut db, b"Rows", &mut b)?;
+        let leaf = crate::unique_leaf::validate(&mut db, &def, &mut b)?;
+        leaf.check_map(&mut db, &def, &mut b)?;
+        assert_eq!(fs::read_dir(&self.directory)?.count(), 1);
+        Ok(())
+    }
+}
+fn page(bytes: &[u8], number: crate::PageNumber) -> Result<&[u8; PAGE_BYTES], Box<dyn StdError>> {
+    let start = number.get() as usize * PAGE_BYTES;
+    Ok(bytes[start..start + PAGE_BYTES].try_into()?)
+}
+fn preserve(
+    before: &[u8],
+    after: &[u8],
+    table: &crate::TableDefinition,
+    row: RowLocator,
+    insertion: bool,
+) -> TestResult {
+    let mut expected = before.to_vec();
+    let root = table.root().get() as usize * PAGE_BYTES;
+    expected[root + 12..root + 16].copy_from_slice(&after[root + 12..root + 16]);
+    expected[root + 47..root + 51].copy_from_slice(&after[root + 47..root + 51]);
+    let leaf = table.physical_indexes()[0].root();
+    let base = leaf.get() as usize * PAGE_BYTES;
+    let count = crate::index_tree_page::boundaries(page(after, leaf)?).count();
+    assert_eq!(
+        &after[base + 2..base + 4],
+        &((1800 - count * 9) as u16).to_le_bytes()
+    );
+    assert_eq!(
+        crate::index_tree_page::boundaries(page(after, leaf)?).collect::<Vec<_>>(),
+        (1..=count).map(|n| n * 9).collect::<Vec<_>>()
+    );
+    expected[base + 2..base + 4].copy_from_slice(&after[base + 2..base + 4]);
+    expected[base + 22..base + 248 + count * 9]
+        .copy_from_slice(&after[base + 22..base + 248 + count * 9]);
+    let old = page(before, row.page())?;
+    let new = page(after, row.page())?;
+    let dir =
+        crate::row_directory::RowDirectory::validate(row.page(), table.root(), old, &mut budget())?;
+    let next =
+        crate::row_directory::RowDirectory::validate(row.page(), table.root(), new, &mut budget())?;
+    let base = row.page().get() as usize * PAGE_BYTES;
+    expected[base + 2..base + 4].copy_from_slice(&new[2..4]);
+    let lowest = dir.entry(old, (dir.row_count() - 1) as u8)?.range().start;
+    if insertion {
+        assert_eq!(next.row_count(), dir.row_count() + 1);
+        expected[base + 8..base + 10].copy_from_slice(&new[8..10]);
+        let slot = 10 + usize::from(dir.row_count()) * 2;
+        expected[base + slot..base + slot + 2].copy_from_slice(&new[slot..slot + 2]);
+        let added = next.entry(new, row.slot())?.range();
+        assert_eq!(added.end, lowest);
+        expected[base + added.start..base + added.end].copy_from_slice(&new[added]);
+    } else {
+        assert_eq!(next.row_count(), dir.row_count());
+        let removed = dir.entry(old, row.slot())?.range();
+        let affected_start = lowest + removed.len();
+        expected[base + affected_start..base + removed.end]
+            .copy_from_slice(&new[affected_start..removed.end]);
+        let slot = 10 + usize::from(row.slot()) * 2;
+        let end = 10 + usize::from(dir.row_count()) * 2;
+        expected[base + slot..base + end].copy_from_slice(&new[slot..end]);
+    }
+    assert_eq!(after, expected);
+    Ok(())
+}
+#[test]
+fn indexed_rows_insert_delete_and_repeat_preserve_three_page_scope() -> TestResult {
+    for (kind, descending) in [(IndexKind::Primary, false), (IndexKind::Unique, true)] {
+        let f = Fixture::new(4, descending, kind)?;
+        for value in [i32::MIN, i32::MAX] {
+            let before = fs::read(f.path())?;
+            let table = f.definition()?;
+            let prior = f.rows()?;
+            let row = insert_row(
+                f.path(),
+                b"Rows",
+                &[RowValue::Long(value), RowValue::Long(73)],
+                &mut budget(),
+            )?;
+            preserve(&before, &fs::read(f.path())?, &table, row, true)?;
+            f.validate()?;
+            for pair in prior {
+                assert!(f.rows()?.contains(&pair));
+            }
+        }
+        for id in [1, 0, 3, i32::MIN] {
+            let before = fs::read(f.path())?;
+            let table = f.definition()?;
+            let prior = f.rows()?;
+            let row = prior.iter().find(|(v, _)| *v == id).ok_or("row")?.1;
+            crate::delete_row(
+                f.path(),
+                RowDelete {
+                    table: b"Rows",
+                    row,
+                },
+                &mut budget(),
+            )?;
+            preserve(&before, &fs::read(f.path())?, &table, row, false)?;
+            f.validate()?;
+            assert_eq!(
+                f.rows()?,
+                prior
+                    .into_iter()
+                    .filter(|(v, _)| *v != id)
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+    Ok(())
+}
+#[test]
+fn indexed_rows_actual_leaf_capacity_and_last_row_refuse_without_publication() -> TestResult {
+    let f = Fixture::new(199, false, IndexKind::Primary)?;
+    insert_row(
+        f.path(),
+        b"Rows",
+        &[RowValue::Long(-1), RowValue::Long(3)],
+        &mut budget(),
+    )?;
+    f.validate()?;
+    let before = fs::read(f.path())?;
+    assert!(matches!(
+        insert_row(
+            f.path(),
+            b"Rows",
+            &[RowValue::Long(-2), RowValue::Long(3)],
+            &mut budget()
+        ),
+        Err(UpdateError::Unsupported("full root leaf"))
+    ));
+    assert_eq!(fs::read(f.path())?, before);
+    for count in [1, 201] {
+        let f = Fixture::new(count, false, IndexKind::Primary)?;
+        let before = fs::read(f.path())?;
+        let row = f.rows()?[0].1;
+        assert!(
+            crate::delete_row(
+                f.path(),
+                RowDelete {
+                    table: b"Rows",
+                    row
+                },
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(f.path())?, before);
+        if count != 1 {
+            assert!(
+                insert_row(
+                    f.path(),
+                    b"Rows",
+                    &[RowValue::Long(-1), RowValue::Long(3)],
+                    &mut budget()
+                )
+                .is_err()
+            );
+            assert_eq!(fs::read(f.path())?, before);
+        }
+    }
+    Ok(())
+}
+#[test]
+fn indexed_rows_duplicate_null_ordinary_and_budget_refuse() -> TestResult {
+    let f = Fixture::new(3, false, IndexKind::Unique)?;
+    let before = fs::read(f.path())?;
+    for value in [RowValue::Long(1), RowValue::Null] {
+        assert!(
+            insert_row(
+                f.path(),
+                b"Rows",
+                &[value, RowValue::Long(5)],
+                &mut budget()
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(f.path())?, before);
+    }
+    let mut limited = ResourceBudget::new(ResourceLimits::default().with_max_total_work_units(1));
+    assert!(
+        insert_row(
+            f.path(),
+            b"Rows",
+            &[RowValue::Long(-1), RowValue::Long(5)],
+            &mut limited
+        )
+        .is_err()
+    );
+    assert_eq!(fs::read(f.path())?, before);
+    let f = Fixture::new(3, false, IndexKind::Ordinary)?;
+    let before = fs::read(f.path())?;
+    assert!(
+        insert_row(
+            f.path(),
+            b"Rows",
+            &[RowValue::Long(-1), RowValue::Long(5)],
+            &mut budget()
+        )
+        .is_err()
+    );
+    assert!(
+        crate::delete_row(
+            f.path(),
+            RowDelete {
+                table: b"Rows",
+                row: f.rows()?[0].1
+            },
+            &mut budget()
+        )
+        .is_err()
+    );
+    assert_eq!(fs::read(f.path())?, before);
+    Ok(())
+}
+#[test]
+fn indexed_rows_corrupt_keys_counts_map_and_leaf_framing_refuse() -> TestResult {
+    let f = Fixture::new(3, false, IndexKind::Primary)?;
+    let original = fs::read(f.path())?;
+    let table = f.definition()?;
+    let row = f.rows()?[1].1;
+    let index = table.physical_indexes()[0].root().get() as usize * PAGE_BYTES;
+    let location = table.physical_indexes()[0].usage_map();
+    let map = page(&original, location.page())?;
+    let directory = crate::row_directory::RowDirectory::validate(
+        location.page(),
+        crate::PageNumber::new(0),
+        map,
+        &mut budget(),
+    )?;
+    let map_start = location.page().get() as usize * PAGE_BYTES
+        + directory.entry(map, location.row())?.range().start;
+    for (offset, value) in [
+        (index + 252, 99),
+        (index + 256, 1),
+        (index + 2, 0),
+        (index + 20, 1),
+        (index + 23, 0),
+        (table.root().get() as usize * PAGE_BYTES + 12, 9),
+        (table.root().get() as usize * PAGE_BYTES + 47, 9),
+        (map_start + 5, 0xff),
+    ] {
+        let mut bytes = original.clone();
+        bytes[offset] = value;
+        fs::write(f.path(), &bytes)?;
+        assert!(
+            insert_row(
+                f.path(),
+                b"Rows",
+                &[RowValue::Long(-1), RowValue::Long(5)],
+                &mut budget()
+            )
+            .is_err(),
+            "offset {offset}"
+        );
+        assert!(
+            crate::delete_row(
+                f.path(),
+                RowDelete {
+                    table: b"Rows",
+                    row
+                },
+                &mut budget()
+            )
+            .is_err(),
+            "offset {offset}"
+        );
+        assert_eq!(fs::read(f.path())?, bytes);
+    }
+    Ok(())
+}
+#[test]
+fn indexed_rows_private_corruption_preserves_original() -> TestResult {
+    let f = Fixture::new(3, false, IndexKind::Primary)?;
+    let before = fs::read(f.path())?;
+    let result = insert_with_hook(
+        &f.path(),
+        b"Rows",
+        &[RowValue::Long(-1), RowValue::Long(5)],
+        &mut budget(),
+        |stage| {
+            if stage == PublishStage::Validation {
+                let path = fs::read_dir(&f.directory)?
+                    .filter_map(Result::ok)
+                    .map(|e| e.path())
+                    .find(|p| *p != f.path())
+                    .ok_or_else(|| std::io::Error::other("private"))?;
+                let mut bytes = fs::read(&path)?;
+                bytes[100] ^= 1;
+                fs::write(path, bytes)?;
+            }
+            Ok::<(), std::io::Error>(())
+        },
+    );
+    assert!(result.is_err());
+    assert_eq!(fs::read(f.path())?, before);
+    assert_eq!(fs::read_dir(&f.directory)?.count(), 1);
+    Ok(())
+}
+
+#[test]
+fn indexed_rows_no_data_capacity_and_multiple_indexes_refuse() -> TestResult {
+    let f = Fixture::new(3, false, IndexKind::Primary)?;
+    let table = f.definition()?;
+    let map = table.maps().available();
+    let mut bytes = fs::read(f.path())?;
+    let raw = page(&bytes, map.page())?;
+    let directory = crate::row_directory::RowDirectory::validate(
+        map.page(),
+        crate::PageNumber::new(0),
+        raw,
+        &mut budget(),
+    )?;
+    let range = directory.entry(raw, map.row())?.range();
+    let start = map.page().get() as usize * PAGE_BYTES + range.start + 5;
+    let end = map.page().get() as usize * PAGE_BYTES + range.end;
+    bytes[start..end].fill(0);
+    fs::write(f.path(), &bytes)?;
+    assert!(matches!(
+        insert_row(
+            f.path(),
+            b"Rows",
+            &[RowValue::Long(-1), RowValue::Long(2)],
+            &mut budget()
+        ),
+        Err(UpdateError::Unsupported(
+            "indexed insertion requires populated page capacity"
+        ))
+    ));
+    assert_eq!(fs::read(f.path())?, bytes);
+    fs::remove_file(f.path())?;
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(b"Value", ColumnType::Long),
+    ];
+    let fields = [IndexColumnSpec::ascending(0)];
+    let indexes = [
+        IndexSpec {
+            name: b"One",
+            kind: IndexKind::Primary,
+            fields: &fields,
+        },
+        IndexSpec {
+            name: b"Two",
+            kind: IndexKind::Unique,
+            fields: &fields,
+        },
+    ];
+    let values = [
+        [RowValue::Long(1), RowValue::Long(2)],
+        [RowValue::Long(2), RowValue::Long(3)],
+    ];
+    crate::create_database_with_rows(
+        f.path(),
+        &TableSpec {
+            name: b"Rows",
+            columns: &columns,
+            indexes: &indexes,
+        },
+        &[&values[0], &values[1]],
+        &mut budget(),
+    )?;
+    let before = fs::read(f.path())?;
+    let row = f.rows()?[0].1;
+    assert!(
+        insert_row(
+            f.path(),
+            b"Rows",
+            &[RowValue::Long(-1), RowValue::Long(2)],
+            &mut budget()
+        )
+        .is_err()
+    );
+    assert!(
+        crate::delete_row(
+            f.path(),
+            RowDelete {
+                table: b"Rows",
+                row
+            },
+            &mut budget()
+        )
+        .is_err()
+    );
+    assert_eq!(fs::read(f.path())?, before);
+    Ok(())
+}

--- a/crates/jet3/src/insert.rs
+++ b/crates/jet3/src/insert.rs
@@ -11,9 +11,13 @@ use std::path::Path;
 /// Inserts an encoded row on a populated available page or one new EOF page.
 ///
 /// Values use the existing checked scalar/Text/Binary row encoder, including null
-/// and Boolean fields. AutoIncrement, long values, indexes and relationships are
-/// refused. If no populated page fits, including an empty table, one EOF page is
-/// appended only within existing inline global/owned/available maps. No reuse,
+/// and Boolean fields. One unique/primary present Long index is supported when
+/// its complete tree is an uncompressed root leaf with capacity for another key.
+/// Indexed insertion requires an existing populated data page; its leaf records,
+/// boundary bitmap, free count and physical distinct-key count are updated too.
+/// Other indexes, AutoIncrement, long values and relationships are refused.
+/// For unindexed tables, if no populated page fits, one EOF page is appended
+/// only within existing inline global/owned/available maps. No reuse,
 /// map growth or compaction is implemented. An existing selected page must
 /// retain capacity for one more equal-sized row and representable directory slot;
 /// this is a candidate restriction, not a DAO free-space threshold.
@@ -65,7 +69,7 @@ where
     HE: StdError + Send + Sync + 'static,
 {
     let mut database = DatabaseReader::open(path, budget)?;
-    let definition = crate::update::writable_table(&mut database, table, budget)?;
+    let definition = crate::update::indexed_writable_table(&mut database, table, budget)?;
     if !definition.long_value_maps().is_empty()
         || definition.columns().iter().any(|c| {
             c.auto_increment()
@@ -79,6 +83,13 @@ where
             "AutoIncrement or long-value table",
         ));
     }
+    let mut index = if definition.indexes().is_empty() && definition.physical_indexes().is_empty() {
+        None
+    } else {
+        let leaf = crate::unique_leaf::validate(&mut database, &definition, budget)?;
+        leaf.check_map(&mut database, &definition, budget)?;
+        Some(leaf)
+    };
     let columns = definition.columns();
     if columns.len() > usize::from(u8::MAX) {
         return Err(UpdateError::Unsupported("row column count"));
@@ -112,7 +123,7 @@ where
     }
     let mut source_definition = [0; PAGE_BYTES];
     database.read_raw_page(definition.root(), &mut source_definition, budget)?;
-    let patched_definition =
+    let mut patched_definition =
         crate::row_insert_page::increment_count(&source_definition, observed_rows, budget)?;
     let mut owned_bytes = [0; PAGE_BYTES];
     let owned = inline_map(
@@ -161,6 +172,12 @@ where
         }
     };
     let Some(selected) = selected else {
+        if index.is_some() {
+            return Err(UpdateError::Unsupported(
+                "indexed insertion requires populated page capacity",
+            ));
+        }
+
         let mut minimum = [0; PAGE_BYTES];
         let nulls = [RowValue::Null; u8::MAX as usize];
         let minimum_length = crate::encode_row(
@@ -192,6 +209,37 @@ where
         )?;
         return Ok(RowLocator::new(plan.page, 0));
     };
+    if let Some(leaf) = &mut index {
+        let Some(RowValue::Long(value)) = values.get(usize::from(leaf.column.get())) else {
+            return Err(UpdateError::Unsupported("insert requires present Long key"));
+        };
+        let after = leaf.insert(*value, RowLocator::new(selected.0, selected.2), budget)?;
+        crate::index_key_page::set_distinct_count(&mut patched_definition, leaf.count, budget)?;
+        crate::update_pages::publish_changes(
+            path,
+            database.into_source(),
+            &[
+                crate::update_pages::PageChange {
+                    page: selected.0,
+                    before: &source_page,
+                    after: selected.1.as_bytes(),
+                },
+                crate::update_pages::PageChange {
+                    page: definition.root(),
+                    before: &source_definition,
+                    after: patched_definition.as_bytes(),
+                },
+                crate::update_pages::PageChange {
+                    page: leaf.page,
+                    before: &leaf.before,
+                    after: after.as_bytes(),
+                },
+            ],
+            budget,
+            hook,
+        )?;
+        return Ok(RowLocator::new(selected.0, selected.2));
+    }
     crate::update_pages::publish_changes(
         path,
         database.into_source(),
@@ -216,3 +264,7 @@ where
 #[cfg(all(test, unix))]
 #[path = "insert_tests.rs"]
 mod tests;
+
+#[cfg(all(test, unix))]
+#[path = "indexed_row_tests.rs"]
+mod indexed_tests;

--- a/crates/jet3/src/lib.rs
+++ b/crates/jet3/src/lib.rs
@@ -95,6 +95,7 @@ pub mod table_definition;
 mod table_definition_layout;
 pub mod table_definition_writer;
 pub mod text;
+mod unique_leaf;
 pub mod update;
 mod update_index_key;
 mod update_pages;

--- a/crates/jet3/src/unique_leaf.rs
+++ b/crates/jet3/src/unique_leaf.rs
@@ -1,0 +1,195 @@
+//! Complete unique Long leaf correlation from EXP-0062/0073/0186.
+use crate::index_key_page::{MAX_ENTRIES, RECORD_BYTES};
+use crate::{
+    ColumnOrdinal, ColumnPhysicalType, DatabaseReader, FileSource, IndexDirection, PAGE_BYTES,
+    PageImage, PageNumber, ResourceBudget, RowLocator, TableDefinition, UpdateError,
+};
+
+pub(crate) struct UniqueLeaf {
+    pub(crate) column: ColumnOrdinal,
+    pub(crate) direction: IndexDirection,
+    pub(crate) page: PageNumber,
+    pub(crate) before: [u8; PAGE_BYTES],
+    pub(crate) records: [[u8; RECORD_BYTES]; MAX_ENTRIES],
+    pub(crate) count: usize,
+}
+
+pub(crate) fn validate(
+    database: &mut DatabaseReader<FileSource>,
+    table: &TableDefinition,
+    budget: &mut ResourceBudget,
+) -> Result<UniqueLeaf, UpdateError> {
+    let ([physical], [_logical]) = (table.physical_indexes(), table.indexes()) else {
+        return Err(UpdateError::Unsupported("key update requires one index"));
+    };
+    let [key] = physical.fields() else {
+        return Err(UpdateError::Unsupported(
+            "key update requires one Long field",
+        ));
+    };
+    let column = table
+        .columns()
+        .get(usize::from(key.column().get()))
+        .ok_or(UpdateError::NotFound("column"))?;
+    if !physical.unique()
+        || column.auto_increment()
+        || column.physical_type() != ColumnPhysicalType::Long
+    {
+        return Err(UpdateError::Unsupported(
+            "key update requires unique ordinary Long",
+        ));
+    }
+    let mut before = [0; PAGE_BYTES];
+    database.read_raw_page(physical.root(), &mut before, budget)?;
+    let count = crate::index_key_page::validate(
+        physical.root(),
+        table.root(),
+        database.geometry(),
+        &before,
+        budget,
+    )?;
+    let tree = database.index_tree(table, 0, budget)?;
+    if count == 0 || count > MAX_ENTRIES || tree.nodes().len() != 1 || tree.entries().len() != count
+    {
+        return Err(UpdateError::Mismatch("single leaf entry inventory"));
+    }
+    let mut records = [[0; RECORD_BYTES]; MAX_ENTRIES];
+    for (ordinal, entry) in tree.entries().iter().enumerate() {
+        budget.charge_items(1)?;
+        let raw = crate::index_key_page::record(&before, ordinal)
+            .ok_or(UpdateError::Mismatch("leaf record"))?;
+        if entry.key().raw_bytes().len() != 5
+            || &raw[..5] != entry.key().raw_bytes()
+            || crate::index_key_page::locator(raw) != Some(entry.row())
+        {
+            return Err(UpdateError::Mismatch("Long leaf framing"));
+        }
+        if ordinal > 0 && tree.entries()[ordinal - 1].key().raw_bytes() >= entry.key().raw_bytes() {
+            return Err(UpdateError::Mismatch("unique key ordering"));
+        }
+        records[ordinal].copy_from_slice(raw);
+    }
+    let mut seen = [false; MAX_ENTRIES];
+    let mut rows_count = 0;
+    // At most 200 leaf entries; precharge the complete linear-search work per row.
+    budget.charge_work_units((count * count) as u64)?;
+    let mut cursor = database.rows(table, budget)?;
+    while let Some(row) = cursor.next_row()? {
+        if rows_count == count {
+            return Err(UpdateError::Mismatch("row/index count"));
+        }
+        if row.locator() != row.storage_locator() {
+            return Err(UpdateError::Unsupported("overflow indexed row"));
+        }
+        let raw = row
+            .field(key.column())
+            .and_then(|f| f.raw_bytes())
+            .ok_or(UpdateError::Unsupported("null indexed field"))?;
+        let raw: [u8; 4] = raw
+            .try_into()
+            .map_err(|_| UpdateError::Mismatch("Long field width"))?;
+        let encoded = crate::long_index_key::encode(i32::from_le_bytes(raw), key.direction());
+        let ordinal = tree
+            .entries()
+            .iter()
+            .position(|entry| entry.row() == row.locator())
+            .ok_or(UpdateError::Mismatch("unindexed live row"))?;
+        if seen[ordinal] || tree.entries()[ordinal].key().raw_bytes() != encoded {
+            return Err(UpdateError::Mismatch("key/row correlation"));
+        }
+        seen[ordinal] = true;
+        rows_count += 1;
+    }
+    drop(cursor);
+    if rows_count != count || seen[..count].contains(&false) {
+        return Err(UpdateError::Mismatch("row/index bijection"));
+    }
+    let mut definition_page = [0; PAGE_BYTES];
+    database.read_raw_page(table.root(), &mut definition_page, budget)?;
+    crate::index_key_page::check_counts(&definition_page, physical.sourced_prefix(), count)?;
+    Ok(UniqueLeaf {
+        column: key.column(),
+        direction: key.direction(),
+        page: physical.root(),
+        before,
+        records,
+        count,
+    })
+}
+
+impl UniqueLeaf {
+    // EXP-0057 inline membership must describe this complete one-page index.
+    pub(crate) fn check_map(
+        &self,
+        database: &mut DatabaseReader<FileSource>,
+        table: &TableDefinition,
+        budget: &mut ResourceBudget,
+    ) -> Result<(), UpdateError> {
+        let location = table.physical_indexes()[0].usage_map();
+        let mut bytes = [0; PAGE_BYTES];
+        let page = database
+            .read_classified_page(location.page(), &mut bytes, budget)
+            .map_err(crate::TableDefinitionError::Page)?;
+        let row = crate::locate_usage_map(
+            page,
+            crate::MapRowLocator::new(location.page(), location.row()),
+            budget,
+        )
+        .map_err(UpdateError::UsageMap)?;
+        let crate::AllocationMap::Inline(map) =
+            crate::decode_allocation_map(row.raw(), budget).map_err(UpdateError::Allocation)?
+        else {
+            return Err(UpdateError::Unsupported("indirect index map"));
+        };
+        let mut pages = map.allocated_pages(database.geometry());
+        if pages.next_page(budget).map_err(UpdateError::Allocation)? != Some(self.page)
+            || pages
+                .next_page(budget)
+                .map_err(UpdateError::Allocation)?
+                .is_some()
+        {
+            return Err(UpdateError::Mismatch("isolated index map"));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        value: i32,
+        row: RowLocator,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, UpdateError> {
+        if self.count == MAX_ENTRIES {
+            return Err(UpdateError::Unsupported("full root leaf"));
+        }
+        let key = crate::long_index_key::encode(value, self.direction);
+        budget.charge_work_units((2 * (self.count + 2) * RECORD_BYTES) as u64)?;
+        if self.records[..self.count].iter().any(|r| r[..5] == key) {
+            return Err(UpdateError::Unsupported("duplicate unique key"));
+        }
+        let record = crate::index_key_page::encode_record(key, row)?;
+        let position = self.records[..self.count].partition_point(|r| r < &record);
+        self.records.copy_within(position..self.count, position + 1);
+        self.records[position] = record;
+        self.count += 1;
+        crate::index_key_page::resize(&self.before, &self.records[..self.count], budget)
+    }
+
+    pub(crate) fn remove(
+        &mut self,
+        row: RowLocator,
+        budget: &mut ResourceBudget,
+    ) -> Result<PageImage, UpdateError> {
+        if self.count <= 1 {
+            return Err(UpdateError::Unsupported("last indexed row"));
+        }
+        budget.charge_work_units((2 * (self.count + 2) * RECORD_BYTES) as u64)?;
+        let position = self.records[..self.count]
+            .iter()
+            .position(|r| crate::index_key_page::locator(r) == Some(row))
+            .ok_or(UpdateError::NotFound("indexed row"))?;
+        self.records.copy_within(position + 1..self.count, position);
+        self.count -= 1;
+        crate::index_key_page::resize(&self.before, &self.records[..self.count], budget)
+    }
+}

--- a/crates/jet3/src/update.rs
+++ b/crates/jet3/src/update.rs
@@ -151,7 +151,7 @@ where
         return Err(UpdateError::Unsupported("null replacement"));
     }
     let mut database = DatabaseReader::open(path, budget)?;
-    let definition = guarded_table(&mut database, request.table, Some(request.column), budget)?;
+    let definition = guarded_table(&mut database, request.table, true, budget)?;
     let column = definition
         .columns()
         .get(usize::from(request.column.get()))
@@ -257,13 +257,21 @@ pub(crate) fn writable_table(
     table: &[u8],
     budget: &mut ResourceBudget,
 ) -> Result<crate::TableDefinition, UpdateError> {
-    guarded_table(database, table, None, budget)
+    guarded_table(database, table, false, budget)
+}
+
+pub(crate) fn indexed_writable_table(
+    database: &mut DatabaseReader<FileSource>,
+    table: &[u8],
+    budget: &mut ResourceBudget,
+) -> Result<crate::TableDefinition, UpdateError> {
+    guarded_table(database, table, true, budget)
 }
 
 fn guarded_table(
     database: &mut DatabaseReader<FileSource>,
     table: &[u8],
-    field: Option<ColumnOrdinal>,
+    allow_indexes: bool,
     budget: &mut ResourceBudget,
 ) -> Result<crate::TableDefinition, UpdateError> {
     let mut root = None;
@@ -292,7 +300,7 @@ fn guarded_table(
     if definition.kind() != TableDefinitionKind::User {
         return Err(UpdateError::Unsupported("non-user table"));
     }
-    if field.is_some() {
+    if allow_indexes {
         // EXP-0059/0062: the typed decoder validates every logical selector,
         // physical key field and complete logical-to-physical coverage.
         for index in definition.indexes() {

--- a/crates/jet3/src/update_index_key.rs
+++ b/crates/jet3/src/update_index_key.rs
@@ -1,8 +1,8 @@
 //! Bounded key/row correlation; only fixed-size isolated-leaf replacement.
-use crate::index_key_page::{MAX_ENTRIES, RECORD_BYTES};
+use crate::index_key_page::RECORD_BYTES;
 use crate::{
-    ColumnPhysicalType, DatabaseReader, FieldUpdate, FileSource, PAGE_BYTES, PageImage, PageNumber,
-    ResourceBudget, RowValue, TableDefinition, UpdateError,
+    DatabaseReader, FieldUpdate, FileSource, PAGE_BYTES, PageImage, PageNumber, ResourceBudget,
+    RowValue, TableDefinition, UpdateError,
 };
 
 pub(crate) struct KeyChange {
@@ -27,114 +27,28 @@ pub(crate) fn plan(
     if !indexed {
         return Ok(None);
     }
-    let ([physical], [_logical]) = (table.physical_indexes(), table.indexes()) else {
-        return Err(UpdateError::Unsupported("key update requires one index"));
-    };
-    let [key] = physical.fields() else {
-        return Err(UpdateError::Unsupported(
-            "key update requires one Long field",
-        ));
-    };
-    let column = table
-        .columns()
-        .get(usize::from(request.column.get()))
-        .ok_or(UpdateError::NotFound("column"))?;
-    if !physical.unique()
-        || column.auto_increment()
-        || column.physical_type() != ColumnPhysicalType::Long
-    {
-        return Err(UpdateError::Unsupported(
-            "key update requires unique ordinary Long",
-        ));
-    }
+    let mut leaf = crate::unique_leaf::validate(database, table, budget)?;
     let RowValue::Long(value) = request.value else {
         return Err(UpdateError::Unsupported("key update requires present Long"));
     };
-    let mut before = [0; PAGE_BYTES];
-    database.read_raw_page(physical.root(), &mut before, budget)?;
-    let count = crate::index_key_page::validate(
-        physical.root(),
-        table.root(),
-        database.geometry(),
-        &before,
-        budget,
-    )?;
-    let tree = database.index_tree(table, 0, budget)?;
-    if count == 0 || count > MAX_ENTRIES || tree.nodes().len() != 1 || tree.entries().len() != count
-    {
-        return Err(UpdateError::Mismatch("single leaf entry inventory"));
-    }
-    let replacement = crate::long_index_key::encode(value, key.direction());
-    let mut records = [[0; RECORD_BYTES]; MAX_ENTRIES];
+    let replacement = crate::long_index_key::encode(value, leaf.direction);
+    budget.charge_work_units((leaf.count * RECORD_BYTES) as u64)?;
     let mut selected = None;
-    for (ordinal, entry) in tree.entries().iter().enumerate() {
-        budget.charge_items(1)?;
-        let raw = crate::index_key_page::record(&before, ordinal)
-            .ok_or(UpdateError::Mismatch("leaf record"))?;
-        if entry.key().raw_bytes().len() != replacement.len()
-            || &raw[..replacement.len()] != entry.key().raw_bytes()
-            || crate::index_key_page::locator(raw) != Some(entry.row())
-        {
-            return Err(UpdateError::Mismatch("Long leaf framing"));
-        }
-        if ordinal > 0 && tree.entries()[ordinal - 1].key().raw_bytes() >= entry.key().raw_bytes() {
-            return Err(UpdateError::Mismatch("unique key ordering"));
-        }
-        if entry.row() == request.row {
-            if selected.replace(ordinal).is_some() {
-                return Err(UpdateError::Mismatch("duplicate row locator"));
-            }
-        } else if entry.key().raw_bytes() == replacement {
+    for (ordinal, record) in leaf.records[..leaf.count].iter().enumerate() {
+        if crate::index_key_page::locator(record) == Some(request.row) {
+            selected = Some(ordinal);
+        } else if record[..replacement.len()] == replacement {
             return Err(UpdateError::Unsupported("duplicate unique key"));
         }
-        records[ordinal].copy_from_slice(raw);
     }
     let selected = selected.ok_or(UpdateError::NotFound("indexed row"))?;
-    let mut seen = [false; MAX_ENTRIES];
-    let mut rows_count = 0;
-    // At most 200 leaf entries; precharge the complete linear-search work per row.
-    budget.charge_work_units((count * count) as u64)?;
-    let mut cursor = database.rows(table, budget)?;
-    while let Some(row) = cursor.next_row()? {
-        if rows_count == count {
-            return Err(UpdateError::Mismatch("row/index count"));
-        }
-        if row.locator() != row.storage_locator() {
-            return Err(UpdateError::Unsupported("overflow indexed row"));
-        }
-        let raw = row
-            .field(request.column)
-            .and_then(|f| f.raw_bytes())
-            .ok_or(UpdateError::Unsupported("null indexed field"))?;
-        let raw: [u8; 4] = raw
-            .try_into()
-            .map_err(|_| UpdateError::Mismatch("Long field width"))?;
-        let encoded = crate::long_index_key::encode(i32::from_le_bytes(raw), key.direction());
-        let ordinal = tree
-            .entries()
-            .iter()
-            .position(|entry| entry.row() == row.locator())
-            .ok_or(UpdateError::Mismatch("unindexed live row"))?;
-        if seen[ordinal] || tree.entries()[ordinal].key().raw_bytes() != encoded {
-            return Err(UpdateError::Mismatch("key/row correlation"));
-        }
-        seen[ordinal] = true;
-        rows_count += 1;
-    }
-    drop(cursor);
-    if rows_count != count || seen[..count].contains(&false) {
-        return Err(UpdateError::Mismatch("row/index bijection"));
-    }
-    let mut definition_page = [0; PAGE_BYTES];
-    database.read_raw_page(table.root(), &mut definition_page, budget)?;
-    crate::index_key_page::check_counts(&definition_page, physical.sourced_prefix(), count)?;
-    records[selected][..replacement.len()].copy_from_slice(&replacement);
-    budget.charge_work_units((count * count) as u64)?;
-    records[..count].sort_unstable();
-    let after = crate::index_key_page::replace(&before, &records[..count], budget)?;
+    leaf.records[selected][..replacement.len()].copy_from_slice(&replacement);
+    budget.charge_work_units((leaf.count * leaf.count) as u64)?;
+    leaf.records[..leaf.count].sort_unstable();
+    let after = crate::index_key_page::replace(&leaf.before, &leaf.records[..leaf.count], budget)?;
     Ok(Some(KeyChange {
-        page: physical.root(),
-        before,
+        page: leaf.page,
+        before: leaf.before,
         after,
     }))
 }

--- a/crates/jet3/src/update_indexed_tests.rs
+++ b/crates/jet3/src/update_indexed_tests.rs
@@ -42,7 +42,7 @@ fn nonkey_update_preserves_every_index_and_unrelated_byte() -> TestResult {
     fs::write(fixture.path(), &original)?;
     let mut b = budget();
     let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
-    let definition = guarded_table(&mut db, b"Items", Some(ColumnOrdinal::new(2)), &mut b)?;
+    let definition = guarded_table(&mut db, b"Items", true, &mut b)?;
     assert_eq!(definition.physical_indexes().len(), 1);
     let relative = {
         let mut cursor = db.rows(&definition, &mut b)?;
@@ -102,7 +102,7 @@ fn inconsistent_or_out_of_range_index_mapping_refuses_publication() -> TestResul
     let original = fs::read(fixture.path())?;
     let mut b = budget();
     let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
-    let definition = guarded_table(&mut db, b"Items", Some(ColumnOrdinal::new(2)), &mut b)?;
+    let definition = guarded_table(&mut db, b"Items", true, &mut b)?;
     let record = definition.indexes()[0].raw_record();
     let root_offset = definition.root().get() as usize * PAGE_BYTES;
     let matches: Vec<_> = original[root_offset..root_offset + PAGE_BYTES]

--- a/crates/jet3/src/update_key_tests.rs
+++ b/crates/jet3/src/update_key_tests.rs
@@ -41,12 +41,7 @@ fn keyed(
 fn definition(fixture: &Fixture) -> Result<crate::TableDefinition, Box<dyn StdError>> {
     let mut b = budget();
     let mut db = DatabaseReader::open(fixture.path(), &mut b)?;
-    Ok(guarded_table(
-        &mut db,
-        b"Items",
-        Some(ColumnOrdinal::new(0)),
-        &mut b,
-    )?)
+    Ok(guarded_table(&mut db, b"Items", true, &mut b)?)
 }
 
 #[test]


### PR DESCRIPTION
Existing rows can now be inserted or deleted while maintaining one unique Long index whose entries fit in an isolated leaf. Insertion uses a populated page; deletion retains at least one live row. Both operations validate complete row/key correspondence and publish only the data page, table definition and index leaf changes. Unsupported allocation, split and schema cases return structured errors before publication.

Independent review found no issues. The focused mutation and existing update tests, Clippy and final `just ready` pass. DAO candidate validation follows separately; this change makes no compatibility claim.
