### PR TITLE
test: record grouped indexed row mutation validation

### DIFF
--- a/crates/jet3/examples/indexed_row_mutation_candidate.rs
+++ b/crates/jet3/examples/indexed_row_mutation_candidate.rs
@@ -1,0 +1,140 @@
+//! Finite public row/index mutation candidates for EXP-0215.
+use jet3::{
+    ColumnSpec, ColumnType, DatabaseReader, IndexColumnSpec, IndexKind, IndexSpec, ResourceBudget,
+    ResourceLimits, RowDelete, RowLocator, RowValue, TableSpec, UpdateError,
+};
+use std::{env, fs, path::Path};
+fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+fn locate(path: &Path, id: i32) -> Result<(u64, RowLocator), Box<dyn std::error::Error>> {
+    let mut b = budget();
+    let mut db = DatabaseReader::open(path, &mut b)?;
+    let root = {
+        let mut c = db.catalog(&mut b)?;
+        let mut root = None;
+        while let Some(r) = c.next_record()? {
+            if r.name().raw_bytes() == b"Items" {
+                root = r.table_definition();
+            }
+        }
+        root.ok_or("Items")?
+    };
+    let table = db.table_definition(root, &mut b)?;
+    let mut c = db.rows(&table, &mut b)?;
+    let mut found = None;
+    while let Some(r) = c.next_row()? {
+        if r.field(table.columns()[0].ordinal())
+            .and_then(|f| f.raw_bytes())
+            == Some(id.to_le_bytes().as_slice())
+            && found.replace(r.locator()).is_some()
+        {
+            return Err("duplicate Id".into());
+        }
+    }
+    Ok((root.get(), found.ok_or("Id")?))
+}
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = env::args().skip(1).collect();
+    let [directory] = args.as_slice() else {
+        return Err("usage: indexed_row_mutation_candidate NEW_DIRECTORY".into());
+    };
+    let directory = Path::new(directory);
+    fs::create_dir(directory)?;
+    let mut receipts = Vec::new();
+    for (name, descending, count, insertion) in [
+        ("ascending", false, 3, Some(i32::MIN)),
+        ("descending", true, 3, Some(i32::MAX)),
+        ("capacity", false, 199, Some(199)),
+        ("deletions", false, 6, None),
+    ] {
+        let original = directory.join(format!("{name}-original.mdb"));
+        let candidate = directory.join(format!("{name}-candidate.mdb"));
+        let columns = [
+            ColumnSpec::new(b"Id", ColumnType::Long),
+            ColumnSpec::new(b"Value", ColumnType::Long),
+        ];
+        let keys = [if descending {
+            IndexColumnSpec::descending(0)
+        } else {
+            IndexColumnSpec::ascending(0)
+        }];
+        let indexes = [IndexSpec {
+            name: b"ByKey",
+            kind: if descending {
+                IndexKind::Unique
+            } else {
+                IndexKind::Primary
+            },
+            fields: &keys,
+        }];
+        let values: Vec<_> = (0..count)
+            .map(|n| [RowValue::Long(n), RowValue::Long(n + 100)])
+            .collect();
+        let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+        jet3::create_database_with_rows(
+            &original,
+            &TableSpec {
+                name: b"Items",
+                columns: &columns,
+                indexes: &indexes,
+            },
+            &rows,
+            &mut budget(),
+        )?;
+        fs::copy(&original, &candidate)?;
+        let root = locate(&original, 0)?.0;
+        let mut actions = Vec::new();
+        if let Some(id) = insertion {
+            let r = jet3::insert_row(
+                &candidate,
+                b"Items",
+                &[RowValue::Long(id), RowValue::Long(-777)],
+                &mut budget(),
+            )?;
+            actions.push(format!(
+                "{{\"kind\":\"insert\",\"page\":{},\"slot\":{}}}",
+                r.page().get(),
+                r.slot()
+            ));
+        } else {
+            for id in [1, 4, 0] {
+                let (_, r) = locate(&candidate, id)?;
+                jet3::delete_row(
+                    &candidate,
+                    RowDelete {
+                        table: b"Items",
+                        row: r,
+                    },
+                    &mut budget(),
+                )?;
+                actions.push(format!(
+                    "{{\"kind\":\"delete\",\"page\":{},\"slot\":{}}}",
+                    r.page().get(),
+                    r.slot()
+                ));
+            }
+        }
+        let before = fs::read(&candidate)?;
+        let existing = if insertion.is_some() { 0 } else { 2 };
+        let error = jet3::insert_row(
+            &candidate,
+            b"Items",
+            &[RowValue::Long(existing), RowValue::Long(0)],
+            &mut budget(),
+        )
+        .err()
+        .ok_or("duplicate accepted")?;
+        let refusal = match error {
+            UpdateError::Unsupported("duplicate unique key") => "duplicate",
+            UpdateError::Unsupported("full root leaf") => "capacity",
+            _ => return Err("unexpected refusal".into()),
+        };
+        if fs::read(&candidate)? != before {
+            return Err("refusal changed source".into());
+        }
+        receipts.push(format!("\"{name}\":{{\"root\":{root},\"actions\":[{}],\"public_refusal\":\"{refusal}\",\"refusal_preserved\":true}}",actions.join(",")));
+    }
+    println!("{{{}}}", receipts.join(","));
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -14848,3 +14848,30 @@ Retained original/control SHA-256 identities; the sole Rust destination repeats
 - No matching EXP-0215 plan or result exists in the external shared inbox/outbox.
   The three focused analyzer tests and exact exporter reproduction passed.
   Independent review must pass before the one authorized dispatch.
+
+## EXP-0216 — Unique Long leaf indexed row mutation validation outcome
+
+- The one authorized EXP-0215 acquisition,
+  `20260905T135208Z-indexed-row-candidate`, returned **`no_outcome`** under
+  the unchanged all-pairs decision rule. Preregistration commit
+  `c00b0e0728a5e6e179e4e29647f09a52e4953410` was pushed before dispatch;
+  plan SHA-256 `6fbee41dc0d54d7e47568a701b5bcce10dd0aecc5d5883575cf4f1261cbf46ff`.
+- The x86 `DAO.DBEngine.36` producer completed all twelve pairs and 96 captures,
+  with mutation started, no acquisition error, no retention failures, and all
+  96 MDBs retained outside the repository. The frozen analyzer accepted nine
+  pair observations before failing on the first deletions control with
+  `Index coverage or distinct count mismatch`. No subset is promoted.
+- Read-only diagnosis: each native deletions control retains physical distinct
+  count 6 after deleting three of six rows; its independent continuation has
+  count 7 after adding one row. Their live/table counts are respectively 3 and
+  4. The public deletion candidate has count 3 and its continuation count 4.
+  Deletion snapshots match the requested logical rows, traversal and Seek, but
+  these diagnostics are not accepted format or compatibility evidence and do
+  not weaken the frozen raw-count predicate. No reacquisition was attempted.
+- The report was independently rebuilt with the pinned analyzer and matched
+  exactly. Retained `report.json` SHA-256
+  `ca203ec4d46164e03319bc3e6c28c2e909a8f47d90f8c58e48876cadb0adf76f`;
+  retained `result.json` SHA-256
+  `032966c5ecea74fe2be0bc12ca09d2fc36084aff698ac02c2f6e51cdb3e2b914`. Artifacts remain in the external shared
+  outbox under the run identifier above. This local development result makes
+  no compatibility claim or hosted support-matrix movement.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -13487,6 +13487,46 @@ Retained MDB identities (filename: bytes, SHA-256):
   `development_only=true`, `compatibility_claim=false` and
   `support_matrix_movement=false` remain unchanged.
 
