### PR TITLE
feat: insert indexed rows across a data-page boundary

### DIFF
--- a/crates/jet3/examples/indexed_boundary_candidate.rs
+++ b/crates/jet3/examples/indexed_boundary_candidate.rs
@@ -1,0 +1,39 @@
+//! Deterministic public insertion matrix for the indexed data-page boundary.
+#[path = "support/indexed_boundary.rs"]
+mod fixture;
+use fixture::*;
+use std::{env, fs, path::Path};
+fn main() -> Result<()> {
+    let directory = env::args()
+        .nth(1)
+        .ok_or("usage: indexed_boundary_candidate NEW_DIRECTORY")?;
+    let directory = Path::new(&directory);
+    fs::create_dir(directory)?;
+    for (name, count, id, refusal) in [
+        ("space", 3, 101, None),
+        ("eof", 20, 101, None),
+        ("duplicate", 20, 0, Some("duplicate unique key")),
+        ("split", 200, 201, Some("full root leaf")),
+    ] {
+        let original = directory.join(format!("{name}-original.mdb"));
+        let candidate = directory.join(format!("{name}-candidate.mdb"));
+        create(&original, count)?;
+        fs::copy(&original, &candidate)?;
+        let result = jet3::insert_row(&candidate, b"Items", &values(id), &mut budget());
+        if let Some(message) = refusal {
+            if !matches!(result,Err(jet3::UpdateError::Unsupported(m)) if m==message)
+                || fs::read(&original)? != fs::read(&candidate)?
+            {
+                return Err("refusal or preservation".into());
+            }
+        } else {
+            let row = result?;
+            let size = fs::metadata(&original)?.len();
+            if (name == "eof") != (row.page().get() * 2048 == size) {
+                return Err("wrong insertion path".into());
+            }
+        }
+        let _ = definition(&candidate)?;
+    }
+    Ok(())
+}

--- a/crates/jet3/examples/support/indexed_boundary.rs
+++ b/crates/jet3/examples/support/indexed_boundary.rs
@@ -1,0 +1,87 @@
+use jet3::{
+    ColumnSpec, ColumnType, DatabaseReader, IndexColumnSpec, IndexKind, IndexSpec, ResourceBudget,
+    ResourceLimits, RowValue, TableDefinition, TableRows, TableSpec,
+};
+use std::{num::NonZeroU8, path::Path};
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub const NAME: &[u8; 80] = &[b'x'; 80];
+pub const MEMO: &[u8; 4096] = &[b'n'; 4096];
+pub fn budget() -> ResourceBudget {
+    ResourceBudget::new(ResourceLimits::default())
+}
+pub fn values(id: i32) -> [RowValue<'static>; 4] {
+    [
+        RowValue::Long(id),
+        RowValue::Text(NAME),
+        if id % 2 == 0 {
+            RowValue::Null
+        } else {
+            RowValue::Currency { scaled: -123456 }
+        },
+        RowValue::Boolean(id % 2 != 0),
+    ]
+}
+pub fn create(path: &Path, count: i32) -> Result<()> {
+    let columns = [
+        ColumnSpec::new(b"Id", ColumnType::Long),
+        ColumnSpec::new(
+            b"Name",
+            ColumnType::Text {
+                max_len: NonZeroU8::new(80).ok_or("length")?,
+            },
+        ),
+        ColumnSpec::new(b"Price", ColumnType::Currency),
+        ColumnSpec::new(b"Active", ColumnType::Boolean),
+    ];
+    let indexes = [IndexSpec {
+        name: b"ById",
+        kind: IndexKind::Primary,
+        fields: &[IndexColumnSpec::ascending(0)],
+    }];
+    let values: Vec<_> = (0..count).map(values).collect();
+    let rows: Vec<_> = values.iter().map(|r| r.as_slice()).collect();
+    jet3::create_database_with_table_rows(
+        path,
+        &[
+            TableRows {
+                table: TableSpec {
+                    name: b"Items",
+                    columns: &columns,
+                    indexes: &indexes,
+                },
+                rows: &rows,
+            },
+            TableRows {
+                table: TableSpec {
+                    name: b"Notes",
+                    columns: &[
+                        ColumnSpec::new(b"Id", ColumnType::Long),
+                        ColumnSpec::new(b"Body", ColumnType::Memo),
+                    ],
+                    indexes: &[],
+                },
+                rows: &[
+                    &[RowValue::Long(7), RowValue::Memo(MEMO)],
+                    &[RowValue::Long(8), RowValue::Null],
+                ],
+            },
+        ],
+        &mut budget(),
+    )?;
+    Ok(())
+}
+pub fn definition(path: &Path) -> Result<TableDefinition> {
+    let mut b = budget();
+    let mut db = DatabaseReader::open(path, &mut b)?;
+    let root = {
+        let mut c = db.catalog(&mut b)?;
+        let mut root = None;
+        while let Some(r) = c.next_record()? {
+            if r.name().raw_bytes() == b"Items" {
+                root = r.table_definition();
+            }
+        }
+        root.ok_or("Items")?
+    };
+    Ok(db.table_definition(root, &mut b)?)
+}

--- a/crates/jet3/src/indexed_row_tests.rs
+++ b/crates/jet3/src/indexed_row_tests.rs
@@ -401,7 +401,7 @@ fn indexed_rows_private_corruption_preserves_original() -> TestResult {
 }
 
 #[test]
