### PR TITLE
test: validate explicit empty Memo candidates with DAO

### DIFF
--- a/.github/workflows/windows-dao-row-replacement.yml
+++ b/.github/workflows/windows-dao-row-replacement.yml
@@ -1,0 +1,107 @@
+name: Windows DAO row replacement differential
+on:
+  workflow_dispatch:
+    inputs:
+      run_acquisition:
+        description: Run the reviewed single update acquisition
+        type: boolean
+        default: false
+      plan_sha256:
+        description: SHA-256 of the committed row replacement plan
+        type: string
+        required: false
+permissions:
+  contents: read
+concurrency:
+  group: windows-dao-row-replacement-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  generate:
+    if: inputs.run_acquisition
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          test "$GITHUB_RUN_ATTEMPT" = 1
+          python3 oracle/windows-dao/scripts/dao_row_replacement_diff.py plan "$PLAN_SHA256"
+      - name: Build public fixture and snapshot producers
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-row-replacement-fixture
+      - name: Create requested fixtures on supported publication platform
+        run: python3 oracle/windows-dao/scripts/dao_row_replacement_diff.py prepare artifacts/dao-row-replacement-v1_2 target/release/jet3-row-replacement-fixture target/release/jet3-cli "$GITHUB_SHA"
+      - name: Retain exact generated files and preparation diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-row-replacement-${{ github.sha }}
+          path: artifacts/dao-row-replacement-v1_2
+          if-no-files-found: warn
+          retention-days: 14
+  update-differential:
+    needs: generate
+    if: always() && (needs.generate.result == 'success' || !inputs.run_acquisition)
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - name: Verify reviewed acquisition inputs
+        if: inputs.run_acquisition
+        shell: powershell
+        env:
+          PLAN_SHA256: ${{ inputs.plan_sha256 }}
+        run: |
+          if ($env:GITHUB_RUN_ATTEMPT -ne '1') { throw 'No automatic acquisition retry' }
+          python oracle/windows-dao/scripts/dao_row_replacement_diff.py plan $env:PLAN_SHA256
+          if ($LASTEXITCODE -ne 0) { throw 'Reviewed update plan verification failed' }
+      - name: Probe stock x86 provider
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/probe-provider.ps1 -ProtocolVersion 1.2.0 -OutputPath artifacts/environment.json
+          if ($LASTEXITCODE -ne 0) { throw 'Stock provider unavailable; retained probe explains missing prerequisite' }
+      - name: Download the exact Unix-generated candidates
+        if: inputs.run_acquisition
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: generated-row-replacement-${{ github.sha }}
+          path: artifacts/dao-row-replacement-v1_2
+      - name: Build the read-only Rust snapshot producer
+        if: inputs.run_acquisition
+        shell: powershell
+        run: cargo build --locked --release -p jet3-cli -p jet3-testkit --bin jet3-cli --bin jet3-row-replacement-fixture
+      - name: Verify downloads and snapshot them on Windows
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_row_replacement_diff.py snapshot artifacts/dao-row-replacement-v1_2 target/release/jet3-row-replacement-fixture.exe target/release/jet3-cli.exe $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'Downloaded fixture snapshot failed' }
+      - name: Observe Rust files read-only with DAO
+        id: dao
+        if: inputs.run_acquisition
+        shell: powershell
+        run: |
+          $x86 = Join-Path $env:WINDIR 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'
+          & $x86 -NoProfile -NonInteractive -ExecutionPolicy Bypass -File oracle/windows-dao/scripts/Invoke-DaoIndexedUpdateV12.ps1 -InventoryPath oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json -EnvironmentPath artifacts/environment.json -OutputRoot artifacts/dao-row-replacement-v1_2 -SourceRevision $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'DAO update observation failed' }
+      - name: Compare protocol snapshots and recipe semantics
+        if: always() && inputs.run_acquisition && steps.dao.outcome != 'skipped'
+        shell: powershell
+        run: |
+          python oracle/windows-dao/scripts/dao_row_replacement_diff.py evaluate artifacts/dao-row-replacement-v1_2
+          if ($LASTEXITCODE -ne 0) { throw 'Update differential failed' }
+      - name: Retain diagnostics including failed files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-dao-row-replacement-${{ github.sha }}-${{ github.run_attempt }}
+          path: artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ resource budgeting outside the parser.
 
 ## DAO experiments
 
+- Plan experiments around a capability or shared format question. Group
+  related types, boundary cases, names, and control variants into one bounded
+  case matrix with one preregistration and one outcome report, rather than
+  registering each small variation separately. State expected observations
+  and acceptance criteria per case so partial results remain explicit.
+- Before adding an experiment, check existing evidence and identify the
+  remaining questions for that deliverable. Batch cases that can be specified
+  up front and share a setup/analyzer; split when a later case depends on an
+  earlier result or answers an unrelated question. Do not expand a frozen plan
+  after acquisition or weaken the post-mutation failure rule to keep a batch
+  moving.
 - Preregister each experiment: commit a SHA-256-pinned plan before acquiring
   data. If the plan is wrong, fix it in the next experiment; do not stack
   revision files.

--- a/crates/jet3-cli/src/snapshot.rs
+++ b/crates/jet3-cli/src/snapshot.rs
@@ -7,13 +7,13 @@ use std::path::PathBuf;
 use jet3::TextCodePage;
 use jet3_testkit::{
     INDEXED_UPDATE_SCENARIOS, PROTOCOL_SCENARIOS, Producer, ROW_ALLOCATION_SCENARIOS,
-    ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome, UPDATE_SCENARIOS, WRITE_SCENARIOS,
-    canonical_json, coverage, parse_scenarios, snapshot_bytes,
+    ROW_REPLACEMENT_SCENARIOS, ROW_UPDATE_SCENARIOS, SnapshotOptions, SnapshotOutcome,
+    UPDATE_SCENARIOS, WRITE_SCENARIOS, canonical_json, coverage, parse_scenarios, snapshot_bytes,
 };
 
 pub(crate) const HELP: &str = "\
   jet3-cli snapshot <file> --out <dir> --scenario <DAO-READ-...|DAO-WRITE-...|DAO-UPDATE-...> \
-    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update|row-allocation|indexed-update]
+    [--source-revision <text>] [--code-page 1252|1251] [--inventory row-update|row-allocation|indexed-update|row-replacement]
 
 snapshot reads the whole database with the jet3 reader and writes
 <dir>/snapshot.json (protocol 1.2 canonical semantic snapshot; omitted when
@@ -59,6 +59,7 @@ pub(crate) fn parse_args(
                 "row-update" => ROW_UPDATE_SCENARIOS,
                 "row-allocation" => ROW_ALLOCATION_SCENARIOS,
                 "indexed-update" => INDEXED_UPDATE_SCENARIOS,
+                "row-replacement" => ROW_REPLACEMENT_SCENARIOS,
                 _ => return Err("invalid_inventory"),
             });
         } else if option == "--code-page" {

--- a/crates/jet3-testkit/src/bin/jet3-row-replacement-fixture.rs
+++ b/crates/jet3-testkit/src/bin/jet3-row-replacement-fixture.rs
@@ -1,0 +1,9 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    let [command, scenario, directory] = args.as_slice() else {
+        return Err(
+            "usage: jet3-row-replacement-fixture generate|verify SCENARIO DIRECTORY".into(),
+        );
+    };
+    jet3_testkit::row_replacement_fixture(command, scenario, std::path::Path::new(directory))
+}