+## EXP-0215 — Unique Long leaf indexed row mutation candidates
+
+- Preregistered local validation; no acquisition has run. Plan
+  `oracle/windows-dao/acquisition/indexed-row-candidate.plan.json`, SHA-256
+  `1fd6426e6e2061d3e2d8ef99c2f3abad0a0f8d31a7b30ed74ff5364fd35b3cb3`. Reviewed parser source
+  `d459298020e5cfa9710eb27b2e6cfc2925366261`; the standalone public exporter,
+  eight image hashes, four preparation receipts and 45 scoped inputs are pinned.
+- Four profiles, each with three fresh native DAO controls: ascending primary
+  insertion, descending unique insertion, the 199-to-200 leaf boundary, and
+  deletions of Ids 1, 4, 0 among six rows. The schema is
+  `Items(Id Long, Value Long)` with the single directed unique `ByKey` index.
+- Public preparation creates four databases, performs six successful mutations
+  and four refused duplicate/capacity requests with unchanged bytes. Its exact
+  original/candidate pairs and action locators are pinned. Native control
+  originals are created independently from the same schemas and seed values.
+- Each of twelve pairs retains eight closed images/captures: public original and
+  candidate, native control original and mutated control, and separate candidate/
+  control copies for successful continuation insertion and duplicate-only rejection.
+  There are 633 native seed inserts, eighteen control mutations, twenty-four
+  successful continuation inserts and twenty-four planned duplicate attempts.
+- Require all 96 unchanged read identities, complete requested schema/rows,
+  full directed index traversal, every declared present/removed/follow/missing Seek,
+  and matched control semantics. Decode complete raw row/key/locator inventories,
+  distinct/table counts, index graphs and maps for non-duplicate roles, permitting
+  native compression/placement while requiring the public root leaf and exact map.
+- Reconstruct every public data-row/directory/free/count patch and its leaf entry/
+  boundary/free/distinct-count changes. Preserve all other bytes, including maps,
+  page zero, unrelated objects and vacated slack. No public index split, EOF data
+  append, null-key or last-row release behavior is claimed.
+- EXP-0190 observed rejected unique-insert count residue. Duplicate-only copies
+  therefore require native 3022 rejection, matched actual error numbers and exact
+  unchanged logical/schema/traversal/Seek state. Their raw table/live/distinct
+  counts are retained separately without requiring unchanged physical counts.
+- Three focused classifier tests, final exporter Clippy, exact image/receipt
+  reproduction, and actual x86 parsing plus 222 mock typed assignments passed.
+  Independent plan review and final repository checks precede one dispatch.
+  Unexpected acquisition/retention/comparison failure is `no_outcome`, with no
+  retry or subset promotion. EXP-0216 records the validated outcome once;
+  this preregistration moves no hosted support status.
+
 ## EXP-0185 — Typed-setter successor for unique Long key validation
 
 - Preregistered only; no acquisition. Outcome reserved as EXP-0186. Plan:

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -14836,3 +14836,15 @@ Retained original/control SHA-256 identities; the sole Rust destination repeats
   and DAO continuation mutations remain outside this inventory. The report's
   `support_matrix_movement` remains false; no general update compatibility is
   claimed. Earlier provenance entries and the consumed plan remain unchanged.
+
+### EXP-0215 — Final source integration before acquisition
+
+- Finalize the same unacquired matrix against merged source
+  `0fa4d07b1fc779e67ffb81e996f284abd962feec`. Plan SHA-256
+  `6fbee41dc0d54d7e47568a701b5bcce10dd0aecc5d5883575cf4f1261cbf46ff` supersedes the initial preregistration hash
+  above before any DAO acquisition. Only the source revision and two changed
+  creation-source pins were refreshed; all eight image identities, four public
+  preparation receipts, cases and acceptance rules reproduce unchanged.
+- No matching EXP-0215 plan or result exists in the external shared inbox/outbox.
+  The three focused analyzer tests and exact exporter reproduction passed.
+  Independent review must pass before the one authorized dispatch.