-fn indexed_rows_no_data_capacity_and_multiple_indexes_refuse() -> TestResult {
+fn indexed_rows_no_available_page_appends_and_multiple_indexes_refuse() -> TestResult {
     let f = Fixture::new(3, false, IndexKind::Primary)?;
     let table = f.definition()?;
     let map = table.maps().available();
@@ -418,18 +418,15 @@ fn indexed_rows_no_data_capacity_and_multiple_indexes_refuse() -> TestResult {
     let end = map.page().get() as usize * PAGE_BYTES + range.end;
     bytes[start..end].fill(0);
     fs::write(f.path(), &bytes)?;
-    assert!(matches!(
-        insert_row(
-            f.path(),
-            b"Rows",
-            &[RowValue::Long(-1), RowValue::Long(2)],
-            &mut budget()
-        ),
-        Err(UpdateError::Unsupported(
-            "indexed insertion requires populated page capacity"
-        ))
-    ));
-    assert_eq!(fs::read(f.path())?, bytes);
+    let row = insert_row(
+        f.path(),
+        b"Rows",
+        &[RowValue::Long(-1), RowValue::Long(2)],
+        &mut budget(),
+    )?;
+    assert_eq!(row.page().get() as usize * PAGE_BYTES, bytes.len());
+    assert_eq!(row.slot(), 0);
+    f.validate()?;
     fs::remove_file(f.path())?;
     let columns = [
         ColumnSpec::new(b"Id", ColumnType::Long),
@@ -485,5 +482,54 @@ fn indexed_rows_no_data_capacity_and_multiple_indexes_refuse() -> TestResult {
         .is_err()
     );
     assert_eq!(fs::read(f.path())?, before);
+    Ok(())
+}
+
+#[test]
+fn indexed_eof_private_leaf_and_append_corruption_preserve_original() -> TestResult {
+    let f = Fixture::new(3, false, IndexKind::Primary)?;
+    let table = f.definition()?;
+    let map = table.maps().available();
+    let mut before = fs::read(f.path())?;
+    let raw = page(&before, map.page())?;
+    let directory = crate::row_directory::RowDirectory::validate(
+        map.page(),
+        crate::PageNumber::new(0),
+        raw,
+        &mut budget(),
+    )?;
+    let range = directory.entry(raw, map.row())?.range();
+    let base = map.page().get() as usize * PAGE_BYTES;
+    before[base + range.start + 5..base + range.end].fill(0);
+    fs::write(f.path(), &before)?;
+    for offset in [
+        before.len() + 100,
+        table.physical_indexes()[0].root().get() as usize * PAGE_BYTES + 250,
+    ] {
+        let result = insert_with_hook(
+            &f.path(),
+            b"Rows",
+            &[RowValue::Long(-1), RowValue::Long(5)],
+            &mut budget(),
+            |stage| -> Result<(), std::io::Error> {
+                if stage == PublishStage::Validation {
+                    let private = fs::read_dir(&f.directory)?
+                        .filter_map(Result::ok)
+                        .map(|e| e.path())
+                        .find(|p| *p != f.path())
+                        .ok_or_else(|| std::io::Error::other("private"))?;
+                    let mut bytes = fs::read(&private)?;
+                    bytes[offset] ^= 1;
+                    fs::write(private, bytes)?;
+                }
+                Ok(())
+            },
+        );
+        assert!(
+            matches!(result, Err(UpdateError::Publish(e)) if e.stage() == PublishStage::Validation)
+        );
+        assert_eq!(fs::read(f.path())?, before);
+        assert_eq!(fs::read_dir(&f.directory)?.count(), 1);
+    }
     Ok(())
 }

--- a/crates/jet3/src/insert.rs
+++ b/crates/jet3/src/insert.rs
@@ -16,14 +16,15 @@ use std::path::Path;
 /// Indexed insertion requires an existing populated data page; its leaf records,
 /// boundary bitmap, free count and physical distinct-key count are updated too.
 /// Other indexes, AutoIncrement, long values and relationships are refused.
-/// For unindexed tables, if no populated page fits, one EOF page is appended
+/// If no populated page fits, one EOF page is appended
 /// only within existing inline global/owned/available maps. No reuse,
 /// map growth or compaction is implemented. An existing selected page must
 /// retain capacity for one more equal-sized row and representable directory slot;
 /// this is a candidate restriction, not a DAO free-space threshold.
 ///
 /// Only the new row, appended slot, page free/count fields and table row count
-/// change on existing-page insertion. EOF insertion also clears its global free
+/// change on unindexed existing-page insertion. Indexed insertion additionally
+/// updates the leaf and physical distinct count. EOF insertion clears its global free
 /// bit and sets owned/available bits, marking available when a minimum encoded
 /// row still fits. All other bytes, including page zero, remain exact. This
 /// construction requires separate DAO validation and makes no compatibility claim.
@@ -172,12 +173,6 @@ where
         }
     };
     let Some(selected) = selected else {
-        if index.is_some() {
-            return Err(UpdateError::Unsupported(
-                "indexed insertion requires populated page capacity",
-            ));
-        }
-
         let mut minimum = [0; PAGE_BYTES];
         let nulls = [RowValue::Null; u8::MAX as usize];
         let minimum_length = crate::encode_row(
@@ -194,11 +189,33 @@ where
             &minimum[..minimum_length],
             budget,
         )?;
-        let (changes, count) = plan.changes(crate::update_pages::PageChange {
+        let leaf_image = if let Some(leaf) = &mut index {
+            let Some(RowValue::Long(value)) = values.get(usize::from(leaf.column.get())) else {
+                return Err(UpdateError::Unsupported("insert requires present Long key"));
+            };
+            let image = leaf.insert(*value, RowLocator::new(plan.page, 0), budget)?;
+            crate::index_key_page::set_distinct_count(&mut patched_definition, leaf.count, budget)?;
+            Some(image)
+        } else {
+            None
+        };
+        let (planned, count) = plan.changes(crate::update_pages::PageChange {
             page: definition.root(),
             before: &source_definition,
             after: patched_definition.as_bytes(),
         });
+        let mut changes = [planned[0]; 5];
+        changes[..count].copy_from_slice(&planned[..count]);
+        let count = if let (Some(leaf), Some(image)) = (&index, &leaf_image) {
+            changes[count] = crate::update_pages::PageChange {
+                page: leaf.page,
+                before: &leaf.before,
+                after: image.as_bytes(),
+            };
+            count + 1
+        } else {
+            count
+        };
         crate::update_pages::publish_changes_with_append(
             path,
             database.into_source(),

--- a/crates/jet3/tests/indexed_boundary.rs
+++ b/crates/jet3/tests/indexed_boundary.rs
@@ -1,0 +1,181 @@
+#![cfg(unix)]
+#[path = "../examples/support/indexed_boundary.rs"]
+mod fixture;
+use fixture::*;
+use jet3::{DatabaseReader, MapRowLocator, PAGE_BYTES, PageNumber, UpdateError};
+use std::fs;
+struct Temp(std::path::PathBuf);
+impl Drop for Temp {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+#[test]
+fn indexed_boundary_grouped_matrix() -> Result<()> {
+    let dir = Temp(std::env::temp_dir().join(format!("jet3-boundary-test-{}", std::process::id())));
+    fs::create_dir(&dir.0)?;
+    for (name, count, id, error) in [
+        ("space", 3, 101, None),
+        ("eof", 20, 101, None),
+        ("duplicate", 20, 0, Some("duplicate unique key")),
+        ("split", 200, 201, Some("full root leaf")),
+    ] {
+        let path = dir.0.join(name);
+        create(&path, count)?;
+        let before = fs::read(&path)?;
+        let table = definition(&path)?;
+        let mut b = budget();
+        let mut db = DatabaseReader::open(&path, &mut b)?;
+        let mut cursor = db.rows(&table, &mut b)?;
+        let mut prior = Vec::new();
+        while let Some(r) = cursor.next_row()? {
+            prior.push(r.locator());
+        }
+        drop(cursor);
+        if name != "space" {
+            for page in prior
+                .iter()
+                .map(|r| r.page())
+                .collect::<std::collections::BTreeSet<_>>()
+            {
+                let start = page.get() as usize * PAGE_BYTES;
+                assert!(u16::from_le_bytes(before[start + 2..start + 4].try_into()?) < 99);
+            }
+        }
+        let result = jet3::insert_row(&path, b"Items", &values(id), &mut budget());
+        if let Some(message) = error {
+            assert!(matches!(result,Err(UpdateError::Unsupported(m)) if m==message));
+            assert_eq!(fs::read(&path)?, before);
+            continue;
+        }
+        let added = result?;
+        let after = fs::read(&path)?;
+        let eof = name == "eof";
+        assert_eq!(after.len(), before.len() + if eof { PAGE_BYTES } else { 0 });
+        assert_eq!(
+            added.page().get() as usize * PAGE_BYTES == before.len(),
+            eof
+        );
+        let mut expected = before.clone();
+        let root = table.root().get() as usize * PAGE_BYTES;
+        for offset in [12, 47] {
+            expected[root + offset..root + offset + 4]
+                .copy_from_slice(&((count + 1) as u32).to_le_bytes());
+        }
+        let leaf = table.physical_indexes()[0].root().get() as usize * PAGE_BYTES;
+        expected[leaf + 2..leaf + 4]
+            .copy_from_slice(&(1800 - ((count + 1) * 9) as u16).to_le_bytes());
+        expected[leaf + 22..leaf + 248].fill(0);
+        let mut records = Vec::new();
+        for (key, row) in (0..count)
+            .zip(prior.iter())
+            .chain(std::iter::once((id, &added)))
+        {
+            let mut record = vec![0x7f];
+            record.extend_from_slice(&((key as u32) ^ 0x80000000).to_be_bytes());
+            record.extend_from_slice(&(row.page().get() as u32).to_be_bytes()[1..]);
+            record.push(row.slot());
+            records.push(record);
+        }
+        records.sort();
+        for (n, record) in records.iter().enumerate() {
+            expected[leaf + 248 + n * 9..leaf + 248 + (n + 1) * 9].copy_from_slice(record);
+            let end = (n + 1) * 9;
+            expected[leaf + 22 + end / 8] |= 1 << (end % 8);
+        }
+        if eof {
+            let page = added.page().get() as usize;
+            for (role, loc) in [
+                MapRowLocator::new(PageNumber::new(1), 0),
+                table.maps().owned(),
+                table.maps().available(),
+            ]
+            .iter()
+            .enumerate()
+            {
+                let mut bytes = [0; PAGE_BYTES];
+                let classified = db.read_classified_page(loc.page(), &mut bytes, &mut b)?;
+                let record = jet3::locate_usage_map(classified, *loc, &mut b)?;
+                let raw = record.raw();
+                let base = u32::from_le_bytes(raw[1..5].try_into()?) as usize;
+                let offset = loc.page().get() as usize * PAGE_BYTES
+                    + record.range().start
+                    + 5
+                    + (page - base) / 8;
+                let mask = 1 << ((page - base) % 8);
+                if role == 0 {
+                    expected[offset] &= !mask;
+                } else {
+                    expected[offset] |= mask;
+                }
+            }
+            expected.extend_from_slice(&after[before.len()..]);
+        } else {
+            let start = added.page().get() as usize * PAGE_BYTES;
+            let old = &before[start..start + PAGE_BYTES];
+            let new = &after[start..start + PAGE_BYTES];
+            expected[start + 2..start + 4].copy_from_slice(&new[2..4]);
+            expected[start + 8..start + 10].copy_from_slice(&new[8..10]);
+            let slot = 10 + usize::from(added.slot()) * 2;
+            expected[start + slot..start + slot + 2].copy_from_slice(&new[slot..slot + 2]);
+            let low = u16::from_le_bytes(new[slot..slot + 2].try_into()?) as usize;
+            let high = u16::from_le_bytes(old[slot - 2..slot].try_into()?) as usize;
+            expected[start + low..start + high].copy_from_slice(&new[low..high]);
+        }
+        assert_eq!(
+            after, expected,
+            "all unrelated metadata, Notes payloads and slack"
+        );
+        let mut db = DatabaseReader::open(&path, &mut b)?;
+        let table = definition(&path)?;
+        let tree = db.index_tree(&table, 0, &mut b)?;
+        assert_eq!(tree.nodes().len(), 1);
+        assert_eq!(tree.entries().len(), (count + 1) as usize);
+        assert_eq!(
+            tree.entries()
+                .iter()
+                .map(|e| e.key().raw_bytes())
+                .collect::<Vec<_>>(),
+            records.iter().map(|r| &r[..5]).collect::<Vec<_>>()
+        );
+        let mut cursor = db.rows(&table, &mut b)?;
+        let mut seen = 0;
+        while let Some(mut r) = cursor.next_row()? {
+            let raw = r
+                .field(table.columns()[0].ordinal())
+                .and_then(|f| f.raw_bytes())
+                .ok_or("Id")?;
+            let key = i32::from_le_bytes(raw.try_into()?);
+            assert_eq!(
+                r.field(table.columns()[1].ordinal())
+                    .and_then(|f| f.raw_bytes()),
+                Some(NAME.as_slice())
+            );
+            let currency = (-123456_i64).to_le_bytes();
+            assert_eq!(
+                r.field(table.columns()[2].ordinal())
+                    .and_then(|f| f.raw_bytes()),
+                if key % 2 == 0 {
+                    None
+                } else {
+                    Some(currency.as_slice())
+                }
+            );
+            assert!(
+                matches!(r.value(table.columns()[3].ordinal(), jet3::TextCodePage::Windows1252)?.ok_or("Active")?.kind(), jet3::ValueKind::Boolean(v) if *v == (key%2!=0))
+            );
+            let entry = tree
+                .entries()
+                .iter()
+                .find(|e| e.row() == r.locator())
+                .ok_or("locator")?;
+            assert_eq!(
+                &entry.key().raw_bytes()[1..],
+                &((key as u32) ^ 0x80000000).to_be_bytes()
+            );
+            seen += 1;
+        }
+        assert_eq!(seen, count + 1);
+    }
+    Ok(())
+}

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -14970,3 +14970,33 @@ Retained original/control SHA-256 identities; the sole Rust destination repeats
   and no automatic retry or diagnostic subset promotion. Record EXP-0218 once
   from the validated report. Local observations make no compatibility claim or
   support-matrix movement and do not complete the lifecycle milestone.
+
+## EXP-0218 — Indexed data-page boundary validation no-outcome
+
+- The one EXP-0217 acquisition, `20260905T145600Z-indexed-boundary`, returned
+  **`no_outcome`** under the frozen all-matrix rule. Preregistration commit
+  `dc4ce4d` was pushed before dispatch; plan SHA-256
+  `04345d7dd0f2a217f4ba74b0662fdcced750ac05976281168a1b5554f8f73c99`.
+- The x86 `DAO.DBEngine.36` producer recorded eight captures, native `space`
+  and `eof` insertion operations, and then failed in the duplicate-control arm
+  at `Mutate` line 51 with `Specified cast is not valid.` That line assigns
+  the nullable Price value through COM; the even Id requests `DBNull.Value`.
+  The expected duplicate-key operation never completed. Mutation had started;
+  the producer retained eleven MDBs with no retention failures. No reacquisition
+  occurred, and neither completed insertions nor capture subsets are promoted.
+- The unchanged analyzer returned `reasons: ["Acquisition failure"]` and no
+  accepted observations. Its report was rebuilt from the retained result and
+  reproduced byte-for-byte; all sixteen retained files remained unchanged.
+  `report.json`: 371 bytes, SHA-256
+  `49ceeead3863c401f2156163034e2190818a9bd06ae54ea72cee1608023c3aed`.
+  `result.json` SHA-256:
+  `ccabd23670d30b6de0a5080816870cdcaa8008b48c3875c2a553c9974207e3c1`.
+- Retained external root:
+  `/home/alex/development/vms/jet3-windows/shared/outbox/20260905T145600Z-indexed-boundary/`.
+  No MDB or provider bytes are committed. The plan and consumed harness remain
+  unchanged. Any corrected acquisition requires a new reviewed plan and human
+  decision; this is not an infrastructure retry.
+- The bounded implementation and focused Rust preservation/refusal checks remain
+  implemented, but this result establishes no DAO compatibility or hosted
+  support. EXP-0214/0216 remain `no_outcome`, the support matrix is unchanged,
+  and the larger practical lifecycle milestone remains incomplete.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -14933,3 +14933,40 @@ Retained original/control SHA-256 identities; the sole Rust destination repeats
   `032966c5ecea74fe2be0bc12ca09d2fc36084aff698ac02c2f6e51cdb3e2b914`. Artifacts remain in the external shared
   outbox under the run identifier above. This local development result makes
   no compatibility claim or hosted support-matrix movement.
+
+## EXP-0217 — Indexed insertion across a data-page boundary preregistration
+
+- Plan: `oracle/windows-dao/acquisition/indexed-boundary.plan.json`, SHA-256
+  `04345d7dd0f2a217f4ba74b0662fdcced750ac05976281168a1b5554f8f73c99`. Implementation source
+  `53a87df61c944ce971a8662932305ac0338eaef2`; commit this plan before acquisition.
+- One local x86 `DAO.DBEngine.36` insertion-only matrix: existing-space
+  insertion (3 to 4 rows), physically exhausted data page (20 to 21 rows),
+  duplicate rejection, and refusal at the 200-key isolated root-leaf capacity.
+  Items has Long primary Id, Text(80) Name, nullable Currency Price and Boolean
+  Active; Notes retains Long Id and a 4,096-byte Memo plus a null Memo row.
+- The eight pinned public original/candidate images are generated on Unix.
+  Native controls are byte-identical original copies, with DAO insertion or
+  duplicate rejection; the split-refusal control remains the original baseline.
+  No native split, deletion, independent DAO creation or continuation is claimed.
+  Capture all twelve images once, with complete user schema/index/rows, table
+  inventory, query/relation inventory, directed traversal and Seek -1..201.
+- Acceptance requires every capture and operation, exact typed full snapshots,
+  candidate/control equality, fresh insertion live/table/distinct-count agreement,
+  complete raw key/locator correlation, and independent reconstruction of every
+  changed byte. EOF allocation, table and leaf changes publish together; Notes
+  metadata and payloads and all unrelated original bytes remain exact.
+- Existing accepted EXP-0057/0059/0060/0061/0062/0065/0073/0126/0162/0186
+  primitives supply the construction; this composition needs its own validation.
+  Read-only inspection of retained EXP-0214/0216 diagnostics confirmed Double
+  strings and deletion live/table count 3 versus distinct count 6. Neither is
+  promoted: this matrix contains no Double or deletion history, and explicitly
+  freezes Currency as invariant four-decimal text and Boolean as JSON Boolean.
+- Independent review found and resolved a mixed-schema assumption in the new
+  analyzer before freezing. The full synthetic-result analyzer test uses real
+  deterministic images and passes its acceptance and corruption/refusal cases;
+  focused Rust insertion and private-EOF corruption checks pass. Actual x86
+  no-DAO checks passed producer parsing, typed rows and nested JSON/Seek roundtrip.
+- Any post-mutation failure is one `no_outcome`, with artifacts retained externally
+  and no automatic retry or diagnostic subset promotion. Record EXP-0218 once
+  from the validated report. Local observations make no compatibility claim or
+  support-matrix movement and do not complete the lifecycle milestone.

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -166,3 +166,18 @@ Stop after this bounded insertion deliverable and its recorded validation.
 Index splits/rebalancing, empty indexed-table insertion, indexed variable-width
 replacement, general deletion/reuse, indirect-map growth, relationship mutation,
 and CLI expansion are outside this slice.
+
+### Bounded slice outcome (2026-09-05)
+
+The indexed data-page-boundary insertion above is implemented: one EOF page,
+inline allocation bits, table counts and isolated Long root-leaf maintenance
+publish together. The deterministic Items/Notes grouped matrix covers existing
+space, physical page exhaustion, duplicate refusal and the 200-key leaf limit,
+with unrelated-byte preservation and private-publication corruption checks.
+
+EXP-0217 preregistered one local DAO matrix; EXP-0218 records its **no_outcome**.
+The producer failed assigning null Currency through COM in the duplicate-control
+arm after the two native insertion operations. No subset is accepted, no retry
+occurred and hosted support is unchanged. This bounded implementation and its
+validation outcome finish this slice; the larger lifecycle remains incomplete.
+Any successor validation needs a separate reviewed plan and human decision.

--- a/docs/plans/V1_SCOPE.md
+++ b/docs/plans/V1_SCOPE.md
@@ -108,3 +108,61 @@ successor analysis; this local result moves no hosted support state.
   stored-query preservation and failure/rollback behavior.
 - Meet all three release gates on a release commit. Current evidence binds its
   recorded revisions and finite recipes; no whole-v1 compatibility is claimed.
+
+## Practical acceptance target
+
+Use one inventory database to measure a workable read/write lifecycle:
+
+- `Items`: `Id` Long primary key (explicit IDs), `Name` Text(80), nullable
+  `Price` Currency, and `Active` Boolean.
+- `Notes`: `Id` Long and `Body` Memo, with retained unrelated rows and payloads.
+
+The target is complete when public library APIs can create the database,
+populate Items beyond both a data-page boundary and an index-leaf boundary,
+reopen it, and read every row with correct index traversal and lookups. Then
+change names, prices and null values, delete scattered rows, insert more rows,
+and reopen again. DAO must observe the complete expected schema and contents
+at the declared checkpoints. Notes metadata, rows and payload bytes must remain
+unchanged through Items mutations. Unsupported requests, validation failures
+and resource failures rejected before publication must preserve the original
+file byte-for-byte; post-publication sync errors retain their documented
+potentially-visible-change semantics.
+
+This is a concrete milestone within v1, not a substitute for the full scope or
+release gates. Several operations require later slices; the next slice below
+does not claim to complete this lifecycle.
+
+## Next implementation slice: indexed insertion across a data-page boundary
+
+Track implementation under #112 and hosted verification under #113. An existing
+populated Items table should accept another row by appending one data page when
+no existing page can admit it, while its unique Long index still fits in one
+isolated, uncompressed root leaf. Reuse existing EOF allocation within inline
+maps and publish data, allocation, table-count and index changes together.
+
+1. Build a deterministic fixture using the target schema, with Notes populated
+   and Items at a data-page boundary while the index retains capacity.
+2. Extend the public insertion path by combining the existing EOF-page planner
+   with unique Long leaf maintenance. Keep checked encoding and format constants
+   in typed low-level modules and cite existing accepted provenance or establish
+   any missing fact before implementation relies on it.
+3. Test one grouped matrix: insertion into existing space, insertion requiring
+   a new page, duplicate-key rejection, and refusal when the index needs a split.
+   Check full rows, key/locator correspondence, index traversal/lookups, unrelated
+   byte preservation, and unchanged originals on pre-publication rejection.
+4. Independently review the change and commit one SHA-256-pinned DAO plan for
+   that matrix before acquisition. Record its single outcome, run final checks,
+   and merge the deliverable. Only hosted accepted evidence may move support.
+
+Start with `crates/jet3/src/insert.rs`, `row_insert_eof.rs`, `unique_leaf.rs`,
+`index_key_page.rs`, and `update_pages.rs`, plus their existing focused tests.
+Review EXP-0214/0216 and the retained artifacts for assumptions this slice
+depends on. Resolve any necessary evidence gap under a distinct reviewed plan;
+do not promote diagnostics from either `no_outcome`, edit a consumed plan, or
+repeat acquisition automatically. Unrelated retained-data questions remain
+separate work.
+
+Stop after this bounded insertion deliverable and its recorded validation.
+Index splits/rebalancing, empty indexed-table insertion, indexed variable-width
+replacement, general deletion/reuse, indirect-map growth, relationship mutation,
+and CLI expansion are outside this slice.

--- a/oracle/windows-dao/acquisition/indexed-boundary.plan.json
+++ b/oracle/windows-dao/acquisition/indexed-boundary.plan.json
@@ -1,0 +1,112 @@
+{
+  "document_type": "dao_indexed_boundary_plan",
+  "provenance": "EXP-0217",
+  "outcome_provenance": "EXP-0218",
+  "source_revision": "53a87df61c944ce971a8662932305ac0338eaef2",
+  "replicas": 1,
+  "arms": [
+    {
+      "name": "space",
+      "count": 3,
+      "id": 101,
+      "expected": "Insert in existing data page, retain file length"
+    },
+    {
+      "name": "eof",
+      "count": 20,
+      "id": 101,
+      "expected": "Append exactly one data page; retain isolated root leaf"
+    },
+    {
+      "name": "duplicate",
+      "count": 20,
+      "id": 0,
+      "expected": "Public duplicate refusal; exact original; DAO error 3022"
+    },
+    {
+      "name": "split",
+      "count": 200,
+      "id": 201,
+      "expected": "Public full root leaf refusal; exact original; control is unchanged baseline, no native split attempted"
+    }
+  ],
+  "schema": {
+    "Items": [
+      "Id Long primary ById ascending",
+      "Name Text(80)",
+      "Price nullable Currency",
+      "Active Boolean"
+    ],
+    "Notes": [
+      "Id Long",
+      "Body nullable Memo"
+    ]
+  },
+  "seed": "Items IDs 0..count-1, Name 80 ASCII x, even Price null/Active false, odd Price -12.3456/Active true. Notes (7,4096 ASCII n), (8,null). No deletion history.",
+  "controls": "Byte-identical copies of each public original; native DAO insertion for space/eof, native duplicate rejection for duplicate; read-only baseline for split. These are not independently DAO-created controls.",
+  "capture": "One x86 DAO.DBEngine.36 pass; original/candidate/control for all four arms: 12 closed images with unchanged read-only hashes. Complete user schema/index/rows, system/user table-name inventory, queries/relations, complete Items index traversal and Seek -1..201. Currency is invariant four-decimal text, Long JSON integer, Boolean JSON boolean, Text/Memo JSON strings, null JSON null.",
+  "acceptance": [
+    "Every capture and operation completes; all retained identities match; no partial acceptance.",
+    "Exact expected schema and all Items/Notes rows; complete ordered traversal and every present/missing Seek; candidate/control full snapshots equal.",
+    "Raw live/table/distinct counts equal for these fresh insertion-only inputs; raw tree key/locator bijection holds. Native tree compression is allowed.",
+    "Independent Python reconstruction matches every candidate byte: row, slot, counts, leaf bitmap/records/free, EOF image and only the three EOF map bits. All unrelated bytes including Notes metadata/Memo payloads and page zero exact.",
+    "EOF source pages physically lack room for the 97-byte incoming row plus 2-byte slot; index 20 -> 21 keys. Split source exactly 200 keys and byte-identical refusal.",
+    "Rust focused grouped matrix and EOF private-page corruption checks pass before acquisition."
+  ],
+  "failure_rule": "Any failure after first DAO mutation is one no_outcome. Retain all available images/result/log externally; do not redispatch, edit the consumed plan, or accept diagnostic subsets. Missing/failed acquisition or comparison is no_outcome.",
+  "evidence_scope": "Local development validation only. No compatibility claim or support-matrix movement; only hosted accepted evidence can move support. Does not complete lifecycle milestone.",
+  "prior_results": "EXP-0214 and EXP-0216 remain no_outcome. Read-only retained diagnosis confirmed Double sidecar strings and native deletion table/live 3 versus distinct 6. No Double or deletion in this matrix; no retained subset is evidence.",
+  "inputs": {
+    "crates/jet3/examples/indexed_boundary_candidate.rs": "5cff370241f4ac0d730a56ff9875f0f5843d896282da94651a4de06a7ec3280c",
+    "crates/jet3/examples/support/indexed_boundary.rs": "1f875c970cfedb7beff6d9e4119e6003a7f775c84afacdcc7a35f6875097ff3c",
+    "crates/jet3/src/allocation_patch.rs": "13f962e9704a3cd7a5bcdd9f132c404e5d6c86c727920ca04da0d162fecd41c1",
+    "crates/jet3/src/index_key_page.rs": "b12d4c19205ad390cd11aa9546e8a5ffc030545b147b79e6c38cc1fa766392be",
+    "crates/jet3/src/insert.rs": "3f6bec3e30c3c237975b655b77c4a6c6feeb556eabb1e749c8e5de8a2db35eae",
+    "crates/jet3/src/row_insert_eof.rs": "2b33c18de09f377bddf91b19431d7af8b7708e872e59bf2775f420b69629b5de",
+    "crates/jet3/src/unique_leaf.rs": "9367160561b9509e37ae2f169d5344c31497f8e697c69b5c62ac0d009e1565f5",
+    "crates/jet3/src/update_pages.rs": "431201c558c17c9a19affd0850ddf9591109a3b2b70a51546cbc155013d6d0b5",
+    "oracle/windows-dao/scripts/field_update.ps1": "9bef9e7e83e6cfd346067e221826937d043d2a31e77ab3df5d9dacd7df29f201",
+    "oracle/windows-dao/scripts/field_update.py": "0c6d6536ad69126b53d596e011a4bede7293fd34a1efa8f313fa7f391212ba76",
+    "oracle/windows-dao/scripts/indexed_boundary.ps1": "15ec9a2aa6ba19f44eafe1fea36f38f2e0d00495fd25a50226fd4ccdd22cbff5",
+    "oracle/windows-dao/scripts/indexed_boundary.py": "e8fe30cd67665cad034f76263bf71b99cd85cee8ea93e0405f6736773d6e9139",
+    "oracle/windows-dao/scripts/multi_level_index_structure.py": "a4291fd040cb6a90fb68dfbb5dfe75f9f5990caa1d3cec6893577b118191d928",
+    "oracle/windows-dao/scripts/system_catalog.py": "3a710d97a83aab55f9c56cbbeb2e7dd4f75078e8567d0134cd7bfa59f44ee7d9",
+    "oracle/windows-dao/tests/check_indexed_boundary.ps1": "144e47e799a3d83530a47e44bedaebe63ebb2181c6db908412e3cda3e897160f",
+    "scripts/windows-dao-ps.py": "9895d9b1eb13aaaf031dff3f19b958c85eec7bcf024ea188746d7cdd06a9dbe9",
+    "oracle/windows-dao/tests/test_indexed_boundary.py": "ac5ec17158ef634080925c32e3ab8fc60f58fc11da05ba30941c06d941af43c5"
+  },
+  "images": {
+    "duplicate-candidate.mdb": {
+      "size": 63488,
+      "sha256": "b4a78c165ab24f9a051fea08b9acd5f510910ab09987bf3161595a5a3c65a224"
+    },
+    "duplicate-original.mdb": {
+      "size": 63488,
+      "sha256": "b4a78c165ab24f9a051fea08b9acd5f510910ab09987bf3161595a5a3c65a224"
+    },
+    "eof-candidate.mdb": {
+      "size": 65536,
+      "sha256": "179d526fe20c4f3d8d61de93b17302eb7f00d0d8703a3e58be07af00d29469ff"
+    },
+    "eof-original.mdb": {
+      "size": 63488,
+      "sha256": "b4a78c165ab24f9a051fea08b9acd5f510910ab09987bf3161595a5a3c65a224"
+    },
+    "space-candidate.mdb": {
+      "size": 63488,
+      "sha256": "1067476c6acb589cc5ef88f96071be34ec0f734c52663c91e4e1e7ff95566350"
+    },
+    "space-original.mdb": {
+      "size": 63488,
+      "sha256": "d761fbcf50c29b3958b56ff6714321a082b1f9c0a98d19d8f607ea5f5a270954"
+    },
+    "split-candidate.mdb": {
+      "size": 81920,
+      "sha256": "898549826db150c7f90cf788248db122506d7d7d58fc889c8df8a7a198490278"
+    },
+    "split-original.mdb": {
+      "size": 81920,
+      "sha256": "898549826db150c7f90cf788248db122506d7d7d58fc889c8df8a7a198490278"
+    }
+  }
+}

--- a/oracle/windows-dao/scripts/indexed_boundary.ps1
+++ b/oracle/windows-dao/scripts/indexed_boundary.ps1
@@ -1,0 +1,83 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected x86 DAO'}
+$helper=Join-Path $env:JET3_WORK 'field_update.ps1';$tokens=$null;$errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile($helper,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw 'Helper syntax'}
+foreach($name in @('Identity','Release','Write-Json')){
+    $found=@($ast.FindAll({param($n)$n-is [Management.Automation.Language.FunctionDefinitionAst]-and $n.Name-eq $name},$false))
+    if($found.Count-ne 1){throw 'Missing helper'};Invoke-Expression $found[0].Extent.Text
+}
+function Row($Rs,[string]$Table){
+    $id=[int]$Rs.Fields.Item('Id').Value
+    if($Table-eq 'Notes'){
+        $body=$Rs.Fields.Item('Body').Value
+        return ,([object[]]@($id,$(if($body-is [DBNull]){$null}else{[string]$body})))
+    }
+    $price=$Rs.Fields.Item('Price').Value
+    return ,([object[]]@($id,[string]$Rs.Fields.Item('Name').Value,$(if($price-is [DBNull]){$null}else{([decimal]$price).ToString('0.0000',[Globalization.CultureInfo]::InvariantCulture)}),[bool]$Rs.Fields.Item('Active').Value))
+}
+function Capture([string]$Path){
+    $before=Identity $Path;$engine=$db=$rs=$null
+    try{
+        $engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$true)
+        $snapshot=@{version=[string]$db.Version;tables=@($db.TableDefs|ForEach-Object{[string]$_.Name}|Sort-Object);queries=@($db.QueryDefs|ForEach-Object{[string]$_.Name});relations=@($db.Relations|ForEach-Object{[string]$_.Name});user_tables=@()}
+        foreach($name in @('Items','Notes')){
+            $table=$db.TableDefs.Item($name)
+            try{
+                $item=@{name=$name;attributes=[int]$table.Attributes}
+                $item.fields=@($table.Fields|ForEach-Object{@{name=[string]$_.Name;type=[int]$_.Type;size=[int]$_.Size;attributes=[int]$_.Attributes;required=[bool]$_.Required;allow_zero_length=[bool]$_.AllowZeroLength;default_value=[string]$_.DefaultValue}})
+                $item.indexes=@($table.Indexes|ForEach-Object{@{name=[string]$_.Name;primary=[bool]$_.Primary;unique=[bool]$_.Unique;required=[bool]$_.Required;foreign=[bool]$_.Foreign;ignore_nulls=[bool]$_.IgnoreNulls;fields=@($_.Fields|ForEach-Object{@{name=[string]$_.Name;attributes=[int]$_.Attributes}})}})
+                $rs=$db.OpenRecordset($name,4);$rows=New-Object Collections.ArrayList
+                while(-not $rs.EOF){[void]$rows.Add((Row $rs $name));$rs.MoveNext()}
+                $item.rows=[object[]]$rows.ToArray();$snapshot.user_tables+=,$item;$rs.Close();Release $rs;$rs=$null
+            }finally{Release $table}
+        }
+        $rs=$db.OpenRecordset('Items',1);$rs.Index='ById';$rows=New-Object Collections.ArrayList
+        if(-not $rs.EOF){$rs.MoveFirst()};while(-not $rs.EOF){[void]$rows.Add((Row $rs 'Items'));$rs.MoveNext()}
+        $snapshot.traversal=[object[]]$rows.ToArray();$seeks=New-Object Collections.ArrayList
+        foreach($query in -1..201){$rs.Seek('=',[int]$query);$row=if($rs.NoMatch){$null}else{Row $rs 'Items'};[void]$seeks.Add(@{query=[int]$query;row=$row})}
+        $snapshot.seek=[object[]]$seeks.ToArray()
+    }finally{if($null-ne $rs){$rs.Close();Release $rs};if($null-ne $db){$db.Close();Release $db};Release $engine}
+    return @{before=$before;after=(Identity $Path);snapshot=$snapshot}
+}
+function Mutate([string]$Path,[int]$Id,[bool]$Duplicate){
+    $engine=$db=$rs=$null
+    try{
+        $engine=New-Object -ComObject DAO.DBEngine.36;$db=$engine.OpenDatabase($Path,$false,$false);$rs=$db.OpenRecordset('Items',2)
+        $script:mutationStarted=$true
+        try{
+            $rs.AddNew();$rs.Fields.Item('Id').Value=[int]$Id;$rs.Fields.Item('Name').Value=[string]('x'*80)
+            $rs.Fields.Item('Price').Value=$(if($Id%2-eq 0){[DBNull]::Value}else{[decimal]::Parse('-12.3456',[Globalization.CultureInfo]::InvariantCulture)})
+            $rs.Fields.Item('Active').Value=[bool]($Id%2-ne 0);$rs.Update()
+        }catch{
+            $numbers=@($engine.Errors|ForEach-Object{[int]$_.Number})
+            if(-not $Duplicate-or $numbers-notcontains 3022){throw}
+            $rs.CancelUpdate();return @{status='duplicate';numbers=$numbers}
+        }
+        if($Duplicate){throw 'Duplicate accepted'}
+        return @{status='inserted'}
+    }finally{if($null-ne $rs){$rs.Close();Release $rs};if($null-ne $db){$db.Close();Release $db};Release $engine}
+}
+$planPath=Join-Path $env:JET3_WORK 'indexed-boundary.plan.json';$plan=Get-Content -LiteralPath $planPath -Raw|ConvertFrom-Json
+foreach($pair in @(@($PSCommandPath,'oracle/windows-dao/scripts/indexed_boundary.ps1'),@($helper,'oracle/windows-dao/scripts/field_update.ps1'))){if((Identity $pair[0]).sha256-cne $plan.inputs.($pair[1])){throw 'Producer pin'}}
+$script:mutationStarted=$false
+$result=@{document_type='dao_indexed_boundary_result';plan_sha256=(Identity $planPath).sha256;environment=@{process_bits=32;provider='DAO.DBEngine.36'};captures=@{};operations=@{};error=$null;mutation_started=$false;retention_failures=@()}
+try{
+    foreach($arm in $plan.arms){
+        foreach($role in @('original','candidate')){
+            $name="$($arm.name)-$role.mdb";$path=Join-Path $env:JET3_WORK $name;$pin=$plan.images.$name;$actual=Identity $path
+            if($actual.sha256-cne $pin.sha256-or $actual.size-ne $pin.size){throw 'Image pin'}
+            $result.captures[$name]=Capture $path
+        }
+        $name="$($arm.name)-control.mdb";$path=Join-Path $env:JET3_WORK $name
+        Copy-Item (Join-Path $env:JET3_WORK "$($arm.name)-original.mdb") $path
+        if($arm.name-ne 'split'){$result.operations[$arm.name]=Mutate $path ([int]$arm.id) ($arm.name-eq 'duplicate')}
+        $result.captures[$name]=Capture $path
+    }
+}catch{$result.error=@{message=$_.Exception.Message;stack=$_.ScriptStackTrace}}finally{
+    $result.mutation_started=$script:mutationStarted
+    foreach($file in Get-ChildItem -LiteralPath $env:JET3_WORK -Filter '*.mdb'){try{Copy-Item $file.FullName $env:JET3_OUTBOX}catch{$result.retention_failures+=,$file.Name}}
+    Write-Json $result (Join-Path $env:JET3_OUTBOX 'result.json')
+}
+if($null-ne $result.error-or $result.retention_failures.Count){exit 1}

--- a/oracle/windows-dao/scripts/indexed_boundary.py
+++ b/oracle/windows-dao/scripts/indexed_boundary.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""One frozen insertion-only boundary matrix; no acquisition retries."""
+import argparse
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import field_update as common
+import multi_level_index_structure as structure
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN = ROOT / 'oracle/windows-dao/acquisition/indexed-boundary.plan.json'
+SCRIPT = 'oracle/windows-dao/scripts/indexed_boundary.ps1'
+identity, canonical = common.identity, common.canonical
+catalog = structure.catalog
+
+
+def require(value, message):
+    if not value:
+        raise ValueError(message)
+
+
+def definition(data):
+    catalog_table, _, objects = catalog._discover_catalog(data)
+    name, ident = [catalog._ordinal(catalog_table, k) for k in ('Name', 'Id')]
+    roots = [r['values'][ident] for r in objects if r['values'][name] == 'Items']
+    require(len(roots) == 1, 'Items root')
+    table = catalog._definition(data, roots[0])
+    pages, lval = catalog._table_pages(data, table)
+    require(not lval and len(table['physical_indexes']) == len(table['logical_indexes']) == 1, 'One scalar index')
+    return table, catalog._table_rows(data, table, pages)
+
+
+def values(key):
+    return [key, 'x' * 80, None if key % 2 == 0 else '-12.3456', key % 2 != 0]
+
+
+def patch_check(before, after, arm):
+    table, rows = definition(before)
+    require(len(rows) == table['row_count'] == arm['count'], 'Original count')
+    if arm['name'] in ('duplicate', 'split'):
+        require(before == after, 'Refusal changed bytes')
+        return dict(refusal=arm['name'], preserved=True)
+    key = arm['id']
+    # EXP-0060/0061 fixed fields, variable text footer and Boolean presence.
+    encoded = bytes([4]) + key.to_bytes(4, 'little', signed=True) + (-123456).to_bytes(8, 'little', signed=True) + b'x'*80 + bytes([93, 13, 1, 15])
+    require(key % 2 == 1, 'Finite present Currency insertion')
+    expected = bytearray(before)
+    pages = sorted(catalog._locator_pages(before, table['maps']['owned'], 'owned'))
+    eof = arm['name'] == 'eof'
+    free_pages = []
+    for page in pages:
+        raw = catalog._page(before, page, 'Items')
+        directory = catalog._row_directory(raw, page)
+        require(directory and all(not e['hidden'] and not e['overflow'] for e in directory), 'Ordinary populated data')
+        free = directory[-1]['start'] - 10 - 2*len(directory)
+        require(free == int.from_bytes(raw[2:4], 'little'), 'Free count')
+        if free >= 2*(len(encoded)+2): free_pages.append(page)
+        if eof: require(free < len(encoded)+2, 'Physical boundary required')
+    if eof:
+        page, slot = len(before)//2048, 0
+        require(len(after) == len(before)+2048, 'One appended page')
+        for role, locator, set_value in [('global', dict(page=1,row=0),False), ('owned',table['maps']['owned'],True), ('available',table['maps']['available'],True)]:
+            raw = catalog._locator_row(before, locator, role)
+            relative = page-int.from_bytes(raw[1:5], 'little')
+            require(raw[0] == 0 and 0 <= relative < 8*(len(raw)-5), 'Inline map coverage')
+            entry = catalog._row_directory(catalog._page(before,locator['page'],role),locator['page'])[locator['row']]
+            offset = locator['page']*2048+entry['start']+5+relative//8
+            mask = 1 << (relative%8)
+            require(bool(before[offset]&mask) != set_value, 'Original EOF map bit')
+            expected[offset] = expected[offset]|mask if set_value else expected[offset]&~mask
+        image = bytearray(2048)
+        image[:2] = b'\x01\x01'; image[2:4] = (2036-len(encoded)).to_bytes(2,'little')
+        image[4:8] = table['root'].to_bytes(4,'little'); image[8:10] = b'\x01\x00'
+        image[10:12] = (2048-len(encoded)).to_bytes(2,'little'); image[-len(encoded):] = encoded
+        expected.extend(image)
+    else:
+        require(len(free_pages) == 1 and len(before) == len(after), 'One existing candidate')
+        page = free_pages[0]; base = page*2048
+        raw = before[base:base+2048]; directory = catalog._row_directory(raw,page)
+        slot = len(directory); high = directory[-1]['start']; low = high-len(encoded)
+        expected[base+low:base+high] = encoded
+        expected[base+10+slot*2:base+12+slot*2] = low.to_bytes(2,'little')
+        expected[base+8:base+10] = (slot+1).to_bytes(2,'little')
+        expected[base+2:base+4] = (low-12-slot*2).to_bytes(2,'little')
+    count = len(rows)+1; root = table['root']*2048
+    for offset in (12,47): expected[root+offset:root+offset+4] = count.to_bytes(4,'little')
+    records = [(r['values'][0],r['page'],r['row']) for r in rows] + [(key,page,slot)]
+    records = sorted(b'\x7f'+(k^0x80000000).to_bytes(4,'big')+p.to_bytes(3,'big')+bytes([s]) for k,p,s in records)
+    leaf = table['physical_indexes'][0]['root']*2048
+    require(before[leaf:leaf+2] == b'\x04\x01' and before[leaf+8:leaf+22] == bytes(14), 'Isolated uncompressed root leaf')
+    expected[leaf+2:leaf+4] = (1800-count*9).to_bytes(2,'little')
+    bitmap = bytearray(226)
+    for n in range(1,count+1): bitmap[n*9//8] |= 1 << (n*9%8)
+    expected[leaf+22:leaf+248] = bitmap; expected[leaf+248:leaf+248+count*9] = b''.join(records)
+    require(expected == after, 'Exact data/allocation/count/leaf patch and unrelated preservation')
+    return dict(page=page,slot=slot,count=count,eof=eof,unrelated_bytes_preserved=True)
+
+
+def expected(snapshot, arm, role):
+    value = copy.deepcopy(snapshot)
+    rows = [values(k) for k in range(arm['count'])]
+    if role != 'original' and arm['name'] in ('space','eof'): rows.append(values(arm['id']))
+    rows.sort()
+    require(value['version'] == '3.0' and value['queries'] == value['relations'] == [] and value['tables'] == sorted(['Items','Notes','MSysACEs','MSysObjects','MSysQueries','MSysRelationships']), 'Database inventory')
+    require([t['name'] for t in value['user_tables']] == ['Items','Notes'], 'User inventory')
+    items, notes = value['user_tables']
+    items['rows'].sort(); notes['rows'].sort()
+    for row in items['rows'] + value['traversal'] + [s['row'] for s in value['seek'] if s['row'] is not None]:
+        require(len(row) == 4 and type(row[0]) is int and type(row[1]) is str and (row[2] is None or type(row[2]) is str) and type(row[3]) is bool, 'Typed Items serialization')
+    require(items['rows'] == rows and notes['rows'] == [[7,'n'*4096],[8,None]], 'Complete typed rows and Memo')
+    for table, fields in [(items,[('Id',4,4),('Name',10,80),('Price',5,8),('Active',1,1)]),(notes,[('Id',4,4),('Body',12,0)])]:
+        require(table['attributes'] == 0 and [(f['name'],f['type'],f['size']) for f in table['fields']] == fields, 'Exact schema')
+    require(notes['indexes'] == [] and items['indexes'] == [dict(name='ById',primary=True,unique=True,required=True,foreign=False,ignore_nulls=False,fields=[dict(name='Id',attributes=0)])], 'Exact index metadata')
+    require(value['traversal'] == rows and value['seek'] == [dict(query=k,row=next((r for r in rows if r[0]==k),None)) for k in range(-1,202)], 'Complete traversal and present/missing Seek')
+    return value
+
+
+def raw_check(data, arm, role):
+    table, rows = definition(data)
+    require([(c['name'], c['type'], c['size']) for c in table['columns']] == [('Id','Long',4),('Name','Text',80),('Price','Currency',8),('Active','Boolean',1)], 'Raw schema')
+    ids = list(range(arm['count']))
+    if role != 'original' and arm['name'] in ('space','eof'): ids.append(arm['id'])
+    expected_rows = [[k, 'x'*80, None if k%2 == 0 else dict(raw_hex=(-123456).to_bytes(8,'little',signed=True).hex()), k%2 != 0] for k in sorted(ids)]
+    require(sorted((r['values'] for r in rows), key=lambda r:r[0]) == expected_rows, 'Complete raw rows')
+    physical = table['physical_indexes'][0]
+    require(physical['flags'] == 9 and physical['keys'] == [dict(column=0,direction=1)], 'Raw index metadata')
+    nodes, entries = structure.tree(data, physical['root'], table['root'])
+    require(len(nodes) == 1 and not nodes[0]['children'] and (role == 'control' or nodes[0]['prefix'] == 0), 'Single root leaf')
+    require(structure.map_pages(data, physical['map'], 'index') == {physical['root']}, 'Isolated index map')
+    expected_entries = sorted(b'\x7f'+(r['values'][0]^0x80000000).to_bytes(4,'big')+r['page'].to_bytes(3,'big')+bytes([r['row']]) for r in rows)
+    require(entries == expected_entries and len(entries) == len(set(ids)) == table['row_count'] == physical['entry_count'], 'Key/locator/count bijection')
+    pages, _ = catalog._table_pages(data, table)
+    require(structure.map_pages(data, table['maps']['available'], 'available') <= set(pages), 'Available ownership')
+    return dict(count=len(entries), nodes=nodes, data_pages=pages)
+
+
+def verify_inputs():
+    plan = json.loads(PLAN.read_text())
+    for name, sha in plan['inputs'].items(): require(identity(ROOT/name)['sha256'] == sha, 'Input pin: '+name)
+    return plan
+
+
+def build_report(result, outbox, plan):
+    observations, reasons = [], []
+    try:
+        require(result['document_type'] == 'dao_indexed_boundary_result' and result['plan_sha256'] == identity(PLAN)['sha256'] and result['environment'] == dict(process_bits=32,provider='DAO.DBEngine.36') and result['error'] is None and result['retention_failures'] == [] and result['mutation_started'] is True, 'Acquisition failure')
+        require(set(result['captures']) == {f"{a['name']}-{r}.mdb" for a in plan['arms'] for r in ('original','candidate','control')}, 'Complete captures')
+        require(set(result['operations']) == {'space','eof','duplicate'}, 'Operations inventory')
+        for name in ('space','eof'): require(result['operations'][name] == dict(status='inserted'), 'Native insertion')
+        duplicate = result['operations']['duplicate']
+        require(duplicate['status'] == 'duplicate' and 3022 in duplicate['numbers'], 'Native duplicate rejection')
+        for arm in plan['arms']:
+            snapshots = {}; raw_counts = {}
+            for role in ('original','candidate','control'):
+                name = f"{arm['name']}-{role}.mdb"; capture = result['captures'][name]; path = outbox/name
+                require(capture['before'] == capture['after'] == identity(path), 'Read-only identity')
+                if role != 'control': require(identity(path) == plan['images'][name], 'Pinned public image')
+                snapshots[role] = expected(capture['snapshot'],arm,role)
+                table, rows = definition(path.read_bytes())
+                require(table['row_count'] == table['physical_indexes'][0]['entry_count'] == len(rows), 'Fresh insertion count correlation')
+                raw_counts[role] = raw_check(path.read_bytes(), arm, role)
+
+            require(snapshots['candidate'] == snapshots['control'], 'Full native control comparison')
+            metadata = []
+            for snapshot in snapshots.values():
+                value = copy.deepcopy(snapshot); value.pop('traversal'); value.pop('seek'); value['user_tables'][0].pop('rows'); metadata.append(value)
+            require(all(m == metadata[0] for m in metadata), 'Unrelated metadata/Notes preservation')
+            patch = patch_check((outbox/f"{arm['name']}-original.mdb").read_bytes(),(outbox/f"{arm['name']}-candidate.mdb").read_bytes(),arm)
+            observations.append(dict(arm=arm['name'],patch=patch,raw=raw_counts))
+    except (ValueError,KeyError,TypeError,OSError,catalog.DecodeError) as error: reasons.append(str(error))
+    return dict(document_type='dao_indexed_boundary_report',outcome='no_outcome' if reasons else 'observed_accepted',plan_sha256=identity(PLAN)['sha256'],reasons=reasons,observations=observations,development_only=True,compatibility_claim=False,support_matrix_movement=False)
+
+
+def preflight(images):
+    plan = verify_inputs()
+    require(subprocess.check_output(['git','show',f'HEAD:{PLAN.relative_to(ROOT)}'],cwd=ROOT) == PLAN.read_bytes(), 'Plan not committed')
+    for name,pin in plan['images'].items(): require(identity(images/name) == pin, 'Image pin: '+name)
+    for arm in plan['arms']: patch_check((images/f"{arm['name']}-original.mdb").read_bytes(),(images/f"{arm['name']}-candidate.mdb").read_bytes(),arm)
+    return plan
+
+
+def analyze(outbox):
+    plan = verify_inputs(); report = build_report(json.loads((outbox/'result.json').read_text(encoding='utf-8-sig')),outbox,plan)
+    report['result_sha256'] = identity(outbox/'result.json')['sha256']; (outbox/'report.json').write_text(canonical(report)+'\n'); print(report['outcome'])
+
+
+def dispatch(args):
+    plan=preflight(args.images);require(re.fullmatch(r'[0-9]{8}T[0-9]{6}Z-[a-z0-9-]{1,24}',args.run_id),'Run id');shared=args.shared_root.resolve();inbox=shared/'inbox'/args.run_id;outbox=shared/'outbox'/args.run_id;require(not inbox.exists() and not outbox.exists(),'Used run; no retry');inbox.mkdir(parents=True)
+    for name in plan['images']:shutil.copyfile(args.images/name,inbox/name)
+    shutil.copyfile(ROOT/SCRIPT,inbox/'script.ps1');shutil.copyfile(ROOT/'oracle/windows-dao/scripts/field_update.ps1',inbox/'field_update.ps1');shutil.copyfile(PLAN,inbox/PLAN.name)
+    spec=importlib.util.spec_from_file_location('transport',ROOT/'scripts/windows-dao-ps.py');transport=importlib.util.module_from_spec(spec);spec.loader.exec_module(transport)
+    command=['ssh','-p',args.port,'-o','BatchMode=yes','-o','ConnectTimeout=15','-o','IdentitiesOnly=yes','-i',args.identity,f'{args.user}@{args.host}','powershell.exe','-NoProfile','-NonInteractive','-EncodedCommand',transport.encoded(transport.guest_script(args.remote_shared_root,args.run_id,'script.ps1'))]
+    done=subprocess.run(command,stdin=subprocess.DEVNULL,capture_output=True,timeout=900);outbox.mkdir(exist_ok=True);(outbox/'ssh.txt').write_bytes(done.stdout+done.stderr)
+    require((outbox/'result.json').exists(),'Missing result; no retry');analyze(outbox);require(done.returncode==0,'Guest failed; no retry')
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__);sub=p.add_subparsers(dest='command',required=True)
+    c=sub.add_parser('preflight');c.add_argument('--images',type=Path,required=True);c=sub.add_parser('analyze');c.add_argument('outbox',type=Path)
+    c=sub.add_parser('run');c.add_argument('--images',type=Path,required=True);c.add_argument('--run-id',required=True);c.add_argument('--shared-root',type=Path,required=True)
+    for n,d in [('host','127.0.0.1'),('port','2222'),('user','jet3runner'),('identity',str(Path.home()/'.ssh/jet3-dao')),('remote-shared-root',r'\\host.lan\Data')]:c.add_argument('--'+n,default=d)
+    a=p.parse_args()
+    if a.command=='preflight':preflight(a.images);print('Committed inputs/images match.')
+    elif a.command=='analyze':analyze(a.outbox)
+    else:dispatch(a)
+if __name__=='__main__':main()

--- a/oracle/windows-dao/tests/check_indexed_boundary.ps1
+++ b/oracle/windows-dao/tests/check_indexed_boundary.ps1
@@ -1,0 +1,28 @@
+param([Parameter(Mandatory=$true)][string]$ScriptPath)
+Set-StrictMode -Version Latest
+$ErrorActionPreference='Stop'
+if([IntPtr]::Size-ne 4){throw 'Expected x86'}
+$tokens=$null;$errors=$null
+$ast=[Management.Automation.Language.Parser]::ParseFile($ScriptPath,[ref]$tokens,[ref]$errors)
+if($errors.Count){throw ($errors|Out-String)}
+$row=@($ast.FindAll({param($n)$n-is [Management.Automation.Language.FunctionDefinitionAst]-and $n.Name-eq 'Row'},$false))
+if($row.Count-ne 1){throw 'Row helper'};Invoke-Expression $row[0].Extent.Text
+$fields=@{Id=[pscustomobject]@{Value=101};Name=[pscustomobject]@{Value=('x'*80)};Price=[pscustomobject]@{Value=[decimal]::Parse('-12.3456',[Globalization.CultureInfo]::InvariantCulture)};Active=[pscustomobject]@{Value=$true};Body=[pscustomobject]@{Value=('n'*4096)}}
+$collection=[pscustomobject]@{Fields=$fields};$collection|Add-Member ScriptMethod Item {param($Name)return $this.Fields[$Name]}
+$rs=[pscustomobject]@{Fields=$collection}
+$value=Row $rs 'Items'
+if($value.Count-ne 4-or $value[0]-isnot [int]-or $value[1]-cne ('x'*80)-or $value[2]-cne '-12.3456'-or $value[3]-isnot [bool]-or -not $value[3]){throw 'Typed Items'}
+$fields.Price.Value=[DBNull]::Value;$fields.Active.Value=$false
+$value=Row $rs 'Items';if($null-ne $value[2]-or $value[3]){throw 'Null/false'}
+$value=Row $rs 'Notes';if($value.Count-ne 2-or $value[1]-cne ('n'*4096)){throw 'Memo'}
+$fields.Body.Value=[DBNull]::Value;$value=Row $rs 'Notes';if($null-ne $value[1]){throw 'Null Memo'}
+Write-Output 'x86 producer syntax and typed full-row serialization passed; no DAO executed'
+
+$fields.Price.Value=[decimal]::Parse('-12.3456',[Globalization.CultureInfo]::InvariantCulture)
+$fields.Active.Value=$true
+$rows=New-Object Collections.ArrayList;[void]$rows.Add((Row $rs 'Items'))
+$found=if($true){Row $rs 'Items'}else{$null}
+$nested=@{rows=[object[]]$rows.ToArray();seek=@(@{query=101;row=$found},@{query=-1;row=$null})}
+$roundtrip=$nested|ConvertTo-Json -Depth 12 -Compress|ConvertFrom-Json
+if($roundtrip.rows.Count-ne 1-or $roundtrip.rows[0].Count-ne 4-or $roundtrip.rows[0][2]-isnot [string]-or $roundtrip.rows[0][2]-cne '-12.3456'-or $roundtrip.seek[0].row.Count-ne 4-or $roundtrip.seek[0].row[3]-isnot [bool]-or $null-ne $roundtrip.seek[1].row){throw 'Nested JSON rows/Seek'}
+Write-Output 'Nested JSON rows/Seek roundtrip passed; no DAO executed'

--- a/oracle/windows-dao/tests/test_indexed_boundary.py
+++ b/oracle/windows-dao/tests/test_indexed_boundary.py
@@ -1,0 +1,63 @@
+"""Full new analyzer path against deterministic public images; no DAO."""
+import copy
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import indexed_boundary as a
+
+
+def snapshot(arm, role):
+    ids = list(range(arm['count']))
+    if role != 'original' and arm['name'] in ('space', 'eof'):
+        ids.append(arm['id'])
+    rows = [a.values(k) for k in sorted(ids)]
+    tables = []
+    for name, fields, data in [('Items', [('Id',4,4),('Name',10,80),('Price',5,8),('Active',1,1)], rows), ('Notes', [('Id',4,4),('Body',12,0)], [[7,'n'*4096],[8,None]])]:
+        tables.append(dict(name=name, attributes=0, fields=[dict(name=n,type=t,size=s) for n,t,s in fields], indexes=[], rows=data))
+    tables[0]['indexes'] = [dict(name='ById',primary=True,unique=True,required=True,foreign=False,ignore_nulls=False,fields=[dict(name='Id',attributes=0)])]
+    return dict(version='3.0', tables=sorted(['Items','Notes','MSysACEs','MSysObjects','MSysQueries','MSysRelationships']), queries=[], relations=[], user_tables=tables, traversal=copy.deepcopy(rows), seek=[dict(query=k,row=next((r for r in rows if r[0]==k),None)) for k in range(-1,202)])
+
+
+class BoundaryTests(unittest.TestCase):
+    def test_full_report_and_failure_matrix(self):
+        plan = json.loads(a.PLAN.read_text())
+        with tempfile.TemporaryDirectory() as tmp:
+            images = Path(tmp)/'images'
+            subprocess.run(['cargo','run','--quiet','-p','jet3','--example','indexed_boundary_candidate','--',str(images)],cwd=a.ROOT,check=True)
+            result = dict(document_type='dao_indexed_boundary_result',plan_sha256=a.identity(a.PLAN)['sha256'],environment=dict(process_bits=32,provider='DAO.DBEngine.36'),error=None,retention_failures=[],mutation_started=True,captures={},operations=dict(space=dict(status='inserted'),eof=dict(status='inserted'),duplicate=dict(status='duplicate',numbers=[3022])))
+            for arm in plan['arms']:
+                shutil.copyfile(images/f"{arm['name']}-candidate.mdb", images/f"{arm['name']}-control.mdb")
+                for role in ('original','candidate','control'):
+                    name = f"{arm['name']}-{role}.mdb"
+                    pin = a.identity(images/name)
+                    if role != 'control': self.assertEqual(pin,plan['images'][name])
+                    result['captures'][name] = dict(before=pin,after=pin,snapshot=snapshot(arm,role))
+            report = a.build_report(result,images,plan)
+            self.assertEqual(report['outcome'],'observed_accepted',report['reasons'])
+            for defect in ('currency','boolean','memo','seek','capture','operation','retention'):
+                bad = copy.deepcopy(result)
+                s = bad['captures']['eof-candidate.mdb']['snapshot']
+                if defect == 'currency': s['user_tables'][0]['rows'][1][2] = -12.3456
+                elif defect == 'boolean': s['user_tables'][0]['rows'][1][3] = 1
+                elif defect == 'memo': s['user_tables'][1]['rows'][0][1] = 'changed'
+                elif defect == 'seek': s['seek'].pop()
+                elif defect == 'capture': bad['captures'].pop('split-control.mdb')
+                elif defect == 'operation': bad['operations']['duplicate']['numbers'] = []
+                else: bad['retention_failures'] = ['lost']
+                self.assertEqual(a.build_report(bad,images,plan)['outcome'],'no_outcome',defect)
+            arm = plan['arms'][1]
+            before = (images/'eof-original.mdb').read_bytes()
+            after = (images/'eof-candidate.mdb').read_bytes()
+            table, _ = a.definition(before)
+            memo_offset = before.index(b'n'*4096) if b'n'*4096 in before else before.index(b'n'*100)
+            for offset in (table['physical_indexes'][0]['root']*2048+250, memo_offset, len(before)+100):
+                bad = bytearray(after); bad[offset] ^= 1
+                with self.assertRaises(ValueError): a.patch_check(before,bad,arm)
+
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
An existing populated table with one unique Long index can now insert across a data-page boundary while its isolated, uncompressed root leaf still has capacity. EOF data allocation, inline map bits, table counts and leaf changes publish together. Duplicate keys and required index splits preserve the original file on refusal.

The deterministic Items/Notes fixture covers existing space, physical data-page exhaustion, duplicate rejection and the 200-key leaf limit, including full rows, index/locator correlation, unrelated Memo/metadata bytes and private-publication corruption. Includes the existing uncommitted acceptance-target documentation.

Validation: independent implementation/plan review, focused Rust and full analyzer tests, x86 no-DAO typed JSON checks, and `just ready` passed. EXP-0217 was SHA-pinned, committed and pushed before one DAO acquisition. EXP-0218 records **no_outcome**: the duplicate-control null Currency COM assignment failed after the two native insertion operations. The frozen report was independently reproduced; artifacts remain external, with no retry or subset promotion. Hosted support is unchanged.

Refs #112, #113. This finishes the bounded implementation and records its validation outcome; it does not complete the larger lifecycle milestone. A successor DAO acquisition requires a separate reviewed plan and human decision.