--- a/crates/jet3-testkit/src/lib.rs
+++ b/crates/jet3-testkit/src/lib.rs
@@ -44,3 +44,6 @@ pub use row_allocation_fixture::{ROW_ALLOCATION_SCENARIOS, row_allocation_fixtur
 
 mod indexed_update_fixture;
 pub use indexed_update_fixture::{INDEXED_UPDATE_SCENARIOS, indexed_update_fixture};
+
+mod row_replacement_fixture;
+pub use row_replacement_fixture::{ROW_REPLACEMENT_SCENARIOS, row_replacement_fixture};

--- a/crates/jet3-testkit/src/row_replacement_fixture.rs
+++ b/crates/jet3-testkit/src/row_replacement_fixture.rs
@@ -1,0 +1,392 @@
+//! Finite hosted sole-release and full-row replacements through public APIs.
+use jet3::{
+    CatalogObjectClass, ColumnSpec, ColumnType, DatabaseReader, ResourceBudget, ResourceLimits,
+    RowDelete, RowLocator, RowUpdate, RowValue, TableRows, TableSpec,
+    create_database_with_table_rows, delete_row, update_row,
+};
+use serde_json::{Value, json};
+use std::{fs, num::NonZeroU8, path::Path};
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub const ROW_REPLACEMENT_SCENARIOS: &str =
+    include_str!("../../../oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json");
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn integer(v: &Value) -> Result<i32> {
+    Ok(v.as_i64().ok_or("Long")?.try_into()?)
+}
+fn scenario(id: &str) -> Result<Value> {
+    let v: Value = serde_json::from_str(ROW_REPLACEMENT_SCENARIOS)?;
+    v["scenarios"]
+        .as_array()
+        .ok_or("scenarios")?
+        .iter()
+        .find(|s| s["id"] == id)
+        .cloned()
+        .ok_or_else(|| "unknown scenario".into())
+}
+fn values(row: &Value) -> Result<Vec<RowValue<'_>>> {
+    row.as_array()
+        .ok_or("row")?
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            Ok(if v.is_null() {
+                RowValue::Null
+            } else {
+                match i {
+                    0 | 1 => RowValue::Long(integer(v)?),
+                    2 => RowValue::Text(v.as_str().ok_or("Text")?.as_bytes()),
+                    3 => RowValue::Binary(v.as_str().ok_or("Binary ASCII")?.as_bytes()),
+                    4 => RowValue::Boolean(v.as_bool().ok_or("Boolean")?),
+                    _ => return Err("column".into()),
+                }
+            })
+        })
+        .collect()
+}
+fn generate(path: &Path, case: &Value) -> Result<()> {
+    let tables = case["tables"].as_array().ok_or("tables")?;
+    let columns = tables
+        .iter()
+        .map(|t| {
+            t["columns"]
+                .as_array()
+                .ok_or("columns")?
+                .iter()
+                .map(|c| {
+                    Ok(ColumnSpec::new(
+                        c["name"].as_str().ok_or("name")?.as_bytes(),
+                        match c["kind"].as_str() {
+                            Some("Long") => ColumnType::Long,
+                            Some("Text") => ColumnType::Text {
+                                max_len: NonZeroU8::MAX,
+                            },
+                            Some("Binary") => ColumnType::Binary {
+                                max_len: NonZeroU8::MAX,
+                            },
+                            Some("Boolean") => ColumnType::Boolean,
+                            _ => return Err("column type".into()),
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let rows = tables
+        .iter()
+        .map(|t| {
+            t.get("seed_rows")
+                .unwrap_or(&t["rows"])
+                .as_array()
+                .ok_or("rows")?
+                .iter()
+                .map(values)
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let slices = rows
+        .iter()
+        .map(|r| r.iter().map(Vec::as_slice).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let requests = tables
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            Ok(TableRows {
+                table: TableSpec {
+                    name: t["name"].as_str().ok_or("name")?.as_bytes(),
+                    columns: &columns[i],
+                    indexes: &[],
+                },
+                rows: &slices[i],
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    create_database_with_table_rows(path, &requests, &mut budget())?;
+    if let Some(id) = case["request"].get("seed_delete") {
+        let table = case["request"]["table"].as_str().ok_or("table")?;
+        let (_, row) = locate(path, table, integer(id)?)?;
+        delete_row(
+            path,
+            RowDelete {
+                table: table.as_bytes(),
+                row,
+            },
+            &mut budget(),
+        )?;
+    }
+    Ok(())
+}
+fn locate(path: &Path, table: &str, id: i32) -> Result<(u64, RowLocator)> {
+    let mut b = budget();
+    let mut db = DatabaseReader::open(path, &mut b)?;
+    let root = {
+        let mut c = db.catalog(&mut b)?;
+        let mut roots = Vec::new();
+        while let Some(r) = c.next_record()? {
+            if r.class() == CatalogObjectClass::User && r.name().raw_bytes() == table.as_bytes() {
+                roots.push(r.table_definition().ok_or("root")?);
+            }
+        }
+        if roots.len() != 1 {
+            return Err("table identity".into());
+        }
+        roots[0]
+    };
+    let def = db.table_definition(root, &mut b)?;
+    let column = def.columns().first().ok_or("Id")?.ordinal();
+    let mut found = Vec::new();
+    {
+        let mut rows = db.rows(&def, &mut b)?;
+        while let Some(r) = rows.next_row()? {
+            if r.field(column).and_then(|v| v.raw_bytes()) == Some(id.to_le_bytes().as_slice()) {
+                if r.locator() != r.storage_locator() {
+                    return Err("overflow".into());
+                }
+                found.push(r.locator());
+            }
+        }
+    }
+    if found.len() != 1 {
+        return Err("selected Id".into());
+    }
+    Ok((root.get(), found[0]))
+}
+fn word(bytes: &[u8], offset: usize) -> Result<usize> {
+    Ok(u16::from_le_bytes(
+        bytes
+            .get(offset..offset + 2)
+            .ok_or("word range")?
+            .try_into()?,
+    ) as usize)
+}
+fn dword(bytes: &[u8], offset: usize) -> Result<usize> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .ok_or("dword range")?
+            .try_into()?,
+    ) as usize)
+}
+fn put(bytes: &mut [u8], offset: usize, value: &[u8]) -> Result<()> {
+    bytes
+        .get_mut(offset..offset + value.len())
+        .ok_or("patch range")?
+        .copy_from_slice(value);
+    Ok(())
+}
+fn encoded(row: &Value) -> Result<Vec<u8>> {
+    let r = row.as_array().ok_or("row")?;
+    if r.len() != 5 {
+        return Err("five columns".into());
+    }
+    let mut bytes = vec![5];
+    bytes.extend(integer(&r[0])?.to_le_bytes());
+    bytes.extend(if r[1].is_null() { 0 } else { integer(&r[1])? }.to_le_bytes());
+    let mut ends = vec![9_u8];
+    let mut bitmap = 1_u8;
+    if !r[1].is_null() {
+        bitmap |= 2;
+    }
+    for (n, v) in r.iter().enumerate().take(4).skip(2) {
+        if !v.is_null() {
+            let text = v.as_str().ok_or("ASCII variable field")?;
+            if !text.is_ascii() {
+                return Err("ASCII recipe".into());
+            }
+            bytes.extend(text.as_bytes());
+            bitmap |= 1 << n;
+        }
+        ends.push(bytes.len().try_into()?);
+    }
+    if r[4].as_bool().ok_or("Boolean")? {
+        bitmap |= 16;
+    }
+    bytes.extend(ends.into_iter().rev());
+    bytes.extend([2, bitmap]);
+    Ok(bytes)
+}
+fn release_maps(bytes: &mut [u8], root: usize, page: usize) -> Result<()> {
+    let locators = [
+        (1, 0),
+        (dword(bytes, root + 35)? >> 8, bytes[root + 35] as usize),
+        (dword(bytes, root + 39)? >> 8, bytes[root + 39] as usize),
+    ];
+    for (role, (map, slot)) in locators.into_iter().enumerate() {
+        let base = map * 2048;
+        let start = word(bytes, base + 10 + 2 * slot)?;
+        let end = if slot == 0 {
+            2048
+        } else {
+            word(bytes, base + 8 + 2 * slot)?
+        };
+        if start >= end || end > 2048 || bytes.get(base + start) != Some(&0) {
+            return Err("inline map".into());
+        }
+        let relative = page
+            .checked_sub(dword(bytes, base + start + 1)?)
+            .ok_or("map base")?;
+        let offset = base + start + 5 + relative / 8;
+        if offset >= base + end {
+            return Err("map coverage".into());
+        }
+        let mask = 1 << (relative % 8);
+        if (bytes[offset] & mask != 0) == (role == 0) {
+            return Err("release membership".into());
+        }
+        bytes[offset] = if role == 0 {
+            bytes[offset] | mask
+        } else {
+            bytes[offset] & !mask
+        };
+    }
+    Ok(())
+}
+fn verify(id: &str, case: &Value, directory: &Path) -> Result<Value> {
+    let request = &case["request"];
+    let table = request["table"].as_str().ok_or("table")?;
+    let original = directory.join("before/database.mdb");
+    let updated = directory.join("after/database.mdb");
+    let before = fs::read(&original)?;
+    let after = fs::read(&updated)?;
+    let (root, locator) = locate(&original, table, integer(&request["selected_id"])?)?;
+    let base = locator.page().get() as usize * 2048;
+    let count = word(&before, base + 8)?;
+    let mut expected = before.clone();
+    if request["kind"] == "sole_release" {
+        if count != 1 || locator.slot() != 0 || word(&before, base + 10)? >= 2048 {
+            return Err("sole physical row".into());
+        }
+        expected[base] = 9;
+        put(&mut expected, base + 2, &2036_u16.to_le_bytes())?;
+        put(&mut expected, base + 10, &0xc800_u16.to_le_bytes())?;
+        let definition = root as usize * 2048;
+        let rows = dword(&before, definition + 12)?
+            .checked_sub(1)
+            .ok_or("row count")?;
+        put(
+            &mut expected,
+            definition + 12,
+            &u32::try_from(rows)?.to_le_bytes(),
+        )?;
+        release_maps(&mut expected, definition, locator.page().get() as usize)?;
+    } else {
+        let replacement = encoded(&request["replacement"])?;
+        let mut end = 2048_usize;
+        let mut has_tombstone = false;
+        for slot in 0..count {
+            let raw = word(&before, base + 10 + 2 * slot)?;
+            let start = raw & 0x1fff;
+            let oldend = if slot == 0 {
+                2048
+            } else {
+                word(&before, base + 8 + 2 * slot)? & 0x1fff
+            };
+            if start > oldend || oldend > 2048 {
+                return Err("row boundaries".into());
+            }
+            if raw & 0xe000 != 0 {
+                if raw & 0xe000 != 0xc000 || start != oldend {
+                    return Err("row flags".into());
+                }
+                has_tombstone = true;
+            }
+            let row = if slot == locator.slot() as usize {
+                replacement.as_slice()
+            } else {
+                &before[base + start..base + oldend]
+            };
+            end = end.checked_sub(row.len()).ok_or("row width")?;
+            put(&mut expected, base + end, row)?;
+            put(
+                &mut expected,
+                base + 10 + 2 * slot,
+                &u16::try_from((raw & 0xe000) | end)?.to_le_bytes(),
+            )?;
+        }
+        if request["tombstone"] == true && !has_tombstone {
+            return Err("missing tombstone".into());
+        }
+        let free = end.checked_sub(10 + 2 * count).ok_or("directory overlap")?;
+        put(&mut expected, base + 2, &u16::try_from(free)?.to_le_bytes())?;
+        if locate(&updated, table, integer(&request["selected_id"])?)?.1 != locator {
+            return Err("changed target slot".into());
+        }
+    }
+    if before.len() != after.len() || expected != after {
+        return Err("unplanned replacement/release bytes".into());
+    }
+    Ok(
+        json!({"scenario_id":id,"request":request,"locator":{"root":root,"page":locator.page().get(),"slot":locator.slot()},"preserved":true,"before_sha256":crate::sha256_hex(&before),"after_sha256":crate::sha256_hex(&after)}),
+    )
+}
+/// Generates finite public mutation pairs, or verifies retained bytes read-only.
+pub fn row_replacement_fixture(command: &str, id: &str, directory: &Path) -> Result<()> {
+    let case = scenario(id)?;
+    let kind = case["request"]["kind"].as_str().unwrap_or("");
+    if !matches!(kind, "sole_release" | "row_replace") {
+        return crate::indexed_update_fixture(command, id, directory);
+    }
+    if command == "generate" {
+        fs::create_dir(directory.join("before"))?;
+        fs::create_dir(directory.join("after"))?;
+        let before = directory.join("before/database.mdb");
+        let after = directory.join("after/database.mdb");
+        generate(&before, &case)?;
+        fs::copy(&before, &after)?;
+        let request = &case["request"];
+        let table = request["table"].as_str().ok_or("table")?;
+        let (_, row) = locate(&before, table, integer(&request["selected_id"])?)?;
+        if kind == "sole_release" {
+            delete_row(
+                &after,
+                RowDelete {
+                    table: table.as_bytes(),
+                    row,
+                },
+                &mut budget(),
+            )?;
+        } else {
+            update_row(
+                &after,
+                RowUpdate {
+                    table: table.as_bytes(),
+                    row,
+                    values: &values(&request["replacement"])?,
+                },
+                &mut budget(),
+            )?;
+        }
+    } else if command != "verify" {
+        return Err("expected generate or verify".into());
+    }
+    println!("{}", verify(id, &case, directory)?);
+    Ok(())
+}
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    #[test]
+    fn public_replacement_release_and_exact_preservation() -> Result<()> {
+        for suffix in [
+            "SOLE-RELEASE",
+            "ROW-GROW",
+            "ROW-SHRINK",
+            "ROW-LATER-TOMBSTONE",
+        ] {
+            let id = format!("DAO-UPDATE-{suffix}");
+            let d = tempfile::tempdir()?;
+            row_replacement_fixture("generate", &id, d.path())?;
+            let p = d.path().join("after/database.mdb");
+            let original = fs::read(&p)?;
+            for offset in [1538, original.len() - 1] {
+                let mut bad = original.clone();
+                bad[offset] ^= 1;
+                fs::write(&p, bad)?;
+                assert!(verify(&id, &scenario(&id)?, d.path()).is_err());
+            }
+        }
+        Ok(())
+    }
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11186,6 +11186,65 @@ Copy this block under the appropriate section and remove this instruction:
   additive EXP-0168 outcome. No general deletion grammar, sole-row page release,
   arbitrary compaction, hosted compatibility or support-state movement is claimed.
 
+## EXP-0210 — Explicit empty Memo candidates and native continuations
+
+- Status: local `observed_accepted`, six observations and no reasons, from the
+  single EXP-0209 run `20260905T122000Z-memo-candidate`. This is finite local
+  candidate evidence; `compatibility_claim` and `support_matrix_movement` remain
+  false and `development_only` remains true.
+- Frozen plan SHA-256
+  `9f517d9ae1d8563ccce84c2bfbfc9738acd14ac6f501d0f8aa305b6d970a9097`,
+  committed at `e5a403a`; reviewed public writer source
+  `871f71c315938bb7143a07d9f2f428cfef8c11e1`. The original analyzer and all 24
+  scoped input pins remain unchanged.
+- Retained under local VM `shared/outbox/20260905T122000Z-memo-candidate`:
+  `result.json`, 1,455,243 bytes, SHA-256
+  `abbf00348650a04471040dc4dafc135fe1eedfd20367e9b32bbb7f903d16dbab`;
+  `report.json`, 138,372 bytes, SHA-256
+  `c3bafaff967c8c68d2a8fc69d040e888ec23b4ca917ddafd791260230159ae1d`.
+  The unchanged analyzer reproduced the report byte-for-byte on a temporary copy.
+  All 41 retained files stayed byte-identical; all 36 captured MDB identities
+  matched their before/after receipts. Each MDB is 49,152 bytes.
+- The x86 `DAO.DBEngine.36` result records no acquisition or retention errors.
+  Three replicas each of `Rows(Id Long, M Memo)` and
+  `Ledger7(Id Long, Memo42Long Memo)` matched independent native DAO controls:
+  complete table/field metadata and properties, `AllowZeroLength = true`, empty
+  index/relationship/query inventories, and all baseline rows `(1, Null)`,
+  `(2, "")`, `(3, "A")` agreed.
+- Null remained `IsNull = true`, `FieldSize = 0`, with no Memo descriptor;
+  present-empty remained `IsNull = false`, `FieldSize = 0`, with inline bytes
+  `000000800000000000000000`. `"A"` remained present with `FieldSize = 2` and
+  `01000080000000000000000041`. These distinctions held in both roles.
+- All 24 native continuation inserts completed on separate baseline copies:
+  `(4, "")` or independently `(5, "B")`. Each yielded exactly four rows,
+  preserving the three baseline values and metadata. The added empty descriptor
+  matched the baseline empty descriptor; `"B"` used
+  `01000080000000000000000042` and `FieldSize = 2`. No baseline file was mutated.
+- Across all 36 captures, the table root was 20, data page 23, baseline slots
+  0/1/2 and continuation slot 3. Owned/available data maps were both `[23]`;
+  inline Memo long-value maps were empty. The catalog property maps both included
+  only page 22, which was excluded from the global free map.
+- Named property payloads exactly matched EXP-0208's true-state bytes: 91 bytes
+  for `M`, 100 for `Memo42Long`. Candidate LvProp used page 22 slot 0, controls
+  page 22 slot 2, including after continuation. Corresponding headers were
+  `5b0000400016000000000000` / `5b0000400216000000000000` and
+  `640000400016000000000000` / `640000400216000000000000`. Physical layout equality
+  between roles was not required.
+- This supports only the two tested names, Long-plus-Memo schemas, null/empty/A
+  baseline and separate empty/B continuation. It does not establish general
+  property grammar, other schema combinations, empty OLE behavior or hosted
+  support. EXP-0200 and EXP-0208 remain unchanged.
+
+Captured identities below are ordered candidate, control, candidate-empty-next,
+control-empty-next, candidate-value-next, control-value-next (SHA-256):
+
+- `short` replica 1: `f34785c20fb969f7668ef88ff007c370ef22cfa1d41deda7e1577aa447214a4b`, `adcf37b1984ca4614ca6b502aa723172e66283982917993ab98c36c773f90324`, `edc0f630282b5fedff4c82361af4d797c4bb1f98d13eb19695404efe9d2f81be`, `c0eb5121bd2c181cdc6614a46a1224e549362f8e9a6865af295f93fe38226ea8`, `06c9e32492f2a42cf9cb70ea297762913af169b1e5b67d5de7f316e0ac26c3fb`, `b9fc7e499b32a990f4dbc85eb8a4b344a13eed34d7d93d0f99faecda89560a82`.
+- `short` replica 2: `f34785c20fb969f7668ef88ff007c370ef22cfa1d41deda7e1577aa447214a4b`, `c724a63d23961bf26795e61f7a66dbe5992d8e8fd191e81a00c2700c422c7f65`, `edc0f630282b5fedff4c82361af4d797c4bb1f98d13eb19695404efe9d2f81be`, `ff0ab53103e7c7d4441d5c69a285c6c386645b1c08aafca6b256a5c6fd849e5a`, `06c9e32492f2a42cf9cb70ea297762913af169b1e5b67d5de7f316e0ac26c3fb`, `3dcf8eb2529822348e3b3d4edd1f397dd5a3a8ae77728f464369e7f13fdc4d6e`.
+- `short` replica 3: `f34785c20fb969f7668ef88ff007c370ef22cfa1d41deda7e1577aa447214a4b`, `515ee8d009e96380a3d7fdac6a25b77f1cbd3ed2080c2da3a963c3f048086b2b`, `edc0f630282b5fedff4c82361af4d797c4bb1f98d13eb19695404efe9d2f81be`, `84366b0d0d5f334025cad1a7feb1ed40766848c253bc82a3a593d45297c6ac42`, `06c9e32492f2a42cf9cb70ea297762913af169b1e5b67d5de7f316e0ac26c3fb`, `44d7a1f43dc8bed32031fea6ee5815f7872bd5cd5ab7f0b431f5653cf7600631`.
+- `renamed` replica 1: `fdd01464baab625fac257faa358df8b74af7ebaf4443272dd5348705b680460d`, `7dffc0b7085397e2d6a70c9ddae05e5f98f828804ed4f10fc36739cedd1c2998`, `e4125bd25bf13252f7aaf57bf7673ea27b62739e12ba2c4bcc7e77ecc607081d`, `186d6ce414fe51d3194e796dabffa979f4135c3f6437c633997c57cf236fba6d`, `75c27e952287cff4b987683078733b97f9e664337a937a5ccdaa40f691f23cb3`, `5551c71d84f16a4e539e3a1562353075fb526dda7ac410f1cd6c1e44cb6fc463`.
+- `renamed` replica 2: `fdd01464baab625fac257faa358df8b74af7ebaf4443272dd5348705b680460d`, `661025cea0c6f45cab22f0a5b6449e3fbfc9fd03e70e14dad6b200f8b079fa25`, `e4125bd25bf13252f7aaf57bf7673ea27b62739e12ba2c4bcc7e77ecc607081d`, `c91588662e906d7ec8572719e926410038fb724bd94d6cd8daf29d9a60a6ad46`, `75c27e952287cff4b987683078733b97f9e664337a937a5ccdaa40f691f23cb3`, `b46b39376c2426b1723ac0699c49fda5e72a95bd05950d23b5c5e4fe21d2fd1c`.
+- `renamed` replica 3: `fdd01464baab625fac257faa358df8b74af7ebaf4443272dd5348705b680460d`, `a73e2e46bb698c615935ce92ce159a99cf7c9d0bb4bcd311a11cfa9c08d66916`, `e4125bd25bf13252f7aaf57bf7673ea27b62739e12ba2c4bcc7e77ecc607081d`, `f9b97f9de28317310d65b0f5678331019d68be15377cabfcdde9c8ee8049bc2d`, `75c27e952287cff4b987683078733b97f9e664337a937a5ccdaa40f691f23cb3`, `ff82955570b86e5fc23b2c3ec7f43a7a89ceada7700d4062faaf200df5f9ba01`.
+
 ## EXP-0209 — Explicit empty Memo public creation candidates
 
 - Status: preregistered local candidate validation; acquisition has not run.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -11186,6 +11186,39 @@ Copy this block under the appropriate section and remove this instruction:
   additive EXP-0168 outcome. No general deletion grammar, sole-row page release,
   arbitrary compaction, hosted compatibility or support-state movement is claimed.
 
+## EXP-0209 — Explicit empty Memo public creation candidates
+
+- Status: preregistered local candidate validation; acquisition has not run.
+- Plan: `oracle/windows-dao/acquisition/memo-candidate.plan.json`, SHA-256
+  `9f517d9ae1d8563ccce84c2bfbfc9738acd14ac6f501d0f8aa305b6d970a9097`.
+- Reviewed implementation: `871f71c315938bb7143a07d9f2f428cfef8c11e1`;
+  generator `crates/jet3/examples/memo_allow_empty_candidate.rs` calls the public
+  creation API. The plan pins both generated images and 24 relevant source,
+  producer, decoder and transport inputs. No MDB bytes are committed.
+- Question: do explicit `AllowZeroLength` candidates retain null, present-empty
+  and nonempty Memo values under DAO reads and subsequent native inserts?
+- Two finite profiles are `Rows(Id Long, M Memo)` and
+  `Ledger7(Id Long, Memo42Long Memo)`, each with `(1, Null)`, `(2, "")`, `(3, "A")`.
+  Three independent native DAO controls per profile set `AllowZeroLength = true`.
+  Candidate/control baseline images are opened read-only and must remain unchanged.
+- Each baseline also supplies two separate writable copies: one receives `(4, "")`,
+  the other `(5, "B")`. All are closed before read-only observation. The inventory
+  is six pairs, 36 captures/images and 24 native continuation inserts.
+- Compare complete requested table/column metadata, all field properties including
+  `AllowZeroLength`, full rows with `IsNull` and `FieldSize`, and empty index,
+  relationship and query inventories. Raw checks bind every Id/slot/presence bit
+  and inline descriptor/payload; the catalog external LvProp payload must equal
+  the named true-state bytes from EXP-0208 with valid ownership/availability and
+  global allocation membership. Physical locations may differ across roles.
+- Acceptance requires every planned pair, operation, capture, identity and raw
+  check. Missing data or any failure produces `no_outcome`; subset matches do not
+  promote it. Initiating error endpoints and retained artifacts survive failure.
+  One coordinated dispatch is allowed, without automatic retry or resume.
+- This tests only the two named schemas and the specified small inline values.
+  It establishes no general property grammar, empty OLE behavior or hosted support.
+  EXP-0210 is reserved for the additive validated outcome; EXP-0200 and EXP-0208
+  remain unchanged.
+
 ## EXP-0208 — Named Memo AllowZeroLength property payload transitions
 
 - Single local EXP-0207 run `20260905T111500Z-memo-property`, frozen runtime

--- a/fuzz/tests/test_fuzz_campaign.py
+++ b/fuzz/tests/test_fuzz_campaign.py
@@ -520,12 +520,58 @@ class FuzzCampaignValidationTests(unittest.TestCase):
                 {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
             )
         self.assertLess(1024, reported_rss)
-        self.assertGreaterEqual(observer["peak_rss_bytes"], reported_rss)
+        self.assertGreaterEqual(observer["peak_rss_bytes"], 32 * 1024 * 1024)
         self.assertGreaterEqual(
             observer["peak_rss_bytes"],
             fuzz_evidence.parse_reported_rss(log_path.read_text(encoding="utf-8")),
         )
         self.assertEqual(observer["executable"]["path"], str(executable))
+
+    @unittest.skipUnless(sys.platform == "linux", "Linux inherited RSS regression")
+    def test_observer_excludes_parent_peak_and_keeps_target_exit_signal(self) -> None:
+        # Touch a large live coordinator allocation before the intermediary exec.
+        parent = bytearray(160 * 1024 * 1024)
+        for offset in range(0, len(parent), 4096): parent[offset] = 1
+        script = (
+            "import resource,time\n"
+            "print('#1 DONE rss: %dMb' % (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss // 1024), flush=True)\n"
+            "time.sleep(0.1)\n"
+        )
+        observer = fuzz_evidence.observe_producer(
+            self.root, self.bundle / "small.log", [str(Path(sys.executable).resolve()), "-c", script],
+            10, {}, {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+        )
+        self.assertLess(observer["peak_rss_bytes"], 80 * 1024 * 1024)
+        self.assertLess(fuzz_evidence.parse_reported_rss((self.bundle / "small.log").read_text()), 80 * 1024 * 1024)
+        self.assertEqual(observer["exit_code"], 0)
+        del parent
+        for ending, expected in [("raise SystemExit(7)", 7), ("import os,signal; os.kill(os.getpid(), signal.SIGTERM)", -15)]:
+            observer = fuzz_evidence.observe_producer(
+                self.root, self.bundle / "exit.log",
+                [str(Path(sys.executable).resolve()), "-c", "print('#1 DONE rss: 1Mb', flush=True); " + ending],
+                10, {}, {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+            )
+            self.assertEqual(observer["exit_code"], expected)
+
+    @unittest.skipUnless(sys.platform == "linux", "Linux process-group cleanup")
+    def test_observer_timeout_kills_target_descendants(self) -> None:
+        pidfile = self.bundle / "descendant.pid"
+        script = (
+            "import subprocess,sys,time\n"
+            "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)'])\n"
+            f"open({str(pidfile)!r},'w').write(str(p.pid))\n"
+            "print('#1 INITED rss: 1Mb',flush=True)\n"
+            "time.sleep(30)\n"
+        )
+        observer = fuzz_evidence.observe_producer(
+            self.root, self.bundle / "timeout.log", [str(Path(sys.executable).resolve()), "-c", script],
+            0.5, {}, {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+        )
+        self.assertTrue(observer["timed_out"])
+        self.assertIsNone(observer["exit_code"])
+        self.assertEqual(observer["result"], "hang")
+        state = Path('/proc') / pidfile.read_text() / 'stat'
+        if state.exists(): self.assertEqual(state.read_text().split()[2], 'Z')
 
     def test_vacuous_registry_is_rejected(self) -> None:
         self.registry["targets"] = []

--- a/fuzz/tools/fuzz_evidence.py
+++ b/fuzz/tools/fuzz_evidence.py
@@ -11,6 +11,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -154,8 +155,8 @@ def _process_tree_rss(root_pid: int) -> int:
     return sum(rows[pid][1] for pid in descendants if pid in rows) * 1024
 
 
-def _rusage_peak_rss_bytes(usage: Any) -> int:
-    peak = int(usage.ru_maxrss)
+def _rusage_peak_rss_bytes(peak: int) -> int:
+    peak = int(peak)
     return peak if sys.platform == "darwin" else peak * 1024
 
 
@@ -180,10 +181,15 @@ def observe_producer(
     peak_rss = 0
     timed_out = False
     wait_status: int | None = None
-    producer_usage: Any | None = None
-    with log_path.open("wb") as log:
+    with log_path.open("wb") as log, tempfile.TemporaryFile() as receipt:
         producer = subprocess.Popen(
-            command,
+            [
+                str(Path(sys.executable).resolve()),
+                str(Path(__file__).with_name("fuzz_process.py")),
+                str(receipt.fileno()),
+                *command,
+            ],
+            pass_fds=(receipt.fileno(),),
             cwd=root,
             env=environment,
             stdout=log,
@@ -193,29 +199,34 @@ def observe_producer(
         deadline = started_clock + timeout_seconds
         try:
             while True:
-                waited_pid, status, usage = os.wait4(producer.pid, os.WNOHANG)
+                waited_pid, status, _ = os.wait4(producer.pid, os.WNOHANG)
                 if waited_pid == producer.pid:
                     wait_status = status
-                    producer_usage = usage
                     break
                 peak_rss = max(peak_rss, _process_tree_rss(producer.pid))
                 if time.monotonic() >= deadline:
                     timed_out = True
                     os.killpg(producer.pid, signal.SIGKILL)
-                    _, wait_status, producer_usage = os.wait4(producer.pid, 0)
+                    _, wait_status, _ = os.wait4(producer.pid, 0)
                     break
                 time.sleep(0.05)
         except BaseException:
             if wait_status is None:
                 os.killpg(producer.pid, signal.SIGKILL)
-                _, wait_status, producer_usage = os.wait4(producer.pid, 0)
+                _, wait_status, _ = os.wait4(producer.pid, 0)
             raise
         finally:
             if wait_status is not None:
                 producer.returncode = os.waitstatus_to_exitcode(wait_status)
-        if producer_usage is not None:
-            peak_rss = max(peak_rss, _rusage_peak_rss_bytes(producer_usage))
         exit_code = None if timed_out else producer.returncode
+        if not timed_out:
+            receipt.seek(0)
+            try:
+                target = json.load(receipt)
+                peak_rss = max(peak_rss, _rusage_peak_rss_bytes(target["maxrss"]))
+                exit_code = os.waitstatus_to_exitcode(target["status"])
+            except (ValueError, KeyError, TypeError) as error:
+                raise EvidenceError("target process did not return resource usage") from error
         log.flush()
         os.fsync(log.fileno())
     finished_clock = time.monotonic()

--- a/fuzz/tools/fuzz_process.py
+++ b/fuzz/tools/fuzz_process.py
@@ -1,0 +1,20 @@
+"""Launch a fuzz target from a fresh process so its RSS excludes the coordinator."""
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    receipt_fd = int(sys.argv[1])
+    # Fork only after this interpreter has exec'd: Linux otherwise carries the
+    # coordinator's resident memory into the target's getrusage high-water mark.
+    child = subprocess.Popen(sys.argv[2:])
+    _, status, usage = os.wait4(child.pid, 0)
+    child.returncode = os.waitstatus_to_exitcode(status)
+    receipt = json.dumps({"status": status, "maxrss": usage.ru_maxrss}).encode()
+    os.write(receipt_fd, receipt)
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle/windows-dao/acquisition/memo-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/memo-candidate.plan.json
@@ -1,0 +1,112 @@
+{
+  "document_type": "dao_memo_candidate_plan",
+  "provenance": "EXP-0209",
+  "outcome_provenance": "EXP-0210",
+  "source_revision": "871f71c315938bb7143a07d9f2f428cfef8c11e1",
+  "replicas": 3,
+  "arms": [
+    {
+      "name": "short",
+      "table": "Rows",
+      "memo": "M",
+      "rows": [
+        [
+          1,
+          null
+        ],
+        [
+          2,
+          ""
+        ],
+        [
+          3,
+          "A"
+        ]
+      ],
+      "property_payload_hex": "4b4b4400210000008000080052657175697265640f00416c6c6f775a65726f4c656e67746817000000010008000000020049640900010100000100001f00000001000700000001004d0900010101000100ff090001010000010000"
+    },
+    {
+      "name": "renamed",
+      "table": "Ledger7",
+      "memo": "Memo42Long",
+      "rows": [
+        [
+          1,
+          null
+        ],
+        [
+          2,
+          ""
+        ],
+        [
+          3,
+          "A"
+        ]
+      ],
+      "property_payload_hex": "4b4b4400210000008000080052657175697265640f00416c6c6f775a65726f4c656e6774681700000001000800000002004964090001010000010000280000000100100000000a004d656d6f34324c6f6e670900010101000100ff090001010000010000"
+    }
+  ],
+  "continuations": [
+    {
+      "name": "empty-next",
+      "row": [
+        4,
+        ""
+      ]
+    },
+    {
+      "name": "value-next",
+      "row": [
+        5,
+        "B"
+      ]
+    }
+  ],
+  "images": {
+    "short.mdb": {
+      "size": 49152,
+      "sha256": "f34785c20fb969f7668ef88ff007c370ef22cfa1d41deda7e1577aa447214a4b"
+    },
+    "renamed.mdb": {
+      "size": 49152,
+      "sha256": "fdd01464baab625fac257faa358df8b74af7ebaf4443272dd5348705b680460d"
+    }
+  },
+  "inputs": {
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/memo_allow_empty_candidate.rs": "acd8f5f1afd1532d3a924ea7c9cc26877b04aa42d7c398eafd28197d2871d9f8",
+    "crates/jet3/src/creation/columns.rs": "e7dc54eab60544ae5fbcc835f1c0abb9024df2f8b6eb51295fac8f0977c9543e",
+    "crates/jet3/src/creation/api.rs": "a5b178f1b42a079ba21606fdbe588f214e5ea5601f12fbc89c703e70fdb41be5",
+    "crates/jet3/src/creation/schema_plan.rs": "a6829efba233b33e1f8d332f7840b5cb4ba0ccbb8919eec46383647bc5552143",
+    "crates/jet3/src/creation/composer/mod.rs": "b0681c4c3e8c1fd15443e79e6abccfcebcf8f9d622113c82103db1838d4c4e44",
+    "crates/jet3/src/creation/composer/table_create.rs": "6b696fb00c229a0517116736339c6b25cc62439fb5514e3514edbd662ca78d93",
+    "crates/jet3/src/creation/composer/initial_long_values.rs": "61f53ea644ef8c7525d309b86caf32ac8f914a94c7786643fc1fc9225d0b71af",
+    "crates/jet3/src/memo_property.rs": "5943bc57a58281f569e1274d7e3781a299b96996a64d512fc93ff7c11644df1f",
+    "crates/jet3/src/long_value_writer.rs": "1ba31d64927c4120276945296fd27c194389c57f3c5fd3115858f78ea5172bae",
+    "crates/jet3/src/long_value.rs": "0fe9ec300202d10e8ced2329012283e5f81e0e861ad4f54a0d5529ac76e581df",
+    "crates/jet3/src/row_writer.rs": "35c8310d027db4321a6251b1b68616d9ae0c6c8f4e82af0b1fd5e36b729420fb",
+    "crates/jet3/src/row.rs": "64647c6c4ed50f88841d6d28fcf170653055e44ec4e3ee61f1ec2aaa50a5d1ae",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "oracle/windows-dao/scripts/memo_candidate.py": "ff4b5a31695503e3c5f9512e917e3bd06db0a20d8259b191c9e614326bf8008c",
+    "oracle/windows-dao/scripts/memo_candidate.ps1": "dded3d865f5a336ed2943d1c51a2404eb0f0549135234c89636e6a7e44f636a0",
+    "oracle/windows-dao/scripts/empty_long_values.ps1": "f057ca96ee79c32e8fdca259eaabce60582fc2f95a535db8e9ac1a7b0d249608",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "question": "Do the two exact explicit-AllowZeroLength public Memo candidates preserve null, present-empty and nonempty values/properties under DAO reads and subsequent independent empty/nonempty inserts?",
+  "sequence": [
+    "Commit and independently review the plan and source/image pins before one local dispatch. No retry or resume.",
+    "Two Long Id + Memo profiles use table/column names Rows/M and Ledger7/Memo42Long. Create three independent native DAO controls per profile, setting AllowZeroLength true before rows (1, Null), (2, empty), (3, A); compare immutable public API candidates.",
+    "Capture each candidate/control baseline read-only and unchanged. Compare complete requested schema and field properties, empty relation/index/query inventory, all typed rows, IsNull, FieldSize and raw row/descriptor/payload/maps.",
+    "On separate candidate/control copies insert (4, empty), or independently (5, B); close and capture read-only. There are 36 total images/captures and 24 native continuation inserts. Originals remain unchanged.",
+    "Require the exact named property payload observed in EXP-0208 (locations may differ), catalog LvProp framing/map ownership, complete row/null-mask/inline-payload bindings and image identities. Candidate/control physical-byte equality is not required.",
+    "Any acquisition, source, pin, metadata, payload, continuation or retention failure gives no_outcome without subset promotion. Retain original/copy MDBs and initiating native failure diagnostics."
+  ],
+  "decision_rule": "observed_accepted iff all six pairs and 36 captures satisfy complete expected baseline or independent continuation snapshots and raw catalog/property/row/map checks with unchanged read identities; all 24 continuation inserts completed. Otherwise no_outcome.",
+  "bounds": "Only these two three-row Long + Memo profiles plus one independent empty/nonempty continuation; no empty OLE normalization, other property types, arbitrary schema/update/allocation policy or hosted support. Existing 64-page/64-slot decoder bounds suffice; one SSH call with a 600-second timeout."
+}

--- a/oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json
+++ b/oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json
@@ -1,0 +1,3530 @@
+{
+  "document_type": "dao_update_scenario_inventory",
+  "protocol_version": "1.2.0",
+  "scenarios": [
+    {
+      "id": "DAO-UPDATE-FIRST-FIELD",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              1000,
+              "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "00!!"
+            ],
+            [
+              1,
+              1001,
+              "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "01!!"
+            ],
+            [
+              2,
+              1002,
+              "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "02!!"
+            ],
+            [
+              3,
+              1003,
+              "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "03!!"
+            ],
+            [
+              4,
+              1004,
+              "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "04!!"
+            ],
+            [
+              5,
+              1005,
+              "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "05!!"
+            ],
+            [
+              6,
+              1006,
+              "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "06!!"
+            ],
+            [
+              7,
+              1007,
+              "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "07!!"
+            ],
+            [
+              8,
+              1008,
+              "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "08!!"
+            ],
+            [
+              9,
+              1009,
+              "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "09!!"
+            ],
+            [
+              10,
+              1010,
+              "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "10!!"
+            ],
+            [
+              11,
+              1011,
+              "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "11!!"
+            ],
+            [
+              12,
+              1012,
+              "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "12!!"
+            ],
+            [
+              13,
+              1013,
+              "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "13!!"
+            ],
+            [
+              14,
+              1014,
+              "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "14!!"
+            ],
+            [
+              15,
+              1015,
+              "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "15!!"
+            ],
+            [
+              16,
+              1016,
+              "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "16!!"
+            ],
+            [
+              17,
+              1017,
+              "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "17!!"
+            ],
+            [
+              18,
+              1018,
+              "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "18!!"
+            ],
+            [
+              19,
+              1019,
+              "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "19!!"
+            ],
+            [
+              20,
+              1020,
+              "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "20!!"
+            ],
+            [
+              21,
+              1021,
+              "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "21!!"
+            ],
+            [
+              22,
+              1022,
+              "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "22!!"
+            ],
+            [
+              23,
+              1023,
+              "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "23!!"
+            ],
+            [
+              24,
+              1024,
+              "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "24!!"
+            ],
+            [
+              25,
+              1025,
+              "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "25!!"
+            ],
+            [
+              26,
+              1026,
+              "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "26!!"
+            ],
+            [
+              27,
+              1027,
+              "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "27!!"
+            ],
+            [
+              28,
+              1028,
+              "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "28!!"
+            ],
+            [
+              29,
+              1029,
+              "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "29!!"
+            ],
+            [
+              30,
+              1030,
+              "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "30!!"
+            ],
+            [
+              31,
+              1031,
+              "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "31!!"
+            ],
+            [
+              32,
+              1032,
+              "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "32!!"
+            ]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Id",
+        "row_index": 0,
+        "before": 0,
+        "after": -42
+      }
+    },
+    {
+      "id": "DAO-UPDATE-LATER-ROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              1000,
+              "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "00!!"
+            ],
+            [
+              1,
+              1001,
+              "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "01!!"
+            ],
+            [
+              2,
+              1002,
+              "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "02!!"
+            ],
+            [
+              3,
+              1003,
+              "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "03!!"
+            ],
+            [
+              4,
+              1004,
+              "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "04!!"
+            ],
+            [
+              5,
+              1005,
+              "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "05!!"
+            ],
+            [
+              6,
+              1006,
+              "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "06!!"
+            ],
+            [
+              7,
+              1007,
+              "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "07!!"
+            ],
+            [
+              8,
+              1008,
+              "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "08!!"
+            ],
+            [
+              9,
+              1009,
+              "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "09!!"
+            ],
+            [
+              10,
+              1010,
+              "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "10!!"
+            ],
+            [
+              11,
+              1011,
+              "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "11!!"
+            ],
+            [
+              12,
+              1012,
+              "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "12!!"
+            ],
+            [
+              13,
+              1013,
+              "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "13!!"
+            ],
+            [
+              14,
+              1014,
+              "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "14!!"
+            ],
+            [
+              15,
+              1015,
+              "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "15!!"
+            ],
+            [
+              16,
+              1016,
+              "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "16!!"
+            ],
+            [
+              17,
+              1017,
+              "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "17!!"
+            ],
+            [
+              18,
+              1018,
+              "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "18!!"
+            ],
+            [
+              19,
+              1019,
+              "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "19!!"
+            ],
+            [
+              20,
+              1020,
+              "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "20!!"
+            ],
+            [
+              21,
+              1021,
+              "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "21!!"
+            ],
+            [
+              22,
+              1022,
+              "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "22!!"
+            ],
+            [
+              23,
+              1023,
+              "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "23!!"
+            ],
+            [
+              24,
+              1024,
+              "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "24!!"
+            ],
+            [
+              25,
+              1025,
+              "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "25!!"
+            ],
+            [
+              26,
+              1026,
+              "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "26!!"
+            ],
+            [
+              27,
+              1027,
+              "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "27!!"
+            ],
+            [
+              28,
+              1028,
+              "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "28!!"
+            ],
+            [
+              29,
+              1029,
+              "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "29!!"
+            ],
+            [
+              30,
+              1030,
+              "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "30!!"
+            ],
+            [
+              31,
+              1031,
+              "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "31!!"
+            ],
+            [
+              32,
+              1032,
+              "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "32!!"
+            ]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Value",
+        "row_index": 31,
+        "before": 1031,
+        "after": -2147483648
+      }
+    },
+    {
+      "id": "DAO-UPDATE-LATER-TABLE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "present fixed Long replacement",
+        "unrelated Text/Binary/Memo and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Prefix",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              100
+            ],
+            [
+              101
+            ]
+          ]
+        },
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Label",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Blob",
+              "kind": "Binary",
+              "size": 4
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              1000,
+              "row000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "00!!"
+            ],
+            [
+              1,
+              1001,
+              "row001:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "01!!"
+            ],
+            [
+              2,
+              1002,
+              "row002:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "02!!"
+            ],
+            [
+              3,
+              1003,
+              "row003:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "03!!"
+            ],
+            [
+              4,
+              1004,
+              "row004:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "04!!"
+            ],
+            [
+              5,
+              1005,
+              "row005:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "05!!"
+            ],
+            [
+              6,
+              1006,
+              "row006:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "06!!"
+            ],
+            [
+              7,
+              1007,
+              "row007:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "07!!"
+            ],
+            [
+              8,
+              1008,
+              "row008:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "08!!"
+            ],
+            [
+              9,
+              1009,
+              "row009:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "09!!"
+            ],
+            [
+              10,
+              1010,
+              "row010:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "10!!"
+            ],
+            [
+              11,
+              1011,
+              "row011:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "11!!"
+            ],
+            [
+              12,
+              1012,
+              "row012:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "12!!"
+            ],
+            [
+              13,
+              1013,
+              "row013:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "13!!"
+            ],
+            [
+              14,
+              1014,
+              "row014:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "14!!"
+            ],
+            [
+              15,
+              1015,
+              "row015:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "15!!"
+            ],
+            [
+              16,
+              1016,
+              "row016:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "16!!"
+            ],
+            [
+              17,
+              1017,
+              "row017:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "17!!"
+            ],
+            [
+              18,
+              1018,
+              "row018:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "18!!"
+            ],
+            [
+              19,
+              1019,
+              "row019:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "19!!"
+            ],
+            [
+              20,
+              1020,
+              "row020:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "20!!"
+            ],
+            [
+              21,
+              1021,
+              "row021:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "21!!"
+            ],
+            [
+              22,
+              1022,
+              "row022:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "22!!"
+            ],
+            [
+              23,
+              1023,
+              "row023:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "23!!"
+            ],
+            [
+              24,
+              1024,
+              "row024:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "24!!"
+            ],
+            [
+              25,
+              1025,
+              "row025:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "25!!"
+            ],
+            [
+              26,
+              1026,
+              "row026:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "26!!"
+            ],
+            [
+              27,
+              1027,
+              "row027:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "27!!"
+            ],
+            [
+              28,
+              1028,
+              "row028:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "28!!"
+            ],
+            [
+              29,
+              1029,
+              "row029:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "29!!"
+            ],
+            [
+              30,
+              1030,
+              "row030:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "30!!"
+            ],
+            [
+              31,
+              1031,
+              "row031:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "31!!"
+            ],
+            [
+              32,
+              1032,
+              "row032:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "32!!"
+            ]
+          ]
+        },
+        {
+          "name": "Notes",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Body",
+              "kind": "Memo"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              7,
+              {
+                "repeat_text": "m",
+                "count": 2048
+              }
+            ],
+            [
+              8,
+              null
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "table": "Items",
+        "column": "Value",
+        "row_index": 17,
+        "before": 1017,
+        "after": 2147483647
+      }
+    },
+    {
+      "id": "DAO-UPDATE-INSERT-ROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public row insert",
+        "exact unrelated-byte and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "insert",
+        "table": "Items",
+        "row": [
+          88,
+          -8800,
+          "inserted"
+        ]
+      }
+    },
+    {
+      "id": "DAO-UPDATE-DELETE-TAIL",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public row delete",
+        "exact unrelated-byte and table preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa"
+            ],
+            [
+              2,
+              -202,
+              "bbb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "delete",
+        "table": "Items",
+        "selected_id": 3
+      }
+    },
+    {
+      "id": "DAO-UPDATE-EMPTY-EOF",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded eof_insert",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": []
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "eof_insert",
+        "row": [
+          88,
+          -8800,
+          "inserted"
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-FULL-EOF",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded eof_insert",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              -1,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              2,
+              -2,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              3,
+              -3,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              4,
+              -4,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              5,
+              -5,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              6,
+              -6,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ],
+            [
+              7,
+              -7,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "eof_insert",
+        "row": [
+          88,
+          -8800,
+          "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-MIDDLE-COMPACT",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded compact_delete",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "a"
+            ],
+            [
+              2,
+              -202,
+              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ],
+            [
+              3,
+              303,
+              "short"
+            ],
+            [
+              4,
+              404,
+              "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "compact_delete",
+        "selected_ids": [
+          2
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-REPEATED-COMPACT",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded compact_delete",
+        "exact unrelated-byte preservation including page zero and maps"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "a"
+            ],
+            [
+              2,
+              -202,
+              "bb"
+            ],
+            [
+              3,
+              303,
+              "ccc"
+            ],
+            [
+              4,
+              404,
+              "dddd"
+            ],
+            [
+              5,
+              505,
+              "eeeee"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "compact_delete",
+        "selected_ids": [
+          2,
+          4,
+          1
+        ],
+        "table": "Items"
+      }
+    },
+    {
+      "id": "DAO-UPDATE-PRIMARY-KEY",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              -10,
+              100,
+              "payload"
+            ],
+            [
+              0,
+              101,
+              "payload"
+            ],
+            [
+              10,
+              102,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 0,
+        "selector_column": 0,
+        "selected": 0,
+        "replacement": -2147483648
+      },
+      "index_queries": [
+        -2147483648,
+        -10,
+        0,
+        10,
+        999
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-DESCENDING-KEY",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "unique",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": true
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              -2147483648,
+              100,
+              "payload"
+            ],
+            [
+              0,
+              101,
+              "payload"
+            ],
+            [
+              2147483647,
+              102,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 0,
+        "selector_column": 0,
+        "selected": 0,
+        "replacement": 2147483646
+      },
+      "index_queries": [
+        -2147483648,
+        0,
+        999,
+        2147483646,
+        2147483647
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-FULL-LEAF-KEY",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "primary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              0,
+              100,
+              "payload"
+            ],
+            [
+              1,
+              101,
+              "payload"
+            ],
+            [
+              2,
+              102,
+              "payload"
+            ],
+            [
+              3,
+              103,
+              "payload"
+            ],
+            [
+              4,
+              104,
+              "payload"
+            ],
+            [
+              5,
+              105,
+              "payload"
+            ],
+            [
+              6,
+              106,
+              "payload"
+            ],
+            [
+              7,
+              107,
+              "payload"
+            ],
+            [
+              8,
+              108,
+              "payload"
+            ],
+            [
+              9,
+              109,
+              "payload"
+            ],
+            [
+              10,
+              110,
+              "payload"
+            ],
+            [
+              11,
+              111,
+              "payload"
+            ],
+            [
+              12,
+              112,
+              "payload"
+            ],
+            [
+              13,
+              113,
+              "payload"
+            ],
+            [
+              14,
+              114,
+              "payload"
+            ],
+            [
+              15,
+              115,
+              "payload"
+            ],
+            [
+              16,
+              116,
+              "payload"
+            ],
+            [
+              17,
+              117,
+              "payload"
+            ],
+            [
+              18,
+              118,
+              "payload"
+            ],
+            [
+              19,
+              119,
+              "payload"
+            ],
+            [
+              20,
+              120,
+              "payload"
+            ],
+            [
+              21,
+              121,
+              "payload"
+            ],
+            [
+              22,
+              122,
+              "payload"
+            ],
+            [
+              23,
+              123,
+              "payload"
+            ],
+            [
+              24,
+              124,
+              "payload"
+            ],
+            [
+              25,
+              125,
+              "payload"
+            ],
+            [
+              26,
+              126,
+              "payload"
+            ],
+            [
+              27,
+              127,
+              "payload"
+            ],
+            [
+              28,
+              128,
+              "payload"
+            ],
+            [
+              29,
+              129,
+              "payload"
+            ],
+            [
+              30,
+              130,
+              "payload"
+            ],
+            [
+              31,
+              131,
+              "payload"
+            ],
+            [
+              32,
+              132,
+              "payload"
+            ],
+            [
+              33,
+              133,
+              "payload"
+            ],
+            [
+              34,
+              134,
+              "payload"
+            ],
+            [
+              35,
+              135,
+              "payload"
+            ],
+            [
+              36,
+              136,
+              "payload"
+            ],
+            [
+              37,
+              137,
+              "payload"
+            ],
+            [
+              38,
+              138,
+              "payload"
+            ],
+            [
+              39,
+              139,
+              "payload"
+            ],
+            [
+              40,
+              140,
+              "payload"
+            ],
+            [
+              41,
+              141,
+              "payload"
+            ],
+            [
+              42,
+              142,
+              "payload"
+            ],
+            [
+              43,
+              143,
+              "payload"
+            ],
+            [
+              44,
+              144,
+              "payload"
+            ],
+            [
+              45,
+              145,
+              "payload"
+            ],
+            [
+              46,
+              146,
+              "payload"
+            ],
+            [
+              47,
+              147,
+              "payload"
+            ],
+            [
+              48,
+              148,
+              "payload"
+            ],
+            [
+              49,
+              149,
+              "payload"
+            ],
+            [
+              50,
+              150,
+              "payload"
+            ],
+            [
+              51,
+              151,
+              "payload"
+            ],
+            [
+              52,
+              152,
+              "payload"
+            ],
+            [
+              53,
+              153,
+              "payload"
+            ],
+            [
+              54,
+              154,
+              "payload"
+            ],
+            [
+              55,
+              155,
+              "payload"
+            ],
+            [
+              56,
+              156,
+              "payload"
+            ],
+            [
+              57,
+              157,
+              "payload"
+            ],
+            [
+              58,
+              158,
+              "payload"
+            ],
+            [
+              59,
+              159,
+              "payload"
+            ],
+            [
+              60,
+              160,
+              "payload"
+            ],
+            [
+              61,
+              161,
+              "payload"
+            ],
+            [
+              62,
+              162,
+              "payload"
+            ],
+            [
+              63,
+              163,
+              "payload"
+            ],
+            [
+              64,
+              164,
+              "payload"
+            ],
+            [
+              65,
+              165,
+              "payload"
+            ],
+            [
+              66,
+              166,
+              "payload"
+            ],
+            [
+              67,
+              167,
+              "payload"
+            ],
+            [
+              68,
+              168,
+              "payload"
+            ],
+            [
+              69,
+              169,
+              "payload"
+            ],
+            [
+              70,
+              170,
+              "payload"
+            ],
+            [
+              71,
+              171,
+              "payload"
+            ],
+            [
+              72,
+              172,
+              "payload"
+            ],
+            [
+              73,
+              173,
+              "payload"
+            ],
+            [
+              74,
+              174,
+              "payload"
+            ],
+            [
+              75,
+              175,
+              "payload"
+            ],
+            [
+              76,
+              176,
+              "payload"
+            ],
+            [
+              77,
+              177,
+              "payload"
+            ],
+            [
+              78,
+              178,
+              "payload"
+            ],
+            [
+              79,
+              179,
+              "payload"
+            ],
+            [
+              80,
+              180,
+              "payload"
+            ],
+            [
+              81,
+              181,
+              "payload"
+            ],
+            [
+              82,
+              182,
+              "payload"
+            ],
+            [
+              83,
+              183,
+              "payload"
+            ],
+            [
+              84,
+              184,
+              "payload"
+            ],
+            [
+              85,
+              185,
+              "payload"
+            ],
+            [
+              86,
+              186,
+              "payload"
+            ],
+            [
+              87,
+              187,
+              "payload"
+            ],
+            [
+              88,
+              188,
+              "payload"
+            ],
+            [
+              89,
+              189,
+              "payload"
+            ],
+            [
+              90,
+              190,
+              "payload"
+            ],
+            [
+              91,
+              191,
+              "payload"
+            ],
+            [
+              92,
+              192,
+              "payload"
+            ],
+            [
+              93,
+              193,
+              "payload"
+            ],
+            [
+              94,
+              194,
+              "payload"
+            ],
+            [
+              95,
+              195,
+              "payload"
+            ],
+            [
+              96,
+              196,
+              "payload"
+            ],
+            [
+              97,
+              197,
+              "payload"
+            ],
+            [
+              98,
+              198,
+              "payload"
+            ],
+            [
+              99,
+              199,
+              "payload"
+            ],
+            [
+              100,
+              200,
+              "payload"
+            ],
+            [
+              101,
+              201,
+              "payload"
+            ],
+            [
+              102,
+              202,
+              "payload"
+            ],
+            [
+              103,
+              203,
+              "payload"
+            ],
+            [
+              104,
+              204,
+              "payload"
+            ],
+            [
+              105,
+              205,
+              "payload"
+            ],
+            [
+              106,
+              206,
+              "payload"
+            ],
+            [
+              107,
+              207,
+              "payload"
+            ],
+            [
+              108,
+              208,
+              "payload"
+            ],
+            [
+              109,
+              209,
+              "payload"
+            ],
+            [
+              110,
+              210,
+              "payload"
+            ],
+            [
+              111,
+              211,
+              "payload"
+            ],
+            [
+              112,
+              212,
+              "payload"
+            ],
+            [
+              113,
+              213,
+              "payload"
+            ],
+            [
+              114,
+              214,
+              "payload"
+            ],
+            [
+              115,
+              215,
+              "payload"
+            ],
+            [
+              116,
+              216,
+              "payload"
+            ],
+            [
+              117,
+              217,
+              "payload"
+            ],
+            [
+              118,
+              218,
+              "payload"
+            ],
+            [
+              119,
+              219,
+              "payload"
+            ],
+            [
+              120,
+              220,
+              "payload"
+            ],
+            [
+              121,
+              221,
+              "payload"
+            ],
+            [
+              122,
+              222,
+              "payload"
+            ],
+            [
+              123,
+              223,
+              "payload"
+            ],
+            [
+              124,
+              224,
+              "payload"
+            ],
+            [
+              125,
+              225,
+              "payload"
+            ],
+            [
+              126,
+              226,
+              "payload"
+            ],
+            [
+              127,
+              227,
+              "payload"
+            ],
+            [
+              128,
+              228,
+              "payload"
+            ],
+            [
+              129,
+              229,
+              "payload"
+            ],
+            [
+              130,
+              230,
+              "payload"
+            ],
+            [
+              131,
+              231,
+              "payload"
+            ],
+            [
+              132,
+              232,
+              "payload"
+            ],
+            [
+              133,
+              233,
+              "payload"
+            ],
+            [
+              134,
+              234,
+              "payload"
+            ],
+            [
+              135,
+              235,
+              "payload"
+            ],
+            [
+              136,
+              236,
+              "payload"
+            ],
+            [
+              137,
+              237,
+              "payload"
+            ],
+            [
+              138,
+              238,
+              "payload"
+            ],
+            [
+              139,
+              239,
+              "payload"
+            ],
+            [
+              140,
+              240,
+              "payload"
+            ],
+            [
+              141,
+              241,
+              "payload"
+            ],
+            [
+              142,
+              242,
+              "payload"
+            ],
+            [
+              143,
+              243,
+              "payload"
+            ],
+            [
+              144,
+              244,
+              "payload"
+            ],
+            [
+              145,
+              245,
+              "payload"
+            ],
+            [
+              146,
+              246,
+              "payload"
+            ],
+            [
+              147,
+              247,
+              "payload"
+            ],
+            [
+              148,
+              248,
+              "payload"
+            ],
+            [
+              149,
+              249,
+              "payload"
+            ],
+            [
+              150,
+              250,
+              "payload"
+            ],
+            [
+              151,
+              251,
+              "payload"
+            ],
+            [
+              152,
+              252,
+              "payload"
+            ],
+            [
+              153,
+              253,
+              "payload"
+            ],
+            [
+              154,
+              254,
+              "payload"
+            ],
+            [
+              155,
+              255,
+              "payload"
+            ],
+            [
+              156,
+              256,
+              "payload"
+            ],
+            [
+              157,
+              257,
+              "payload"
+            ],
+            [
+              158,
+              258,
+              "payload"
+            ],
+            [
+              159,
+              259,
+              "payload"
+            ],
+            [
+              160,
+              260,
+              "payload"
+            ],
+            [
+              161,
+              261,
+              "payload"
+            ],
+            [
+              162,
+              262,
+              "payload"
+            ],
+            [
+              163,
+              263,
+              "payload"
+            ],
+            [
+              164,
+              264,
+              "payload"
+            ],
+            [
+              165,
+              265,
+              "payload"
+            ],
+            [
+              166,
+              266,
+              "payload"
+            ],
+            [
+              167,
+              267,
+              "payload"
+            ],
+            [
+              168,
+              268,
+              "payload"
+            ],
+            [
+              169,
+              269,
+              "payload"
+            ],
+            [
+              170,
+              270,
+              "payload"
+            ],
+            [
+              171,
+              271,
+              "payload"
+            ],
+            [
+              172,
+              272,
+              "payload"
+            ],
+            [
+              173,
+              273,
+              "payload"
+            ],
+            [
+              174,
+              274,
+              "payload"
+            ],
+            [
+              175,
+              275,
+              "payload"
+            ],
+            [
+              176,
+              276,
+              "payload"
+            ],
+            [
+              177,
+              277,
+              "payload"
+            ],
+            [
+              178,
+              278,
+              "payload"
+            ],
+            [
+              179,
+              279,
+              "payload"
+            ],
+            [
+              180,
+              280,
+              "payload"
+            ],
+            [
+              181,
+              281,
+              "payload"
+            ],
+            [
+              182,
+              282,
+              "payload"
+            ],
+            [
+              183,
+              283,
+              "payload"
+            ],
+            [
+              184,
+              284,
+              "payload"
+            ],
+            [
+              185,
+              285,
+              "payload"
+            ],
+            [
+              186,
+              286,
+              "payload"
+            ],
+            [
+              187,
+              287,
+              "payload"
+            ],
+            [
+              188,
+              288,
+              "payload"
+            ],
+            [
+              189,
+              289,
+              "payload"
+            ],
+            [
+              190,
+              290,
+              "payload"
+            ],
+            [
+              191,
+              291,
+              "payload"
+            ],
+            [
+              192,
+              292,
+              "payload"
+            ],
+            [
+              193,
+              293,
+              "payload"
+            ],
+            [
+              194,
+              294,
+              "payload"
+            ],
+            [
+              195,
+              295,
+              "payload"
+            ],
+            [
+              196,
+              296,
+              "payload"
+            ],
+            [
+              197,
+              297,
+              "payload"
+            ],
+            [
+              198,
+              298,
+              "payload"
+            ],
+            [
+              199,
+              299,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 0,
+        "selector_column": 0,
+        "selected": 100,
+        "replacement": -1
+      },
+      "index_queries": [
+        -1,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        128,
+        129,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        144,
+        145,
+        146,
+        147,
+        148,
+        149,
+        150,
+        151,
+        152,
+        153,
+        154,
+        155,
+        156,
+        157,
+        158,
+        159,
+        160,
+        161,
+        162,
+        163,
+        164,
+        165,
+        166,
+        167,
+        168,
+        169,
+        170,
+        171,
+        172,
+        173,
+        174,
+        175,
+        176,
+        177,
+        178,
+        179,
+        180,
+        181,
+        182,
+        183,
+        184,
+        185,
+        186,
+        187,
+        188,
+        189,
+        190,
+        191,
+        192,
+        193,
+        194,
+        195,
+        196,
+        197,
+        198,
+        199,
+        999
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-INDEXED-PAYLOAD",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded indexed public field update",
+        "complete index traversal/full-key Seek and exact unrelated-byte preservation"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 8
+            }
+          ],
+          "indexes": [
+            {
+              "name": "ByKey",
+              "kind": "ordinary",
+              "fields": [
+                {
+                  "column": 0,
+                  "descending": false
+                }
+              ]
+            }
+          ],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "payload"
+            ],
+            [
+              1,
+              202,
+              "payload"
+            ],
+            [
+              2,
+              303,
+              "payload"
+            ],
+            [
+              2,
+              404,
+              "payload"
+            ],
+            [
+              3,
+              505,
+              "payload"
+            ],
+            [
+              3,
+              606,
+              "payload"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "indexed_field",
+        "table": "Items",
+        "column": 1,
+        "selector_column": 1,
+        "selected": 303,
+        "replacement": -2147483648
+      },
+      "index_queries": [
+        1,
+        2,
+        3,
+        999
+      ]
+    },
+    {
+      "id": "DAO-UPDATE-SOLE-RELEASE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public sole release",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "sole"
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd"
+            ],
+            [
+              12,
+              1202,
+              "eee"
+            ],
+            [
+              13,
+              -1303,
+              "fff"
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "sole_release",
+        "table": "Items",
+        "selected_id": 1
+      }
+    },
+    {
+      "id": "DAO-UPDATE-ROW-GROW",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public full-row replacement",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa",
+              "bytes",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "bbbbbbbbbbbbbbbbbbbb",
+              false
+            ],
+            [
+              3,
+              303,
+              "ccc",
+              "bytes",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              12,
+              1202,
+              "eee",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "row_replace",
+        "table": "Items",
+        "selected_id": 1,
+        "replacement": [
+          1,
+          null,
+          "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+          "abcdefgh",
+          false
+        ],
+        "tombstone": false
+      }
+    },
+    {
+      "id": "DAO-UPDATE-ROW-SHRINK",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public full-row replacement",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa",
+              "bytes",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "bbbbbbbbbbbbbbbbbbbb",
+              false
+            ],
+            [
+              3,
+              303,
+              "ccc",
+              "bytes",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              12,
+              1202,
+              "eee",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "row_replace",
+        "table": "Items",
+        "selected_id": 2,
+        "replacement": [
+          2,
+          -42,
+          null,
+          "ab",
+          true
+        ],
+        "tombstone": false
+      }
+    },
+    {
+      "id": "DAO-UPDATE-ROW-LATER-TOMBSTONE",
+      "operation": {
+        "mode": "dao_open_rust_update",
+        "expected_outcome": "success",
+        "error_class": null
+      },
+      "required_branches": [
+        "open.header_page"
+      ],
+      "boundary": null,
+      "coverage": [
+        "bounded public full-row replacement",
+        "exact unrelated bytes and row slots"
+      ],
+      "tables": [
+        {
+          "name": "Items",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              1,
+              101,
+              "aaa",
+              "bytes",
+              true
+            ],
+            [
+              2,
+              202,
+              "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              "bbbbbbbbbbbbbbbbbbbb",
+              false
+            ],
+            [
+              3,
+              303,
+              "ccc",
+              "bytes",
+              true
+            ]
+          ]
+        },
+        {
+          "name": "Later",
+          "columns": [
+            {
+              "name": "Id",
+              "kind": "Long"
+            },
+            {
+              "name": "Value",
+              "kind": "Long"
+            },
+            {
+              "name": "Payload",
+              "kind": "Text",
+              "size": 255
+            },
+            {
+              "name": "Bytes",
+              "kind": "Binary",
+              "size": 255
+            },
+            {
+              "name": "Flag",
+              "kind": "Boolean"
+            }
+          ],
+          "indexes": [],
+          "repeat": null,
+          "rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ],
+          "seed_rows": [
+            [
+              11,
+              -1101,
+              "ddd",
+              "bytes",
+              true
+            ],
+            [
+              12,
+              1202,
+              "eee",
+              "bytes",
+              true
+            ],
+            [
+              13,
+              -1303,
+              "fff",
+              "bytes",
+              true
+            ]
+          ]
+        }
+      ],
+      "relationship": null,
+      "request": {
+        "kind": "row_replace",
+        "table": "Later",
+        "selected_id": 13,
+        "replacement": [
+          13,
+          null,
+          null,
+          null,
+          false
+        ],
+        "tombstone": true,
+        "seed_delete": 12
+      }
+    }
+  ],
+  "deferred_requirements": [
+    "free-page or slot reuse, indirect allocation maps",
+    "indexed row insertion/deletion and relationship mutations",
+    "arbitrary wide full-row replacement and Auto/LVAL targets",
+    "hosted stored-query preservation and continuation DAO mutations"
+  ]
+}

