### PR TITLE
fix: exclude coordinator memory from fuzz target RSS

### DIFF
--- a/fuzz/tests/test_fuzz_campaign.py
+++ b/fuzz/tests/test_fuzz_campaign.py
@@ -520,12 +520,58 @@ class FuzzCampaignValidationTests(unittest.TestCase):
                 {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
             )
         self.assertLess(1024, reported_rss)
-        self.assertGreaterEqual(observer["peak_rss_bytes"], reported_rss)
+        self.assertGreaterEqual(observer["peak_rss_bytes"], 32 * 1024 * 1024)
         self.assertGreaterEqual(
             observer["peak_rss_bytes"],
             fuzz_evidence.parse_reported_rss(log_path.read_text(encoding="utf-8")),
         )
         self.assertEqual(observer["executable"]["path"], str(executable))
+
+    @unittest.skipUnless(sys.platform == "linux", "Linux inherited RSS regression")
+    def test_observer_excludes_parent_peak_and_keeps_target_exit_signal(self) -> None:
+        # Touch a large live coordinator allocation before the intermediary exec.
+        parent = bytearray(160 * 1024 * 1024)
+        for offset in range(0, len(parent), 4096): parent[offset] = 1
+        script = (
+            "import resource,time\n"
+            "print('#1 DONE rss: %dMb' % (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss // 1024), flush=True)\n"
+            "time.sleep(0.1)\n"
+        )
+        observer = fuzz_evidence.observe_producer(
+            self.root, self.bundle / "small.log", [str(Path(sys.executable).resolve()), "-c", script],
+            10, {}, {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+        )
+        self.assertLess(observer["peak_rss_bytes"], 80 * 1024 * 1024)
+        self.assertLess(fuzz_evidence.parse_reported_rss((self.bundle / "small.log").read_text()), 80 * 1024 * 1024)
+        self.assertEqual(observer["exit_code"], 0)
+        del parent
+        for ending, expected in [("raise SystemExit(7)", 7), ("import os,signal; os.kill(os.getpid(), signal.SIGTERM)", -15)]:
+            observer = fuzz_evidence.observe_producer(
+                self.root, self.bundle / "exit.log",
+                [str(Path(sys.executable).resolve()), "-c", "print('#1 DONE rss: 1Mb', flush=True); " + ending],
+                10, {}, {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+            )
+            self.assertEqual(observer["exit_code"], expected)
+
+    @unittest.skipUnless(sys.platform == "linux", "Linux process-group cleanup")
+    def test_observer_timeout_kills_target_descendants(self) -> None:
+        pidfile = self.bundle / "descendant.pid"
+        script = (
+            "import subprocess,sys,time\n"
+            "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(30)'])\n"
+            f"open({str(pidfile)!r},'w').write(str(p.pid))\n"
+            "print('#1 INITED rss: 1Mb',flush=True)\n"
+            "time.sleep(30)\n"
+        )
+        observer = fuzz_evidence.observe_producer(
+            self.root, self.bundle / "timeout.log", [str(Path(sys.executable).resolve()), "-c", script],
+            0.5, {}, {"PATH": os.environ.get("PATH") or "/usr/bin:/bin"},
+        )
+        self.assertTrue(observer["timed_out"])
+        self.assertIsNone(observer["exit_code"])
+        self.assertEqual(observer["result"], "hang")
+        state = Path('/proc') / pidfile.read_text() / 'stat'
+        if state.exists(): self.assertEqual(state.read_text().split()[2], 'Z')
 
     def test_vacuous_registry_is_rejected(self) -> None:
         self.registry["targets"] = []

--- a/fuzz/tools/fuzz_evidence.py
+++ b/fuzz/tools/fuzz_evidence.py
@@ -11,6 +11,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -154,8 +155,8 @@ def _process_tree_rss(root_pid: int) -> int:
     return sum(rows[pid][1] for pid in descendants if pid in rows) * 1024
 
 
-def _rusage_peak_rss_bytes(usage: Any) -> int:
-    peak = int(usage.ru_maxrss)
+def _rusage_peak_rss_bytes(peak: int) -> int:
+    peak = int(peak)
     return peak if sys.platform == "darwin" else peak * 1024
 
 
@@ -180,10 +181,15 @@ def observe_producer(
     peak_rss = 0
     timed_out = False
     wait_status: int | None = None
-    producer_usage: Any | None = None
-    with log_path.open("wb") as log:
+    with log_path.open("wb") as log, tempfile.TemporaryFile() as receipt:
         producer = subprocess.Popen(
-            command,
+            [
+                str(Path(sys.executable).resolve()),
+                str(Path(__file__).with_name("fuzz_process.py")),
+                str(receipt.fileno()),
+                *command,
+            ],
+            pass_fds=(receipt.fileno(),),
             cwd=root,
             env=environment,
             stdout=log,
@@ -193,29 +199,34 @@ def observe_producer(
         deadline = started_clock + timeout_seconds
         try:
             while True:
-                waited_pid, status, usage = os.wait4(producer.pid, os.WNOHANG)
+                waited_pid, status, _ = os.wait4(producer.pid, os.WNOHANG)
                 if waited_pid == producer.pid:
                     wait_status = status
-                    producer_usage = usage
                     break
                 peak_rss = max(peak_rss, _process_tree_rss(producer.pid))
                 if time.monotonic() >= deadline:
                     timed_out = True
                     os.killpg(producer.pid, signal.SIGKILL)
-                    _, wait_status, producer_usage = os.wait4(producer.pid, 0)
+                    _, wait_status, _ = os.wait4(producer.pid, 0)
                     break
                 time.sleep(0.05)
         except BaseException:
             if wait_status is None:
                 os.killpg(producer.pid, signal.SIGKILL)
-                _, wait_status, producer_usage = os.wait4(producer.pid, 0)
+                _, wait_status, _ = os.wait4(producer.pid, 0)
             raise
         finally:
             if wait_status is not None:
                 producer.returncode = os.waitstatus_to_exitcode(wait_status)
-        if producer_usage is not None:
-            peak_rss = max(peak_rss, _rusage_peak_rss_bytes(producer_usage))
         exit_code = None if timed_out else producer.returncode
+        if not timed_out:
+            receipt.seek(0)
+            try:
+                target = json.load(receipt)
+                peak_rss = max(peak_rss, _rusage_peak_rss_bytes(target["maxrss"]))
+                exit_code = os.waitstatus_to_exitcode(target["status"])
+            except (ValueError, KeyError, TypeError) as error:
+                raise EvidenceError("target process did not return resource usage") from error
         log.flush()
         os.fsync(log.fileno())
     finished_clock = time.monotonic()

--- a/fuzz/tools/fuzz_process.py
+++ b/fuzz/tools/fuzz_process.py
@@ -1,0 +1,20 @@
+"""Launch a fuzz target from a fresh process so its RSS excludes the coordinator."""
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    receipt_fd = int(sys.argv[1])
+    # Fork only after this interpreter has exec'd: Linux otherwise carries the
+    # coordinator's resident memory into the target's getrusage high-water mark.
+    child = subprocess.Popen(sys.argv[2:])
+    _, status, usage = os.wait4(child.pid, 0)
+    child.returncode = os.waitstatus_to_exitcode(status)
+    receipt = json.dumps({"status": status, "maxrss": usage.ru_maxrss}).encode()
+    os.write(receipt_fd, receipt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fuzz smoke can falsely exceed its RSS limit because Linux carries the Python coordinator’s resident-memory peak through fork/exec into both wait4 and libFuzzer reporting. Launch the target through a small fresh interpreter, then retain the actual target’s complete resource peak and the existing process-tree sampling. Memory limits are unchanged.

Regression checks cover a large parent with a small child, short-lived allocations, exit codes, signals and descendant cleanup on timeout. Independent review, all 50 campaign tests and final `just ready` pass.