--- a/oracle/windows-dao/acquisition/indexed-row-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/indexed-row-candidate.plan.json
@@ -1,0 +1,1325 @@
+{
+  "document_type": "dao_indexed_row_plan",
+  "provenance": "EXP-0215",
+  "outcome_provenance": "EXP-0216",
+  "source_revision": "d459298020e5cfa9710eb27b2e6cfc2925366261",
+  "replicas": 3,
+  "arms": [
+    {
+      "name": "ascending",
+      "kind": "insert",
+      "descending": false,
+      "primary": true,
+      "rows": [
+        [
+          0,
+          100
+        ],
+        [
+          1,
+          101
+        ],
+        [
+          2,
+          102
+        ]
+      ],
+      "insert": [
+        -2147483648,
+        -777
+      ],
+      "delete": [],
+      "follow": [
+        500000,
+        777
+      ],
+      "duplicate": [
+        0,
+        0
+      ],
+      "queries": [
+        -2147483648,
+        0,
+        1,
+        2,
+        500000,
+        600000
+      ]
+    },
+    {
+      "name": "descending",
+      "kind": "insert",
+      "descending": true,
+      "primary": false,
+      "rows": [
+        [
+          0,
+          100
+        ],
+        [
+          1,
+          101
+        ],
+        [
+          2,
+          102
+        ]
+      ],
+      "insert": [
+        2147483647,
+        -777
+      ],
+      "delete": [],
+      "follow": [
+        500000,
+        777
+      ],
+      "duplicate": [
+        0,
+        0
+      ],
+      "queries": [
+        0,
+        1,
+        2,
+        500000,
+        600000,
+        2147483647
+      ]
+    },
+    {
+      "name": "capacity",
+      "kind": "insert",
+      "descending": false,
+      "primary": true,
+      "rows": [
+        [
+          0,
+          100
+        ],
+        [
+          1,
+          101
+        ],
+        [
+          2,
+          102
+        ],
+        [
+          3,
+          103
+        ],
+        [
+          4,
+          104
+        ],
+        [
+          5,
+          105
+        ],
+        [
+          6,
+          106
+        ],
+        [
+          7,
+          107
+        ],
+        [
+          8,
+          108
+        ],
+        [
+          9,
+          109
+        ],
+        [
+          10,
+          110
+        ],
+        [
+          11,
+          111
+        ],
+        [
+          12,
+          112
+        ],
+        [
+          13,
+          113
+        ],
+        [
+          14,
+          114
+        ],
+        [
+          15,
+          115
+        ],
+        [
+          16,
+          116
+        ],
+        [
+          17,
+          117
+        ],
+        [
+          18,
+          118
+        ],
+        [
+          19,
+          119
+        ],
+        [
+          20,
+          120
+        ],
+        [
+          21,
+          121
+        ],
+        [
+          22,
+          122
+        ],
+        [
+          23,
+          123
+        ],
+        [
+          24,
+          124
+        ],
+        [
+          25,
+          125
+        ],
+        [
+          26,
+          126
+        ],
+        [
+          27,
+          127
+        ],
+        [
+          28,
+          128
+        ],
+        [
+          29,
+          129
+        ],
+        [
+          30,
+          130
+        ],
+        [
+          31,
+          131
+        ],
+        [
+          32,
+          132
+        ],
+        [
+          33,
+          133
+        ],
+        [
+          34,
+          134
+        ],
+        [
+          35,
+          135
+        ],
+        [
+          36,
+          136
+        ],
+        [
+          37,
+          137
+        ],
+        [
+          38,
+          138
+        ],
+        [
+          39,
+          139
+        ],
+        [
+          40,
+          140
+        ],
+        [
+          41,
+          141
+        ],
+        [
+          42,
+          142
+        ],
+        [
+          43,
+          143
+        ],
+        [
+          44,
+          144
+        ],
+        [
+          45,
+          145
+        ],
+        [
+          46,
+          146
+        ],
+        [
+          47,
+          147
+        ],
+        [
+          48,
+          148
+        ],
+        [
+          49,
+          149
+        ],
+        [
+          50,
+          150
+        ],
+        [
+          51,
+          151
+        ],
+        [
+          52,
+          152
+        ],
+        [
+          53,
+          153
+        ],
+        [
+          54,
+          154
+        ],
+        [
+          55,
+          155
+        ],
+        [
+          56,
+          156
+        ],
+        [
+          57,
+          157
+        ],
+        [
+          58,
+          158
+        ],
+        [
+          59,
+          159
+        ],
+        [
+          60,
+          160
+        ],
+        [
+          61,
+          161
+        ],
+        [
+          62,
+          162
+        ],
+        [
+          63,
+          163
+        ],
+        [
+          64,
+          164
+        ],
+        [
+          65,
+          165
+        ],
+        [
+          66,
+          166
+        ],
+        [
+          67,
+          167
+        ],
+        [
+          68,
+          168
+        ],
+        [
+          69,
+          169
+        ],
+        [
+          70,
+          170
+        ],
+        [
+          71,
+          171
+        ],
+        [
+          72,
+          172
+        ],
+        [
+          73,
+          173
+        ],
+        [
+          74,
+          174
+        ],
+        [
+          75,
+          175
+        ],
+        [
+          76,
+          176
+        ],
+        [
+          77,
+          177
+        ],
+        [
+          78,
+          178
+        ],
+        [
+          79,
+          179
+        ],
+        [
+          80,
+          180
+        ],
+        [
+          81,
+          181
+        ],
+        [
+          82,
+          182
+        ],
+        [
+          83,
+          183
+        ],
+        [
+          84,
+          184
+        ],
+        [
+          85,
+          185
+        ],
+        [
+          86,
+          186
+        ],
+        [
+          87,
+          187
+        ],
+        [
+          88,
+          188
+        ],
+        [
+          89,
+          189
+        ],
+        [
+          90,
+          190
+        ],
+        [
+          91,
+          191
+        ],
+        [
+          92,
+          192
+        ],
+        [
+          93,
+          193
+        ],
+        [
+          94,
+          194
+        ],
+        [
+          95,
+          195
+        ],
+        [
+          96,
+          196
+        ],
+        [
+          97,
+          197
+        ],
+        [
+          98,
+          198
+        ],
+        [
+          99,
+          199
+        ],
+        [
+          100,
+          200
+        ],
+        [
+          101,
+          201
+        ],
+        [
+          102,
+          202
+        ],
+        [
+          103,
+          203
+        ],
+        [
+          104,
+          204
+        ],
+        [
+          105,
+          205
+        ],
+        [
+          106,
+          206
+        ],
+        [
+          107,
+          207
+        ],
+        [
+          108,
+          208
+        ],
+        [
+          109,
+          209
+        ],
+        [
+          110,
+          210
+        ],
+        [
+          111,
+          211
+        ],
+        [
+          112,
+          212
+        ],
+        [
+          113,
+          213
+        ],
+        [
+          114,
+          214
+        ],
+        [
+          115,
+          215
+        ],
+        [
+          116,
+          216
+        ],
+        [
+          117,
+          217
+        ],
+        [
+          118,
+          218
+        ],
+        [
+          119,
+          219
+        ],
+        [
+          120,
+          220
+        ],
+        [
+          121,
+          221
+        ],
+        [
+          122,
+          222
+        ],
+        [
+          123,
+          223
+        ],
+        [
+          124,
+          224
+        ],
+        [
+          125,
+          225
+        ],
+        [
+          126,
+          226
+        ],
+        [
+          127,
+          227
+        ],
+        [
+          128,
+          228
+        ],
+        [
+          129,
+          229
+        ],
+        [
+          130,
+          230
+        ],
+        [
+          131,
+          231
+        ],
+        [
+          132,
+          232
+        ],
+        [
+          133,
+          233
+        ],
+        [
+          134,
+          234
+        ],
+        [
+          135,
+          235
+        ],
+        [
+          136,
+          236
+        ],
+        [
+          137,
+          237
+        ],
+        [
+          138,
+          238
+        ],
+        [
+          139,
+          239
+        ],
+        [
+          140,
+          240
+        ],
+        [
+          141,
+          241
+        ],
+        [
+          142,
+          242
+        ],
+        [
+          143,
+          243
+        ],
+        [
+          144,
+          244
+        ],
+        [
+          145,
+          245
+        ],
+        [
+          146,
+          246
+        ],
+        [
+          147,
+          247
+        ],
+        [
+          148,
+          248
+        ],
+        [
+          149,
+          249
+        ],
+        [
+          150,
+          250
+        ],
+        [
+          151,
+          251
+        ],
+        [
+          152,
+          252
+        ],
+        [
+          153,
+          253
+        ],
+        [
+          154,
+          254
+        ],
+        [
+          155,
+          255
+        ],
+        [
+          156,
+          256
+        ],
+        [
+          157,
+          257
+        ],
+        [
+          158,
+          258
+        ],
+        [
+          159,
+          259
+        ],
+        [
+          160,
+          260
+        ],
+        [
+          161,
+          261
+        ],
+        [
+          162,
+          262
+        ],
+        [
+          163,
+          263
+        ],
+        [
+          164,
+          264
+        ],
+        [
+          165,
+          265
+        ],
+        [
+          166,
+          266
+        ],
+        [
+          167,
+          267
+        ],
+        [
+          168,
+          268
+        ],
+        [
+          169,
+          269
+        ],
+        [
+          170,
+          270
+        ],
+        [
+          171,
+          271
+        ],
+        [
+          172,
+          272
+        ],
+        [
+          173,
+          273
+        ],
+        [
+          174,
+          274
+        ],
+        [
+          175,
+          275
+        ],
+        [
+          176,
+          276
+        ],
+        [
+          177,
+          277
+        ],
+        [
+          178,
+          278
+        ],
+        [
+          179,
+          279
+        ],
+        [
+          180,
+          280
+        ],
+        [
+          181,
+          281
+        ],
+        [
+          182,
+          282
+        ],
+        [
+          183,
+          283
+        ],
+        [
+          184,
+          284
+        ],
+        [
+          185,
+          285
+        ],
+        [
+          186,
+          286
+        ],
+        [
+          187,
+          287
+        ],
+        [
+          188,
+          288
+        ],
+        [
+          189,
+          289
+        ],
+        [
+          190,
+          290
+        ],
+        [
+          191,
+          291
+        ],
+        [
+          192,
+          292
+        ],
+        [
+          193,
+          293
+        ],
+        [
+          194,
+          294
+        ],
+        [
+          195,
+          295
+        ],
+        [
+          196,
+          296
+        ],
+        [
+          197,
+          297
+        ],
+        [
+          198,
+          298
+        ]
+      ],
+      "insert": [
+        199,
+        -777
+      ],
+      "delete": [],
+      "follow": [
+        500000,
+        777
+      ],
+      "duplicate": [
+        0,
+        0
+      ],
+      "queries": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        128,
+        129,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        144,
+        145,
+        146,
+        147,
+        148,
+        149,
+        150,
+        151,
+        152,
+        153,
+        154,
+        155,
+        156,
+        157,
+        158,
+        159,
+        160,
+        161,
+        162,
+        163,
+        164,
+        165,
+        166,
+        167,
+        168,
+        169,
+        170,
+        171,
+        172,
+        173,
+        174,
+        175,
+        176,
+        177,
+        178,
+        179,
+        180,
+        181,
+        182,
+        183,
+        184,
+        185,
+        186,
+        187,
+        188,
+        189,
+        190,
+        191,
+        192,
+        193,
+        194,
+        195,
+        196,
+        197,
+        198,
+        199,
+        500000,
+        600000
+      ]
+    },
+    {
+      "name": "deletions",
+      "kind": "delete",
+      "descending": false,
+      "primary": true,
+      "rows": [
+        [
+          0,
+          100
+        ],
+        [
+          1,
+          101
+        ],
+        [
+          2,
+          102
+        ],
+        [
+          3,
+          103
+        ],
+        [
+          4,
+          104
+        ],
+        [
+          5,
+          105
+        ]
+      ],
+      "insert": null,
+      "delete": [
+        1,
+        4,
+        0
+      ],
+      "follow": [
+        500000,
+        777
+      ],
+      "duplicate": [
+        2,
+        0
+      ],
+      "queries": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        500000,
+        600000
+      ]
+    }
+  ],
+  "receipts": {
+    "ascending": {
+      "root": 20,
+      "actions": [
+        {
+          "kind": "insert",
+          "page": 24,
+          "slot": 3
+        }
+      ],
+      "public_refusal": "duplicate",
+      "refusal_preserved": true
+    },
+    "descending": {
+      "root": 20,
+      "actions": [
+        {
+          "kind": "insert",
+          "page": 24,
+          "slot": 3
+        }
+      ],
+      "public_refusal": "duplicate",
+      "refusal_preserved": true
+    },
+    "capacity": {
+      "root": 20,
+      "actions": [
+        {
+          "kind": "insert",
+          "page": 25,
+          "slot": 30
+        }
+      ],
+      "public_refusal": "capacity",
+      "refusal_preserved": true
+    },
+    "deletions": {
+      "root": 20,
+      "actions": [
+        {
+          "kind": "delete",
+          "page": 24,
+          "slot": 1
+        },
+        {
+          "kind": "delete",
+          "page": 24,
+          "slot": 4
+        },
+        {
+          "kind": "delete",
+          "page": 24,
+          "slot": 0
+        }
+      ],
+      "public_refusal": "duplicate",
+      "refusal_preserved": true
+    }
+  },
+  "images": {
+    "ascending-candidate.mdb": {
+      "size": 51200,
+      "sha256": "a8160e4723e42c919b66b60ab9211bfc1a1451ffb9b1bfebafcf6ab01f69008c"
+    },
+    "ascending-original.mdb": {
+      "size": 51200,
+      "sha256": "da7943a89ddbe8534bfd2a192eb7ca31d65fb0a9ebd3562d05a211ba46630e0c"
+    },
+    "capacity-candidate.mdb": {
+      "size": 53248,
+      "sha256": "aab4a8fc0ce9d22d55c493b312994d8263b1f189842277fc250f7c87712a2019"
+    },
+    "capacity-original.mdb": {
+      "size": 53248,
+      "sha256": "499c8b10b022899f1672d71b7b0444cef8b4cd831b218766b38d3c017419b0a7"
+    },
+    "deletions-candidate.mdb": {
+      "size": 51200,
+      "sha256": "3c2b078819eaf9fe3a61603a60bd2621c35387a756f3f9eecf7c31613df161ca"
+    },
+    "deletions-original.mdb": {
+      "size": 51200,
+      "sha256": "4a6d7d7c170913e1e3790e5cc53de3d8f3c1f9a8c0d1fe2267bc9e3a7b0ef438"
+    },
+    "descending-candidate.mdb": {
+      "size": 51200,
+      "sha256": "1832e82dae72b7b00f82d749b02861a61549ffa7c48f39e9c457b9d103c3d313"
+    },
+    "descending-original.mdb": {
+      "size": 51200,
+      "sha256": "689335626dcba8810dd80203e8e4c521cbaaca18f46d19a7c611a94e0a5d8abb"
+    }
+  },
+  "inputs": {
+    "Cargo.lock": "862e85e19ae578d9ed7be1113041b1053c30500badccd8b88c29233efc2af5a2",
+    "Cargo.toml": "6d13cd82b6ea190311d8ba28311f23122e4cffa69c02135f465460236e951c60",
+    "crates/jet3/Cargo.toml": "3061aa9102924ee6e74c24752ba1b0a630440dfcc60708f984a4aa238dff4b75",
+    "crates/jet3/examples/indexed_row_mutation_candidate.rs": "643b2c155954cd3b35660ebef32280f0c3899f75f26f3e1717bf525fd228caad",
+    "crates/jet3/src/allocation_patch.rs": "13f962e9704a3cd7a5bcdd9f132c404e5d6c86c727920ca04da0d162fecd41c1",
+    "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
+    "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
+    "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
+    "crates/jet3/src/creation/api.rs": "b8bf08eb99dae36180c35f1bdc5158b1e68be091d2bf0069983acf96f9f5a946",
+    "crates/jet3/src/creation/composer/initial_index.rs": "ec8ea416ebec5956b3272c9bee120964c318b456fd239079f3721fce554d99af",
+    "crates/jet3/src/creation/composer/initial_index_pages.rs": "b74c06692d4edee4731a30e449e3068f078b9a4e22f47deccb4884d38c046974",
+    "crates/jet3/src/creation/composer/table_create.rs": "d6a81c7b1b92b07d2b3b5346fddb2f16048ff873a18f207dec7f3705c4e4b00e",
+    "crates/jet3/src/creation/schema_plan.rs": "a6829efba233b33e1f8d332f7840b5cb4ba0ccbb8919eec46383647bc5552143",
+    "crates/jet3/src/delete.rs": "98add115d5a85e5066cef6374189b5d993e3b4d01f70d4cf3add2cfa746aec73",
+    "crates/jet3/src/index_definition.rs": "8e9c99fd2a0a1441de0fc3e2d897ba64709439a3ea548b4bc845bad48df513d6",
+    "crates/jet3/src/index_key_page.rs": "b12d4c19205ad390cd11aa9546e8a5ffc030545b147b79e6c38cc1fa766392be",
+    "crates/jet3/src/index_tree.rs": "40f2d099b6416c09e70b51366d51a4555238ab031d94b51ef1fc416085d679bc",
+    "crates/jet3/src/index_tree_page.rs": "feef6c5b3415bb8d3fc105d81da40c4d5a79599211bb33bdff9dd05a41f933cd",
+    "crates/jet3/src/index_tree_rows.rs": "d702307f87223133f7109ae217e463cb99188c8c494ebcd4efbf27231450409e",
+    "crates/jet3/src/insert.rs": "7dab0fa43e1f459569015edcfe53c2efb719784a3b77491cbeb7fde6353961a3",
+    "crates/jet3/src/long_index_key.rs": "e036ab5a853cc997571d0fac38dd559edc5203e10e2310fdc89bea11d5202575",
+    "crates/jet3/src/page_image.rs": "a33211ac27927bab6ddaf773af18c2e8a2de4bb7735fa9e5382ee54322a9c093",
+    "crates/jet3/src/physical_index_definition.rs": "920f2d0d2e51307781cc18c27693772e1472186630f1e909c7ab135515e96553",
+    "crates/jet3/src/resource.rs": "0495f6264de1254f42bd31bd4369e0941d65cb96a4b53c91a45bbf0acca95750",
+    "crates/jet3/src/row.rs": "64647c6c4ed50f88841d6d28fcf170653055e44ec4e3ee61f1ec2aaa50a5d1ae",
+    "crates/jet3/src/row_delete_page.rs": "ab61456a71c46aa6ab8db25afb55dae00a05a915c89ae003b6b129b7d7706de8",
+    "crates/jet3/src/row_directory.rs": "0f683eec5d9d0f13e114de04e6c137bf953ee55c80fe6436508776299169a844",
+    "crates/jet3/src/row_insert_eof.rs": "2b33c18de09f377bddf91b19431d7af8b7708e872e59bf2775f420b69629b5de",
+    "crates/jet3/src/row_insert_page.rs": "c338292a412b187b097defc4a4f88fc17dd2a30549c6ee93ad5ce754b7d44a6a",
+    "crates/jet3/src/row_writer.rs": "35c8310d027db4321a6251b1b68616d9ae0c6c8f4e82af0b1fd5e36b729420fb",
+    "crates/jet3/src/source.rs": "84ebc1c169b9441a4c2932c61b8faf46f0546e19bbc686a8e84718ec781a950a",
+    "crates/jet3/src/table_definition.rs": "7bc113e3fbd73dbb33d40476feb0e27ef11ddc4fcb9e7ac98dfe8f7dd34793c2",
+    "crates/jet3/src/unique_leaf.rs": "9367160561b9509e37ae2f169d5344c31497f8e697c69b5c62ac0d009e1565f5",
+    "crates/jet3/src/update.rs": "e10419cf6c9671b42aa93cff671f00e1a63fde9522853b0b3150f8e98df662fc",
+    "crates/jet3/src/update_index_key.rs": "1e73214c8f5ccd3ca0cdac34495d3e3f90e717c4d9a1c30c76768fc6a3f5b9fa",
+    "crates/jet3/src/update_pages.rs": "431201c558c17c9a19affd0850ddf9591109a3b2b70a51546cbc155013d6d0b5",
+    "oracle/windows-dao/acquisition/single-leaf-key.plan.json": "40a1258ee08926d97df3f3edf8549a752d28b7aaaf58e7b7e9bdc82863c6e656",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/indexed_row_candidate.ps1": "a39b51879f1488c12aed746b456228dafc198725cb96e2cdc694c8986e52e39f",
+    "oracle/windows-dao/scripts/indexed_row_candidate.py": "beb35fc02c57441efff8275f0e7a23a9aeb3200decaf2bfb33a0f24c61052422",
+    "oracle/windows-dao/scripts/multi_level_index_structure.py": "a4291fd040cb6a90fb68dfbb5dfe75f9f5990caa1d3cec6893577b118191d928",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/tests/check_indexed_row_candidate.ps1": "dd5d445462093b8c78b6bebb434f7d2a7f2744974c139b9ebbcad4ebaa245597",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9"
+  },
+  "question": "Do exact bounded public unique Long leaf row inserts/deletes preserve semantics and unrelated bytes under DAO and independent continuation/rejection probes?",
+  "sequence": [
+    "Commit independently reviewed plan and all source/candidate pins before one local dispatch; no retry or resume.",
+    "Four profiles times three: ascending primary insert, descending unique insert,199-to200 root-leaf capacity insert, retained deletions1/4/0 among six initial rows. All table schemas are Items(Id Long, Value Long), indexed ByKey.",
+    "Copy immutable public original/candidate images; create twelve independent native DAO controls from the same seeds/index schema. Retain native control originals, apply equivalent control operations and capture all baselines read-only.",
+    "On separate candidate/control copies insert500000/777; on other separate copies attempt the existing duplicate key with Value0. Capture all copies closed/reopened read-only, complete schema/rows/traversal and every finite present/removed/follow/missing key in queries.",
+    "Ninety-six images/captures: eight roles for each of twelve pairs. Twelve DAO creations with633 seed-row inserts, eighteen successful control row mutations (nine inserts and nine deletes), twenty-four successful continuation inserts and twenty-four planned duplicate attempts.",
+    "Complete raw table/index/rows/locator/count/map/graph checks apply to all non-duplicate roles, permitting native compression and native depth up to32 with declared8192page/1019slot limits. Candidate original/final index graph exactly equals index map and has one root leaf.",
+    "Public exact patches reconstruct row/slot compaction or insertion plus TDEF row/distinct counts and leaf records/bitmap/free count; all other bytes including map pages/page0/vacated slack unchanged. Public duplicate/capacity rejection and unchanged candidate bytes are recorded by the pinned exporter receipts.",
+    "EXP-0190 observed failed unique-insert distinct-count residue. Duplicate-only probes require rejection3022, matched actual native codes and exact unchanged logical/schema/traversal/Seek post-state. Raw table/live/distinct counts are retained separately, without guessing that rejected operations leave physical counts unchanged.",
+    "Any unexpected mutation/observation/identity/retention or comparison failure is no_outcome, no subset promotion. Preserve initiating failure endpoint/stack and all existing MDBs; no automatic reacquisition."
+  ],
+  "decision_rule": "observed_accepted iff all twelve pairs,96 unchanged read identities, complete semantic/control/probe gates and exact public patch/raw structural checks pass; otherwise no_outcome.",
+  "limits": "Local development-only candidate acceptance, no hosted support movement. Public index splits/EOF row insertion/last-row release/null/compressed/multiple-key mutation remain unsupported. Raw native graph checks do not require identical physical placement or writer packing. Single SSH timeout900seconds.",
+  "public_preparation": "Four public creations, six successful row mutations (three inserts/three deletes), four refused duplicate/capacity requests with exact preservation. Eight image hashes and four receipts are pinned; the standalone exporter reproduces all eight images and receipts exactly.",
+  "pure_preflight": "Actual x86 PowerShell parser and222 mock Int32 row assignments passed without executing DAO; repeat via pinned check_indexed_row_candidate.ps1."
+}