--- a/oracle/windows-dao/scripts/dao_row_replacement_diff.py
+++ b/oracle/windows-dao/scripts/dao_row_replacement_diff.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Seventeen-case hosted update adapter; frozen indexed sidecar gates retained."""
+import copy
+import importlib.util
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[3]
+def private(name,file):
+    spec=importlib.util.spec_from_file_location(name,ROOT/'oracle/windows-dao/scripts'/file);module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module);return module
+indexed=private('_replacement_indexed','dao_indexed_update_diff.py');base=indexed.base
+release=private('_replacement_release','row_delete_release.py')
+replacement=private('_replacement_rows','row_update_candidate.py')
+base.INVENTORY=ROOT/'oracle/windows-dao/protocol/v1_2/row-replacement-scenarios.json'
+base.PLAN=ROOT/'oracle/windows-dao/acquisition/row-replacement-v1_2.plan.json'
+IDS=indexed.IDS+['DAO-UPDATE-'+n for n in ('SOLE-RELEASE','ROW-GROW','ROW-SHRINK','ROW-LATER-TOMBSTONE')]
+require=indexed.require
+
+def recipe(scenario,role):
+    request=scenario['request'];kind=request.get('kind')
+    if kind not in ('sole_release','row_replace'):return indexed.recipe(scenario,role)
+    result=copy.deepcopy(scenario);table,=[t for t in result['tables'] if t['name']==request['table']]
+    require(sum(r[0]==request['selected_id'] for r in table['rows'])==1,'Unique requested row')
+    if role=='after':
+        table['rows']=[r for r in table['rows'] if r[0]!=request['selected_id']] if kind=='sole_release' else [request['replacement'] if r[0]==request['selected_id'] else r for r in table['rows']]
+    else:require(role=='before','Unknown role')
+    return result
+
+def inventory():
+    value=base.load_json(base.INVENTORY)
+    require(value['document_type']=='dao_update_scenario_inventory' and value['protocol_version']=='1.2.0' and [s['id'] for s in value['scenarios']]==IDS,'Seventeen-case inventory')
+    historical=base.load_json(ROOT/'oracle/windows-dao/protocol/v1_2/indexed-update-scenarios.json')['scenarios'];require(value['scenarios'][:13]==historical,'Historical indexed cases changed')
+    for scenario in value['scenarios']:
+        require(scenario['operation']==dict(mode='dao_open_rust_update',expected_outcome='success',error_class=None) and not set(scenario['required_branches'])-base.write.protocol.load_branch_ids() and scenario['coverage'],'Operation/coverage');recipe(scenario,'after')
+    require(value['deferred_requirements'],'Missing limitations');return value
+
+def check_preservation(root,scenario,receipt):
+    request=scenario['request'];kind=request.get('kind')
+    if kind not in ('sole_release','row_replace'):return indexed.check_preservation(root,scenario,receipt)
+    require(receipt.get('scenario_id')==scenario['id'] and receipt.get('request')==request and receipt.get('preserved') is True,'Replacement request binding')
+    before,after=[(root/role/'database.mdb').read_bytes() for role in base.ROLES]
+    for role in base.ROLES:require(receipt[role+'_sha256']==base.write.digest(root/role/'database.mdb'),'Replacement image identity')
+    if kind=='sole_release':release.patch_check(before,after,request,receipt['locator'])
+    else:
+        arm=copy.deepcopy(request);binary=arm['replacement'][3]
+        if binary is not None:arm['replacement'][3]=binary.encode('ascii').hex()
+        replacement.patch_check(before,after,arm,receipt['locator'])
+
+def command(root,label,args):
+    if len(args)>1 and str(args[1])=='snapshot':args=[*args,'--inventory','row-replacement']
+    return indexed.allocation.rows.old_command(root,label,args)
+
+# The indexed evaluator directly reads its module's inventory for every sidecar;
+# make that same complete inventory visible without changing any frozen source.
+indexed.inventory=inventory
+base.inventory,base.recipe,base.check_preservation,base.command=inventory,recipe,check_preservation,command
+if __name__=='__main__':base.main()

--- a/oracle/windows-dao/scripts/memo_candidate.ps1
+++ b/oracle/windows-dao/scripts/memo_candidate.ps1
@@ -1,0 +1,74 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected x86 DAO'}
+$helper=Join-Path $env:JET3_WORK 'empty_long_values.ps1';$tokens=$null;$errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile($helper,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Helper parse failure'}
+foreach($name in @('Identity','Release','Write-Json','Detail','Close-Object','Field-Properties')){
+    $definitions=@($ast.FindAll({param($n)$n-is [Management.Automation.Language.FunctionDefinitionAst]-and $n.Name-eq $name},$false))
+    if($definitions.Count-ne 1){throw 'Missing helper'};Invoke-Expression $definitions[0].Extent.Text
+}
+function Append-Row($Rs,$Row){
+    $field=$null
+    try{
+        $script:endpoint='insert/add_new';$Rs.AddNew();$field=$Rs.Fields.Item('Id');$script:endpoint='insert/Id';$field.Value=[int]$Row[0];Release $field;$field=$null
+        $field=$Rs.Fields.Item(1);$script:endpoint='insert/Memo'
+        if($null-eq $Row[1]){$field.Value=[DBNull]::Value}else{$field.Value=[string]$Row[1]}
+        Release $field;$field=$null;$script:endpoint='insert/Update';$Rs.Update()
+    }finally{Close-Object $field $false}
+}
+function Create-Control([string]$Path,$Arm){
+    $engine=$workspace=$db=$table=$field=$rs=$null
+    try{
+        $engine=New-Object -ComObject DAO.DBEngine.36;$workspace=$engine.Workspaces.Item(0);$script:endpoint='create_database';$script:mutationStarted=$true
+        $db=$workspace.CreateDatabase($Path,';LANGID=0x0409;CP=1252;COUNTRY=0',32);$table=$db.CreateTableDef([string]$Arm.table)
+        $field=$table.CreateField('Id',4);$table.Fields.Append($field);Release $field;$field=$table.CreateField([string]$Arm.memo,12);$field.AllowZeroLength=$true;$table.Fields.Append($field);Release $field;$field=$null
+        $db.TableDefs.Append($table);$rs=$db.OpenRecordset([string]$Arm.table,2)
+        foreach($row in $Arm.rows){Append-Row $rs $row}
+    }catch{if($null-eq $script:failure){$script:failure=Detail $_ $engine};throw}finally{Close-Object $rs $true;Close-Object $field $false;Close-Object $table $false;Close-Object $db $true;Close-Object $workspace $false;Close-Object $engine $false}
+}
+function Insert-Copy([string]$Source,[string]$Path,$Arm,$Row){
+    Copy-Item -LiteralPath $Source -Destination $Path;$engine=$db=$rs=$null
+    try{$script:endpoint='continuation/open';$engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$false);$rs=$db.OpenRecordset([string]$Arm.table,2);Append-Row $rs $Row}
+    catch{if($null-eq $script:failure){$script:failure=Detail $_ $engine};throw}finally{Close-Object $rs $true;Close-Object $db $true;Close-Object $engine $false}
+}
+function Capture([string]$Path,$Arm){
+    $before=Identity $Path;$engine=$db=$table=$field=$rs=$null;$snapshot=@{};$errorDetail=$null
+    try{
+        $script:endpoint='capture/open';$engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$true)
+        $script:endpoint='capture/schema';$snapshot.version=[string]$db.Version;$snapshot.tables=@($db.TableDefs|ForEach-Object{[string]$_.Name}|Sort-Object);$snapshot.relations=@($db.Relations|ForEach-Object{[string]$_.Name});$snapshot.queries=@($db.QueryDefs|ForEach-Object{[string]$_.Name})
+        $table=$db.TableDefs.Item([string]$Arm.table);$snapshot.attributes=[int]$table.Attributes;$snapshot.indexes=@($table.Indexes|ForEach-Object{[string]$_.Name});$fields=New-Object Collections.ArrayList
+        foreach($field in $table.Fields){[void]$fields.Add(@{name=[string]$field.Name;type=[int]$field.Type;size=[int]$field.Size;attributes=[int]$field.Attributes;properties=(Field-Properties $field);allow_zero_length=if([int]$field.Type-eq 12){[bool]$field.AllowZeroLength}else{$null}});Release $field};$field=$null;$snapshot.fields=[object[]]$fields.ToArray()
+        $script:endpoint='capture/rows';$rs=$db.OpenRecordset([string]$Arm.table,4);$rows=New-Object Collections.ArrayList
+        while(-not $rs.EOF){
+            $field=$rs.Fields.Item('Id');$id=[int]$field.Value;Release $field;$field=$rs.Fields.Item(1);$value=$field.Value;$isNull=$null-eq $value-or [Convert]::IsDBNull($value)
+            [void]$rows.Add(@{id=$id;is_null=$isNull;payload=if($isNull){$null}else{[string]$value};field_size=[int]$field.FieldSize});Release $field;$field=$null;$rs.MoveNext()
+        };$snapshot.rows=[object[]]$rows.ToArray()
+    }catch{$errorDetail=Detail $_ $engine;if($null-eq $script:failure){$script:failure=$errorDetail}}finally{Close-Object $field $false;Close-Object $rs $true;Close-Object $table $false;Close-Object $db $true;Close-Object $engine $false}
+    return @{file=[IO.Path]::GetFileName($Path);before=$before;after=(Identity $Path);status=if($null-eq $errorDetail){'pass'}else{'error'};error=$errorDetail;snapshot=$snapshot}
+}
+$planPath=Join-Path $env:JET3_WORK 'memo-candidate.plan.json';$plan=Get-Content -LiteralPath $planPath -Raw|ConvertFrom-Json
+if((Identity $PSCommandPath).sha256-cne $plan.inputs.'oracle/windows-dao/scripts/memo_candidate.ps1'-or (Identity $helper).sha256-cne $plan.inputs.'oracle/windows-dao/scripts/empty_long_values.ps1'){throw 'Producer pin mismatch'}
+$script:failure=$null;$script:mutationStarted=$false;$script:endpoint='start'
+$result=@{document_type='dao_memo_candidate_result';plan_sha256=(Identity $planPath).sha256;source_revision=$plan.source_revision;environment=@{process_bits=32;provider='DAO.DBEngine.36'};mutation_started=$false;pairs=@();error=$null;retention_failures=@()}
+try{
+    foreach($arm in $plan.arms){foreach($replica in 1..3){
+        $prefix="$($arm.name)-r$replica";$pair=@{arm=$arm.name;replica=$replica;captures=@{};operations=@{}};$result.pairs+=,$pair
+        $source=Join-Path $env:JET3_WORK "$($arm.name).mdb";$expected=$plan.images."$($arm.name).mdb";$actual=Identity $source
+        if($actual.sha256-cne $expected.sha256-or $actual.size-ne $expected.size){throw 'Candidate image pin'}
+        Copy-Item -LiteralPath $source -Destination (Join-Path $env:JET3_WORK "$prefix-candidate.mdb");Create-Control (Join-Path $env:JET3_WORK "$prefix-control.mdb") $arm
+        foreach($role in @('candidate','control')){
+            $path=Join-Path $env:JET3_WORK "$prefix-$role.mdb";$pair.captures[$role]=Capture $path $arm
+            if($pair.captures[$role].status-ne 'pass'-or $null-ne $script:failure){throw 'Baseline failure'}
+        }
+        foreach($request in $plan.continuations){foreach($role in @('candidate','control')){
+            $name="$role-$($request.name)";$path=Join-Path $env:JET3_WORK "$prefix-$name.mdb";Insert-Copy (Join-Path $env:JET3_WORK "$prefix-$role.mdb") $path $arm $request.row
+            if($null-ne $script:failure){throw 'Continuation cleanup failure'};$pair.operations[$name]=@{status='complete';row=$request.row};$pair.captures[$name]=Capture $path $arm
+            if($pair.captures[$name].status-ne 'pass'-or $null-ne $script:failure){throw 'Continuation capture failure'}
+        }}
+    }}
+}catch{if($null-eq $script:failure){$script:failure=Detail $_ $null}}finally{
+    $result.error=$script:failure;$result.mutation_started=$script:mutationStarted
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb'){try{Copy-Item -LiteralPath $file.FullName -Destination $env:JET3_OUTBOX}catch{$result.retention_failures+=@{file=$file.Name;message=$_.Exception.Message}}};Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if($null-ne $result.error-or $result.retention_failures.Count){exit 1}

--- a/oracle/windows-dao/scripts/memo_candidate.py
+++ b/oracle/windows-dao/scripts/memo_candidate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""EXP-0209 finite explicit empty Memo candidate validation."""
+import argparse
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import field_update as common
+import system_catalog as catalog
+ROOT=Path(__file__).resolve().parents[3]
+PLAN=ROOT/'oracle/windows-dao/acquisition/memo-candidate.plan.json'
+SCRIPT='oracle/windows-dao/scripts/memo_candidate.ps1'
+identity,canonical=common.identity,common.canonical
+
+def require(condition,message):
+    if not condition:raise ValueError(message)
+
+def verify_inputs():
+    plan=json.loads(PLAN.read_text())
+    for name,sha in plan['inputs'].items():require(identity(ROOT/name)['sha256']==sha,'Input pin mismatch: '+name)
+    return plan
+
+def preflight(images):
+    plan=verify_inputs();require(subprocess.check_output(['git','show',f'HEAD:{PLAN.relative_to(ROOT)}'],cwd=ROOT)==PLAN.read_bytes(),'Plan must be committed')
+    for arm in plan['arms']:
+        path=images/(arm['name']+'.mdb');require(identity(path)==plan['images'][path.name],'Candidate pin');raw_check(path.read_bytes(),arm,arm['rows'])
+    return plan
+
+def expected_rows(arm,role,plan):
+    rows=copy.deepcopy(arm['rows'])
+    for request in plan['continuations']:
+        if role.endswith('-'+request['name']):rows.append(request['row'])
+    return rows
+
+def snapshot(value,arm,rows):
+    value=copy.deepcopy(value)
+    require(value['version']=='3.0' and value['tables']==sorted(['MSysACEs','MSysObjects','MSysQueries','MSysRelationships',arm['table']]) and value['relations']==value['queries']==value['indexes']==[] and value['attributes']==0,'Requested inventory')
+    require([{k:f[k] for k in ('name','type','size','attributes')} for f in value['fields']]==[dict(name='Id',type=4,size=4,attributes=1),dict(name=arm['memo'],type=12,size=0,attributes=2)] and value['fields'][1]['allow_zero_length'] is True,'Requested schema/option')
+    for field in value['fields']:
+        properties=field['properties'];require(len({p['name'] for p in properties})==len(properties),'Duplicate property');field['properties']=sorted(properties,key=lambda p:p['name'])
+    value['rows']=sorted(value['rows'],key=lambda r:r['id'])
+    require(value['rows']==[dict(id=i,is_null=v is None,payload=v,field_size=0 if v is None else len(v)*2) for i,v in rows],'Complete Memo rows/IsNull/FieldSize')
+    return value
+
+def raw_check(data,arm,expected):
+    definition,_,records=catalog._discover_catalog(data);n,i,l=[catalog._ordinal(definition,k) for k in ('Name','Id','LvProp')]
+    matches=[r for r in records if r['values'][n]==arm['table']];require(len(matches)==1,'Catalog root');record=matches[0];table=catalog._definition(data,record['values'][i]);pages,lval=catalog._table_pages(data,table);rows=catalog._table_rows(data,table,pages)
+    require(table['row_count']==len(rows)==len(expected) and not table['physical_indexes'] and not table['logical_indexes'] and not lval,'Raw row/index/LVAL inventory')
+    require([(c['name'],c['type'],c['size']) for c in table['columns']]==[('Id','Long',4),(arm['memo'],'Memo',0)],'Raw field bindings')
+    observed=[]
+    for row in rows:
+        ident=row['values'][0];wanted=[v for i,v in expected if i==ident];require(len(wanted)==1,'Id binding');wanted=wanted[0]
+        require(row['present']==[True,wanted is not None],'Presence binding')
+        page=catalog._page(data,row['page'],'data');entry=catalog._row_directory(page,row['page'])[row['row']];raw=page[entry['start']:entry['end']];require(len(raw)<=255 and raw[-2]==1,'Small variable row')
+        field=raw[raw[-3]:raw[-4]];payload=b'' if wanted is None else wanted.encode('ascii')
+        encoded=b'' if wanted is None else (0x80000000|len(payload)).to_bytes(4,'little')+bytes(8)+payload
+        require(field==encoded,'Inline Memo descriptor/payload');observed.append(dict(id=ident,page=row['page'],slot=row['row'],field_hex=field.hex()))
+    require(sorted(o['id'] for o in observed)==[i for i,v in expected],'Complete raw row bindings')
+    header=bytes.fromhex(record['values'][l]['long_value_header_hex']);require(len(header)==12 and header[8:]==bytes(4) and int.from_bytes(header[:4],'little')==0x40000000+len(bytes.fromhex(arm['property_payload_hex'])),'Property header')
+    locator=int.from_bytes(header[4:8],'little');page,slot=locator>>8,locator&255;image=catalog._page(data,page,'LvProp');directory=catalog._row_directory(image,page);require(slot<len(directory),'Property slot');entry=directory[slot];payload=image[entry['start']:entry['end']];require(not entry['hidden'] and not entry['overflow'] and payload.hex()==arm['property_payload_hex'],'Exact named property payload')
+    group,=[g for g in definition['long_value_maps'] if g['column']==14];owned=catalog._locator_pages(data,group['owned'],'catalog property owned');available=catalog._locator_pages(data,group['available'],'catalog property available')
+    require(page in owned and page in available and page not in catalog._map_pages(catalog._locator_row(data,dict(page=1,row=0),'global free'),len(data)//2048,'global free',bounded=False),'Catalog property map membership')
+    group,=table['long_value_maps'];require(group['column']==1 and not catalog._locator_pages(data,group['owned'],'Memo owned') and not catalog._locator_pages(data,group['available'],'Memo available'),'Inline Memo maps')
+    maps={k:sorted(catalog._locator_pages(data,v,k)) for k,v in table['maps'].items()};require(set(maps['owned'])=={r['page'] for r in rows} and set(maps['available'])==set(maps['owned']),'Data map inventory')
+    return dict(root=table['root'],rows=sorted(observed,key=lambda r:r['id']),maps=maps,property_header_hex=header.hex(),property_payload_hex=payload.hex(),property_page=page,property_slot=slot,catalog_property_maps=dict(owned=sorted(owned),available=sorted(available)))
+
+def build_report(result,outbox,plan):
+    observations=[];reasons=[]
+    try:
+        require(result['document_type']=='dao_memo_candidate_result' and result['plan_sha256']==identity(PLAN)['sha256'] and result['source_revision']==plan['source_revision'] and result['error'] is None and result['retention_failures']==[] and result['mutation_started'] is True and result['environment']==dict(process_bits=32,provider='DAO.DBEngine.36'),'Acquisition/source failure')
+        pairs={(p['arm'],p['replica']):p for p in result['pairs']};require(len(pairs)==len(result['pairs']) and set(pairs)=={(a['name'],r) for a in plan['arms'] for r in range(1,4)},'Pair inventory')
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                pair=pairs[arm['name'],replica];operations={role+'-'+p['name']:dict(status='complete',row=p['row']) for role in ('candidate','control') for p in plan['continuations']};require(pair['operations']==operations and set(pair['captures'])==set(operations)|{'candidate','control'},'Complete capture/continuation inventory')
+                snapshots={};raw={};images={}
+                for role,capture in pair['captures'].items():
+                    path=outbox/f"{arm['name']}-r{replica}-{role}.mdb";require(capture['file']==path.name and capture['status']=='pass' and capture['error'] is None and capture['before']==capture['after']==identity(path),'Unchanged capture identity');images[role]=identity(path)
+                    if role=='candidate':require(images[role]==plan['images'][arm['name']+'.mdb'],'Pinned candidate')
+                    rows=expected_rows(arm,role,plan);snapshots[role]=snapshot(capture['snapshot'],arm,rows);raw[role]=raw_check(path.read_bytes(),arm,rows)
+                for suffix in ['',*['-'+p['name'] for p in plan['continuations']]]:require(snapshots['candidate'+suffix]==snapshots['control'+suffix],'Control semantics differ')
+                for role,value in snapshots.items():
+                    metadata=copy.deepcopy(value);metadata.pop('rows');baseline=copy.deepcopy(snapshots['candidate']);baseline.pop('rows');require(metadata==baseline,'Continuation metadata changed')
+                observations.append(dict(arm=arm['name'],replica=replica,identities=images,raw=raw,operations=pair['operations'],snapshots=snapshots))
+    except (ValueError,KeyError,TypeError,OSError,catalog.DecodeError) as error:reasons.append(str(error))
+    return dict(document_type='dao_memo_candidate_report',plan_sha256=identity(PLAN)['sha256'],outcome='observed_accepted' if not reasons else 'no_outcome',reasons=reasons,observations=observations,development_only=True,compatibility_claim=False,support_matrix_movement=False)
+
+def analyze(outbox):
+    plan=verify_inputs();report=build_report(json.loads((outbox/'result.json').read_text(encoding='utf-8-sig')),outbox,plan);report['result_sha256']=identity(outbox/'result.json')['sha256'];(outbox/'report.json').write_text(canonical(report)+'\n');print(report['outcome'])
+
+def dispatch(args):
+    plan=preflight(args.images);require(re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id),'Run id')
+    shared=args.shared_root.resolve();inbox=shared/'inbox'/args.run_id;outbox=shared/'outbox'/args.run_id;require(not inbox.exists() and not outbox.exists(),'Run used; no retry');inbox.mkdir(parents=True)
+    shutil.copyfile(ROOT/SCRIPT,inbox/'script.ps1');shutil.copyfile(PLAN,inbox/PLAN.name);shutil.copyfile(ROOT/'oracle/windows-dao/scripts/empty_long_values.ps1',inbox/'empty_long_values.ps1')
+    for name in plan['images']:shutil.copyfile(args.images/name,inbox/name)
+    spec=importlib.util.spec_from_file_location('transport',ROOT/'scripts/windows-dao-ps.py');transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,args.run_id,'script.ps1'))]
+    done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=600);outbox.mkdir(exist_ok=True);(outbox/'ssh.txt').write_bytes(done.stdout+done.stderr)
+    require((outbox/'result.json').exists(),'Missing result; no retry');analyze(outbox);require(done.returncode==0,'Guest failed; no retry')
+
+def main():
+    parser=argparse.ArgumentParser(description=__doc__);sub=parser.add_subparsers(dest='command',required=True);p=sub.add_parser('preflight');p.add_argument('--images',type=Path,required=True);p=sub.add_parser('analyze');p.add_argument('outbox',type=Path)
+    p=sub.add_parser('run');p.add_argument('--images',type=Path,required=True);p.add_argument('--run-id',required=True);p.add_argument('--shared-root',type=Path,required=True)
+    for name,default in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:p.add_argument('--'+name,default=default)
+    args=parser.parse_args()
+    if args.command=='preflight':preflight(args.images);print('Committed inputs/images match.')
+    elif args.command=='analyze':analyze(args.outbox)
+    else:dispatch(args)
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/test_dao_row_replacement_diff.py
+++ b/oracle/windows-dao/tests/test_dao_row_replacement_diff.py
@@ -1,0 +1,41 @@
+import copy
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import dao_row_replacement_diff as a
+import dao_indexed_update_diff as historical
+
+class ReplacementTests(unittest.TestCase):
+    def test_inventory_recipe_and_sidecar_inventory(self):
+        cases=a.inventory()['scenarios'];self.assertEqual(len(cases),17)
+        self.assertEqual(cases[:13],historical.inventory()['scenarios'])
+        self.assertEqual(a.indexed.inventory()['scenarios'],cases)
+        for case,count in zip(cases[13:],[0,3,3,2]):
+            expected=a.recipe(case,'after');table=next(t for t in expected['tables'] if t['name']==case['request']['table']);self.assertEqual(len(table['rows']),count)
+        tombstone=cases[-1];self.assertEqual(len(tombstone['tables'][1]['seed_rows']),3);self.assertEqual(len(tombstone['tables'][1]['rows']),2)
+        self.assertEqual(a.recipe(tombstone,'after')['tables'][1]['rows'][1],[13,None,None,None,False])
+
+    def test_request_identity_and_binary_conversion(self):
+        case=a.inventory()['scenarios'][14]
+        with tempfile.TemporaryDirectory() as temp:
+            root=Path(temp)
+            for role in a.base.ROLES:(root/role).mkdir();(root/role/'database.mdb').write_bytes(role.encode())
+            receipt=dict(scenario_id=case['id'],request=case['request'],preserved=True,locator={'root':20,'page':23,'slot':0},before_sha256=a.base.write.digest(root/'before/database.mdb'),after_sha256=a.base.write.digest(root/'after/database.mdb'))
+            with patch.object(a.replacement,'patch_check') as check:
+                a.check_preservation(root,case,receipt);self.assertEqual(check.call_args.args[2]['replacement'][3],b'abcdefgh'.hex());self.assertEqual(check.call_args.args[3],receipt['locator'])
+                self.assertEqual(case['request']['replacement'][3],'abcdefgh')
+                bad=copy.deepcopy(receipt);bad['request']['selected_id']=9
+                with self.assertRaises(a.base.ValidationError):a.check_preservation(root,case,bad)
+                (root/'after/database.mdb').write_bytes(b'changed')
+                with self.assertRaises(a.base.ValidationError):a.check_preservation(root,case,receipt)
+
+    def test_cli_selector_retains_frozen_indexed_runner(self):
+        with patch.object(a.indexed.allocation.rows,'old_command') as run:
+            a.command(Path('.'),'snapshot',['cli','snapshot','file'])
+            self.assertEqual(run.call_args.args[2][-2:],['--inventory','row-replacement'])
+        self.assertEqual(len(historical.inventory()['scenarios']),13)
+
+if __name__=='__main__':unittest.main()