--- a/oracle/windows-dao/acquisition/indexed-row-candidate.plan.json
+++ b/oracle/windows-dao/acquisition/indexed-row-candidate.plan.json
@@ -2,7 +2,7 @@
   "document_type": "dao_indexed_row_plan",
   "provenance": "EXP-0215",
   "outcome_provenance": "EXP-0216",
-  "source_revision": "d459298020e5cfa9710eb27b2e6cfc2925366261",
+  "source_revision": "0fa4d07b1fc779e67ffb81e996f284abd962feec",
   "replicas": 3,
   "arms": [
     {
@@ -1268,10 +1268,10 @@
     "crates/jet3/src/atomic.rs": "450e15e7730150b87f936d0bbb207910e225fd1a512f240c98d96e1dfdf9ed6f",
     "crates/jet3/src/catalog.rs": "c755f928445950b35aaaf5ca7dfa33744fcbcbdae548eaf49c19a85b42246c33",
     "crates/jet3/src/column_definition.rs": "f3f0741ce47d48f0fd368bca117f13e773326e4b77ee14bbc18e4a44f10861de",
-    "crates/jet3/src/creation/api.rs": "b8bf08eb99dae36180c35f1bdc5158b1e68be091d2bf0069983acf96f9f5a946",
+    "crates/jet3/src/creation/api.rs": "a5b178f1b42a079ba21606fdbe588f214e5ea5601f12fbc89c703e70fdb41be5",
     "crates/jet3/src/creation/composer/initial_index.rs": "ec8ea416ebec5956b3272c9bee120964c318b456fd239079f3721fce554d99af",
     "crates/jet3/src/creation/composer/initial_index_pages.rs": "b74c06692d4edee4731a30e449e3068f078b9a4e22f47deccb4884d38c046974",
-    "crates/jet3/src/creation/composer/table_create.rs": "d6a81c7b1b92b07d2b3b5346fddb2f16048ff873a18f207dec7f3705c4e4b00e",
+    "crates/jet3/src/creation/composer/table_create.rs": "6b696fb00c229a0517116736339c6b25cc62439fb5514e3514edbd662ca78d93",
     "crates/jet3/src/creation/schema_plan.rs": "a6829efba233b33e1f8d332f7840b5cb4ba0ccbb8919eec46383647bc5552143",
     "crates/jet3/src/delete.rs": "98add115d5a85e5066cef6374189b5d993e3b4d01f70d4cf3add2cfa746aec73",
     "crates/jet3/src/index_definition.rs": "8e9c99fd2a0a1441de0fc3e2d897ba64709439a3ea548b4bc845bad48df513d6",

--- a/oracle/windows-dao/scripts/indexed_row_candidate.ps1
+++ b/oracle/windows-dao/scripts/indexed_row_candidate.ps1
@@ -1,0 +1,84 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected x86 DAO'}
+$helper=Join-Path $env:JET3_WORK 'field_update.ps1';$tokens=$null;$errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile($helper,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Helper parse failure'}
+foreach($name in @('Identity','Release','Write-Json')){
+    $found=@($ast.FindAll({param($n)$n-is [Management.Automation.Language.FunctionDefinitionAst]-and $n.Name-eq $name},$false))
+    if($found.Count-ne 1){throw 'Missing helper'};Invoke-Expression $found[0].Extent.Text
+}
+function Failure($Record){return @{type=$Record.Exception.GetType().FullName;message=$Record.Exception.Message;hresult=$Record.Exception.HResult;endpoint=$script:endpoint;stack=$Record.ScriptStackTrace}}
+function Close($Object,[bool]$Database){if($null-eq $Object){return};try{if($Database){$Object.Close()}}catch{if($null-eq $script:failure){$script:failure=Failure $_}}finally{Release $Object}}
+function Set-Long($Rs,[string]$Name,[int]$Value){
+    $field=$null;$prior=$script:endpoint;$script:endpoint="$prior/field/$Name"
+    try{$field=$Rs.Fields.Item($Name);$field.Value=[int]$Value}catch{if($null-eq $script:failure){$script:failure=Failure $_};throw}finally{Release $field;$script:endpoint=$prior}
+}
+function Append-Row($Rs,$Values){$Rs.AddNew();Set-Long $Rs 'Id' ([int]$Values[0]);Set-Long $Rs 'Value' ([int]$Values[1]);$Rs.Update()}
+function Row($Rs){return ,([object[]]@([int]$Rs.Fields.Item('Id').Value,[int]$Rs.Fields.Item('Value').Value))}
+function Create-Control([string]$Path,$Arm){
+    $engine=$workspace=$db=$table=$index=$field=$rs=$null
+    try{
+        $engine=New-Object -ComObject DAO.DBEngine.36;$workspace=$engine.Workspaces.Item(0);$script:endpoint='control/create';$script:mutationStarted=$true
+        $db=$workspace.CreateDatabase($Path,';LANGID=0x0409;CP=1252;COUNTRY=0',32);$table=$db.CreateTableDef('Items')
+        foreach($name in @('Id','Value')){$field=$table.CreateField($name,4);$table.Fields.Append($field);Release $field;$field=$null}
+        $index=$table.CreateIndex('ByKey');$index.Primary=[bool]$Arm.primary;$index.Unique=$true;$index.Required=[bool]$Arm.primary
+        $field=$index.CreateField('Id');$field.Attributes=[int]$Arm.descending;$index.Fields.Append($field);Release $field;$field=$null;$table.Indexes.Append($index);$db.TableDefs.Append($table)
+        $rs=$db.OpenRecordset('Items',2);foreach($row in $Arm.rows){$script:endpoint='control/seed';Append-Row $rs $row}
+    }catch{if($null-eq $script:failure){$script:failure=Failure $_};throw}finally{Close $rs $true;Close $field $false;Close $index $false;Close $table $false;Close $db $true;Close $workspace $false;Close $engine $false}
+}
+function Mutate([string]$Path,$Arm,[string]$Mode){
+    $engine=$db=$rs=$null;$operation=@{status='complete'}
+    try{
+        $engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$false);$rs=$db.OpenRecordset('Items',1);$rs.Index='ByKey';$script:endpoint="mutate/$Mode"
+        if($Mode-eq 'duplicate'){
+            $accepted=$false;$errorDetail=$null;$numbers=@()
+            try{Append-Row $rs $Arm.duplicate;$accepted=$true}catch{$errorDetail=Failure $_;$numbers=@($engine.Errors|ForEach-Object{[int]$_.Number})}
+            $operation=@{accepted=$accepted;error=$errorDetail;numbers=$numbers}
+            if(-not $accepted){$rs.CancelUpdate()}
+            if($accepted-or $numbers-notcontains 3022){throw 'Expected duplicate-key rejection'}
+        }elseif($Mode-eq 'next'){Append-Row $rs $Arm.follow}
+        elseif($Arm.kind-eq 'insert'){Append-Row $rs $Arm.insert}
+        else{foreach($id in $Arm.delete){$rs.Seek('=',[int]$id);if($rs.NoMatch){throw 'Deleted key absent'};$rs.Delete()}}
+    }catch{if($null-eq $script:failure){$script:failure=Failure $_};throw}finally{Close $rs $true;Close $db $true;Close $engine $false}
+    return $operation
+}
+function Capture([string]$Path,$Arm){
+    $before=Identity $Path;$engine=$db=$table=$rs=$null;$snapshot=@{};$errorDetail=$null
+    try{
+        $script:endpoint='capture/open';$engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$true)
+        $snapshot.version=[string]$db.Version;$snapshot.tables=@($db.TableDefs|ForEach-Object{[string]$_.Name}|Sort-Object);$snapshot.relations=@($db.Relations|ForEach-Object{[string]$_.Name});$snapshot.queries=@($db.QueryDefs|ForEach-Object{[string]$_.Name})
+        $table=$db.TableDefs.Item('Items');$item=@{name=[string]$table.Name;attributes=[int]$table.Attributes}
+        $item.fields=@($table.Fields|ForEach-Object{@{name=[string]$_.Name;type=[int]$_.Type;size=[int]$_.Size;attributes=[int]$_.Attributes;required=[bool]$_.Required;allow_zero_length=[bool]$_.AllowZeroLength;default_value=[string]$_.DefaultValue}})
+        $item.indexes=@($table.Indexes|ForEach-Object{@{name=[string]$_.Name;primary=[bool]$_.Primary;unique=[bool]$_.Unique;required=[bool]$_.Required;foreign=[bool]$_.Foreign;ignore_nulls=[bool]$_.IgnoreNulls;fields=@($_.Fields|ForEach-Object{@{name=[string]$_.Name;attributes=[int]$_.Attributes}})}})
+        $script:endpoint='capture/rows';$rs=$db.OpenRecordset('Items',4);$rows=New-Object Collections.ArrayList
+        while(-not $rs.EOF){[void]$rows.Add((Row $rs));$rs.MoveNext()};$item.rows=[object[]]$rows.ToArray();$snapshot.user_tables=@($item);Close $rs $true;$rs=$null
+        $script:endpoint='capture/index';$rs=$db.OpenRecordset('Items',1);$rs.Index='ByKey';$rows=New-Object Collections.ArrayList
+        if(-not $rs.EOF){$rs.MoveFirst()};while(-not $rs.EOF){[void]$rows.Add((Row $rs));$rs.MoveNext()};$snapshot.traversal=[object[]]$rows.ToArray();$seeks=New-Object Collections.ArrayList
+        foreach($query in $Arm.queries){$rs.Seek('=',[int]$query);$row=if($rs.NoMatch){$null}else{Row $rs};[void]$seeks.Add(@{query=[int]$query;row=$row})};$snapshot.seek=[object[]]$seeks.ToArray()
+    }catch{$errorDetail=Failure $_;if($null-eq $script:failure){$script:failure=$errorDetail}}finally{Close $rs $true;Close $table $false;Close $db $true;Close $engine $false}
+    return @{file=[IO.Path]::GetFileName($Path);before=$before;after=(Identity $Path);status=if($null-eq $errorDetail){'pass'}else{'error'};error=$errorDetail;snapshot=$snapshot}
+}
+$planPath=Join-Path $env:JET3_WORK 'indexed-row-candidate.plan.json';$plan=Get-Content -LiteralPath $planPath -Raw|ConvertFrom-Json
+if((Identity $PSCommandPath).sha256-cne $plan.inputs.'oracle/windows-dao/scripts/indexed_row_candidate.ps1'-or (Identity $helper).sha256-cne $plan.inputs.'oracle/windows-dao/scripts/field_update.ps1'){throw 'Producer input mismatch'}
+$script:failure=$null;$script:mutationStarted=$false;$script:endpoint='start'
+$result=@{document_type='dao_indexed_row_result';plan_sha256=(Identity $planPath).sha256;source_revision=$plan.source_revision;environment=@{process_bits=32;provider='DAO.DBEngine.36'};pairs=@();error=$null;retention_failures=@();mutation_started=$false}
+try{
+    foreach($arm in $plan.arms){foreach($replica in 1..3){
+        $prefix="$($arm.name)-r$replica";$pair=@{arm=$arm.name;replica=$replica;captures=@{};operations=@{}};$result.pairs+=,$pair
+        foreach($role in @('original','candidate')){$source=Join-Path $env:JET3_WORK "$($arm.name)-$role.mdb";$pin=$plan.images."$($arm.name)-$role.mdb";$actual=Identity $source;if($actual.sha256-cne $pin.sha256-or $actual.size-ne $pin.size){throw 'Public image pin'};Copy-Item $source (Join-Path $env:JET3_WORK "$prefix-$role.mdb")}
+        $control=Join-Path $env:JET3_WORK "$prefix-control-original.mdb";Create-Control $control $arm
+        foreach($role in @('original','candidate','control-original')){$pair.captures[$role]=Capture (Join-Path $env:JET3_WORK "$prefix-$role.mdb") $arm;if($pair.captures[$role].status-ne 'pass'-or $null-ne $script:failure){throw 'Baseline capture failed'}}
+        $path=Join-Path $env:JET3_WORK "$prefix-control.mdb";Copy-Item $control $path;$pair.operations.control=Mutate $path $arm 'control';$pair.captures.control=Capture $path $arm
+        if($pair.captures.control.status-ne 'pass'-or $null-ne $script:failure){throw 'Control mutation/capture failed'}
+        foreach($mode in @('next','duplicate')){foreach($role in @('candidate','control')){
+            $name="$role-$mode";$path=Join-Path $env:JET3_WORK "$prefix-$name.mdb";Copy-Item (Join-Path $env:JET3_WORK "$prefix-$role.mdb") $path
+            $pair.operations[$name]=Mutate $path $arm $mode;$pair.captures[$name]=Capture $path $arm
+            if($pair.captures[$name].status-ne 'pass'-or $null-ne $script:failure){throw 'Continuation mutation/capture failed'}
+        }}
+    }}
+}catch{if($null-eq $script:failure){$script:failure=Failure $_}}finally{
+    $result.error=$script:failure;$result.mutation_started=$script:mutationStarted
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*-r*.mdb'){try{Copy-Item $file.FullName $env:JET3_OUTBOX}catch{$result.retention_failures+=@{file=$file.Name;error=$_.Exception.Message}}};Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if($null-ne $result.error-or $result.retention_failures.Count){exit 1}

--- a/oracle/windows-dao/scripts/indexed_row_candidate.py
+++ b/oracle/windows-dao/scripts/indexed_row_candidate.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Finite public indexed insertion/deletion validation; EXP-0215, no retries."""
+import argparse
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import field_update as common
+import multi_level_index_structure as structure
+ROOT=Path(__file__).resolve().parents[3]
+PLAN=ROOT/'oracle/windows-dao/acquisition/indexed-row-candidate.plan.json'
+SCRIPT='oracle/windows-dao/scripts/indexed_row_candidate.ps1'
+identity,canonical=common.identity,common.canonical
+catalog=structure.catalog
+
+def require(value,message):
+    if not value:raise ValueError(message)
+
+def verify_inputs():
+    plan=json.loads(PLAN.read_text())
+    for name,sha in plan['inputs'].items():require(identity(ROOT/name)['sha256']==sha,'Input pin mismatch: '+name)
+    return plan
+
+def rows_for(arm,role):
+    rows=copy.deepcopy(arm['rows'])
+    if role not in ('original','control-original'):
+        if arm['kind']=='insert':rows.append(arm['insert'])
+        else:rows=[r for r in rows if r[0] not in arm['delete']]
+    if role.endswith('-next'):rows.append(arm['follow'])
+    return sorted(rows)
+
+def definition(data):
+    d,_,objects=catalog._discover_catalog(data);n,i=[catalog._ordinal(d,k) for k in ('Name','Id')]
+    roots=[r['values'][i] for r in objects if r['values'][n]=='Items'];require(len(roots)==1,'Items root')
+    table=catalog._definition(data,roots[0]);pages,lval=catalog._table_pages(data,table);rows=catalog._table_rows(data,table,pages)
+    require(not lval and len(table['physical_indexes'])==len(table['logical_indexes'])==1,'One scalar index')
+    return table,rows
+
+def raw_check(data,arm,rows,candidate=False):
+    table,physical_rows=definition(data);physical=table['physical_indexes'][0]
+    require(physical['flags']==(9 if arm['primary'] else 1) and physical['keys']==[dict(column=0,direction=int(not arm['descending']))],'Physical key metadata')
+    spec=dict(name='Items',fields=[dict(name=n) for n in ('Id','Value')],indexes=[dict(fields=[dict(name='Id',descending=arm['descending'])])],candidate_depth=1)
+    result=structure.observe(data,[spec],{'Items':rows},candidate)
+    result[0]['row_locators']=[dict(values=r['values'],page=r['page'],slot=r['row']) for r in physical_rows]
+    return result
+
+def patch_check(before,after,arm,receipt):
+    raw_check(before,arm,arm['rows'],True);raw_check(after,arm,rows_for(arm,'candidate'),True)
+    expected=bytearray(before);actions=receipt['actions'];require(len(actions)==(1 if arm['kind']=='insert' else len(arm['delete'])),'Action inventory')
+    for step,action in enumerate(actions):
+        table,rows=definition(bytes(expected));require(table['root']==receipt['root'],'Receipt root')
+        page,slot=action['page'],action['slot'];offset=page*2048;image=bytes(expected[offset:offset+2048]);directory=catalog._row_directory(image,page)
+        require(image[:2]==b'\x01\x01' and int.from_bytes(image[4:8],'little')==table['root'] and directory,'Data page owner/kind')
+        lowest=directory[-1]['start'];free=lowest-10-2*len(directory)
+        require(int.from_bytes(image[2:4],'little')==free,'Data free bytes')
+        if arm['kind']=='insert':
+            require(action['kind']=='insert' and slot==len(directory) and slot<256,'Appended physical slot')
+            row=bytes([2])+b''.join(v.to_bytes(4,'little',signed=True) for v in arm['insert'])+b'\x03'
+            start=lowest-len(row);require(start>=10+2*(slot+1),'Row capacity')
+            expected[offset+start:offset+lowest]=row;expected[offset+10+slot*2:offset+12+slot*2]=start.to_bytes(2,'little')
+            expected[offset+8:offset+10]=(slot+1).to_bytes(2,'little');new_free=free-len(row)-2;count=len(rows)+1
+        else:
+            require(action['kind']=='delete' and slot<len(directory),'Deleted slot')
+            selected=[r for r in rows if r['values'][0]==arm['delete'][step]]
+            require(len(selected)==1 and (selected[0]['page'],selected[0]['row'])==(page,slot),'Deleted Id/locator')
+            target=directory[slot];start,end=target['start'],target['end'];length=end-start;require(length>0,'Live deletion')
+            expected[offset+lowest+length:offset+end]=image[lowest:start]
+            for n in range(slot,len(directory)):
+                old=int.from_bytes(image[10+2*n:12+2*n],'little');word=(end|0xc000) if n==slot else ((old&0xf000)|((old&0x0fff)+length))
+                expected[offset+10+2*n:offset+12+2*n]=word.to_bytes(2,'little')
+            new_free=free+length;count=len(rows)-1
+        expected[offset+2:offset+4]=new_free.to_bytes(2,'little');root=table['root']*2048
+        expected[root+12:root+16]=count.to_bytes(4,'little');expected[root+47:root+51]=count.to_bytes(4,'little')
+        _,new_rows=definition(bytes(expected));index=table['physical_indexes'][0]['root'];leaf=bytes(expected[index*2048:(index+1)*2048])
+        require(leaf[:2]==b'\x04\x01' and leaf[8:22]==bytes(14),'Candidate uncompressed root leaf')
+        records=sorted(structure.key_bytes(r['values'],[dict(name='Id',descending=arm['descending'])],['Id','Value'])+r['page'].to_bytes(3,'big')+bytes([r['row']]) for r in new_rows)
+        require(len(records)==count<=200,'Unique leaf capacity');bitmap=bytearray(226)
+        for n in range(1,count+1):bitmap[n*9//8]|=1<<(n*9%8)
+        base=index*2048;expected[base+2:base+4]=(1800-count*9).to_bytes(2,'little');expected[base+22:base+248]=bitmap;expected[base+248:base+248+count*9]=b''.join(records)
+    require(bytes(expected)==after,'Exact three-page patches, slack/maps/page0 and unrelated preservation')
+    require(receipt['refusal_preserved'] is True and receipt['public_refusal']==('capacity' if arm['name']=='capacity' else 'duplicate'),'Public duplicate/capacity refusal')
+    return dict(actions=actions,refusal=receipt['public_refusal'],changed_offsets=[i for i,(a,b) in enumerate(zip(before,after)) if a!=b],page0_unchanged=before[:2048]==after[:2048])
+
+def expected(snapshot,arm,role):
+    value=common.normalized(snapshot);rows=rows_for(arm,role)
+    require(value['version']=='3.0' and value['relations']==value['queries']==[] and value['tables']==['Items','MSysACEs','MSysObjects','MSysQueries','MSysRelationships'] and len(value['user_tables'])==1,'Complete table inventory')
+    table=value['user_tables'][0];fields=[dict(name=n,type=4,size=4,attributes=1) for n in ('Id','Value')]
+    index=dict(name='ByKey',primary=arm['primary'],unique=True,required=arm['primary'],foreign=False,ignore_nulls=False,fields=[dict(name='Id',attributes=int(arm['descending']))])
+    require(table['name']=='Items' and table['attributes']==0 and [{k:f[k] for k in ('name','type','size','attributes')} for f in table['fields']]==fields and table['indexes']==[index] and table['rows']==rows,'Exact schema/index/full rows')
+    require(value['traversal']==sorted(rows,reverse=arm['descending']) and value['seek']==[dict(query=q,row=next((r for r in rows if r[0]==q),None)) for q in arm['queries']],'Full directed traversal/present and missing Seek')
+    return value
+
+def build_report(result,outbox,plan):
+    observations=[];reasons=[]
+    try:
+        require(result['document_type']=='dao_indexed_row_result' and result['plan_sha256']==identity(PLAN)['sha256'] and result['source_revision']==plan['source_revision'] and result['error'] is None and result['retention_failures']==[] and result['mutation_started'] is True and result['environment']==dict(process_bits=32,provider='DAO.DBEngine.36'),'Acquisition/source failure')
+        pairs={(p['arm'],p['replica']):p for p in result['pairs']};require(len(pairs)==len(result['pairs']) and set(pairs)=={(a['name'],r) for a in plan['arms'] for r in range(1,4)},'Complete pairs')
+        for arm in plan['arms']:
+            for replica in range(1,4):
+                pair=pairs[arm['name'],replica];roles=['original','candidate','control-original','control','candidate-next','control-next','candidate-duplicate','control-duplicate'];snapshots={};images={};raw={};duplicate_counts={}
+                require(set(pair['captures'])==set(roles) and set(pair['operations'])=={'control','candidate-next','control-next','candidate-duplicate','control-duplicate'},'Complete capture/operation inventory')
+                for role in roles:
+                    c=pair['captures'][role];path=outbox/f"{arm['name']}-r{replica}-{role}.mdb"
+                    require(c['file']==path.name and c['status']=='pass' and c['error'] is None and c['before']==c['after']==identity(path),'Unchanged retained image');images[role]=identity(path)
+                    if role in ('original','candidate'):require(images[role]==plan['images'][arm['name']+'-'+role+'.mdb'],'Pinned public image')
+                    snapshots[role]=expected(c['snapshot'],arm,role)
+                    if role.endswith('-duplicate'):
+                        t,rs=definition(path.read_bytes());duplicate_counts[role]=dict(table_count=t['row_count'],distinct_count=t['physical_indexes'][0]['entry_count'],live_rows=len(rs))
+                    else:raw[role]=raw_check(path.read_bytes(),arm,rows_for(arm,role),role in ('original','candidate'))
+                for role in ('control','candidate-next','control-next'):require(pair['operations'][role]==dict(status='complete'),'Completed mutation')
+                for role in ('candidate-duplicate','control-duplicate'):
+                    p=pair['operations'][role];require(p['accepted'] is False and p['error'] is not None and 3022 in p['numbers'],'Duplicate native rejection')
+                require(pair['operations']['candidate-duplicate']['numbers']==pair['operations']['control-duplicate']['numbers'],'Matched native duplicate errors')
+                for a,b in [('original','control-original'),('candidate','control'),('candidate-next','control-next'),('candidate-duplicate','control-duplicate'),('candidate','candidate-duplicate')]:require(snapshots[a]==snapshots[b],'Full control or rejected post-state semantics')
+                metadata=[]
+                for snapshot in snapshots.values():
+                    value=copy.deepcopy(snapshot);value.pop('traversal');value.pop('seek');value['user_tables'][0].pop('rows');metadata.append(value)
+                require(all(v==metadata[0] for v in metadata),'Unrelated metadata changed')
+                patch=patch_check((outbox/f"{arm['name']}-r{replica}-original.mdb").read_bytes(),(outbox/f"{arm['name']}-r{replica}-candidate.mdb").read_bytes(),arm,plan['receipts'][arm['name']])
+                observations.append(dict(arm=arm['name'],replica=replica,identities=images,raw=raw,patch=patch,duplicate_counts=duplicate_counts,operations=pair['operations']))
+    except (ValueError,KeyError,TypeError,OSError,catalog.DecodeError) as e:reasons.append(str(e))
+    return dict(document_type='dao_indexed_row_report',outcome='no_outcome' if reasons else 'observed_accepted',plan_sha256=identity(PLAN)['sha256'],reasons=reasons,observations=observations,development_only=True,compatibility_claim=False,support_matrix_movement=False)
+
+def preflight(images):
+    plan=verify_inputs();require(subprocess.check_output(['git','show',f'HEAD:{PLAN.relative_to(ROOT)}'],cwd=ROOT)==PLAN.read_bytes(),'Plan not committed')
+    for name,pin in plan['images'].items():require(identity(images/name)==pin,'Candidate pin: '+name)
+    for a in plan['arms']:patch_check((images/(a['name']+'-original.mdb')).read_bytes(),(images/(a['name']+'-candidate.mdb')).read_bytes(),a,plan['receipts'][a['name']])
+    return plan
+
+def analyze(outbox):
+    plan=verify_inputs();report=build_report(json.loads((outbox/'result.json').read_text(encoding='utf-8-sig')),outbox,plan);report['result_sha256']=identity(outbox/'result.json')['sha256'];(outbox/'report.json').write_text(canonical(report)+'\n');print(report['outcome'])
+
+def dispatch(args):
+    plan=preflight(args.images);require(re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id),'Run id');shared=args.shared_root.resolve();inbox=shared/'inbox'/args.run_id;outbox=shared/'outbox'/args.run_id;require(not inbox.exists() and not outbox.exists(),'Used run; no retry');inbox.mkdir(parents=True)
+    for name in plan['images']:shutil.copyfile(args.images/name,inbox/name)
+    shutil.copyfile(ROOT/SCRIPT,inbox/'script.ps1');shutil.copyfile(ROOT/'oracle/windows-dao/scripts/field_update.ps1',inbox/'field_update.ps1');shutil.copyfile(PLAN,inbox/PLAN.name)
+    spec=importlib.util.spec_from_file_location('transport',ROOT/'scripts/windows-dao-ps.py');transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,args.run_id,'script.ps1'))]
+    done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=900);outbox.mkdir(exist_ok=True);(outbox/'ssh.txt').write_bytes(done.stdout+done.stderr)
+    require((outbox/'result.json').exists(),'Missing result; no retry');analyze(outbox);require(done.returncode==0,'Guest failed; no retry')
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__);sub=p.add_subparsers(dest='command',required=True)
+    c=sub.add_parser('preflight');c.add_argument('--images',type=Path,required=True);c=sub.add_parser('analyze');c.add_argument('outbox',type=Path)
+    c=sub.add_parser('run');c.add_argument('--images',type=Path,required=True);c.add_argument('--run-id',required=True);c.add_argument('--shared-root',type=Path,required=True)
+    for n,d in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:c.add_argument('--'+n,default=d)
+    a=p.parse_args()
+    if a.command=='preflight':preflight(a.images);print('Committed inputs/images match.')
+    elif a.command=='analyze':analyze(a.outbox)
+    else:dispatch(a)
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/check_indexed_row_candidate.ps1
+++ b/oracle/windows-dao/tests/check_indexed_row_candidate.ps1
@@ -1,0 +1,30 @@
+param([Parameter(Mandatory=$true)][string]$ScriptPath,[Parameter(Mandatory=$true)][string]$PlanPath,[Parameter(Mandatory=$true)][string]$HelperPath)
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected actual x86 process'}
+$tokens=$null;$errors=$null;$ast=[Management.Automation.Language.Parser]::ParseFile($ScriptPath,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw ($errors|Out-String)}
+$helper=[Management.Automation.Language.Parser]::ParseFile($HelperPath,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Helper syntax'}
+foreach($item in @(@($ast,'Set-Long'),@($ast,'Append-Row'),@($ast,'Row'),@($ast,'Failure'),@($helper,'Release'))){
+    $name=$item[1];$found=@($item[0].FindAll({param($n)$n-is [Management.Automation.Language.FunctionDefinitionAst]-and $n.Name-eq $name},$false))
+    if($found.Count-ne 1){throw "Missing pure helper $name"};Invoke-Expression $found[0].Extent.Text
+}
+$fields=@{Id=[pscustomobject]@{Value=$null};Value=[pscustomobject]@{Value=$null}}
+$collection=[pscustomobject]@{Fields=$fields};$collection|Add-Member ScriptMethod Item {param($Name)return $this.Fields[$Name]}
+$rs=[pscustomobject]@{Fields=$collection};$rs|Add-Member ScriptMethod AddNew {}
+$rs|Add-Member ScriptMethod Update {foreach($name in @('Id','Value')){if($this.Fields.Item($name).Value-isnot [int]){throw 'Non-Int32 assignment'}};$script:updates++}
+$script:updates=0;$script:failure=$null;$script:endpoint='pure'
+$plan=Get-Content -LiteralPath $PlanPath -Raw|ConvertFrom-Json
+foreach($arm in $plan.arms){
+    $requests=New-Object Collections.ArrayList
+    foreach($row in $arm.rows){[void]$requests.Add($row)}
+    if($null-ne $arm.insert){[void]$requests.Add($arm.insert)}
+    [void]$requests.Add($arm.follow);[void]$requests.Add($arm.duplicate)
+    foreach($request in $requests){
+        Append-Row $rs $request;$actual=Row $rs
+        if($actual-isnot [object[]]-or $actual.Count-ne 2-or $actual[0]-ne [int]$request[0]-or $actual[1]-ne [int]$request[1]){throw 'Typed row return differs'}
+    }
+}
+if($script:updates-ne 222-or $null-ne $script:failure){throw "Unexpected pure helper count $script:updates"}
+Write-Output "x86 parser and $script:updates typed row assignments passed; no DAO executed"

--- a/oracle/windows-dao/tests/test_indexed_row_candidate.py
+++ b/oracle/windows-dao/tests/test_indexed_row_candidate.py
@@ -1,0 +1,63 @@
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+sys.path.insert(0,str(Path(__file__).resolve().parents[1]/'scripts'))
+import indexed_row_candidate as a
+
+def snapshot(arm,role):
+    rows=a.rows_for(arm,role)
+    return dict(version='3.0',tables=['Items','MSysACEs','MSysObjects','MSysQueries','MSysRelationships'],queries=[],relations=[],user_tables=[dict(name='Items',attributes=0,fields=[dict(name=n,type=4,size=4,attributes=1,required=False) for n in ('Id','Value')],indexes=[dict(name='ByKey',primary=arm['primary'],unique=True,required=arm['primary'],foreign=False,ignore_nulls=False,fields=[dict(name='Id',attributes=int(arm['descending']))])],rows=rows)],traversal=sorted(rows,reverse=arm['descending']),seek=[dict(query=q,row=next((r for r in rows if r[0]==q),None)) for q in arm['queries']])
+
+class IndexedRowTests(unittest.TestCase):
+    def test_finite_rows_full_traversal_and_missing_seek(self):
+        plan=json.loads(a.PLAN.read_text())
+        self.assertEqual([len(a.rows_for(arm,'candidate')) for arm in plan['arms']],[4,4,200,3])
+        for arm in plan['arms']:
+            a.expected(snapshot(arm,'candidate'),arm,'candidate')
+            for defect in ('row','traversal','seek','flags'):
+                value=snapshot(arm,'candidate')
+                if defect=='row':value['user_tables'][0]['rows'].pop()
+                elif defect=='traversal':value['traversal'].reverse()
+                elif defect=='seek':value['seek'].pop()
+                else:value['user_tables'][0]['indexes'][0]['unique']=False
+                with self.assertRaises(ValueError):a.expected(value,arm,'candidate')
+
+    def test_complete_capture_source_operation_identity_and_rejection_gates(self):
+        plan=json.loads(a.PLAN.read_text());plan['images']={}
+        result=dict(document_type='dao_indexed_row_result',plan_sha256=a.identity(a.PLAN)['sha256'],source_revision=plan['source_revision'],error=None,retention_failures=[],mutation_started=True,environment=dict(process_bits=32,provider='DAO.DBEngine.36'),pairs=[])
+        with tempfile.TemporaryDirectory() as tmp:
+            out=Path(tmp)
+            for arm in plan['arms']:
+                for replica in range(1,4):
+                    operations={r:dict(status='complete') for r in ('control','candidate-next','control-next')}
+                    operations.update({r:dict(accepted=False,error=dict(message='duplicate'),numbers=[3022]) for r in ('candidate-duplicate','control-duplicate')})
+                    pair=dict(arm=arm['name'],replica=replica,captures={},operations=operations);result['pairs'].append(pair)
+                    for role in ['original','candidate','control-original','control','candidate-next','control-next','candidate-duplicate','control-duplicate']:
+                        path=out/f"{arm['name']}-r{replica}-{role}.mdb";path.write_bytes(role.encode());ident=a.identity(path)
+                        if role in ('original','candidate'):plan['images'][arm['name']+'-'+role+'.mdb']=ident
+                        pair['captures'][role]=dict(file=path.name,status='pass',error=None,before=copy.deepcopy(ident),after=copy.deepcopy(ident),snapshot=snapshot(arm,role))
+            with patch.object(a,'raw_check',return_value={}),patch.object(a,'patch_check',return_value={}),patch.object(a,'definition',return_value=(dict(row_count=4,physical_indexes=[dict(entry_count=5)]),[0]*4)):
+                self.assertEqual(a.build_report(result,out,plan)['outcome'],'observed_accepted')
+                for defect in ('source','missing','identity','accepted','numbers','poststate','retention'):
+                    bad=copy.deepcopy(result);p=bad['pairs'][0]
+                    if defect=='source':bad['source_revision']='wrong'
+                    elif defect=='missing':p['captures'].pop('control-original')
+                    elif defect=='identity':p['captures']['candidate']['after']['size']+=1
+                    elif defect=='accepted':p['operations']['candidate-duplicate']['accepted']=True
+                    elif defect=='numbers':p['operations']['candidate-duplicate']['numbers']=[3022,99]
+                    elif defect=='poststate':p['captures']['candidate-duplicate']['snapshot']['user_tables'][0]['rows'].append([42,0])
+                    else:bad['retention_failures']=['failed']
+                    self.assertEqual(a.build_report(bad,out,plan)['outcome'],'no_outcome',defect)
+
+    def test_preflight_and_analysis_use_shared_input_pins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp);source=root/'input';source.write_text('old');plan=root/'plan';plan.write_text(json.dumps(dict(inputs={'input':a.identity(source)['sha256']})))
+            with patch.object(a,'ROOT',root),patch.object(a,'PLAN',plan):
+                a.verify_inputs();source.write_text('changed')
+                with self.assertRaisesRegex(ValueError,'pin'):a.verify_inputs()
+                with self.assertRaisesRegex(ValueError,'pin'):a.analyze(root)
+if __name__=='__main__':unittest.main()


### PR DESCRIPTION
Adds the grouped DAO validation for public unique Long leaf insertion/deletion and records its original acquisition as EXP-0216 `no_outcome`. The four-arm, three-replica run retained all 96 captures, but native deletion controls retained distinct-key counts that failed the frozen analyzer predicate. No subset acceptance or compatibility claim is made.

The finalized plan was committed and independently reviewed before the single acquisition. The original artifacts and report remain unchanged; no retry or successor was run.

Validation: three focused analyzer tests, exact reproduction of eight images and four receipts, exporter Clippy, independent readiness review, retained-report reproduction, and final `just ready` passed.

Progress toward #112; follow-up analysis of the native deletion count semantics remains necessary.