--- a/oracle/windows-dao/tests/test_memo_candidate.py
+++ b/oracle/windows-dao/tests/test_memo_candidate.py
@@ -1,0 +1,45 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import memo_candidate as a
+
+class MemoTests(unittest.TestCase):
+    def test_complete_pairs_and_failure_gates(self):
+        plan=json.loads(a.PLAN.read_text());plan['images']={}
+        result=dict(document_type='dao_memo_candidate_result',plan_sha256=a.identity(a.PLAN)['sha256'],source_revision=plan['source_revision'],error=None,retention_failures=[],mutation_started=True,environment=dict(process_bits=32,provider='DAO.DBEngine.36'),pairs=[])
+        with tempfile.TemporaryDirectory() as tmp:
+            out=Path(tmp)
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    operations={role+'-'+p['name']:dict(status='complete',row=p['row']) for role in ['candidate','control'] for p in plan['continuations']};pair=dict(arm=arm['name'],replica=replica,operations=operations,captures={});result['pairs'].append(pair)
+                    for role in ['candidate','control',*operations]:
+                        path=out/f"{arm['name']}-r{replica}-{role}.mdb";path.write_bytes(role.encode());identity=a.identity(path)
+                        if role=='candidate':plan['images'][arm['name']+'.mdb']=identity
+                        rows=a.expected_rows(arm,role,plan);fields=[dict(name='Id',type=4,size=4,attributes=1,allow_zero_length=None,properties=[]),dict(name=arm['memo'],type=12,size=0,attributes=2,allow_zero_length=True,properties=[])]
+                        snapshot=dict(version='3.0',tables=sorted(['MSysACEs','MSysObjects','MSysQueries','MSysRelationships',arm['table']]),relations=[],queries=[],indexes=[],attributes=0,fields=fields,rows=[dict(id=i,payload=v,is_null=v is None,field_size=0 if v is None else len(v)*2) for i,v in rows])
+                        pair['captures'][role]=dict(file=path.name,status='pass',error=None,before=identity,after=identity,snapshot=snapshot)
+            with patch.object(a,'raw_check',return_value={}):
+                self.assertEqual(a.build_report(result,out,plan)['outcome'],'observed_accepted')
+                for defect in ['source','operation','empty','option','identity']:
+                    bad=copy.deepcopy(result);pair=bad['pairs'][0]
+                    if defect=='source':bad['source_revision']='wrong'
+                    elif defect=='operation':pair['operations'].pop('candidate-empty-next')
+                    elif defect=='empty':pair['captures']['candidate']['snapshot']['rows'][1].update(payload=None,is_null=True)
+                    elif defect=='option':pair['captures']['candidate']['snapshot']['fields'][1]['allow_zero_length']=False
+                    else:pair['captures']['candidate']['after']['size']+=1
+                    self.assertEqual(a.build_report(bad,out,plan)['outcome'],'no_outcome')
+
+    def test_route_and_input_pin(self):
+        plan=json.loads(a.PLAN.read_text());self.assertIn(a.SCRIPT,plan['inputs']);self.assertTrue((a.ROOT/a.SCRIPT).is_file())
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp);(root/'runtime').write_text('old');path=root/'plan';path.write_text(json.dumps(dict(inputs={'runtime':a.identity(root/'runtime')['sha256']})))
+            with patch.object(a,'ROOT',root),patch.object(a,'PLAN',path):
+                a.verify_inputs();(root/'runtime').write_text('changed')
+                with self.assertRaisesRegex(ValueError,'pin'):a.verify_inputs()
+
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Explicitly enabled empty Memo values now have a preregistered DAO comparison and a recorded local outcome. Both named schemas distinguish null, empty and nonempty payloads, preserve the exact property encoding, and match native DAO controls and independent continuation inserts.

EXP-0210 records all six accepted candidate/control pairs and 24 successful continuation inserts from the original run. The frozen plan and original evidence remain unchanged; this is finite local evidence, with no hosted support movement.

Validation: prior independent implementation/experiment review and `just ready`; two focused analyzer tests pass. The unchanged pinned analyzer reproduced the retained report byte-for-byte during completion.

Progress toward #100.
